### PR TITLE
Enable sidecar injection in the default namespace for e2e tests.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -56,6 +56,8 @@ function create_istio() {
   cat ${ISTIO_DIR}/istio-sidecar-injector.yaml | \
     ${ISTIO_DIR}/webhook-patch-ca-bundle.sh | \
     kubectl apply -f -
+
+  kubectl label namespace default istio-injection=enabled
 }
 
 function create_everything() {


### PR DESCRIPTION
cc @bobcatfish @nikkithurmond  We should make sure we do this for other suites that may do stuff in other namespaces.