### PR TITLE
Add gitattributes marking generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+**/zz_generated.*.go linguist-generated=true
+/pkg/client/** linguist-generated=true


### PR DESCRIPTION
All files in the pkg/client tree and all zz_generated* files are generated. The `linguist-generated` attribute is used by GitHub to hide changes to generated code in PR diffs. Comments at the top of the file point readers to the official docs for the file and the Linguist-specific docs.

Sample `git check-attr` output:

```shell
git check-attr linguist-generated pkg/client/listers/istio/v1alpha2/routerule.go
# pkg/client/listers/istio/v1alpha2/routerule.go: linguist-generated: true

git check-attr linguist-generated pkg/apis/build/register.go
# pkg/apis/build/register.go: linguist-generated: unspecified

git check-attr linguist-generated pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
# pkg/apis/build/v1alpha1/zz_generated.deepcopy.go: linguist-generated: true
```

Fixes #610

## Proposed Changes

  *  Add a `.gitattributes` file listing generated paths