### PR TITLE
Replace Elafros with Knative Serving in *.go

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -77,7 +77,7 @@ type RouteSpec struct {
 	// ObjectMeta.Generation instead.
 	Generation int64 `json:"generation,omitempty"`
 
-	// Traffic specifies how to distribute traffic over a collection of Elafros Revisions and Configurations.
+	// Traffic specifies how to distribute traffic over a collection of Knative Serving Revisions and Configurations.
 	Traffic []TrafficTarget `json:"traffic,omitempty"`
 }
 

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -36,7 +36,7 @@ func GetElaConfigMapName() string {
 
 // Various functions for naming the resources for consistency
 func GetElaNamespaceName(ns string) string {
-	// We create resources in the same namespace as the Elafros resources by default.
+	// We create resources in the same namespace as the Knative Serving resources by default.
 	// TODO(mattmoor): Expose a knob for creating resources in an alternate namespace.
 	return ns
 }
@@ -77,11 +77,11 @@ func GetElaK8SActivatorNamespace() string {
 }
 
 func GetRevisionHeaderName() string {
-	return "Elafros-Revision"
+	return "Knative-Serving-Revision"
 }
 
 func GetRevisionHeaderNamespace() string {
-	return "Elafros-Namespace"
+	return "Knative-Serving-Namespace"
 }
 
 func GetOrCreateRevisionNamespace(ctx context.Context, ns string, c clientset.Interface) (string, error) {

--- a/pkg/controller/revision/ela_pod.go
+++ b/pkg/controller/revision/ela_pod.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	// Each Elafros pod gets 1 cpu.
+	// Each Knative Serving pod gets 1 cpu.
 	elaContainerCPU     = "400m"
 	queueContainerCPU   = "25m"
 	fluentdContainerCPU = "75m"

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -101,7 +101,7 @@ func validateContainer(container corev1.Container) error {
 	if reflect.DeepEqual(container, corev1.Container{}) {
 		return errEmptyContainerInRevisionTemplate
 	}
-	// Some corev1.Container fields are set by Elafros controller.  We disallow them
+	// Some corev1.Container fields are set by Knative Serving controller.  We disallow them
 	// here to avoid silently overwriting these fields and causing confusions for
 	// the users.  See pkg/controller/revision.MakeElaPodSpec for the list of fields
 	// overridden.

--- a/sample/telemetrysample/telemetrysample.go
+++ b/sample/telemetrysample/telemetrysample.go
@@ -98,7 +98,7 @@ func main() {
 	// Tracing setup
 	//
 
-	// If your service only calls other Elafros revisions, then Zipkin setup below
+	// If your service only calls other Knative Serving revisions, then Zipkin setup below
 	// is not needed. All that you need is to extract the following headers from incoming
 	// requests and copy them to your outgoing requests.
 	// x-request-id, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags, x-ot-span-context

--- a/test/clients.go
+++ b/test/clients.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// Clients holds instances of interfaces for making requests to Elafros.
+// Clients holds instances of interfaces for making requests to Knative Serving.
 type Clients struct {
 	Kube      *kubernetes.Clientset
 	Routes    elatyped.RouteInterface
@@ -34,7 +34,7 @@ type Clients struct {
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
-// Elafros cluster specified by the combination of clusterName and configPath. Clients can
+// Knative Serving cluster specified by the combination of clusterName and configPath. Clients can
 // make requests within namespace.
 func NewClients(configPath string, clusterName string, namespace string) (*Clients, error) {
 	clients := &Clients{}

--- a/test/crd_polling.go
+++ b/test/crd_polling.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// crdpolling contains functions which poll Elafros CRDs until they
+// crdpolling contains functions which poll Knative Serving CRDs until they
 // get into the state desired by the caller or time out.
 
 package test

--- a/test/states.go
+++ b/test/states.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// states contains functions for asserting against the state of Elafros
+// states contains functions for asserting against the state of Knative Serving
 // crds to see if they have achieved the states specified in the spec
 // (https://github.com/knative/serving/blob/master/docs/spec/spec.md).
 


### PR DESCRIPTION
There is one place we use `Knative-Serving` instead (`pkg/controller/names.go`)
