### PR TITLE
Refactor ResourceDefaulters to allow different patch base paths

### DIFF
--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -146,7 +146,7 @@ func SetConfigurationSpecDefaults(patches *[]jsonpatch.JsonPatchOperation, patch
 	if spec.RevisionTemplate.Spec.ConcurrencyModel == "" {
 		*patches = append(*patches, jsonpatch.JsonPatchOperation{
 			Operation: "add",
-			Path:      path.Join(patchBase, "/revisionTemplate/spec/concurrencyModel"),
+			Path:      path.Join(patchBase, "revisionTemplate/spec/concurrencyModel"),
 			Value:     v1alpha1.RevisionRequestConcurrencyModelMulti,
 		})
 	}

--- a/pkg/webhook/revision.go
+++ b/pkg/webhook/revision.go
@@ -59,7 +59,7 @@ func SetRevisionSpecDefaults(patches *[]jsonpatch.JsonPatchOperation, patchBase 
 	if spec.ServingState == "" {
 		*patches = append(*patches, jsonpatch.JsonPatchOperation{
 			Operation: "add",
-			Path:      path.Join(patchBase, "/servingState"),
+			Path:      path.Join(patchBase, "servingState"),
 			Value:     v1alpha1.RevisionServingStateActive,
 		})
 	}
@@ -67,7 +67,7 @@ func SetRevisionSpecDefaults(patches *[]jsonpatch.JsonPatchOperation, patchBase 
 	if spec.ConcurrencyModel == "" {
 		*patches = append(*patches, jsonpatch.JsonPatchOperation{
 			Operation: "add",
-			Path:      path.Join(patchBase, "/concurrencyModel"),
+			Path:      path.Join(patchBase, "concurrencyModel"),
 			Value:     v1alpha1.RevisionRequestConcurrencyModelMulti,
 		})
 	}


### PR DESCRIPTION
This enables patches to be rooted at something other than "/spec/. This
is needed to implement the Service ResourceDefaulter, which will
delegate to the Configuration ResourceDefaulter to set its defaults.

This adds a SetFooSpecDefaults which takes a patchBase path, and changes SetFooDefaults to call it with "/spec" as the patchBase. Resources managing subresources (e.g. Service -> Configuration) may call the defaulter with a different patchBase.

Concretely, when setting the defaults for a Configuration, the patchBase
passed to SetConfigurationSpecDefaults will be "/spec"; when setting the
defaults for a Configuration embedded in a Service, the patchBase passed
to SetConfigurationSpecDefaults will be "/spec/pinned/configuration" or
"/spec/runLatest/configuration".