### PR TITLE
Fail creating of revision is istio-injection label  is not in namespace

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -398,6 +398,21 @@ func (rs *RevisionStatus) MarkInactive() {
 	})
 }
 
+func (rs *RevisionStatus) MarkNetworkProxyMissing() {
+	for _, cond := range []RevisionConditionType{
+		RevisionConditionContainerHealthy,
+		RevisionConditionReady,
+		RevisionConditionResourcesAvailable,
+	} {
+		rs.setCondition(&RevisionCondition{
+			Type:    cond,
+			Status:  corev1.ConditionFalse,
+			Reason:  "NetworkProxyMissing",
+			Message: "Missing istio proxy",
+		})
+	}
+}
+
 func (rs *RevisionStatus) MarkContainerMissing(message string) {
 	for _, cond := range []RevisionConditionType{
 		RevisionConditionContainerHealthy,

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -438,6 +438,33 @@ func TestTypicalFlowWithContainerMissing(t *testing.T) {
 	}
 }
 
+func TestMarkNetworkMissing(t *testing.T) {
+	r := &Revision{}
+	r.Status.InitializeConditions()
+	r.Status.InitializeBuildCondition()
+
+	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
+
+	// Mark the revision status NetworkProxyMissing
+	r.Status.MarkNetworkProxyMissing()
+
+	// Marking NetworkProxyMissing shouldn't affect the build condition
+	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
+
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionReady, t); got == nil || got.Reason != "NetworkProxyMissing" {
+		t.Errorf("MarkNetworkProxyMissing = %v, want missing istio proxy", got)
+	}
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionContainerHealthy, t); got == nil || got.Reason != "NetworkProxyMissing" {
+		t.Errorf("MarkNetworkProxyMissing = %v, want missing istio proxy", got)
+	}
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionResourcesAvailable, t); got == nil || got.Reason != "NetworkProxyMissing" {
+		t.Errorf("MarkNetworkProxyMissing = %v, want missing istio proxy", got)
+	}
+}
+
 func TestTypicalFlowWithSuspendResume(t *testing.T) {
 	r := &Revision{}
 	r.Status.InitializeConditions()

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -18,6 +18,7 @@ package revision
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -44,7 +45,6 @@ import (
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -60,6 +60,8 @@ import (
 )
 
 const (
+	istioInjectionLabel string = "istio-injection"
+
 	userContainerName string = "user-container"
 	userPortName      string = "user-port"
 	userPort                 = 8080
@@ -262,12 +264,13 @@ func (c *Controller) Reconcile(key string) error {
 	// Get the Revision resource with this namespace/name
 	rev, err := c.revisionLister.Revisions(namespace).Get(name)
 	// The resource may no longer exist, in which case we stop processing.
-	if errors.IsNotFound(err) {
+	if apierrs.IsNotFound(err) {
 		runtime.HandleError(fmt.Errorf("revision %q in work queue no longer exists", key))
 		return nil
 	} else if err != nil {
 		return err
 	}
+
 	// Don't modify the informer's copy.
 	rev = rev.DeepCopy()
 	rev.Status.InitializeConditions()
@@ -317,6 +320,15 @@ func (c *Controller) Reconcile(key string) error {
 		switch rev.Spec.ServingState {
 		case v1alpha1.RevisionServingStateActive:
 			logger.Info("Creating or reconciling resources for revision")
+			err := c.checkNamespaceHasIstioInjectionLabel(rev.Namespace)
+			if err != nil {
+				rev.Status.MarkNetworkProxyMissing()
+				if _, err := c.updateStatus(rev); err != nil {
+					logger.Error("Error recording inactivation of revision for: ", zap.Error(err))
+					return err
+				}
+				return apierrs.NewBadRequest("Missing Istio Proxy")
+			}
 			return c.createK8SResources(ctx, rev)
 
 		case v1alpha1.RevisionServingStateReserve:
@@ -443,6 +455,24 @@ func (c *Controller) SyncEndpoints(endpoint *corev1.Endpoints) {
 	}
 	c.Recorder.Eventf(rev, corev1.EventTypeWarning, "RevisionFailed", "Revision did not become ready due to endpoint %q", endpoint.Name)
 	return
+}
+
+func (c *Controller) checkNamespaceHasIstioInjectionLabel(namespace string) error {
+	ns, err := c.KubeClientSet.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error fetching namespace: %s", err)
+	}
+
+	val, ok := ns.GetLabels()[istioInjectionLabel]
+
+	if !ok {
+		return errors.New("Missing istio injection label")
+	}
+
+	if val != "enabled" {
+		return errors.New("Expected istio injection label value to be 'enabled'")
+	}
+	return nil
 }
 
 func (c *Controller) deleteK8SResources(ctx context.Context, rev *v1alpha1.Revision) error {

--- a/test/README.md
+++ b/test/README.md
@@ -88,7 +88,12 @@ These tests require:
     kubectl create namespace pizzaplanet
     kubectl create namespace noodleburg
     ```
-3. A docker repo containing [the test images](#test-images)
+3. Label the `pizzaplanet` and `noodleburg` namespaces with `istio-injection=enabled`.
+    ```bash
+    kubectl label namespace pizzaplanet istio-injection=enabled
+    kubectl label namespace noodleburg istio-injection=enabled
+    ```
+4. A docker repo containing [the test images](#test-images)
 
 ## Test images
 


### PR DESCRIPTION
## Proposed Changes

  * Fail creation of deployments if istio-injection label is not present in namespace 
  * Update api status to "NetworkProxyMissing".
  * corresponding [issue](https://github.com/knative/serving/issues/766)

Regards
Shash
