### PR TITLE
Use the correct signature for example test

### DIFF
--- a/pkg/controller/testing/hooks_test.go
+++ b/pkg/controller/testing/hooks_test.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Example_hooks(t *testing.T) {
+func ExampleHooks() {
 	h := NewHooks()
 	f := fake.NewSimpleClientset()
 
@@ -64,7 +65,7 @@ func Example_hooks(t *testing.T) {
 
 	f.CoreV1().Pods("test").Delete(pod.Name, &metav1.DeleteOptions{})
 	if err := h.WaitForHooks(time.Second); err != nil {
-		t.Error(err)
+		log.Fatal(err)
 	}
 
 	// Output:


### PR DESCRIPTION
Example tests don't get the testing object, so the signature is empty and they can't use `t.Error`. This PR replaces that with `log.Fatal`, which is equivalent because it will cause output comparison to fail if it prints anything.

@mattmoor: @bobcatfish discovered that Bazel's `go_test` rule doesn't run example tests, which is why this stayed broken for so long. See https://github.com/google/elafros/pull/193#discussion_r169734313.

