### PR TITLE
Add an 'app:revName' label to Deployment when 'app:*' label not specified.

### DIFF
--- a/pkg/controller/revision/ela_autoscaler.go
+++ b/pkg/controller/revision/ela_autoscaler.go
@@ -35,6 +35,8 @@ import (
 // non-default namespaces continue to work with autoscaling.
 const AutoscalerNamespace = "ela-system"
 
+// MakeElaAutoscalerDeployment creates the deployment of the
+// autoscaler for a particular revision.
 func MakeElaAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string) *v1beta1.Deployment {
 	rollingUpdateConfig := v1beta1.RollingUpdateDeployment{
 		MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
@@ -110,6 +112,8 @@ func MakeElaAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string)
 	}
 }
 
+// MakeElaAutoscalerService returns a service for the autoscaler of
+// the given revision.
 func MakeElaAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/pkg/controller/revision/ela_resource.go
+++ b/pkg/controller/revision/ela_resource.go
@@ -9,25 +9,23 @@ const appLabelKey = "app"
 
 // MakeElaResourceLabels constructs the labels we will apply to K8s resources.
 func MakeElaResourceLabels(revision *v1alpha1.Revision) map[string]string {
-	labels := make(map[string]string, len(revision.ObjectMeta.Labels)+1)
+	labels := make(map[string]string, len(revision.ObjectMeta.Labels)+2)
 	labels[ela.RevisionLabelKey] = revision.Name
 
-	hasAppLabel := false
 	for k, v := range revision.ObjectMeta.Labels {
 		labels[k] = v
-		if k == appLabelKey {
-			hasAppLabel = true
-		}
 	}
 	// If users don't specify an app: label we will automatically
 	// populate it with the revision name to get the benefit of richer
 	// tracing information.
-	if !hasAppLabel {
+	if _, ok := labels[appLabelKey]; !ok {
 		labels[appLabelKey] = revision.Name
 	}
 	return labels
 }
 
+// MakeElaResourceAnnotations creates the annotations we will apply to
+// child resource of the given revision.
 func MakeElaResourceAnnotations(revision *v1alpha1.Revision) map[string]string {
 	annotations := make(map[string]string, len(revision.ObjectMeta.Annotations)+1)
 	for k, v := range revision.ObjectMeta.Annotations {


### PR DESCRIPTION
This gives the benefit of adding richer tracing information for
Istio even if users haven't set the 'app:' labels of their own.

Fixes #530 