### PR TITLE
Temporarily disable the autoscaling E2E tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -386,8 +386,9 @@ kubectl label namespace default istio-injection=enabled
 
 run_hello_world
 exit_if_failed
-test_autoscale
-exit_if_failed
+# TODO(adrcunha): Reenable once https://github.com/elafros/elafros/issues/739 is fixed.
+# test_autoscale
+# exit_if_failed
 run_conformance_tests
 exit_if_failed
 


### PR DESCRIPTION
Lately, the autoscaling E2E started failing too often, blocking presubmits.

For details, see https://github.com/elafros/elafros/issues/739.