### PR TITLE
Fix release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -143,10 +143,9 @@ ko resolve -R -f config/monitoring/100-common \
     -f config/monitoring/200-common/100-istio.yaml >> ${OUTPUT_YAML}
 # Use ko to do the same for the lite version.
 ko resolve -R -f config/monitoring/100-common \
-    -f config/monitoring/150-prod \
-    -f third_party/config/monitoring/istio \
-    -f third_party/config/monitoring/kubernetes/kube-state-metrics \
-    -f third_party/config/monitoring/prometheus-operator \
+    -f third_party/config/monitoring/common/istio \
+    -f third_party/config/monitoring/common/kubernetes/kube-state-metrics \
+    -f third_party/config/monitoring/common/prometheus-operator \
     -f config/monitoring/200-common/100-fluentd.yaml \
     -f config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml \
     -f config/monitoring/200-common/100-grafana-dash-knative.yaml \


### PR DESCRIPTION
- remove reference to `config/monitoring/150-prod`

- change references to renamed `third_party/config/monitoring/common` files

Fixes #1087

## Proposed Changes

  * remove reference to `config/monitoring/150-prod`
  * change references to renamed `third_party/config/monitoring/common` files

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
