### PR TITLE
Remove obsolete constraints

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,32 +33,8 @@ required = [
 ]
 
 [[constraint]]
-  name = "cloud.google.com/go"
-  version = "0.17.0"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/go-openapi/loads"
-
-[[constraint]]
   branch = "master"
   name = "github.com/golang/glog"
-
-[[constraint]]
-  name = "github.com/onsi/ginkgo"
-  version = "1.4.0"
-
-[[constraint]]
-  name = "github.com/onsi/gomega"
-  version = "1.3.0"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"
-
-[[constraint]]
-  name = "google.golang.org/appengine"
-  version = "1.0.0"
 
 [[constraint]]
   name = "k8s.io/api"
@@ -71,7 +47,3 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   branch = "release-6.0"  # Matches 1.9
-
-[[constraint]]
-  name = "k8s.io/kubernetes"
-  branch = "v1.9.0"


### PR DESCRIPTION
We don't use these packages anymore, and the new dep complains about constraints for unreferenced packages.

FYI the latest dep also complains about `dep prune` being deprecated as it's been rolled into `dep ensure`.