### PR TITLE
Update test to use json instead of yaml

### DIFF
--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -282,7 +282,7 @@ func TestValidNewRevisionObject(t *testing.T) {
 	}
 
 	revision := createRevision(testRevisionName)
-	marshaled, err := yaml.Marshal(revision)
+	marshaled, err := json.Marshal(revision)
 	if err != nil {
 		t.Fatalf("Failed to marshal revision: %s", err)
 	}


### PR DESCRIPTION
This was caused by a merge conflict with 66899d1.