### PR TITLE
Initial script to deploy Elafros

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -115,5 +115,6 @@ kubectl apply -f ${ELAFROS_RELEASE} || true
 kubectl apply -f ${ELAFROS_RELEASE}
 
 wait_until_running ela-system
+wait_until_running build-system
 
 header "Elafros deployed successfully to ${K8S_CLUSTER_NAME}"


### PR DESCRIPTION
This script creates/replaces a k8s cluster and deploys the latest Elafros to it.

Elafros images are not built from source, but fetched from gcr.io/elafros-releases instead.

Documentation will be added once the weekly prow job is properly setup and running.