### PR TITLE
Run only "hello world" integration test

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -250,8 +250,16 @@ exit_if_failed
 
 # Run the tests
 
-run_tests conformance pizzaplanet ela-conformance-test
-run_tests e2e noodleburg ela-e2e-test
+echo "Waiting 2 minutes before starting the tests"
+echo "See https://github.com/knative/serving/issues/1070 for details"
+sleep 120
+header "Running 'hello world' test"
+kubectl create namespace noodleburg
+go test -v ./test/e2e -run HelloWorld -dockerrepo gcr.io/elafros-e2e-tests/ela-e2e-test
+exit_if_failed
+
+# run_tests conformance pizzaplanet ela-conformance-test
+# run_tests e2e noodleburg ela-e2e-test
 
 # kubetest teardown might fail and thus incorrectly report failure of the
 # script, even if the tests pass.


### PR DESCRIPTION
Temporarily knock out the conformance and autoscale tests until they're passing again.

For details, see https://github.com/knative/serving/issues/1070.