### PR TITLE
Use detect_exceptions for /var/log to combine multi line logs

### DIFF
--- a/pkg/controller/revision/ela_fluentd.go
+++ b/pkg/controller/revision/ela_fluentd.go
@@ -50,8 +50,14 @@ const fluentdSidecarPreOutputConfig = `
 	@type record_transformer
 	enable_ruby true
 	<record>
-	  kubernetes ${ {"container_name": "#{ENV['ELA_CONTAINER_NAME']}", "namespace_name": "#{ENV['ELA_NAMESPACE']}", "pod_name": "#{ENV['ELA_POD_NAME']}", "labels": {"elafros_dev/configuration": "#{ENV['ELA_CONFIGURATION']}", "elafros_dev/revision": "#{ENV['ELA_REVISION']}"} } }
+		kubernetes.container_name "#{ENV['ELA_CONTAINER_NAME']}"
+		kubernetes.labels.elafros_dev/configuration "#{ENV['ELA_CONFIGURATION']}"
+		kubernetes.labels.elafros_dev/revision "#{ENV['ELA_REVISION']}"
+		kubernetes.namespace_name "#{ENV['ELA_NAMESPACE']}"
+		kubernetes.pod_name "#{ENV['ELA_POD_NAME']}"
 		stream varlog
+		# Line breaks may be trimmed when collecting from files. Add them back so that
+		# multi line logs are still in multi line after combined by detect_exceptions.
 		# Remove this if https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions/pull/10 is released
 		log ${ if record["log"].end_with?("\n") then record["log"] else record["log"] + "\n" end }
 	</record>


### PR DESCRIPTION
Fixes #761

## Proposed Changes

  * Use `detect_exceptions` plugin for /var/log to combine multi line logs which form an exception stack trace into a single log entry
  * Add `\n` to each log line if it doesn't end up with '\n'. This is because `detect_exceptions` doesn't add `\n` to each line when combining them to one log record. This can be removed once [this feature](https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions/pull/10) of `detect_exceptions` is released.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
