### PR TITLE
Mark samples as either "app" or "function"

### DIFF
--- a/sample/autoscale/configuration.yaml
+++ b/sample/autoscale/configuration.yaml
@@ -21,7 +21,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: autoscale-sample:latest

--- a/sample/buildpack-app/configuration.yaml.tpl
+++ b/sample/buildpack-app/configuration.yaml.tpl
@@ -24,7 +24,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: *image

--- a/sample/gitwebhook/configuration.yaml
+++ b/sample/gitwebhook/configuration.yaml
@@ -21,7 +21,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: git-webhook:latest

--- a/sample/helloworld/configuration.yaml
+++ b/sample/helloworld/configuration.yaml
@@ -21,7 +21,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: sample:latest

--- a/sample/helloworld/updated_configuration.yaml
+++ b/sample/helloworld/updated_configuration.yaml
@@ -21,7 +21,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: sample:latest

--- a/sample/private-repos/manifest.yaml
+++ b/sample/private-repos/manifest.yaml
@@ -40,7 +40,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: *image

--- a/sample/steren-app/configuration.yaml.tpl
+++ b/sample/steren-app/configuration.yaml.tpl
@@ -32,7 +32,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: *image

--- a/sample/telemetrysample/configuration.yaml
+++ b/sample/telemetrysample/configuration.yaml
@@ -32,7 +32,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: telemetrysample:latest

--- a/sample/thumbnailer/thumbnailer-prebuilt.yaml
+++ b/sample/thumbnailer/thumbnailer-prebuilt.yaml
@@ -31,7 +31,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: docker.io/mchmarny/rester-tester:latest

--- a/sample/thumbnailer/thumbnailer.yaml.tpl
+++ b/sample/thumbnailer/thumbnailer.yaml.tpl
@@ -41,7 +41,7 @@ spec:
   revisionTemplate:
     metadata:
       labels:
-        elafros.dev/type: container
+        elafros.dev/type: app
     spec:
       container:
         image: *image


### PR DESCRIPTION
Based on discussion with @mattmoor in #444 , marking configurations based on whether they create an application (have a "main" which creates an http server) or specify only a function (and assume web wrapper injection).
