### PR TITLE
Integrate a comment from review feedback that Tide happily ignored.

### DIFF
--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -28,7 +28,7 @@ You can:
 * [Use common test flags](#use-common-test-flags)
 * [Get access to client objects](#get-access-to-client-objects)
 * [Make requests against deployed services](#make-requests-against-deployed-services)
-* [Poll Knative Serving resources](#poll-knative-resources)
+* [Poll Knative Serving resources](#poll-knative-serving-resources)
 * [Verify resource state transitions](#verify-resource-state-transitions)
 * [Generate boilerplate CRDs](#generate-boilerplate-crds)
 * [Ensure test cleanup](#ensure-test-cleanup)
@@ -139,7 +139,7 @@ _See [crd_polling.go](./crd_polling.go)._
 
 ### Verify resource state transitions
 
-To use the [polling functions](#poll-knative-resources) you must provide a function to check the
+To use the [polling functions](#poll-knative-serving-resources) you must provide a function to check the
 state. Some of the expected transition states (as defined in [the Knative Serving spec](/docs/spec/spec.md))
 are expressed in functions in [states.go](./states.go).
 


### PR DESCRIPTION
Fixes a couple links in the markdown that were messed up by the rename.