### PR TITLE
Avoid go test caching when running conformance tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -30,18 +30,18 @@ Since these tests are fairly slow (~1 minute), running them with logging
 enabled is recommended.
 
 To run the conformance tests against the current cluster in `~/.kube/config`
-using `go test` using the environment specified in [your environment
+use `go test` with test caching disabled and the environment specified in [your environment
 variables](/DEVELOPMENT.md#environment-setup):
 
 ```bash
-go test -v ./test/conformance
+go test -v -count=1 ./test/conformance
 ```
 
 You can [use test flags](#flags) to control the environment
 your tests run against, i.e. override [your environment variables](/DEVELOPMENT.md#environment-setup):
 
 ```bash
-go test -v ./test/conformance --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
+go test -v -count=1 ./test/conformance --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
 ```
 
 If you are running against an environment with no loadbalancer for the ingress, at the moment
@@ -49,7 +49,7 @@ your only option is to use a domain which will resolve to the IP of the running 
 [#609](https://github.com/elafros/elafros/issues/609)):
 
 ```bash
-go test -v ./test/conformance --resolvabledomain
+go test -v -count=1 ./test/conformance --resolvabledomain
 ```
 
 ## Conformance test environment requirements
@@ -250,7 +250,7 @@ go test ./test/e2e --dockerrepo gcr.myhappyproject
 
 #### Using a resolvable domain
 
-If you setup your cluster using [the getting started
+If you set up your cluster using [the getting started
 docs](/DEVELOPMENT.md#getting-started), Routes created in the test will
 use the domain `demo-domain.com`, unless the route has label `app=prod` in which
 case they will use the domain `prod-domain.com`.  Since these domains will not be


### PR DESCRIPTION
Go test caching causes the second and subsequent runs of the conformance tests
to be skipped even though changes may have been made to the system under test.

According to `go help test`, the idiomatic way to disable test caching
explicitly is to use -count=1.