### PR TITLE
Correct "Fixes issue" line in PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,4 +1,4 @@
-Fixes Issue #
+Fixes #
 
 ## Proposed Changes
 


### PR DESCRIPTION
According to https://help.github.com/articles/closing-issues-using-keywords, close keywords only work if the issue number immediately follows. The "Fixes issue #" prompt in our PR template didn't actually work as a keyword because of the "issue" part.

You can see whether the keyword was recognized by looking for a dotted line under the keyword and a tooltip saying "This pull request closes issue N".

Note this one doesn't work:

Fixes Issue #613

This one does:

Fixes #613