### PR TITLE
Add release note block to PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -2,6 +2,13 @@ Fixes Issue #
 
 ## Proposed Changes
 
-  *  
-  * 
-  * 
+  *
+  *
+  *
+
+**Release Note**
+<!-- Enter your extended release note in the below block. If the PR requires
+additional action from users switching to the new release, include the string
+"action required". If no release note is required, write "NONE". -->
+```release-note
+```


### PR DESCRIPTION
This is inspired by the Kubernetes PR template's release note block. The intent is that release managers (or a bot) can collate these notes into the changelog on release. The `release-note` syntax annotation is not a real syntax, but is intended to make this easier to automate by scanning PR bodies.

Followup from https://github.com/elafros/elafros/pull/563#discussion_r178647034.

## Proposed Changes

  *  Adds instructions to add a release note to the PR description, or `NONE` if no release note is required.


