### PR TITLE
Update references to "revision" label

### DIFF
--- a/pkg/controller/revision/BUILD.bazel
+++ b/pkg/controller/revision/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/build/v1alpha1:go_default_library",
+        "//pkg/apis/ela:go_default_library",
         "//pkg/apis/ela/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned/fake:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",

--- a/pkg/controller/revision/ela_service.go
+++ b/pkg/controller/revision/ela_service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package revision
 
 import (
+	"github.com/elafros/elafros/pkg/apis/ela"
 	"github.com/elafros/elafros/pkg/apis/ela/v1alpha1"
 	"github.com/elafros/elafros/pkg/controller"
 
@@ -29,7 +30,7 @@ var httpServicePortName = "http"
 var servicePort = 80
 
 // MakeRevisionK8sService creates a Service that targets all pods with the same
-// "revision" label. Traffic is routed to queue-proxy port.
+// ela.RevisionLabelKey label. Traffic is routed to queue-proxy port.
 func MakeRevisionK8sService(u *v1alpha1.Revision, ns string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -47,7 +48,7 @@ func MakeRevisionK8sService(u *v1alpha1.Revision, ns string) *corev1.Service {
 			},
 			Type: "NodePort",
 			Selector: map[string]string{
-				"revision": u.Name,
+				ela.RevisionLabelKey: u.Name,
 			},
 		},
 	}

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -22,6 +22,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/elafros/elafros/pkg/apis/ela"
+
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
@@ -880,8 +882,8 @@ func (c *Controller) updateStatus(rev *v1alpha1.Revision) (*v1alpha1.Revision, e
 // TODO: Consider using OwnerReferences.
 // https://github.com/kubernetes/sample-controller/blob/master/controller.go#L373-L384
 func lookupServiceOwner(endpoint *corev1.Endpoints) string {
-	// see if there's a 'revision' label on this object marking it as ours.
-	if revisionName, ok := endpoint.Labels["revision"]; ok {
+	// see if there's a label on this object marking it as ours.
+	if revisionName, ok := endpoint.Labels[ela.RevisionLabelKey]; ok {
 		return revisionName
 	}
 	return ""

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -93,7 +93,7 @@ func getTestReadyEndpoints(revName string) *corev1.Endpoints {
 			Name:      fmt.Sprintf("%s-service", revName),
 			Namespace: testNamespace,
 			Labels: map[string]string{
-				"revision": revName,
+				ela.RevisionLabelKey: revName,
 			},
 		},
 		Subsets: []corev1.EndpointSubset{
@@ -114,7 +114,7 @@ func getTestAuxiliaryReadyEndpoints(revName string) *corev1.Endpoints {
 			Name:      fmt.Sprintf("%s-auxiliary", revName),
 			Namespace: "test",
 			Labels: map[string]string{
-				"revision": revName,
+				ela.RevisionLabelKey: revName,
 			},
 		},
 		Subsets: []corev1.EndpointSubset{
@@ -135,7 +135,7 @@ func getTestNotReadyEndpoints(revName string) *corev1.Endpoints {
 			Name:      fmt.Sprintf("%s-service", revName),
 			Namespace: "test",
 			Labels: map[string]string{
-				"revision": revName,
+				ela.RevisionLabelKey: revName,
 			},
 		},
 		Subsets: []corev1.EndpointSubset{


### PR DESCRIPTION
In ba3f94551b0cf9978b5e31730031f16d186a72f9 the name of the revision
label was changed from "revision" to "elafros.dev/revision" but some
references were not updated.

This caused the conformance tests to fail because:
- The selector for the k8s services was using the wrong label
- The logic to lookup the owner of an endpoint in revision.go
  was using the wrong label

So the Revision was never being marked as ServiceReady.

Fixes #547
