### PR TITLE
This adds LastTransitionTime to all knative/serving resources.

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	build "github.com/knative/build/pkg/apis/build/v1alpha1"
 
@@ -90,6 +91,9 @@ type ConfigurationCondition struct {
 	Type ConfigurationConditionType `json:"type" description:"type of Configuration condition"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
 
 	// +optional
 	Reason string `json:"reason,omitempty" description:"one-word CamelCase reason for the condition's last transition"`
@@ -183,6 +187,7 @@ func (cs *ConfigurationStatus) setCondition(new *ConfigurationCondition) {
 			conditions = append(conditions, cond)
 		}
 	}
+	new.LastTransitionTime = metav1.NewTime(time.Now())
 	conditions = append(conditions, *new)
 	cs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,6 +94,9 @@ type RouteCondition struct {
 	Type RouteConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
 
 	// +optional
 	Reason string `json:"reason,omitempty" description:"one-word CamelCase reason for the condition's last transition"`
@@ -194,6 +198,7 @@ func (rs *RouteStatus) setCondition(new *RouteCondition) {
 			conditions = append(conditions, cond)
 		}
 	}
+	new.LastTransitionTime = metav1.NewTime(time.Now())
 	conditions = append(conditions, *new)
 	rs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,6 +81,9 @@ type ServiceCondition struct {
 	Type ServiceConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
 
 	// +optional
 	Reason string `json:"reason,omitempty" description:"one-word CamelCase reason for the condition's last transition"`
@@ -156,6 +160,7 @@ func (ss *ServiceStatus) setCondition(new *ServiceCondition) {
 			conditions = append(conditions, cond)
 		}
 	}
+	new.LastTransitionTime = metav1.NewTime(time.Now())
 	conditions = append(conditions, *new)
 	ss.Conditions = conditions
 }

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -343,9 +343,9 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 	for _, ct := range []v1alpha1.ConfigurationConditionType{"Ready"} {
 		got := readyConfig.Status.GetCondition(ct)
 		want := &v1alpha1.ConfigurationCondition{
-			Type:   ct,
-			Status: corev1.ConditionTrue,
-			// TODO(mattmoor): LastTransitionTime: got.LastTransitionTime,
+			Type:               ct,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: got.LastTransitionTime,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)
@@ -522,11 +522,11 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 	for _, ct := range []v1alpha1.ConfigurationConditionType{"LatestRevisionReady"} {
 		got := readyConfig.Status.GetCondition(ct)
 		want := &v1alpha1.ConfigurationCondition{
-			Type:    ct,
-			Status:  corev1.ConditionFalse,
-			Reason:  "RevisionFailed",
-			Message: `revision "test-config-00001" failed with message: Build step failed with error`,
-			// TODO(mattmoor): LastTransitionTime: got.LastTransitionTime,
+			Type:               ct,
+			Status:             corev1.ConditionFalse,
+			Reason:             "RevisionFailed",
+			Message:            `revision "test-config-00001" failed with message: Build step failed with error`,
+			LastTransitionTime: got.LastTransitionTime,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)
@@ -590,9 +590,9 @@ func TestMarkConfigurationReadyWhenLatestRevisionRecovers(t *testing.T) {
 	for _, ct := range []v1alpha1.ConfigurationConditionType{"Ready"} {
 		got := readyConfig.Status.GetCondition(ct)
 		want := &v1alpha1.ConfigurationCondition{
-			Type:   ct,
-			Status: corev1.ConditionTrue,
-			// TODO(mattmoor): LastTransitionTime: got.LastTransitionTime,
+			Type:               ct,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: got.LastTransitionTime,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -108,9 +108,7 @@ func getTestRevisionWithCondition(name string, cond v1alpha1.RevisionCondition) 
 		},
 		Status: v1alpha1.RevisionStatus{
 			ServiceName: fmt.Sprintf("%s-service", name),
-			Conditions: []v1alpha1.RevisionCondition{
-				cond,
-			},
+			Conditions:  []v1alpha1.RevisionCondition{cond},
 		},
 	}
 }
@@ -246,12 +244,10 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 
 	// A route targeting the revision
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			RevisionName: "test-rev",
+			Percent:      100,
+		}},
 	)
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
@@ -266,12 +262,10 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 		t.Errorf("error getting service: %v", err)
 	}
 
-	expectedPorts := []corev1.ServicePort{
-		corev1.ServicePort{
-			Name: "http",
-			Port: 80,
-		},
-	}
+	expectedPorts := []corev1.ServicePort{{
+		Name: "http",
+		Port: 80,
+	}}
 
 	if diff := cmp.Diff(expectedPorts, service.Spec.Ports); diff != "" {
 		t.Errorf("Unexpected service ports diff (-want +got): %v", diff)
@@ -306,13 +300,11 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 	}
 
 	// Check owner refs
-	expectedRefs := []metav1.OwnerReference{
-		metav1.OwnerReference{
-			APIVersion: "serving.knative.dev/v1alpha1",
-			Kind:       "Route",
-			Name:       route.Name,
-		},
-	}
+	expectedRefs := []metav1.OwnerReference{{
+		APIVersion: "serving.knative.dev/v1alpha1",
+		Kind:       "Route",
+		Name:       route.Name,
+	}}
 
 	if diff := cmp.Diff(expectedRefs, routerule.OwnerReferences, cmpopts.IgnoreFields(expectedRefs[0], "Controller", "BlockOwnerDeletion")); diff != "" {
 		t.Errorf("Unexpected rule owner refs diff (-want +got): %v", diff)
@@ -334,15 +326,13 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "test-rev-service",
-					Namespace: testNamespace,
-				},
-				Weight: 100,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      "test-rev-service",
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 100,
+		}},
 	}
 
 	if diff := cmp.Diff(expectedRouteSpec, routerule.Spec); diff != "" {
@@ -378,12 +368,10 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 
 	// A route targeting the revision
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			RevisionName: "test-rev",
+			Percent:      100,
+		}},
 	)
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
@@ -404,13 +392,11 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	}
 
 	// Check owner refs
-	expectedRefs := []metav1.OwnerReference{
-		metav1.OwnerReference{
-			APIVersion: "serving.knative.dev/v1alpha1",
-			Kind:       "Route",
-			Name:       route.Name,
-		},
-	}
+	expectedRefs := []metav1.OwnerReference{{
+		APIVersion: "serving.knative.dev/v1alpha1",
+		Kind:       "Route",
+		Name:       route.Name,
+	}}
 
 	if diff := cmp.Diff(expectedRefs, routerule.OwnerReferences, cmpopts.IgnoreFields(expectedRefs[0], "Controller", "BlockOwnerDeletion")); diff != "" {
 		t.Errorf("Unexpected rule owner refs diff (-want +got): %v", diff)
@@ -435,9 +421,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			getActivatorDestinationWeight(100),
-		},
+		Route:         []v1alpha2.DestinationWeight{getActivatorDestinationWeight(100)},
 		AppendHeaders: appendHeaders,
 	}
 
@@ -480,12 +464,10 @@ func TestCreateRouteFromConfigsWithMultipleRevs(t *testing.T) {
 
 	// A route targeting both the config and standalone revision
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           100,
+		}},
 	)
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
@@ -514,22 +496,19 @@ func TestCreateRouteFromConfigsWithMultipleRevs(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      fmt.Sprintf("%s-service", latestReadyRev.Name),
-					Namespace: testNamespace,
-				},
-				Weight: 100,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      fmt.Sprintf("%s-service", latestReadyRev.Name),
+				Namespace: testNamespace,
 			},
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      fmt.Sprintf("%s-service", otherRev.Name),
-					Namespace: testNamespace,
-				},
-				Weight: 0,
+			Weight: 100,
+		}, {
+			Destination: v1alpha2.IstioService{
+				Name:      fmt.Sprintf("%s-service", otherRev.Name),
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 0,
+		}},
 	}
 
 	if diff := cmp.Diff(expectedRouteSpec, routerule.Spec); diff != "" {
@@ -555,16 +534,13 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 
 	// A route targeting both the config and standalone revision
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           90,
-			},
-			v1alpha1.TrafficTarget{
-				RevisionName: rev.Name,
-				Percent:      10,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           90,
+		}, {
+			RevisionName: rev.Name,
+			Percent:      10,
+		}},
 	)
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
@@ -593,22 +569,19 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      fmt.Sprintf("%s-service", cfgrev.Name),
-					Namespace: testNamespace,
-				},
-				Weight: 90,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      fmt.Sprintf("%s-service", cfgrev.Name),
+				Namespace: testNamespace,
 			},
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      fmt.Sprintf("%s-service", rev.Name),
-					Namespace: testNamespace,
-				},
-				Weight: 10,
+			Weight: 90,
+		}, {
+			Destination: v1alpha2.IstioService{
+				Name:      fmt.Sprintf("%s-service", rev.Name),
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 10,
+		}},
 	}
 
 	if diff := cmp.Diff(expectedRouteSpec, routerule.Spec); diff != "" {
@@ -643,16 +616,13 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 
 	// A route targeting both the config and standalone revision
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           90,
-			},
-			v1alpha1.TrafficTarget{
-				RevisionName: rev.Name,
-				Percent:      10,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           90,
+		}, {
+			RevisionName: rev.Name,
+			Percent:      10,
+		}},
 	)
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
@@ -684,16 +654,13 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      fmt.Sprintf("%s-service", cfgrev.Name),
-					Namespace: testNamespace,
-				},
-				Weight: 90,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      fmt.Sprintf("%s-service", cfgrev.Name),
+				Namespace: testNamespace,
 			},
-			getActivatorDestinationWeight(10),
-		},
+			Weight: 90,
+		}, getActivatorDestinationWeight(10)},
 		AppendHeaders: appendHeaders,
 	}
 
@@ -722,39 +689,31 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 
 	// A route with duplicate targets. These will be deduped.
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: "test-config",
-				Percent:           30,
-			},
-			v1alpha1.TrafficTarget{
-				ConfigurationName: "test-config",
-				Percent:           20,
-			},
-			v1alpha1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      10,
-			},
-			v1alpha1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      5,
-			},
-			v1alpha1.TrafficTarget{
-				Name:         "test-revision-1",
-				RevisionName: "test-rev",
-				Percent:      10,
-			},
-			v1alpha1.TrafficTarget{
-				Name:         "test-revision-1",
-				RevisionName: "test-rev",
-				Percent:      10,
-			},
-			v1alpha1.TrafficTarget{
-				Name:         "test-revision-2",
-				RevisionName: "test-rev",
-				Percent:      15,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: "test-config",
+			Percent:           30,
+		}, {
+			ConfigurationName: "test-config",
+			Percent:           20,
+		}, {
+			RevisionName: "test-rev",
+			Percent:      10,
+		}, {
+			RevisionName: "test-rev",
+			Percent:      5,
+		}, {
+			Name:         "test-revision-1",
+			RevisionName: "test-rev",
+			Percent:      10,
+		}, {
+			Name:         "test-revision-1",
+			RevisionName: "test-rev",
+			Percent:      10,
+		}, {
+			Name:         "test-revision-2",
+			RevisionName: "test-rev",
+			Percent:      15,
+		}},
 	)
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since updateRouteEvent looks in the lister, we need to add it to the informer
@@ -783,36 +742,31 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "p-deadbeef-service",
-					Namespace: testNamespace,
-				},
-				Weight: 50,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      "p-deadbeef-service",
+				Namespace: testNamespace,
 			},
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "test-rev-service",
-					Namespace: testNamespace,
-				},
-				Weight: 15,
+			Weight: 50,
+		}, {
+			Destination: v1alpha2.IstioService{
+				Name:      "test-rev-service",
+				Namespace: testNamespace,
 			},
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "test-rev-service",
-					Namespace: testNamespace,
-				},
-				Weight: 20,
+			Weight: 15,
+		}, {
+			Destination: v1alpha2.IstioService{
+				Name:      "test-rev-service",
+				Namespace: testNamespace,
 			},
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "test-rev-service",
-					Namespace: testNamespace,
-				},
-				Weight: 15,
+			Weight: 20,
+		}, {
+			Destination: v1alpha2.IstioService{
+				Name:      "test-rev-service",
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 15,
+		}},
 	}
 
 	if diff := cmp.Diff(expectedRouteSpec, routerule.Spec); diff != "" {
@@ -839,18 +793,15 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 	// A route targeting both the config and standalone revision with named
 	// targets
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				Name:         "foo",
-				RevisionName: "test-rev",
-				Percent:      50,
-			},
-			v1alpha1.TrafficTarget{
-				Name:              "bar",
-				ConfigurationName: "test-config",
-				Percent:           50,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			Name:         "foo",
+			RevisionName: "test-rev",
+			Percent:      50,
+		}, {
+			Name:              "bar",
+			ConfigurationName: "test-config",
+			Percent:           50,
+		}},
 	)
 
 	elaClient.ServingV1alpha1().Routes(testNamespace).Create(route)
@@ -886,22 +837,19 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "test-rev-service",
-					Namespace: testNamespace,
-				},
-				Weight: 50,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      "test-rev-service",
+				Namespace: testNamespace,
 			},
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "p-deadbeef-service",
-					Namespace: testNamespace,
-				},
-				Weight: 50,
+			Weight: 50,
+		}, {
+			Destination: v1alpha2.IstioService{
+				Name:      "p-deadbeef-service",
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 50,
+		}},
 	})
 
 	// Expects authority header to have the traffic target name prefixed to the
@@ -923,15 +871,13 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "test-rev-service",
-					Namespace: testNamespace,
-				},
-				Weight: 100,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      "test-rev-service",
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 100,
+		}},
 	})
 
 	// Expects authority header to have the traffic target name prefixed to the
@@ -953,15 +899,13 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				},
 			},
 		},
-		Route: []v1alpha2.DestinationWeight{
-			v1alpha2.DestinationWeight{
-				Destination: v1alpha2.IstioService{
-					Name:      "p-deadbeef-service",
-					Namespace: testNamespace,
-				},
-				Weight: 100,
+		Route: []v1alpha2.DestinationWeight{{
+			Destination: v1alpha2.IstioService{
+				Name:      "p-deadbeef-service",
+				Namespace: testNamespace,
 			},
-		},
+			Weight: 100,
+		}},
 	})
 }
 
@@ -970,17 +914,14 @@ func TestCreateRouteDeletesOutdatedRouteRules(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           50,
-			},
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           100,
-				Name:              "foo",
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           50,
+		}, {
+			ConfigurationName: config.Name,
+			Percent:           100,
+			Name:              "foo",
+		}},
 	)
 	extraRouteRule := &v1alpha2.RouteRule{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1038,12 +979,10 @@ func TestSetLabelToConfigurationDirectlyConfigured(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           100,
+		}},
 	)
 
 	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
@@ -1070,12 +1009,10 @@ func TestSetLabelToRevisionDirectlyConfigured(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           100,
+		}},
 	)
 
 	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
@@ -1126,12 +1063,10 @@ func TestSetLabelToConfigurationAndRevisionIndirectlyConfigured(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName: rev.Name,
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			RevisionName: rev.Name,
+			Percent:      100,
+		}},
 	)
 
 	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
@@ -1173,12 +1108,10 @@ func TestCreateRouteWithInvalidConfigurationShouldReturnError(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName: rev.Name,
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			RevisionName: rev.Name,
+			Percent:      100,
+		}},
 	)
 	// Set config's route label with another route name to trigger an error.
 	config.Labels = map[string]string{serving.RouteLabelKey: "another-route"}
@@ -1223,14 +1156,12 @@ func TestCreateRouteRevisionMissingCondition(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				// Note that since no Revision with this name exists,
-				// this will trigger the RevisionMissing condition.
-				RevisionName: "does-not-exist",
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			// Note that since no Revision with this name exists,
+			// this will trigger the RevisionMissing condition.
+			RevisionName: "does-not-exist",
+			Percent:      100,
+		}},
 	)
 
 	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
@@ -1247,23 +1178,20 @@ func TestCreateRouteRevisionMissingCondition(t *testing.T) {
 	}
 
 	// Verify that Route.Status.Conditions were correctly set.
-	expectedConditions := []v1alpha1.RouteCondition{{
-		Type:    v1alpha1.RouteConditionAllTrafficAssigned,
-		Status:  corev1.ConditionFalse,
-		Reason:  "RevisionMissing",
-		Message: `Referenced Revision "does-not-exist" not found`,
-	}, {
-		Type:   v1alpha1.RouteConditionIngressReady,
-		Status: corev1.ConditionUnknown,
-	}, {
-		Type:    v1alpha1.RouteConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  "RevisionMissing",
-		Message: `Referenced Revision "does-not-exist" not found`,
-	}}
 	newRoute, _ := elaClient.ServingV1alpha1().Routes(route.Namespace).Get(route.Name, metav1.GetOptions{})
-	if diff := cmp.Diff(expectedConditions, newRoute.Status.Conditions, cmpopts.SortSlices(sortConditions)); diff != "" {
-		t.Errorf("Unexpected condition diff (-want +got): %v", diff)
+
+	for _, ct := range []v1alpha1.RouteConditionType{"AllTrafficAssigned", "Ready"} {
+		got := newRoute.Status.GetCondition(ct)
+		want := &v1alpha1.RouteCondition{
+			Type:               ct,
+			Status:             corev1.ConditionFalse,
+			Reason:             "RevisionMissing",
+			Message:            `Referenced Revision "does-not-exist" not found`,
+			LastTransitionTime: got.LastTransitionTime,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)
+		}
 	}
 }
 
@@ -1272,14 +1200,12 @@ func TestCreateRouteConfigurationMissingCondition(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				// Note that since no Configuration with this name exists,
-				// this will trigger the ConfigurationMissing condition.
-				ConfigurationName: "does-not-exist",
-				Percent:           100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			// Note that since no Configuration with this name exists,
+			// this will trigger the ConfigurationMissing condition.
+			ConfigurationName: "does-not-exist",
+			Percent:           100,
+		}},
 	)
 
 	elaClient.ServingV1alpha1().Configurations(testNamespace).Create(config)
@@ -1296,23 +1222,20 @@ func TestCreateRouteConfigurationMissingCondition(t *testing.T) {
 	}
 
 	// Verify that Route.Status.Conditions were correctly set.
-	expectedConditions := []v1alpha1.RouteCondition{{
-		Type:    v1alpha1.RouteConditionAllTrafficAssigned,
-		Status:  corev1.ConditionFalse,
-		Reason:  "ConfigurationMissing",
-		Message: `Referenced Configuration "does-not-exist" not found`,
-	}, {
-		Type:   v1alpha1.RouteConditionIngressReady,
-		Status: corev1.ConditionUnknown,
-	}, {
-		Type:    v1alpha1.RouteConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  "ConfigurationMissing",
-		Message: `Referenced Configuration "does-not-exist" not found`,
-	}}
 	newRoute, _ := elaClient.ServingV1alpha1().Routes(route.Namespace).Get(route.Name, metav1.GetOptions{})
-	if diff := cmp.Diff(expectedConditions, newRoute.Status.Conditions, cmpopts.SortSlices(sortConditions)); diff != "" {
-		t.Errorf("Unexpected condition diff (-want +got): %v", diff)
+
+	for _, ct := range []v1alpha1.RouteConditionType{"AllTrafficAssigned", "Ready"} {
+		got := newRoute.Status.GetCondition(ct)
+		want := &v1alpha1.RouteCondition{
+			Type:               ct,
+			Status:             corev1.ConditionFalse,
+			Reason:             "ConfigurationMissing",
+			Message:            `Referenced Configuration "does-not-exist" not found`,
+			LastTransitionTime: got.LastTransitionTime,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)
+		}
 	}
 }
 
@@ -1321,12 +1244,10 @@ func TestSetLabelNotChangeConfigurationAndRevisionLabelIfLabelExists(t *testing.
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName: rev.Name,
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			RevisionName: rev.Name,
+			Percent:      100,
+		}},
 	)
 	// Set config's route label with route name to make sure config's label will not be set
 	// by function setLabelForGivenConfigurations.
@@ -1461,12 +1382,10 @@ func TestUpdateRouteWhenConfigurationChanges(t *testing.T) {
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           100,
+		}},
 	)
 
 	routeClient.Create(route)
@@ -1513,12 +1432,10 @@ func TestUpdateRouteWhenConfigurationChanges(t *testing.T) {
 
 	// Now the configuration has a LatestReadyRevisionName, so its revision should
 	// be targeted
-	expectedTrafficTargets = []v1alpha1.TrafficTarget{
-		v1alpha1.TrafficTarget{
-			RevisionName: rev.Name,
-			Percent:      100,
-		},
-	}
+	expectedTrafficTargets = []v1alpha1.TrafficTarget{{
+		RevisionName: rev.Name,
+		Percent:      100,
+	}}
 	if diff := cmp.Diff(expectedTrafficTargets, route.Status.Traffic); diff != "" {
 		t.Errorf("Unexpected traffic target diff (-want +got): %v", diff)
 	}
@@ -1534,12 +1451,10 @@ func TestAddConfigurationEventNotUpdateAnythingIfHasNoLatestReady(t *testing.T) 
 	config := getTestConfiguration()
 	rev := getTestRevisionForConfig(config)
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			ConfigurationName: config.Name,
+			Percent:           100,
+		}},
 	)
 	// If set config.Status.LatestReadyRevisionName = rev.Name, the test should fail.
 	config.Status.LatestCreatedRevisionName = rev.Name
@@ -1579,12 +1494,10 @@ func TestUpdateIngressEventUpdateRouteStatus(t *testing.T) {
 	elaClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 
 	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{
-			{
-				RevisionName: rev.Name,
-				Percent:      100,
-			},
-		},
+		[]v1alpha1.TrafficTarget{{
+			RevisionName: rev.Name,
+			Percent:      100,
+		}},
 	)
 	// Create a route.
 	routeClient := elaClient.ServingV1alpha1().Routes(route.Namespace)
@@ -1598,39 +1511,38 @@ func TestUpdateIngressEventUpdateRouteStatus(t *testing.T) {
 	ingressClient := kubeClient.ExtensionsV1beta1().Ingresses(route.Namespace)
 	ingress, _ := ingressClient.Get(ctrl.GetElaK8SIngressName(route), metav1.GetOptions{})
 	controller.updateIngressEvent(nil, ingress)
-	expectedConditions := []v1alpha1.RouteCondition{{
-		Type:   v1alpha1.RouteConditionIngressReady,
-		Status: corev1.ConditionUnknown,
-	}, {
-		Type:   v1alpha1.RouteConditionReady,
-		Status: corev1.ConditionUnknown,
-	}, {
-		Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-		Status: corev1.ConditionTrue,
-	}}
+
 	newRoute, _ := routeClient.Get(route.Name, metav1.GetOptions{})
-	if diff := cmp.Diff(expectedConditions, newRoute.Status.Conditions); diff != "" {
-		t.Errorf("Unexpected condition diff (-want +got): %v", diff)
+	for _, ct := range []v1alpha1.RouteConditionType{"Ready"} {
+		got := newRoute.Status.GetCondition(ct)
+		want := &v1alpha1.RouteCondition{
+			Type:               ct,
+			Status:             corev1.ConditionUnknown,
+			LastTransitionTime: got.LastTransitionTime,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)
+		}
 	}
+
 	// Update the Ingress IP.
 	ingress.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{
 		IP: "127.0.0.1",
 	}}
 	controller.updateIngressEvent(nil, ingress)
+
 	// Verify now that Route.Status.Conditions is set correctly.
-	expectedConditions = []v1alpha1.RouteCondition{{
-		Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-		Status: corev1.ConditionTrue,
-	}, {
-		Type:   v1alpha1.RouteConditionIngressReady,
-		Status: corev1.ConditionTrue,
-	}, {
-		Type:   v1alpha1.RouteConditionReady,
-		Status: corev1.ConditionTrue,
-	}}
 	newRoute, _ = routeClient.Get(route.Name, metav1.GetOptions{})
-	if diff := cmp.Diff(expectedConditions, newRoute.Status.Conditions); diff != "" {
-		t.Errorf("Unexpected condition diff (-want +got): %v", diff)
+	for _, ct := range []v1alpha1.RouteConditionType{"Ready"} {
+		got := newRoute.Status.GetCondition(ct)
+		want := &v1alpha1.RouteCondition{
+			Type:               ct,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: got.LastTransitionTime,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("Unexpected config conditions diff (-want +got): %v", diff)
+		}
 	}
 }
 
@@ -1651,78 +1563,73 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 	expectations := []struct {
 		apply                func()
 		expectedDomainSuffix string
-	}{
-		{
-			expectedDomainSuffix: prodDomainSuffix,
-			apply:                func() {},
+	}{{
+		expectedDomainSuffix: prodDomainSuffix,
+		apply:                func() {},
+	}, {
+		expectedDomainSuffix: "mytestdomain.com",
+		apply: func() {
+			domainConfig := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ctrl.GetDomainConfigMapName(),
+					Namespace: pkg.GetServingSystemNamespace(),
+				},
+				Data: map[string]string{
+					defaultDomainSuffix: "",
+					"mytestdomain.com":  "selector:\n  app: prod",
+				},
+			}
+			controller.updateConfigMapEvent(nil, &domainConfig)
 		},
-		{
-			expectedDomainSuffix: "mytestdomain.com",
-			apply: func() {
-				domainConfig := corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      ctrl.GetDomainConfigMapName(),
-						Namespace: pkg.GetServingSystemNamespace(),
-					},
-					Data: map[string]string{
-						defaultDomainSuffix: "",
-						"mytestdomain.com":  "selector:\n  app: prod",
-					},
-				}
-				controller.updateConfigMapEvent(nil, &domainConfig)
-			},
+	}, {
+		expectedDomainSuffix: "newdefault.net",
+		apply: func() {
+			domainConfig := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ctrl.GetDomainConfigMapName(),
+					Namespace: pkg.GetServingSystemNamespace(),
+				},
+				Data: map[string]string{
+					"newdefault.net":   "",
+					"mytestdomain.com": "selector:\n  app: prod",
+				},
+			}
+			controller.updateConfigMapEvent(nil, &domainConfig)
+			route.Labels = make(map[string]string)
 		},
-		{
-			expectedDomainSuffix: "newdefault.net",
-			apply: func() {
-				domainConfig := corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      ctrl.GetDomainConfigMapName(),
-						Namespace: pkg.GetServingSystemNamespace(),
-					},
-					Data: map[string]string{
-						"newdefault.net":   "",
-						"mytestdomain.com": "selector:\n  app: prod",
-					},
-				}
-				controller.updateConfigMapEvent(nil, &domainConfig)
-				route.Labels = make(map[string]string)
-			},
-		},
+	}, {
 		// An unrelated config map
-		{
-			expectedDomainSuffix: "newdefault.net",
-			apply: func() {
-				domainConfig := corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "SomethingDifferent",
-						Namespace: pkg.GetServingSystemNamespace(),
-					},
-					Data: map[string]string{
-						defaultDomainSuffix: "",
-					},
-				}
-				controller.updateConfigMapEvent(nil, &domainConfig)
-				route.Labels = make(map[string]string)
-			},
+		expectedDomainSuffix: "newdefault.net",
+		apply: func() {
+			domainConfig := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "SomethingDifferent",
+					Namespace: pkg.GetServingSystemNamespace(),
+				},
+				Data: map[string]string{
+					defaultDomainSuffix: "",
+				},
+			}
+			controller.updateConfigMapEvent(nil, &domainConfig)
+			route.Labels = make(map[string]string)
 		},
+	}, {
 		// An invalid config map
-		{
-			expectedDomainSuffix: "newdefault.net",
-			apply: func() {
-				domainConfig := corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      ctrl.GetDomainConfigMapName(),
-						Namespace: pkg.GetServingSystemNamespace(),
-					},
-					Data: map[string]string{
-						"mytestdomain.com": "selector:\n  app: prod",
-					},
-				}
-				controller.updateConfigMapEvent(nil, &domainConfig)
-				route.Labels = make(map[string]string)
-			},
-		}}
+		expectedDomainSuffix: "newdefault.net",
+		apply: func() {
+			domainConfig := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ctrl.GetDomainConfigMapName(),
+					Namespace: pkg.GetServingSystemNamespace(),
+				},
+				Data: map[string]string{
+					"mytestdomain.com": "selector:\n  app: prod",
+				},
+			}
+			controller.updateConfigMapEvent(nil, &domainConfig)
+			route.Labels = make(map[string]string)
+		},
+	}}
 	for _, expectation := range expectations {
 		expectation.apply()
 		elaInformer.Serving().V1alpha1().Routes().Informer().GetIndexer().Add(route)


### PR DESCRIPTION
This is automatically populated by `setCondition`.

Other misc changes:
 * Switch `route_test.go` to us compact array syntax.
 * Switch `route_test.go` to the same pattern for checking conditions as used by the other controller tests.

Fixes: https://github.com/knative/serving/issues/1141