### PR TITLE
Fix conformance tests and reenable them

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -339,7 +339,7 @@ kubectl create namespace noodleburg
 go test -v -tags=e2e ./test/e2e -run HelloWorld -dockerrepo gcr.io/elafros-e2e-tests/ela-e2e-test
 exit_if_failed
 
-# run_e2e_tests conformance pizzaplanet ela-conformance-test
+run_e2e_tests conformance pizzaplanet ela-conformance-test
 # run_e2e_tests e2e noodleburg ela-e2e-test
 
 # kubetest teardown might fail and thus incorrectly report failure of the

--- a/test/states.go
+++ b/test/states.go
@@ -51,7 +51,7 @@ func IsRevisionReady(revisionName string) func(r *v1alpha1.Revision) (bool, erro
 	return func(r *v1alpha1.Revision) (bool, error) {
 		if len(r.Status.Conditions) > 0 {
 			if r.Status.Conditions[0].Type != v1alpha1.RevisionConditionType("Ready") {
-				return true, fmt.Errorf("Expected Revision to have a \"Ready\" status but only had %s", r.Status.Conditions[0].Type)
+				return false, nil
 			}
 			if r.Status.Conditions[0].Status == corev1.ConditionTrue {
 				return true, nil


### PR DESCRIPTION
Fixes #1164.

`IsRevisionReady` is assuming that the Ready condition comes first when multiple conditions are present, which is in no way guaranteed / specified.