### PR TITLE
Remove e2e instructions using Bazel.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -66,27 +66,6 @@ The configuration for the images used for the existing conformance tests lives i
 [`test_images`](./conformance/test_images). See the [section about test
 images](#test-images) for details about building and adding new ones.
 
-### Running conformance tests with Bazel
-
-To run the conformance tests with `bazel` you must:
-
-* Provide a `kubeconfig` file. This file must be a `data` dependency of the test in
-  [`BUILD.bazel`](./conformance/BUILD.bazel). By default [`BUILD.bazel`](./conformance/BUILD.bazel)
-  is configured to use [`test/conformance/kubeconfig`](/test/conformance/kubeconfig).
-* Provide a docker repo from which the built images will be pulled. This is done
-  via the `--dockerrepo` argument.
-
-_The `bazel` execution environment will not contain your environment variables, so you must
-explicitly specify them with [command line args](#flags)._
-
-To run the tests with `bazel` (assuming you have populated [`./kubeconfig`](./conformance/kubeconfig)
-and your [`DOCKER_REPO_OVERRIDE`](/DEVELOPMENT.md#environment-setup) is configured
-to the location where [you have pushed the conformance test images](#conformance-test-images)):
-
-```bash
-bazel test //test/... --test_arg=--dockerrepo=$DOCKER_REPO_OVERRIDE --test_arg=--kubeconfig=./kubeconfig
-```
-
 ## Running end-to-end tests
 
 The e2e tests have almost the exact same requirements and specs as the conformance tests, but they will be enumerated for clarity.
@@ -133,27 +112,6 @@ These tests require:
 The configuration for the images used for the existing e2e tests lives in
 [`test_images`](./e2e/test_images). See the [section about test
 images](#test-images) for details about building and adding new ones.
-
-### Running e2e tests with Bazel
-
-To run the e2e tests with `bazel` you must:
-
-* Provide a `kubeconfig` file. This file must be a `data` dependency of the test in
-  [`BUILD.bazel`](./e2e/BUILD.bazel). By default [`BUILD.bazel`](./e2e/BUILD.bazel)
-  is configured to use [`test/e2e/kubeconfig`](/test/e2e/kubeconfig).
-* Provide a docker repo from which the built images will be pulled. This is done
-  via the `--dockerrepo` argument.
-
-_The `bazel` execution environment will not contain your environment variables, so you must
-explicitly specify them with [command line args](#flags)._
-
-To run the tests with `bazel` (assuming you have populated [`./kubeconfig`](./e2e/kubeconfig)
-and your [`DOCKER_REPO_OVERRIDE`](/DEVELOPMENT.md#environment-setup) is configured
-to the location where [you have pushed the e2e test images](#e2e-test-images)):
-
-```bash
-bazel test //test/... --test_arg=--dockerrepo=$DOCKER_REPO_OVERRIDE --test_arg=--kubeconfig=./kubeconfig
-```
 
 ## Test images
 

--- a/test/conformance/BUILD.bazel
+++ b/test/conformance/BUILD.bazel
@@ -3,9 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["route_test.go"],
-    data = [
-        "go_default_files",
-    ],
     deps = [
         "//pkg/apis/serving/v1alpha1:go_default_library",
         "//test:go_default_library",
@@ -13,12 +10,5 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
-    ],
-)
-
-filegroup(
-    name = "go_default_files",
-    srcs = [
-        "kubeconfig",
     ],
 )

--- a/test/conformance/kubeconfig
+++ b/test/conformance/kubeconfig
@@ -1,1 +1,0 @@
-# Put kubeconfig here when running with bazel

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -7,9 +7,6 @@ go_test(
         "e2e_test.go",
         "helloworld_test.go",
     ],
-    data = [
-        "go_default_files",
-    ],
     deps = [
         "//pkg/apis/serving/v1alpha1:go_default_library",
         "//test:go_default_library",
@@ -17,12 +14,5 @@ go_test(
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
-    ],
-)
-
-filegroup(
-    name = "go_default_files",
-    srcs = [
-        "kubeconfig",
     ],
 )

--- a/test/e2e/kubeconfig
+++ b/test/e2e/kubeconfig
@@ -1,1 +1,0 @@
-# Put kubeconfig here when running with bazel


### PR DESCRIPTION
We should use `go test` it is all we actually use in Prow.

