### PR TITLE
Remove build-controller logs from getting into Elastic Search.

### DIFF
--- a/config/monitoring/fluentd/configmap.yaml
+++ b/config/monitoring/fluentd/configmap.yaml
@@ -125,7 +125,7 @@ data:
     <source>
       @id fluentd-containers.log
       @type tail
-      path /var/log/containers/*ela-container-*.log,/var/log/containers/build-controller-*.log,/var/log/containers/*build-step-*.log
+      path /var/log/containers/*ela-container-*.log,/var/log/containers/*build-step-*.log
       pos_file /var/log/es-containers.log.pos
       time_format %Y-%m-%dT%H:%M:%S.%NZ
       tag raw.kubernetes.*


### PR DESCRIPTION
Fixes #519

## Proposed Changes
Logs from build-controller is not something the customer should look into or understand. Status messages as well as logs from builds should be sufficient to debug issues. This change removes build controller logs from appearing in Elastic Search.