### PR TITLE
Delete outdated route rules

### DIFF
--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -738,11 +738,13 @@ func (c *Controller) removeOutdatedRouteRules(u *v1alpha1.Route) error {
 	ns := u.Namespace
 	routeClient := c.elaclientset.ConfigV1alpha2().RouteRules(ns)
 	if routeClient == nil {
-		glog.Errorf("Failed to create resource client")
+		glog.Error("Failed to create resource client")
 		return errors.New("Couldn't get a routeClient")
 	}
 
-	routeRuleList, err := routeClient.List(metav1.ListOptions{})
+	routeRuleList, err := routeClient.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("route=%s", u.Name),
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes Issue # https://github.com/elafros/elafros/issues/313

## Proposed Changes

* Deletes outdated route rules which can occur if route rule names have
been deleted.

* Followup from: https://github.com/elafros/elafros/pull/360
