### PR TITLE
Typo fix for command group name

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -60,7 +60,7 @@ To use a k8s cluster running in GKE:
     
     ```shell
     # Load credentials for the new cluster in us-east1-d
-    gcloud container cluster get-credentials --zone us-east1-d knative-demo
+    gcloud container clusters get-credentials --zone us-east1-d knative-demo
     ```
 
 1.  If you haven't installed `kubectl` yet, you can install it now with


### PR DESCRIPTION
Command group name has to be `clusters` instead of `cluster` for (GKE/step 5); the `get-credentials` sample command

Failed with group name `cluster`:
```
± |master ✓| → gcloud container cluster get-credentials ssuresh-knative-dev
ERROR: (gcloud.container) Invalid choice: 'cluster'. Did you mean 'clusters'?
Usage: gcloud container [optional flags] <group | command>
  group may be           builds | clusters | images | node-pools | operations
  command may be         get-server-config

For detailed information on this command and its flags, run:
  gcloud container --help
```

Works with group name `clusters`:
```
± |master ✓| → gcloud container clusters get-credentials ssuresh-knative-dev
Fetching cluster endpoint and auth data.
kubeconfig entry generated for ssuresh-knative-dev.
```