### PR TITLE
Standardize on using corev1 for k8s.io/api/core/v1

### DIFF
--- a/pkg/controller/elaservice/ela_service.go
+++ b/pkg/controller/elaservice/ela_service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/elafros/pkg/apis/ela/v1alpha1"
 	"github.com/google/elafros/pkg/controller/util"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,14 +30,14 @@ var servicePort = 80
 // MakeElaServiceService creates a Service that targets nothing. This is now only
 // a placeholder so that we can route the traffic to Istio and the balance with
 // route rules exclusively to underlying k8s services that represent Revisions.
-func MakeElaServiceK8SService(u *v1alpha1.ElaService) *apiv1.Service {
-	return &apiv1.Service{
+func MakeElaServiceK8SService(u *v1alpha1.ElaService) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      util.GetElaK8SServiceName(u),
 			Namespace: u.Namespace,
 		},
-		Spec: apiv1.ServiceSpec{
-			Ports: []apiv1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
 				{
 					Name: httpServicePortName,
 					Port: int32(servicePort),

--- a/pkg/controller/revision/ela_nginx.go
+++ b/pkg/controller/revision/ela_nginx.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/elafros/pkg/apis/ela/v1alpha1"
 	"github.com/google/elafros/pkg/controller/util"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,16 +40,16 @@ func getNginxConfig(enableQueue bool) (string, error) {
 
 // MakeNginxConfigMap creates a ConfigMap that gets mounted for nginx container
 // on the pod.
-func MakeNginxConfigMap(u *v1alpha1.Revision, namespace string) (*apiv1.ConfigMap, error) {
+func MakeNginxConfigMap(u *v1alpha1.Revision, namespace string) (*corev1.ConfigMap, error) {
 	// The request queue is disabled by default. To enable the queue, change this to true.
 	var enableQueue = false
 	log.Printf("Queue enabled: %t", enableQueue)
 	nginxConfiguration, err := getNginxConfig(enableQueue)
 	if err != nil {
-		return &apiv1.ConfigMap{}, err
+		return &corev1.ConfigMap{}, err
 	}
 
-	return &apiv1.ConfigMap{
+	return &corev1.ConfigMap{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      util.GetRevisionNginxConfigMapName(u),
 			Namespace: namespace,

--- a/pkg/controller/revision/ela_pod.go
+++ b/pkg/controller/revision/ela_pod.go
@@ -21,31 +21,31 @@ import (
 
 	"github.com/google/elafros/pkg/controller/util"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MakeElaPodSpec creates a pod spec.
-func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
+func MakeElaPodSpec(u *v1alpha1.Revision) *corev1.PodSpec {
 	name := u.Name
 	serviceID := u.Spec.Service
 	nginxConfigMapName := name + "-" + serviceID + "-proxy-configmap"
 
-	elaContainer := apiv1.Container{
+	elaContainer := corev1.Container{
 		Name:  elaContainerName,
 		Image: u.Spec.ContainerSpec.Image,
-		Resources: apiv1.ResourceRequirements{
-			Requests: apiv1.ResourceList{
-				apiv1.ResourceName("cpu"): resource.MustParse("25m"),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceName("cpu"): resource.MustParse("25m"),
 			},
 		},
-		Ports: []apiv1.ContainerPort{{
+		Ports: []corev1.ContainerPort{{
 			Name:          elaPortName,
 			ContainerPort: int32(elaPort),
 		}},
-		VolumeMounts: []apiv1.VolumeMount{
+		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: elaContainerLogVolumeMountPath,
 				Name:      elaContainerLogVolumeName,
@@ -58,22 +58,22 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
 		Env: u.Spec.Env,
 	}
 
-	elaContainerLogVolume := apiv1.Volume{
+	elaContainerLogVolume := corev1.Volume{
 		Name: elaContainerLogVolumeName,
-		VolumeSource: apiv1.VolumeSource{
-			EmptyDir: &apiv1.EmptyDirVolumeSource{},
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
 
-	nginxContainer := apiv1.Container{
+	nginxContainer := corev1.Container{
 		Name:  nginxContainerName,
 		Image: nginxSidecarImage,
-		Resources: apiv1.ResourceRequirements{
-			Requests: apiv1.ResourceList{
-				apiv1.ResourceName("cpu"): resource.MustParse("25m"),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceName("cpu"): resource.MustParse("25m"),
 			},
 		},
-		Ports: []apiv1.ContainerPort{
+		Ports: []corev1.ContainerPort{
 			// TOOD: HTTPS connections from the Cloud LB require
 			// certs. Right now, the static nginx.conf file has
 			// been modified to only allow HTTP connections.
@@ -82,13 +82,13 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
 				ContainerPort: int32(nginxHttpPort),
 			},
 		},
-		Env: []apiv1.EnvVar{
+		Env: []corev1.EnvVar{
 			{
 				Name:  "CONF_FILE",
 				Value: nginxConfigMountPath + "/nginx.conf",
 			},
 		},
-		VolumeMounts: []apiv1.VolumeMount{
+		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: nginxConfigMountPath,
 				Name:      nginxConfigMapName,
@@ -103,18 +103,18 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
 				Name:      "health-checks",
 			},
 		},
-		Lifecycle: &apiv1.Lifecycle{
-			PostStart: &apiv1.Handler{
-				Exec: &apiv1.ExecAction{
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: &corev1.Handler{
+				Exec: &corev1.ExecAction{
 					Command: []string{
 						"rm", "/tmp/health-checks/app_lameducked",
 					},
 				},
 			},
 		},
-		ReadinessProbe: &apiv1.Probe{
-			Handler: apiv1.Handler{
-				Exec: &apiv1.ExecAction{
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
 					Command: []string{
 						"/bin/sh", "-c",
 						"test ! -f /tmp/health-checks/app_lameducked",
@@ -124,33 +124,33 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
 		},
 	}
 
-	nginxConfigVolume := apiv1.Volume{
+	nginxConfigVolume := corev1.Volume{
 		Name: nginxConfigMapName,
-		VolumeSource: apiv1.VolumeSource{
-			ConfigMap: &apiv1.ConfigMapVolumeSource{
-				LocalObjectReference: apiv1.LocalObjectReference{
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: nginxConfigMapName,
 				},
 			},
 		},
 	}
 
-	nginxLogVolume := apiv1.Volume{
+	nginxLogVolume := corev1.Volume{
 		Name: nginxLogVolumeName,
-		VolumeSource: apiv1.VolumeSource{
-			EmptyDir: &apiv1.EmptyDirVolumeSource{},
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
 
-	fluentdContainer := apiv1.Container{
+	fluentdContainer := corev1.Container{
 		Name:  fluentdContainerName,
 		Image: fluentdSidecarImage,
-		Resources: apiv1.ResourceRequirements{
-			Requests: apiv1.ResourceList{
-				apiv1.ResourceName("cpu"): resource.MustParse("25m"),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceName("cpu"): resource.MustParse("25m"),
 			},
 		},
-		VolumeMounts: []apiv1.VolumeMount{
+		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: nginxLogVolumeMountPath,
 				Name:      nginxLogVolumeName,
@@ -164,19 +164,19 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
 		},
 	}
 
-	initContainer := apiv1.Container{
+	initContainer := corev1.Container{
 		Name:  "health-check-seeder",
 		Image: "gcr.io/google_appengine/base",
-		Resources: apiv1.ResourceRequirements{
-			Requests: apiv1.ResourceList{
-				apiv1.ResourceName("cpu"): resource.MustParse("25m"),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceName("cpu"): resource.MustParse("25m"),
 			},
 		},
 		Command: []string{
 			"touch", "/tmp/health-checks/app_lameducked",
 			"/tmp/health-checks/lameducked",
 		},
-		VolumeMounts: []apiv1.VolumeMount{
+		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/tmp/health-checks",
 				Name:      "health-checks",
@@ -184,16 +184,16 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *apiv1.PodSpec {
 		},
 	}
 
-	healthCheckVolume := apiv1.Volume{
+	healthCheckVolume := corev1.Volume{
 		Name: "health-checks",
-		VolumeSource: apiv1.VolumeSource{
-			EmptyDir: &apiv1.EmptyDirVolumeSource{},
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
 
-	return &apiv1.PodSpec{
-		Volumes:    []apiv1.Volume{healthCheckVolume, elaContainerLogVolume, nginxConfigVolume, nginxLogVolume},
-		Containers: []apiv1.Container{elaContainer, nginxContainer, fluentdContainer}, InitContainers: []apiv1.Container{initContainer},
+	return &corev1.PodSpec{
+		Volumes:    []corev1.Volume{healthCheckVolume, elaContainerLogVolume, nginxConfigVolume, nginxLogVolume},
+		Containers: []corev1.Container{elaContainer, nginxContainer, fluentdContainer}, InitContainers: []corev1.Container{initContainer},
 	}
 }
 
@@ -227,7 +227,7 @@ func MakeElaDeployment(u *v1alpha1.Revision, namespace string) *v1beta1.Deployme
 				Type:          "RollingUpdate",
 				RollingUpdate: &rollingUpdateConfig,
 			},
-			Template: apiv1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Labels: MakeElaDeploymentLabels(u),
 				},

--- a/pkg/controller/revision/ela_service.go
+++ b/pkg/controller/revision/ela_service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/elafros/pkg/apis/ela/v1alpha1"
 	"github.com/google/elafros/pkg/controller/util"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -31,8 +31,8 @@ var servicePort = 80
 // MakeRevisionK8sService creates a Service that targets all pods with the same
 // "revision" label. Traffic is routed to nginx-http-port on those ports.
 // This makes it so that Istio routerules handle the load balancing.
-func MakeRevisionK8sService(u *v1alpha1.Revision, ns string) *apiv1.Service {
-	return &apiv1.Service{
+func MakeRevisionK8sService(u *v1alpha1.Revision, ns string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      util.GetElaK8SServiceNameForRevision(u),
 			Namespace: ns,
@@ -40,8 +40,8 @@ func MakeRevisionK8sService(u *v1alpha1.Revision, ns string) *apiv1.Service {
 				"revision": u.Name,
 			},
 		},
-		Spec: apiv1.ServiceSpec{
-			Ports: []apiv1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       httpServicePortName,
 					Port:       int32(servicePort),

--- a/pkg/controller/util/util.go
+++ b/pkg/controller/util/util.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/elafros/pkg/apis/ela/v1alpha1"
 
 	"github.com/google/uuid"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -88,7 +88,7 @@ func GetOrCreateNamespace(namespace string, c clientset.Interface) (string, erro
 			return "", err
 		}
 		log.Printf("namespace: %v, not found. Creating...", namespace)
-		nsObj := &apiv1.Namespace{
+		nsObj := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      namespace,
 				Namespace: "",

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/elafros/pkg/apis/ela/v1alpha1"
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -152,8 +152,8 @@ func TestValidRTEnvChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createRevisionTemplate(1)
 	new := createRevisionTemplate(1)
-	new.Spec.Template.Spec.Env = []apiv1.EnvVar{
-		apiv1.EnvVar{
+	new.Spec.Template.Spec.Env = []corev1.EnvVar{
+		corev1.EnvVar{
 			Name:  envVarName,
 			Value: "different",
 		},
@@ -344,8 +344,8 @@ func createRevisionTemplate(generation int64) v1alpha1.RevisionTemplate {
 					ContainerSpec: &v1alpha1.ContainerSpec{
 						Image: imageName,
 					},
-					Env: []apiv1.EnvVar{
-						apiv1.EnvVar{
+					Env: []corev1.EnvVar{
+						corev1.EnvVar{
 							Name:  envVarName,
 							Value: envVarValue,
 						},


### PR DESCRIPTION
We had 15 files where we were using corev1 and 6 where we were using
apiv1, so I updated the latter set of files to use corev1.