### PR TITLE
Fix the race condition in Configuration updates

### DIFF
--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -18,7 +18,6 @@ package configuration
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/elafros/elafros/pkg/controller"
@@ -296,43 +295,54 @@ func (c *Controller) syncHandler(key string) error {
 		spec.BuildName = created.Name
 	}
 
-	rev := &v1alpha1.Revision{
-		ObjectMeta: config.Spec.RevisionTemplate.ObjectMeta,
-		Spec:       spec,
-	}
 	revName, err := generateRevisionName(config)
 	if err != nil {
 		return err
 	}
-	// TODO: Should this just use rev.ObjectMeta.GenerateName =
-	rev.ObjectMeta.Name = revName
-	// Can't generate objects in a different namespace from what the call is made against,
-	// so use the namespace of the configuration that's being updated for the Revision being
-	// created.
-	rev.ObjectMeta.Namespace = config.Namespace
 
-	if rev.ObjectMeta.Labels == nil {
-		rev.ObjectMeta.Labels = make(map[string]string)
-	}
-	rev.ObjectMeta.Labels[ela.ConfigurationLabelKey] = config.Name
-
-	if rev.ObjectMeta.Annotations == nil {
-		rev.ObjectMeta.Annotations = make(map[string]string)
-	}
-	rev.ObjectMeta.Annotations[ela.ConfigurationGenerationAnnotationKey] = fmt.Sprintf("%v", config.Spec.Generation)
-
-	// Delete revisions when the parent Configuration is deleted.
-	rev.OwnerReferences = append(rev.OwnerReferences, *controllerRef)
-
-	created, err := c.elaclientset.ElafrosV1alpha1().Revisions(config.Namespace).Create(rev)
+	revClient := c.elaclientset.ElafrosV1alpha1().Revisions(config.Namespace)
+	created, err := revClient.Get(revName, metav1.GetOptions{})
 	if err != nil {
-		glog.Errorf("Failed to create Revision:\n%+v\n%s", rev, err)
-		c.recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision %q: %v", rev.Name, err)
-		return err
-	}
-	c.recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Revision %q", rev.Name)
-	glog.Infof("Created Revision:\n%+v", created)
+		if !errors.IsNotFound(err) {
+			glog.Errorf("Revisions Get for %q failed: %s", revName, err)
+			return err
+		}
 
+		rev := &v1alpha1.Revision{
+			ObjectMeta: config.Spec.RevisionTemplate.ObjectMeta,
+			Spec:       spec,
+		}
+		// TODO: Should this just use rev.ObjectMeta.GenerateName =
+		rev.ObjectMeta.Name = revName
+		// Can't generate objects in a different namespace from what the call is made against,
+		// so use the namespace of the configuration that's being updated for the Revision being
+		// created.
+		rev.ObjectMeta.Namespace = config.Namespace
+
+		if rev.ObjectMeta.Labels == nil {
+			rev.ObjectMeta.Labels = make(map[string]string)
+		}
+		rev.ObjectMeta.Labels[ela.ConfigurationLabelKey] = config.Name
+
+		if rev.ObjectMeta.Annotations == nil {
+			rev.ObjectMeta.Annotations = make(map[string]string)
+		}
+		rev.ObjectMeta.Annotations[ela.ConfigurationGenerationAnnotationKey] = fmt.Sprintf("%v", config.Spec.Generation)
+
+		// Delete revisions when the parent Configuration is deleted.
+		rev.OwnerReferences = append(rev.OwnerReferences, *controllerRef)
+
+		created, err = revClient.Create(rev)
+		if err != nil {
+			glog.Errorf("Failed to create Revision:\n%+v\n%s", rev, err)
+			c.recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision %q: %v", rev.Name, err)
+			return err
+		}
+		c.recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Revision %q", rev.Name)
+		glog.Infof("Created Revision:\n%+v", created)
+	} else {
+		glog.Infof("Revision already created %s: %s", created.ObjectMeta.Name, err)
+	}
 	// Update the Status of the configuration with the latest generation that
 	// we just reconciled against so we don't keep generating revisions.
 	// Also update the LatestCreatedRevisionName so that we'll know revision to check
@@ -340,10 +350,10 @@ func (c *Controller) syncHandler(key string) error {
 	config.Status.LatestCreatedRevisionName = created.ObjectMeta.Name
 	config.Status.ObservedGeneration = config.Spec.Generation
 
-	log.Printf("Updating the configuration status:\n%+v", config)
+	glog.Infof("Updating the configuration status:\n%+v", config)
 
 	if _, err = c.updateStatus(config); err != nil {
-		log.Printf("Failed to update the configuration %s", err)
+		glog.Errorf("Failed to update the configuration %s", err)
 		return err
 	}
 


### PR DESCRIPTION
Fixes #710

This fixes the irreconcilable state issue due to a race condition
in configuration updates from route controller and configuration
controller. If route controller succeeds in updating the configuration
first, it gets into a state where revision is created but configuration
status is not updated. This causes the synchandler to return error each
time when it is called.
