### PR TITLE
Change the error messages used by the configuration validation webhook.

### DIFF
--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -27,11 +27,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func errMissingField(fieldPath string) error {
+	return fmt.Errorf("Configuration is missing %q", fieldPath)
+}
+
 var (
-	errEmptyContainerInTemplate = errors.New("The configuration template must have a container spec")
-	errEmptySpecInConfiguration     = errors.New("The configuration must have configuration spec")
-	errEmptyTemplateInSpec          = errors.New("The configuration spec must have configuration")
-	errInvalidConfigurationInput    = errors.New("Failed to convert input into configuration")
+	errEmptySpecInConfiguration  = errMissingField("spec")
+	errEmptyTemplateInSpec       = errMissingField("spec.template")
+	errEmptyContainerInTemplate  = errMissingField("spec.template.spec.container")
+	errInvalidConfigurationInput = errors.New(`Failed to convert input into configuration`)
 )
 
 // ValidateConfiguration is Configuration resource specific validation and mutation handler

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -434,7 +434,9 @@ func (ac *AdmissionController) mutate(kind string, oldBytes []byte, newBytes []b
 
 	if err := cb(&patches, oldObj, newObj); err != nil {
 		glog.Warningf("Failed the resource specific callback: %s", err)
-		return nil, fmt.Errorf("Failed the Resource Specific Callback: %s", err)
+		// Return the error message as-is to give the callback discretion
+		// over (our portion of) the message that the user sees.
+		return nil, err
 	}
 	return json.Marshal(patches)
 }


### PR DESCRIPTION
The error messages now contain the path to the field in question for missing fields.

Fixes: https://github.com/elafros/elafros/issues/370
