### PR TITLE
Clean up revisions if the associated revision template is deleted

### DIFF
--- a/pkg/controller/revisiontemplate/controller_test.go
+++ b/pkg/controller/revisiontemplate/controller_test.go
@@ -125,6 +125,11 @@ func TestCreateRTCreatesPR(t *testing.T) {
 		if rt.Spec.Template.Spec.Service != rev.Spec.Service {
 			t.Errorf("rev service was not %s", rt.Spec.Template.Spec.Service)
 		}
+
+		if len(rev.OwnerReferences) != 1 || rt.Name != rev.OwnerReferences[0].Name {
+			t.Errorf("expected owner references to have 1 ref with name %s", rt.Name)
+		}
+
 		return hooks.HookComplete
 	})
 


### PR DESCRIPTION
My cluster kept getting full because the revisions created when I was trying things out were left orphaned after I had deleted the associated revision template and service. I saw issue #73 and tried to make a start on it. This change does not currently affect the relationship between a service and revision as the issue discusses. I'll leave this in WIP until I can do that bit too. However, this change is enough to clean revisions up when running an `:everything.delete` rule.

This is my first code change to the project so I'm keen to hear any feedback you have about any aspect of it. I realize it's a very small change but I'm all ears!