### PR TITLE
Add a createRevision helper method in the revision controller test

### DIFF
--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -226,7 +226,7 @@ func compareRevisionConditions(want []v1alpha1.RevisionCondition, got []v1alpha1
 }
 
 func createRevision(elaClient *fakeclientset.Clientset, elaInformer informers.SharedInformerFactory, controller *Controller, rev *v1alpha1.Revision) {
-	elaClient.ElafrosV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ElafrosV1alpha1().Revisions(rev.Namespace).Create(rev)
 	// Since syncHandler looks in the lister, we need to add it to the informer
 	elaInformer.Elafros().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
 


### PR DESCRIPTION
This refactors some code that is seen everywhere in the test into its
own helper method to reduce duplicated code and make it easier to
understand.

The createRevision method creates a revision in the elaClient, adds it
to the elaInformer, and runs a sync on the controller.

```release-note
NONE
```
