### PR TITLE
Update Route.Status.Conditions after Ingress has an IP address.

### DIFF
--- a/pkg/apis/ela/v1alpha1/route_types.go
+++ b/pkg/apis/ela/v1alpha1/route_types.go
@@ -128,28 +128,44 @@ func (r *Route) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(r.Spec)
 }
 
-func (ess *RouteStatus) SetCondition(new *RouteCondition) {
+func (rs *RouteStatus) IsReady() bool {
+	if c := rs.GetCondition(RouteConditionReady); c != nil {
+		return c.Status == corev1.ConditionTrue
+	}
+	return false
+}
+
+func (rs *RouteStatus) GetCondition(t RouteConditionType) *RouteCondition {
+	for _, cond := range rs.Conditions {
+		if cond.Type == t {
+			return &cond
+		}
+	}
+	return nil
+}
+
+func (rs *RouteStatus) SetCondition(new *RouteCondition) {
 	if new == nil {
 		return
 	}
 
 	t := new.Type
 	var conditions []RouteCondition
-	for _, cond := range ess.Conditions {
+	for _, cond := range rs.Conditions {
 		if cond.Type != t {
 			conditions = append(conditions, cond)
 		}
 	}
 	conditions = append(conditions, *new)
-	ess.Conditions = conditions
+	rs.Conditions = conditions
 }
 
-func (ess *RouteStatus) RemoveCondition(t RouteConditionType) {
+func (rs *RouteStatus) RemoveCondition(t RouteConditionType) {
 	var conditions []RouteCondition
-	for _, cond := range ess.Conditions {
+	for _, cond := range rs.Conditions {
 		if cond.Type != t {
 			conditions = append(conditions, cond)
 		}
 	}
-	ess.Conditions = conditions
+	rs.Conditions = conditions
 }

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -798,7 +798,7 @@ func TestUpdateIngressEventUpdateRouteStatus(t *testing.T) {
 	routeClient := elaClient.ElafrosV1alpha1().Routes(route.Namespace)
 	routeClient.Create(route)
 	// Create an ingress owned by this route.
-	controller.ensureIngressExists(route)
+	controller.reconcileIngress(route)
 	// Before ingress has an IP address, route isn't marked as Ready.
 	ingressClient := kubeClient.Extensions().Ingresses(route.Namespace)
 	ingress, _ := ingressClient.Get(ctrl.GetElaK8SIngressName(route), metav1.GetOptions{})


### PR DESCRIPTION
Partially Fixes Issue #24 

Sometimes Ingress aren't immediately available after creation.  This PR adds an event handler for Ingress updates in Route controller so that we update Route.Status.Conditions to READY only after the Ingress is available and having an IP address.