### PR TITLE
 Run the end-to-end tests in presubmit

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -79,8 +79,6 @@ bazel test //cmd/... //pkg/...
 go test ./cmd/... ./pkg/...
 
 # Step 3: Run end-to-end tests.
-if (( ! IS_PROW )); then
-  # Restore environment variables, as they are needed when running locally.
-  restore_env
-fi
+# Restore environment variables, let e2e-tests.sh handle them.
+restore_env
 ./test/e2e-tests.sh


### PR DESCRIPTION
The end-to-end tests are run only if the build and unit tests pass.

Bonus:
* assorted minor cleanups in the script
* partially addresses issue #503