### PR TITLE
Improve the quality of our comments on resources under pkg/apis/ela.

### DIFF
--- a/pkg/apis/ela/v1alpha1/configuration_types.go
+++ b/pkg/apis/ela/v1alpha1/configuration_types.go
@@ -53,9 +53,8 @@ type ConfigurationSpec struct {
 	// ObjectMeta.Generation instead.
 	Generation int64 `json:"generation,omitempty"`
 
-	// Build optionally holds the specification for the build to be
-	// performed to produce the container image referenced by the
-	// Revision's Container.
+	// Build optionally holds the specification for the build to
+	// perform to produce the Revision's container image.
 	Build *build.BuildSpec `json:"build,omitempty"`
 
 	// RevisionTemplate holds the latest specification for the Revision to

--- a/pkg/apis/ela/v1alpha1/revision_types.go
+++ b/pkg/apis/ela/v1alpha1/revision_types.go
@@ -48,7 +48,7 @@ type RevisionTemplateSpec struct {
 	Spec RevisionSpec `json:"spec,omitempty"`
 }
 
-// RevisionServingStateType is an enumeration of the levels of serving readiness into which the Revision may be put.
+// RevisionServingStateType is an enumeration of the levels of serving readiness of the Revision.
 // See also: https://github.com/elafros/elafros/blob/master/docs/spec/errors.md#error-conditions-and-reporting
 type RevisionServingStateType string
 
@@ -62,7 +62,8 @@ const (
 	RevisionServingStateReserve RevisionServingStateType = "Reserve"
 	// The revision has been decommissioned and is not needed to serve traffic
 	// anymore. It should not have any Istio routes or Kubernetes resources.
-	// A Revision may be brought out of retirement, but it may take longer.
+	// A Revision may be brought out of retirement, but it may take longer than
+	// it would from a "Reserve" state.
 	RevisionServingStateRetired RevisionServingStateType = "Retired"
 )
 
@@ -76,7 +77,7 @@ type RevisionSpec struct {
 
 	// ServingState holds a value describing the desired state the Kubernetes
 	// resources should be in for this Revision.
-	// Users may not specify this when creating a revision. It is expected
+	// Users must not specify this when creating a revision. It is expected
 	// that the system will manipulate this based on routability and load.
 	ServingState RevisionServingStateType `json:"servingState"`
 
@@ -90,7 +91,7 @@ type RevisionSpec struct {
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// BuildName optionally holds the name of the Build responsible for
-	// producing the container image for tis Revision.
+	// producing the container image for its Revision.
 	BuildName string `json:"buildName,omitempty"`
 
 	// Container defines the unit of execution for this Revision.
@@ -135,7 +136,6 @@ type RevisionCondition struct {
 
 // RevisionStatus communicates the observed state of the Revision (from the controller).
 type RevisionStatus struct {
-
 	// ServiceName holds the name of a core Kubernetes Service resource that
 	// load balances over the pods backing this Revision. When the Revision
 	// is Active, this service would be an appropriate ingress target for

--- a/pkg/apis/ela/v1alpha1/route_types.go
+++ b/pkg/apis/ela/v1alpha1/route_types.go
@@ -26,9 +26,11 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Route is responsible for configuring ingress over a collection of Revisions,
-// possibly by referencing the Configuration from which they are stamped out
-// and smoothly rolling out its "latest ready" Revision.
+// Route is responsible for configuring ingress over a collection of Revisions.
+// Some of the Revisions a Route distributes traffic over may be specified by
+// referencing the Configuration responsible for creating them; in these cases
+// the Route is additionally responsible for monitoring the Configuration for
+// "latest ready" revision changes, and smoothly rolling out latest revisions.
 // See also: https://github.com/elafros/elafros/blob/master/docs/spec/overview.md#route
 type Route struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -53,15 +55,16 @@ type TrafficTarget struct {
 	// +optional
 	RevisionName string `json:"revisionName,omitempty"`
 
-	// ConfigurationName of a configuration to whose latest revision we will send this portion of traffic.
-	// When the "status.latestReadyRevisionName" of the referenced configuration changes we will automatically
-	// migrate traffic from the prior "latest ready" revision to the new one.
+	// ConfigurationName of a configuration to whose latest revision we will send
+	// this portion of traffic. When the "status.latestReadyRevisionName" of the
+	// referenced configuration changes, we will automatically migrate traffic
+	// from the prior "latest ready" revision to the new one.
 	// This field is never set in Route's status, only its spec.
 	// This is mutually exclusive with RevisionName.
 	// +optional
 	ConfigurationName string `json:"configurationName,omitempty"`
 
-	// Percent specifies percent of the traffic to this Revision or Configuration
+	// Percent specifies percent of the traffic to this Revision or Configuration.
 	// This defaults to zero if unspecified.
 	Percent int `json:"percent"`
 }


### PR DESCRIPTION
This does a pass to improve the documentation on our Go types wherever possible, and cross-link to relevant portions of our specification in a few places.

Fixes: https://github.com/elafros/elafros/issues/650