### PR TITLE
Remove references to Service in the Revision spec from tests

### DIFF
--- a/pkg/controller/configuration/controller_test.go
+++ b/pkg/controller/configuration/controller_test.go
@@ -67,7 +67,6 @@ func getTestConfiguration() *v1alpha1.Configuration {
 			Generation: 1,
 			Template: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
-					Service: "test-service",
 					// corev1.Container has a lot of setting.  We try to pass many
 					// of them here to verify that we pass through the settings to
 					// the derived Revisions.
@@ -102,7 +101,6 @@ func getTestRevision() *v1alpha1.Revision {
 			Namespace: testNamespace,
 		},
 		Spec: v1alpha1.RevisionSpec{
-			Service: "test-service",
 			ContainerSpec: &corev1.Container{
 				Image: "test-image",
 			},
@@ -165,10 +163,6 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 	h.OnCreate(&elaClient.Fake, "revisions", func(obj runtime.Object) hooks.HookResult {
 		rev := obj.(*v1alpha1.Revision)
 		glog.Infof("checking revision %s", rev.Name)
-		if config.Spec.Template.Spec.Service != rev.Spec.Service {
-			t.Errorf("rev service was not %s", config.Spec.Template.Spec.Service)
-		}
-
 		if diff := cmp.Diff(config.Spec.Template.Spec, rev.Spec); diff != "" {
 			t.Errorf("rev spec != config template spec (-want +got): %v", diff)
 		}
@@ -218,9 +212,6 @@ func TestCreateConfigurationCreatesBuildAndPR(t *testing.T) {
 	h.OnCreate(&elaClient.Fake, "revisions", func(obj runtime.Object) hooks.HookResult {
 		rev := obj.(*v1alpha1.Revision)
 		glog.Infof("checking revision %s", rev.Name)
-		if config.Spec.Template.Spec.Service != rev.Spec.Service {
-			t.Errorf("rev service was not %s", config.Spec.Template.Spec.Service)
-		}
 		// TODO(mattmoor): The fake doesn't properly support GenerateName,
 		// so it never looks like the BuildName is populated.
 		// if rev.Spec.BuildName == "" {


### PR DESCRIPTION
It looks like a few references to this field in the configuration controller test were not removed or added on merge.