### PR TITLE
Annotate revision with the configuration generation label

### DIFF
--- a/pkg/apis/ela/register.go
+++ b/pkg/apis/ela/register.go
@@ -23,6 +23,10 @@ const (
 	// which Configuration it is created.
 	ConfigurationLabelKey = GroupName + "/configuration"
 
+	// ConfigurationGenerationAnnotationKey is the annotation key attached to a Revision indicating the
+	// generation of the Configuration that created this revision
+	ConfigurationGenerationAnnotationKey = GroupName + "/configurationGeneration"
+
 	// RouteLabelKey is the label key attached to a Configuration indicating by
 	// which Route it is configured as traffic target.
 	RouteLabelKey = GroupName + "/route"

--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -318,6 +318,11 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	rev.ObjectMeta.Labels[ela.ConfigurationLabelKey] = config.Name
 
+	if rev.ObjectMeta.Annotations == nil {
+		rev.ObjectMeta.Annotations = make(map[string]string)
+	}
+	rev.ObjectMeta.Annotations[ela.ConfigurationGenerationAnnotationKey] = fmt.Sprintf("%v", config.Spec.Generation)
+
 	// Delete revisions when the parent Configuration is deleted.
 	rev.OwnerReferences = append(rev.OwnerReferences, *controllerRef)
 

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -27,6 +27,7 @@ package configuration
 	Congfiguration.
 */
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -211,7 +212,11 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 	}
 
 	if rev.Labels[ela.ConfigurationLabelKey] != config.Name {
-		t.Errorf("rev does not have label <%s:%s>", ela.ConfigurationLabelKey, config.Name)
+		t.Errorf("rev does not have configuration label <%s:%s>", ela.ConfigurationLabelKey, config.Name)
+	}
+
+	if rev.Annotations[ela.ConfigurationGenerationAnnotationKey] != fmt.Sprintf("%v", config.Spec.Generation) {
+		t.Errorf("rev does not have generation annotation <%s:%s>", ela.ConfigurationGenerationAnnotationKey, config.Name)
 	}
 
 	for k, v := range config.Spec.RevisionTemplate.ObjectMeta.Labels {


### PR DESCRIPTION
Fixes #458

Adds a revision label with generation of the configuration that created the revision