### PR TITLE
Remove Host matching for RouteRules

### DIFF
--- a/pkg/apis/istio/v1alpha2/routerule_types.go
+++ b/pkg/apis/istio/v1alpha2/routerule_types.go
@@ -85,9 +85,9 @@ type MatchString struct {
 
 type RouteRuleSpec struct {
 	Destination   IstioService        `json:"destination"`
-	Match         Match               `json:"match,omitempty"`
+	Match         *Match              `json:"match,omitempty"`
 	Route         []DestinationWeight `json:"route"`
-	AppendHeaders map[string]string   `json:"appendHeaders"`
+	AppendHeaders *map[string]string  `json:"appendHeaders,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/istio/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1alpha2/zz_generated.deepcopy.go
@@ -190,7 +190,15 @@ func (in *RouteRuleList) DeepCopyObject() runtime.Object {
 func (in *RouteRuleSpec) DeepCopyInto(out *RouteRuleSpec) {
 	*out = *in
 	out.Destination = in.Destination
-	out.Match = in.Match
+	if in.Match != nil {
+		in, out := &in.Match, &out.Match
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(Match)
+			**out = **in
+		}
+	}
 	if in.Route != nil {
 		in, out := &in.Route, &out.Route
 		*out = make([]DestinationWeight, len(*in))
@@ -198,9 +206,17 @@ func (in *RouteRuleSpec) DeepCopyInto(out *RouteRuleSpec) {
 	}
 	if in.AppendHeaders != nil {
 		in, out := &in.AppendHeaders, &out.AppendHeaders
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(map[string]string)
+			if **in != nil {
+				in, out := *in, *out
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
 		}
 	}
 	return

--- a/pkg/controller/route/ela_istio_route.go
+++ b/pkg/controller/route/ela_istio_route.go
@@ -50,7 +50,7 @@ func makeIstioRouteSpec(u *v1alpha1.Route, tt *v1alpha1.TrafficTarget, ns string
 		appendHeaders := make(map[string]string)
 		appendHeaders[controller.GetRevisionHeaderName()] = inactiveRev
 		appendHeaders[controller.GetRevisionHeaderNamespace()] = u.Namespace
-		spec.AppendHeaders = appendHeaders
+		spec.AppendHeaders = &appendHeaders
 	}
 	return spec
 }

--- a/pkg/controller/route/ela_istio_route_test.go
+++ b/pkg/controller/route/ela_istio_route_test.go
@@ -88,7 +88,7 @@ func TestMakeIstioRouteSpecRevisionInactive(t *testing.T) {
 				Weight: 2,
 			},
 		},
-		AppendHeaders: appendHeaders,
+		AppendHeaders: &appendHeaders,
 	}
 
 	istioRouteSpec := makeIstioRouteSpec(route, nil, testNamespace, rr, testDomain, testInactiveRev)

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -412,7 +412,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		Route: []v1alpha2.DestinationWeight{
 			getActivatorDestinationWeight(100),
 		},
-		AppendHeaders: appendHeaders,
+		AppendHeaders: &appendHeaders,
 	}
 
 	if diff := cmp.Diff(expectedRouteSpec, routerule.Spec); diff != "" {
@@ -635,7 +635,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			},
 			getActivatorDestinationWeight(10),
 		},
-		AppendHeaders: appendHeaders,
+		AppendHeaders: &appendHeaders,
 	}
 
 	if diff := cmp.Diff(expectedRouteSpec, routerule.Spec); diff != "" {


### PR DESCRIPTION
Inside the cluster it's common to make a request to a service using
a service's short name. For a service name foobar, you can make a
request for http://foobar/. Istio RouteRules effectively intercept
traffic destined for one Service and route it to another Service.
Within the RouteRule, a filter can be applied based on the HTTP Host
header. If the header is not matched, the rule is not applied.

A Knative Route sends traffic destined for a single Service (fronted by
an Ingress) to another Service backed by a Revision. The Ingress already
applies Host based routing, the RouteRule also applying Host based
routing is at best redundant.

With the new Eventing Channel work, we'd like to be able to send
requests from inside the cluster to a Route, utilizing the RouteRule.
Currently, these requests are dropped because the request inside the
cluster is made to the service hostname and not the external fqdn.

Unless there is a reason to keep the redundant Host matching, I'd like
to drop the matching on the RouteRule so that traffic from inside the
cluster can easily be routed. Host matching will still occur at the
Ingress.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
<!--
/assign @vaikas-google
-->