### PR TITLE
 Add instructions about running the unit tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Conduct](./code-of-conduct.md) at all times.
 
 * All PRs must be pulled from [forks](./DEVELOPMENT.md#checkout-your-fork)
 * All PRs must [be reviewed](#code-reviews)
+* All PRs must [pass the tests](./DEVELOPMENT.md#running-the-tests)
 
 ### Code reviews
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,7 +21,6 @@ You must install these tools:
 1. [`bazel`](https://docs.bazel.build/versions/master/getting-started.html): For performing builds.
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For managing development environments.
 
-
 You'll also need to setup:
 
 1. [This repo](#setup-your-repo)
@@ -94,6 +93,7 @@ _It is notable that if you change the `*_OVERRIDE` variables, you may need to `b
 to properly pick up the change._
 
 Once you reach this point you are ready to do a full build and deploy as described [here](./README.md#start-elafros).
+
 ### Iterating
 
 As you make changes to the code-base, there are two special cases to be aware of:
@@ -110,3 +110,11 @@ bazel run :controller.replace
 
 Or you can [clean it up completely](./README.md#clean-up) and [completely
 redeploy `Elafros`](./README.md#start-elafros).
+
+### Running the tests
+
+Running tests as you make changes to the code-base is pretty simple. Just run the `unit_tests.sh` script:
+
+```shell
+./testing/unit_tests.sh
+```


### PR DESCRIPTION
Until the CI/CD system is set up, tests must be run manually.