### PR TITLE
Set HPA target CPU to 50% (#107).

### DIFF
--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -30,7 +30,7 @@ func MakeElaAutoscaler(u *v1alpha1.Revision, namespace string) *autoscaling_v1.H
 
 	var min int32 = 1
 	var max int32 = 10
-	var targetPercentage int32 = 80
+	var targetPercentage int32 = 50
 
 	return &autoscaling_v1.HorizontalPodAutoscaler{
 		ObjectMeta: meta_v1.ObjectMeta{


### PR DESCRIPTION
80% is too small a threshold for CPU bound workloads (#107).