### PR TITLE
Only run e2e tests when -tag=e2e is specified

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -3,108 +3,69 @@
 This directory contains tests and testing docs for `Knative Serving`:
 
 * [Unit tests](#running-unit-tests) currently reside in the codebase alongside the code they test
-* [Conformance tests](#running-conformance-tests) in [`/test/conformance`](./conformance)
-* [End-to-end tests](#running-end-to-end-tests) in [`/test/e2e`](./e2e)
+* [End-to-end tests](#running-end-to-end-tests), of which there are two types:
+  * Conformance tests in [`/test/conformance`](./conformance)
+  * Other end-to-end tests in [`/test/e2e`](./e2e)
+
+The conformance tests are a subset of the end to end test with [more strict requirements](./conformance/README.md#requirements) around what can be tested.
 
 If you want to add more tests, see [adding_tests.md](./adding_tests.md).
 
 ## Running unit tests
 
-```shell
-go test -v ./pkg/...
-```
-
-## Running conformance tests
-
-To run [the conformance tests](./conformance), you need to have a running environment that meets
-[the conformance test environment requirements](#conformance-test-environment-requirements).
-
-Since these tests are fairly slow (~1 minute), running them with logging
-enabled is recommended.
-
-To run the conformance tests against the current cluster in `~/.kube/config`
-use `go test` with test caching disabled and the environment specified in [your environment
-variables](/DEVELOPMENT.md#environment-setup):
+To run all unit tests:
 
 ```bash
-go test -v -count=1 ./test/conformance
+go test ./...
 ```
+
+_By default `go test` will not run [the e2e tests](#running-end-to-end-tests), which need
+[`-tags=e2e`](#running-end-to-end-tests) to be enabled._
+
+## Running end to end tests
+
+To run [the e2e tests](./e2e) and [the conformance tests](./conformance), you need to have a running environment that meets
+[the e2e test environment requirements](#environment-requirements), and you need to specify the build tag `e2e`.
+
+```bash
+go test -v -tags=e2e -count=1 ./test/conformance
+go test -v -tags=e2e -count=1 ./test/e2e
+```
+
+* By default the e2e tests against the current cluster in `~/.kube/config`
+  using the environment specified in [your environment variables](/DEVELOPMENT.md#environment-setup).
+* Since these tests are fairly slow, running them with logging
+  enabled is recommended (`-v`).
+* Using `-count=1` is [the idiomatic way to disable test caching](https://golang.org/doc/go1.10#test)
 
 You can [use test flags](#flags) to control the environment
 your tests run against, i.e. override [your environment variables](/DEVELOPMENT.md#environment-setup):
 
 ```bash
-go test -v -count=1 ./test/conformance --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
+go test -v -tags=e2e -count=1 ./test/conformance --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
+go test -v -tags=e2e -count=1 ./test/e2e --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
 ```
 
 If you are running against an environment with no loadbalancer for the ingress, at the moment
-your only option is to use a domain which will resolve to the IP of the running node (see 
+your only option is to use a domain which will resolve to the IP of the running node (see
 [#609](https://github.com/knative/serving/issues/609)):
 
 ```bash
-go test -v -count=1 ./test/conformance --resolvabledomain
+go test -v -tags=e2e -count=1 ./test/conformance --resolvabledomain
+go test -v -tags=e2e -count=1 ./test/e2e --resolvabledomain
 ```
 
-## Conformance test environment requirements
+### Environment requirements
 
 These tests require:
 
 1. [A running `Knative Serving` cluster.](/DEVELOPMENT.md#getting-started)
-2. The namespace `pizzaplanet` to exist in the cluster: `kubectl create namespace pizzaplanet`
-3. A docker repo contianing [the conformance test images](#conformance-test-images)
-
-### Conformance test images
-
-The configuration for the images used for the existing conformance tests lives in
-[`test_images`](./conformance/test_images). See the [section about test
-images](#test-images) for details about building and adding new ones.
-
-## Running end-to-end tests
-
-The e2e tests have almost the exact same requirements and specs as the conformance tests, but they will be enumerated for clarity.
-
-To run [the e2e tests](./e2e), you need to have a running environment that meets
-[the e2e test environment requirements](#e2e-test-environment-requirements).
-
-To run the e2e tests against the current cluster in `~/.kube/config`
-using `go test` using the environment specified in [your environment
-variables](/DEVELOPMENT.md#environment-setup):
-
-Since these tests are fairly slow,  running them with logging
-enabled is recommended. Do so by passing the `-v` flag to go test like so: 
-
-```bash
-go test -v ./test/e2e
-```
-
-You can [use test flags](#flags) to control the environment
-your tests run against, i.e. override [your environment variables](/DEVELOPMENT.md#environment-setup):
-
-```bash
-go test -v ./test/e2e --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
-```
-
-If you are running against an environment with no loadbalancer for the ingress, at the moment
-your only option is to use a domain which will resolve to the IP of the running node (see 
-[#609](https://github.com/knative/serving/issues/609)):
-
-```bash
-go test -v ./test/e2e --resolvabledomain
-```
-
-## End-to-end test environment requirements
-
-These tests require:
-
-1. [A running `Knative Serving` cluster.](/DEVELOPMENT.md#getting-started)
-2. The namespace `noodleburg` to exist in the cluster: `kubectl create namespace noodleburg`
-3. A docker repo containing [the e2e test images](#e2e-test-images)
-
-### End-to-end test images
-
-The configuration for the images used for the existing e2e tests lives in
-[`test_images`](./e2e/test_images). See the [section about test
-images](#test-images) for details about building and adding new ones.
+2. The namespaces `pizzaplanet` and `noodleburg`:
+    ```bash
+    kubectl create namespace pizzaplanet
+    kubectl create namespace noodleburg
+    ```
+3. A docker repo containing [the test images](#test-images)
 
 ## Test images
 
@@ -118,14 +79,12 @@ test images used by the conformance and e2e tests. It requires:
   `DOCKER_REPO_OVERRIDE`](/docs/setting-up-a-docker-registry.md)
 * [`docker`](https://docs.docker.com/install/) to be installed
 
-To run the script:
+To run the script for all end to end test images:
 
 ```bash
-./test/upload-test-images.sh /path/containing/test/images
+./test/upload-test-images.sh ./test/e2e/test_images
+./test/upload-test-images.sh ./test/conformance/test_images
 ```
-
-The path containing test images is any directory whose subdirectories contain the `Dockerfile`
-and any required files to build Docker images (e.g., `./test/e2e/test_images`).
 
 ### Adding new test images
 
@@ -147,7 +106,7 @@ Tests importing [`github.com/knative/serving/test`](adding_tests.md#test-library
 * [`--dockerrepo`](#overriding-docker-repo)
 * [`--resolvabledomain`](#using-a-resolvable-domain)
 
-#### Specifying kubeconfig
+### Specifying kubeconfig
 
 By default the tests will use the [kubeconfig
 file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
@@ -157,13 +116,11 @@ You can specify a different config file with the argument `--kubeconfig`.
 To run the tests with a non-default kubeconfig file:
 
 ```bash
-go test ./test/conformance --kubeconfig /my/path/kubeconfig
+go test -v -tags=e2e -count=1 ./test/conformance --kubeconfig /my/path/kubeconfig
+go test -v -tags=e2e -count=1 ./test/e2e --kubeconfig /my/path/kubeconfig
 ```
 
-```bash
-go test ./test/e2e --kubeconfig /my/path/kubeconfig
-```
-#### Specifying cluster
+### Specifying cluster
 
 The `--cluster` argument lets you use a different cluster than [your specified
 kubeconfig's](#specifying-kubeconfig) active context. This will default to the value
@@ -171,11 +128,8 @@ of your [`K8S_CLUSTER_OVERRIDE` environment variable](/DEVELOPMENT.md#environmen
 if not specified.
 
 ```bash
-go test ./test/conformance --cluster your-cluster-name
-```
-
-```bash
-go test ./test/e2e --cluster your-cluster-name
+go test -v -tags=e2e -count=1 ./test/conformance --cluster your-cluster-name
+go test -v -tags=e2e -count=1 ./test/e2e --cluster your-cluster-name
 ```
 
 The current cluster names can be obtained by running:
@@ -192,11 +146,8 @@ of your [`DOCKER_REPO_OVERRIDE` environment variable](/DEVELOPMENT.md#environmen
 if not specified.
 
 ```bash
-go test ./test/conformance --dockerrepo gcr.myhappyproject
-```
-
-```bash
-go test ./test/e2e --dockerrepo gcr.myhappyproject
+go test -v -tags=e2e -count=1 ./test/conformance --dockerrepo gcr.myhappyproject
+go test -v -tags=e2e -count=1 ./test/e2e --dockerrepo gcr.myhappyproject
 ```
 
 #### Using a resolvable domain

--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -9,6 +9,13 @@ Both tests can use our [test library](#test-library).
 
 Reviewers of conformance and e2e tests (i.e. [OWNERS](/test/OWNERS)) are responsible for the style and quality of the resulting tests. In order to not discourage contributions, when style change are required, the reviewers can make the changes themselves.
 
+All e2e and conformance tests _must_ be marked with the `e2e` [build constraint](https://golang.org/pkg/go/build/)
+so that `go test ./...` can be used to run only [the unit tests](README.md#running-unit-tests), i.e.:
+
+```go
+// +build e2e
+```
+
 ## Presubmit tests
 
 [`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for both the [end-to-end tests](/test/e2e) and the [conformance tests](/test/conformance)

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2018 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -114,10 +114,10 @@ function exit_if_failed() {
   exit 1
 }
 
-function run_tests() {
+function run_e2e_tests() {
   header "Running tests in $1"
   kubectl create namespace $2
-  go test -v ./test/$1 -dockerrepo gcr.io/elafros-e2e-tests/$3
+  go test -v -tags=e2e ./test/$1 -dockerrepo gcr.io/elafros-e2e-tests/$3
   exit_if_failed
 }
 
@@ -258,8 +258,8 @@ kubectl create namespace noodleburg
 go test -v ./test/e2e -run HelloWorld -dockerrepo gcr.io/elafros-e2e-tests/ela-e2e-test
 exit_if_failed
 
-# run_tests conformance pizzaplanet ela-conformance-test
-# run_tests e2e noodleburg ela-e2e-test
+# run_e2e_tests conformance pizzaplanet ela-conformance-test
+# run_e2e_tests e2e noodleburg ela-e2e-test
 
 # kubetest teardown might fail and thus incorrectly report failure of the
 # script, even if the tests pass.

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2018 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2018 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2018 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -43,7 +43,7 @@ function build_tests() {
 
 function unit_tests() {
   header "Running unit tests"
-  go test ./cmd/... ./pkg/...
+  go test ./...
 }
 
 function integration_tests() {


### PR DESCRIPTION
As part of the move to ko (and generally improving the dev experience)
@mattmoor would like `go test ./...` to run only the unit tests and
not the end to end tests. One neat way to accomplish that is to use
[build constraints](http://peter.bourgon.org/go-in-production/#testing-and-validation).
(One downside here is that folks adding new e2e tests need to
remember to add the constraint.)

I also tried to de-dupe the docs on how to run tests since they're
pretty much the same for conformance tests and e2e tests. It's a bit
confusing that conformance tests are also e2e tests but maybe it's
okay? ¯\_(ツ)_/¯

Fixes #1028

## Proposed Changes

  * Add build constraint `e2e` to end to end tests (including conformance)

```release-note
NONE
```
