### PR TITLE
Improve the coverage of error paths in resolve.go

### DIFF
--- a/pkg/controller/revision/resolve_test.go
+++ b/pkg/controller/revision/resolve_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/name"
 	"github.com/google/go-containerregistry/v1"
 	"github.com/google/go-containerregistry/v1/random"
@@ -71,6 +72,33 @@ func fakeRegistry(t *testing.T, repo, username, password string, img v1.Image) *
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
 			w.Write(mustRawManifest(t, img))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+}
+
+func fakeRegistryPingFailure(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			http.Error(w, "Oops", http.StatusInternalServerError)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+}
+
+func fakeRegistryManifestFailure(t *testing.T, repo string) *httptest.Server {
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", repo)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			// Issue a "Basic" auth challenge, so we can check the auth sent to the registry.
+			w.Header().Set("WWW-Authenticate", `Basic `)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		case manifestPath:
+			http.Error(w, "Boom", http.StatusInternalServerError)
 		default:
 			t.Fatalf("Unexpected path: %v", r.URL.Path)
 		}
@@ -153,5 +181,192 @@ func TestResolve(t *testing.T) {
 	}
 	if got, want := digest.DigestStr(), mustDigest(t, img).String(); got != want {
 		t.Fatalf("Resolve() = %v, want %v", got, want)
+	}
+}
+
+func TestResolveWithDigest(t *testing.T) {
+	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "foo",
+		},
+	})
+	dr := &digestResolver{client: client, transport: http.DefaultTransport}
+	original := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blah",
+			Namespace: "foo",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "default",
+					Containers: []corev1.Container{{
+						Image: "ubuntu@sha256:e7def0d56013d50204d73bb588d99e0baa7d69ea1bc1157549b898eb67287612",
+					}},
+				},
+			},
+		},
+	}
+	deploy := original.DeepCopy()
+	if err := dr.Resolve(deploy); err != nil {
+		t.Fatalf("Resolve() = %v", err)
+	}
+
+	if diff := cmp.Diff(original, deploy); diff != "" {
+		t.Errorf("Deployment should not change (-want +got): %s", diff)
+	}
+}
+
+func TestResolveWithBadTag(t *testing.T) {
+	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "foo",
+		},
+	})
+	dr := &digestResolver{client: client, transport: http.DefaultTransport}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blah",
+			Namespace: "foo",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "default",
+					Containers: []corev1.Container{{
+						// Invalid character
+						Image: "ubuntu%latest",
+					}},
+				},
+			},
+		},
+	}
+	if err := dr.Resolve(deploy); err == nil {
+		t.Fatalf("Resolve() = %v, want error", deploy)
+	}
+}
+
+func TestResolveWithPingFailure(t *testing.T) {
+	ns, svcacct := "user-project", "user-robot"
+
+	// Stand up a fake registry
+	expectedRepo := "booger/nose"
+	server := fakeRegistryPingFailure(t)
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	// Create a tag pointing to an image on our fake registry
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	// Set up a fake service account with pull secrets for our fake registry
+	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcacct,
+			Namespace: ns,
+		},
+	})
+
+	// Resolve our tag on the fake registry to the digest of the random.Image()
+	dr := &digestResolver{client: client, transport: http.DefaultTransport}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blah",
+			Namespace: ns,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: svcacct,
+					Containers: []corev1.Container{{
+						Image: tag.String(),
+					}},
+				},
+			},
+		},
+	}
+	if err := dr.Resolve(deploy); err == nil {
+		t.Fatalf("Resolve() = %v, want error", deploy)
+	}
+}
+
+func TestResolveWithManifestFailure(t *testing.T) {
+	ns, svcacct := "user-project", "user-robot"
+
+	// Stand up a fake registry
+	expectedRepo := "booger/nose"
+	server := fakeRegistryManifestFailure(t, expectedRepo)
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	// Create a tag pointing to an image on our fake registry
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	// Set up a fake service account with pull secrets for our fake registry
+	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcacct,
+			Namespace: ns,
+		},
+	})
+
+	// Resolve our tag on the fake registry to the digest of the random.Image()
+	dr := &digestResolver{client: client, transport: http.DefaultTransport}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blah",
+			Namespace: ns,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: svcacct,
+					Containers: []corev1.Container{{
+						Image: tag.String(),
+					}},
+				},
+			},
+		},
+	}
+	if err := dr.Resolve(deploy); err == nil {
+		t.Fatalf("Resolve() = %v, want error", deploy)
+	}
+}
+
+func TestResolveNoAccess(t *testing.T) {
+	client := fakeclient.NewSimpleClientset()
+	dr := &digestResolver{client: client, transport: http.DefaultTransport}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blah",
+			Namespace: "foo",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "default",
+					Containers: []corev1.Container{{
+						Image: "ubuntu:latest",
+					}},
+				},
+			},
+		},
+	}
+	// If there is a failure accessing the ServiceAccount for this Pod, then we should see an error.
+	if err := dr.Resolve(deploy); err == nil {
+		t.Fatalf("Resolve() = %v, want error", deploy)
 	}
 }


### PR DESCRIPTION
This adds coverage of most of the error paths through resolve.go.  At this point the sole remaining failure path should be impossible to hit because `k8schain.Resolve` cannot return a non-nil error (but that's the `authn.Keychain` interface, so it has to have that signature).

Fixes: https://github.com/knative/serving/issues/1149

cc @jonjohnsonjr 