### PR TITLE
Add instuctions on how to install kubetest

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,22 @@ The conformance tests are a subset of the end to end test with [more strict requ
 
 If you want to add more tests, see [adding_tests.md](./adding_tests.md).
 
+## Presubmit tests
+
+[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for both the [end-to-end tests](/test/e2e) and the [conformance tests](/test/conformance)
+
+This script, and consequently, the e2e and conformance tests will be run before every code submission. You can run these tests manually with:
+
+```shell
+test/presubmit-tests.sh
+```
+
+_Note that to run `presubmit-tests.sh` or `e2e-tests.sh` scripts, you'll need kubernetes `kubetest` installed:_
+
+```bash
+go get -u k8s.io/test-infra/kubetest
+```
+
 ## Running unit tests
 
 To run all unit tests:

--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -16,16 +16,6 @@ so that `go test ./...` can be used to run only [the unit tests](README.md#runni
 // +build e2e
 ```
 
-## Presubmit tests
-
-[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for both the [end-to-end tests](/test/e2e) and the [conformance tests](/test/conformance)
-
-This script, and consequently, the e2e and conformance tests will be run before every code submission. You can run these tests manually with:
-
-```shell
-test/presubmit-tests.sh
-```
-
 ## Test library
 
 In the [`test`](/test/) dir you will find several libraries in the `test` package


### PR DESCRIPTION
That should avoid confusion with another project with the same name (https://github.com/garethr/kubetest).

Also move the section about running the presubmit tests from `adding_tests.md` to the README, as it makes more sense in the new location.