### PR TITLE
Autogo demo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,3 +107,13 @@ repositories()
 load(":ca_bundle.bzl", "cluster_ca_bundle")
 
 cluster_ca_bundle(name = "cluster_ca_bundle")
+
+git_repository(
+    name="fejta_autogo",
+    remote="https://github.com/fejta/test-infra.git",
+    commit="fdeeb70b2af50fbc6503dd47ebdced5e8e73cebd",
+)
+load("@fejta_autogo//autogo:deps.bzl", "autogo_dependencies")
+autogo_dependencies()
+load("@fejta_autogo//autogo:def.bzl", "autogo_generate")
+autogo_generate(name="autogo", prefix="github.com/elafros/elafros")


### PR DESCRIPTION
/assign @mattmoor @adrcunha @bobcatfish 

`bazel build -- @autogo//... -@autogo//vendor/...`

```
fejta@fejta1:~/test/elafros$ bazel build -- @autogo//... -@autogo//vendor/...
DEBUG: /usr/local/google/home/fejta/.cache/bazel/_bazel_fejta/8f92d5a822c0e6c47becb65cf5cd2c00/external/fejta_autogo/autogo/def.bzl:16:3: Generating rules for github.com/elafros/elafros...
DEBUG: /usr/local/google/home/fejta/.cache/bazel/_bazel_fejta/8f92d5a822c0e6c47becb65cf5cd2c00/external/fejta_autogo/autogo/deps.bzl:10:5: Detected @io_bazel_rules_go
INFO: Analysed 69 targets (0 packages loaded).
INFO: Found 69 targets...
INFO: Elapsed time: 53.018s, Critical Path: 40.49s
INFO: Build completed successfully, 571 total actions
```


How does this effect `bazel build`?
* It has no impact if you do `bazel build //...`
* It does allow you to say `@autogo//some/go/pkg` instead of `//some/go/pkg`, which will build even if there is no `some/go/pkg/BUILD` file.

If we try this out and if people like it, we could consider deleting any rule produced by gazelle from the repo.

How does this effect `go get`?
* It doesn't, as this doesn't delete any files.
* Even if we delete BUILD files, `go get` doesn't care about BUILD files.