### PR TITLE
Add orders for fluent config files

### DIFF
--- a/config/monitoring/150-dev/fluentd-configmap-dev.yaml
+++ b/config/monitoring/150-dev/fluentd-configmap-dev.yaml
@@ -20,11 +20,11 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
-  system.conf: |-
+  100.system.conf: |-
     <system>
       root_dir /tmp/fluentd-buffers/
     </system>
-  containers.input.conf: |-
+  200.containers.input.conf: |-
     <source>
       @id fluentd-containers.log
       @type tail
@@ -47,16 +47,17 @@ data:
       max_bytes 500000
       max_lines 1000
     </match>
-  forward.input.conf: |-
+    # Add Kubernetes metadata
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+  300.forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>
       @type forward
     </source>
-  output.conf: |-
-    # Add Kubernetes metadata and send to Elastic Search
-    <filter kubernetes.**>
-      @type kubernetes_metadata
-    </filter>
+  900.output.conf: |-
+    # Send to Elastic Search
     <match **>
       @id elasticsearch
       @type elasticsearch

--- a/config/monitoring/150-prod/fluentd-configmap.yaml
+++ b/config/monitoring/150-prod/fluentd-configmap.yaml
@@ -20,11 +20,11 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
-  system.conf: |-
+  100.system.conf: |-
     <system>
       root_dir /tmp/fluentd-buffers/
     </system>
-  containers.input.conf: |-
+  200.containers.input.conf: |-
     <source>
       @id fluentd-containers.log
       @type tail
@@ -46,15 +46,16 @@ data:
       max_bytes 500000
       max_lines 1000
     </match>
-  forward.input.conf: |-
-    <source>
-      @type forward
-    </source>
-  output.conf: |-
-    # Add Kubernetes metadata and send to Elastic Search
+    # Add Kubernetes metadata
     <filter kubernetes.**>
       @type kubernetes_metadata
     </filter>
+  300.forward.input.conf: |-
+    <source>
+      @type forward
+    </source>
+  900.output.conf: |-
+    # Send to Elastic Search
     <match **>
       @id elasticsearch
       @type elasticsearch


### PR DESCRIPTION

## Proposed Changes

  * Adds 3-digital number as prefix for fluentd config files because they are included only in one place and are [expanded in the alphabetical order](https://docs.fluentd.org/v0.12/articles/config-file#(6)-re-use-your-config:-the-%E2%80%9C@include%E2%80%9D-directive). Without this, It is so error prone when adding new config files.
  * Moves `kubernetes_metadata` filter from `output.conf` to `containers.input.conf`. `output.conf` is the part where operators can specify logging destination.
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
