### PR TITLE
Delete leaked target pools and health checks after test finishes

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -188,20 +188,22 @@ if [[ -z $1 ]]; then
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/elafros/elafros/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.
+  gcp_project=${PROJECT_ID}
+  [[ -z ${gcp_project} ]] && gcp_project=$(gcloud config get-value project)
   http_health_checks="$(gcloud compute target-pools list \
-    --project=${PROJECT_ID} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcp_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     grep httpHealthChecks | tr '\n' ' ')"
   target_pools="$(gcloud compute target-pools list \
-    --project=${PROJECT_ID} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcp_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     tr '\n' ' ')"
   region="$(gcloud compute zones list --filter=name=${E2E_CLUSTER_ZONE} --format='value(region)')"
   if [[ -n "${target_pools}" ]]; then
     echo "Found leaked target pools, deleting"
-    gcloud compute target-pools delete -q --project=${PROJECT_ID} --region=${region} ${target_pools}
+    gcloud compute target-pools delete -q --project=${gcp_project} --region=${region} ${target_pools}
   fi
   if [[ -n "${http_health_checks}" ]]; then
     echo "Found leaked health checks, deleting"
-    gcloud compute http-health-checks delete -q --project=${PROJECT_ID} ${http_health_checks}
+    gcloud compute http-health-checks delete -q --project=${gcp_project} ${http_health_checks}
   fi
   result="$(cat ${TEST_RESULT_FILE})"
   echo "Test result code is $result"


### PR DESCRIPTION
This is a temporary workaround until #959 is properly fixed.