### PR TITLE
Refactor: change signature for webhook Defaulters

### DIFF
--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -132,13 +132,13 @@ func validateContainer(container corev1.Container) error {
 	return nil
 }
 
-func SetConfigurationDefaults(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
-	newC, ok := new.(*v1alpha1.Configuration)
+func SetConfigurationDefaults(patches *[]jsonpatch.JsonPatchOperation, crd GenericCRD) error {
+	config, ok := crd.(*v1alpha1.Configuration)
 	if !ok {
-		return fmt.Errorf("Failed to convert new into a Configuration: %+v", new)
+		return fmt.Errorf("Failed to convert crd into a Configuration: %+v", config)
 	}
 
-	if newC.Spec.RevisionTemplate.Spec.ConcurrencyModel == "" {
+	if config.Spec.RevisionTemplate.Spec.ConcurrencyModel == "" {
 		*patches = append(*patches, jsonpatch.JsonPatchOperation{
 			Operation: "add",
 			Path:      "/spec/revisionTemplate/spec/concurrencyModel",

--- a/pkg/webhook/revision.go
+++ b/pkg/webhook/revision.go
@@ -45,13 +45,13 @@ func ValidateRevision(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, n
 	return nil
 }
 
-func SetRevisionDefaults(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
-	_, newR, err := unmarshal(old, new, "SetRevisionDefaults")
+func SetRevisionDefaults(patches *[]jsonpatch.JsonPatchOperation, crd GenericCRD) error {
+	_, revision, err := unmarshal(nil, crd, "SetRevisionDefaults")
 	if err != nil {
 		return err
 	}
 
-	if newR.Spec.ServingState == "" {
+	if revision.Spec.ServingState == "" {
 		*patches = append(*patches, jsonpatch.JsonPatchOperation{
 			Operation: "add",
 			Path:      "/spec/servingState",
@@ -59,7 +59,7 @@ func SetRevisionDefaults(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD
 		})
 	}
 
-	if newR.Spec.ConcurrencyModel == "" {
+	if revision.Spec.ConcurrencyModel == "" {
 		*patches = append(*patches, jsonpatch.JsonPatchOperation{
 			Operation: "add",
 			Path:      "/spec/concurrencyModel",


### PR DESCRIPTION
The Defaulter methods currenty implement ResourceCallback. This is
generic and takes both an old and new GenericCRD. Defaulters shouldn't
need to see the old object, since they are setting static defaults on
the new object.

Also update some comments to make more sense.

See https://github.com/elafros/elafros/pull/930#discussion_r189948367