### PR TITLE
use versioned kube api

### DIFF
--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -89,7 +89,7 @@ func GetOrCreateRevisionNamespace(ctx context.Context, ns string, c clientset.In
 }
 
 func GetOrCreateNamespace(ctx context.Context, namespace string, c clientset.Interface) (string, error) {
-	_, err := c.Core().Namespaces().Get(namespace, metav1.GetOptions{})
+	_, err := c.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
 	if err != nil {
 		logger := logging.FromContext(ctx)
 		if !apierrs.IsNotFound(err) {
@@ -103,7 +103,7 @@ func GetOrCreateNamespace(ctx context.Context, namespace string, c clientset.Int
 				Namespace: "",
 			},
 		}
-		_, err := c.Core().Namespaces().Create(nsObj)
+		_, err := c.CoreV1().Namespaces().Create(nsObj)
 		if err != nil {
 			logger.Error("Unexpected error while creating namespace", zap.Error(err))
 			return "", err

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -804,7 +804,7 @@ func (c *Controller) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 
 func (c *Controller) deleteService(ctx context.Context, rev *v1alpha1.Revision, ns string) error {
 	logger := logging.FromContext(ctx)
-	sc := c.KubeClientSet.Core().Services(ns)
+	sc := c.KubeClientSet.CoreV1().Services(ns)
 	serviceName := controller.GetElaK8SServiceNameForRevision(rev)
 
 	logger.Infof("Deleting service %q", serviceName)
@@ -821,7 +821,7 @@ func (c *Controller) deleteService(ctx context.Context, rev *v1alpha1.Revision, 
 
 func (c *Controller) reconcileService(ctx context.Context, rev *v1alpha1.Revision, ns string) (string, error) {
 	logger := logging.FromContext(ctx)
-	sc := c.KubeClientSet.Core().Services(ns)
+	sc := c.KubeClientSet.CoreV1().Services(ns)
 	serviceName := controller.GetElaK8SServiceNameForRevision(rev)
 
 	if _, err := sc.Get(serviceName, metav1.GetOptions{}); err != nil {
@@ -853,7 +853,7 @@ func (c *Controller) reconcileFluentdConfigMap(ctx context.Context, rev *v1alpha
 	// references. Can not set blockOwnerDeletion and Controller to true.
 	revRef := newRevisionNonControllerRef(rev)
 
-	cmc := c.KubeClientSet.Core().ConfigMaps(ns)
+	cmc := c.KubeClientSet.CoreV1().ConfigMaps(ns)
 	configMap, err := cmc.Get(fluentdConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrs.IsNotFound(err) {
@@ -907,7 +907,7 @@ func addOwnerReference(configMap *corev1.ConfigMap, ownerReference *metav1.Owner
 func (c *Controller) deleteAutoscalerService(ctx context.Context, rev *v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	autoscalerName := controller.GetRevisionAutoscalerName(rev)
-	sc := c.KubeClientSet.Core().Services(AutoscalerNamespace)
+	sc := c.KubeClientSet.CoreV1().Services(AutoscalerNamespace)
 	if _, err := sc.Get(autoscalerName, metav1.GetOptions{}); err != nil && apierrs.IsNotFound(err) {
 		return nil
 	}
@@ -926,7 +926,7 @@ func (c *Controller) deleteAutoscalerService(ctx context.Context, rev *v1alpha1.
 func (c *Controller) reconcileAutoscalerService(ctx context.Context, rev *v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	autoscalerName := controller.GetRevisionAutoscalerName(rev)
-	sc := c.KubeClientSet.Core().Services(AutoscalerNamespace)
+	sc := c.KubeClientSet.CoreV1().Services(AutoscalerNamespace)
 	_, err := sc.Get(autoscalerName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrs.IsNotFound(err) {

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -580,7 +580,7 @@ func TestCreateRevCreatesStuff(t *testing.T) {
 	}
 
 	// Look for the config map.
-	configMap, err := kubeClient.Core().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
+	configMap, err := kubeClient.CoreV1().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get config map: %v", err)
 	}
@@ -695,7 +695,7 @@ func TestCreateRevDoesNotSetUpFluentdSidecarIfVarLogCollectionDisabled(t *testin
 	}
 
 	// Look for the config map.
-	_, err = kubeClient.Core().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
+	_, err = kubeClient.CoreV1().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
 	if !apierrs.IsNotFound(err) {
 		t.Fatalf("The ConfigMap %s shouldn't exist: %v", fluentdConfigMapName, err)
 	}
@@ -715,12 +715,12 @@ func TestCreateRevUpdateConfigMap_NewData(t *testing.T) {
 			"varlog.conf": "test-config",
 		},
 	}
-	kubeClient.Core().ConfigMaps(testNamespace).Create(existingConfigMap)
+	kubeClient.CoreV1().ConfigMaps(testNamespace).Create(existingConfigMap)
 
 	createRevision(elaClient, elaInformer, controller, rev)
 
 	// Look for the config map.
-	configMap, err := kubeClient.Core().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
+	configMap, err := kubeClient.CoreV1().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get config map: %v", err)
 	}
@@ -749,12 +749,12 @@ func TestCreateRevUpdateConfigMap_NewRevOwnerReference(t *testing.T) {
 			"varlog.conf": fluentdConfigSource,
 		},
 	}
-	kubeClient.Core().ConfigMaps(testNamespace).Create(existingConfigMap)
+	kubeClient.CoreV1().ConfigMaps(testNamespace).Create(existingConfigMap)
 
 	createRevision(elaClient, elaInformer, controller, rev)
 
 	// Look for the config map.
-	configMap, err := kubeClient.Core().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
+	configMap, err := kubeClient.CoreV1().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get config map: %v", err)
 	}

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -283,7 +283,7 @@ func (c *Controller) syncTrafficTargetsAndUpdateRouteStatus(ctx context.Context,
 func (c *Controller) reconcilePlaceholderService(ctx context.Context, route *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 	service := MakeRouteK8SService(route)
-	if _, err := c.KubeClientSet.Core().Services(route.Namespace).Create(service); err != nil {
+	if _, err := c.KubeClientSet.CoreV1().Services(route.Namespace).Create(service); err != nil {
 		if apierrs.IsAlreadyExists(err) {
 			// Service already exist.
 			return nil


### PR DESCRIPTION
/assign @mattmoor 

## Proposed Changes

This is one of the steps to fine tune RBAC rules. Using versioned API helps to identify what resource and api groups are being used.

Replace `Core()` with  `CoreV1()`

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
