### PR TITLE
Predicate readiness strictly on Route's "Ready" condition.

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	"github.com/mattbaird/jsonpatch"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -82,34 +83,19 @@ func updateConfigWithImage(clients *test.Clients, names test.ResourceNames, imag
 }
 
 func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedText string) {
-	glog.Infof("The Revision will be marked as Ready when it can serve traffic")
-	err := test.WaitForRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady(names.Revision))
-	if err != nil {
-		t.Fatalf("Revision %s did not become ready to serve traffic: %v", names.Revision, err)
-	}
-
-	glog.Infof("Updates the Configuration that the Revision is ready")
-	err = test.WaitForConfigurationState(clients.Configs, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
-		return c.Status.LatestReadyRevisionName == names.Revision, nil
-	})
-	if err != nil {
-		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
-	}
-
-	glog.Infof("Updates the Route to route traffic to the Revision")
-	err = test.WaitForRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names.Route, names.Revision))
-	if err != nil {
-		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
-	}
-
-	glog.Infof("When the Revision can have traffic routed to it, the Route is marked as Ready")
-	err = test.WaitForRouteState(clients.Routes, names.Route, func(r *v1alpha1.Route) (bool, error) {
-		return r.Status.IsReady(), nil
+	glog.Infof("When the Route reports as Ready, everything should be ready.")
+	err := test.WaitForRouteState(clients.Routes, names.Route, func(r *v1alpha1.Route) (bool, error) {
+		if cond := r.Status.GetCondition(v1alpha1.RouteConditionReady); cond == nil {
+			return false, nil
+		} else {
+			return cond.Status == corev1.ConditionTrue, nil
+		}
 	})
 	if err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic to Revision %s: %v", names.Route, names.Revision, err)
 	}
 
+	// TODO(#1178): Remove "Wait" from all checks below this point.
 	glog.Infof("Serves the expected data at the endpoint")
 	updatedRoute, err := clients.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
@@ -120,6 +106,25 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 	})
 	if err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, updatedRoute.Status.Domain, expectedText, err)
+	}
+
+	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
+	glog.Infof("The Revision will be marked as Ready when it can serve traffic")
+	err = test.WaitForRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady(names.Revision))
+	if err != nil {
+		t.Fatalf("Revision %s did not become ready to serve traffic: %v", names.Revision, err)
+	}
+	glog.Infof("Updates the Configuration that the Revision is ready")
+	err = test.WaitForConfigurationState(clients.Configs, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+		return c.Status.LatestReadyRevisionName == names.Revision, nil
+	})
+	if err != nil {
+		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v\n", names.Config, names.Revision, err)
+	}
+	glog.Infof("Updates the Route to route traffic to the Revision")
+	err = test.WaitForRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names.Route, names.Revision))
+	if err != nil {
+		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
 }
 
@@ -189,6 +194,7 @@ func TestRouteCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, image2, err)
 	}
+	names.Revision = revisionName
 
 	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, "Re-energize yourself with a slice of pepperoni!")
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -339,7 +339,7 @@ kubectl create namespace noodleburg
 go test -v -tags=e2e ./test/e2e -run HelloWorld -dockerrepo gcr.io/elafros-e2e-tests/ela-e2e-test
 exit_if_failed
 
-# run_e2e_tests conformance pizzaplanet ela-conformance-test
+run_e2e_tests conformance pizzaplanet ela-conformance-test
 # run_e2e_tests e2e noodleburg ela-e2e-test
 
 # kubetest teardown might fail and thus incorrectly report failure of the

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,7 +54,11 @@ func TestHelloWorld(t *testing.T) {
 
 	glog.Infof("When the Revision can have traffic routed to it, the Route is marked as Ready.")
 	err = test.WaitForRouteState(clients.Routes, names.Route, func(r *v1alpha1.Route) (bool, error) {
-		return r.Status.IsReady(), nil
+		if cond := r.Status.GetCondition(v1alpha1.RouteConditionReady); cond == nil {
+			return false, nil
+		} else {
+			return cond.Status == corev1.ConditionTrue, nil
+		}
 	})
 	if err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)

--- a/test/states.go
+++ b/test/states.go
@@ -49,16 +49,10 @@ func AllRouteTrafficAtRevision(routeName string, revisionName string) func(r *v1
 // or being ready. It will also return false if the type of the condition is unexpected.
 func IsRevisionReady(revisionName string) func(r *v1alpha1.Revision) (bool, error) {
 	return func(r *v1alpha1.Revision) (bool, error) {
-		if len(r.Status.Conditions) > 0 {
-			if r.Status.Conditions[0].Type != v1alpha1.RevisionConditionType("Ready") {
-				return true, fmt.Errorf("Expected Revision to have a \"Ready\" status but only had %s", r.Status.Conditions[0].Type)
-			}
-			if r.Status.Conditions[0].Status == corev1.ConditionTrue {
-				return true, nil
-			} else if r.Status.Conditions[0].Status != corev1.ConditionUnknown {
-				return true, fmt.Errorf("Expected Revision Status Condition Status to be True or Unknown but was %s", r.Status.Conditions[0].Status)
-			}
+		if cond := r.Status.GetCondition(v1alpha1.RevisionConditionReady); cond == nil {
+			return false, nil
+		} else {
+			return cond.Status == corev1.ConditionTrue, nil
 		}
-		return false, nil
 	}
 }


### PR DESCRIPTION
In the conformance and e2e testing, we should be able to curl a given endpoint
as soon as it reports "Ready: True".  By checking any additional conditions, we
potentially hide bugs where the Route reports "Ready: True" before that's
actually correct.