### PR TITLE
Specify the APIVersion of the autoscaler target.

### DIFF
--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -43,8 +43,9 @@ func MakeElaAutoscaler(u *v1alpha1.Revision, namespace string) *autoscaling_v1.H
 		},
 		Spec: autoscaling_v1.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscaling_v1.CrossVersionObjectReference{
-				Kind: "Deployment",
-				Name: util.GetRevisionDeploymentName(u),
+				APIVersion: "extensions/v1beta1",
+				Kind:       "Deployment",
+				Name:       util.GetRevisionDeploymentName(u),
 			},
 			MinReplicas:                    &min,
 			MaxReplicas:                    int32(max),


### PR DESCRIPTION
Autoscaling was broken because the horizontal pod autoscaler was unable to find the deployment.  Message was "the HPA controller was unable to get the target's current scale: no matches for /, Kind=Deployment\" and it showed <unknown> / 80%.

Now the autoscale is able to find the deployment and shows the actual CPU usage.