### PR TITLE
Add Build and BuildTemplate CRDs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -61,6 +61,16 @@ k8s_object(
 )
 
 k8s_object(
+  name = "build",
+  template = "build.yaml",
+)
+
+k8s_object(
+  name = "buildtemplate",
+  template = "buildtemplate.yaml",
+)
+
+k8s_object(
     name = "istio",
     template = "@istio_release//:istio.yaml",
 )
@@ -81,6 +91,8 @@ k8s_objects(
         ":elaservice",
         ":revisiontemplate",
         ":revision",
+        ":build",
+        ":buildtemplate",
     ],
 )
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,26 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: builds.cloudbuild.googleapis.com
+spec:
+  group: cloudbuild.googleapis.com
+  version: v1alpha1
+  names:
+    kind: Build
+    plural: builds
+  scope: Namespaced
+

--- a/buildtemplate.yaml
+++ b/buildtemplate.yaml
@@ -1,0 +1,24 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: buildtemplates.cloudbuild.googleapis.com
+spec:
+  group: cloudbuild.googleapis.com
+  version: v1alpha1
+  names:
+    kind: BuildTemplate
+    plural: buildtemplates
+  scope: Namespaced


### PR DESCRIPTION
Needed for the new build code in Revision controller to work. Existing deployments will need to run `bazel run :everything.apply` to create the new CRDs.