### PR TITLE
Call enqueueWork on resource deletion

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -122,6 +122,7 @@ func NewBase(
 		UpdateFunc: func(old, new interface{}) {
 			base.enqueueWork(new)
 		},
+		DeleteFunc: base.enqueueWork,
 	})
 
 	return base
@@ -132,7 +133,7 @@ func NewBase(
 func (c *Base) enqueueWork(obj interface{}) {
 	var key string
 	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+	if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
 		runtime.HandleError(err)
 		return
 	}
@@ -214,7 +215,7 @@ func (c *Base) processNextWorkItem(syncHandler func(string) error) bool {
 			return nil
 		}
 		// Run the syncHandler, passing it the namespace/name string of the
-		// Configuration resource to be synced.
+		// resource to be synced.
 		if err := syncHandler(key); err != nil {
 			return fmt.Errorf("error syncing %q: %v", key, err)
 		}


### PR DESCRIPTION
/area api

## Proposed Changes

  * Call `syncHandler` when tracked resources are deleted.

The multitenant autoscaling controller in #963 needs to clean up internal state when resources are deleted. This change adds a `DeleteFunc` to the informer event handlers that calls `syncHandler` any time a resource of the controlled type is deleted.

Normally the final state of the deleted resource will be given to the `enqueueWork` handler, but if the informer is unable to retrieve its final state for some reason (perhaps the watch failed and the resource was deleted before it could be reestablished), the event handler receives an object of type `DeletedFinalStateUnknown` containing only the resource key. To handle that properly, we need to call `DeletionHandlingMetaNamespaceKeyFunc()` instead of the standard `MetaNamespaceKeyFunc()`.

All controllers (not just the multitenant autoscaling controller) will now run the syncHandler when a controlled resource is deleted. This shouldn't cause any issues as all current sync handlers immediately return success when a resource does not exist:

```go
// Get the Service resource with this namespace/name
service, err := c.lister.Services(namespace).Get(name)
if err != nil {
  // The resource may no longer exist, in which case we stop
  // processing.
  if apierrs.IsNotFound(err) {
    runtime.HandleError(fmt.Errorf("service %q in work queue no longer exists", key))
    return nil
  }

  return err
}
```

**Release Note**
```release-note
Controllers will now reconcile when controlled resources are deleted.
```
