### PR TITLE
Fix istio dashboard deployment

### DIFF
--- a/config/grafana/dashboard-definition/istio-mixer.yaml
+++ b/config/grafana/dashboard-definition/istio-mixer.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-istio-mixer
+  namespace: monitoring
 data:
   istio-mixer-dashboard.json: |+
     {

--- a/config/grafana/dashboard-definition/istio-pilot.yaml
+++ b/config/grafana/dashboard-definition/istio-pilot.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-istio-pilot
+  namespace: monitoring
 data:
   istio-pilot-dashboard.json: |+
     {

--- a/config/grafana/dashboard-definition/istio.yaml
+++ b/config/grafana/dashboard-definition/istio.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-istio
+  namespace: monitoring
 data:
   istio-dashboard.json: |+
     {


### PR DESCRIPTION
The namespace for the dashboards were not put correctly and that causes Grafana deployment to fail.