### PR TITLE
Update development instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,7 +100,7 @@ To check out this repository:
 _Adding the `upstream` remote sets you up nicely for regularly [syncing your
 fork](https://help.github.com/articles/syncing-a-fork/)._
 
-Once you reach this point you are ready to do a full build and deploy as described [here](./README.md#start-knative).
+Once you reach this point you are ready to do a full build and deploy as described below.
 
 ## Starting Knative Serving
 
@@ -129,6 +129,8 @@ kubectl apply -f ./third_party/config/build/release.yaml
 ```
 
 ### Deploy Knative Serving
+
+This step includes building Knative Serving, creating and pushing developer images and deploying them to your Kubernetes cluster.
 
 ```shell
 # With ko


### PR DESCRIPTION
- remove the `#start-elafros` dead link to README page, this anchor and text was removed previously

- clarifying that the apply command builds and pushes images as well as applies resources to k8s

Fixes #

## Proposed Changes

For someone used to a build, push and deploy process the development instructions were missing the build step, plus there was an old dead link to the README page for building and deploying.

  * remove the dead link
  * add a paragraph explaining where the build, push and deploy happens

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
