### PR TITLE
Updates to namespace, readiness probe & domain

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -5,21 +5,30 @@ of the Elafros API to ensure the API has been implemented consistently.
 Passing these tests indicates that apps and functions deployed to
 this implementation could be ported to other implementations as well.
 
-_The precedent for these tests is the k8s conformance tests which k8s
-vendors use to prove they have ["certified kubernetes"
-deployments](https://github.com/cncf/k8s-conformance#certified-kubernetes)._
+_The precedent for these tests is [the k8s conformance tests](https://github.com/cncf/k8s-conformance)._
 
 ## Environment requirements
 
-These test require:
+These tests require:
 
-* A running `Elafros` cluster up. The tests will use a
-  [kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
-  to determine what `Elafros` cluster to connect to (the `current-context`).
+* **A running `Elafros` cluster.** Specify which cluster to test against using
+  [`--kubeconfig`](#specifying-kubeconfig) and/or [`--cluster`](#specifying-cluster).
   _See [getting started docs](../../DEVELOPMENT.md#getting-started) to set up
   an `Elafros` environment._
-* A docker repo at [`DOCKER_REPO_OVERRIDE`](../../DEVELOPMENT.md#environment-setup)
-  that contains [the conformance test images](#conformance-test-images).
+* **The namespace `pizzaplanet` to exist in the cluster.** To create the namespace:
+
+  ```bash
+  cat <<EOF |
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: pizzaplanet
+  EOF
+  kubectl create -f -
+  ```
+
+* **[`DOCKER_REPO_OVERRIDE`](../../DEVELOPMENT.md#environment-setup)
+  to contain [the conformance test images](#conformance-test-images).**
   _You will need [`docker`](https://docs.docker.com/install/) to build [the conformance test
   images](#conformance-test-images)._
 
@@ -27,10 +36,7 @@ These test require:
 
 The configuration for the images used for the existing conformance tests lives in
 [`test_images_node`](./test_images_node). The images contain a node.js webserver that
-will by default listens on port `8080` and expose:
-
-* A service at `/`
-* A healthcheck at `/healthz` which can be used for [liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
+will by default listens on port `8080` and expose a service at `/`.
 
 The two versions of the image ([`Dockerfile.v1`](./test_images_node/Dockerfile.v1),
 [`Dockerfile.v2`](./test_images_node/Dockerfile.v2)) differ in the message they return
@@ -44,7 +50,7 @@ docker images. It requires:
   `DOCKER_REPO_OVERRIDE`](../../docs/setting-up-a-docker-registry.md)
 * [`docker`](https://docs.docker.com/install/) to be installed
 
-Run it with:
+To run the script:
 
 ```bash
 ./test/conformance/upload-test-images.sh
@@ -52,13 +58,11 @@ Run it with:
 
 ## Running conformance tests
 
-All conformance tests can be triggered via `go test`. (You can also use
-[the ginkgo cli](https://onsi.github.io/ginkgo/#the-ginkgo-cli).)
-
 You need to have a running environment that meets [the conformance test
 environment requirements](#environment-requirements).
 
-To run the conformance tests against the current cluster in `~/.kube/config`:
+To run the conformance tests against the current cluster in `~/.kube/config`
+using `go test`:
 
 ```bash
 go test ./test/conformance
@@ -73,8 +77,19 @@ To run with logging enabled use `-v` AND `-ginkgo.v`:
 go test -v ./test/conformance -ginkgo.v
 ```
 
-### Using a custom kubeconfig
-By default the tests will use the kubeconfig file at `~./kube/config`.
+### Flags
+
+The conformance tests recognize these flags:
+
+* [`--kubeconfig`](#specifying-kubeconfig)
+* [`--cluster`](#specifying-cluster)
+* [`--resolvabledomain`](#using-a-resolvable-domain)
+
+#### Specifying kubeconfig
+
+By default the tests will use the [kubeconfig
+file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+at `~./kube/config`.
 You can specify a different config file with the argument `--kubeconfig`.
 
 To run the conformance tests with a non-default kubeconfig file:
@@ -82,16 +97,33 @@ To run the conformance tests with a non-default kubeconfig file:
 ```bash
 go test ./test/conformance -args --kubeconfig /my/path/kubeconfig
 ```
-### Using a different cluster than the one in your /kube/config's active context
+
+#### Specifying cluster
+
+The `--cluster` argument lets you use a different cluster than [your specified
+kubeconfig's](#specifying-kubeconfig) active context:
+
 ```bash
 go test ./test/conformance -args --cluster your-cluster-name
 ```
 
 The current cluster names can be obtained by runing:
+
 ```bash
 kubectl config get-clusters
 ```
 
+#### Using a resolvable domain
+
+If you setup your cluster using [the getting started
+docs](../../DEVELOPMENT.md#getting-started), `Route`s created in the test will use the
+domain `demo-domain.com`.  Since this domain will not be resolvable to deployments in
+your test cluster, in order to make a request against the endpoint, the test use the
+IP addsigned to the istio `*-ela-ingress` and spoof the `Host` in the header.
+
+If you have configured your cluster to use a resolvable domain, you can use the
+`--resolvabledomain` flag to indicate that the test should make requests directly against
+`Route.Status.Domain` and does not need to spoof the `Host`.
 
 ### Bazel
 
@@ -120,7 +152,7 @@ bazel test //test/... --test_arg=--dockerrepo=$DOCKER_REPO_OVERRIDE --test_arg=-
 
 The conformance tests should **ONLY** cover:
 
-  * Functionality that applies to any implementation of the API
+* Functionality that applies to any implementation of the API
 
 The tests must **NOT** require any specific file system permissions to run or
 require any additional binaries to be installed in the target environment before

--- a/test/conformance/conformance_suite_test.go
+++ b/test/conformance/conformance_suite_test.go
@@ -31,9 +31,10 @@ import (
 )
 
 var (
-	cluster    string
-	dockerRepo string
-	kubeconfig string
+	cluster          string
+	dockerRepo       string
+	kubeconfig       string
+	resolvableDomain bool
 )
 
 func init() {
@@ -52,6 +53,9 @@ func init() {
 		usr, _ := user.Current()
 		kubeconfig = path.Join(usr.HomeDir, ".kube/config")
 	}
+
+	flag.BoolVar(&resolvableDomain, "resolvabledomain", false,
+		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
 }
 
 func TestConformance(t *testing.T) {

--- a/test/conformance/request.go
+++ b/test/conformance/request.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// request contains logic to poll an ingress endpoint with host spoofing.
+// request contains logic to make polling HTTP requests against an endpoint with optional host spoofing.
 
 package conformance
 
@@ -34,16 +34,19 @@ const (
 	requestTimeout  = 1 * time.Minute
 )
 
-// WaitForIngressRequestToDomainState makes requests to address every requestInterval until
+// WaitForRequestToDomainState makes requests to address every requestInterval until
 // timeout has passed, or inState returns `true` (indicating it is done) or
-// returns an error. Requests are made with domain spoofed in the `Host` header.
+// returns an error. Requests are made with spoofDomain spoofed in the `Host` header. If
+// spoofDomain is not specified, `Host` will not be spoofed.
 // Will retry when responses return the HTTP codes in retryableCodes.
-func WaitForIngressRequestToDomainState(address string, domain string, retryableCodes []int, inState func(body string) (bool, error)) {
+func WaitForRequestToDomainState(address string, spoofDomain string, retryableCodes []int, inState func(body string) (bool, error)) {
 	h := http.Client{}
 	req, err := http.NewRequest("GET", address, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	req.Host = domain
+	if spoofDomain != "" {
+		req.Host = spoofDomain
+	}
 
 	var body []byte
 	err = wait.PollImmediate(requestInterval, requestTimeout, func() (bool, error) {

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -33,10 +33,7 @@ import (
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -79,43 +76,11 @@ func configuration(imagePath string) *v1alpha1.Configuration {
 				Spec: v1alpha1.RevisionSpec{
 					Container: &corev1.Container{
 						Image: imagePath,
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/healthz",
-									Port: intstr.IntOrString{
-										Type:   intstr.Int,
-										IntVal: 8080,
-									},
-								},
-							},
-						},
 					},
 				},
 			},
 		},
 	}
-}
-
-func namespace() *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespaceName,
-		},
-	}
-}
-
-func createNamespace(namespaceClient typedcorev1.NamespaceInterface) {
-	// A previous test run may have created this namespace already. We aren't cleaning it up
-	// because it can take up to 3 minutes to delete.
-	n, err := namespaceClient.List(metav1.ListOptions{})
-	for _, item := range n.Items {
-		if item.Name == namespaceName {
-			return
-		}
-	}
-	_, err = namespaceClient.Create(namespace())
-	Expect(err).NotTo(HaveOccurred())
 }
 
 func allRouteTrafficAtRevision(routeName string, revisionName string) func(r *v1alpha1.Route) (bool, error) {
@@ -148,6 +113,33 @@ func isRevisionReady(revisionName string) func(r *v1alpha1.Revision) (bool, erro
 	}
 }
 
+func waitForEndpointState(clientset *kubernetes.Clientset, namespace string, domain string, ingressName string, inState func(body string) (bool, error)) {
+	var endpoint, spoofDomain string
+
+	// If the domain that the Route controller is configured to assign to Route.Status.Domain
+	// (the domainSuffix) is not resolvable, we need to retrieve the IP of the endpoint and
+	// spoof the Host in our requests.
+	if !resolvableDomain {
+		ingressClient := clientset.ExtensionsV1beta1().Ingresses(namespace)
+		By("Wait for the ingress loadbalancer address to be set")
+		WaitForIngressState(ingressClient, ingressName, func(i *apiv1beta1.Ingress) (bool, error) {
+			if len(i.Status.LoadBalancer.Ingress) > 0 {
+				endpoint = fmt.Sprintf("http://%s", i.Status.LoadBalancer.Ingress[0].IP)
+				return true, nil
+			}
+			return false, nil
+		})
+		spoofDomain = domain
+		// If the domain is resolvable, we can use it directly when we make requests
+	} else {
+		endpoint = domain
+	}
+
+	By("Wait for the endpoint to be up and handling requests")
+	// TODO(#348): The ingress endpoint tends to return 503's and 404's
+	WaitForRequestToDomainState(endpoint, spoofDomain, []int{503, 404}, inState)
+}
+
 func BuildClientConfig(kubeConfigPath string, clusterName string) (*rest.Config, error) {
 	overrides := clientcmd.ConfigOverrides{}
 	// Override the cluster name if provided.
@@ -161,9 +153,7 @@ func BuildClientConfig(kubeConfigPath string, clusterName string) (*rest.Config,
 
 var _ = Describe("Route", func() {
 	var (
-		namespaceClient typedcorev1.NamespaceInterface
-		ingressClient   v1beta1.IngressInterface
-
+		kubeClientset  *kubernetes.Clientset
 		routeClient    elatyped.RouteInterface
 		configClient   elatyped.ConfigurationInterface
 		revisionClient elatyped.RevisionInterface
@@ -172,13 +162,8 @@ var _ = Describe("Route", func() {
 	BeforeSuite(func() {
 		cfg, err := BuildClientConfig(kubeconfig, cluster)
 		Expect(err).NotTo(HaveOccurred())
-		kubeClientset, err := kubernetes.NewForConfig(cfg)
+		kubeClientset, err = kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
-
-		namespaceClient = kubeClientset.CoreV1().Namespaces()
-		createNamespace(namespaceClient)
-
-		ingressClient = kubeClientset.ExtensionsV1beta1().Ingresses(namespaceName)
 
 		clientset, err := versioned.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
@@ -237,24 +222,11 @@ var _ = Describe("Route", func() {
 
 			By("Once the Configuration has been updated with the Revision, the Route will be updated to route traffic to the Revision")
 			WaitForRouteState(routeClient, routeName, allRouteTrafficAtRevision(routeName, revisionName))
-			updated_route, err := routeClient.Get(routeName, metav1.GetOptions{})
+			updatedRoute, err := routeClient.Get(routeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			// TODO: The test needs to be able to make a request without needing to retrieve
-			// the ingress manually (i.e. by using the host directly)
-			var endpoint string
-			By("Wait for the ingress loadbalancer address to be set")
-			WaitForIngressState(ingressClient, ingressName, func(i *apiv1beta1.Ingress) (bool, error) {
-				if len(i.Status.LoadBalancer.Ingress) > 0 {
-					endpoint = fmt.Sprintf("http://%s", i.Status.LoadBalancer.Ingress[0].IP)
-					return true, nil
-				}
-				return false, nil
-			})
 			By("Make a request to the Revision that is now deployed and serving traffic")
-			// TODO: The ingress endpoint tends to return 503's and 404's after an initial deployment of a Revision.
-			// Open a bug for this? We're even using readinessProbe, seems like this shouldn't happen.
-			WaitForIngressRequestToDomainState(endpoint, updated_route.Status.Domain, []int{503, 404}, func(body string) (bool, error) {
+			waitForEndpointState(kubeClientset, namespaceName, updatedRoute.Status.Domain, ingressName, func(body string) (bool, error) {
 				return body == "What a spaceport!", nil
 			})
 
@@ -286,11 +258,11 @@ var _ = Describe("Route", func() {
 
 			By("The Route will then immediately send all traffic to the new revision")
 			WaitForRouteState(routeClient, routeName, allRouteTrafficAtRevision(routeName, newRevisionName))
-			updated_route, err = routeClient.Get(routeName, metav1.GetOptions{})
+			updatedRoute, err = routeClient.Get(routeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Wait for the ingress to actually start serving traffic from the newly deployed Revision")
-			WaitForIngressRequestToDomainState(endpoint, updated_route.Status.Domain, []int{503, 404}, func(body string) (bool, error) {
+			waitForEndpointState(kubeClientset, namespaceName, updatedRoute.Status.Domain, ingressName, func(body string) (bool, error) {
 				if body == "Re-energize yourself with a slice of pepperoni!" {
 					// This is the string we are looking for
 					return true, nil

--- a/test/conformance/test_images_node/server.js
+++ b/test/conformance/test_images_node/server.js
@@ -12,10 +12,5 @@ app.get('/', (req, res) => {
   res.send(process.env.MESSAGE);
 });
 
-// Health check for k8s readiness probe
-app.get('/healthz', (req, res) => {
-  res.sendStatus(200)
-});
-
 app.listen(PORT, HOST);
 console.log(`Running on http://${HOST}:${PORT}`);


### PR DESCRIPTION
Make these tweaks to the conformance tests:

* Move namespace creation to test fixture setup (it's super slow and it
  was leaving the namespace around as a side effect of the test)
* Support the case where a cluster is configured to use a resolvable
  domain, in which case we don't need to get the IP of the ingress and
  spoof the host (see #443 re. adding docs for how to set this up in a
  cluster)
* Remove readiness probe from container; this wasn't accomplishing what
  it was intended to b/c of #348 anyway

Also tried to make the conformance test docs more succinct.