### PR TITLE
Use ssh address for build-crd instead of https

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,7 +104,7 @@ load(
 private_git_repository(
    name = "buildcrd",
    commit = "c68c218d67987d71e496e9c1b48f270614c8e5f2",
-   remote = "https://github.com/google/build-crd",
+   remote = "git@github.com:google/build-crd.git",
 )
 
 # If you would like to test changes to both repositories,


### PR DESCRIPTION
Using `https` causes git to not use a person's configured SSH
keys when checking out build-crd, which fails since bazel can't/won't
prompt for a person's username and password.

@mattmoor I assume it's also possible to setup a person's development environment so that the `https` target works so alternatively we could add that to the docs instead of making this change, however I think most people won't have that set up?