### PR TITLE
Add some triage options to issue template.

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,3 +1,30 @@
+<!--
+Uncomment leaving one or more of the following to ensure that the appropriate
+working groups are aware of the issue:
+
+/label area/API
+/label area/autoscale
+/label area/build
+/label area/monitoring
+/label area/networking
+/label area/test-and-release
+-->
+
+<!--
+Uncomment leaving one or more of the following to classify the type of issue:
+
+/label bug
+/label dev
+/label doc
+-->
+
+<!--
+You may also do one of the following:
+
+/assign @user
+
+-->
+
 ## Expected Behavior
 
 


### PR DESCRIPTION
This updates the issue template to encourage a bit more triage (via Prow) by folks opening issues.
