### PR TITLE
Fail fast when images flags are not specified

### DIFF
--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package revision
 
 import (
-	"flag"
 	"strconv"
 
 	"github.com/elafros/elafros/pkg/apis/ela"
@@ -36,13 +35,7 @@ import (
 // non-default namespaces continue to work with autoscaling.
 const AutoscalerNamespace = "ela-system"
 
-var autoscalerImage string
-
-func init() {
-	flag.StringVar(&autoscalerImage, "autoscalerImage", "", "The digest of the autoscaler image.")
-}
-
-func MakeElaAutoscalerDeployment(u *v1alpha1.Revision) *v1beta1.Deployment {
+func MakeElaAutoscalerDeployment(u *v1alpha1.Revision, autoscalerImage string) *v1beta1.Deployment {
 	rollingUpdateConfig := v1beta1.RollingUpdateDeployment{
 		MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 		MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: 1},

--- a/pkg/controller/revision/ela_pod.go
+++ b/pkg/controller/revision/ela_pod.go
@@ -35,7 +35,7 @@ const (
 )
 
 // MakeElaPodSpec creates a pod spec.
-func MakeElaPodSpec(u *v1alpha1.Revision) *corev1.PodSpec {
+func MakeElaPodSpec(u *v1alpha1.Revision, queueSidecarImage string) *corev1.PodSpec {
 	elaContainer := u.Spec.Container.DeepCopy()
 	// Adding or removing an overwritten corev1.Container field here? Don't forget to
 	// update the validations in pkg/webhook.validateContainer.
@@ -100,7 +100,7 @@ func MakeElaPodSpec(u *v1alpha1.Revision) *corev1.PodSpec {
 	}
 
 	return &corev1.PodSpec{
-		Containers: []corev1.Container{*elaContainer, queueContainer},
+		Containers:         []corev1.Container{*elaContainer, queueContainer},
 		ServiceAccountName: u.Spec.ServiceAccountName,
 	}
 }

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -48,6 +48,8 @@ import (
 )
 
 const testNamespace string = "test"
+const testQueueImage string = "queueImage"
+const testAutoscalerImage string = "autoscalerImage"
 
 func getTestRevision() *v1alpha1.Revision {
 	return &v1alpha1.Revision{
@@ -183,6 +185,8 @@ func newTestController(t *testing.T, elaObjects ...runtime.Object) (
 		elaInformer,
 		&rest.Config{},
 		ctrl.Config{},
+		testQueueImage,
+		testAutoscalerImage,
 	).(*Controller)
 
 	return


### PR DESCRIPTION
Fixes #298

During the controller startup, images flags are validated. If ela-queue or
ela-autoscale image is not specified, exit immediately