### PR TITLE
Update the minikube k8s version to 1.9.4

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -83,7 +83,7 @@ To use a k8s cluster running in GKE:
 
 ```shell
 minikube start \
-  --kubernetes-version=v1.9.0 \
+  --kubernetes-version=v1.9.4 \
   --vm-driver=kvm2 \
   --extra-config=apiserver.Admission.PluginNames=DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,SecurityContextDeny,MutatingAdmissionWebhook
 ```


### PR DESCRIPTION
This is the latest version as of minikube v0.25.2, and the same version used in the GKE cluster docs.