### PR TITLE
Add Prow help to contributor guide

### DIFF
--- a/community/CONTRIBUTING.md
+++ b/community/CONTRIBUTING.md
@@ -143,8 +143,11 @@ marked WIP.
 When ready, if you have not already done so, sign a [contributor license
 agreement](#contributor-license-agreements) and submit the PR.
 
+This project uses [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)
+to assign reviewers to the PR, set labels, run tests automatically, and so forth.
+
 See [Reviewing and Merging Pull Requests](REVIEWING.md) for the PR review and
-merge process used for Elafros.
+merge process used for Elafros and for more information about [Prow](./REVIEWING.md#prow).
 
 ## Issues
 


### PR DESCRIPTION
I couldn't see a link to the Prow help elsewhwere in the contributing docs.

/area test-and-release
/kind doc