### PR TITLE
Assorted fixes to e2e-tests.sh

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -226,8 +226,12 @@ if (( USING_EXISTING_CLUSTER )); then
   bazel run //:everything.delete  # ignore if not running
 fi
 if (( IS_PROW )); then
-  # If this is a prow job, authenticate against GCR.
-  docker login -u _json_key -p "$(cat /etc/service-account/service-account.json)" https://gcr.io
+  echo "Authenticating to GCR"
+  # kubekins-e2e images lack docker-credential-gcr, install it manually.
+  # TODO(adrcunha): Remove this step once docker-credential-gcr is available.
+  gcloud components install docker-credential-gcr
+  docker-credential-gcr configure-docker
+  echo "Successfully authenticated"
 fi
 
 bazel run //:everything.apply


### PR DESCRIPTION
* don't run the conformance tests, they're timing out (issue #547)
* deploy and verify the "Hello World!" app instead
* ignore kubetest teardown failures, which can wrongly report the test as failed
* configure the test cluster the way it's recommended in the docs
* authenticate against GCR when running on prow so images can be pushed to the registry