### PR TITLE
Changing autoscaler e2e test to use a more CPU intensive app

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -139,12 +139,13 @@ function exit_if_failed() {
   exit 1
 }
 
-function wait_for_hello_world_ingress() {
+function wait_for_ingress() {
+  local ingress_name=$1
   for i in {1..150}; do  # timeout after 5 minutes
     echo "Waiting for Ingress to come up"
-    if [[ $(kubectl get ingress | grep example | wc -w) == 5 ]]; then
-      service_host=$(kubectl get route route-example -o jsonpath="{.status.domain}")
-      service_ip=$(kubectl get ingress route-example-ela-ingress -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}")
+    if [[ $(kubectl get ingress | grep $ingress_name | wc -w) == 5 ]]; then
+      service_host=$(kubectl get route $ingress_name -o jsonpath="{.status.domain}")
+      service_ip=$(kubectl get ingress $ingress_name-ela-ingress -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}")
       echo -e -n "Ingress is at $service_ip / $service_host\n"
       return 0
     fi
@@ -168,7 +169,7 @@ function run_hello_world() {
   bazel run //sample/helloworld:everything.create || return 1
   local service_host=""
   local service_ip=""
-  if ! wait_for_hello_world_ingress;then
+  if ! wait_for_ingress "route-example";then
     echo "ERROR: No ingress, stopping test."
     bazel run //sample/helloworld:everything.delete  # ignore errors
     return 1
@@ -184,14 +185,14 @@ function run_hello_world() {
 }
 
 function test_autoscale() {
-  header "Running hello-world and ramping up/down traffic."
-  bazel run //sample/helloworld:everything.create || return 1
+  header "Running autoscaler sample and ramping up/down traffic."
+  bazel run //sample/autoscale:everything.create || return 1
   local service_host=""
   local service_ip=""
 
-  if ! wait_for_hello_world_ingress;then
+  if ! wait_for_ingress "autoscale-route";then
     echo "ERROR: No ingress, stopping test."
-    bazel run //sample/helloworld:everything.delete  # ignore errors
+    bazel run //sample/autoscale:everything.delete  # ignore errors
     return 1
   fi
 
@@ -218,9 +219,9 @@ function test_autoscale() {
 }
 
 function test_scale_up_autoscaler() {
-  # Queue up 128 simultaneous calls to hello world app.
-  local command='curl --header "Host:$service_host" http://${service_ip} >/dev/null  2>&1 & '
-  for i in {1..7};do
+  # Queue up 8 simultaneous calls to prime-number finding app.
+  local command='curl --header "Host:$service_host" http://${service_ip}/primes/40000000 >/dev/null  2>&1 & '
+  for i in {1..3};do
     command+=$command
   done
   eval $command
@@ -386,10 +387,9 @@ kubectl label namespace default istio-injection=enabled
 
 run_hello_world
 exit_if_failed
-# TODO(adrcunha): Reenable once https://github.com/elafros/elafros/issues/739 is fixed.
-# test_autoscale
-# exit_if_failed
 run_conformance_tests
+exit_if_failed
+test_autoscale
 exit_if_failed
 
 # kubetest teardown might fail and thus incorrectly report failure of the


### PR DESCRIPTION
Fixes #739

## Proposed Changes

  * Use the autoscaler app instead of hello world in the autoscaler E2E test.

**Release Note**
NONE

