### PR TITLE
Add buildpack-function sample

### DIFF
--- a/sample/buildpack-function/README.md
+++ b/sample/buildpack-function/README.md
@@ -1,0 +1,73 @@
+# Buildpack Sample Function
+
+A sample function that demonstrates usage of Cloud Foundry buildpacks on
+Elafros, using the [packs Docker images](https://github.com/sclevine/packs).
+
+This deploys the [riff square](https://github.com/socthis/riff-square-buildpack)
+sample function for riff.
+
+## Prerequisites
+
+1. [Setup your development environment](../../DEVELOPMENT.md#getting-started)
+2. [Start Elafros](../../README.md#start-elafros)
+
+## Running
+
+You can deploy this to Elafros from the root directory via:
+```shell
+# Replace the token string with a suitable registry
+REPO="gcr.io/<your-project-here>"
+perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample/buildpack-function/sample.yaml
+
+# Create the Kubernetes resources
+kubectl apply -f sample/templates/buildpack.yaml -f sample/buildpack-function/sample.yaml
+```
+
+Once deployed, you will see that it first builds:
+
+```shell
+$ kubectl get revision -o yaml
+apiVersion: v1
+items:
+- apiVersion: elafros.dev/v1alpha1
+  kind: Revision
+  ...
+  status:
+    conditions:
+    - reason: Building
+      status: "False"
+      type: BuildComplete
+...
+```
+
+Once the `BuildComplete` status becomes `True` the resources will start getting created.
+
+
+To access this service via `curl`, we first need to determine its ingress address:
+```shell
+$ watch kubectl get ing
+NAME                             HOSTS                                        ADDRESS   PORTS   AGE
+buildpack-function-ela-ingress   buildpack-function.default.demo-domain.com   0.0.0.0   80      3m
+```
+
+Once the `ADDRESS` gets assigned to the cluster, you can run:
+
+```shell
+# Put the Ingress Host name into an environment variable.
+$ export SERVICE_HOST=`kubectl get route buildpack-function -o jsonpath="{.status.domain}"`
+
+# Put the Ingress IP into an environment variable.
+$ export SERVICE_IP=`kubectl get ingress buildpack-function-ela-ingress -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+
+# Curl the Ingress IP "as-if" DNS were properly configured.
+$ curl http://${SERVICE_IP}/ -H "Host: $SERVICE_HOST" -H "Content-Type: application/json" -d "33"
+[response]
+```
+
+## Cleaning up
+
+To clean up the sample service:
+
+```shell
+kubectl delete -f sample/buildpack-function/sample.yaml
+```

--- a/sample/buildpack-function/sample.yaml
+++ b/sample/buildpack-function/sample.yaml
@@ -1,0 +1,44 @@
+apiVersion: elafros.dev/v1alpha1
+kind: Route
+metadata:
+  name: buildpack-function
+  namespace: default
+spec:
+  traffic:
+  - configurationName: buildpack-function
+    percent: 100
+---
+apiVersion: elafros.dev/v1alpha1
+kind: Configuration
+metadata:
+  name: buildpack-function
+  namespace: default
+spec:
+  build:
+    source:
+      git:
+        url: https://github.com/projectriff-samples/node-square
+        branch: master
+    template:
+      name: buildpack
+      arguments:
+      - name: IMAGE
+        value: &image DOCKER_REPO_OVERRIDE/buildpack-function
+      - name: BUILDPACK_ORDER
+        value: https://github.com/projectriff/node-function-invoker.git#buildpack
+      - name: SKIP_DETECT
+        value: "true"
+    # - name: CACHE
+    #   value: buildpack-function-cache
+    # volumes:
+    # - name: buildpack-function-cache
+    #   persistentVolumeClaim:
+    #     claimName: buildpack-function-cache
+
+  revisionTemplate:
+    metadata:
+      labels:
+        elafros.dev/type: function
+    spec:
+      container:
+        image: *image

--- a/sample/templates/buildpack.yaml
+++ b/sample/templates/buildpack.yaml
@@ -6,6 +6,12 @@ spec:
   parameters:
   - name: IMAGE
     description: The name of the image to push
+  - name: BUILDPACK_ORDER
+    description: A comma separated list of names or URLs for the buildpacks to use. Each buildpack is applied in order.
+    default: ""
+  - name: SKIP_DETECT
+    description: By default, the first buildpack to match is used. If true, detection is skipped and each buildpack contributes in order.
+    default: "false"
   - name: DIRECTORY
     description: The directory containing the app
     default: /workspace
@@ -19,6 +25,7 @@ spec:
   # Out: a build cache in /cache
   - name: build
     image: packs/cf:build
+    args: ["-skipDetect=${SKIP_DETECT}", "-buildpackOrder=${BUILDPACK_ORDER}"]
     workingdir: "${DIRECTORY}"
     volumeMounts:
     - name: droplet


### PR DESCRIPTION
## Proposed Changes

  * Adding buildpack-function sample, which uses the buildpack build template with a custom buildpack. The buildpack uses the projectriff node-function-invoker to host the function in a container that confirms to the Elafros container spec
  * Synced the buildpack build template from elafros/build-templates

**Release Note**

```release-note
NONE
```