### PR TITLE
Add Elafros project roles to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,43 @@
-# How to contribute
+# Elafros Contribution and Project Roles
 
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
+The Elafros project is open sourced under [the Apache 2 license](./LICENSE).
+Its source code is freely available at
+[github.com/google/elafros](https://github.com/google/elafros).
 
-## Contributor License Agreement
+* [Community](#community)
+* [Contributors](#contributors)
+* [Maintainers](#maintainers)
+* [Admins](#admins)
+
+**Every community member, contributor, maintainer and admin is bound at all
+times while representing Elafros to uphold the project's [Code of
+Conduct](./code-of-conduct.md).**
+
+## Community
+
+The Elafros community is open. It is comprised of everyone who uses, wants
+to use, or is just curious about the Elafros project. The members of the
+Elafros community are the future contributors and maintainers of this project.
+
+**Mailing list:** [elafros-users@groups.google.com](https://groups.google.com/forum/#!forum/elafros-users)
+(public, open to everyone)
+
+**Slack channel:** [#community](https://elafros.slack.com#community) (free, but Slack account is required)
+
+## Contributors
+
+Elafros contributors are the individuals who have had an impact
+on Elafros through their contributions to the project itself. While all
+[have signed a CLA](#contributor-license-agreement), this isn’t an otherwise
+formally defined group, which today maps somewhat to [GitHub
+contributors](https://github.com/google/elafros/graphs/contributors).
+
+Active contributors will be invited to join [the Elafros Slack team (a paid account)](https://elafros.slack.com).
+
+**Mailing list:** [elafros-dev@groups.google.com](https://groups.google.com/forum/#!forum/elafros-dev)
+(public, anyone can use, frequently used)
+
+### Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License
 Agreement. You (or your employer) retain the copyright to your contribution,
@@ -15,21 +49,61 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
-## Code of Conduct
-
-Please make sure to read and observe our [Code of
-Conduct](./code-of-conduct.md) at all times.
-
-## Workflow
+### Workflow
 
 * All PRs must be pulled from [forks](./DEVELOPMENT.md#checkout-your-fork)
 * All PRs must [be reviewed](#code-reviews)
 * All PRs must [pass the tests](./test/README.md)
 
-### Code reviews
+#### Code reviews
 
 All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult [GitHub Help] for more
-information on using pull requests.
+use [GitHub pull requests](https://help.github.com/articles/about-pull-requests/)
+for this purpose.
 
-[GitHub Help]: https://help.github.com/articles/about-pull-requests/
+## Maintainers
+
+Elafros maintainers are the consensus-seeking deciders of what is and what is
+not part of the Elafros project. This is a small group of active members of the
+community who have a demonstrated history of leading Elafros projects and
+making sound, appropriate project-level and technical decisions. Maintainers
+alone have the right to merge changes into master, enforce [the Contributor
+License Agreement](#contributor-license-agreement), ensure compliance with
+all appropriate rules and regulations, and are ultimately responsible for
+enforcing the Elafros project [Code of Conduct](./code-of-conduct.md).
+
+All communication about Elafros design and development should be made public,
+so this group should only talk privately about sensitive concerns (security
+issues, CoC violations, etc).
+
+**Current maintainers:**
+
+* [vaikas@google.com](https://github.com/vaikas-google)
+* [mattmoor@google.com](https://github.com/mattmoor)
+* [argent@google.com ](https://github.com/evankanderson)
+
+**Mailing list:** [elafros-maintainers@groups.google.com](https://groups.google.com/forum/#!forum/elafros-maintainers)
+(private, invite only, rarely used)
+
+**Slack channel:** [#maintainers](https://elafros.slack.com#maintainers) (private)
+
+## Admins
+
+Elafros admins are the individuals in the project who are responsible for
+billing and general project administration on GitHub, Slack, Google Groups,
+etc. Elafros admins have NO special power or decision-making authority over
+the code or project direction itself. It is purely an administrative, and
+largely invisible role. Note, the Elafros admins group is intended to be as
+small as possible while still provide sufficient redundancy in case of need
+for immediate action (2-3 active users maximum).
+
+**Current admins:**
+
+* [dewitt@google.com](https://github.com/dewitt)
+* [mchmarny@google.com](https://github.com/mchmarny)
+* [isdal@google.com](https://github.com/isdal)
+
+**Mailing list:** [elafros-admins@groups.google.com](https://groups.google.com/forum/#!forum/elafros-admins)
+(private, requires invitation)
+
+**Slack channel:** [#admins](https://elafros.slack.com#admins) (private)


### PR DESCRIPTION
These roles have been authored by dewitt@ and mchmarny@.

This set of role definitions will also change our development
process such that:

1. A narrower group of individuals will be able to approve PRs
(maintainers)
2. Maintainers will be responsible for merging PRs