### PR TITLE
[Coverage] Use PR# as GCS file name & changed ACL

### DIFF
--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -23,4 +23,4 @@ cd ${ELAFROS_ROOT}/pkg
 # Generate the coverage profile for all tests, and store it in the GCS bucket.
 # TODO(steuhs): get PR number and use that as the file name
 go test ./... -coverprofile coverage_profile.txt
-gsutil cp -a project-private coverage_profile.txt gs://gke-prow/pr-logs/directory/elafros-coverage/$PULL_PULL_SHA
+gsutil cp -a project-private coverage_profile.txt gs://gke-prow/pr-logs/directory/elafros-coverage/profiles/$PULL_PULL_SHA


### PR DESCRIPTION
Fixes Issue #514, #513
Partly fixes  #503 
## Proposed Changes
1) use PR number as object name to enable indexing. Indexing allows
incremental coverage done on a commit #514 

2) make the object project-private. Without specifying, object will be
public (which is strange because GCS document says the default is
project-private) #513 

3) changed the name SCRIPT_ROOT to ELAFROS_ROOT, because the name SCRIPT_ROOT may mislead the reader to thinks it's the directory of the script. #503 

