### PR TITLE
Fix the Service selector for Autoscaler

### DIFF
--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -129,7 +129,7 @@ func MakeElaAutoscalerService(u *v1alpha1.Revision) *corev1.Service {
 			},
 			Type: "NodePort",
 			Selector: map[string]string{
-				"autoscaler": controller.GetRevisionAutoscalerName(u),
+				ela.AutoscalerLabelKey: controller.GetRevisionAutoscalerName(u),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #584

Groupname was added to autoscaler label as part of #532. However, it
was not added to the autoscaler service selector. Hence, service endpoint is not
populated correctly and autoscaling feature is broken.