### PR TITLE
Fix comment on RevisionLabelKey

### DIFF
--- a/pkg/apis/ela/register.go
+++ b/pkg/apis/ela/register.go
@@ -31,8 +31,8 @@ const (
 	// which Route it is configured as traffic target.
 	RouteLabelKey = GroupName + "/route"
 
-	// RevisionLabelKey is the label key attached to a Revision indicating by
-	// which Revision deployment it is created.
+	// RevisionLabelKey is the label key attached to k8s resources to indicate
+	// which Revision triggered their creation.
 	RevisionLabelKey = GroupName + "/revision"
 
 	// AutoscalerLabelKey is the label key attached to a autoscaler pod indicating by


### PR DESCRIPTION
While looking through recent changes that should be reflected in the Conformance tests, I found this change. The comment made it sound like this was a label I should expect to see on a Revision, so I though the conformance tests needed updating, but after some digging, it looks like this label is set via
`MakeElaResourceLabels` in ela_resource.go, which is used to set labels on k8s resources such as (k8s) Services and Deployments.

## Proposed Changes

  *  Updating comment to reflect purpose of `RevisionLabelKey`

@bsnchan let me know if I've interpreted `RevisionLabelKey` incorrectly and it is intended to be set on the Revision object after all!