### PR TITLE
Make package name consistent with dir.

### DIFF
--- a/pkg/apis/build/register.go
+++ b/pkg/apis/build/register.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudbuild
+package build
 
 const (
 	GroupName = "build.dev"

--- a/pkg/client/informers/externalversions/ela/interface.go
+++ b/pkg/client/informers/externalversions/ela/interface.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package elafros
+package ela
 
 import (
 	v1alpha1 "github.com/elafros/elafros/pkg/client/informers/externalversions/ela/v1alpha1"

--- a/pkg/client/informers/externalversions/istio/interface.go
+++ b/pkg/client/informers/externalversions/istio/interface.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package config
+package istio
 
 import (
 	internalinterfaces "github.com/elafros/elafros/pkg/client/informers/externalversions/internalinterfaces"


### PR DESCRIPTION
The names of these dirs and packages did not match, so this commit
changes the name of the package to be consistent for any sort of tooling that
expects these things to be consistent >.>
## Proposed Changes
  * Change the cloudbuild package to be called build, like the dir it is in.
  * Change the elafros package to be ela
  * Change the config package to be istio

**Release Note**
NONE