### PR TITLE
Make Jason Hall an owner of pkg/apis/build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,9 @@
 # API governance.
 /pkg/apis @evankanderson @mattmoor @vaikas-google
 
+# Build API (imported from elafros/build)
+/pkg/apis/build @mattmoor @ImJasonH
+
 # All groups can review docs.
 /docs/ @elafros/elafros-writers @google/elafros-readers
 


### PR DESCRIPTION
These types are imported directly from the Build repo (we have a test that won't let us change them), so adding Jason Hall to approve importing updates to the Build surface that have already landed in elafros/build.