### PR TITLE
Update Build CRD vendor, use new build conditions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -342,7 +342,7 @@
     "pkg/client/informers/externalversions/internalinterfaces",
     "pkg/client/listers/build/v1alpha1"
   ]
-  revision = "bfc0222e894da677b45fd63828a89676aa706589"
+  revision = "8624fda54557ac4461d35921765b7bf48e5aba6d"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -952,6 +952,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "621e4f5bec0b084d127193a1a2ec95460b8368224d81f7c2611900a91c1bbb12"
+  inputs-digest = "d18bf8494f8ff68a79c816a83d8e7a6b9b72629d89b137ffb3f0bf0ee9f19e5b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,8 +50,8 @@ required = [
 
 [[constraint]]
   name = "github.com/knative/build"
-  # HEAD as of 2018-05-31
-  revision = "bfc0222e894da677b45fd63828a89676aa706589"
+  # HEAD as of 2018-06-05
+  revision = "8624fda54557ac4461d35921765b7bf48e5aba6d"
 
 [[constraint]]
   name = "github.com/google/go-containerregistry"

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -964,14 +964,12 @@ func TestCreateRevWithFailedBuildNameFails(t *testing.T) {
 	// watching for this build to complete, so make it complete, but
 	// with a failure.
 	bld.Status = buildv1alpha1.BuildStatus{
-		Conditions: []buildv1alpha1.BuildCondition{
-			{
-				Type:    buildv1alpha1.BuildFailed,
-				Status:  corev1.ConditionTrue,
-				Reason:  reason,
-				Message: errMessage,
-			},
-		},
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:    buildv1alpha1.BuildSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  reason,
+			Message: errMessage,
+		}},
 	}
 
 	controller.addBuildEvent(bld)
@@ -1054,15 +1052,14 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 	controller.syncHandler(KeyOrDie(rev))
 
 	// After the initial update to the revision, we should be
-	// watching for this build to complete, so make it complete.
+	// watching for this build to complete, so make it complete
+	// successfully.
 	bld.Status = buildv1alpha1.BuildStatus{
-		Conditions: []buildv1alpha1.BuildCondition{
-			{
-				Type:    buildv1alpha1.BuildComplete,
-				Status:  corev1.ConditionTrue,
-				Message: completeMessage,
-			},
-		},
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:    buildv1alpha1.BuildSucceeded,
+			Status:  corev1.ConditionTrue,
+			Message: completeMessage,
+		}},
 	}
 
 	controller.addBuildEvent(bld)

--- a/third_party/istio-0.8.0/BUILD.bazel
+++ b/third_party/istio-0.8.0/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@k8s_object//:defaults.bzl", "k8s_object")
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2
+
+k8s_object(
+    name = "istio",
+    template = "istio.yaml",
+)

--- a/vendor/github.com/knative/build/pkg/apis/build/v1alpha1/build_template_types.go
+++ b/vendor/github.com/knative/build/pkg/apis/build/v1alpha1/build_template_types.go
@@ -49,6 +49,8 @@ type BuildTemplateConditionType string
 
 const (
 	// BuildTemplateInvalid specifies that the given specification is invalid.
+	//
+	// TODO(jasonhall): Remove when webhook validation rejects invalid build templates.
 	BuildTemplateInvalid BuildTemplateConditionType = "Invalid"
 )
 

--- a/vendor/github.com/knative/build/pkg/apis/build/v1alpha1/build_types.go
+++ b/vendor/github.com/knative/build/pkg/apis/build/v1alpha1/build_types.go
@@ -147,11 +147,16 @@ type GoogleSpec struct {
 type BuildConditionType string
 
 const (
-	// BuildComplete specifies that the build has completed successfully.
-	BuildComplete BuildConditionType = "Complete"
-	// BuildFailed specifies that the build has failed.
-	BuildFailed BuildConditionType = "Failed"
+	// BuildSucceeded is set when the build is running, and becomes True
+	// when the build finishes successfully.
+	//
+	// If the build is ongoing, its status will be Unknown. If it fails,
+	// its status will be False.
+	BuildSucceeded BuildConditionType = "Succeeded"
+
 	// BuildInvalid specifies that the given build specification is invalid.
+	//
+	// TODO(jasonhall): Remove when webhook validation rejects invalid builds.
 	BuildInvalid BuildConditionType = "Invalid"
 )
 


### PR DESCRIPTION
Pulls in https://github.com/knative/build/pull/177 which uses new consistent build conditions described in [errors.md](https://github.com/knative/serving/blob/master/docs/spec/errors.md#error-conditions-and-reporting).