### PR TITLE
Reduce ela-container CPU request.

### DIFF
--- a/pkg/controller/revision/ela_pod.go
+++ b/pkg/controller/revision/ela_pod.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// Each Elafros pod gets 1 cpu.
-	elaContainerCpu     = "850m"
+	elaContainerCpu     = "400m"
 	queueContainerCpu   = "25m"
 	nginxContainerCpu   = "25m"
 	fluentdContainerCpu = "100m"


### PR DESCRIPTION
A pod with all features enabled use:
100m for fluentd-gcp
100m for kube-proxy-gke
110m for node-exporter daemon (this exports node metrics to Prometheus)
25m for nginx-proxy 
25m for queue-container
100m for fluentd-appengine (this should be removed - will look into this later)
850m for ela-container

The total comes to 1310m - a single core VM has 940m in GKE and this causes the pod to be unscheduled. I am reducing the ela-container to 400m to make it schedule-able in GKE with single-core installations.