### PR TITLE
Add instructions for getting service IP on a minikube cluster

### DIFF
--- a/sample/helloworld/README.md
+++ b/sample/helloworld/README.md
@@ -42,21 +42,18 @@ Once the `ADDRESS` gets assigned to the cluster, you can run:
 ```shell
 # Put the Ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get ingress route-example-ela-ingress -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
-
-# Curl the Ingress IP "as-if" DNS were properly configured.
-curl --header 'Host:demo.myhost.net' http://${SERVICE_IP}
-Hello World: shiniestnewestversion!
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, you can hit the
-`istio-ingress` service directly via its nodePort:
+your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
-# Get the istio ingress pod IP and service nodePort
 export SERVICE_IP=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+```
 
-# Curl Istio directly, bypassing the Ingresses
+Now curl the service IP as if DNS were properly configured:
+
+```shell
 curl --header 'Host:demo.myhost.net' http://${SERVICE_IP}
 Hello World: shiniestnewestversion!
 ```

--- a/sample/private-repos/README.md
+++ b/sample/private-repos/README.md
@@ -160,7 +160,14 @@ export SERVICE_IP=`kubectl get ing private-repos-ela-ingress \
   -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
 ```
 
-Then you can curl the service with:
+If your cluster is running outside a cloud provider (for example on Minikube),
+your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+
+```shell
+export SERVICE_IP=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+```
+
+Now curl the service IP as if DNS were properly configured:
 
 ```
 curl -H "Host: private-repos.googlecustomer.net" http://$SERVICE_IP
@@ -207,4 +214,3 @@ func main() {
 	http.ListenAndServe(port, nil)
 }
 ```
-

--- a/sample/steren-app/README.md
+++ b/sample/steren-app/README.md
@@ -61,8 +61,18 @@ Once the `ADDRESS` gets assigned to the cluster, you can run:
 ```shell
 # Put the Ingress IP into an environment variable.
 $ export SERVICE_IP=`kubectl get ingress steren-sample-app-ela-ingress -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+```
 
-# Curl the Ingress IP "as-if" DNS were properly configured.
+If your cluster is running outside a cloud provider (for example on Minikube),
+your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+
+```shell
+export SERVICE_IP=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+```
+
+Now curl the service IP as if DNS were properly configured:
+
+```shell
 $ curl --header 'Host:sample-app.googlecustomer.net' http://${SERVICE_IP}/
 <!DOCTYPE html><html><head><title>Demo</title><link rel="stylesheet" href="/stylesheets/style.css"></head><body><h1>Demo</h1><form action="/messages" method="POST"><input type="text" name="text"><input type="submit"></form><ol></ol></body></html>
 ```

--- a/sample/steren-function/README.md
+++ b/sample/steren-function/README.md
@@ -60,8 +60,18 @@ Once the `ADDRESS` gets assigned to the cluster, you can run:
 ```shell
 # Put the Ingress IP into an environment variable.
 $ export SERVICE_IP=`kubectl get ingress steren-sample-fn-ela-ingress -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+```
 
-# Curl the Ingress IP "as-if" DNS were properly configured.
+If your cluster is running outside a cloud provider (for example on Minikube),
+your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+
+```shell
+export SERVICE_IP=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+```
+
+Now curl the service IP as if DNS were properly configured:
+
+```shell
 $ curl --header 'Host:sample-fn.googlecustomer.net' http://${SERVICE_IP}/execute?name=${USER}
 Hello mattmoor
 ```

--- a/sample/thumbnailer/README.md
+++ b/sample/thumbnailer/README.md
@@ -6,7 +6,7 @@ Thumbnailer demo is a walk-through example on how to deploy a 'dockerized' appli
 
 ## Sample Code
 
-In this demo we are going to use a simple `golang` REST app called [rester-tester](https://github.com/mchmarny/rester-tester). It's important to point out that this application doesn't use any 'special' Elafros components nor does it have any Elafros SDK dependencies. 
+In this demo we are going to use a simple `golang` REST app called [rester-tester](https://github.com/mchmarny/rester-tester). It's important to point out that this application doesn't use any 'special' Elafros components nor does it have any Elafros SDK dependencies.
 
 ### App code
 
@@ -38,10 +38,10 @@ You can now run the `rester-tester` application locally in `go` or using Docker
 
 **Local**
 
-> Note: to run the application locally in `go` you will need [FFmpeg](https://www.ffmpeg.org/) in your path. 
+> Note: to run the application locally in `go` you will need [FFmpeg](https://www.ffmpeg.org/) in your path.
 
 ```
-go build 
+go build
 ./rester-tester
 ```
 
@@ -142,7 +142,14 @@ The Elafros ingress service will automatically be assigned an IP so let's captur
 
 ```
 export SERVICE_IP=`kubectl get ing thumb-ela-ingress \
-  -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"` 
+  -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+```
+
+If your cluster is running outside a cloud provider (for example on Minikube),
+your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+
+```shell
+export SERVICE_IP=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 ```
 
 > To make the JSON service responses more readable consider installing [jq](https://stedolan.github.io/jq/), makes JSON pretty
@@ -158,7 +165,7 @@ curl -H "Content-Type: application/json" -H "Host: thumb.googlecustomer.net" \
 
 ### Video Thumbnail
 
-Now the video thumbnail. 
+Now the video thumbnail.
 
 ```
 curl -X POST -H "Content-Type: application/json" -H "Host: thumb.googlecustomer.net" \
@@ -174,6 +181,4 @@ curl -H "Host: thumb.googlecustomer.net" \
 
 ## Final Thoughts
 
-While we used in this demo an external application, the Elafros deployment steps would be similar for any 'dockerized' app you may already have... just copy the `thumbnailer.yaml` and change a few variables. 
-
-
+While we used in this demo an external application, the Elafros deployment steps would be similar for any 'dockerized' app you may already have... just copy the `thumbnailer.yaml` and change a few variables.


### PR DESCRIPTION
This PR adds documentation in the helloworld sample for hitting an Elafros service on minikube. This should either be copied to all samples, or put in a single spot that the samples can refer to.

On minikube, the Ingress never gets an IP. We can work around this by hitting the `hostIP` of the `istio-ingress` pod directly on the `nodePort` of the `istio-ingress` service.

Example:

```shell
kubectl config current-context
# minikube

bazel run sample/helloworld:everything.create
# route "route-example" created
# configuration "configuration-example" created

export SERVICE_IP=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
echo $SERVICE_IP
# 192.168.39.47:30659

curl --header 'Host:demo.myhost.net' http://${SERVICE_IP}
# Hello World: shiniestnewestversion!
```

`SERVICE_IP` is stable as long as the `istio-ingress` pod exists. If the pod is deleted and its replacement is allocated to a different node, `SERVICE_IP` would change. On Minikube, there is only one node, so in practice `SERVICE_IP` never changes.

Fixes #185.