### PR TITLE
Make release.sh more flexible

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -20,7 +20,7 @@ set -o pipefail
 source "$(dirname $(readlink -f ${BASH_SOURCE}))/../test/library.sh"
 
 # Set default GCS/GCR
-: ${ELAFROS_RELEASE_GCS:="elafros-releases/latest"}
+: ${ELAFROS_RELEASE_GCS:="elafros-releases"}
 : ${ELAFROS_RELEASE_GCR:="gcr.io/elafros-releases"}
 readonly ELAFROS_RELEASE_GCS
 readonly ELAFROS_RELEASE_GCR
@@ -94,9 +94,9 @@ bazel run config/monitoring:everything >> ${OUTPUT_YAML}
 tag_elafros_images ${OUTPUT_YAML} ${TAG}
 
 echo "Publishing release.yaml"
-gsutil cp ${OUTPUT_YAML} gs://${ELAFROS_RELEASE_GCS}/release.yaml
+gsutil cp ${OUTPUT_YAML} gs://${ELAFROS_RELEASE_GCS}/latest/release.yaml
 if [[ -n ${TAG} ]]; then
-  gsutil cp ${OUTPUT_YAML} gs://elafros-releases/previous/${TAG}/
+  gsutil cp ${OUTPUT_YAML} gs://${ELAFROS_RELEASE_GCS}/previous/${TAG}/
 fi
 
 echo "New release published successfully"


### PR DESCRIPTION
* pass `--skip-tests` as argument to skip build validation tests
* set `ELAFROS_RELEASE_GCR` environment variable to use your custom GCR for publishing the Elafros images
* likewise, set `ELAFROS_RELEASE_GCS` environment variable to use your custom GCS bucket for publishing `release.yaml`

Fixes #917