### PR TITLE
use versioned api for Extensions and Admissionregistration

### DIFF
--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -295,7 +295,7 @@ func (c *Controller) reconcileIngress(ctx context.Context, route *v1alpha1.Route
 	ingressNamespace := route.Namespace
 	ingressName := controller.GetElaK8SIngressName(route)
 	ingress := MakeRouteIngress(route)
-	ingressClient := c.KubeClientSet.Extensions().Ingresses(ingressNamespace)
+	ingressClient := c.KubeClientSet.ExtensionsV1beta1().Ingresses(ingressNamespace)
 	existing, err := ingressClient.Get(ingressName, metav1.GetOptions{})
 
 	if err != nil {

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -1400,7 +1400,7 @@ func TestUpdateRouteDomainWhenRouteLabelChanges(t *testing.T) {
 	kubeClient, elaClient, controller, _, elaInformer := newTestController(t)
 	route := getTestRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
 	routeClient := elaClient.ServingV1alpha1().Routes(route.Namespace)
-	ingressClient := kubeClient.Extensions().Ingresses(route.Namespace)
+	ingressClient := kubeClient.ExtensionsV1beta1().Ingresses(route.Namespace)
 
 	// Create a route.
 	elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)
@@ -1579,7 +1579,7 @@ func TestUpdateIngressEventUpdateRouteStatus(t *testing.T) {
 	// Create an ingress owned by this route.
 	controller.reconcileIngress(testCtx, route)
 	// Before ingress has an IP address, route isn't marked as Ready.
-	ingressClient := kubeClient.Extensions().Ingresses(route.Namespace)
+	ingressClient := kubeClient.ExtensionsV1beta1().Ingresses(route.Namespace)
 	ingress, _ := ingressClient.Get(ctrl.GetElaK8SIngressName(route), metav1.GetOptions{})
 	controller.updateIngressEvent(nil, ingress)
 	route, _ = routeClient.Get(route.Name, metav1.GetOptions{})

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -453,8 +453,8 @@ func TestValidServiceEnvChanges(t *testing.T) {
 func TestValidWebhook(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	createDeployment(ac)
-	ac.register(testCtx, ac.client.Admissionregistration().MutatingWebhookConfigurations(), []byte{})
-	_, err := ac.client.Admissionregistration().MutatingWebhookConfigurations().Get(ac.options.WebhookName, metav1.GetOptions{})
+	ac.register(testCtx, ac.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations(), []byte{})
+	_, err := ac.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ac.options.WebhookName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create webhook: %s", err)
 	}
@@ -477,8 +477,8 @@ func TestUpdatingWebhook(t *testing.T) {
 
 	createDeployment(ac)
 	createWebhook(ac, webhook)
-	ac.register(testCtx, ac.client.Admissionregistration().MutatingWebhookConfigurations(), []byte{})
-	currentWebhook, _ := ac.client.Admissionregistration().MutatingWebhookConfigurations().Get(ac.options.WebhookName, metav1.GetOptions{})
+	ac.register(testCtx, ac.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations(), []byte{})
+	currentWebhook, _ := ac.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ac.options.WebhookName, metav1.GetOptions{})
 	if reflect.DeepEqual(currentWebhook.Webhooks, webhook.Webhooks) {
 		t.Fatalf("Expected webhook to be updated")
 	}
@@ -614,7 +614,7 @@ func createValidCreateServiceRunLatest() *admissionv1beta1.AdmissionRequest {
 }
 
 func createWebhook(ac *AdmissionController, webhook *admissionregistrationv1beta1.MutatingWebhookConfiguration) {
-	client := ac.client.Admissionregistration().MutatingWebhookConfigurations()
+	client := ac.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	_, err := client.Create(webhook)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create test webhook: %s", err))


### PR DESCRIPTION
## Proposed Changes
This is one of the steps to fine tune RBAC rules. Using versioned API helps to identify what resource and api groups are being used.

These are the last deprecated API calls. 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
/assign @grantr 