### PR TITLE
Autoscaler: add debug metrics

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -166,9 +166,9 @@ func scaleTo(podCount int32) {
 		deployment.Status.Replicas,
 		deployment.Status.AvailableReplicas,
 		deployment.Status.ReadyReplicas)
-	statsReporter.Report(ela_autoscaler.DesiredPodCountM, (int64)(podCount))
-	statsReporter.Report(ela_autoscaler.RequestedPodCountM, (int64)(deployment.Status.Replicas))
-	statsReporter.Report(ela_autoscaler.ActualPodCountM, (int64)(deployment.Status.ReadyReplicas))
+	statsReporter.Report(ela_autoscaler.DesiredPodCountM, float64(podCount))
+	statsReporter.Report(ela_autoscaler.RequestedPodCountM, float64(deployment.Status.Replicas))
+	statsReporter.Report(ela_autoscaler.ActualPodCountM, float64(deployment.Status.ReadyReplicas))
 
 	if *deployment.Spec.Replicas == podCount {
 		return

--- a/config/monitoring/200-common/100-grafana-dash-knative.yaml
+++ b/config/monitoring/200-common/100-grafana-dash-knative.yaml
@@ -1718,401 +1718,805 @@ data:
       "uid": "bKOoE9Wmk",
       "version": 4
     }
-  autoscaler-dashboard.json: |+
+  scaling-dashboard.json: |+
     {
       "__inputs": [
         {
-          "description": "",
-          "label": "prometheus",
           "name": "prometheus",
+          "label": "prometheus",
+          "description": "",
+          "type": "datasource",
           "pluginId": "prometheus",
-          "pluginName": "Prometheus",
-          "type": "datasource"
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "5.0.3"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "5.0.0"
         }
       ],
       "annotations": {
-        "list": []
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
       },
-      "description": "Knative Serving - Autoscaler",
+      "description": "Knative Serving - Scaling",
       "editable": false,
       "gnetId": null,
       "graphTooltip": 0,
       "id": null,
-      "iteration": 1525724908045,
-      "links": [],
+      "iteration": 1527886043818,
+      "links": [
+        
+      ],
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
+          "collapsed": true,
           "gridPos": {
-            "h": 17,
+            "h": 1,
             "w": 24,
             "x": 0,
             "y": 0
           },
-          "id": 2,
-          "legend": {
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
+          "id": 14,
+          "panels": [
             {
-              "alias": "Panic Mode",
-              "color": "#f29191",
-              "dashes": true,
-              "fill": 2,
-              "linewidth": 2,
+              "aliasColors": {
+                
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 1
+              },
+              "id": 2,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [
+                
+              ],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                
+              ],
+              "spaceLength": 10,
+              "stack": false,
               "steppedLine": true,
-              "yaxis": 2
+              "targets": [
+                {
+                  "expr": "sum(autoscaler_actual_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Actual Pods",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(autoscaler_requested_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Requested Pods",
+                  "refId": "C"
+                }
+              ],
+              "thresholds": [
+                
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Revision Pod Counts",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "decimals": null,
+                  "format": "short",
+                  "label": "Concurrency",
+                  "logBase": 1,
+                  "max": "1",
+                  "min": null,
+                  "show": false
+                }
+              ]
             }
           ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "autoscaler_actual_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"}",
-              "format": "time_series",
-              "interval": "1s",
-              "intervalFactor": 1,
-              "legendFormat": "Actual Pods",
-              "refId": "A"
-            },
-            {
-              "expr": "autoscaler_desired_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"} ",
-              "format": "time_series",
-              "interval": "1s",
-              "intervalFactor": 1,
-              "legendFormat": "Desired Pods",
-              "refId": "B"
-            },
-            {
-              "expr": "autoscaler_requested_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"} ",
-              "format": "time_series",
-              "interval": "1s",
-              "intervalFactor": 1,
-              "legendFormat": "Requested Pods",
-              "refId": "C"
-            },
-            {
-              "expr": "autoscaler_panic_mode{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"} ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "1s",
-              "intervalFactor": 1,
-              "legendFormat": "Panic Mode",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "Revision Pod Counts",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": "Panic Mode",
-              "logBase": 1,
-              "max": "1.0",
-              "min": "0",
-              "show": true
-            }
-          ]
+          "type": "row"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
+          "collapsed": true,
           "gridPos": {
-            "h": 9,
-            "w": 12,
+            "h": 1,
+            "w": 24,
             "x": 0,
-            "y": 17
+            "y": 1
           },
