### PR TITLE
Configuration.Status.LatestReady -> LatestReadyRevisionName

### DIFF
--- a/pkg/apis/ela/v1alpha1/configuration_types.go
+++ b/pkg/apis/ela/v1alpha1/configuration_types.go
@@ -76,7 +76,7 @@ type ConfigurationStatus struct {
 	Conditions []ConfigurationCondition `json:"conditions,omitempty"`
 
 	// Latest revision that is ready.
-	LatestReady string `json:"latestReady,omitempty"`
+	LatestReadyRevisionName string `json:"latestReadyRevisionName,omitempty"`
 
 	// LatestCreatedRevisionName is the last revision that was created; it might not be
 	// ready yet. When it's ready, it will get moved to LatestReady.

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -456,8 +456,8 @@ func (c *Controller) markConfigurationReady(
 			Reason: "LatestRevisionReady",
 		})
 
-	glog.Infof("Setting LatestReady of Configuration %q to revision %q", config.Name, revision.Name)
-	config.Status.LatestReady = revision.Name
+	glog.Infof("Setting LatestReadyRevisionName of Configuration %q to revision %q", config.Name, revision.Name)
+	config.Status.LatestReadyRevisionName = revision.Name
 
 	_, err := c.updateStatus(config)
 	return err

--- a/pkg/controller/configuration/controller_test.go
+++ b/pkg/controller/configuration/controller_test.go
@@ -20,7 +20,7 @@ package configuration
 - If a Congfiguration is created and deleted before the queue fires, no Revision
   is created.
 - When a Congfiguration is updated, a new Revision is created and
-	Congfiguration's LatestReady points to it. Also the previous Congfiguration
+	Congfiguration's LatestReadyRevisionName points to it. Also the previous Congfiguration
 	still exists.
 - When a Congfiguration controller is created and a Congfiguration is already
 	out of sync, the controller creates or updates a Revision for the out of sync
@@ -257,7 +257,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 			if got, want := len(config.Status.Conditions), 0; !reflect.DeepEqual(got, want) {
 				t.Errorf("Conditions length diff; got %v, want %v", got, want)
 			}
-			if got, want := config.Status.LatestReady, ""; got != want {
+			if got, want := config.Status.LatestReadyRevisionName, ""; got != want {
 				t.Errorf("Latest in Stauts diff; got %v, want %v", got, want)
 			}
 			// After the initial update to the configuration, we should be
@@ -283,7 +283,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 			if got, want := config.Status.Conditions, expectedConfigConditions; !reflect.DeepEqual(got, want) {
 				t.Errorf("Conditions diff; got %v, want %v", got, want)
 			}
-			if got, want := config.Status.LatestReady, revision.Name; got != want {
+			if got, want := config.Status.LatestReadyRevisionName, revision.Name; got != want {
 				t.Errorf("Latest in Stauts diff; got %v, want %v", got, want)
 			}
 		}
@@ -322,7 +322,7 @@ func TestDoNotSetLatestWhenReadyRevisionIsNotLastestCreated(t *testing.T) {
 		if got, want := len(config.Status.Conditions), 0; !reflect.DeepEqual(got, want) {
 			t.Errorf("Conditions length diff; got %v, want %v", got, want)
 		}
-		if got, want := config.Status.LatestReady, ""; got != want {
+		if got, want := config.Status.LatestReadyRevisionName, ""; got != want {
 			t.Errorf("Latest in Stauts diff; got %v, want %v", got, want)
 		}
 		return hooks.HookComplete

--- a/pkg/controller/route/controller.go
+++ b/pkg/controller/route/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) getRouteForTrafficTarget(tt v1alpha1.TrafficTarget, ns stri
 		if err != nil {
 			return RevisionRoute{}, err
 		}
-		revisionName = config.Status.LatestReady
+		revisionName = config.Status.LatestReadyRevisionName
 	}
 	//TODO(grantr): What should happen if revisionName is empty?
 	prClient := c.elaclientset.ElafrosV1alpha1().Revisions(ns)

--- a/pkg/controller/route/controller_test.go
+++ b/pkg/controller/route/controller_test.go
@@ -307,8 +307,8 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		cfgrev := getTestRevisionForConfig(cfg)
 		// This must be a goroutine to avoid deadlocking the Fake fixture
 		go elaClient.ElafrosV1alpha1().Revisions(cfg.Namespace).Create(cfgrev)
-		// Set LatestReady to this revision
-		cfg.Status.LatestReady = cfgrev.Name
+		// Set LatestReadyRevisionName to this revision
+		cfg.Status.LatestReadyRevisionName = cfgrev.Name
 		// Return the modified Configuration so the object passed to later reactors
 		// (including the fixture reactor) has our Status mutation
 		return false, cfg, nil

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Route", func() {
 
 			By("The Configuration will be updated when the Revision is ready to serve traffic")
 			WaitForConfigurationState(configClient, configName, func(c *v1alpha1.Configuration)(bool, error){
-				return c.Status.LatestReady == revisionName, nil
+				return c.Status.LatestReadyRevisionName == revisionName, nil
 			})
 
 			By("Once the Configuration has been updated with the Revision, the Route will be updated to route traffic to the Revision")
@@ -270,7 +270,7 @@ var _ = Describe("Route", func() {
 
 			By("The Configuration will be updated to indicate the new revision is ready")
 			WaitForConfigurationState(configClient, configName, func(c *v1alpha1.Configuration)(bool, error){
-				return c.Status.LatestReady == newRevisionName, nil
+				return c.Status.LatestReadyRevisionName == newRevisionName, nil
 			})
 
 			By("The Route will then immediately send all traffic to the new revision")


### PR DESCRIPTION
This is to be more compliant with Kubernetes naming conventions.

This is a pure refactoing change, no functionality should change.