### PR TITLE
Fix node exporter dashboard

### DIFF
--- a/config/monitoring/prometheus-servicemonitor/BUILD
+++ b/config/monitoring/prometheus-servicemonitor/BUILD
@@ -65,7 +65,7 @@ k8s_objects(
         ":kube-scheduler",
         ":kube-state-metrics",
         ":kubelet",
-        "//third_party/config/monitoring/prometheus-operator/node-exporter:node-exporter",
+        "//third_party/config/monitoring/prometheus-operator/node-exporter:node-exporter-monitor",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Recent changes to move to third_party folder broke node dashboards. This fixes the issue by installing the correct YAML file.