-          "id": 4,
-          "legend": {
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
+          "id": 18,
+          "panels": [
             {
-              "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Cores requested",
-              "refId": "A"
+              "aliasColors": {
+                
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 13
+              },
+              "id": 4,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [
+                
+              ],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Cores requested",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Cores used",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Core limit",
+                  "refId": "C"
+                }
+              ],
+              "thresholds": [
+                
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Revision CPU Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  
+                ]
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
             },
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"}[1m]))",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Cores used",
-              "refId": "B"
-            },
-            {
-              "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Core limit",
-              "refId": "C"
+              "aliasColors": {
+                
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 13
+              },
+              "id": 6,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [
+                
+              ],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Memory requested",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"})",
+                  "format": "time_series",
+                  "hide": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "Memory used",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "C"
+                }
+              ],
+              "thresholds": [
+                
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Pod Memory Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "decbytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
             }
           ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Revision CPU Usage",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "title": "Resource Usages",
+          "type": "row"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
+          "collapsed": true,
           "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 17
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
           },
-          "id": 6,
-          "legend": {
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
+          "id": 16,
+          "panels": [
             {
-              "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Memory requested",
-              "refId": "A"
+              "aliasColors": {
+                
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 3
+              },
+              "id": 10,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [
+                
+              ],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "sum(autoscaler_desired_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"}) ",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Desired Pods",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(autoscaler_observed_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Observed Pods",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [
+                
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Pod Counts",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ]
             },
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"})",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "Memory used",
-              "refId": "B"
+              "aliasColors": {
+                
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 13
+              },
+              "id": 8,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [
+                
+              ],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "Panic Mode",
+                  "color": "#ea6460",
+                  "dashes": true,
+                  "fill": 2,
+                  "linewidth": 2,
+                  "steppedLine": true,
+                  "yaxis": 2
+                },
+                {
+                  "alias": "Target Concurrency Per Pod",
+                  "color": "#0a50a1",
+                  "dashes": true,
+                  "steppedLine": false
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "sum(autoscaler_observed_stable_concurrency{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Stable Concurrency",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(autoscaler_observed_panic_concurrency{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Panic Concurrency",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(autoscaler_target_concurrency_per_pod{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Target Concurrency Per Pod",
+                  "refId": "C"
+                }
+              ],
+              "thresholds": [
+                
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Observed Concurrency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
             },
             {
-              "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "refId": "C"
+              "aliasColors": {
+                
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "decimals": null,
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 22
+              },
+              "id": 12,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [
+                
+              ],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "Panic Mode",
+                  "color": "#e24d42",
+                  "linewidth": 2,
+                  "yaxis": 2
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "sum(autoscaler_panic_mode{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"} )",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Panic Mode",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [
+                
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Panic Mode",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": "1.0",
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
             }
           ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Pod Memory Usage",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decbytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "title": "Debugging Metrics",
+          "type": "row"
         }
       ],
-      "refresh": "5s",
+      "refresh": false,
       "schemaVersion": 16,
       "style": "dark",
