### PR TITLE
Run helloworld with `-tags=e2e` in presubmit

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -255,7 +255,7 @@ echo "See https://github.com/knative/serving/issues/1070 for details"
 sleep 120
 header "Running 'hello world' test"
 kubectl create namespace noodleburg
-go test -v ./test/e2e -run HelloWorld -dockerrepo gcr.io/elafros-e2e-tests/ela-e2e-test
+go test -v -tags=e2e ./test/e2e -run HelloWorld -dockerrepo gcr.io/elafros-e2e-tests/ela-e2e-test
 exit_if_failed
 
 # run_e2e_tests conformance pizzaplanet ela-conformance-test


### PR DESCRIPTION
In #1053 we updated the e2e tests so they don't run unless `tags=e2e`
is specified, which means that when we just the hello world e2e test
we need to provide this flag or no actual tests will be run (though
they will quietly pass, outputing a "no test files" message).

```release-note
NONE
```
