### PR TITLE
Log pod counts for metrics collection.

### DIFF
--- a/cmd/ela-autoscaler/main.go
+++ b/cmd/ela-autoscaler/main.go
@@ -131,6 +131,12 @@ func scaleTo(podCount int32) {
 		glog.Error("Error getting Deployment %q: %s", elaDeployment, err)
 		return
 	}
+	glog.Infof("===SCALE=== %v %v %v %v %v",
+		time.Now().Unix(),
+		podCount,
+		deployment.Status.Replicas,
+		deployment.Status.AvailableReplicas,
+		deployment.Status.ReadyReplicas)
 	if *deployment.Spec.Replicas == podCount {
 		return
 	}

--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -91,6 +91,10 @@ func MakeElaAutoscalerDeployment(u *v1alpha1.Revision, namespace string) *v1beta
 									Value: strconv.Itoa(autoscalerPort),
 								},
 							},
+							Args: []string{
+								"-logtostderr=true",
+								"-stderrthreshold=INFO",
+							},
 						},
 					},
 					ServiceAccountName: "ela-autoscaler",


### PR DESCRIPTION
Emit a few interesting pod count stat to the autoscaler logs to help with load testing.  They are emitted in a format that can be concatenated to the logs used in the autoscaler readme: https://github.com/elafros/elafros/blob/master/sample/autoscale/README.md 