-      "tags": [],
+      "tags": [
+        
+      ],
       "templating": {
         "list": [
           {
             "allValue": null,
-            "current": {},
+            "current": {
+              
+            },
             "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Namespace",
             "multi": false,
             "name": "namespace",
-            "options": [],
+            "options": [
+              
+            ],
             "query": "label_values(autoscaler_actual_pod_count, configuration_namespace)",
             "refresh": 1,
             "regex": "",
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [],
+            "tags": [
+              
+            ],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
           },
           {
             "allValue": null,
-            "current": {},
+            "current": {
+              
+            },
             "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Configuration",
             "multi": false,
             "name": "configuration",
-            "options": [],
+            "options": [
+              
+            ],
             "query": "label_values(autoscaler_actual_pod_count{configuration_namespace=\"$namespace\"}, configuration)",
             "refresh": 1,
             "regex": "",
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [],
+            "tags": [
+              
+            ],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
           },
           {
             "allValue": null,
-            "current": {},
+            "current": {
+              
+            },
             "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Revision",
             "multi": false,
             "name": "revision",
-            "options": [],
+            "options": [
+              
+            ],
             "query": "label_values(autoscaler_actual_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\"}, revision)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
             "tagValuesQuery": "",
-            "tags": [],
+            "tags": [
+              
+            ],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
@@ -2120,7 +2524,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-15m",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {
@@ -2149,7 +2553,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Knative Serving - Autoscaler",
+      "title": "Knative Serving - Scaling",
       "uid": "u_-9SIMiz",
-      "version": 4
+      "version": 5
     }

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -163,10 +163,14 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 		return 0, false
 	}
 
+	a.reporter.Report(ObservedPodCountM, float64(len(stablePods)))
 	// Observed concurrency is the average of all data points in each window
 	observedStableConcurrency := stableTotal / stableCount
+	a.reporter.Report(ObservedStableConcurrencyM, observedStableConcurrency)
 	observedPanicConcurrency := panicTotal / panicCount
+	a.reporter.Report(ObservedPanicConcurrencyM, observedPanicConcurrency)
 
+	a.reporter.Report(TargetConcurrencyM, a.TargetConcurrency.Get())
 	// Desired scaling ratio is observed concurrency over desired
 	// (stable) concurrency. Rate limited to within MaxScaleUpRate.
 	desiredStableScalingRatio := a.rateLimited(observedStableConcurrency / a.TargetConcurrency.Get())

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -270,7 +270,7 @@ type linearSeries struct {
 
 type mockReporter struct{}
 
-func (r *mockReporter) Report(m Measurement, v int64) error {
+func (r *mockReporter) Report(m Measurement, v float64) error {
 	return nil
 }
 

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -39,10 +39,18 @@ func TestReporter_Report(t *testing.T) {
 	expectSuccess(t, func() error { return r.Report(RequestedPodCountM, 7) })
 	expectSuccess(t, func() error { return r.Report(ActualPodCountM, 5) })
 	expectSuccess(t, func() error { return r.Report(PanicM, 0) })
+	expectSuccess(t, func() error { return r.Report(ObservedPodCountM, 1) })
+	expectSuccess(t, func() error { return r.Report(ObservedStableConcurrencyM, 2) })
+	expectSuccess(t, func() error { return r.Report(ObservedPanicConcurrencyM, 3) })
+	expectSuccess(t, func() error { return r.Report(TargetConcurrencyM, 0.9) })
 	checkData(t, "desired_pod_count", wantTags, 10)
 	checkData(t, "requested_pod_count", wantTags, 7)
 	checkData(t, "actual_pod_count", wantTags, 5)
 	checkData(t, "panic_mode", wantTags, 0)
+	checkData(t, "observed_pod_count", wantTags, 1)
+	checkData(t, "observed_stable_concurrency", wantTags, 2)
+	checkData(t, "observed_panic_concurrency", wantTags, 3)
+	checkData(t, "target_concurrency_per_pod", wantTags, 0.9)
 
 	// All the stats are gauges - record multiple entries for one stat - last one should stick
 	expectSuccess(t, func() error { return r.Report(DesiredPodCountM, 1) })
@@ -75,7 +83,7 @@ func expectSuccess(t *testing.T, f func() error) {
 	}
 }
 
-func checkData(t *testing.T, name string, wantTags map[string]string, wantValue int) {
+func checkData(t *testing.T, name string, wantTags map[string]string, wantValue float64) {
 	if d, err := view.RetrieveData(name); err != nil {
 		t.Errorf("Reporter.Report() error = %v, wantErr %v", err, false)
 	} else {


### PR DESCRIPTION
Fixes #
https://github.com/knative/serving/issues/916

## Proposed Changes

  * Add metrics observed_pod_count, observed_stable_concurrency, observed_panic_concurrency, target_concurrency_per_pod
  * Edit the autoscaler dashboard.
