### PR TITLE
Make sure docs explain SSH key setup.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Conduct](./code-of-conduct.md) at all times.
 
 ## Workflow
 
-* All PRs must be pulled from [forks](./DEVELOPMENT.md#setup-your-repo)
+* All PRs must be pulled from [forks](./DEVELOPMENT.md#checkout-your-fork)
 * All PRs must [be reviewed](#code-reviews)
 
 ### Code reviews

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,9 +2,12 @@
 
 ## Getting started
 
-* Create [a github account](https://github.com/join)
-* Install [requirements](#requirements)
-* Setup [environment](#environment-setup)
+1. Create [a GitHub account](https://github.com/join)
+1. Setup [GitHub access via
+   SSH](https://help.github.com/articles/connecting-to-github-with-ssh/)
+1. Install [requirements](#requirements)
+1. [Create and checkout a repo fork](#checkout-your-fork)
+1. Setup your [environment](#environment-setup)
 
 Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -35,7 +38,7 @@ You'll also need to setup:
 Once you meet these requirements, you can [start an `Elafros`
 environment](README.md#start-elafros)!
 
-### Setup your repo
+### Checkout your fork
 
 The repository must be set up properly relative to your
 [`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
@@ -53,6 +56,10 @@ To check out this repository:
   git remote add upstream git@github.com:google/elafros.git
   git remote set-url --push upstream no_push
   ```
+
+_Adding the `upstream` remote sets you up nicely for regularly [syncing your
+fork](https://help.github.com/articles/syncing-a-fork/)._
+
 ### Environment setup
 
 To [start your envrionment](./README.md#start-elafros) you'll need to set these environment


### PR DESCRIPTION
Bazel will be trying to checkout repos it depends on, and it is
currently configured to assume SSH key access, so we should make
sure the docs explain to do this.

Also the list of tasks you have to perform to get ready for
development was missing a bullet point for forking the repo.

Trying to make all of this more clear for folks newer to github also.
I mean GitHub.