### PR TITLE
Remove `ServingState` from `RevisionTemplateSpec` requests

### DIFF
--- a/pkg/apis/ela/v1alpha1/revision_types.go
+++ b/pkg/apis/ela/v1alpha1/revision_types.go
@@ -95,7 +95,7 @@ type RevisionSpec struct {
 	// resources should be in for this Revision.
 	// Users must not specify this when creating a revision. It is expected
 	// that the system will manipulate this based on routability and load.
-	ServingState RevisionServingStateType `json:"servingState"`
+	ServingState RevisionServingStateType `json:"servingState,omitempty"`
 
 	// ConcurrencyModel specifies the desired concurrency model
 	// (SingleConcurrency or MultiConcurrency) for the


### PR DESCRIPTION
The `RevisionTemplateSpec`, which the user specifies when creating a
`Configuration`, contains the `ServingState` field because it contains
all of the fields that the `RevisionSpec` contains. `RevisionSpec` is
created internally from the `RevisionTemplateSpec` and the user should
not be providing a value for `ServingState` as this will be provided
internally when the `RevisionSpec` is created.

However since the field did not have `omitempty`, it was actually being
provided in requests from Elafros clients with `""` as the value. Since
we never want the user to provide a value for `ServingState`, this adds
`omitempty` so that the field will not be included in the request.

## Proposed Changes

  * Add `omitempty` to `ServingState`

```release-note
Requests that create/update `Configuration` objects will no longer contain `servingState: ""` in the revision template.
```
