### PR TITLE
Start the build informers.

### DIFF
--- a/cmd/ela-controller/main.go
+++ b/cmd/ela-controller/main.go
@@ -140,6 +140,7 @@ func main() {
 
 	go kubeInformerFactory.Start(stopCh)
 	go elaInformerFactory.Start(stopCh)
+	go buildInformerFactory.Start(stopCh)
 
 	// Start all of the controllers.
 	for _, ctrlr := range controllers {


### PR DESCRIPTION
In my change earlier to vendor the build clients, the build informer was split off of the ela informer.

In doing this, I missed a line to actually start the build informer, so samples with build were broken by this change.
