### PR TITLE
Update autoscaling 2018 roadmap

### DIFF
--- a/pkg/autoscaler/roadmap-2018.md
+++ b/pkg/autoscaler/roadmap-2018.md
@@ -22,34 +22,35 @@ In 2018 we will focus primarily on making autoscaling correct, fast and light.
 
 ### Correctness
 
-1. **Write autoscaler conformance tests** to cover low-scale regressions, runnable by individual developers before checkin.
-2. **Test error rates at high scale** to cover regressions at larger scales (~1000 QPS and ~1000 clients).
-3. **Test error rates around idle states** to cover various scale-to-zero edge cases.
+1. **Write autoscaler end-to-end tests** to cover low-scale regressions, runnable by individual developers before checkin. ([#420](https://github.com/elafros/elafros/issues/420))
+2. **Test error rates at high scale** to cover regressions at larger scales (~1000 QPS and ~1000 clients). ([#421](https://github.com/elafros/elafros/issues/421))
+3. **Test error rates around idle states** to cover various scale-to-zero edge cases. ([#422](https://github.com/elafros/elafros/issues/422))
 
 ### Performance
 
 1. **Establish canonical load test scenarios** to prove autoscaler performance and guide development.  We need to establish the code to run, the request load to generate, and the performance expected.  This will tell us where we need to improve.
-2. **Reproducable load tests** which can be run by anyone with minimal setup.  These must be transparent and easy to run.  They must be meaningful tests which prove autoscaler performance.
+2. **Reproducable load tests** which can be run by anyone with minimal setup.  These must be transparent and easy to run.  They must be meaningful tests which prove autoscaler performance. ([#424](https://github.com/elafros/elafros/pull/424))
+3. **Vertical pod autoscaling** to allow revisions to adapt the differing requirements of user's code.  Rather than applying the same resource requests to all revision deployments, use vertical pod autoscaler (or something) to adjust the resources required.  Resource requirements for one revision should be inherited by the next revision so there isn't always a learning period with new revisions.
 
 ### Scale to Zero
 
-1. **Reduce Reserve Revision start time** from 4 seconds to 1 second or less.  Maybe we can keep some resources around like the Replica Set or pre-cache images so that Pods are spun up faster.
+1. **Implement scale to zero**.  Revisions should autoamtically scale to zero after a period of inactivity.  And scale back up from zero to one with the first request.  The first requests should succeed (even if latency is high) and then latency should return to normal levels once the revision is active.
+2. **Reduce Reserve Revision start time** from 4 seconds to 1 second or less.  Maybe we can keep some resources around like the Replica Set or pre-cache images so that Pods are spun up faster.
 
 ### Development
 
-1. **Custom resource definition and controller** to encapsulate the autoscaling implementation.  This will let autoscaling evolve independently from the Revision custom resource and controller.  This makes development more independent and scalable.
+1. **Decouple autoscaling from revision controller** to allow the two to evolve separately.  The revision controller should not be setting up the autoscaler deployment and service.
 
 ### Integration
 
-1. **Autoscaler multitenancy** will allow the autoscaler to remain "always on".  It will also reduce the overhead of running 1 single-tenant autoscaler pod per revision.
+1. **Autoscaler multitenancy** will allow the autoscaler to remain "always on".  It will also reduce the overhead of running one single-tenant autoscaler pod per revision.
 2. **Consume custom metrics API** as an abstraction to allow pluggability.  This may require another metrics aggregation component to get the queue-proxy produced concurrency metrics behind a custom metrics API.  It will also allow autoscaling based on Prometheus metrics through an adapter.  A good acceptance criteria is the ability to plug in the vanilla Horizontal Pod Autoscaler (HPA) in lieu of the Elafros autoscaler (minus scale-to-zero capabilities).
 3. **Autoscale queue-based workloads** in addition to request/reply workloads.  The first use-case is the integration of Riff autoscaling into the multitenant autoscaler.  The autoscaler must be able to select the appropriate strategy for scaling the revision.
 
-## What We Are Not Doing
+## What We Are Not Doing Yet
 
 These are things we are explicitly leaving off the roadmap.  But we might do exploratory work to set them up for later development.  Most of these are related to Design Goal #3: *make everything better*.
 
 1. **Use Envoy for single-threading** instead of using the Queue Proxy to enforce serialization of requests to the application container.  This only applies in single-threaded mode.  It would allow us to remove the Queue Proxy entirely.  But it would probably require feature work in Envoy/Istio.
 2. **Remove metrics reporting from the Queue Proxy** in order to rely on a common, Elafros metrics pipeline.  This could mean polling the Pods to get the same metrics as are reported to Prometheus.  Or going to Prometheus to get the metrics it has aggregated.  It means removing the metrics push from the [Queue Proxy to the Autoscaler](README.md#context).
-3. **[Slow Brain](README.md#slow-brain--fast-brain) implementation** to automatically adjust autoscaling parameters to the application's behavior.
-
+3. **[Slow Brain](README.md#slow-brain--fast-brain) implementation** to automatically adjust target concurrency to the application's behavior.  Instead, we can rely on vertical pod autoscaling for now to size the pod to an average of one request at a time.


### PR DESCRIPTION
## Proposed Changes

  * Bring autoscaler multitenancy into scope.
  * Bring supporting HPA into scope.
  * Remove slow brain from scope.
  * Add vertical pod autoscaling.

**Release Note**
```release-note
NONE
```
