### PR TITLE
Fix ProgressDeadlineExceeded handling.

### DIFF
--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -384,8 +384,13 @@ func (c *Controller) SyncDeployment(deployment *appsv1.Deployment) {
 		return
 	}
 
-	//Get the handle of Revision in context
-	revName := deployment.Name
+	or := metav1.GetControllerOf(deployment)
+	if or == nil || or.Kind != "Revision" {
+		return
+	}
+
+	// Get the handle of Revision in context
+	revName := or.Name
 	namespace := deployment.Namespace
 	logger := loggerWithRevisionInfo(c.Logger, namespace, revName)
 


### PR DESCRIPTION
The manner in which we were looking up the controlling Revision on Deployment events was relying on (an incorrect) naming convention where `deployment.Name == revision.Name`.  In reality, `deployment.Name == revision.Name + "-deployment"`, but relying on this for looking up the controlling object is an antipattern.

Instead, we should utilize `metav1.GetControllerOf` to determine the controlling `OwnerReference` and use this name to lookup the owning `Revision.

This fixes the local issue, but I've opened #1165 to track a broader triage of this.

Progress toward: https://github.com/knative/serving/issues/1150
