### PR TITLE
Fix the race condition in Configuration updates

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -82,7 +82,7 @@ function teardown() {
 function wait_for_elafros() {
   echo -n "Waiting for Elafros to come up"
   for i in {1..150}; do  # timeout after 5 minutes
-    if [[ $(kubectl -n ela-system get pods | grep "Running" | wc -l) == 2 ]]; then
+    if [[ $(kubectl -n ela-system get pods | grep "Running" | wc -l) == 3 ]]; then
       echo -e "\nElafros is up:"
       kubectl -n ela-system get pods
       return 0


### PR DESCRIPTION
Fixes #710

This fixes the irreconcilable state issue due to a race condition
in configuration updates from route controller and configuration
controller. If route controller succeeds in updating the configuration
first, it gets into a state where revision is created but configuration
status is not updated. This causes the synchandler to return error each
time when it is called.
