### PR TITLE
Add notes about how to use `gcloud container clusters get-credentials`

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -54,6 +54,14 @@ To use a k8s cluster running in GKE:
     # Get the list of valid versions in us-east1-d
     gcloud container get-server-config --zone us-east1-d
     ```
+    
+1.  **Alternately**, if you wish to re-use an already-created cluster,
+    you can fetch the credentials to your local machine with:
+    
+    ```shell
+    # Load credentials for the new cluster in us-east1-d
+    gcloud container cluster get-credentials --zone us-east1-d knative-demo
+    ```
 
 1.  If you haven't installed `kubectl` yet, you can install it now with
     `gcloud`:


### PR DESCRIPTION
I sometimes use the Google UI to create clusters, so adding a note about how to get creds.

<!--
/assign @bobcatfish 
-->

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
