### PR TITLE
Configuration.Status.LatestCreated -> LatestCreatedRevisionName

### DIFF
--- a/pkg/apis/ela/v1alpha1/configuration_types.go
+++ b/pkg/apis/ela/v1alpha1/configuration_types.go
@@ -78,9 +78,9 @@ type ConfigurationStatus struct {
 	// Latest revision that is ready.
 	LatestReady string `json:"latestReady,omitempty"`
 
-	// LatestCreated is the last revision that was created; it might not be
+	// LatestCreatedRevisionName is the last revision that was created; it might not be
 	// ready yet. When it's ready, it will get moved to LatestReady.
-	LatestCreated string `json:"latestCreated,omitempty"`
+	LatestCreatedRevisionName string `json:"latestCreatedRevisionName,omitempty"`
 
 	// ReconciledGeneration is the 'Generation' of the Configuration that
 	// was last processed by the controller. The reconciled generation is updated

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) syncHandler(key string) error {
 
 	// Configuration business logic
 	if config.GetGeneration() == config.Status.ReconciledGeneration {
-		// TODO(vaikas): Check to see if Status.LatestCreated is ready and update Status.LatestReady
+		// TODO(vaikas): Check to see if Status.LatestCreatedRevisionName is ready and update Status.LatestReady
 		glog.Infof("Skipping reconcile since already reconciled %d == %d",
 			config.Spec.Generation, config.Status.ReconciledGeneration)
 		return nil
@@ -349,9 +349,9 @@ func (c *Controller) syncHandler(key string) error {
 
 	// Update the Status of the configuration with the latest generation that
 	// we just reconciled against so we don't keep generating revisions.
-	// Also update the LatestCreated so that we'll know revision to check
+	// Also update the LatestCreatedRevisionName so that we'll know revision to check
 	// for ready state so that when ready, we can make it Latest.
-	config.Status.LatestCreated = created.ObjectMeta.Name
+	config.Status.LatestCreatedRevisionName = created.ObjectMeta.Name
 	config.Status.ReconciledGeneration = config.Spec.Generation
 
 	log.Printf("Updating the configuration status:\n%+v", config)
@@ -413,7 +413,7 @@ func (c *Controller) addRevisionEvent(obj interface{}) {
 		return
 	}
 
-	if revision.Name != config.Status.LatestCreated {
+	if revision.Name != config.Status.LatestCreatedRevisionName {
 		// The revision isn't the latest created one, so ignore this event.
 		glog.Infof("Revision %q is not the latest created one", revisionName)
 		return

--- a/pkg/controller/configuration/controller_test.go
+++ b/pkg/controller/configuration/controller_test.go
@@ -219,7 +219,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 	controllerRef := metav1.NewControllerRef(config, controllerKind)
 	revision := getTestRevision()
 	revision.OwnerReferences = append(revision.OwnerReferences, *controllerRef)
-	config.Status.LatestCreated = revision.Name
+	config.Status.LatestCreatedRevisionName = revision.Name
 
 	// Ensure that the Configuration status is updated.
 	update := 0

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -210,8 +210,8 @@ var _ = Describe("Route", func() {
 			By("The Configuration will be updated with the Revision after it is created")
 			var revisionName string
 			WaitForConfigurationState(configClient, configName, func(c *v1alpha1.Configuration) (bool, error){
-				if c.Status.LatestCreated != "" {
-					revisionName = c.Status.LatestCreated
+				if c.Status.LatestCreatedRevisionName != "" {
+					revisionName = c.Status.LatestCreatedRevisionName
 					return true, nil
 				}
 				return false, nil
@@ -258,8 +258,8 @@ var _ = Describe("Route", func() {
 			By("A new Revision will be made and the Configuration will be updated with it")
 			var newRevisionName string
 			WaitForConfigurationState(configClient, configName, func(c *v1alpha1.Configuration)(bool, error){
-				if c.Status.LatestCreated != revisionName {
-					newRevisionName = c.Status.LatestCreated
+				if c.Status.LatestCreatedRevisionName != revisionName {
+					newRevisionName = c.Status.LatestCreatedRevisionName
 					return true, nil
 				}
 				return false, nil


### PR DESCRIPTION
This is to be more compliant with Kubernetes naming conventions.