### PR TITLE
Create Check methods parallel to WaitFor methods.

### DIFF
--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -27,7 +27,7 @@ You can:
 * [Output log](#output-log)
 * [Get access to client objects](#get-access-to-client-objects)
 * [Make requests against deployed services](#make-requests-against-deployed-services)
-* [Poll Knative Serving resources](#poll-knative-serving-resources)
+* [Check Knative Serving resources](#check-knative-serving-resources)
 * [Verify resource state transitions](#verify-resource-state-transitions)
 * [Generate boilerplate CRDs](#generate-boilerplate-crds)
 * [Ensure test cleanup](#ensure-test-cleanup)
@@ -114,13 +114,13 @@ should be used or the domain should be used directly.
 
 _See [request.go](./request.go)._
 
-### Poll Knative Serving resources
+### Check Knative Serving resources
 
 After creating Knative Serving resources or making changes to them, you will need to wait for the system
-to realize those chnages. You can use the Knative Serving CRD polling methods to poll the resources until
-they get into the desired state or time out.
+to realize those changes. You can use the Knative Serving CRD check and polling methods to check the
+resources are either in or reach the desired state.
 
-These functions use the kubernetes [`wait` package](https://godoc.org/k8s.io/apimachinery/pkg/util/wait).
+The `WaitFor*` functions use the kubernetes [`wait` package](https://godoc.org/k8s.io/apimachinery/pkg/util/wait).
 To poll they use [`PollImmediate`](https://godoc.org/k8s.io/apimachinery/pkg/util/wait#PollImmediate)
 and the return values of the function you provide behave the same as
 [`ConditionFunc`](https://godoc.org/k8s.io/apimachinery/pkg/util/wait#ConditionFunc):
@@ -141,7 +141,20 @@ err := test.WaitForConfigurationState(clients.Configs, configName, func(c *v1alp
 })
 ```
 
-_See [crd_polling.go](./crd_polling.go)._
+We also have `Check*` variants of many of these methods with identical signatures, same example:
+
+```go
+var revisionName string
+err := test.CheckConfigurationState(clients.Configs, configName, func(c *v1alpha1.Configuration) (bool, error) {
+    if c.Status.LatestCreatedRevisionName != "" {
+        revisionName = c.Status.LatestCreatedRevisionName
+        return true, nil
+    }
+    return false, nil
+})
+```
+
+_See [crd_checks.go](./crd_checks.go)._
 
 ### Verify resource state transitions
 

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -47,6 +48,22 @@ func WaitForRouteState(client elatyped.RouteInterface, name string, inState func
 	})
 }
 
+// CheckRouteState verifies the status of the Route called name from client
+// is in a particular state by calling `inState` and expecting `true`.
+// This is the non-polling variety of WaitForRouteState
+func CheckRouteState(client elatyped.RouteInterface, name string, inState func(r *v1alpha1.Route) (bool, error)) error {
+	r, err := client.Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if done, err := inState(r); err != nil {
+		return err
+	} else if !done {
+		return fmt.Errorf("route %q is not in desired state: %+v", name, r)
+	}
+	return nil
+}
+
 // WaitForConfigurationState polls the status of the Configuration called name
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout.
@@ -60,6 +77,22 @@ func WaitForConfigurationState(client elatyped.ConfigurationInterface, name stri
 	})
 }
 
+// CheckConfigurationState verifies the status of the Configuration called name from client
+// is in a particular state by calling `inState` and expecting `true`.
+// This is the non-polling variety of WaitForConfigurationState
+func CheckConfigurationState(client elatyped.ConfigurationInterface, name string, inState func(r *v1alpha1.Configuration) (bool, error)) error {
+	c, err := client.Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if done, err := inState(c); err != nil {
+		return err
+	} else if !done {
+		return fmt.Errorf("configuration %q is not in desired state: %+v", name, c)
+	}
+	return nil
+}
+
 // WaitForRevisionState polls the status of the Revision called name
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout.
@@ -71,6 +104,22 @@ func WaitForRevisionState(client elatyped.RevisionInterface, name string, inStat
 		}
 		return inState(r)
 	})
+}
+
+// CheckRevisionState verifies the status of the Revision called name from client
+// is in a particular state by calling `inState` and expecting `true`.
+// This is the non-polling variety of WaitForRevisionState
+func CheckRevisionState(client elatyped.RevisionInterface, name string, inState func(r *v1alpha1.Revision) (bool, error)) error {
+	r, err := client.Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if done, err := inState(r); err != nil {
+		return err
+	} else if !done {
+		return fmt.Errorf("revision %q is not in desired state: %+v", name, r)
+	}
+	return nil
 }
 
 // WaitForIngressState polls the status of the Ingress called name


### PR DESCRIPTION
Every check we perform shouldn't be a WaitFor; we should WaitFor readiness and then assert things work in-the-now.  This creates parallel methods for checking things, which has the same signature as their `WaitFor` siblings.

This uses these methods for the recently sunk checks in the routing conformance test.

Related: https://github.com/knative/serving/issues/1178
