### PR TITLE
Retired serving state is not set anywhere

### DIFF
--- a/docs/scaling/DEVELOPMENT.md
+++ b/docs/scaling/DEVELOPMENT.md
@@ -26,6 +26,8 @@ In the Reserve state, the Revision has no scheduled Pods and consumes no CPU.  T
 
 In the Retired state, the Revision has provisioned resources.  No requests will be served for the Revision.
 
+Note: Retired state is currently not set anywhere. See [issue 1203](https://github.com/knative/serving/issues/1203).
+
 ## Context 
 
 ```

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -71,6 +71,7 @@ const (
 	// anymore. It should not have any Istio routes or Kubernetes resources.
 	// A Revision may be brought out of retirement, but it may take longer than
 	// it would from a "Reserve" state.
+	// Note: currently not set anywhere. See https://github.com/knative/serving/issues/1203
 	RevisionServingStateRetired RevisionServingStateType = "Retired"
 )
 


### PR DESCRIPTION
See [issue 1203](https://github.com/knative/serving/issues/1203) and [slack](https://knative.slack.com/archives/C93E33SN8/p1528909644000570?thread_ts=1528849979.000306&cid=C93E33SN8).