### PR TITLE
Increase default node cpu size from 1 to 4.

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -37,6 +37,8 @@ To use a k8s cluster running in GKE:
     *   Version 1.9+ is required
     *   Change this to whichever zone you choose
     *   cloud-platform scope is required to access GCB
+    *   Elafros currently requires 4-cpu nodes to run conformance tests.
+        Changing the machine type from the default may cause failures.
     *   Autoscale from 1 to 3 nodes. Adjust this for your use case
     *   Change this to your preferred cluster name
 


### PR DESCRIPTION
Previously we were requesting 2.5% of a CPU for Revisions which is not enough to run any meaningful load.  And the scheduler will happily pack way too many Pods into each node and therefore the cluster autoscaler won't kick in when needed.

The Elafros autoscaler commit (#229) increases the CPU request per Pod to 1 full CPU.  This was necessary to make autoscaling work correctly.  However the default, tiny cluster of 3, 1-core nodes simply couldn't fit the Elafros control plane (Istio, Controllers, Webhooks) and two Revisions.  Even 2-core machines are a little small.

So I'm increasing the default to 4 cores and autoscaling will bring the cluster down to 1 node when not used.