### PR TITLE
Use unique IDs for kubetest resources under prow

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,9 +29,8 @@
 source "$(dirname $(readlink -f ${BASH_SOURCE}))/library.sh"
 
 # Test cluster parameters and location of generated test images
-readonly RESOURCE_UID=$(date +%s)
-readonly E2E_CLUSTER_NAME=ela-e2e-cluster-${RESOURCE_UID}
-readonly E2E_NETWORK_NAME=ela-e2e-net-${RESOURCE_UID}
+readonly E2E_CLUSTER_NAME=ela-e2e-cluster${BUILD_NUMBER}
+readonly E2E_NETWORK_NAME=ela-e2e-net${BUILD_NUMBER}
 readonly E2E_CLUSTER_ZONE=us-central1-a
 readonly E2E_CLUSTER_NODES=3
 readonly E2E_CLUSTER_MACHINE=n1-standard-4
@@ -150,7 +149,7 @@ if [[ -z $1 ]]; then
   kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
-    --extract "${ELAFROS_GKE_VERSION}" \
+    --extract "v${ELAFROS_GKE_VERSION}" \
     --test-cmd "${SCRIPT_CANONICAL_PATH}" \
     --test-cmd-args --run-tests
   result="$(cat ${TEST_RESULT_FILE})"

--- a/test/library.sh
+++ b/test/library.sh
@@ -19,10 +19,10 @@
 # called from command line.
 
 # Default GKE version to be used with Elafros
-readonly ELAFROS_GKE_VERSION=v1.9.6-gke.1
+readonly ELAFROS_GKE_VERSION=1.9.6-gke.1
 
 # Useful environment variables
-[[ $USER == "prow" ]] && IS_PROW=1 || IS_PROW=0
+[[ -n "${PROW_JOB_ID}" ]] && IS_PROW=1 || IS_PROW=0
 readonly IS_PROW
 readonly ELAFROS_ROOT_DIR="$(dirname $(readlink -f ${BASH_SOURCE}))/.."
 


### PR DESCRIPTION
This should help minimize test infrastructure flakiness due to resource name conflicts (see #871 for details).

Use Prow's BUILD_NUMBER as unique ID because:
  * it won't change within nested invocations of e2e-tests.sh (used by kubetest)
  * it won't affect local runs

Bonuses:
* use PROW_JOB_ID to detect Prow instead of a custom environment variable
* fix the GKE cluster version, which was not pushed to #862 