### PR TITLE
Put Prow commands in issue template in markdown quote block

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,7 +1,6 @@
 **Leave one or more of the following to ensure that the appropriate
 working groups are aware of the issue:**
 
-```
 > /area API
 > /area autoscale
 > /area build


### PR DESCRIPTION
This will avoid Prow interpreting the commands inside the HTML comment block.

Fixes #764.