### PR TITLE
Allow non-empty status in route when validating

### DIFF
--- a/pkg/webhook/route.go
+++ b/pkg/webhook/route.go
@@ -17,7 +17,6 @@ package webhook
 
 import (
 	"errors"
-	"reflect"
 
 	"github.com/golang/glog"
 	"github.com/google/elafros/pkg/apis/ela/v1alpha1"
@@ -29,7 +28,6 @@ var (
 	errInvalidRouteInput       = errors.New("Failed to convert input into Route")
 	errInvalidTargetPercentSum = errors.New("The route must has traffic percent sum equal to 100")
 	errNegativeTargetPercent   = errors.New("The route cannot has negative traffic percent")
-	errNonEmptyStatusInRoute   = errors.New("The route cannot have status when it is created")
 )
 
 // ValidateRoute is Route resource specific validation and mutation handler
@@ -49,19 +47,11 @@ func ValidateRoute(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new 
 	}
 	glog.Infof("ValidateRoute: NEW Route is\n%+v", newRoute)
 
-	if err := validateRoute(newRoute); err != nil {
+	if err := validateTrafficTarget(newRoute); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func validateRoute(route *v1alpha1.Route) error {
-	if !reflect.DeepEqual(route.Status, v1alpha1.RouteStatus{}) {
-		return errNonEmptyStatusInRoute
-	}
-
-	return validateTrafficTarget(route)
 }
 
 func validateTrafficTarget(route *v1alpha1.Route) error {

--- a/pkg/webhook/route_test.go
+++ b/pkg/webhook/route_test.go
@@ -152,20 +152,3 @@ func TestNotAllowedIfTrafficPercentSumIsNot100(t *testing.T) {
 			"Expected: %s. Failed with: %s.", errInvalidTargetPercentSum, err)
 	}
 }
-
-func TestNonEmptyStatusInRoute(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				Revision: testRevisionName,
-				Percent:  100,
-			},
-		})
-	route.Status = v1alpha1.RouteStatus{
-		Domain: "test-domain",
-	}
-
-	if err := ValidateRoute(nil, &route, &route); err != errNonEmptyStatusInRoute {
-		t.Fatalf("Expected: %s. Failed with %s", errNonEmptyStatusInRoute, err)
-	}
-}


### PR DESCRIPTION
Similar to #155, disallowing non-empty status in route breaks updating route status. 