### PR TITLE
Enables status subresource in order to fix generation bumping

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -681,6 +681,7 @@
 [[projects]]
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",

--- a/config/300-configuration.yaml
+++ b/config/300-configuration.yaml
@@ -23,3 +23,5 @@ spec:
     kind: Configuration
     plural: configurations
   scope: Namespaced
+  subresources:
+    status: {}

--- a/config/300-revision.yaml
+++ b/config/300-revision.yaml
@@ -23,3 +23,5 @@ spec:
     kind: Revision
     plural: revisions
   scope: Namespaced
+  subresources:
+    status: {}

--- a/config/300-route.yaml
+++ b/config/300-route.yaml
@@ -23,3 +23,5 @@ spec:
     kind: Route
     plural: routes
   scope: Namespaced
+  subresources:
+    status: {}

--- a/config/300-service.yaml
+++ b/config/300-service.yaml
@@ -23,3 +23,5 @@ spec:
     kind: Service
     plural: services
   scope: Namespaced
+  subresources:
+    status: {}

--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -36,6 +36,7 @@ To use a k8s cluster running in GKE:
       --scopes=cloud-platform \
       --machine-type=n1-standard-4 \
       --enable-autoscaling --min-nodes=1 --max-nodes=3 \
+      --enable-kubernetes-alpha \
       knative-demo
     ```
 
@@ -45,6 +46,7 @@ To use a k8s cluster running in GKE:
     *   Knative Serving currently requires 4-cpu nodes to run conformance tests.
         Changing the machine type from the default may cause failures.
     *   Autoscale from 1 to 3 nodes. Adjust this for your use case
+    *   Kubernetes alpha features are required to enable the `CustomResourceSubresources` feature.
     *   Change this to your preferred cluster name
 
     You can see the list of supported cluster versions in a particular zone by

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -47,12 +47,6 @@ type Configuration struct {
 
 // ConfigurationSpec holds the desired state of the Configuration (from the client).
 type ConfigurationSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
-	Generation int64 `json:"generation,omitempty"`
-
 	// Build optionally holds the specification for the build to
 	// perform to produce the Revision's container image.
 	Build *build.BuildSpec `json:"build,omitempty"`
@@ -120,14 +114,6 @@ type ConfigurationList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []Configuration `json:"items"`
-}
-
-func (r *Configuration) GetGeneration() int64 {
-	return r.Spec.Generation
-}
-
-func (r *Configuration) SetGeneration(generation int64) {
-	r.Spec.Generation = generation
 }
 
 func (r *Configuration) GetSpecJSON() ([]byte, error) {

--- a/pkg/apis/serving/v1alpha1/configuration_types_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types_test.go
@@ -18,18 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestConfigurationGeneration(t *testing.T) {
-	config := Configuration{}
-	if e, a := int64(0), config.GetGeneration(); e != a {
-		t.Errorf("empty revision generation should be 0 was: %d", a)
-	}
-
-	config.SetGeneration(5)
-	if e, a := int64(5), config.GetGeneration(); e != a {
-		t.Errorf("getgeneration mismatch expected: %d got: %d", e, a)
-	}
-}
-
 func TestConfigurationIsReady(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -85,12 +85,6 @@ const (
 
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
-	Generation int64 `json:"generation,omitempty"`
-
 	// ServingState holds a value describing the desired state the Kubernetes
 	// resources should be in for this Revision.
 	// Users must not specify this when creating a revision. It is expected
@@ -189,14 +183,6 @@ type RevisionList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []Revision `json:"items"`
-}
-
-func (r *Revision) GetGeneration() int64 {
-	return r.Spec.Generation
-}
-
-func (r *Revision) SetGeneration(generation int64) {
-	r.Spec.Generation = generation
 }
 
 func (r *Revision) GetSpecJSON() ([]byte, error) {

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -19,19 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestGeneration(t *testing.T) {
-	r := Revision{}
-	if a := r.GetGeneration(); a != 0 {
-		t.Errorf("empty revision generation should be 0 was: %d", a)
-	}
-
-	r.SetGeneration(5)
-	if e, a := int64(5), r.GetGeneration(); e != a {
-		t.Errorf("getgeneration mismatch expected: %d got: %d", e, a)
-	}
-
-}
-
 func TestIsReady(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -71,12 +71,6 @@ type TrafficTarget struct {
 
 // RouteSpec holds the desired state of the Route (from the client).
 type RouteSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
-	Generation int64 `json:"generation,omitempty"`
-
 	// Traffic specifies how to distribute traffic over a collection of Knative Serving Revisions and Configurations.
 	Traffic []TrafficTarget `json:"traffic,omitempty"`
 }
@@ -139,14 +133,6 @@ type RouteList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []Route `json:"items"`
-}
-
-func (r *Route) GetGeneration() int64 {
-	return r.Spec.Generation
-}
-
-func (r *Route) SetGeneration(generation int64) {
-	r.Spec.Generation = generation
 }
 
 func (r *Route) GetSpecJSON() ([]byte, error) {

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -36,14 +36,8 @@ type Service struct {
 }
 
 // ServiceSpec represents the configuration for the Service object.
-// Exactly one of its members (other than Generation) must be specified.
+// Exactly one of its members must be specified.
 type ServiceSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
-	Generation int64 `json:"generation,omitempty"`
-
 	// RunLatest defines a simple Service. It will automatically
 	// configure a route that keeps the latest ready revision
 	// from the supplied configuration running.
@@ -106,14 +100,6 @@ type ServiceList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []Service `json:"items"`
-}
-
-func (s *Service) GetGeneration() int64 {
-	return s.Spec.Generation
-}
-
-func (s *Service) SetGeneration(generation int64) {
-	s.Spec.Generation = generation
 }
 
 func (s *Service) GetSpecJSON() ([]byte, error) {

--- a/pkg/apis/serving/v1alpha1/service_types_test.go
+++ b/pkg/apis/serving/v1alpha1/service_types_test.go
@@ -13,173 +13,160 @@ limitations under the License.
 package v1alpha1
 
 import (
-  "testing"
+	"testing"
 
-  corev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func TestServiceGeneration(t *testing.T) {
-  service := Service{}
-  if got, want := service.GetGeneration(), int64(0); got != want {
-    t.Errorf("Empty Service generation should be %d, was %d", want, got)
-  }
-
-  answer := int64(42)
-  service.SetGeneration(answer)
-  if got := service.GetGeneration(); got != answer {
-    t.Errorf("GetGeneration mismatch; got %d, want %d", got, answer)
-  }
-}
-
 func TestServiceIsReady(t *testing.T) {
-  cases := []struct {
-    name    string
-    status  ServiceStatus
-    isReady bool
-  }{
-    {
-      name:    "empty status should not be ready",
-      status:  ServiceStatus{},
-      isReady: false,
-    },
-    {
-      name: "Different condition type should not be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type:   "Foo",
-            Status: corev1.ConditionTrue,
-          },
-        },
-      },
-      isReady: false,
-    },
-    {
-      name: "False condition status should not be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type:   ServiceConditionReady,
-            Status: corev1.ConditionFalse,
-          },
-        },
-      },
-      isReady: false,
-    },
-    {
-      name: "Unknown condition status should not be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type:   ServiceConditionReady,
-            Status: corev1.ConditionUnknown,
-          },
-        },
-      },
-      isReady: false,
-    },
-    {
-      name: "Missing condition status should not be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type: ServiceConditionReady,
-          },
-        },
-      },
-      isReady: false,
-    },
-    {
-      name: "True condition status should be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type:   ServiceConditionReady,
-            Status: corev1.ConditionTrue,
-          },
-        },
-      },
-      isReady: true,
-    },
-    {
-      name: "Multiple conditions with ready status should be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type:   "Foo",
-            Status: corev1.ConditionTrue,
-          },
-          {
-            Type:   ServiceConditionReady,
-            Status: corev1.ConditionTrue,
-          },
-        },
-      },
-      isReady: true,
-    },
-    {
-      name: "Multiple conditions with ready status false should not be ready",
-      status: ServiceStatus{
-        Conditions: []ServiceCondition{
-          {
-            Type:   "Foo",
-            Status: corev1.ConditionTrue,
-          },
-          {
-            Type:   ServiceConditionReady,
-            Status: corev1.ConditionFalse,
-          },
-        },
-      },
-      isReady: false,
-    },
-  }
+	cases := []struct {
+		name    string
+		status  ServiceStatus
+		isReady bool
+	}{
+		{
+			name:    "empty status should not be ready",
+			status:  ServiceStatus{},
+			isReady: false,
+		},
+		{
+			name: "Different condition type should not be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type:   "Foo",
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+			isReady: false,
+		},
+		{
+			name: "False condition status should not be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type:   ServiceConditionReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+			isReady: false,
+		},
+		{
+			name: "Unknown condition status should not be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type:   ServiceConditionReady,
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+			isReady: false,
+		},
+		{
+			name: "Missing condition status should not be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type: ServiceConditionReady,
+					},
+				},
+			},
+			isReady: false,
+		},
+		{
+			name: "True condition status should be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type:   ServiceConditionReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+			isReady: true,
+		},
+		{
+			name: "Multiple conditions with ready status should be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type:   "Foo",
+						Status: corev1.ConditionTrue,
+					},
+					{
+						Type:   ServiceConditionReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+			isReady: true,
+		},
+		{
+			name: "Multiple conditions with ready status false should not be ready",
+			status: ServiceStatus{
+				Conditions: []ServiceCondition{
+					{
+						Type:   "Foo",
+						Status: corev1.ConditionTrue,
+					},
+					{
+						Type:   ServiceConditionReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+			isReady: false,
+		},
+	}
 
-  for _, tc := range cases {
-    if e, a := tc.isReady, tc.status.IsReady(); e != a {
-      t.Errorf("%q expected: %v got: %v", tc.name, e, a)
-    }
-  }
+	for _, tc := range cases {
+		if e, a := tc.isReady, tc.status.IsReady(); e != a {
+			t.Errorf("%q expected: %v got: %v", tc.name, e, a)
+		}
+	}
 }
 
 func TestServiceConditions(t *testing.T) {
-  svc := &Service{}
-  foo := &ServiceCondition {
-    Type:   "Foo",
-    Status: "True",
-  }
-  bar := &ServiceCondition {
-    Type:   "Bar",
-    Status: "True",
-  }
+	svc := &Service{}
+	foo := &ServiceCondition{
+		Type:   "Foo",
+		Status: "True",
+	}
+	bar := &ServiceCondition{
+		Type:   "Bar",
+		Status: "True",
+	}
 
-  // Add a single condition.
-  svc.Status.SetCondition(foo)
-  if got, want := len(svc.Status.Conditions), 1; got != want {
-    t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-  }
+	// Add a single condition.
+	svc.Status.SetCondition(foo)
+	if got, want := len(svc.Status.Conditions), 1; got != want {
+		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
+	}
 
-  // Remove non-existent condition.
-  svc.Status.RemoveCondition(bar.Type)
-  if got, want := len(svc.Status.Conditions), 1; got != want {
-    t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-  }
+	// Remove non-existent condition.
+	svc.Status.RemoveCondition(bar.Type)
+	if got, want := len(svc.Status.Conditions), 1; got != want {
+		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
+	}
 
-  // Add a second Condition.
-  svc.Status.SetCondition(bar)
-  if got, want := len(svc.Status.Conditions), 2; got != want {
-    t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-  }
+	// Add a second Condition.
+	svc.Status.SetCondition(bar)
+	if got, want := len(svc.Status.Conditions), 2; got != want {
+		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
+	}
 
-  // Remove the first Condition.
-  svc.Status.RemoveCondition(foo.Type)
-  if got, want := len(svc.Status.Conditions), 1; got != want {
-    t.Fatalf("Unexpected condition length; got %d, want %d", got, want)
-  }
+	// Remove the first Condition.
+	svc.Status.RemoveCondition(foo.Type)
+	if got, want := len(svc.Status.Conditions), 1; got != want {
+		t.Fatalf("Unexpected condition length; got %d, want %d", got, want)
+	}
 
-  // Test Add nil condition.
-  svc.Status.SetCondition(nil)
-  if got, want := len(svc.Status.Conditions), 1; got != want {
-    t.Fatal("Error, nil condition was allowed to be added.")
-  }
+	// Test Add nil condition.
+	svc.Status.SetCondition(nil)
+	if got, want := len(svc.Status.Conditions), 1; got != want {
+		t.Fatal("Error, nil condition was allowed to be added.")
+	}
 }

--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -19,6 +19,7 @@ package configuration
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/golang/glog"
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
@@ -199,7 +200,7 @@ func (c *Controller) syncHandler(key string) error {
 		if rev.ObjectMeta.Annotations == nil {
 			rev.ObjectMeta.Annotations = make(map[string]string)
 		}
-		rev.ObjectMeta.Annotations[serving.ConfigurationGenerationAnnotationKey] = fmt.Sprintf("%v", config.Generation)
+		rev.ObjectMeta.Annotations[serving.ConfigurationGenerationAnnotationKey] = strconv.Itoa(int(config.Generation))
 
 		// Delete revisions when the parent Configuration is deleted.
 		rev.OwnerReferences = append(rev.OwnerReferences, *controllerRef)

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -62,13 +62,12 @@ const (
 func getTestConfiguration() *v1alpha1.Configuration {
 	return &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/configurations/test-config",
-			Name:      "test-config",
-			Namespace: testNamespace,
+			SelfLink:   "/apis/serving/v1alpha1/namespaces/test/configurations/test-config",
+			Name:       "test-config",
+			Namespace:  testNamespace,
+			Generation: 1,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			//TODO(grantr): This is a workaround for generation initialization
-			Generation: 1,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -225,7 +224,7 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 		t.Errorf("rev does not have configuration label <%s:%s>", serving.ConfigurationLabelKey, config.Name)
 	}
 
-	if rev.Annotations[serving.ConfigurationGenerationAnnotationKey] != fmt.Sprintf("%v", config.Spec.Generation) {
+	if rev.Annotations[serving.ConfigurationGenerationAnnotationKey] != fmt.Sprintf("%v", config.Generation) {
 		t.Errorf("rev does not have generation annotation <%s:%s>", serving.ConfigurationGenerationAnnotationKey, config.Name)
 	}
 

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -27,7 +27,7 @@ package configuration
 	Congfiguration.
 */
 import (
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -224,7 +224,7 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 		t.Errorf("rev does not have configuration label <%s:%s>", serving.ConfigurationLabelKey, config.Name)
 	}
 
-	if rev.Annotations[serving.ConfigurationGenerationAnnotationKey] != fmt.Sprintf("%v", config.Generation) {
+	if rev.Annotations[serving.ConfigurationGenerationAnnotationKey] != strconv.Itoa(int(config.Generation)) {
 		t.Errorf("rev does not have generation annotation <%s:%s>", serving.ConfigurationGenerationAnnotationKey, config.Name)
 	}
 

--- a/pkg/controller/label_helpers.go
+++ b/pkg/controller/label_helpers.go
@@ -1,0 +1,108 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/mattbaird/jsonpatch"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type configurationClient interface {
+	Patch(string, types.PatchType, []byte, ...string) (result *v1alpha1.Configuration, err error)
+}
+
+type revisionClient interface {
+	Patch(string, types.PatchType, []byte, ...string) (result *v1alpha1.Revision, err error)
+}
+
+func SetConfigLabel(
+	client configurationClient,
+	configName,
+	labelKey,
+	labelValue string) error {
+
+	patch, err := createAddLabelPatch(labelKey, labelValue)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Patch(configName, types.JSONPatchType, patch)
+	return err
+}
+
+func RemoveConfigLabel(
+	client configurationClient,
+	configName,
+	labelKey string) error {
+
+	patch, err := createRemoveLabelPatch(labelKey)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Patch(configName, types.JSONPatchType, patch)
+	return err
+}
+
+func SetRevisionLabel(
+	client revisionClient,
+	revisionName,
+	labelKey,
+	labelValue string) error {
+
+	patch, err := createAddLabelPatch(labelKey, labelValue)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Patch(revisionName, types.JSONPatchType, patch)
+	return err
+
+}
+
+func RemoveRevisionLabel(
+	client revisionClient,
+	revisionName,
+	labelKey string) error {
+
+	patch, err := createRemoveLabelPatch(labelKey)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Patch(revisionName, types.JSONPatchType, patch)
+	return err
+}
+
+func createAddLabelPatch(key, value string) ([]byte, error) {
+	patch := []jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      makePath("/metadata/labels", key),
+			Value:     value,
+		},
+	}
+
+	return json.Marshal(patch)
+}
+
+func createRemoveLabelPatch(key string) ([]byte, error) {
+	patch := []jsonpatch.JsonPatchOperation{
+		{
+			Operation: "remove",
+			Path:      makePath("/metadata/labels", key),
+		},
+	}
+
+	return json.Marshal(patch)
+}
+
+// TODO(bsnchan) switch to jsonpatch.MakePath when merged
+// https://github.com/mattbaird/jsonpatch/pull/15
+func makePath(path, part string) string {
+	pathPart := strings.Replace(part, "/", "~1", -1)
+	return fmt.Sprintf("%s/%s", path, pathPart)
+}

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -1014,15 +1014,7 @@ func (c *Controller) removeFinalizers(ctx context.Context, rev *v1alpha1.Revisio
 
 func (c *Controller) updateStatus(rev *v1alpha1.Revision) (*v1alpha1.Revision, error) {
 	prClient := c.ElaClientSet.ServingV1alpha1().Revisions(rev.Namespace)
-	newRev, err := prClient.Get(rev.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	newRev.Status = rev.Status
-
-	// TODO: for CRD there's no updatestatus, so use normal update
-	return prClient.Update(newRev)
-	//	return prClient.UpdateStatus(newRev)
+	return prClient.UpdateStatus(rev)
 }
 
 // Given an endpoint see if it's managed by us and return the

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -444,7 +444,6 @@ func (c *Controller) setLabelForGivenConfigurations(
 		if _, ok := config.Labels[serving.RouteLabelKey]; ok {
 			continue
 		}
-
 		err := controller.SetConfigLabel(configClient, config.Name, serving.RouteLabelKey, route.Name)
 		if err != nil {
 			logger.Errorf("Failed add route label to Configuration %q: %q", config.Name, err)

--- a/pkg/webhook/configuration_test.go
+++ b/pkg/webhook/configuration_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	build "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,7 +28,7 @@ import (
 )
 
 func TestValidConfigurationAllowed(t *testing.T) {
-	configuration := createConfiguration(testGeneration, testConfigurationName)
+	configuration := createConfiguration(testConfigurationName)
 
 	if err := ValidateConfiguration(testCtx)(nil, &configuration, &configuration); err != nil {
 		t.Fatalf("Expected allowed. Failed with %s", err)
@@ -61,7 +62,7 @@ func TestEmptyTemplateInSpecNotAllowed(t *testing.T) {
 			Name:      testConfigurationName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation:       testGeneration,
+			Build:            new(build.BuildSpec),
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{},
 		},
 	}
@@ -78,7 +79,6 @@ func TestEmptyContainerNotAllowed(t *testing.T) {
 			Name:      testConfigurationName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation: testGeneration,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					ServiceAccountName: "Fred",
@@ -102,7 +102,6 @@ func TestServingStateNotAllowed(t *testing.T) {
 			Name:      testConfigurationName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation: testGeneration,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					ServingState: v1alpha1.RevisionServingStateActive,
@@ -140,7 +139,6 @@ func TestUnwantedFieldInContainerNotAllowed(t *testing.T) {
 			Name:      testConfigurationName,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation: testGeneration,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					Container: container,

--- a/pkg/webhook/route_test.go
+++ b/pkg/webhook/route_test.go
@@ -29,8 +29,7 @@ func createRouteWithTraffic(trafficTargets []v1alpha1.TrafficTarget) v1alpha1.Ro
 			Name:      testRouteName,
 		},
 		Spec: v1alpha1.RouteSpec{
-			Generation: testGeneration,
-			Traffic:    trafficTargets,
+			Traffic: trafficTargets,
 		},
 	}
 }

--- a/pkg/webhook/service_test.go
+++ b/pkg/webhook/service_test.go
@@ -39,7 +39,7 @@ func TestRunLatest(t *testing.T) {
 	s := v1alpha1.Service{
 		Spec: v1alpha1.ServiceSpec{
 			RunLatest: &v1alpha1.RunLatestType{
-				Configuration: createConfiguration(1, "config").Spec,
+				Configuration: createConfiguration("config").Spec,
 			},
 		},
 	}
@@ -69,7 +69,7 @@ func TestPinned(t *testing.T) {
 		Spec: v1alpha1.ServiceSpec{
 			Pinned: &v1alpha1.PinnedType{
 				RevisionName:  "revision",
-				Configuration: createConfiguration(1, "config").Spec,
+				Configuration: createConfiguration("config").Spec,
 			},
 		},
 	}
@@ -117,7 +117,7 @@ func TestPinnedSetsDefaults(t *testing.T) {
 	s := v1alpha1.Service{
 		Spec: v1alpha1.ServiceSpec{
 			Pinned: &v1alpha1.PinnedType{
-				Configuration: createConfiguration(1, "config").Spec,
+				Configuration: createConfiguration("config").Spec,
 			},
 		},
 	}
@@ -147,7 +147,7 @@ func TestLatestSetsDefaults(t *testing.T) {
 	s := v1alpha1.Service{
 		Spec: v1alpha1.ServiceSpec{
 			RunLatest: &v1alpha1.RunLatestType{
-				Configuration: createConfiguration(1, "config").Spec,
+				Configuration: createConfiguration("config").Spec,
 			},
 		},
 	}

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -76,8 +76,8 @@ func updateConfigWithImage(clients *test.Clients, imagePaths []string) error {
 	if err != nil {
 		return err
 	}
-	if newConfig.Spec.Generation != int64(2) {
-		return fmt.Errorf("The spec was updated so the Generation should be 2 but it was actually %d", newConfig.Spec.Generation)
+	if newConfig.Generation != int64(2) {
+		return fmt.Errorf("The spec was updated so the Generation should be 2 but it was actually %d", newConfig.Generation)
 	}
 	return nil
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -137,7 +137,7 @@ if [[ -z $1 ]]; then
   header "Creating test cluster"
   # Smallest cluster required to run the end-to-end-tests
   CLUSTER_CREATION_ARGS=(
-    --gke-create-args="--enable-autoscaling --min-nodes=1 --max-nodes=${E2E_CLUSTER_NODES} --scopes=cloud-platform"
+    --gke-create-args="--enable-autoscaling --enable-kubernetes-alpha --min-nodes=1 --max-nodes=${E2E_CLUSTER_NODES} --scopes=cloud-platform"
     --gke-shape={\"default\":{\"Nodes\":${E2E_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke

--- a/vendor/k8s.io/apimachinery/pkg/api/equality/BUILD.bazel
+++ b/vendor/k8s.io/apimachinery/pkg/api/equality/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["semantic.go"],
+    importmap = "elafros/vendor/k8s.io/apimachinery/pkg/api/equality",
+    importpath = "k8s.io/apimachinery/pkg/api/equality",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Semantic can do semantic deep equality checks for api objects.
+// Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var Semantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+)


### PR DESCRIPTION
Fixes #642 

## Proposed Changes
*  all Elafros CRDs now use the status subresource - api server now bumps metadata.generation
* remove all generation bumping logic from the webhook
* controllers now reference `metadata.generation` instead of `spec.generation`
* patching is used instead of update when adding route labels to the configuration
  - prevents bumping the generation since nested template specs have a k8s
    Time struct which, during serialization, are not omitted
    when empty

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
* all Elafros CRDs now use the status subresource to enable automatic generation bumping
* action required: Requires k8s 1.10
* action required: kube-apiserver has the feature gate `CustomResourceSubresources=true` set
```

cc @dprotaso 