### PR TITLE
Use typed handler methods.

### DIFF
--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -81,8 +81,12 @@ func NewController(
 
 	controller.Logger.Info("Setting up event handlers")
 	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.addRevisionEvent,
-		UpdateFunc: controller.updateRevisionEvent,
+		AddFunc: func(obj interface{}) {
+			controller.SyncRevision(obj.(*v1alpha1.Revision))
+		},
+		UpdateFunc: func(old, new interface{}) {
+			controller.SyncRevision(new.(*v1alpha1.Revision))
+		},
 	})
 	return controller
 }
@@ -251,8 +255,7 @@ func (c *Controller) updateStatus(u *v1alpha1.Configuration) (*v1alpha1.Configur
 	//	return configClient.UpdateStatus(newu)
 }
 
-func (c *Controller) addRevisionEvent(obj interface{}) {
-	revision := obj.(*v1alpha1.Revision)
+func (c *Controller) SyncRevision(revision *v1alpha1.Revision) {
 	revisionName := revision.Name
 	namespace := revision.Namespace
 	// Lookup and see if this Revision corresponds to a Configuration that
@@ -310,8 +313,4 @@ func (c *Controller) addRevisionEvent(obj interface{}) {
 		c.Recorder.Eventf(config, corev1.EventTypeWarning, "LatestCreatedFailed",
 			"Latest created revision %q has failed", revision.Name)
 	}
-}
-
-func (c *Controller) updateRevisionEvent(old, new interface{}) {
-	c.addRevisionEvent(new)
 }

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -331,9 +331,9 @@ func TestMarkConfigurationReadyWhenLatestRevisionReady(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		}},
 	}
-	// Since addRevisionEvent looks in the lister, we need to add it to the informer
+	// Since SyncRevision looks in the lister, we need to add it to the informer
 	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(reconciledConfig)
-	controller.addRevisionEvent(&revision)
+	controller.SyncRevision(&revision)
 
 	readyConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
 	if err != nil {
@@ -370,7 +370,7 @@ func TestDoNotUpdateConfigurationWhenRevisionIsNotReady(t *testing.T) {
 	config.Status.LatestCreatedRevisionName = revName
 
 	configClient.Create(config)
-	// Since addRevisionEvent looks in the lister, we need to add it to the informer
+	// Since SyncRevision looks in the lister, we need to add it to the informer
 	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 
 	// Get the configuration after reconciling
@@ -384,7 +384,7 @@ func TestDoNotUpdateConfigurationWhenRevisionIsNotReady(t *testing.T) {
 	controllerRef := ctrl.NewConfigurationControllerRef(config)
 	revision := getTestRevision()
 	revision.OwnerReferences = append(revision.OwnerReferences, *controllerRef)
-	controller.addRevisionEvent(revision)
+	controller.SyncRevision(revision)
 
 	// Configuration should not have changed.
 	actualConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -405,7 +405,7 @@ func TestDoNotUpdateConfigurationWhenReadyRevisionIsNotLatestCreated(t *testing.
 	// Don't set LatestCreatedRevisionName.
 
 	configClient.Create(config)
-	// Since addRevisionEvent looks in the lister, we need to add it to the informer
+	// Since SyncRevision looks in the lister, we need to add it to the informer
 	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 
 	// Get the configuration after reconciling
@@ -426,7 +426,7 @@ func TestDoNotUpdateConfigurationWhenReadyRevisionIsNotLatestCreated(t *testing.
 		}},
 	}
 
-	controller.addRevisionEvent(revision)
+	controller.SyncRevision(revision)
 
 	// Configuration should not have changed.
 	actualConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
@@ -454,7 +454,7 @@ func TestDoNotUpdateConfigurationWhenLatestReadyRevisionNameIsUpToDate(t *testin
 		LatestReadyRevisionName:   revName,
 	}
 	configClient.Create(config)
-	// Since addRevisionEvent looks in the lister, we need to add it to the informer
+	// Since SyncRevision looks in the lister, we need to add it to the informer
 	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
 
 	// Create a revision owned by this Configuration. This revision is Ready and
@@ -469,7 +469,7 @@ func TestDoNotUpdateConfigurationWhenLatestReadyRevisionNameIsUpToDate(t *testin
 		}},
 	}
 
-	controller.addRevisionEvent(revision)
+	controller.SyncRevision(revision)
 }
 
 func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
@@ -510,9 +510,9 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 		Message: "Build step failed with error",
 	})
 
-	// Since addRevisionEvent looks in the lister, we need to add it to the informer
+	// Since SyncRevision looks in the lister, we need to add it to the informer
 	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(reconciledConfig)
-	controller.addRevisionEvent(&revision)
+	controller.SyncRevision(&revision)
 
 	readyConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
 	if err != nil {
@@ -578,9 +578,9 @@ func TestMarkConfigurationReadyWhenLatestRevisionRecovers(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		}},
 	}
-	// Since addRevisionEvent looks in the lister, we need to add it to the informer
+	// Since SyncRevision looks in the lister, we need to add it to the informer
 	elaInformer.Serving().V1alpha1().Configurations().Informer().GetIndexer().Add(config)
-	controller.addRevisionEvent(revision)
+	controller.SyncRevision(revision)
 
 	readyConfig, err := configClient.Get(config.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -953,7 +953,7 @@ func TestCreateRevWithFailedBuildNameFails(t *testing.T) {
 		}},
 	}
 
-	controller.addBuildEvent(bld)
+	controller.SyncBuild(bld)
 
 	failedRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1039,7 +1039,7 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 		}},
 	}
 
-	controller.addBuildEvent(bld)
+	controller.SyncBuild(bld)
 
 	completedRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1109,7 +1109,7 @@ func TestCreateRevWithInvalidBuildNameFails(t *testing.T) {
 		}},
 	}
 
