### PR TITLE
Adding generation of release-lite.yaml

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -31,6 +31,8 @@ readonly ISTIO_DIR=./third_party/istio-${ISTIO_VERSION}/
 
 # Local generated yaml file.
 readonly OUTPUT_YAML=release.yaml
+# Local generated lite yaml file.
+readonly LITE_YAML=release-lite.yaml
 
 function cleanup() {
   restore_override_vars
@@ -130,17 +132,36 @@ ko resolve -f config/ >> ${OUTPUT_YAML}
 echo "---" >> ${OUTPUT_YAML}
 
 echo "Building Monitoring & Logging"
+# Make a copy for the lite version
+cp ${OUTPUT_YAML} ${LITE_YAML}
 # Use ko to concatenate them all together.
 ko resolve -R -f config/monitoring/100-common \
     -f config/monitoring/150-prod \
     -f third_party/config/monitoring \
     -f config/monitoring/200-common \
     -f config/monitoring/200-common/100-istio.yaml >> ${OUTPUT_YAML}
+# Use ko to do the same for the lite version.
+ko resolve -R -f config/monitoring/100-common \
+    -f config/monitoring/150-prod \
+    -f third_party/config/monitoring/istio \
+    -f third_party/config/monitoring/kubernetes/kube-state-metrics \
+    -f third_party/config/monitoring/prometheus-operator \
+    -f config/monitoring/200-common/100-fluentd.yaml \
+    -f config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml \
+    -f config/monitoring/200-common/100-grafana-dash-knative.yaml \
+    -f config/monitoring/200-common/100-grafana.yaml \
+    -f config/monitoring/200-common/100-istio.yaml \
+    -f config/monitoring/200-common/200-prometheus-exporter \
+    -f config/monitoring/200-common/300-prometheus \
+    -f config/monitoring/200-common/100-istio.yaml >> ${LITE_YAML}
 
 tag_knative_images ${OUTPUT_YAML} ${TAG}
 
 echo "Publishing release.yaml"
 publish_yaml ${OUTPUT_YAML}
+
+echo "Publishing release-lite.yaml"
+publish_yaml ${LITE_YAML}
 
 echo "Publishing our istio.yaml, so users don't need to use helm."
 publish_yaml ${ISTIO_DIR}/istio.yaml


### PR DESCRIPTION
- the release.yaml deploys resources that won't fit a reasonably sized minikube cluster, the goal is to fit in 4GB

- removing the elastcisearch logging resources seems to be sufficient for this goal

- a developer can use a tool like kail (https://github.com/boz/kail) to view logs

- update the hack/release.sh script to generate a release-lite.yaml file

- update the BUILD files adding a release-lite target

Fixes #1003

## Proposed Changes

  * add a `everything-lite` target to the BUILD files that need it
  *  the `everything-lite` target excludes the elasticsearch resources to reduce memory use
  * add generation and publishing of the `release-lite.yaml` using the `everything-lite` build target 

**Release Note**
```release-note
NONE
```
