### PR TITLE
Update the version of the Build CRD.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,7 +105,7 @@ load(
 
 private_git_repository(
     name = "buildcrd",
-    commit = "d729e217e09b5e14c92eb77a0b6655e359bd7391",
+    commit = "7113dbada60cd418becc92fdbb74b8a9f5e446d9",
     remote = "git@github.com:google/build-crd.git",
 )
 

--- a/pkg/apis/cloudbuild/v1alpha1/build_types.go
+++ b/pkg/apis/cloudbuild/v1alpha1/build_types.go
@@ -115,7 +115,7 @@ type BuildStatus struct {
 
 type ClusterSpec struct {
 	Namespace string `json:"namespace"`
-	JobName   string `json:"jobName"`
+	PodName   string `json:"podName"`
 }
 
 type GoogleSpec struct {


### PR DESCRIPTION
This switches the Build CRD to use Pods directly (vs. Jobs), which results in better error messaging (e.g. which step failed, how to access logs) that we will automatically bubble up to the Revision without any changes.

This also brings in substitution in `VolumeMount` names, which may (still unverified) enable the use of persistent volumes for inter-build caching.