### PR TITLE
bazel supports cross compile, added --platform arg example for cross compile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 build --workspace_status_command=./print-workspace-status.sh
-run --workspace_status_command=./print-workspace-status.sh
 test --test_output=errors
+run --workspace_status_command=./print-workspace-status.sh
+run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ If you are interested in contributing to `Elafros`, see
 Once you've [setup your development
 environment](./DEVELOPMENT.md#getting-started), stand up `Elafros` with:
 
-> Note, from Mac or Windows you will have to append target platform argument for go to cross compile binaries for Linux `--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64`
-
 ```shell
 bazel run :everything.create
 ```


### PR DESCRIPTION
Suspect many will build from Mac or Windows, this should help.