### PR TITLE
Rename the CRD group to serving.knative.dev

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -27,10 +27,10 @@ import (
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
 
+	"github.com/josephburnett/k8sflag/pkg/k8sflag"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	ela_autoscaler "github.com/knative/serving/pkg/autoscaler"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
-	"github.com/josephburnett/k8sflag/pkg/k8sflag"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/websocket"
@@ -195,7 +195,7 @@ func scaleTo(podCount int32) {
 
 	glog.Infof("Scaling to %v", podCount)
 	if podCount == 0 {
-		revisionClient := elaClient.KnativeV1alpha1().Revisions(elaNamespace)
+		revisionClient := elaClient.ServingV1alpha1().Revisions(elaNamespace)
 		revision, err := revisionClient.Get(elaRevision, metav1.GetOptions{})
 
 		if err != nil {

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -15,9 +15,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: configurations.knative.dev
+  name: configurations.serving.knative.dev
 spec:
-  group: knative.dev
+  group: serving.knative.dev
   version: v1alpha1
   names:
     kind: Configuration

--- a/config/monitoring/200-common/100-istio.yaml
+++ b/config/monitoring/200-common/100-istio.yaml
@@ -52,8 +52,8 @@ spec:
     sourceService: source.service | "unknown"
     destinationService: destination.service | ""
     destinationNamespace: destination.namespace | ""
-    destinationRevision: destination.labels["knative.dev/revision"] | "unknown"
-    destinationConfiguration: destination.labels["knative.dev/configuration"] | "unknown"
+    destinationRevision: destination.labels["serving.knative.dev/revision"] | "unknown"
+    destinationConfiguration: destination.labels["serving.knative.dev/configuration"] | "unknown"
     traceId: request.headers["x-b3-traceid"] | "unknown"
     userAgent: request.useragent | "unknown"
     referer: request.referer | "unknown"
@@ -69,8 +69,8 @@ spec:
     source_service: source.service | "unknown"
     destination_namespace: destination.namespace | "unknown"
     destination_service: destination.service | "unknown"
-    destination_revision: destination.labels["knative.dev/revision"] | "unknown"
-    destination_configuration: destination.labels["knative.dev/configuration"] | "unknown"
+    destination_revision: destination.labels["serving.knative.dev/revision"] | "unknown"
+    destination_configuration: destination.labels["serving.knative.dev/configuration"] | "unknown"
     response_code: response.code | 200
   monitored_resource_type: '"UNSPECIFIED"'
 ---
@@ -85,8 +85,8 @@ spec:
     source_service: source.service | "unknown"
     destination_namespace: destination.namespace | "unknown"
     destination_service: destination.service | "unknown"
-    destination_revision: destination.labels["knative.dev/revision"] | "unknown"
-    destination_configuration: destination.labels["knative.dev/configuration"] | "unknown"
+    destination_revision: destination.labels["serving.knative.dev/revision"] | "unknown"
+    destination_configuration: destination.labels["serving.knative.dev/configuration"] | "unknown"
     response_code: response.code | 200
   monitored_resource_type: '"UNSPECIFIED"'
 ---
@@ -101,8 +101,8 @@ spec:
     source_service: source.service | "unknown"
     destination_namespace: destination.namespace | "unknown"
     destination_service: destination.service | "unknown"
-    destination_revision: destination.labels["knative.dev/revision"] | "unknown"
-    destination_configuration: destination.labels["knative.dev/configuration"] | "unknown"
+    destination_revision: destination.labels["serving.knative.dev/revision"] | "unknown"
+    destination_configuration: destination.labels["serving.knative.dev/configuration"] | "unknown"
     response_code: response.code | 200
   monitored_resource_type: '"UNSPECIFIED"'
 ---
@@ -117,8 +117,8 @@ spec:
     source_service: source.service | "unknown"
     destination_namespace: destination.namespace | "unknown"
     destination_service: destination.service | "unknown"
-    destination_revision: destination.labels["knative.dev/revision"] | "unknown"
-    destination_configuration: destination.labels["knative.dev/configuration"] | "unknown"
+    destination_revision: destination.labels["serving.knative.dev/revision"] | "unknown"
+    destination_configuration: destination.labels["serving.knative.dev/configuration"] | "unknown"
     response_code: response.code | 200
   monitored_resource_type: '"UNSPECIFIED"'
 ---

--- a/config/revision.yaml
+++ b/config/revision.yaml
@@ -15,9 +15,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: revisions.knative.dev
+  name: revisions.serving.knative.dev
 spec:
-  group: knative.dev
+  group: serving.knative.dev
   version: v1alpha1
   names:
     kind: Revision

--- a/config/route.yaml
+++ b/config/route.yaml
@@ -15,9 +15,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: routes.knative.dev
+  name: routes.serving.knative.dev
 spec:
-  group: knative.dev
+  group: serving.knative.dev
   version: v1alpha1
   names:
     kind: Route

--- a/config/service.yaml
+++ b/config/service.yaml
@@ -15,9 +15,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: services.knative.dev
+  name: services.serving.knative.dev
 spec:
-  group: knative.dev
+  group: serving.knative.dev
   version: v1alpha1
   names:
     kind: Service

--- a/docs/debugging/application-debugging-guide.md
+++ b/docs/debugging/application-debugging-guide.md
@@ -15,7 +15,7 @@ traffic percent summing to 100:
 
 ```
 Error from server (InternalError): error when applying patch:
-{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"knative.dev/v1alpha1\",\"kind\":\"Route\",\"metadata\":{\"annotations\":{},\"name\":\"route-example\",\"namespace\":\"default\"},\"spec\":{\"traffic\":[{\"configurationName\":\"configuration-example\",\"percent\":50}]}}\n"}},"spec":{"traffic":[{"configurationName":"configuration-example","percent":50}]}}
+{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"serving.knative.dev/v1alpha1\",\"kind\":\"Route\",\"metadata\":{\"annotations\":{},\"name\":\"route-example\",\"namespace\":\"default\"},\"spec\":{\"traffic\":[{\"configurationName\":\"configuration-example\",\"percent\":50}]}}\n"}},"spec":{"traffic":[{"configurationName":"configuration-example","percent":50}]}}
 to:
 &{0xc421d98240 0xc421e77490 default route-example STDIN 0xc421db0488 264682 false}
 for: "STDIN": Internal error occurred: admission webhook "webhook.knative.dev" denied the request: mutation failed: The route must have traffic percent sum equal to 100.

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -113,7 +113,7 @@ this with the `LatestRevisionReady` status, copying the reason and the
 message from the `Ready` condition on the Revision.
 
 ```http
-GET /api/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+GET /api/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 
 ```yaml
@@ -129,7 +129,7 @@ status:
 ```
 
 ```http
-GET /api/knative.dev/v1alpha1/namespaces/default/services/my-service
+GET /api/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 
 ```yaml
@@ -172,7 +172,7 @@ status:
 ```
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 
 ```yaml
@@ -198,7 +198,7 @@ environment, the customer might not have have access or visibility
 into the underlying resources in the hosting environment.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 
 ```yaml
@@ -231,7 +231,7 @@ copy of the container image to avoid having to surface this error if
 the original docker image is deleted.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 
 ```yaml
@@ -264,7 +264,7 @@ should be present, which provides the address of an endpoint which can
 be used to fetch the logs for the failed process.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 
 ```yaml
@@ -298,7 +298,7 @@ reason should be considered a terminal condition, even if Kubernetes
 might attempt to make progress even after the deadline.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 
 ```yaml
@@ -327,7 +327,7 @@ its' `Ready` condition. For example, for a newly-created Service where
 the first Revision is unable to serve:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 
 ```yaml
@@ -345,7 +345,7 @@ status:
 ```
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/services/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 
 ```yaml
@@ -373,7 +373,7 @@ with a reason of `RevisionMissing`, and the Revision will be omitted from the
 Route's  `status.traffic`.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 
 ```yaml
@@ -402,7 +402,7 @@ will be marked as False with a reason of `ConfigurationMissing`, and the
 Revision will be omitted from the Route's  `status.traffic`.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 
 ```yaml
@@ -432,7 +432,7 @@ set the `AllTrafficAssigned` condition to False with reason
 `RevisionMissing`, as above.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 
 ```yaml
@@ -460,7 +460,7 @@ complete/update, the `RolloutInProgress` condition will remain at
 True, but the reason will be set to `ProgressDeadlineExceeded`.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 
 ```yaml

--- a/docs/spec/normative_examples.md
+++ b/docs/spec/normative_examples.md
@@ -73,10 +73,10 @@ The client PATCHes the service's configuration with new container image,
 inheriting previous environment values from the configuration spec:
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/services/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -93,10 +93,10 @@ This causes the controller to PATCH the configuration's template revision
 with the new container image:
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service  # Named the same as the Service
@@ -111,10 +111,10 @@ The update to the Configuration triggers a new Revision being created, and
 the Configuration and Service are updated to reflect the new Revision:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service
@@ -130,10 +130,10 @@ status:
 ```
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/service/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/service/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -154,10 +154,10 @@ new generation of the configuration (1235), indicating the provenance
 of the revision:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/def
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/def
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
 metadata:
   name: def
@@ -192,10 +192,10 @@ traffic to it. During reconciliation, traffic may be routed to both
 existing revision `abc` and new revision `def`:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -224,10 +224,10 @@ status:
 And once reconciled, revision def serves 100% of the traffic :
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -309,10 +309,10 @@ revision.
 The client creates the service in `runLatest` mode:
 
 ```http
-POST /apis/knative.dev/v1alpha1/namespaces/default/services
+POST /apis/serving.knative.dev/v1alpha1/namespaces/default/services
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -336,10 +336,10 @@ This causes the service controller to create route and configuration
 objects with the same name as the Service:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -351,10 +351,10 @@ spec:
 ```
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/configurations
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service  # By convention (not req'd), same name as the service.
@@ -379,10 +379,10 @@ will create a new Revision, generating its name, and applying the spec
 and metadata from the configuration, as well as new metadata labels:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
 metadata:
   name: abc  # generated name
@@ -406,10 +406,10 @@ resources have been fully materialized, the configuration is updated
 with latestCreatedRevisionName:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service
@@ -427,10 +427,10 @@ The configuration watches the revision, and when the revision is
 updated as Ready (to serve), the latestReadyRevisionName is updated:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service
@@ -452,10 +452,10 @@ new revision `abc`, addressable as
 `my-service.default.mydomain.com`. Once reconciled:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -484,10 +484,10 @@ status:
 The Service also watches the Configuration (and Route) and mirrors their status for convenience:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/services/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -568,10 +568,10 @@ of manual rollouts).
 The client updates the service to pin the current revision:
 
 ```http
-PUT /apis/knative.dev/v1alpha1/namespaces/default/services/my-service
+PUT /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -590,10 +590,10 @@ revision (note that the Configuration between the two is equivalent,
 and therefore unchanged).
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -613,10 +613,10 @@ service controller to update the Configuration, in this case updating
 the environment but keeping the same container image:
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/services/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -635,10 +635,10 @@ As in the previous example, the configuration is updated to trigger
 the creation of a new revision:
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/configurations/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service
@@ -655,10 +655,10 @@ A new revision `ghi` is created that has the same code as the previous
 revision `def`, but different config:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/ghi
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/ghi
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
 metadata:
   name: ghi
@@ -687,10 +687,10 @@ receive any traffic by default, but can be accessed for testing,
 verification, etc.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -722,10 +722,10 @@ After testing the new revision at
 updating the service to pin `ghi` as the new revision.
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/services/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service
@@ -737,10 +737,10 @@ spec:
 This causes the service to update the route to assign 
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: route
 metadata:
   name: my-service
@@ -761,10 +761,10 @@ point to the same revision. Both names are left in place so that
 `next.my-service.default.mydomain.com` is always addressable.
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -845,17 +845,17 @@ spec for an git based source build, and referencing a nodejs build
 template:
 
 ```http
-PATCH /apis/knative.dev/v1alpha1/namespaces/default/service
+PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/service
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-service 
 spec:
   runLatest:
     configuration:
-      build:  # knative.dev/v1alpha1.BuildTemplateSpec
+      build:  # build.knative.dev/v1alpha1.BuildTemplateSpec
         source:
           # oneof git|gcs|custom:
           git:
@@ -902,10 +902,10 @@ the high-level state of the build is mirrored into conditions in the
 Revision’s status for convenience:
 
 ```http
-GET /apis/knative.dev/v1alpha1/namespaces/default/revisions/abc
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
 metadata:
   name: abc
@@ -915,7 +915,7 @@ metadata:
     knative.dev/configurationGeneration: 1234
   ...
 spec:
-  # name of the knative.dev/v1alpha1.Build, if built from source.
+  # name of the build.knative.dev/v1alpha1.Build, if built from source.
   # Set by Configuration.
   buildName: ...
 
@@ -1005,17 +1005,17 @@ not a core function of the compute API.
 Creating the service with build and function metadata:
 
 ```http
-POST /apis/knative.dev/v1alpha1/namespaces/default/services
+POST /apis/serving.knative.dev/v1alpha1/namespaces/default/services
 ```
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: my-function 
 spec:
   runLatest:
     configuration:
-      build:  # knative.dev/v1alpha1.BuildTemplateSpec
+      build:  # build.knative.dev/v1alpha1.BuildTemplateSpec
         source:
           # oneof git|gcs|custom
           git:

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -14,7 +14,7 @@ Resource paths in the Elafros API have the following standard k8s form:
 For example:
 
 ```
-/apis/knative.dev/v1alpha1/namespaces/default/routes/my-service
+/apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 
 It is expected that each Route will provide a name within a
@@ -46,7 +46,7 @@ For a high-level description of Routes,
 [see the overview](overview.md#route).
 
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: my-service
@@ -104,7 +104,7 @@ For a high-level description of Configurations,
 
 
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: my-service
@@ -119,7 +119,7 @@ metadata:
   ...
 spec:
   # +optional. composable Build spec, if omitted provide image directly
-  build:  # This is a knative.dev/v1alpha1.BuildTemplateSpec
+  build:  # This is a build.knative.dev/v1alpha1.BuildTemplateSpec
     source:
       # oneof git|gcs|custom: 
       
@@ -207,7 +207,7 @@ For a high-level description of Revisions,
 [see the overview](overview.md#revision).
 
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
 metadata:
   name: myservice-a1e34  # system generated
@@ -229,7 +229,7 @@ metadata:
 
 # spec populated by Configuration
 spec:
-  # +optional. name of the knative.dev/v1alpha1.Build if built from source
+  # +optional. name of the build.knative.dev/v1alpha1.Build if built from source
   buildName: ...
 
   container:  # corev1.Container
@@ -296,7 +296,7 @@ For a high-level description of Services,
 
 
 ```yaml
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: :
 metadata:
   name: myservice
@@ -315,8 +315,8 @@ metadata:
 spec:  # One of "runLatest" or "pinned"
   # Example, only one of runLatest or pinned can be set in practice.
   runLatest:
-    configuration:  # knative.dev/v1alpha1.Configuration
-      # +optional. name of the knative.dev/v1alpha1.Build if built from source
+    configuration:  # serving.knative.dev/v1alpha1.Configuration
+      # +optional. name of the build.knative.dev/v1alpha1.Build if built from source
       buildName: ...
 
       container:  # core.v1.Container
@@ -337,8 +337,8 @@ spec:  # One of "runLatest" or "pinned"
   # Example, only one of runLatest or pinned can be set in practice.
   pinned:
     revisionName: myservice-00013  # Auto-generated revision name
-    configuration:  # knative.dev/v1alpha1.Configuration
-      # +optional. name of the knative.dev/v1alpha1.Build if built from source
+    configuration:  # serving.knative.dev/v1alpha1.Configuration
+      # +optional. name of the build.knative.dev/v1alpha1.Build if built from source
       buildName: ...
 
       container:  # core.v1.Container

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -60,7 +60,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) (end Endpoint
 	}
 
 	// Get the current revision serving state
-	revisionClient := r.elaClient.KnativeV1alpha1().Revisions(rev.namespace)
+	revisionClient := r.elaClient.ServingV1alpha1().Revisions(rev.namespace)
 	revision, err := revisionClient.Get(rev.name, metav1.GetOptions{})
 	if err != nil {
 		return internalError("Unable to get revision %s/%s: %v", rev.namespace, rev.name, err)
@@ -84,7 +84,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) (end Endpoint
 
 	// Wait for the revision to be ready
 	if !revision.Status.IsReady() {
-		wi, err := r.elaClient.KnativeV1alpha1().Revisions(rev.namespace).Watch(metav1.ListOptions{
+		wi, err := r.elaClient.ServingV1alpha1().Revisions(rev.namespace).Watch(metav1.ListOptions{
 			FieldSelector: fmt.Sprintf("metadata.name=%s", rev.name),
 		})
 		if err != nil {

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -36,7 +36,7 @@ const (
 
 func TestActiveEndpoint_Active_StaysActive(t *testing.T) {
 	k8s, ela := fakeClients()
-	ela.KnativeV1alpha1().Revisions(testNamespace).Create(newRevisionBuilder().build())
+	ela.ServingV1alpha1().Revisions(testNamespace).Create(newRevisionBuilder().build())
 	k8s.CoreV1().Endpoints(testNamespace).Create(newEndpointBuilder().build())
 	a := NewRevisionActivator(k8s, ela)
 
@@ -56,7 +56,7 @@ func TestActiveEndpoint_Active_StaysActive(t *testing.T) {
 
 func TestActiveEndpoint_Reserve_BecomesActive(t *testing.T) {
 	k8s, ela := fakeClients()
-	ela.KnativeV1alpha1().Revisions(testNamespace).Create(
+	ela.ServingV1alpha1().Revisions(testNamespace).Create(
 		newRevisionBuilder().
 			withServingState(v1alpha1.RevisionServingStateReserve).
 			build())
@@ -76,7 +76,7 @@ func TestActiveEndpoint_Reserve_BecomesActive(t *testing.T) {
 		t.Errorf("Unexpected error. Want nil. Got %v.", err)
 	}
 
-	rev, _ := ela.KnativeV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
+	rev, _ := ela.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
 	if rev.Spec.ServingState != v1alpha1.RevisionServingStateActive {
 		t.Errorf("Unexpected serving state. Want Active. Got %v.", rev.Spec.ServingState)
 	}
@@ -84,7 +84,7 @@ func TestActiveEndpoint_Reserve_BecomesActive(t *testing.T) {
 
 func TestActiveEndpoint_Retired_StaysRetiredWithError(t *testing.T) {
 	k8s, ela := fakeClients()
-	ela.KnativeV1alpha1().Revisions(testNamespace).Create(
+	ela.ServingV1alpha1().Revisions(testNamespace).Create(
 		newRevisionBuilder().
 			withServingState(v1alpha1.RevisionServingStateRetired).
 			build())
@@ -104,7 +104,7 @@ func TestActiveEndpoint_Retired_StaysRetiredWithError(t *testing.T) {
 		t.Errorf("Expected error. Want error. Got nil.")
 	}
 
-	rev, _ := ela.KnativeV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
+	rev, _ := ela.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
 	if rev.Spec.ServingState != v1alpha1.RevisionServingStateRetired {
 		t.Errorf("Unexpected serving state. Want Retired. Got %v.", rev.Spec.ServingState)
 	}
@@ -112,7 +112,7 @@ func TestActiveEndpoint_Retired_StaysRetiredWithError(t *testing.T) {
 
 func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 	k8s, ela := fakeClients()
-	ela.KnativeV1alpha1().Revisions(testNamespace).Create(
+	ela.ServingV1alpha1().Revisions(testNamespace).Create(
 		newRevisionBuilder().
 			withServingState(v1alpha1.RevisionServingStateReserve).
 			withReady(false).
@@ -133,12 +133,12 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 	default:
 	}
 
-	rev, _ := ela.KnativeV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
+	rev, _ := ela.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
 	rev.Status.SetCondition(&v1alpha1.RevisionCondition{
 		Type:   v1alpha1.RevisionConditionReady,
 		Status: corev1.ConditionTrue,
 	})
-	ela.KnativeV1alpha1().Revisions(testNamespace).Update(rev)
+	ela.ServingV1alpha1().Revisions(testNamespace).Update(rev)
 
 	time.Sleep(100 * time.Millisecond)
 	select {
@@ -160,7 +160,7 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 
 func TestActiveEndpoint_Reserve_ReadyTimeoutWithError(t *testing.T) {
 	k8s, ela := fakeClients()
-	ela.KnativeV1alpha1().Revisions(testNamespace).Create(
+	ela.ServingV1alpha1().Revisions(testNamespace).Create(
 		newRevisionBuilder().
 			withServingState(v1alpha1.RevisionServingStateReserve).
 			withReady(false).

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 package serving
 
 const (
-	GroupName = "knative.dev"
+	GroupName = "serving.knative.dev"
 
 	// ConfigurationLabelKey is the label key attached to a Revision indicating by
 	// which Configuration it is created.

--- a/pkg/apis/serving/v1alpha1/doc.go
+++ b/pkg/apis/serving/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // of the same resource
 
 // +k8s:deepcopy-gen=package
-// +groupName=knative.dev
+// +groupName=serving.knative.dev
 package v1alpha1

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -18,7 +18,7 @@ package versioned
 import (
 	glog "github.com/golang/glog"
 	configv1alpha2 "github.com/knative/serving/pkg/client/clientset/versioned/typed/istio/v1alpha2"
-	knativev1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	servingv1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -29,9 +29,9 @@ type Interface interface {
 	ConfigV1alpha2() configv1alpha2.ConfigV1alpha2Interface
 	// Deprecated: please explicitly pick a version if possible.
 	Config() configv1alpha2.ConfigV1alpha2Interface
-	KnativeV1alpha1() knativev1alpha1.KnativeV1alpha1Interface
+	ServingV1alpha1() servingv1alpha1.ServingV1alpha1Interface
 	// Deprecated: please explicitly pick a version if possible.
-	Knative() knativev1alpha1.KnativeV1alpha1Interface
+	Serving() servingv1alpha1.ServingV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -39,7 +39,7 @@ type Interface interface {
 type Clientset struct {
 	*discovery.DiscoveryClient
 	configV1alpha2  *configv1alpha2.ConfigV1alpha2Client
-	knativeV1alpha1 *knativev1alpha1.KnativeV1alpha1Client
+	servingV1alpha1 *servingv1alpha1.ServingV1alpha1Client
 }
 
 // ConfigV1alpha2 retrieves the ConfigV1alpha2Client
@@ -53,15 +53,15 @@ func (c *Clientset) Config() configv1alpha2.ConfigV1alpha2Interface {
 	return c.configV1alpha2
 }
 
-// KnativeV1alpha1 retrieves the KnativeV1alpha1Client
-func (c *Clientset) KnativeV1alpha1() knativev1alpha1.KnativeV1alpha1Interface {
-	return c.knativeV1alpha1
+// ServingV1alpha1 retrieves the ServingV1alpha1Client
+func (c *Clientset) ServingV1alpha1() servingv1alpha1.ServingV1alpha1Interface {
+	return c.servingV1alpha1
 }
 
-// Deprecated: Knative retrieves the default version of KnativeClient.
+// Deprecated: Serving retrieves the default version of ServingClient.
 // Please explicitly pick a version.
-func (c *Clientset) Knative() knativev1alpha1.KnativeV1alpha1Interface {
-	return c.knativeV1alpha1
+func (c *Clientset) Serving() servingv1alpha1.ServingV1alpha1Interface {
+	return c.servingV1alpha1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -84,7 +84,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
-	cs.knativeV1alpha1, err = knativev1alpha1.NewForConfig(&configShallowCopy)
+	cs.servingV1alpha1, err = servingv1alpha1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 func NewForConfigOrDie(c *rest.Config) *Clientset {
 	var cs Clientset
 	cs.configV1alpha2 = configv1alpha2.NewForConfigOrDie(c)
-	cs.knativeV1alpha1 = knativev1alpha1.NewForConfigOrDie(c)
+	cs.servingV1alpha1 = servingv1alpha1.NewForConfigOrDie(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &cs
@@ -112,7 +112,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
 	cs.configV1alpha2 = configv1alpha2.New(c)
-	cs.knativeV1alpha1 = knativev1alpha1.New(c)
+	cs.servingV1alpha1 = servingv1alpha1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -19,8 +19,8 @@ import (
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	configv1alpha2 "github.com/knative/serving/pkg/client/clientset/versioned/typed/istio/v1alpha2"
 	fakeconfigv1alpha2 "github.com/knative/serving/pkg/client/clientset/versioned/typed/istio/v1alpha2/fake"
-	knativev1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
-	fakeknativev1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
+	servingv1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	fakeservingv1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -79,12 +79,12 @@ func (c *Clientset) Config() configv1alpha2.ConfigV1alpha2Interface {
 	return &fakeconfigv1alpha2.FakeConfigV1alpha2{Fake: &c.Fake}
 }
 
-// KnativeV1alpha1 retrieves the KnativeV1alpha1Client
-func (c *Clientset) KnativeV1alpha1() knativev1alpha1.KnativeV1alpha1Interface {
-	return &fakeknativev1alpha1.FakeKnativeV1alpha1{Fake: &c.Fake}
+// ServingV1alpha1 retrieves the ServingV1alpha1Client
+func (c *Clientset) ServingV1alpha1() servingv1alpha1.ServingV1alpha1Interface {
+	return &fakeservingv1alpha1.FakeServingV1alpha1{Fake: &c.Fake}
 }
 
-// Knative retrieves the KnativeV1alpha1Client
-func (c *Clientset) Knative() knativev1alpha1.KnativeV1alpha1Interface {
-	return &fakeknativev1alpha1.FakeKnativeV1alpha1{Fake: &c.Fake}
+// Serving retrieves the ServingV1alpha1Client
+func (c *Clientset) Serving() servingv1alpha1.ServingV1alpha1Interface {
+	return &fakeservingv1alpha1.FakeServingV1alpha1{Fake: &c.Fake}
 }

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -17,7 +17,7 @@ package fake
 
 import (
 	configv1alpha2 "github.com/knative/serving/pkg/apis/istio/v1alpha2"
-	knativev1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,5 +49,5 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	configv1alpha2.AddToScheme(scheme)
-	knativev1alpha1.AddToScheme(scheme)
+	servingv1alpha1.AddToScheme(scheme)
 }

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -17,7 +17,7 @@ package scheme
 
 import (
 	configv1alpha2 "github.com/knative/serving/pkg/apis/istio/v1alpha2"
-	knativev1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,5 +49,5 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	configv1alpha2.AddToScheme(scheme)
-	knativev1alpha1.AddToScheme(scheme)
+	servingv1alpha1.AddToScheme(scheme)
 }

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/configuration.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/configuration.go
@@ -51,7 +51,7 @@ type configurations struct {
 }
 
 // newConfigurations returns a Configurations
-func newConfigurations(c *KnativeV1alpha1Client, namespace string) *configurations {
+func newConfigurations(c *ServingV1alpha1Client, namespace string) *configurations {
 	return &configurations{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_configuration.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_configuration.go
@@ -27,13 +27,13 @@ import (
 
 // FakeConfigurations implements ConfigurationInterface
 type FakeConfigurations struct {
-	Fake *FakeKnativeV1alpha1
+	Fake *FakeServingV1alpha1
 	ns   string
 }
 
-var configurationsResource = schema.GroupVersionResource{Group: "knative.dev", Version: "v1alpha1", Resource: "configurations"}
+var configurationsResource = schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1alpha1", Resource: "configurations"}
 
-var configurationsKind = schema.GroupVersionKind{Group: "knative.dev", Version: "v1alpha1", Kind: "Configuration"}
+var configurationsKind = schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1alpha1", Kind: "Configuration"}
 
 // Get takes name of the configuration, and returns the corresponding configuration object, and an error if there is any.
 func (c *FakeConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.Configuration, err error) {

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_revision.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_revision.go
@@ -27,13 +27,13 @@ import (
 
 // FakeRevisions implements RevisionInterface
 type FakeRevisions struct {
-	Fake *FakeKnativeV1alpha1
+	Fake *FakeServingV1alpha1
 	ns   string
 }
 
-var revisionsResource = schema.GroupVersionResource{Group: "knative.dev", Version: "v1alpha1", Resource: "revisions"}
+var revisionsResource = schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1alpha1", Resource: "revisions"}
 
-var revisionsKind = schema.GroupVersionKind{Group: "knative.dev", Version: "v1alpha1", Kind: "Revision"}
+var revisionsKind = schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1alpha1", Kind: "Revision"}
 
 // Get takes name of the revision, and returns the corresponding revision object, and an error if there is any.
 func (c *FakeRevisions) Get(name string, options v1.GetOptions) (result *v1alpha1.Revision, err error) {

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_route.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_route.go
@@ -27,13 +27,13 @@ import (
 
 // FakeRoutes implements RouteInterface
 type FakeRoutes struct {
-	Fake *FakeKnativeV1alpha1
+	Fake *FakeServingV1alpha1
 	ns   string
 }
 
-var routesResource = schema.GroupVersionResource{Group: "knative.dev", Version: "v1alpha1", Resource: "routes"}
+var routesResource = schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1alpha1", Resource: "routes"}
 
-var routesKind = schema.GroupVersionKind{Group: "knative.dev", Version: "v1alpha1", Kind: "Route"}
+var routesKind = schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1alpha1", Kind: "Route"}
 
 // Get takes name of the route, and returns the corresponding route object, and an error if there is any.
 func (c *FakeRoutes) Get(name string, options v1.GetOptions) (result *v1alpha1.Route, err error) {

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_service.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_service.go
@@ -27,13 +27,13 @@ import (
 
 // FakeServices implements ServiceInterface
 type FakeServices struct {
-	Fake *FakeKnativeV1alpha1
+	Fake *FakeServingV1alpha1
 	ns   string
 }
 
-var servicesResource = schema.GroupVersionResource{Group: "knative.dev", Version: "v1alpha1", Resource: "services"}
+var servicesResource = schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1alpha1", Resource: "services"}
 
-var servicesKind = schema.GroupVersionKind{Group: "knative.dev", Version: "v1alpha1", Kind: "Service"}
+var servicesKind = schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1alpha1", Kind: "Service"}
 
 // Get takes name of the service, and returns the corresponding service object, and an error if there is any.
 func (c *FakeServices) Get(name string, options v1.GetOptions) (result *v1alpha1.Service, err error) {

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_serving_client.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake/fake_serving_client.go
@@ -21,29 +21,29 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeKnativeV1alpha1 struct {
+type FakeServingV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeKnativeV1alpha1) Configurations(namespace string) v1alpha1.ConfigurationInterface {
+func (c *FakeServingV1alpha1) Configurations(namespace string) v1alpha1.ConfigurationInterface {
 	return &FakeConfigurations{c, namespace}
 }
 
-func (c *FakeKnativeV1alpha1) Revisions(namespace string) v1alpha1.RevisionInterface {
+func (c *FakeServingV1alpha1) Revisions(namespace string) v1alpha1.RevisionInterface {
 	return &FakeRevisions{c, namespace}
 }
 
-func (c *FakeKnativeV1alpha1) Routes(namespace string) v1alpha1.RouteInterface {
+func (c *FakeServingV1alpha1) Routes(namespace string) v1alpha1.RouteInterface {
 	return &FakeRoutes{c, namespace}
 }
 
-func (c *FakeKnativeV1alpha1) Services(namespace string) v1alpha1.ServiceInterface {
+func (c *FakeServingV1alpha1) Services(namespace string) v1alpha1.ServiceInterface {
 	return &FakeServices{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeKnativeV1alpha1) RESTClient() rest.Interface {
+func (c *FakeServingV1alpha1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/revision.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/revision.go
@@ -51,7 +51,7 @@ type revisions struct {
 }
 
 // newRevisions returns a Revisions
-func newRevisions(c *KnativeV1alpha1Client, namespace string) *revisions {
+func newRevisions(c *ServingV1alpha1Client, namespace string) *revisions {
 	return &revisions{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/route.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/route.go
@@ -51,7 +51,7 @@ type routes struct {
 }
 
 // newRoutes returns a Routes
-func newRoutes(c *KnativeV1alpha1Client, namespace string) *routes {
+func newRoutes(c *ServingV1alpha1Client, namespace string) *routes {
 	return &routes{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/service.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/service.go
@@ -51,7 +51,7 @@ type services struct {
 }
 
 // newServices returns a Services
-func newServices(c *KnativeV1alpha1Client, namespace string) *services {
+func newServices(c *ServingV1alpha1Client, namespace string) *services {
 	return &services{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/pkg/client/clientset/versioned/typed/serving/v1alpha1/serving_client.go
+++ b/pkg/client/clientset/versioned/typed/serving/v1alpha1/serving_client.go
@@ -22,7 +22,7 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type KnativeV1alpha1Interface interface {
+type ServingV1alpha1Interface interface {
 	RESTClient() rest.Interface
 	ConfigurationsGetter
 	RevisionsGetter
@@ -30,29 +30,29 @@ type KnativeV1alpha1Interface interface {
 	ServicesGetter
 }
 
-// KnativeV1alpha1Client is used to interact with features provided by the knative.dev group.
-type KnativeV1alpha1Client struct {
+// ServingV1alpha1Client is used to interact with features provided by the serving.knative.dev group.
+type ServingV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *KnativeV1alpha1Client) Configurations(namespace string) ConfigurationInterface {
+func (c *ServingV1alpha1Client) Configurations(namespace string) ConfigurationInterface {
 	return newConfigurations(c, namespace)
 }
 
-func (c *KnativeV1alpha1Client) Revisions(namespace string) RevisionInterface {
+func (c *ServingV1alpha1Client) Revisions(namespace string) RevisionInterface {
 	return newRevisions(c, namespace)
 }
 
-func (c *KnativeV1alpha1Client) Routes(namespace string) RouteInterface {
+func (c *ServingV1alpha1Client) Routes(namespace string) RouteInterface {
 	return newRoutes(c, namespace)
 }
 
-func (c *KnativeV1alpha1Client) Services(namespace string) ServiceInterface {
+func (c *ServingV1alpha1Client) Services(namespace string) ServiceInterface {
 	return newServices(c, namespace)
 }
 
-// NewForConfig creates a new KnativeV1alpha1Client for the given config.
-func NewForConfig(c *rest.Config) (*KnativeV1alpha1Client, error) {
+// NewForConfig creates a new ServingV1alpha1Client for the given config.
+func NewForConfig(c *rest.Config) (*ServingV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -61,12 +61,12 @@ func NewForConfig(c *rest.Config) (*KnativeV1alpha1Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &KnativeV1alpha1Client{client}, nil
+	return &ServingV1alpha1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new KnativeV1alpha1Client for the given config and
+// NewForConfigOrDie creates a new ServingV1alpha1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *KnativeV1alpha1Client {
+func NewForConfigOrDie(c *rest.Config) *ServingV1alpha1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -74,9 +74,9 @@ func NewForConfigOrDie(c *rest.Config) *KnativeV1alpha1Client {
 	return client
 }
 
-// New creates a new KnativeV1alpha1Client for the given RESTClient.
-func New(c rest.Interface) *KnativeV1alpha1Client {
-	return &KnativeV1alpha1Client{c}
+// New creates a new ServingV1alpha1Client for the given RESTClient.
+func New(c rest.Interface) *ServingV1alpha1Client {
+	return &ServingV1alpha1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -94,7 +94,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *KnativeV1alpha1Client) RESTClient() rest.Interface {
+func (c *ServingV1alpha1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -122,13 +122,13 @@ type SharedInformerFactory interface {
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Config() istio.Interface
-	Knative() serving.Interface
+	Serving() serving.Interface
 }
 
 func (f *sharedInformerFactory) Config() istio.Interface {
 	return istio.New(f, f.namespace, f.tweakListOptions)
 }
 
-func (f *sharedInformerFactory) Knative() serving.Interface {
+func (f *sharedInformerFactory) Serving() serving.Interface {
 	return serving.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -54,15 +54,15 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 	case v1alpha2.SchemeGroupVersion.WithResource("routerules"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Config().V1alpha2().RouteRules().Informer()}, nil
 
-		// Group=knative.dev, Version=v1alpha1
+		// Group=serving.knative.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("configurations"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Knative().V1alpha1().Configurations().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Serving().V1alpha1().Configurations().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("revisions"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Knative().V1alpha1().Revisions().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Serving().V1alpha1().Revisions().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("routes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Knative().V1alpha1().Routes().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Serving().V1alpha1().Routes().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("services"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Knative().V1alpha1().Services().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Serving().V1alpha1().Services().Informer()}, nil
 
 	}
 

--- a/pkg/client/informers/externalversions/serving/interface.go
+++ b/pkg/client/informers/externalversions/serving/interface.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package knative
+package serving
 
 import (
 	internalinterfaces "github.com/knative/serving/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/serving/v1alpha1/configuration.go
+++ b/pkg/client/informers/externalversions/serving/v1alpha1/configuration.go
@@ -58,13 +58,13 @@ func NewFilteredConfigurationInformer(client versioned.Interface, namespace stri
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Configurations(namespace).List(options)
+				return client.ServingV1alpha1().Configurations(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Configurations(namespace).Watch(options)
+				return client.ServingV1alpha1().Configurations(namespace).Watch(options)
 			},
 		},
 		&serving_v1alpha1.Configuration{},

--- a/pkg/client/informers/externalversions/serving/v1alpha1/revision.go
+++ b/pkg/client/informers/externalversions/serving/v1alpha1/revision.go
@@ -58,13 +58,13 @@ func NewFilteredRevisionInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Revisions(namespace).List(options)
+				return client.ServingV1alpha1().Revisions(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Revisions(namespace).Watch(options)
+				return client.ServingV1alpha1().Revisions(namespace).Watch(options)
 			},
 		},
 		&serving_v1alpha1.Revision{},

--- a/pkg/client/informers/externalversions/serving/v1alpha1/route.go
+++ b/pkg/client/informers/externalversions/serving/v1alpha1/route.go
@@ -58,13 +58,13 @@ func NewFilteredRouteInformer(client versioned.Interface, namespace string, resy
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Routes(namespace).List(options)
+				return client.ServingV1alpha1().Routes(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Routes(namespace).Watch(options)
+				return client.ServingV1alpha1().Routes(namespace).Watch(options)
 			},
 		},
 		&serving_v1alpha1.Route{},

--- a/pkg/client/informers/externalversions/serving/v1alpha1/service.go
+++ b/pkg/client/informers/externalversions/serving/v1alpha1/service.go
@@ -58,13 +58,13 @@ func NewFilteredServiceInformer(client versioned.Interface, namespace string, re
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Services(namespace).List(options)
+				return client.ServingV1alpha1().Services(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KnativeV1alpha1().Services(namespace).Watch(options)
+				return client.ServingV1alpha1().Services(namespace).Watch(options)
 			},
 		},
 		&serving_v1alpha1.Service{},

--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -70,8 +70,8 @@ func NewController(
 
 	// obtain references to a shared index informer for the Configuration
 	// and Revision type.
-	informer := elaInformerFactory.Knative().V1alpha1().Configurations()
-	revisionInformer := elaInformerFactory.Knative().V1alpha1().Revisions()
+	informer := elaInformerFactory.Serving().V1alpha1().Configurations()
+	revisionInformer := elaInformerFactory.Serving().V1alpha1().Revisions()
 
 	controller := &Controller{
 		Base: controller.NewBase(kubeClientSet, elaClientSet, kubeInformerFactory,
@@ -171,7 +171,7 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	revClient := c.ElaClientSet.KnativeV1alpha1().Revisions(config.Namespace)
+	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(config.Namespace)
 	created, err := revClient.Get(revName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -241,7 +241,7 @@ func generateRevisionName(u *v1alpha1.Configuration) (string, error) {
 }
 
 func (c *Controller) updateStatus(u *v1alpha1.Configuration) (*v1alpha1.Configuration, error) {
-	configClient := c.ElaClientSet.KnativeV1alpha1().Configurations(u.Namespace)
+	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(u.Namespace)
 	newu, err := configClient.Get(u.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -201,12 +201,12 @@ func TestCreateConfigurationsCreatesRevision(t *testing.T) {
 	// hooks here.
 	h.OnCreate(&kubeClient.Fake, "events", ExpectNormalEventDelivery(t, "Created Revision .+"))
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since syncHandler looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 	controller.syncHandler(keyOrDie(config))
 
-	list, err := elaClient.KnativeV1alpha1().Revisions(testNamespace).List(metav1.ListOptions{})
+	list, err := elaClient.ServingV1alpha1().Revisions(testNamespace).List(metav1.ListOptions{})
 
 	if err != nil {
 		t.Fatalf("error listing revisions: %v", err)
@@ -262,12 +262,12 @@ func TestCreateConfigurationCreatesBuildAndRevision(t *testing.T) {
 		}},
 	}
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since syncHandler looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 	controller.syncHandler(keyOrDie(config))
 
-	revList, err := elaClient.KnativeV1alpha1().Revisions(testNamespace).List(metav1.ListOptions{})
+	revList, err := elaClient.ServingV1alpha1().Revisions(testNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("error listing revisions: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestCreateConfigurationCreatesBuildAndRevision(t *testing.T) {
 
 func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 	kubeClient, _, elaClient, controller, _, elaInformer := newTestController(t)
-	configClient := elaClient.KnativeV1alpha1().Configurations(testNamespace)
+	configClient := elaClient.ServingV1alpha1().Configurations(testNamespace)
 
 	config := getTestConfiguration()
 	config.Status.LatestCreatedRevisionName = revName
@@ -307,7 +307,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 
 	configClient.Create(config)
 	// Since syncHandler looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 	controller.syncHandler(keyOrDie(config))
 
 	reconciledConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -325,7 +325,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 	}
 
 	// Get the revision created
-	revList, err := elaClient.KnativeV1alpha1().Revisions(config.Namespace).List(metav1.ListOptions{})
+	revList, err := elaClient.ServingV1alpha1().Revisions(config.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("error listing revisions: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 		}},
 	}
 	// Since addRevisionEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(reconciledConfig)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(reconciledConfig)
 	controller.addRevisionEvent(&revision)
 
 	readyConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -372,14 +372,14 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 
 func TestDoNotUpdateConfigurationWhenRevisionIsNotReady(t *testing.T) {
 	_, _, elaClient, controller, _, elaInformer := newTestController(t)
-	configClient := elaClient.KnativeV1alpha1().Configurations(testNamespace)
+	configClient := elaClient.ServingV1alpha1().Configurations(testNamespace)
 
 	config := getTestConfiguration()
 	config.Status.LatestCreatedRevisionName = revName
 
 	configClient.Create(config)
 	// Since addRevisionEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 
 	// Get the configuration after reconciling
 	reconciledConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -407,14 +407,14 @@ func TestDoNotUpdateConfigurationWhenRevisionIsNotReady(t *testing.T) {
 
 func TestDoNotUpdateConfigurationWhenReadyRevisionIsNotLatestCreated(t *testing.T) {
 	_, _, elaClient, controller, _, elaInformer := newTestController(t)
-	configClient := elaClient.KnativeV1alpha1().Configurations(testNamespace)
+	configClient := elaClient.ServingV1alpha1().Configurations(testNamespace)
 
 	config := getTestConfiguration()
 	// Don't set LatestCreatedRevisionName.
 
 	configClient.Create(config)
 	// Since addRevisionEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 
 	// Get the configuration after reconciling
 	reconciledConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -449,7 +449,7 @@ func TestDoNotUpdateConfigurationWhenReadyRevisionIsNotLatestCreated(t *testing.
 
 func TestDoNotUpdateConfigurationWhenLatestReadyRevisionNameIsUpToDate(t *testing.T) {
 	_, _, elaClient, controller, _, elaInformer := newTestController(t)
-	configClient := elaClient.KnativeV1alpha1().Configurations(testNamespace)
+	configClient := elaClient.ServingV1alpha1().Configurations(testNamespace)
 
 	config := getTestConfiguration()
 	config.Status = v1alpha1.ConfigurationStatus{
@@ -465,7 +465,7 @@ func TestDoNotUpdateConfigurationWhenLatestReadyRevisionNameIsUpToDate(t *testin
 	}
 	configClient.Create(config)
 	// Since addRevisionEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 
 	// Create a revision owned by this Configuration. This revision is Ready and
 	// matches the Configuration's LatestReadyRevisionName.
@@ -484,7 +484,7 @@ func TestDoNotUpdateConfigurationWhenLatestReadyRevisionNameIsUpToDate(t *testin
 
 func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 	kubeClient, _, elaClient, controller, _, elaInformer := newTestController(t)
-	configClient := elaClient.KnativeV1alpha1().Configurations(testNamespace)
+	configClient := elaClient.ServingV1alpha1().Configurations(testNamespace)
 
 	config := getTestConfiguration()
 	config.Status.LatestCreatedRevisionName = revName
@@ -496,7 +496,7 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 
 	configClient.Create(config)
 	// Since syncHandler looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 	controller.syncHandler(keyOrDie(config))
 
 	reconciledConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -505,7 +505,7 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 	}
 
 	// Get the revision created
-	revList, err := elaClient.KnativeV1alpha1().Revisions(config.Namespace).List(metav1.ListOptions{})
+	revList, err := elaClient.ServingV1alpha1().Revisions(config.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("error listing revisions: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 		}},
 	}
 	// Since addRevisionEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(reconciledConfig)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(reconciledConfig)
 	controller.addRevisionEvent(&revision)
 
 	readyConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -558,7 +558,7 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 
 func TestMarkConfigurationReadyWhenLatestRevisionRecovers(t *testing.T) {
 	kubeClient, _, elaClient, controller, _, elaInformer := newTestController(t)
-	configClient := elaClient.KnativeV1alpha1().Configurations(testNamespace)
+	configClient := elaClient.ServingV1alpha1().Configurations(testNamespace)
 
 	config := getTestConfiguration()
 	config.Status.LatestCreatedRevisionName = revName
@@ -590,7 +590,7 @@ func TestMarkConfigurationReadyWhenLatestRevisionRecovers(t *testing.T) {
 		}},
 	}
 	// Since addRevisionEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 	controller.addRevisionEvent(revision)
 
 	readyConfig, err := configClient.Get(config.Name, metav1.GetOptions{})

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/josephburnett/k8sflag/pkg/k8sflag"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/logging/logkey"
-	"github.com/josephburnett/k8sflag/pkg/k8sflag"
 	"go.uber.org/zap"
 
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
@@ -159,7 +159,7 @@ func NewController(
 	logger *zap.SugaredLogger) controller.Interface {
 
 	// obtain references to a shared index informer for the Revision and Endpoint type.
-	informer := elaInformerFactory.Knative().V1alpha1().Revisions()
+	informer := elaInformerFactory.Serving().V1alpha1().Revisions()
 	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 
@@ -999,7 +999,7 @@ func (c *Controller) removeFinalizers(ctx context.Context, rev *v1alpha1.Revisio
 		}
 	}
 	accessor.SetFinalizers(finalizers)
-	prClient := c.ElaClientSet.KnativeV1alpha1().Revisions(rev.Namespace)
+	prClient := c.ElaClientSet.ServingV1alpha1().Revisions(rev.Namespace)
 	prClient.Update(rev)
 	logger.Infof("The finalizer 'controller' is removed.")
 
@@ -1007,7 +1007,7 @@ func (c *Controller) removeFinalizers(ctx context.Context, rev *v1alpha1.Revisio
 }
 
 func (c *Controller) updateStatus(rev *v1alpha1.Revision) (*v1alpha1.Revision, error) {
-	prClient := c.ElaClientSet.KnativeV1alpha1().Revisions(rev.Namespace)
+	prClient := c.ElaClientSet.ServingV1alpha1().Revisions(rev.Namespace)
 	newRev, err := prClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/controller/route/BUILD.bazel
+++ b/pkg/controller/route/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
     importpath = "github.com/knative/serving/pkg/controller/route",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/serving:go_default_library",
         "//pkg/apis/istio/v1alpha2:go_default_library",
+        "//pkg/apis/serving:go_default_library",
         "//pkg/apis/serving/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
@@ -46,8 +46,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/serving:go_default_library",
         "//pkg/apis/istio/v1alpha2:go_default_library",
+        "//pkg/apis/serving:go_default_library",
         "//pkg/apis/serving/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned/fake:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -112,8 +112,8 @@ func NewController(
 
 	// obtain references to a shared index informer for the Routes and
 	// Configurations type.
-	informer := elaInformerFactory.Knative().V1alpha1().Routes()
-	configInformer := elaInformerFactory.Knative().V1alpha1().Configurations()
+	informer := elaInformerFactory.Serving().V1alpha1().Routes()
+	configInformer := elaInformerFactory.Serving().V1alpha1().Configurations()
 	ingressInformer := kubeInformerFactory.Extensions().V1beta1().Ingresses()
 
 	controller := &Controller{
@@ -330,8 +330,8 @@ func (c *Controller) getDirectTrafficTargets(ctx context.Context, route *v1alpha
 	map[string]*v1alpha1.Configuration, map[string]*v1alpha1.Revision, error) {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	configClient := c.ElaClientSet.KnativeV1alpha1().Configurations(ns)
-	revClient := c.ElaClientSet.KnativeV1alpha1().Revisions(ns)
+	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(ns)
+	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(ns)
 	configMap := map[string]*v1alpha1.Configuration{}
 	revMap := map[string]*v1alpha1.Revision{}
 
@@ -363,7 +363,7 @@ func (c *Controller) extendConfigurationsWithIndirectTrafficTargets(
 	revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	configClient := c.ElaClientSet.KnativeV1alpha1().Configurations(ns)
+	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(ns)
 
 	// Get indirect configurations.
 	for _, rev := range revMap {
@@ -390,7 +390,7 @@ func (c *Controller) extendRevisionsWithIndirectTrafficTargets(
 	revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	revisionClient := c.ElaClientSet.KnativeV1alpha1().Revisions(ns)
+	revisionClient := c.ElaClientSet.ServingV1alpha1().Revisions(ns)
 
 	for _, tt := range route.Spec.Traffic {
 		if tt.ConfigurationName != "" {
@@ -422,7 +422,7 @@ func (c *Controller) extendRevisionsWithIndirectTrafficTargets(
 func (c *Controller) setLabelForGivenConfigurations(
 	ctx context.Context, route *v1alpha1.Route, configMap map[string]*v1alpha1.Configuration) error {
 	logger := logging.FromContext(ctx)
-	configClient := c.ElaClientSet.KnativeV1alpha1().Configurations(route.Namespace)
+	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(route.Namespace)
 
 	// Validate
 	for _, config := range configMap {
@@ -458,7 +458,7 @@ func (c *Controller) setLabelForGivenConfigurations(
 func (c *Controller) setLabelForGivenRevisions(
 	ctx context.Context, route *v1alpha1.Route, revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
-	revisionClient := c.ElaClientSet.KnativeV1alpha1().Revisions(route.Namespace)
+	revisionClient := c.ElaClientSet.ServingV1alpha1().Revisions(route.Namespace)
 
 	// Validate revision if it already has a route label
 	for _, rev := range revMap {
@@ -492,7 +492,7 @@ func (c *Controller) setLabelForGivenRevisions(
 func (c *Controller) deleteLabelForOutsideOfGivenConfigurations(
 	ctx context.Context, route *v1alpha1.Route, configMap map[string]*v1alpha1.Configuration) error {
 	logger := logging.FromContext(ctx)
-	configClient := c.ElaClientSet.KnativeV1alpha1().Configurations(route.Namespace)
+	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(route.Namespace)
 	// Get Configurations set as traffic target before this sync.
 	oldConfigsList, err := configClient.List(
 		metav1.ListOptions{
@@ -522,7 +522,7 @@ func (c *Controller) deleteLabelForOutsideOfGivenConfigurations(
 func (c *Controller) deleteLabelForOutsideOfGivenRevisions(
 	ctx context.Context, route *v1alpha1.Route, revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
-	revClient := c.ElaClientSet.KnativeV1alpha1().Revisions(route.Namespace)
+	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(route.Namespace)
 
 	oldRevList, err := revClient.List(
 		metav1.ListOptions{
@@ -653,7 +653,7 @@ func (c *Controller) computeEmptyRevisionRoutes(
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
 	elaNS := controller.GetElaNamespaceName(ns)
-	revClient := c.ElaClientSet.KnativeV1alpha1().Revisions(ns)
+	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(ns)
 	revRoutes := []RevisionRoute{}
 	for _, tt := range route.Spec.Traffic {
 		configName := tt.ConfigurationName
@@ -767,7 +767,7 @@ func (c *Controller) createOrUpdateRouteRules(ctx context.Context, route *v1alph
 }
 
 func (c *Controller) updateStatus(route *v1alpha1.Route) (*v1alpha1.Route, error) {
-	routeClient := c.ElaClientSet.KnativeV1alpha1().Routes(route.Namespace)
+	routeClient := c.ElaClientSet.ServingV1alpha1().Routes(route.Namespace)
 	existing, err := routeClient.Get(route.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -926,7 +926,7 @@ func (c *Controller) updateIngressEvent(old, new interface{}) {
 		}
 	}
 	ns := ingress.Namespace
-	routeClient := c.ElaClientSet.KnativeV1alpha1().Routes(ns)
+	routeClient := c.ElaClientSet.ServingV1alpha1().Routes(ns)
 	route, err := routeClient.Get(routeName, metav1.GetOptions{})
 	if err != nil {
 		c.Logger.Error(

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -36,16 +36,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/josephburnett/k8sflag/pkg/k8sflag"
+	"github.com/knative/serving/pkg/apis/istio/v1alpha2"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/apis/istio/v1alpha2"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	ctrl "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/logging"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/josephburnett/k8sflag/pkg/k8sflag"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
@@ -239,7 +239,7 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 
 	// A standalone revision
 	rev := getTestRevision("test-rev")
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	// A route targeting the revision
 	route := getTestRouteWithTrafficTargets(
@@ -250,9 +250,9 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 			},
 		},
 	)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -305,7 +305,7 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 	// Check owner refs
 	expectedRefs := []metav1.OwnerReference{
 		metav1.OwnerReference{
-			APIVersion: "knative.dev/v1alpha1",
+			APIVersion: "serving.knative.dev/v1alpha1",
 			Kind:       "Route",
 			Name:       route.Name,
 		},
@@ -371,7 +371,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 			Status: corev1.ConditionFalse,
 			Reason: "Inactive",
 		})
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	// A route targeting the revision
 	route := getTestRouteWithTrafficTargets(
@@ -382,9 +382,9 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 			},
 		},
 	)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -403,7 +403,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	// Check owner refs
 	expectedRefs := []metav1.OwnerReference{
 		metav1.OwnerReference{
-			APIVersion: "knative.dev/v1alpha1",
+			APIVersion: "serving.knative.dev/v1alpha1",
 			Kind:       "Route",
 			Name:       route.Name,
 		},
@@ -469,11 +469,11 @@ func TestCreateRouteFromConfigsWithMultipleRevs(t *testing.T) {
 		},
 	}
 	config.Status.LatestReadyRevisionName = latestReadyRev.Name
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(latestReadyRev)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(otherRev)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(latestReadyRev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(otherRev)
 
 	// A route targeting both the config and standalone revision
 	route := getTestRouteWithTrafficTargets(
@@ -484,9 +484,9 @@ func TestCreateRouteFromConfigsWithMultipleRevs(t *testing.T) {
 			},
 		},
 	)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -538,17 +538,17 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 	_, elaClient, controller, _, elaInformer := newTestController(t)
 	// A standalone revision
 	rev := getTestRevision("test-rev")
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration controller.
 	config := getTestConfiguration()
 	cfgrev := getTestRevisionForConfig(config)
 	config.Status.LatestReadyRevisionName = cfgrev.Name
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(cfgrev)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(cfgrev)
 
 	// A route targeting both the config and standalone revision
 	route := getTestRouteWithTrafficTargets(
@@ -563,9 +563,9 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 			},
 		},
 	)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -626,17 +626,17 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			Status: corev1.ConditionFalse,
 			Reason: "Inactive",
 		})
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration controller.
 	config := getTestConfiguration()
 	cfgrev := getTestRevisionForConfig(config)
 	config.Status.LatestReadyRevisionName = cfgrev.Name
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(cfgrev)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(cfgrev)
 
 	// A route targeting both the config and standalone revision
 	route := getTestRouteWithTrafficTargets(
@@ -651,9 +651,9 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			},
 		},
 	)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -705,17 +705,17 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 
 	// A standalone revision
 	rev := getTestRevision("test-rev")
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration controller.
 	config := getTestConfiguration()
 	cfgrev := getTestRevisionForConfig(config)
 	config.Status.LatestReadyRevisionName = cfgrev.Name
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(cfgrev)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(cfgrev)
 
 	// A route with duplicate targets. These will be deduped.
 	route := getTestRouteWithTrafficTargets(
@@ -753,9 +753,9 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			},
 		},
 	)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -821,17 +821,17 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 	_, elaClient, controller, _, elaInformer := newTestController(t)
 	// A standalone revision
 	rev := getTestRevision("test-rev")
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration controller.
 	config := getTestConfiguration()
 	cfgrev := getTestRevisionForConfig(config)
 	config.Status.LatestReadyRevisionName = cfgrev.Name
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(cfgrev)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(cfgrev)
 
 	// A route targeting both the config and standalone revision with named
 	// targets
@@ -850,9 +850,9 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		},
 	)
 
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -1000,8 +1000,8 @@ func TestCreateRouteDeletesOutdatedRouteRules(t *testing.T) {
 	config.Status.LatestCreatedRevisionName = rev.Name
 	config.Labels = map[string]string{serving.RouteLabelKey: route.Name}
 
-	elaClient.KnativeV1alpha1().Configurations("test").Create(config)
-	elaClient.KnativeV1alpha1().Revisions("test").Create(rev)
+	elaClient.ServingV1alpha1().Configurations("test").Create(config)
+	elaClient.ServingV1alpha1().Revisions("test").Create(rev)
 	elaClient.ConfigV1alpha2().RouteRules(route.Namespace).Create(extraRouteRule)
 	elaClient.ConfigV1alpha2().RouteRules(route.Namespace).Create(independentRouteRule)
 
@@ -1012,7 +1012,7 @@ func TestCreateRouteDeletesOutdatedRouteRules(t *testing.T) {
 	if _, err := elaClient.ConfigV1alpha2().RouteRules(route.Namespace).Get(independentRouteRule.Name, metav1.GetOptions{}); err != nil {
 		t.Errorf("Unexpected error occured. Expected route rule %s to exist.", independentRouteRule.Name)
 	}
-	elaClient.KnativeV1alpha1().Routes("test").Create(route)
+	elaClient.ServingV1alpha1().Routes("test").Create(route)
 
 	if err := controller.removeOutdatedRouteRules(testCtx, route); err != nil {
 		t.Errorf("Unexpected error occurred removing outdated route rules: %s", err)
@@ -1043,14 +1043,14 @@ func TestSetLabelToConfigurationDirectlyConfigured(t *testing.T) {
 		},
 	)
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 	controller.updateRouteEvent(KeyOrDie(route))
 
-	config, err := elaClient.KnativeV1alpha1().Configurations(testNamespace).Get(config.Name, metav1.GetOptions{})
+	config, err := elaClient.ServingV1alpha1().Configurations(testNamespace).Get(config.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting config: %v", err)
 	}
@@ -1075,14 +1075,14 @@ func TestSetLabelToRevisionDirectlyConfigured(t *testing.T) {
 		},
 	)
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 	controller.updateRouteEvent(KeyOrDie(route))
 
-	rev, err := elaClient.KnativeV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
+	rev, err := elaClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting revision: %v", err)
 	}
@@ -1099,10 +1099,10 @@ func TestSetLabelToRevisionDirectlyConfigured(t *testing.T) {
 	// Mark the revision as the Config's latest ready revision
 	config.Status.LatestReadyRevisionName = rev.Name
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Update(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Update(config)
 	controller.updateRouteEvent(KeyOrDie(route))
 
-	rev, err = elaClient.KnativeV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
+	rev, err = elaClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting revision: %v", err)
 	}
@@ -1131,14 +1131,14 @@ func TestSetLabelToConfigurationAndRevisionIndirectlyConfigured(t *testing.T) {
 		},
 	)
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 	controller.updateRouteEvent(KeyOrDie(route))
 
-	config, err := elaClient.KnativeV1alpha1().Configurations(testNamespace).Get(config.Name, metav1.GetOptions{})
+	config, err := elaClient.ServingV1alpha1().Configurations(testNamespace).Get(config.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting config: %v", err)
 	}
@@ -1149,7 +1149,7 @@ func TestSetLabelToConfigurationAndRevisionIndirectlyConfigured(t *testing.T) {
 		t.Errorf("Unexpected label in configuration diff (-want +got): %v", diff)
 	}
 
-	rev, err = elaClient.KnativeV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
+	rev, err = elaClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting revision: %v", err)
 	}
@@ -1180,11 +1180,11 @@ func TestCreateRouteWithInvalidConfigurationShouldReturnError(t *testing.T) {
 	// Set config's route label with another route name to trigger an error.
 	config.Labels = map[string]string{serving.RouteLabelKey: "another-route"}
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	// No configuration updates.
 	elaClient.Fake.PrependReactor("update", "configurations",
@@ -1230,11 +1230,11 @@ func TestSetLabelNotChangeConfigurationAndRevisionLabelIfLabelExists(t *testing.
 	// by function setLabelForGivenRevisions.
 	rev.Labels[serving.RouteLabelKey] = route.Name
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	// Assert that the configuration is not updated when updateRouteEvent is called.
 	elaClient.Fake.PrependReactor("update", "configurations",
@@ -1265,14 +1265,14 @@ func TestDeleteLabelOfConfigurationAndRevisionWhenUnconfigured(t *testing.T) {
 	// Set a route label in revision which is expected to be deleted.
 	rev.Labels[serving.RouteLabelKey] = route.Name
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	controller.updateRouteEvent(KeyOrDie(route))
 
-	config, err := elaClient.KnativeV1alpha1().Configurations(testNamespace).Get(config.Name, metav1.GetOptions{})
+	config, err := elaClient.ServingV1alpha1().Configurations(testNamespace).Get(config.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting config: %v", err)
 	}
@@ -1283,7 +1283,7 @@ func TestDeleteLabelOfConfigurationAndRevisionWhenUnconfigured(t *testing.T) {
 		t.Errorf("Unexpected label in Configuration diff (-want +got): %v", diff)
 	}
 
-	rev, err = elaClient.KnativeV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
+	rev, err = elaClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting revision: %v", err)
 	}
@@ -1302,11 +1302,11 @@ func TestDeleteLabelOfConfigurationAndRevisionWhenUnconfigured(t *testing.T) {
 func TestUpdateRouteDomainWhenRouteLabelChanges(t *testing.T) {
 	kubeClient, elaClient, controller, _, elaInformer := newTestController(t)
 	route := getTestRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
-	routeClient := elaClient.KnativeV1alpha1().Routes(route.Namespace)
+	routeClient := elaClient.ServingV1alpha1().Routes(route.Namespace)
 	ingressClient := kubeClient.Extensions().Ingresses(route.Namespace)
 
 	// Create a route.
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 	routeClient.Create(route)
 	controller.updateRouteEvent(KeyOrDie(route))
 
@@ -1323,7 +1323,7 @@ func TestUpdateRouteDomainWhenRouteLabelChanges(t *testing.T) {
 	}
 	for _, expectation := range expectations {
 		route.ObjectMeta.Labels = expectation.labels
-		elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+		elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 		routeClient.Update(route)
 		controller.updateRouteEvent(KeyOrDie(route))
 
@@ -1350,7 +1350,7 @@ func TestUpdateRouteDomainWhenRouteLabelChanges(t *testing.T) {
 
 func TestUpdateRouteWhenConfigurationChanges(t *testing.T) {
 	_, elaClient, controller, _, elaInformer := newTestController(t)
-	routeClient := elaClient.KnativeV1alpha1().Routes(testNamespace)
+	routeClient := elaClient.ServingV1alpha1().Routes(testNamespace)
 
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
@@ -1365,12 +1365,12 @@ func TestUpdateRouteWhenConfigurationChanges(t *testing.T) {
 
 	routeClient.Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
 	// Since addConfigurationEvent looks in the lister, we need to add it to the
 	// informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	controller.addConfigurationEvent(config)
 
@@ -1394,10 +1394,10 @@ func TestUpdateRouteWhenConfigurationChanges(t *testing.T) {
 
 	// We need to update the config in the client since getDirectTrafficTargets
 	// gets the configuration from there
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Update(config)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Update(config)
 	// Since addConfigurationEvent looks in the lister, we need to add it to the
 	// informer
-	elaInformer.Knative().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
+	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 	controller.addConfigurationEvent(config)
 
 	route, err = routeClient.Get(route.Name, metav1.GetOptions{})
@@ -1439,11 +1439,11 @@ func TestAddConfigurationEventNotUpdateAnythingIfHasNoLatestReady(t *testing.T) 
 	config.Status.LatestCreatedRevisionName = rev.Name
 	config.Labels = map[string]string{serving.RouteLabelKey: route.Name}
 
-	elaClient.KnativeV1alpha1().Configurations(testNamespace).Create(config)
-	elaClient.KnativeV1alpha1().Revisions(testNamespace).Create(rev)
-	elaClient.KnativeV1alpha1().Routes(testNamespace).Create(route)
+	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
+	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
-	elaInformer.Knative().V1alpha1().Routes().Informer().GetIndexer().Add(route)
+	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
 
 	// No configuration updates
 	elaClient.Fake.PrependReactor("update", "configurations",
@@ -1477,7 +1477,7 @@ func TestUpdateIngressEventUpdateRouteStatus(t *testing.T) {
 		},
 	)
 	// Create a route.
-	routeClient := elaClient.KnativeV1alpha1().Routes(route.Namespace)
+	routeClient := elaClient.ServingV1alpha1().Routes(route.Namespace)
 	routeClient.Create(route)
 	// Create an ingress owned by this route.
 	controller.reconcileIngress(testCtx, route)

--- a/pkg/controller/service/service.go
+++ b/pkg/controller/service/service.go
@@ -85,7 +85,7 @@ func NewController(
 	logger *zap.SugaredLogger) controller.Interface {
 
 	// obtain references to a shared index informer for the Services.
-	informer := elaInformerFactory.Knative().V1alpha1().Services()
+	informer := elaInformerFactory.Serving().V1alpha1().Services()
 
 	controller := &Controller{
 		Base: controller.NewBase(kubeClientSet, elaClientSet, kubeInformerFactory,
@@ -184,7 +184,7 @@ func (c *Controller) updateServiceEvent(key string) error {
 }
 
 func (c *Controller) updateStatus(service *v1alpha1.Service) (*v1alpha1.Service, error) {
-	serviceClient := c.ElaClientSet.KnativeV1alpha1().Services(service.Namespace)
+	serviceClient := c.ElaClientSet.ServingV1alpha1().Services(service.Namespace)
 	existing, err := serviceClient.Get(service.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ func (c *Controller) updateStatus(service *v1alpha1.Service) (*v1alpha1.Service,
 }
 
 func (c *Controller) reconcileConfiguration(config *v1alpha1.Configuration) error {
-	configClient := c.ElaClientSet.KnativeV1alpha1().Configurations(config.Namespace)
+	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(config.Namespace)
 
 	existing, err := configClient.Get(config.Name, metav1.GetOptions{})
 	if err != nil {
@@ -217,7 +217,7 @@ func (c *Controller) reconcileConfiguration(config *v1alpha1.Configuration) erro
 }
 
 func (c *Controller) reconcileRoute(route *v1alpha1.Route) error {
-	routeClient := c.ElaClientSet.KnativeV1alpha1().Routes(route.Namespace)
+	routeClient := c.ElaClientSet.ServingV1alpha1().Routes(route.Namespace)
 
 	existing, err := routeClient.Get(route.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/controller/service/service_configuration_test.go
+++ b/pkg/controller/service/service_configuration_test.go
@@ -16,10 +16,10 @@ package service
 import (
 	"testing"
 
-	"github.com/knative/serving/pkg/apis/serving"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -139,7 +139,7 @@ func expectOwnerReferencesSetCorrectly(t *testing.T, ownerRefs []metav1.OwnerRef
 
 	expectedRefs := []metav1.OwnerReference{
 		metav1.OwnerReference{
-			APIVersion: "knative.dev/v1alpha1",
+			APIVersion: "serving.knative.dev/v1alpha1",
 			Kind:       "Service",
 			Name:       testServiceName,
 		},

--- a/sample/autoscale/sample.yaml
+++ b/sample/autoscale/sample.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: autoscale-route
@@ -21,7 +21,7 @@ spec:
   - configurationName: autoscale-configuration
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: autoscale-configuration

--- a/sample/buildpack-app/README.md
+++ b/sample/buildpack-app/README.md
@@ -39,7 +39,7 @@ Once deployed, you will see that it first builds:
 $ kubectl get revision -o yaml
 apiVersion: v1
 items:
-- apiVersion: knative.dev/v1alpha1
+- apiVersion: serving.knative.dev/v1alpha1
   kind: Revision
   ...
   status:

--- a/sample/buildpack-app/sample.yaml
+++ b/sample/buildpack-app/sample.yaml
@@ -1,4 +1,4 @@
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: buildpack-sample-app
@@ -8,7 +8,7 @@ spec:
   - configurationName: buildpack-sample-app
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: buildpack-sample-app

--- a/sample/buildpack-function/README.md
+++ b/sample/buildpack-function/README.md
@@ -38,7 +38,7 @@ Once deployed, you will see that it first builds:
 $ kubectl get revision -o yaml
 apiVersion: v1
 items:
-- apiVersion: knative.dev/v1alpha1
+- apiVersion: serving.knative.dev/v1alpha1
   kind: Revision
   ...
   status:

--- a/sample/buildpack-function/sample.yaml
+++ b/sample/buildpack-function/sample.yaml
@@ -1,4 +1,4 @@
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: buildpack-function
@@ -8,7 +8,7 @@ spec:
   - configurationName: buildpack-function
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: buildpack-function

--- a/sample/gitwebhook/sample.yaml
+++ b/sample/gitwebhook/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: git-webhook
@@ -22,7 +22,7 @@ spec:
   - configurationName: git-webhook
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: git-webhook

--- a/sample/helloworld/sample.yaml
+++ b/sample/helloworld/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: route-example
@@ -22,7 +22,7 @@ spec:
   - configurationName: configuration-example
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: configuration-example

--- a/sample/helloworld/updated_configuration.yaml
+++ b/sample/helloworld/updated_configuration.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: configuration-example

--- a/sample/private-repos/manifest.yaml
+++ b/sample/private-repos/manifest.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: private-repos
@@ -20,7 +20,7 @@ spec:
   - configurationName: private-repos
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: private-repos

--- a/sample/pythonsimple/manifest.yaml
+++ b/sample/pythonsimple/manifest.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: route-python-example
@@ -21,7 +21,7 @@ spec:
   - configurationName: configuration-python-example
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: configuration-python-example

--- a/sample/service/pinned_service.yaml
+++ b/sample/service/pinned_service.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: service-example

--- a/sample/service/sample.yaml
+++ b/sample/service/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: service-example

--- a/sample/service/updated_service.yaml
+++ b/sample/service/updated_service.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: service-example

--- a/sample/steren-app/README.md
+++ b/sample/steren-app/README.md
@@ -28,7 +28,7 @@ Once deployed, you will see that it first builds:
 kubectl get revision -o yaml
 apiVersion: v1
 items:
-- apiVersion: knative.dev/v1alpha1
+- apiVersion: serving.knative.dev/v1alpha1
   kind: Revision
   ...
   status:

--- a/sample/steren-app/sample.yaml
+++ b/sample/steren-app/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: steren-sample-app
@@ -22,7 +22,7 @@ spec:
   - configurationName: steren-sample-app
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: steren-sample-app

--- a/sample/steren-function/README.md
+++ b/sample/steren-function/README.md
@@ -27,7 +27,7 @@ Once deployed, you will see that it first builds:
 $ kubectl get revision -o yaml
 apiVersion: v1
 items:
-- apiVersion: knative.dev/v1alpha1
+- apiVersion: serving.knative.dev/v1alpha1
   kind: Revision
   ...
   status:

--- a/sample/steren-function/sample.yaml
+++ b/sample/steren-function/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: steren-sample-fn
@@ -22,7 +22,7 @@ spec:
   - configurationName: steren-sample-function
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: steren-sample-function

--- a/sample/stock-rest-app/sample.yaml
+++ b/sample/stock-rest-app/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: stock-route-example
@@ -22,7 +22,7 @@ spec:
   - configurationName: stock-configuration-example
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: stock-configuration-example

--- a/sample/stock-rest-app/updated_configuration.yaml
+++ b/sample/stock-rest-app/updated_configuration.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: stock-configuration-example

--- a/sample/telemetrysample/configuration.yaml
+++ b/sample/telemetrysample/configuration.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: telemetrysample-configuration

--- a/sample/telemetrysample/route.yaml
+++ b/sample/telemetrysample/route.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: telemetrysample-route

--- a/sample/thumbnailer/README.md
+++ b/sample/thumbnailer/README.md
@@ -98,7 +98,7 @@ Now, if you look at the `status` of the revision, you will see that a build is i
 $ kubectl get revisions -o yaml
 apiVersion: v1
 items:
-- apiVersion: knative.dev/v1alpha1
+- apiVersion: serving.knative.dev/v1alpha1
   kind: Revision
   ...
   status:

--- a/sample/thumbnailer/sample-prebuilt.yaml
+++ b/sample/thumbnailer/sample-prebuilt.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: thumb
@@ -22,7 +22,7 @@ spec:
   - configurationName: thumbtemplate
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: thumbtemplate

--- a/sample/thumbnailer/sample.yaml
+++ b/sample/thumbnailer/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: thumb
@@ -22,7 +22,7 @@ spec:
   - configurationName: thumbtemplate
     percent: 100
 ---
-apiVersion: knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: thumbtemplate

--- a/test/clients.go
+++ b/test/clients.go
@@ -52,9 +52,9 @@ func NewClients(configPath string, clusterName string, namespace string) (*Clien
 		return nil, err
 	}
 
-	clients.Routes = cs.KnativeV1alpha1().Routes(namespace)
-	clients.Configs = cs.KnativeV1alpha1().Configurations(namespace)
-	clients.Revisions = cs.KnativeV1alpha1().Revisions(namespace)
+	clients.Routes = cs.ServingV1alpha1().Routes(namespace)
+	clients.Configs = cs.ServingV1alpha1().Configurations(namespace)
+	clients.Revisions = cs.ServingV1alpha1().Revisions(namespace)
 
 	return clients, nil
 }


### PR DESCRIPTION
Other Knative projects use the project name in the CRD group. Now that the Serving project is no longer called "elafros", the project name should be included in the CRD group namespace.

This is a breaking change, but aligns well with the other breakages caused by the rename.

## Proposed Changes

  * Make `serving.knative.dev` the CRD group name
  * Updated generated client code and references to the generated code
  * I intentionally did not update name for resource labels or for logging.
  * In docs there were a few references to CRDs from the build project. Those CRD groups are now called build.knative.dev.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
CRDs defined by the serving project now use the group name `serving.knative.dev`
```