-	controller.addBuildEvent(bld)
+	controller.SyncBuild(bld)
 
 	failedRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1159,7 +1159,7 @@ func TestCreateRevWithProgressDeadlineSecondsStuff(t *testing.T) {
 
 	//set ProgressDeadlineSeconds on Dep spec
 	deployment.Spec.ProgressDeadlineSeconds = &testProgressDeadlineSeconds
-	controller.addDeploymentProgressEvent(deployment)
+	controller.SyncDeployment(deployment)
 
 	rev2Inspect, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1216,7 +1216,7 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 	}
 
 	endpoints := getTestReadyEndpoints(rev.Name)
-	controller.addEndpointsEvent(endpoints)
+	controller.SyncEndpoints(endpoints)
 
 	readyRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1265,7 +1265,7 @@ func TestDoNotUpdateRevIfRevIsAlreadyReady(t *testing.T) {
 		},
 	)
 
-	controller.addEndpointsEvent(endpoints)
+	controller.SyncEndpoints(endpoints)
 }
 
 func TestDoNotUpdateRevIfRevIsMarkedAsFailed(t *testing.T) {
@@ -1295,7 +1295,7 @@ func TestDoNotUpdateRevIfRevIsMarkedAsFailed(t *testing.T) {
 		},
 	)
 
-	controller.addEndpointsEvent(endpoints)
+	controller.SyncEndpoints(endpoints)
 }
 
 func TestMarkRevAsFailedIfEndpointHasNoAddressesAfterSomeDuration(t *testing.T) {
@@ -1315,7 +1315,7 @@ func TestMarkRevAsFailedIfEndpointHasNoAddressesAfterSomeDuration(t *testing.T) 
 	// Create endpoints owned by this Revision.
 	endpoints := getTestNotReadyEndpoints(rev.Name)
 
-	controller.addEndpointsEvent(endpoints)
+	controller.SyncEndpoints(endpoints)
 
 	currentRev, _ := elaClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 
@@ -1352,7 +1352,7 @@ func TestAuxiliaryEndpointDoesNotUpdateRev(t *testing.T) {
 		},
 	)
 
-	controller.addEndpointsEvent(endpoints)
+	controller.SyncEndpoints(endpoints)
 }
 
 func TestActiveToRetiredRevisionDeletesStuff(t *testing.T) {

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -158,15 +158,29 @@ func NewController(
 
 	controller.Logger.Info("Setting up event handlers")
 	configInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.addConfigurationEvent,
-		UpdateFunc: controller.updateConfigurationEvent,
+		AddFunc: func(obj interface{}) {
+			controller.SyncConfiguration(obj.(*v1alpha1.Configuration))
+		},
+		UpdateFunc: func(old, new interface{}) {
+			controller.SyncConfiguration(new.(*v1alpha1.Configuration))
+		},
 	})
+	// v1beta1.Ingress
 	ingressInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: controller.updateIngressEvent,
+		AddFunc: func(obj interface{}) {
+			controller.SyncIngress(obj.(*v1beta1.Ingress))
+		},
+		UpdateFunc: func(old, new interface{}) {
+			controller.SyncIngress(new.(*v1beta1.Ingress))
+		},
 	})
 	configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.addConfigMapEvent,
-		UpdateFunc: controller.updateConfigMapEvent,
+		AddFunc: func(obj interface{}) {
+			controller.SyncConfigMap(obj.(*corev1.ConfigMap))
+		},
+		UpdateFunc: func(old, new interface{}) {
+			controller.SyncConfigMap(new.(*corev1.ConfigMap))
+		},
 	})
 	return controller
 }
@@ -966,8 +980,7 @@ func (c *Controller) removeOutdatedRouteRules(ctx context.Context, u *v1alpha1.R
 	return nil
 }
 
-func (c *Controller) addConfigurationEvent(obj interface{}) {
-	config := obj.(*v1alpha1.Configuration)
+func (c *Controller) SyncConfiguration(config *v1alpha1.Configuration) {
 	configName := config.Name
 	ns := config.Namespace
 
@@ -997,12 +1010,7 @@ func (c *Controller) addConfigurationEvent(obj interface{}) {
 	}
 }
 
-func (c *Controller) updateConfigurationEvent(old, new interface{}) {
-	c.addConfigurationEvent(new)
-}
-
-func (c *Controller) updateIngressEvent(old, new interface{}) {
-	ingress := new.(*v1beta1.Ingress)
+func (c *Controller) SyncIngress(ingress *v1beta1.Ingress) {
 	// If ingress isn't owned by a route, no route update is required.
 	routeName := controller.LookupOwningRouteName(ingress.OwnerReferences)
 	if routeName == "" {
@@ -1046,8 +1054,7 @@ func (c *Controller) updateIngressEvent(old, new interface{}) {
 	}
 }
 
-func (c *Controller) addConfigMapEvent(obj interface{}) {
-	configMap := obj.(*corev1.ConfigMap)
+func (c *Controller) SyncConfigMap(configMap *corev1.ConfigMap) {
 	if configMap.Namespace != pkg.GetServingSystemNamespace() || configMap.Name != controller.GetDomainConfigMapName() {
 		return
 	}
@@ -1059,8 +1066,4 @@ func (c *Controller) addConfigMapEvent(obj interface{}) {
 		return
 	}
 	c.setDomainConfig(newDomainConfig)
-}
-
-func (c *Controller) updateConfigMapEvent(old, new interface{}) {
-	c.addConfigMapEvent(new)
 }


### PR DESCRIPTION
This change switches us to use typed handler methods on controllers for processing events.  The type assertions are done via anonymous functions inline in the informer call.
