### PR TITLE
 Initial shell script for running the unit tests with bazel.

### DIFF
--- a/testing/unit_tests.sh
+++ b/testing/unit_tests.sh
@@ -18,8 +18,8 @@
 set -ex
 
 # Clean up any leftover configuration
-readonly DOCKER_REPO_OVERRIDE=dummy_docker
-readonly K8S_CLUSTER_OVERRIDE=dummy_k8s_cluster
+export DOCKER_REPO_OVERRIDE=dummy_docker
+export K8S_CLUSTER_OVERRIDE=dummy_k8s_cluster
 bazel clean
 
 set +e


### PR DESCRIPTION
Right now no test talks to docker or to a cluster, so it's safe to use dummy values.
Once integration tests are added, the test targets will be updated so only real unit tests targets are selected.