### PR TITLE
Partially revert #859

### DIFF
--- a/sample/stock-rest-app/BUILD
+++ b/sample/stock-rest-app/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["stock.go"],
+    importpath = "github.com/elafros/elafros/sample/stock-rest-app",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/github.com/gorilla/mux:go_default_library"],
+)
+
+go_binary(
+    name = "stock-rest-app",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "image",
+    binary = ":stock-rest-app",
+)
+
+load("@k8s_object//:defaults.bzl", "k8s_object")
+
+k8s_object(
+    name = "everything",
+    images = {
+        "github.com/elafros/elafros/sample/stock-rest-app": ":image",
+    },
+    template = ":sample.yaml",
+)
+
+k8s_object(
+    name = "updated_configuration",
+    images = {
+        "github.com/elafros/elafros/sample/stock-rest-app": ":image",
+    },
+    template = ":updated_configuration.yaml",
+)

--- a/sample/stock-rest-app/README.md
+++ b/sample/stock-rest-app/README.md
@@ -21,7 +21,7 @@ docker build -t "${REPO}/sample/stock-rest-app" --file=sample/stock-rest-app/Doc
 docker push "${REPO}/sample/stock-rest-app"
 
 # Replace the image reference with our published image.
-sed -i "s@REPLACE_ME@${REPO}/sample/stock-rest-app@g" sample/stock-rest-app/*.yaml
+sed -i "s@github.com/elafros/elafros/sample/stock-rest-app@${REPO}/sample/stock-rest-app@g" sample/stock-rest-app/*.yaml
 
 # Deploy the Elafros sample
 kubectl apply -f sample/stock-rest-app/sample.yaml

--- a/sample/stock-rest-app/sample.yaml
+++ b/sample/stock-rest-app/sample.yaml
@@ -34,7 +34,9 @@ spec:
         elafros.dev/type: container
     spec:
       container:
-        image: REPLACE_ME
+        # This is the Go import path for the binary to containerize
+        # and substitute here.
+        image: github.com/elafros/elafros/sample/stock-rest-app
         env:
           - name: RESOURCE
             value: stock

--- a/sample/stock-rest-app/updated_configuration.yaml
+++ b/sample/stock-rest-app/updated_configuration.yaml
@@ -24,7 +24,9 @@ spec:
         elafros.dev/type: container
     spec:
       container:
-        image: REPLACE_ME
+        # This is the Go import path for the binary to containerize
+        # and substitute here.
+        image: github.com/elafros/elafros/sample/stock-rest-app
         env:
           - name: RESOURCE
             value: share


### PR DESCRIPTION
This brings back the BUILD files and ability to use ko to deploy things during development, while leaving the README changes and Dockerfile.
