### PR TITLE
Add owners for tests.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,12 +5,16 @@
 ### Component-level ownerships
 
 # API governance.
-pkg/apis @evankanderson @mattmoor @vaikas-google
+/pkg/apis @evankanderson @mattmoor @vaikas-google
 
-# All groups can review docs
-docs/ @elafros/elafros-writers @google/elafros-readers
+# All groups can review docs.
+/docs/ @elafros/elafros-writers @google/elafros-readers
+
+# Tests.
+/test/ @adrcunha @srinivashegde86 @steuhs
+/test/conformance/ @bobcatfish @adrcunha
 
 ### To request CODEOWNERS on a subdirectory, propose it above
 ### in a PR to the below maintainers.
-.github/CODEOWNERS @evankanderson @mattmoor @vaikas-google
+/.github/CODEOWNERS @evankanderson @mattmoor @vaikas-google
 ### KEEP THIS LAST, LAST RULE WINS!


### PR DESCRIPTION
@adrcunha @srinivashegde86 and @steuhs are driving the test infracstructure
for Elafros, so they should be reviewing and approving changes to the
test directory.

I will be owning the conformance tests and so would like to review
changes to these tests.

This does not change ownership for the tests in `pkg`, those are
still owned by @evankanderson @mattmoor and @vaikas-google.