### PR TITLE
Skip presubmit tests when changing only .md files

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -33,7 +33,7 @@ function cleanup() {
 cd ${ELAFROS_ROOT_DIR}
 
 # Skip presubmit tests if only markdown files were changed.
-if [[ -z "$(git status -s | grep -v '.md$')" ]]; then
+if [[ -z "$(git status -s | grep -v '^??' | grep -v '.md$')" ]]; then
   header "Documentation only PR, skipping tests"
   exit 0
 fi


### PR DESCRIPTION
Bonuses:
* more clear log section headers
* remove redundant code, use functions in `library.sh`

This is a partial, specific, short term solution for #815.