### PR TITLE
Give maintainers owner bit on pkg/apis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 pkg/apis @evankanderson @mattmoor @vaikas-google
 
 # All groups can review docs
-docs/ @google/elafros-google-users @google/elafros-google-readers
+docs/ @elafros/elafros-writers @google/elafros-readers
 
 ### To request CODEOWNERS on a subdirectory, propose it above
 ### in a PR to the below maintainers.


### PR DESCRIPTION
Gives the current maintainer list (@evankanderson, @mattmoor, @vaikas-google) owner bit on `pkg/apis` with the reasoning that these files are external APIs and thus more important than implementation details.

This is intended as a minimal starting point until we have a more carefully considered ownership model.

To make this meaningful, the `master` branch protection settings must be changed to "require review from code owners".

cc @drewinglis @dewitt @josephburnett 