### PR TITLE
Update controller "Foo" comments

### DIFF
--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -144,7 +144,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	glog.Info("Starting workers")
-	// Launch threadiness workers to process Configuration resources
+	// Launch workers to process Configuration resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -279,7 +279,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	glog.Info("Starting workers")
-	// Launch threadiness workers to process resources
+	// Launch workers to process Revision resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -213,7 +213,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	glog.Info("Starting workers")
-	// Launch threadiness workers to process Route resources
+	// Launch workers to process Route resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}

--- a/pkg/controller/service/service.go
+++ b/pkg/controller/service/service.go
@@ -160,7 +160,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	glog.Info("Starting workers")
-	// Launch threadiness workers to process Service resources
+	// Launch workers to process Service resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}


### PR DESCRIPTION
Clean up a few leftover "Foo"s from the example controller.
Make worker thread count comment consistent ("two" -> "threadiness").
