### PR TITLE
Changing Minikube instructions to use kubeadm as the bootstrapper

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -86,20 +86,22 @@ For Linux use:
 
 ```shell
 minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.10.3 \
+  --kubernetes-version=v1.10.4 \
   --vm-driver=kvm2 \
   --bootstrapper=kubeadm \
-  --extra-config=apiserver.authorization-mode=RBAC \
+  --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
+  --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
   --extra-config=apiserver.admission-control="DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
 ```
 For macOS use:
 
 ```shell
 minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.10.3 \
+  --kubernetes-version=v1.10.4 \
   --vm-driver=hyperkit \
   --bootstrapper=kubeadm \
-  --extra-config=apiserver.authorization-mode=RBAC \
+  --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
+  --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
   --extra-config=apiserver.admission-control="DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
 ```
 


### PR DESCRIPTION
Fixes #1190 

## Proposed Changes

  * changing to k8s v1.10.4
  * changing extra-config options to use kubeadm style keys
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
