### PR TITLE
Use pure go to build helloworld binary

### DIFF
--- a/sample/helloworld/BUILD
+++ b/sample/helloworld/BUILD
@@ -10,6 +10,7 @@ go_binary(
     name = "helloworld",
     embed = [":go_default_library"],
     importpath = "github.com/google/elafros/sample/helloworld",
+    pure = "on",
 )
 
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")


### PR DESCRIPTION
Required to avoid a link to libstdc++ which doesn't exist on images.