### PR TITLE
Set ResourceVersion when updating an existing webhook

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -325,6 +325,8 @@ func (ac *AdmissionController) register(client clientadmissionregistrationv1beta
 		}
 		if !reflect.DeepEqual(configuredWebhook.Webhooks, webhook.Webhooks) {
 			glog.Infof("Updating webhook")
+			// Set the ResourceVersion as required by update.
+			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
 			if _, err := client.Update(webhook); err != nil {
 				return fmt.Errorf("Failed to update webhook: %s", err)
 			}


### PR DESCRIPTION
Fixes #217 

After this change, webhook comes up correctly:
vaikas@vaikas-linux3:~/projects/go/src/github.com/google/elafros$ kubectl -n ela-system logs ela-webhook-6c85fb998b-2cqbf
I0223 01:22:33.876066       1 main.go:31] Starting the Configuration Webhook...
I0223 01:22:33.897479       1 webhook.go:234] Found certificates for webhook...
I0223 01:22:33.981585       1 webhook.go:321] Webhook already exists
I0223 01:22:33.991859       1 webhook.go:327] Updating webhook
I0223 01:22:33.996786       1 webhook.go:251] Successfully registered webhook
