### PR TITLE
Update the API spec and overview to reflect ServingState intent.

### DIFF
--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -61,17 +61,16 @@ and makes both the most recently created and most recently *ready*
 
 The system will be configured to disallow users from creating
 ([NYI](https://github.com/elafros/elafros/issues/664)) or changing
-Revisions. Instead, the creation of immutable Revisions through a
-Configuration provides:
+Revisions. Instead, Revisions are created indirectly when a Configuration
+is created or updated. This provides:
 
 * a single referenceable resource for the route to perform automated
   rollouts
 * a single resource that can be watched to see a history of all the
   revisions created
-* (but doesn’t mandate) PATCH semantics for new revisions to be done
-  on the server, minimizing read-modify-write implemented across
-  multiple clients, which could result in optimistic concurrency
-  errors
+* PATCH semantics for revisions implemented server-side, minimizing
+  read-modify-write implemented across multiple clients, which could result
+  in optimistic concurrency errors
 * the ability to rollback to a known good configuration
 
 In the conventional single live revision scenario, a route has a

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -227,7 +227,7 @@ spec:
 
   container:  # corev1.Container
     # We disallow the following fields from corev1.Container:
-    #  name, resources, prots, and volumeMounts
+    #  name, resources, ports, and volumeMounts
     image: gcr.io/...
     command: ['run']
     args: []
@@ -250,9 +250,13 @@ spec:
   servingState: Active | Reserve | Retired
 
   # NYI: https://github.com/elafros/elafros/issues/456
+  # Some function or server frameworks or application code may be written to
+  # expect that each request will be granted a single-tenant process to run
+  # (i.e. that the request code is run single-threaded).
   concurrencyModel: ...
 
   # NYI: https://github.com/elafros/elafros/issues/457
+  # Many higher-level systems impose a per-request response deadline.
   timeoutSeconds: ...
 
 status:


### PR DESCRIPTION
I've reworded the description of a Revision in the overview docs to capture some of the key lifecycle stages a revision may be in.  I also found the existing wording confusing, since it talked about "history", which is more a property of configuration that is enabled by retirement, and I think the new wording better captures this.

I've updated the specification to include `servingState`, clarify where fields aren't available (pointing to issues), and tweak assorted cosmetic things (e.g. trailing whitespace).

Fixes: https://github.com/elafros/elafros/issues/644