### PR TITLE
Add fluentd rules to collect logs from build init containers.

### DIFF
--- a/config/monitoring/fluentd/configmap.yaml
+++ b/config/monitoring/fluentd/configmap.yaml
@@ -125,7 +125,7 @@ data:
     <source>
       @id fluentd-containers.log
       @type tail
-      path /var/log/containers/*ela-container-*.log,/var/log/containers/build-controller-*.log
+      path /var/log/containers/*ela-container-*.log,/var/log/containers/build-controller-*.log,/var/log/containers/*build-step-*.log
       pos_file /var/log/es-containers.log.pos
       time_format %Y-%m-%dT%H:%M:%S.%NZ
       tag raw.kubernetes.*


### PR DESCRIPTION
Build init containers are not prefixed with "build-step" and this change adds configuration to enable collection of those logs.