### PR TITLE
Add missing golang headers.

### DIFF
--- a/hack/boilerplate/add-boilerplate-go.sh
+++ b/hack/boilerplate/add-boilerplate-go.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-grep -r -L -P "Copyright \d+ Google LLC" $1  \
+grep -r -L -P "Copyright \d+ Google" $1  \
   | grep -P ".go$" \
   | xargs -I {} sh -c \
   'cat hack/boilerplate/boilerplate.go.txt {} > /tmp/boilerplate && mv /tmp/boilerplate {}'

--- a/pkg/controller/revision/ela_resource.go
+++ b/pkg/controller/revision/ela_resource.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package revision
 
 import (

--- a/pkg/controller/service/ela_resource.go
+++ b/pkg/controller/service/ela_resource.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package service
 
 import (

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 // Package queue provides components for the queue-proxy binary.
 
 package queue

--- a/sample/stock-rest-app/stock.go
+++ b/sample/stock-rest-app/stock.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (


### PR DESCRIPTION
## Proposed Changes

  * Add missing boilerplate to golang files.
  * Accept "Google LLC" or "Google Inc" when looking for missing headers.

**Release Note**
```release-note
NONE
```
