### PR TITLE
Don't use namespace as part of the E2E test image name

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -78,7 +78,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	imagePath := strings.Join(
 		[]string{
 			test.Flags.DockerRepo,
-			NamespaceName + "-autoscale"},
+			"autoscale"},
 		"/")
 
 	log.Println("Creating a new Route and Configuration")

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -41,7 +41,7 @@ func TestHelloWorld(t *testing.T) {
 	test.CleanupOnInterrupt(func() { TearDown(clients) })
 
 	var imagePath string
-	imagePath = strings.Join([]string{test.Flags.DockerRepo, NamespaceName + "-helloworld"}, "/")
+	imagePath = strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
 
 	log.Println("Creating a new Route and Configuration")
 	err := CreateRouteAndConfig(clients, imagePath)


### PR DESCRIPTION
Fixes #961.