### PR TITLE
Add an IngressReady condition.

### DIFF
--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -420,6 +420,31 @@ status:
     message: "Configuration 'abc' referenced in traffic not found"
 ```
 
+### Unable to create Ingress
+
+If the Route is unable to create an Ingress resource to route its
+traffic to Revisions, the `IngressReady` condition will be marked
+as `False` with a reason of `NoIngress`.
+
+```http
+GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
+```
+
+```yaml
+...
+status:
+  traffic: []
+  conditions:
+  - type: Ready
+    status: False
+    reason: NoIngress
+    message: "Unable to create Ingress 'my-service-ingress'"
+  - type: IngressReady
+    status: False
+    reason: NoIngress
+    message: "Unable to create Ingress 'my-service-ingress'"
+```
+
 ### Latest Revision of a Configuration deleted
 
 If the most recent Revision is deleted, the Configuration will set

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -107,6 +107,9 @@ const (
 	// RouteConditionReady is set when the service is configured
 	// and has available backends ready to receive traffic.
 	RouteConditionReady RouteConditionType = "Ready"
+	// RouteConditionIngressReady is set when the route's underlying ingress
+	// resource has been set up.
+	RouteConditionIngressReady RouteConditionType = "IngressReady"
 	// RouteConditionAllTrafficAssigned is set to False when the
 	// service is not configured properly or has no available
 	// backends ready to receive traffic.

--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -212,7 +212,7 @@ func (c *Controller) syncHandler(key string) error {
 		c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Revision %q", rev.Name)
 		logger.Infof("Created Revision:\n%+v", created)
 	} else {
-		logger.Infof("Revision already created %s: %s", created.ObjectMeta.Name, err)
+		logger.Infof("Revision already created %s: %v", created.ObjectMeta.Name, err)
 	}
 	// Update the Status of the configuration with the latest generation that
 	// we just reconciled against so we don't keep generating revisions.


### PR DESCRIPTION
Today the "Ready" condition strictly reflects whether the ingress has become available and not whether the revisions they route two have been programmed into route rules.  In #986 Jon is adding AllTrafficAssigned to cover revision readiness, but this doesn't change the fact that the ingress becoming ready will cause the Route to become "Ready", even if traffic is unassigned.

This changes the original sense of "Ready" into "IngressReady", and predicates the new "Ready" on "IngressReady" and "AllTrafficAssigned".

Progress on: #1056
Fixes: #1074