### PR TITLE
Simplify scale-to-zero flags to just one flag.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -59,7 +59,7 @@ var (
 
 	autoscaleFlagSet                  = k8sflag.NewFlagSet("/etc/config-autoscaler")
 	autoscaleConcurrencyQuantumOfTime = autoscaleFlagSet.Duration("concurrency-quantum-of-time", nil, k8sflag.Required)
-	autoscaleEnableScaleToZero        = autoscaleFlagSet.Bool("enable-scale-to-zero", false)
+	autoscaleScaleToZeroThreshold     = autoscaleFlagSet.Duration("scale-to-zero-threshold", nil, k8sflag.Required, k8sflag.Dynamic)
 	autoscaleEnableSingleConcurrency  = autoscaleFlagSet.Bool("enable-single-concurrency", false)
 
 	observabilityFlagSet             = k8sflag.NewFlagSet("/etc/config-observability")
@@ -154,7 +154,7 @@ func main() {
 	controllers := []controller.Interface{
 		configuration.NewController(kubeClient, elaClient, buildClient, kubeInformerFactory, elaInformerFactory, cfg, *controllerConfig, logger),
 		revision.NewController(kubeClient, elaClient, kubeInformerFactory, elaInformerFactory, buildInformerFactory, cfg, &revControllerConfig, logger),
-		route.NewController(kubeClient, elaClient, kubeInformerFactory, elaInformerFactory, cfg, *controllerConfig, autoscaleEnableScaleToZero, logger),
+		route.NewController(kubeClient, elaClient, kubeInformerFactory, elaInformerFactory, cfg, *controllerConfig, autoscaleScaleToZeroThreshold, logger),
 		service.NewController(kubeClient, elaClient, kubeInformerFactory, elaInformerFactory, cfg, *controllerConfig, logger),
 	}
 

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -49,11 +49,9 @@ data:
   # which case the request duration is rounded up.
   concurrency-quantum-of-time: "100ms"
 
-  # Scale to zero feature flag
-  enable-scale-to-zero: "false"
-
   # Dynamic parameters (take effect when config map is updated):
 
-  # Scale to zero threshold is the time a revision must be idle before
-  # it is scaled to zero.
-  scale-to-zero-threshold: "5m"
+  # Scale to zero threshold is the Duration a revision must be idle 
+  # before it is scaled to zero. A positive Duration turns on scale
+  # to zero.
+  scale-to-zero-threshold: "-1s"

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -135,7 +135,8 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 		}
 	}
 
-	if lastRequestTime.Add(*a.ScaleToZeroThreshold.Get()).Before(now) {
+	threshold := *a.ScaleToZeroThreshold.Get()
+	if threshold > 0 && lastRequestTime.Add(threshold).Before(now) {
 		return 0, true
 	}
 


### PR DESCRIPTION
Rather than using a boolean which decides whether to apply the
scale-to-zero-threshold, just use the threshold on it's own. A
negative value means to ignore the threshold. 

This has the advantage of being able to dynamically turn scale-to-zero off and on which is important for pushing e2e tests before turning the feature on.

Fixes # 915

## Proposed Changes

  * Remove enable-scale-to-zero flag
  * Replace checks to the above flag with testing whether scale-to-zero-threshold is negative.
  * Additionally, fixing vet formatting issues.

**Release Note**
```release-note
NONE
```
