### PR TITLE
Only skip presubmit tests on presubmit job

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -35,8 +35,9 @@ cd ${ELAFROS_ROOT_DIR}
 # Skip presubmit tests if only markdown files were changed.
 if [[ -n "${PULL_NUMBER}" ]]; then
   # On a presubmit job
-  git status -s
-  if [[ -z "$(git status -s | grep -v '^??' | grep -v '.md$')" ]]; then
+  changes="$(git log -m -1 --name-only --pretty='format:')"
+  echo -e "Changed files:\n${changes}"
+  if [[ -z "$(echo "${changes}" | grep -v '.md$')" ]]; then
     # Nothing changed other than .md files
     header "Presubmit on documentation only PR, skipping tests"
     exit 0


### PR DESCRIPTION
Fixes #886.

## Proposed Changes

  * Only consider skipping tests when running on a presubmit job.