### PR TITLE
Do not assert against Generation in conformance tests

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -191,16 +191,12 @@ var _ = Describe("Route", func() {
 	Context("Deploying an app with a pre-built container", func() {
 		It("Creates a route, serves traffic to it, and serves traffic to subsequent revisions", func() {
 			By("Creating a new Route")
-			createdRoute, err := routeClient.Create(route())
+			_, err := routeClient.Create(route())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(createdRoute.Generation).To(Equal(int64(0)))
-			Expect(createdRoute.Spec.Generation).To(Equal(int64(1)))
 
 			By("Creating Configuration for the Route using the first image")
-			createdConfig, err := configClient.Create(configuration(imagePaths[0]))
+			_, err = configClient.Create(configuration(imagePaths[0]))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(createdConfig.Generation).To(Equal(int64(0)))
-			Expect(createdConfig.Spec.Generation).To(Equal(int64(1)))
 
 			By("The Configuration will be updated with the Revision after it is created")
 			var revisionName string


### PR DESCRIPTION
The values the conformance test was asserting against were wrong.
Route.Generation and Configuration.Generation should actually have
a value of 1 when they are first created, and the *.Status.Generation
values are just hacks until CRD generations are updated properly
(which is fixed in https://github.com/kubernetes/kubernetes/issues/58778
but we are not yet using).

I want to remove these assertions since they are just asserting
against a hack. We should actually assert against
Configuration.Generation and Route.Generation when we have pulled in the
fix.