### PR TITLE
Use json field `type` for Type instead of `state`

### DIFF
--- a/pkg/apis/ela/v1alpha1/route_types.go
+++ b/pkg/apis/ela/v1alpha1/route_types.go
@@ -84,7 +84,7 @@ type RouteSpec struct {
 // RouteCondition defines a readiness condition.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 type RouteCondition struct {
-	Type RouteConditionType `json:"state"`
+	Type RouteConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 

--- a/pkg/apis/ela/v1alpha1/service_types.go
+++ b/pkg/apis/ela/v1alpha1/service_types.go
@@ -71,7 +71,7 @@ type PinnedType struct {
 }
 
 type ServiceCondition struct {
-	Type ServiceConditionType `json:"state"`
+	Type ServiceConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 


### PR DESCRIPTION
If you create a `Route`, then inspect it, e.g. with `kubectl get routes -o json --all-namespaces`, you'll see a surprise:

![image](https://user-images.githubusercontent.com/432502/40148410-b577f7e8-5922-11e8-8cb0-2d591fa781a1.png)

The `type` field in the condition is represented as `state` :scream:, even though [it should be `type`](https://github.com/elafros/elafros/blob/master/docs/spec/spec.md#route) and in Go the field is called `Type`!

How did this happen you wonder?

I'm glad you asked!

Before the dawn of time as far as git is concerned this was
implemented as a custom api server. Back then, this bug existed:
https://github.com/kubernetes-incubator/apiserver-builder/issues/176

This meant that instead of defining custom types such as we are using
(`RouteConditionType`), one had to use `string` explicitly. At that
time, a good soul added a comment saying when this was fixed, we should
use a line which specifyed a custom type.

BUT LO AND BEHOLD THAT COMMENT CONTAINED A TYPO! Instead of `type`,
it used `state` as the json field!

When the move was made from custom api server to CRDs, the line was
dutifully obeyed, uncommented and BOOM we were serializing and
deserializing the `Type` field as `state`.

This was then copied into the `Service` implementation.

_As for why this was ever `state` in the comment to start with, that
mystery may never be solved._

The end!

## Proposed Changes

  * Use`status/conditions/type` instead of `status/conditions/state` in `Service` and `Route`
```release-note
The `Service` and `Route` yaml/json specs change from using `status/conditions/state` to `status/conditions/type`, as described in [the error condition docs](https://github.com/elafros/elafros/blob/master/docs/spec/errors.md).
```
