### PR TITLE
Fix the issue template to use the appropriate syntax.

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -2,27 +2,19 @@
 Uncomment leaving one or more of the following to ensure that the appropriate
 working groups are aware of the issue:
 
-/label area/API
-/label area/autoscale
-/label area/build
-/label area/monitoring
-/label area/networking
-/label area/test-and-release
+/area API
+/area autoscale
+/area build
+/area monitoring
+/area networking
+/area test-and-release
+
 -->
 
 <!--
-Uncomment leaving one or more of the following to classify the type of issue:
-
-/label bug
-/label dev
-/label doc
--->
-
-<!--
-You may also do one of the following:
+You may also assign an issue via:
 
 /assign @user
-
 -->
 
 ## Expected Behavior


### PR DESCRIPTION
See: https://github.com/elafros/elafros/issues/675

I will look into an appropriate syntax for bug/doc/dev, but this may entail renaming the labels.