### PR TITLE
Enable certificate controller on Minikube

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -81,11 +81,18 @@ To use a k8s cluster running in GKE:
     default](https://github.com/kubernetes/minikube/pull/2547),the
     MutatingAdmissionWebhook plugin must be manually enabled._
 
+    _Until minikube [makes this the
+    default](https://github.com/kubernetes/minikube/issues/1647), the
+    certificate controller must be told where to find the cluster CA certs on
+    the VM._
+
 ```shell
 minikube start \
   --kubernetes-version=v1.9.0 \
   --vm-driver=kvm2 \
-  --extra-config=apiserver.Admission.PluginNames=DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,SecurityContextDeny,MutatingAdmissionWebhook
+  --extra-config=apiserver.Admission.PluginNames=DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,SecurityContextDeny,MutatingAdmissionWebhook \
+  --extra-config=controller-manager.ClusterSigningCertFile="/var/lib/localkube/certs/ca.crt" \
+  --extra-config=controller-manager.ClusterSigningKeyFile="/var/lib/localkube/certs/ca.key"
 ```
 
 ### Minikube with GCR


### PR DESCRIPTION
The certificate controller is required to configure the istio sidecar injector webhook, but Minikube doesn't give it the paths to the CA certs by default, so it can't start. Without the certificate controller running, the Istio webhook's CSR (as documented [here](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection)) can't be approved.

## Proposed Changes

Manually configure CA cert paths to point to the automatically generated files on the Minikube VM. These paths are local to the VM, not the host machine, so they are the same for all users.
