### PR TITLE
Also skip presubmit tests for changes to OWNERS files

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -44,8 +44,8 @@ if [[ -n "${PULL_NUMBER}" ]]; then
   no_presubmit_pattern="\(${no_presubmit_pattern// /\\|}\)$"
   echo -e "Changed files in commit ${commit}:\n${changes}"
   if [[ -z "$(echo "${changes}" | grep -v ${no_presubmit_pattern})" ]]; then
-    # Nothing changed other than .md or .png files
-    header "Presubmit on documentation only PR, skipping tests"
+    # Nothing changed other than files that don't require presubmit tests
+    header "Commit only contains changes that don't affect tests, skipping"
     exit 0
   fi
 fi


### PR DESCRIPTION
Bonuses:
* use a list for files/extensions that don't require presubmit tests, this makes additions and maintenance easier
* fix the header of cleanup()

Yet another small step towards a full solution for #815.