### PR TITLE
Remove unnecessary step from GKE cluster setup.

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -61,14 +61,6 @@ To use a k8s cluster running in GKE:
     gcloud components install kubectl
     ```
 
-1.  Give your gcloud user cluster-admin privileges:
-
-    ```shell
-    kubectl create clusterrolebinding gcloud-admin-binding \
-      --clusterrole=cluster-admin \
-      --user=$(gcloud config get-value core/account)
-    ```
-
 1.  Add to your .bashrc:
     ```shell
     # When using GKE, the K8s user is your GCP user.


### PR DESCRIPTION
This step is now covered in BUILD.istio, so no longer needed to be done manually.