### PR TITLE
Clarify RevisionSpec.Service points to a Route

### DIFF
--- a/pkg/apis/ela/v1alpha1/revision_types.go
+++ b/pkg/apis/ela/v1alpha1/revision_types.go
@@ -44,8 +44,8 @@ type RevisionSpec struct {
 	// ObjectMeta.Generation instead.
 	Generation int64 `json:"generation,omitempty"`
 
-	// TODO(vaikas): I think we still need this?
-	// TODO(grantr): What is the use case for this?
+	// TODO(grantr): This is used to generate names for sub-resources. Can we
+	// do that a different way that doesn't require this reference to the Route?
 	// Service (Route) this is part of. Points to the Service (Route) in the
 	// namespace.
 	Service string `json:"service"`


### PR DESCRIPTION
`RevisionSpec.Service` actually points to a `Route` but wasn't renamed. This PR is the minimal docs change, but maybe the field name itself should be changed to `Route` instead.

Or, the field could simply be removed, since it doesn't appear to be used and the use case for it is unclear to me.