### PR TITLE
Add Revision annotations to conformance tests

### DIFF
--- a/test/conformance/BUILD.bazel
+++ b/test/conformance/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/ela:go_default_library",
         "//pkg/apis/ela/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/clientset/versioned/typed/ela/v1alpha1:go_default_library",


### PR DESCRIPTION
In https://github.com/elafros/elafros/pull/572 Revision was made to be
updated with the generation of the Configuration that triggered its
creation. This commit updates the conformance tests to assert that it is
being populated correctly.

Also fixed a bug: after updating the Configuration with a new image, we
were (I mean *I was*, I created this bug XD) waiting for the previous
Revision to be ready (which of course it was right away), not the new
Revision. This means that the health check we had added MIGHT have
actually been working (i.e. saving us from 404s and 503s).

Snuck in a rename of `routeIsReady` to `isRouteReady` to be consistent
with other functions in the file.

This partially addresses #593.

## Proposed Changes

  *  Assert against `ConfigurationGenerationAnnotationKey` in conformance tests
