### PR TITLE
Plumb revision annotations through to services and deployments

### DIFF
--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -73,6 +73,10 @@ func getTestConfiguration() *v1alpha1.Configuration {
 						"test-label":                   "test",
 						"example.com/namespaced-label": "test",
 					},
+					Annotations: map[string]string{
+						"test-annotation-1": "foo",
+						"test-annotation-2": "bar",
+					},
 				},
 				Spec: v1alpha1.RevisionSpec{
 					// corev1.Container has a lot of setting.  We try to pass many
@@ -217,6 +221,12 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 	for k, v := range config.Spec.RevisionTemplate.ObjectMeta.Labels {
 		if rev.Labels[k] != v {
 			t.Errorf("revisionTemplate label %s=%s not passed to revision", k, v)
+		}
+	}
+
+	for k, v := range config.Spec.RevisionTemplate.ObjectMeta.Annotations {
+		if rev.Annotations[k] != v {
+			t.Errorf("revisionTemplate annotation %s=%s not passed to revision", k, v)
 		}
 	}
 

--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -50,13 +50,16 @@ func MakeElaAutoscalerDeployment(u *v1alpha1.Revision) *v1beta1.Deployment {
 
 	labels := MakeElaResourceLabels(u)
 	labels[ela.AutoscalerLabelKey] = controller.GetRevisionAutoscalerName(u)
+	annotations := MakeElaResourceAnnotations(u)
+	annotations[sidecarIstioInjectAnnotation] = "false"
 
 	replicas := int32(1)
 	return &v1beta1.Deployment{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      controller.GetRevisionAutoscalerName(u),
-			Namespace: AutoscalerNamespace,
-			Labels:    MakeElaResourceLabels(u),
+			Name:        controller.GetRevisionAutoscalerName(u),
+			Namespace:   AutoscalerNamespace,
+			Labels:      MakeElaResourceLabels(u),
+			Annotations: MakeElaResourceAnnotations(u),
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &replicas,
@@ -66,10 +69,8 @@ func MakeElaAutoscalerDeployment(u *v1alpha1.Revision) *v1beta1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Labels: labels,
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "false",
-					},
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -115,9 +116,10 @@ func MakeElaAutoscalerDeployment(u *v1alpha1.Revision) *v1beta1.Deployment {
 func MakeElaAutoscalerService(u *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      controller.GetRevisionAutoscalerName(u),
-			Namespace: AutoscalerNamespace,
-			Labels:    MakeElaResourceLabels(u),
+			Name:        controller.GetRevisionAutoscalerName(u),
+			Namespace:   AutoscalerNamespace,
+			Labels:      MakeElaResourceLabels(u),
+			Annotations: MakeElaResourceAnnotations(u),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/pkg/controller/revision/ela_pod.go
+++ b/pkg/controller/revision/ela_pod.go
@@ -111,11 +111,15 @@ func MakeElaDeployment(u *v1alpha1.Revision, namespace string) *v1beta1.Deployme
 		MaxSurge:       &elaPodMaxSurge,
 	}
 
+	podTemplateAnnotations := MakeElaResourceAnnotations(u)
+	podTemplateAnnotations[sidecarIstioInjectAnnotation] = "true"
+
 	return &v1beta1.Deployment{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      controller.GetRevisionDeploymentName(u),
-			Namespace: namespace,
-			Labels:    MakeElaResourceLabels(u),
+			Name:        controller.GetRevisionDeploymentName(u),
+			Namespace:   namespace,
+			Labels:      MakeElaResourceLabels(u),
+			Annotations: MakeElaResourceAnnotations(u),
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &elaPodReplicaCount,
@@ -125,10 +129,8 @@ func MakeElaDeployment(u *v1alpha1.Revision, namespace string) *v1beta1.Deployme
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Labels: MakeElaResourceLabels(u),
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "true",
-					},
+					Labels:      MakeElaResourceLabels(u),
+					Annotations: podTemplateAnnotations,
 				},
 			},
 		},

--- a/pkg/controller/revision/ela_resource.go
+++ b/pkg/controller/revision/ela_resource.go
@@ -15,3 +15,11 @@ func MakeElaResourceLabels(u *v1alpha1.Revision) map[string]string {
 	}
 	return labels
 }
+
+func MakeElaResourceAnnotations(u *v1alpha1.Revision) map[string]string {
+	annotations := make(map[string]string, len(u.ObjectMeta.Annotations)+1)
+	for k, v := range u.ObjectMeta.Annotations {
+		annotations[k] = v
+	}
+	return annotations
+}

--- a/pkg/controller/revision/ela_service.go
+++ b/pkg/controller/revision/ela_service.go
@@ -34,9 +34,10 @@ var servicePort = 80
 func MakeRevisionK8sService(u *v1alpha1.Revision, ns string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      controller.GetElaK8SServiceNameForRevision(u),
-			Namespace: ns,
-			Labels:    MakeElaResourceLabels(u),
+			Name:        controller.GetElaK8SServiceNameForRevision(u),
+			Namespace:   ns,
+			Labels:      MakeElaResourceLabels(u),
+			Annotations: MakeElaResourceAnnotations(u),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -75,6 +75,8 @@ const (
 	autoscalerPort = 8080
 
 	serviceTimeoutDuration = 5 * time.Minute
+
+	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Brenda Chan <brchan@pivotal.io>

Fixes Issue #359 

## Proposed Changes

* Only propagate the annotations specified under a
configuration's spec.RevisionTemplate.metadata.annotations

* Adds test to ensure revisionTemplate annotations are passed to revisions
