### PR TITLE
Use metav1.GetControllerOf consistently.

### DIFF
--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -249,12 +249,12 @@ func (c *Controller) updateStatus(u *v1alpha1.Configuration) (*v1alpha1.Configur
 func (c *Controller) SyncRevision(revision *v1alpha1.Revision) {
 	revisionName := revision.Name
 	namespace := revision.Namespace
-	// Lookup and see if this Revision corresponds to a Configuration that
-	// we own and hence the Configuration that created this Revision.
-	configName := controller.LookupOwningConfigurationName(revision.OwnerReferences)
-	if configName == "" {
+
+	or := metav1.GetControllerOf(revision)
+	if or == nil || or.Kind != "Configuration" {
 		return
 	}
+	configName := or.Name
 
 	logger := loggerWithConfigInfo(c.Logger, namespace, configName).With(zap.String(logkey.Revision, revisionName))
 

--- a/pkg/controller/owner_references.go
+++ b/pkg/controller/owner_references.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,26 +47,4 @@ func NewConfigurationControllerRef(config *v1alpha1.Configuration) *metav1.Owner
 // NewRevisionControllerRef creates an OwnerReference pointing to the given Service.
 func NewRevisionControllerRef(rev *v1alpha1.Revision) *metav1.OwnerReference {
 	return metav1.NewControllerRef(rev, revControllerKind)
-}
-
-// LookupOwningRouteName returns the name of Route as OwnerReference if
-// there is any in the given OwnerReference array.
-func LookupOwningRouteName(ownerRefs []v1.OwnerReference) string {
-	for _, owner := range ownerRefs {
-		if owner.Kind == routeControllerKind.Kind {
-			return owner.Name
-		}
-	}
-	return ""
-}
-
-// LookupOwningConfigurationName returns the name of Configuration as OwnerReference if
-// there is any in the given OwnerReference array.
-func LookupOwningConfigurationName(ownerRefs []v1.OwnerReference) string {
-	for _, owner := range ownerRefs {
-		if owner.Kind == configControllerKind.Kind {
-			return owner.Name
-		}
-	}
-	return ""
 }

--- a/pkg/controller/revision/pod.go
+++ b/pkg/controller/revision/pod.go
@@ -24,7 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -49,9 +49,12 @@ func hasHTTPPath(p *corev1.Probe) bool {
 }
 
 // MakeElaPodSpec creates a pod spec.
-func MakeElaPodSpec(
-	rev *v1alpha1.Revision,
-	controllerConfig *ControllerConfig) *corev1.PodSpec {
+func MakeElaPodSpec(rev *v1alpha1.Revision, controllerConfig *ControllerConfig) *corev1.PodSpec {
+	configName := ""
+	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
+		configName = owner.Name
+	}
+
 	varLogVolume := corev1.Volume{
 		Name: varLogVolumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -106,7 +109,7 @@ func MakeElaPodSpec(
 		userContainer.ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(queue.RequestQueuePort)
 	}
 
-	podSpe := &corev1.PodSpec{
+	podSpec := &corev1.PodSpec{
 		Containers:         []corev1.Container{*userContainer, *MakeElaQueueContainer(rev, controllerConfig)},
 		Volumes:            []corev1.Volume{varLogVolume},
 		ServiceAccountName: rev.Spec.ServiceAccountName,
@@ -144,7 +147,7 @@ func MakeElaPodSpec(
 				},
 				{
 					Name:  "ELA_CONFIGURATION",
-					Value: controller.LookupOwningConfigurationName(rev.OwnerReferences),
+					Value: configName,
 				},
 				{
 					Name:  "ELA_REVISION",
@@ -175,11 +178,11 @@ func MakeElaPodSpec(
 			},
 		}
 
-		podSpe.Containers = append(podSpe.Containers, fluentdContainer)
-		podSpe.Volumes = append(podSpe.Volumes, fluentdConfigMapVolume)
+		podSpec.Containers = append(podSpec.Containers, fluentdContainer)
+		podSpec.Volumes = append(podSpec.Volumes, fluentdConfigMapVolume)
 	}
 
-	return podSpe
+	return podSpec
 }
 
 // MakeElaDeployment creates a deployment.
@@ -193,7 +196,7 @@ func MakeElaDeployment(u *v1alpha1.Revision, namespace string) *appsv1.Deploymen
 	podTemplateAnnotations[sidecarIstioInjectAnnotation] = "true"
 
 	return &appsv1.Deployment{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        controller.GetRevisionDeploymentName(u),
 			Namespace:   namespace,
 			Labels:      MakeElaResourceLabels(u),
@@ -207,7 +210,7 @@ func MakeElaDeployment(u *v1alpha1.Revision, namespace string) *appsv1.Deploymen
 				RollingUpdate: &rollingUpdateConfig,
 			},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: meta_v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels:      MakeElaResourceLabels(u),
 					Annotations: podTemplateAnnotations,
 				},

--- a/pkg/controller/revision/queue.go
+++ b/pkg/controller/revision/queue.go
@@ -25,11 +25,17 @@ import (
 	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // MakeElaQueueContainer creates the container spec for queue sidecar.
 func MakeElaQueueContainer(rev *v1alpha1.Revision, controllerConfig *ControllerConfig) *corev1.Container {
+	configName := ""
+	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
+		configName = owner.Name
+	}
+
 	const elaQueueConfigVolumeName = "queue-config"
 	return &corev1.Container{
 		Name:  queueContainerName,
@@ -83,7 +89,7 @@ func MakeElaQueueContainer(rev *v1alpha1.Revision, controllerConfig *ControllerC
 			},
 			{
 				Name:  "ELA_CONFIGURATION",
-				Value: controller.LookupOwningConfigurationName(rev.OwnerReferences),
+				Value: configName,
 			},
 			{
 				Name:  "ELA_REVISION",

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -1010,11 +1010,13 @@ func (c *Controller) SyncConfiguration(config *v1alpha1.Configuration) {
 }
 
 func (c *Controller) SyncIngress(ingress *v1beta1.Ingress) {
-	// If ingress isn't owned by a route, no route update is required.
-	routeName := controller.LookupOwningRouteName(ingress.OwnerReferences)
-	if routeName == "" {
+	or := metav1.GetControllerOf(ingress)
+	if or == nil || or.Kind != "Route" {
+		// If ingress isn't owned by a route, no route update is required.
 		return
 	}
+	routeName := or.Name
+
 	if len(ingress.Status.LoadBalancer.Ingress) == 0 {
 		// Route isn't ready if having no load-balancer ingress.
 		return


### PR DESCRIPTION
Replaces our custom utility functions in `pkg/controller` with these library methods in `metav1`.

Fixes: https://github.com/knative/serving/issues/1165

This is the follow-on to the fix in https://github.com/knative/serving/pull/1166