### PR TITLE
Add logic to avoid overwriting conditions in the correct state.

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -19,7 +19,8 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	// TODO(#1181): "time"
+	"reflect"
+	"time"
 
 	build "github.com/knative/build/pkg/apis/build/v1alpha1"
 
@@ -185,9 +186,15 @@ func (cs *ConfigurationStatus) setCondition(new *ConfigurationCondition) {
 	for _, cond := range cs.Conditions {
 		if cond.Type != t {
 			conditions = append(conditions, cond)
+		} else {
+			// If we'd only update the LastTransitionTime, then return.
+			new.LastTransitionTime = cond.LastTransitionTime
+			if reflect.DeepEqual(new, &cond) {
+				return
+			}
 		}
 	}
-	// TODO(#1181): new.LastTransitionTime = metav1.NewTime(time.Now())
+	new.LastTransitionTime = metav1.NewTime(time.Now())
 	conditions = append(conditions, *new)
 	cs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -257,6 +258,12 @@ func (rs *RevisionStatus) setCondition(new *RevisionCondition) {
 	for _, cond := range rs.Conditions {
 		if cond.Type != t {
 			conditions = append(conditions, cond)
+		} else {
+			// If we'd only update the LastTransitionTime, then return.
+			new.LastTransitionTime = cond.LastTransitionTime
+			if reflect.DeepEqual(new, &cond) {
+				return
+			}
 		}
 	}
 	new.LastTransitionTime = metav1.NewTime(time.Now())

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -19,7 +19,8 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	// TODO(#1181): "time"
+	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -196,9 +197,15 @@ func (rs *RouteStatus) setCondition(new *RouteCondition) {
 	for _, cond := range rs.Conditions {
 		if cond.Type != t {
 			conditions = append(conditions, cond)
+		} else {
+			// If we'd only update the LastTransitionTime, then return.
+			new.LastTransitionTime = cond.LastTransitionTime
+			if reflect.DeepEqual(new, &cond) {
+				return
+			}
 		}
 	}
-	// TODO(#1181): new.LastTransitionTime = metav1.NewTime(time.Now())
+	new.LastTransitionTime = metav1.NewTime(time.Now())
 	conditions = append(conditions, *new)
 	rs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -18,7 +18,8 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	// TODO(#1181): "time"
+	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,9 +159,15 @@ func (ss *ServiceStatus) setCondition(new *ServiceCondition) {
 	for _, cond := range ss.Conditions {
 		if cond.Type != t {
 			conditions = append(conditions, cond)
+		} else {
+			// If we'd only update the LastTransitionTime, then return.
+			new.LastTransitionTime = cond.LastTransitionTime
+			if reflect.DeepEqual(new, &cond) {
+				return
+			}
 		}
 	}
-	// TODO(#1181): new.LastTransitionTime = metav1.NewTime(time.Now())
+	new.LastTransitionTime = metav1.NewTime(time.Now())
 	conditions = append(conditions, *new)
 	ss.Conditions = conditions
 }


### PR DESCRIPTION
Prior to the change that disabled `LastTransitionTime` calls to `setCondition` would first remove the prior condition of a given type.  Then it would stamp the new condition with the current timestamp.  Finally it would append the condition to the list.  With this, it was possible that the only thing changing in the condition was the timestamp, leading to constant reconciliation.

This change adds a check to the loop that removes any old conditions.  If the new condition with the old condition's timestamp is identical, then the `setCondition` is simply elided as a nop.  This causes reconciliation the close relatively quickly.

Fixes: https://github.com/knative/serving/issues/1181