### PR TITLE
Renaming Configuration.Spec.Template to Configuration.Spec.RevisionTe…

### DIFF
--- a/pkg/apis/ela/v1alpha1/configuration_types.go
+++ b/pkg/apis/ela/v1alpha1/configuration_types.go
@@ -43,9 +43,9 @@ type ConfigurationSpec struct {
 	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
-	Generation int64            `json:"generation,omitempty"`
-	Build      *build.BuildSpec `json:"build,omitempty"`
-	Template   Revision         `json:"template"`
+	Generation       int64            `json:"generation,omitempty"`
+	Build            *build.BuildSpec `json:"build,omitempty"`
+	RevisionTemplate Revision         `json:"revisionTemplate"`
 }
 
 // ConfigurationConditionType represents a Configuration condition value

--- a/pkg/apis/ela/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/ela/v1alpha1/zz_generated.deepcopy.go
@@ -117,7 +117,7 @@ func (in *ConfigurationSpec) DeepCopyInto(out *ConfigurationSpec) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
-	in.Template.DeepCopyInto(&out.Template)
+	in.RevisionTemplate.DeepCopyInto(&out.RevisionTemplate)
 	return
 }
 

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -273,8 +273,8 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	glog.Infof("Running reconcile Configuration for %s\n%+v\n%+v\n",
-		config.Name, config, config.Spec.Template)
-	spec := config.Spec.Template.Spec
+		config.Name, config, config.Spec.RevisionTemplate)
+	spec := config.Spec.RevisionTemplate.Spec
 	controllerRef := metav1.NewControllerRef(config, controllerKind)
 
 	if config.Spec.Build != nil {
@@ -299,7 +299,7 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	rev := &v1alpha1.Revision{
-		ObjectMeta: config.Spec.Template.ObjectMeta,
+		ObjectMeta: config.Spec.RevisionTemplate.ObjectMeta,
 		Spec:       spec,
 	}
 	revName, err := generateRevisionName(config)

--- a/pkg/controller/configuration/controller_test.go
+++ b/pkg/controller/configuration/controller_test.go
@@ -69,7 +69,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 		Spec: v1alpha1.ConfigurationSpec{
 			//TODO(grantr): This is a workaround for generation initialization
 			Generation: 1,
-			Template: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
 					// corev1.Container has a lot of setting.  We try to pass many
 					// of them here to verify that we pass through the settings to
@@ -212,8 +212,8 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 	}
 
 	rev := list.Items[0]
-	if diff := cmp.Diff(config.Spec.Template.Spec, rev.Spec); diff != "" {
-		t.Errorf("rev spec != config template spec (-want +got): %v", diff)
+	if diff := cmp.Diff(config.Spec.RevisionTemplate.Spec, rev.Spec); diff != "" {
+		t.Errorf("rev spec != config RevisionTemplate spec (-want +got): %v", diff)
 	}
 
 	if rev.Labels[ela.ConfigurationLabelKey] != config.Name {

--- a/pkg/controller/route/controller_test.go
+++ b/pkg/controller/route/controller_test.go
@@ -159,7 +159,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 		Spec: v1alpha1.ConfigurationSpec{
 			// This is a workaround for generation initialization
 			Generation: 1,
-			Template: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
 					Container: &corev1.Container{
 						Image: "test-image",
@@ -171,7 +171,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 }
 
 func getTestRevisionForConfig(config *v1alpha1.Configuration) *v1alpha1.Revision {
-	rev := config.Spec.Template.DeepCopy()
+	rev := config.Spec.RevisionTemplate.DeepCopy()
 	rev.ObjectMeta = metav1.ObjectMeta{
 		SelfLink:  "/apis/ela/v1alpha1/namespaces/test/revisions/p-deadbeef",
 		Name:      "p-deadbeef",

--- a/pkg/webhook/configuration_test.go
+++ b/pkg/webhook/configuration_test.go
@@ -61,13 +61,13 @@ func TestEmptyTemplateInSpecNotAllowed(t *testing.T) {
 			Name:      testConfigurationName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation: testGeneration,
-			Template:   v1alpha1.Revision{},
+			Generation:       testGeneration,
+			RevisionTemplate: v1alpha1.Revision{},
 		},
 	}
 
-	if err := ValidateConfiguration(nil, &configuration, &configuration); err != errEmptyTemplateInSpec {
-		t.Fatalf("Expected: %s. Failed with %s", errEmptyTemplateInSpec, err)
+	if err := ValidateConfiguration(nil, &configuration, &configuration); err != errEmptyRevisionTemplateInSpec {
+		t.Fatalf("Expected: %s. Failed with %s", errEmptyRevisionTemplateInSpec, err)
 	}
 }
 
@@ -79,7 +79,7 @@ func TestEmptyContainerNotAllowed(t *testing.T) {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			Generation: testGeneration,
-			Template: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
 					Container: &corev1.Container{},
 				},
@@ -87,8 +87,8 @@ func TestEmptyContainerNotAllowed(t *testing.T) {
 		},
 	}
 
-	if err := ValidateConfiguration(nil, &configuration, &configuration); err != errEmptyContainerInTemplate {
-		t.Fatalf("Expected: %s. Failed with %s", errEmptyTemplateInSpec, err)
+	if err := ValidateConfiguration(nil, &configuration, &configuration); err != errEmptyContainerInRevisionTemplate {
+		t.Fatalf("Expected: %s. Failed with %s", errEmptyRevisionTemplateInSpec, err)
 	}
 }
 
@@ -116,7 +116,7 @@ func TestUnwantedFieldInContainerNotAllowed(t *testing.T) {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			Generation: testGeneration,
-			Template: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
 					Container: &container,
 				},
@@ -124,10 +124,10 @@ func TestUnwantedFieldInContainerNotAllowed(t *testing.T) {
 		},
 	}
 	unwanted := []string{
-		"template.spec.container.name",
-		"template.spec.container.resources",
-		"template.spec.container.ports",
-		"template.spec.container.volumeMounts",
+		"revisionTemplate.spec.container.name",
+		"revisionTemplate.spec.container.resources",
+		"revisionTemplate.spec.container.ports",
+		"revisionTemplate.spec.container.volumeMounts",
 	}
 	expected := fmt.Sprintf("The configuration spec must not set the field(s) %s", strings.Join(unwanted, ", "))
 	if err := ValidateConfiguration(nil, &configuration, &configuration); err == nil || err.Error() != expected {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -155,7 +155,7 @@ func TestValidConfigurationEnvChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createConfiguration(testGeneration)
 	new := createConfiguration(testGeneration)
-	new.Spec.Template.Spec.Container.Env = []corev1.EnvVar{
+	new.Spec.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{
 		corev1.EnvVar{
 			Name:  envVarName,
 			Value: "different",
@@ -395,7 +395,7 @@ func createConfiguration(generation int64) v1alpha1.Configuration {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			Generation: generation,
-			Template: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
 					Container: &corev1.Container{
 						Image: imageName,

--- a/sample/autoscale/configuration.yaml
+++ b/sample/autoscale/configuration.yaml
@@ -18,7 +18,7 @@ metadata:
   name: autoscale-configuration
   namespace: default
 spec:
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/buildpack-app/configuration.yaml.tpl
+++ b/sample/buildpack-app/configuration.yaml.tpl
@@ -21,7 +21,7 @@ spec:
     #   persistentVolumeClaim:
     #     claimName: buildpack-sample-app-cache
 
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/gitwebhook/configuration.yaml
+++ b/sample/gitwebhook/configuration.yaml
@@ -18,7 +18,7 @@ metadata:
   name: git-webhook
   namespace: default
 spec:
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/helloworld/configuration.yaml
+++ b/sample/helloworld/configuration.yaml
@@ -18,7 +18,7 @@ metadata:
   name: configuration-example
   namespace: default
 spec:
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/helloworld/updated_configuration.yaml
+++ b/sample/helloworld/updated_configuration.yaml
@@ -18,7 +18,7 @@ metadata:
   name: configuration-example
   namespace: default
 spec:
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/private-repos/manifest.yaml
+++ b/sample/private-repos/manifest.yaml
@@ -37,7 +37,7 @@ spec:
       arguments:
       - name: IMAGE
         value: &image REPLACE_ME
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/steren-app/configuration.yaml.tpl
+++ b/sample/steren-app/configuration.yaml.tpl
@@ -29,7 +29,7 @@ spec:
       - name: IMAGE
         value: &image DOCKER_REPO_OVERRIDE/sample-app
 
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/steren-function/configuration.yaml.tpl
+++ b/sample/steren-function/configuration.yaml.tpl
@@ -29,7 +29,7 @@ spec:
       - name: IMAGE
         value: &image DOCKER_REPO_OVERRIDE/sample-fn
 
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: function

--- a/sample/telemetrysample/configuration.yaml
+++ b/sample/telemetrysample/configuration.yaml
@@ -29,7 +29,7 @@ spec:
   #     image: busybox:latest
   #     args: ["echo", "Hello"]
 
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/thumbnailer/thumbnailer-prebuilt.yaml
+++ b/sample/thumbnailer/thumbnailer-prebuilt.yaml
@@ -28,7 +28,7 @@ metadata:
   name: thumbtemplate
   namespace: default
 spec:
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/sample/thumbnailer/thumbnailer.yaml.tpl
+++ b/sample/thumbnailer/thumbnailer.yaml.tpl
@@ -38,7 +38,7 @@ spec:
       arguments:
       - name: IMAGE
         value: &image DOCKER_REPO_OVERRIDE/rester-tester
-  template:
+  revisionTemplate:
     metadata:
       labels:
         elafros.dev/type: container

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -75,7 +75,7 @@ func configuration(imagePath string) *v1alpha1.Configuration {
 			Name:      configName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Template: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.Revision{
 				Spec: v1alpha1.RevisionSpec{
 					Container: &corev1.Container{
 						Image: imagePath,


### PR DESCRIPTION
See https://github.com/elafros/elafros/issues/241

https://github.com/elafros/elafros/pull/281 for previous comments. I deleted the branch while I was flailing around with git. 

The biggest thing to point out here is that Evan suggested changing the type to RevisionTemplateSpec, but that it could be done in a separate PR. I'd rather just push this as is, since it's simple, and save the type refactor for another PR.