### PR TITLE
Marks revision status as failed if service endpoint is not ready

### DIFF
--- a/pkg/apis/ela/v1alpha1/revision_types.go
+++ b/pkg/apis/ela/v1alpha1/revision_types.go
@@ -84,6 +84,8 @@ const (
 	// RevisionConditionReady is set when the revision is starting to materialize
 	// runtime resources, and becomes true when those resources are ready.
 	RevisionConditionReady RevisionConditionType = "Ready"
+	// RevisionConditionFailed is set when the revision readiness check exceeds 3.
+	RevisionConditionFailed RevisionConditionType = "Failed"
 	// RevisionConditionBuildComplete is set when the revision has an associated build
 	// and is marked True if/once the Build has completed succesfully.
 	RevisionConditionBuildComplete RevisionConditionType = "BuildComplete"
@@ -145,6 +147,15 @@ func (r *Revision) GetSpecJSON() ([]byte, error) {
 // RevisionConditionReady returns true if ConditionStatus is True
 func (rs *RevisionStatus) IsReady() bool {
 	if c := rs.GetCondition(RevisionConditionReady); c != nil {
+		return c.Status == corev1.ConditionTrue
+	}
+	return false
+}
+
+// IsFailed looks at the conditions and if the Status has a condition
+// RevisionConditionFailed returns true if ConditionStatus is True
+func (rs *RevisionStatus) IsFailed() bool {
+	if c := rs.GetCondition(RevisionConditionFailed); c != nil {
 		return c.Status == corev1.ConditionTrue
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Brenda Chan <brchan@pivotal.io>
Signed-off-by: Dave Protasowski <davep@pivotal.io>

Fixes Issue #350

## Proposed Changes

* Mark as failed if service endpoint check fails >= 3 times

* Auxiliary endpoints (non service endpoints) will no longer trigger the
revision status to be updated
