### PR TITLE
Update conformance test so it compiles

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -75,7 +75,7 @@ func configuration(imagePath string) *v1alpha1.Configuration {
 			Name:      configName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			RevisionTemplate: v1alpha1.Revision{
+			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					Container: &corev1.Container{
 						Image: imagePath,


### PR DESCRIPTION
In f10f267d1e165d309585eac65cc441e14031ccc5 we started using a
RevisionSpecTemplate type but the conformance test wasn't updated
and our automated testing/building doesn't cover this yet.

This is the missing piece of https://github.com/elafros/elafros/pull/426

@adrcunha re. adding automation to build these tests, even if we can't run them yet :)
