### PR TITLE
Ensure Revision has Ready condition while Building

### DIFF
--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -763,6 +763,11 @@ func TestCreateRevWithBuildNameWaits(t *testing.T) {
 			Status: corev1.ConditionUnknown,
 			Reason: "Building",
 		},
+		{
+			Type:   "Ready",
+			Status: corev1.ConditionUnknown,
+			Reason: "Building",
+		},
 	}
 	if diff := compareRevisionConditions(want, waitRev.Status.Conditions); diff != "" {
 		t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)


### PR DESCRIPTION
This sets the Ready status to Unknown if the build is not finished, which matches the
RevisionConditionBuildSucceeded status.

Per the k8s API Conventions:
> The absence of a condition should be interpreted the same as Unknown.
So this change is just cosmetic and shouldn't be semantically different.

Fixes #850 

## Proposed Changes

  * Set condition status for Revision to Ready=Unknown when setting BuildSucceded=Unknown.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
