### PR TITLE
Disable autoscaler tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -389,8 +389,11 @@ run_hello_world
 exit_if_failed
 run_conformance_tests
 exit_if_failed
-test_autoscale
-exit_if_failed
+
+# These tests are currently failing intermittently for reasons that seem to be
+# unrelated to the PRs they are testing, investigating in https://github.com/elafros/elafros/issues/751
+# test_autoscale
+# exit_if_failed
 
 # kubetest teardown might fail and thus incorrectly report failure of the
 # script, even if the tests pass.


### PR DESCRIPTION
The autoscaler tests were recently improved to work against a beefier
cluster (https://github.com/elafros/elafros/issues/739) but
unfortunately since they were merged they have failed several times
against PRs (one of which was just a doc change).

Our tests have been flakey for a while now, which is motivating folks to
(understandably) ignore their failures and rerun the tests instead of
looking into them, so this commit disabled the autoscaler tests until
they become a more reliable signal, in the hopes that folks can learn to
trust the tests again.

https://github.com/elafros/elafros/issues/751 is about fixing this and re-enabling the tests.

## Proposed Changes

  * Disable autoscaler e2e tests until they are stable

```release-note
NONE
```
