### PR TITLE
Redirect glog to stderr for the autoscaler container

### DIFF
--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -91,6 +91,10 @@ func MakeElaAutoscalerDeployment(u *v1alpha1.Revision, namespace string) *v1beta
 									Value: strconv.Itoa(autoscalerPort),
 								},
 							},
+							Args: []string{
+								"-logtostderr=true",
+								"-stderrthreshold=INFO",
+							},
 						},
 					},
 					ServiceAccountName: "ela-autoscaler",


### PR DESCRIPTION
glog by default writes its output to files and those logs do not show up in kubectl. This change adds startup flags parsed by glog and redirects glog output to stderr, which in turn makes the logs visible in kubectl.
