### PR TITLE
Ensuring correct teardown for e2e tests.

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -33,7 +33,7 @@ func Setup(t *testing.T) *test.Clients {
 // TearDown will delete created names using clients.
 func TearDown(clients *test.Clients, names test.ResourceNames) {
 	if clients != nil {
-		clients.Delete([]string{routeName}, []string{configName})
+		clients.Delete([]string{names.Route}, []string{names.Config})
 	}
 }
 


### PR DESCRIPTION
We now create randomly named test revisions for e2e testing, but the
code to tear down the test resources was not properly updated.

Fixes #1050

**Release Note**
```release-note
NONE
```
