### PR TITLE
Update spec to move configurationGeneration to annotations

### DIFF
--- a/docs/spec/normative_examples.md
+++ b/docs/spec/normative_examples.md
@@ -125,6 +125,7 @@ metadata:
   name: def
   labels:
     elafros.dev/configuration: my-service
+  annotations:
     elafros.dev/configurationGeneration: 1235
   ...
 spec:
@@ -322,6 +323,7 @@ metadata:
   labels:
     # name and generation of the configuration that created the revision
     elafros.dev/configuration: my-service
+  annotations:
     elafros.dev/configurationGeneration: 1234
   ...  # uid, resourceVersion, creationTimestamp, generation, selfLink, etc
 spec:
@@ -791,6 +793,7 @@ metadata:
   name: abc
   labels:
     elafros.dev/configuration: my-service
+  annotations:
     elafros.dev/configurationGeneration: 1234
   ...
 spec:

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -209,8 +209,9 @@ metadata:
   namespace: default
   labels:
     elafros.dev/configuration: ...  # to list configurations/revisions by service
-    elafros.dev/configurationGeneration: ...  # generation of configuration that created this Revision
     elafros.dev/type: "function"  # convention, one of "function" or "app"
+  annotations:
+    elafros.dev/configurationGeneration: ...  # generation of configuration that created this Revision
   # system generated meta
   uid: ...
   resourceVersion: ...  # used for optimistic concurrency control


### PR DESCRIPTION
Correct spec to document that `elafros.dev/configurationGeneration` is an annotation. Thanks to @johnugeorge for the catch on #458.

/assign johnugeorge
/assign grantr