### PR TITLE
Grant @elafros/elafros-maintainers CODEOWNERS over the entire repo.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # updated.
 
 ### Component-level ownerships
-# Note that **unlike Prow**, CODEOWNERS is not transitive.
+# Note that **unlike Prow OWNERS**, CODEOWNERS is not hierarchical.
 # Include @elafros/elafros-maintainers on each line to allow the ToC
 # to approve PRs if needed.
 


### PR DESCRIPTION
**Implicit Governance Change** -- this is granting the technical oversight committee (ToC) direct `CODEOWNERS` on all files in the repo. Previously, a PR (like this one) would be needed for the ToC to get `CODEOWNERS` access to a subdirectory owned by a working group.

In reference to #543, but not fixing it.

## Proposed Changes

  * Changes the explicit list `@evankanderson @mattmoor @vaikas-google` to a reference to the elafros-maintainers group.
  * Grant elafros-maintainers `CODEOWNERS` on all files; this prevents the case where Prow approvals are granted (because `OWNERS` are hierarchical). This prevents Tide from getting backed up merging PRs that don't have `CODEOWNERS` approval.