### PR TITLE
Call AddToScheme in init() instead of during Controller creation

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -13,12 +13,14 @@ go_library(
     deps = [
         "//pkg/apis/ela/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/client/clientset/versioned/scheme:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )

--- a/pkg/controller/configuration/BUILD.bazel
+++ b/pkg/controller/configuration/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/apis/ela:go_default_library",
         "//pkg/apis/ela/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
-        "//pkg/client/clientset/versioned/scheme:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
         "//pkg/client/listers/ela/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/elafros/elafros/pkg/apis/ela"
 	"github.com/elafros/elafros/pkg/apis/ela/v1alpha1"
 	clientset "github.com/elafros/elafros/pkg/client/clientset/versioned"
-	elascheme "github.com/elafros/elafros/pkg/client/clientset/versioned/scheme"
 	informers "github.com/elafros/elafros/pkg/client/informers/externalversions"
 	listers "github.com/elafros/elafros/pkg/client/listers/ela/v1alpha1"
 )
@@ -51,12 +50,6 @@ import (
 const controllerAgentName = "configuration-controller"
 
 var controllerKind = v1alpha1.SchemeGroupVersion.WithKind("Configuration")
-
-func init() {
-	// Add ela types to the default Kubernetes Scheme so Events can be
-	// logged for ela types.
-	elascheme.AddToScheme(scheme.Scheme)
-}
 
 // Controller implements the controller for Configuration resources
 type Controller struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,9 +19,11 @@ package controller
 import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
 	clientset "github.com/elafros/elafros/pkg/client/clientset/versioned"
+	elascheme "github.com/elafros/elafros/pkg/client/clientset/versioned/scheme"
 	informers "github.com/elafros/elafros/pkg/client/informers/externalversions"
 )
 
@@ -30,3 +32,9 @@ type Interface interface {
 }
 
 type Constructor func(kubernetes.Interface, clientset.Interface, kubeinformers.SharedInformerFactory, informers.SharedInformerFactory, *rest.Config) Interface
+
+func init() {
+	// Add ela types to the default Kubernetes Scheme so Events can be
+	// logged for ela types.
+	elascheme.AddToScheme(scheme.Scheme)
+}

--- a/pkg/controller/revision/BUILD.bazel
+++ b/pkg/controller/revision/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/apis/build/v1alpha1:go_default_library",
         "//pkg/apis/ela/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
-        "//pkg/client/clientset/versioned/scheme:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
         "//pkg/client/listers/ela/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/controller/revision/controller.go
+++ b/pkg/controller/revision/controller.go
@@ -45,7 +45,6 @@ import (
 	buildv1alpha1 "github.com/elafros/elafros/pkg/apis/build/v1alpha1"
 	"github.com/elafros/elafros/pkg/apis/ela/v1alpha1"
 	clientset "github.com/elafros/elafros/pkg/client/clientset/versioned"
-	elascheme "github.com/elafros/elafros/pkg/client/clientset/versioned/scheme"
 	informers "github.com/elafros/elafros/pkg/client/informers/externalversions"
 	listers "github.com/elafros/elafros/pkg/client/listers/ela/v1alpha1"
 	"github.com/elafros/elafros/pkg/controller"
@@ -92,9 +91,6 @@ var (
 func init() {
 	prometheus.MustRegister(revisionProcessItemCount)
 	flag.StringVar(&queueSidecarImage, "queueSidecarImage", "", "The digest of the queue sidecar image.")
-	// Add ela types to the default Kubernetes Scheme so Events can be
-	// logged for ela types.
-	elascheme.AddToScheme(scheme.Scheme)
 }
 
 // Helper to make sure we log error messages returned by Reconcile().

--- a/pkg/controller/route/BUILD.bazel
+++ b/pkg/controller/route/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/apis/ela/v1alpha1:go_default_library",
         "//pkg/apis/istio/v1alpha2:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
-        "//pkg/client/clientset/versioned/scheme:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
         "//pkg/client/listers/ela/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/controller/route/controller.go
+++ b/pkg/controller/route/controller.go
@@ -40,7 +40,6 @@ import (
 	"github.com/elafros/elafros/pkg/apis/ela"
 	"github.com/elafros/elafros/pkg/apis/ela/v1alpha1"
 	clientset "github.com/elafros/elafros/pkg/client/clientset/versioned"
-	elascheme "github.com/elafros/elafros/pkg/client/clientset/versioned/scheme"
 	informers "github.com/elafros/elafros/pkg/client/informers/externalversions"
 	listers "github.com/elafros/elafros/pkg/client/listers/ela/v1alpha1"
 	"github.com/elafros/elafros/pkg/controller"
@@ -111,9 +110,6 @@ type Controller struct {
 
 func init() {
 	prometheus.MustRegister(routeProcessItemCount)
-	// Add ela types to the default Kubernetes Scheme so Events can be
-	// logged for ela types.
-	elascheme.AddToScheme(scheme.Scheme)
 }
 
 // NewController initializes the controller and is called by the generated code


### PR DESCRIPTION
The `scheme.Scheme` type maps are not protected from concurrent access, so they should only be written to during initialization. Previously `AddToScheme` was called every time a controller was created. This occasionally caused map access panics in test runs with concurrent running controllers. It was most likely to occur in route tests for reasons unknown. My hunch is that it's because the Route objects are last in the type list: 
https://github.com/elafros/elafros/blob/012c50e2f576a544dbd9e9c7089c844902c18e53/pkg/apis/ela/v1alpha1/register.go#L47-L54

Moving the `elascheme.AddToScheme` calls to `init()` eliminates the panics in my testing.

It might be worth examining the type registration code to make sure it's optimal and correct. It seems odd that `elascheme.AddToScheme` would be required at all, but removing it caused errors.

Fixes #362