### PR TITLE
ReconciledGeneration -> ObservedGeneration

### DIFF
--- a/pkg/apis/ela/v1alpha1/configuration_types.go
+++ b/pkg/apis/ela/v1alpha1/configuration_types.go
@@ -82,10 +82,10 @@ type ConfigurationStatus struct {
 	// ready yet. When it's ready, it will get moved to LatestReady.
 	LatestCreatedRevisionName string `json:"latestCreatedRevisionName,omitempty"`
 
-	// ReconciledGeneration is the 'Generation' of the Configuration that
-	// was last processed by the controller. The reconciled generation is updated
+	// ObservedGeneration is the 'Generation' of the Configuration that
+	// was last processed by the controller. The observed generation is updated
 	// even if the controller failed to process the spec and create the Revision.
-	ReconciledGeneration int64 `json:"reconciledGeneration,omitempty"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/ela/v1alpha1/revision_types.go
+++ b/pkg/apis/ela/v1alpha1/revision_types.go
@@ -111,10 +111,10 @@ type RevisionStatus struct {
 	// Route.
 	ServiceName string              `json:"serviceName,omitempty"`
 	Conditions  []RevisionCondition `json:"conditions,omitempty"`
-	// ReconciledGeneration is the 'Generation' of the Configuration that
-	// was last processed by the controller. The reconciled generation is updated
+	// ObservedGeneration is the 'Generation' of the Configuration that
+	// was last processed by the controller. The observed generation is updated
 	// even if the controller failed to process the spec and create the Revision.
-	ReconciledGeneration int64 `json:"reconciledGeneration,omitempty"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/ela/v1alpha1/route_types.go
+++ b/pkg/apis/ela/v1alpha1/route_types.go
@@ -113,10 +113,10 @@ type RouteStatus struct {
 
 	Conditions []RouteCondition `json:"conditions,omitempty"`
 
-	// ReconciledGeneration is the 'Generation' of the Configuration that
-	// was last processed by the controller. The reconciled generation is updated
+	// ObservedGeneration is the 'Generation' of the Configuration that
+	// was last processed by the controller. The observed generation is updated
 	// even if the controller failed to process the spec and create the Revision.
-	ReconciledGeneration int64 `json:"reconciledGeneration,omitempty"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -286,10 +286,10 @@ func (c *Controller) syncHandler(key string) error {
 	config = config.DeepCopy()
 
 	// Configuration business logic
-	if config.GetGeneration() == config.Status.ReconciledGeneration {
+	if config.GetGeneration() == config.Status.ObservedGeneration {
 		// TODO(vaikas): Check to see if Status.LatestCreatedRevisionName is ready and update Status.LatestReady
 		glog.Infof("Skipping reconcile since already reconciled %d == %d",
-			config.Spec.Generation, config.Status.ReconciledGeneration)
+			config.Spec.Generation, config.Status.ObservedGeneration)
 		return nil
 	}
 
@@ -352,7 +352,7 @@ func (c *Controller) syncHandler(key string) error {
 	// Also update the LatestCreatedRevisionName so that we'll know revision to check
 	// for ready state so that when ready, we can make it Latest.
 	config.Status.LatestCreatedRevisionName = created.ObjectMeta.Name
-	config.Status.ReconciledGeneration = config.Spec.Generation
+	config.Status.ObservedGeneration = config.Spec.Generation
 
 	log.Printf("Updating the configuration status:\n%+v", config)
 


### PR DESCRIPTION
This is to be more consistent with Kubernetes naming conventions.

Fixes #238.