### PR TITLE
Import the latest Build.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,7 +106,7 @@ load(
 
 private_git_repository(
     name = "buildcrd",
-    commit = "098d36d81cf77ffd77d3743f514f0425b29c9597",
+    commit = "ecc11b19d8b84c597062be05a2a14edd73e1f7bb",
     remote = "git@github.com:elafros/build.git",
 )
 

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -74,9 +74,11 @@ type ArgumentSpec struct {
 // SourceSpec defines the input to the Build
 type SourceSpec struct {
 	Git    *GitSourceSpec    `json:"git,omitempty"`
+	GCS    *GCSSourceSpec    `json:"gcs,omitempty"`
 	Custom *corev1.Container `json:"custom,omitempty"`
 }
 
+// GitSourceSpec describes a Git repo source input to the Build.
 type GitSourceSpec struct {
 	Url string `json:"url"`
 
@@ -88,6 +90,20 @@ type GitSourceSpec struct {
 
 	// TODO(mattmoor): authn/z
 }
+
+// GCSSourceSpec describes source input to the Build in the form of an archive,
+// or a source manifest describing files to fetch.
+type GCSSourceSpec struct {
+	Type     GCSSourceType `json:"type,omitempty"`
+	Location string        `json:"location,omitempty"`
+}
+
+type GCSSourceType string
+
+const (
+	GCSArchive  GCSSourceType = "Archive"
+	GCSManifest GCSSourceType = "Manifest"
+)
 
 type BuildProvider string
 


### PR DESCRIPTION
This brings into Elafros the new native GCS source types.
