### PR TITLE
Make a deep copy of informer's cash before changing original objects in controller

### DIFF
--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -401,14 +401,15 @@ func (c *Controller) addRevisionEvent(obj interface{}) {
 			namespace, configName, err)
 		return
 	}
-	// Don't modify the informer's copy.
-	config = config.DeepCopy()
 
 	if revision.Name != config.Status.LatestCreated {
 		// The revision isn't the latest created one, so ignore this event.
 		glog.Infof("Revision %q is not the latest created one", revisionName)
 		return
 	}
+
+	// Don't modify the informer's copy.
+	config = config.DeepCopy()
 
 	if err := c.markConfigurationReady(config, revision); err != nil {
 		glog.Errorf("Error marking configuration ready for '%s/%s': %v",

--- a/pkg/controller/revision/controller.go
+++ b/pkg/controller/revision/controller.go
@@ -509,14 +509,15 @@ func (c *Controller) addEndpointsEvent(obj interface{}) {
 		glog.Errorf("Error fetching revision '%s/%s' upon service becoming ready: %v", namespace, revName, err)
 		return
 	}
-	// Don't modify the informer's copy.
-	rev = rev.DeepCopy()
 
 	// Check to see if the revision has already been marked as ready and if
 	// it is, then there's no need to do anything to it.
 	if rev.Status.IsReady() {
 		return
 	}
+
+	// Don't modify the informer's copy.
+	rev = rev.DeepCopy()
 
 	if err := c.markServiceReady(rev); err != nil {
 		glog.Errorf("Error marking service ready for '%s/%s': %v", namespace, revName, err)


### PR DESCRIPTION
[Guidelines](https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md): Never mutate original objects!

Also rename `u` to `rev` in the controller of revision.