### PR TITLE
Use elafros-related names for the conformance test images.

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -42,8 +42,8 @@ import (
 
 const (
 	namespaceName = "pizzaplanet"
-	image1        = "pizzaplanetv1"
-	image2        = "pizzaplanetv2"
+	image1        = "ela-conformance-test-v1"
+	image2        = "ela-conformance-test-v2"
 	domain        = "weregoingtopizzaplanet.com"
 	configName    = "prod"
 	routeName     = "pizzaplanet"

--- a/test/conformance/upload-test-images.sh
+++ b/test/conformance/upload-test-images.sh
@@ -19,11 +19,11 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 DOCKER_REPO_OVERRIDE=${DOCKER_REPO_OVERRIDE?"You must set `DOCKER_REPO_OVERRIDE`, see DEVELOPMENT.md"}
-IMAGE_NAME="${DOCKER_REPO_OVERRIDE}/pizzaplanet"
+IMAGE_NAME="${DOCKER_REPO_OVERRIDE}/ela-conformance-test"
 
 for version in v1 v2;
 do
-    VERSIONED_NAME="${IMAGE_NAME}${version}"
+    VERSIONED_NAME="${IMAGE_NAME}-${version}"
     docker build "$DIR/test_images_node" -f "$DIR/test_images_node/Dockerfile.$version" -t "$VERSIONED_NAME"
     docker push "$VERSIONED_NAME"
 done


### PR DESCRIPTION
This makes it easier to figure out what's their purpose, no matter the registry they're in.