### PR TITLE
Update rules_k8s to pick up a handful of fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,10 @@ $ kubectl -n ela-system logs $(kubectl -n ela-system get pods -l app=ela-control
 
 You can delete all of the service components with:
 ```shell
-bazel run :elafros.delete
-bazel run @buildcrd//:everything.delete
-bazel run :istio.delete
+bazel run :everything.delete
 ```
 
 Delete all cached environment variables (e.g. `DOCKER_REPO_OVERRIDE`):
 ```shell
 bazel clean
 ```
-
-Due to [a bazel deletion ordering issue](https://github.com/bazelbuild/rules_k8s/issues/97),
-which also prevents `bazel run :everything.delete` from working,
-both of the above commands will output errors such as:
-
-```
-deployments.extensions "ela-webhook" not found
-...
-serviceaccounts "istio-mixer-service-account" not found
-```
-
-Deleting the Custom Resource Definitions will cascade and cause any instances
-of those resources to be cleaned up.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,8 +46,8 @@ _go_image_repos()
 # Pull in rules_k8s
 git_repository(
     name = "io_bazel_rules_k8s",
-    # HEAD as of 2018-02-03
-    commit = "959c5adc2d7863c0ff445c6fd789cfd04bc1815c",
+    # HEAD as of 2018-02-07
+    commit = "d413b49efe2b1ffac3d7548254ff153879b6f9a0",
     remote = "https://github.com/bazelbuild/rules_k8s",
 )
 


### PR DESCRIPTION
```shell
$ bazel run //:everything.delete
INFO: Analysed target //:everything.delete (0 packages loaded).
INFO: Found 1 target...
Target //:everything.delete up-to-date:
  bazel-bin/everything.delete
INFO: Elapsed time: 1.574s, Critical Path: 0.09s
INFO: Build completed successfully, 42 total actions

INFO: Running command line: bazel-bin/everything.delete
service "ela-webhook" deleted
deployment "ela-webhook" deleted
deployment "ela-controller" deleted
customresourcedefinition "revisions.elafros.dev" deleted
customresourcedefinition "revisiontemplates.elafros.dev" deleted
customresourcedefinition "elaservices.elafros.dev" deleted
clusterrolebinding "ela-controller-admin" deleted
serviceaccount "ela-controller" deleted
namespace "ela-system" deleted
deployment "build-controller" deleted
customresourcedefinition "buildtemplates.cloudbuild.googleapis.com" deleted
customresourcedefinition "builds.cloudbuild.googleapis.com" deleted
clusterrolebinding "build-controller-admin" deleted
serviceaccount "build-controller" deleted
namespace "build-system" deleted
deployment "istio-ca" deleted
serviceaccount "istio-ca-service-account" deleted
deployment "istio-ingress" deleted
serviceaccount "istio-ingress-service-account" deleted
service "istio-ingress" deleted
deployment "istio-pilot" deleted
serviceaccount "istio-pilot-service-account" deleted
service "istio-pilot" deleted
customresourcedefinition "routerules.config.istio.io" deleted
customresourcedefinition "egressrules.config.istio.io" deleted
customresourcedefinition "destinationpolicies.config.istio.io" deleted
configmap "istio" deleted
kubernetes "attributes" deleted
rule "kubeattrgenrulerule" deleted
kubernetesenv "handler" deleted
rule "promtcp" deleted
rule "promhttp" deleted
prometheus "handler" deleted
metric "tcpbytereceived" deleted
metric "tcpbytesent" deleted
metric "responsesize" deleted
metric "requestsize" deleted
metric "requestduration" deleted
metric "requestcount" deleted
rule "stdio" deleted
logentry "accesslog" deleted
stdio "handler" deleted
attributemanifest "kubernetes" deleted
attributemanifest "istioproxy" deleted
customresourcedefinition "reportnothings.config.istio.io" deleted
customresourcedefinition "quotas.config.istio.io" deleted
customresourcedefinition "metrics.config.istio.io" deleted
customresourcedefinition "logentries.config.istio.io" deleted
customresourcedefinition "listentries.config.istio.io" deleted
customresourcedefinition "checknothings.config.istio.io" deleted
customresourcedefinition "servicecontrols.config.istio.io" deleted
customresourcedefinition "stdios.config.istio.io" deleted
customresourcedefinition "statsds.config.istio.io" deleted
customresourcedefinition "stackdrivers.config.istio.io" deleted
customresourcedefinition "prometheuses.config.istio.io" deleted
customresourcedefinition "noops.config.istio.io" deleted
customresourcedefinition "memquotas.config.istio.io" deleted
customresourcedefinition "kubernetesenvs.config.istio.io" deleted
customresourcedefinition "kuberneteses.config.istio.io" deleted
customresourcedefinition "listcheckers.config.istio.io" deleted
customresourcedefinition "deniers.config.istio.io" deleted
customresourcedefinition "attributemanifests.config.istio.io" deleted
customresourcedefinition "rules.config.istio.io" deleted
deployment "istio-mixer" deleted
serviceaccount "istio-mixer-service-account" deleted
service "istio-mixer" deleted
configmap "istio-mixer" deleted
clusterrolebinding "istio-mixer-admin-role-binding-istio-system" deleted
clusterrolebinding "istio-sidecar-role-binding-istio-system" deleted
clusterrolebinding "istio-ingress-admin-role-binding-istio-system" deleted
clusterrolebinding "istio-ca-role-binding-istio-system" deleted
clusterrolebinding "istio-initializer-admin-role-binding-istio-system" deleted
clusterrolebinding "istio-pilot-admin-role-binding-istio-system" deleted
clusterrole "istio-sidecar-istio-system" deleted
clusterrole "istio-ca-istio-system" deleted
clusterrole "istio-mixer-istio-system" deleted
clusterrole "istio-initializer-istio-system" deleted
clusterrole "istio-pilot-istio-system" deleted
namespace "istio-system" deleted
```