### PR TITLE
Mount subpath of /var/log to fluentd

### DIFF
--- a/third_party/config/monitoring/kubernetes/elasticsearch/fluentd-es-ds.yaml
+++ b/third_party/config/monitoring/kubernetes/elasticsearch/fluentd-es-ds.yaml
@@ -87,8 +87,12 @@ spec:
             cpu: 100m
             memory: 200Mi
         volumeMounts:
-        - name: varlog
-          mountPath: /var/log
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
@@ -101,9 +105,14 @@ spec:
         beta.kubernetes.io/fluentd-ds-ready: "true"
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: varlog
+      - name: varlogcontainers
         hostPath:
-          path: /var/log
+          path: /var/log/containers
+      # It is needed because files under /var/log/contianers link to /var/log/pods
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      # It is needed because files under /var/log/pods link to /var/lib/docker/containers
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers


### PR DESCRIPTION
## Proposed Changes

  * Mount `/var/log/containers` and `/var/log/pods` to fluentd daemonset instead of the whole `/var/log`. Otherwise the files fluentd generates will be left on host.
  * Limit fluent permission to `/var/log/containers` and `/var/log/pods` to `ReadOnly`.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
