### PR TITLE
Create informers in cmd/controller/main.go

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -30,6 +30,7 @@ import (
 
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -151,24 +152,53 @@ func main() {
 	opt := controller.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: elaClient,
+		BuildClientSet:   buildClient,
 		Logger:           logger,
 	}
+
+	serviceInformer := elaInformerFactory.Serving().V1alpha1().Services()
+	routeInformer := elaInformerFactory.Serving().V1alpha1().Routes()
+	configurationInformer := elaInformerFactory.Serving().V1alpha1().Configurations()
+	revisionInformer := elaInformerFactory.Serving().V1alpha1().Revisions()
+	buildInformer := buildInformerFactory.Build().V1alpha1().Builds()
+	configMapInformer := servingSystemInformerFactory.Core().V1().ConfigMaps()
+	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
+	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
+	ingressInformer := kubeInformerFactory.Extensions().V1beta1().Ingresses()
 
 	// Build all of our controllers, with the clients constructed above.
 	// Add new controllers to this array.
 	controllers := []controller.Interface{
-		configuration.NewController(opt, buildClient, elaInformerFactory, cfg),
-		revision.NewController(opt, kubeInformerFactory, elaInformerFactory,
-			buildInformerFactory, servingSystemInformerFactory, cfg, &revControllerConfig),
-		route.NewController(opt, kubeInformerFactory, elaInformerFactory,
-			servingSystemInformerFactory, cfg, autoscaleEnableScaleToZero),
-		service.NewController(opt, elaInformerFactory, cfg),
+		configuration.NewController(opt, configurationInformer, revisionInformer, cfg),
+		revision.NewController(opt, revisionInformer, buildInformer, configMapInformer,
+			deploymentInformer, endpointsInformer, cfg, &revControllerConfig),
+		route.NewController(opt, routeInformer, configurationInformer, ingressInformer,
+			configMapInformer, cfg, autoscaleEnableScaleToZero),
+		service.NewController(opt, serviceInformer, configurationInformer, routeInformer, cfg),
 	}
 
 	go kubeInformerFactory.Start(stopCh)
 	go elaInformerFactory.Start(stopCh)
 	go buildInformerFactory.Start(stopCh)
 	go servingSystemInformerFactory.Start(stopCh)
+
+	// Wait for the caches to be synced before starting controllers.
+	logger.Info("Waiting for informer caches to sync")
+	for i, synced := range []cache.InformerSynced{
+		serviceInformer.Informer().HasSynced,
+		routeInformer.Informer().HasSynced,
+		configurationInformer.Informer().HasSynced,
+		revisionInformer.Informer().HasSynced,
+		buildInformer.Informer().HasSynced,
+		configMapInformer.Informer().HasSynced,
+		deploymentInformer.Informer().HasSynced,
+		endpointsInformer.Informer().HasSynced,
+		ingressInformer.Informer().HasSynced,
+	} {
+		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
+			logger.Fatalf("failed to wait for cache at index %v to sync", i)
+		}
+	}
 
 	// Start all of the controllers.
 	for _, ctrlr := range controllers {

--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
-	buildclientset "github.com/knative/build/pkg/client/clientset/versioned"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	informers "github.com/knative/serving/pkg/client/informers/externalversions"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/logging/logkey"
@@ -42,8 +41,6 @@ const controllerAgentName = "configuration-controller"
 type Controller struct {
 	*controller.Base
 
-	buildClientSet buildclientset.Interface
-
 	// listers index properties about resources
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
@@ -52,23 +49,12 @@ type Controller struct {
 // NewController creates a new Configuration controller
 func NewController(
 	opt controller.Options,
-	buildClientSet buildclientset.Interface,
-	elaInformerFactory informers.SharedInformerFactory,
+	configurationInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
 	config *rest.Config) controller.Interface {
 
-	// obtain references to a shared index informer for the Configuration
-	// and Revision type.
-	configurationInformer := elaInformerFactory.Serving().V1alpha1().Configurations()
-	revisionInformer := elaInformerFactory.Serving().V1alpha1().Revisions()
-
-	informers := []cache.SharedIndexInformer{
-		configurationInformer.Informer(),
-		revisionInformer.Informer(),
-	}
-
 	c := &Controller{
-		Base:                controller.NewBase(opt, controllerAgentName, "Configurations", informers),
-		buildClientSet:      buildClientSet,
+		Base:                controller.NewBase(opt, controllerAgentName, "Configurations"),
 		configurationLister: configurationInformer.Lister(),
 		revisionLister:      revisionInformer.Lister(),
 	}
@@ -210,7 +196,7 @@ func (c *Controller) createRevision(config *v1alpha1.Configuration, revName stri
 			},
 			Spec: *config.Spec.Build,
 		}
-		created, err := c.buildClientSet.BuildV1alpha1().Builds(build.Namespace).Create(build)
+		created, err := c.BuildClientSet.BuildV1alpha1().Builds(build.Namespace).Create(build)
 		if err != nil {
 			return nil, err
 		}
@@ -237,7 +223,7 @@ func (c *Controller) createRevision(config *v1alpha1.Configuration, revName stri
 	// Delete revisions when the parent Configuration is deleted.
 	rev.OwnerReferences = append(rev.OwnerReferences, *controllerRef)
 
-	created, err := c.ElaClientSet.ServingV1alpha1().Revisions(config.Namespace).Create(rev)
+	created, err := c.ServingClientSet.ServingV1alpha1().Revisions(config.Namespace).Create(rev)
 	if err != nil {
 		return nil, err
 	}
@@ -258,6 +244,6 @@ func (c *Controller) updateStatus(u *v1alpha1.Configuration) (*v1alpha1.Configur
 	}
 	newu.Status = u.Status
 	// TODO: for CRD there's no updatestatus, so use normal update
-	return c.ElaClientSet.ServingV1alpha1().Configurations(u.Namespace).Update(newu)
+	return c.ServingClientSet.ServingV1alpha1().Configurations(u.Namespace).Update(newu)
 	//	return configClient.UpdateStatus(newu)
 }

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -135,12 +135,13 @@ func newTestController(t *testing.T, elaObjects ...runtime.Object) (
 
 	controller = NewController(
 		ctrl.Options{
-			kubeClient,
-			elaClient,
-			zap.NewNop().Sugar(),
+			KubeClientSet:    kubeClient,
+			ServingClientSet: elaClient,
+			BuildClientSet:   buildClient,
+			Logger:           zap.NewNop().Sugar(),
 		},
-		buildClient,
-		elaInformer,
+		elaInformer.Serving().V1alpha1().Configurations(),
+		elaInformer.Serving().V1alpha1().Revisions(),
 		&rest.Config{},
 	).(*Controller)
 

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -242,14 +242,15 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *ControllerConfi
 
 	controller = NewController(
 		ctrl.Options{
-			kubeClient,
-			elaClient,
-			zap.NewNop().Sugar(),
+			KubeClientSet:    kubeClient,
+			ServingClientSet: elaClient,
+			Logger:           zap.NewNop().Sugar(),
 		},
-		kubeInformer,
-		elaInformer,
-		buildInformer,
-		servingSystemInformer,
+		elaInformer.Serving().V1alpha1().Revisions(),
+		buildInformer.Build().V1alpha1().Builds(),
+		servingSystemInformer.Core().V1().ConfigMaps(),
+		kubeInformer.Apps().V1().Deployments(),
+		kubeInformer.Core().V1().Endpoints(),
 		&rest.Config{},
 		controllerConfig,
 	).(*Controller)

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -31,13 +31,12 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	informers "github.com/knative/serving/pkg/client/informers/externalversions"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/logging"
@@ -45,6 +44,8 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	extv1beta1informers "k8s.io/client-go/informers/extensions/v1beta1"
 )
 
 var (
@@ -100,25 +101,12 @@ type Controller struct {
 // reconcileKey - function for mapping queue keys to resource names
 func NewController(
 	opt controller.Options,
-	kubeInformerFactory kubeinformers.SharedInformerFactory,
-	elaInformerFactory informers.SharedInformerFactory,
-	servingSystemInformerFactory kubeinformers.SharedInformerFactory,
+	routeInformer servinginformers.RouteInformer,
+	configInformer servinginformers.ConfigurationInformer,
+	ingressInformer extv1beta1informers.IngressInformer,
+	configMapInformer corev1informers.ConfigMapInformer,
 	config *rest.Config,
 	enableScaleToZero *k8sflag.BoolFlag) controller.Interface {
-
-	// obtain references to a shared index informer for the Routes and
-	// Configurations type.
-	routeInformer := elaInformerFactory.Serving().V1alpha1().Routes()
-	configInformer := elaInformerFactory.Serving().V1alpha1().Configurations()
-	ingressInformer := kubeInformerFactory.Extensions().V1beta1().Ingresses()
-	configMapInformer := servingSystemInformerFactory.Core().V1().ConfigMaps()
-
-	informers := []cache.SharedIndexInformer{
-		routeInformer.Informer(),
-		configInformer.Informer(),
-		ingressInformer.Informer(),
-		configMapInformer.Informer(),
-	}
 
 	domainConfig, err := NewDomainConfig(opt.KubeClientSet)
 	if err != nil {
@@ -128,7 +116,7 @@ func NewController(
 	// No need to lock domainConfigMutex yet since the informers that can modify
 	// domainConfig haven't started yet.
 	controller := &Controller{
-		Base:              controller.NewBase(opt, controllerAgentName, "Routes", informers),
+		Base:              controller.NewBase(opt, controllerAgentName, "Routes"),
 		routeLister:       routeInformer.Lister(),
 		domainConfig:      domainConfig,
 		enableScaleToZero: enableScaleToZero,
@@ -367,8 +355,8 @@ func (c *Controller) getDirectTrafficTargets(ctx context.Context, route *v1alpha
 	map[string]*v1alpha1.Configuration, map[string]*v1alpha1.Revision, error) {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(ns)
-	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(ns)
+	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(ns)
+	revClient := c.ServingClientSet.ServingV1alpha1().Revisions(ns)
 	configMap := map[string]*v1alpha1.Configuration{}
 	revMap := map[string]*v1alpha1.Revision{}
 
@@ -414,7 +402,7 @@ func (c *Controller) extendConfigurationsWithIndirectTrafficTargets(
 	revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(ns)
+	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(ns)
 
 	// Get indirect configurations.
 	for _, rev := range revMap {
@@ -441,7 +429,7 @@ func (c *Controller) extendRevisionsWithIndirectTrafficTargets(
 	revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	revisionClient := c.ElaClientSet.ServingV1alpha1().Revisions(ns)
+	revisionClient := c.ServingClientSet.ServingV1alpha1().Revisions(ns)
 
 	allTrafficAssigned := true
 	for _, tt := range route.Spec.Traffic {
@@ -488,7 +476,7 @@ func (c *Controller) extendRevisionsWithIndirectTrafficTargets(
 func (c *Controller) setLabelForGivenConfigurations(
 	ctx context.Context, route *v1alpha1.Route, configMap map[string]*v1alpha1.Configuration) error {
 	logger := logging.FromContext(ctx)
-	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(route.Namespace)
+	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(route.Namespace)
 
 	// Validate
 	for _, config := range configMap {
@@ -524,7 +512,7 @@ func (c *Controller) setLabelForGivenConfigurations(
 func (c *Controller) setLabelForGivenRevisions(
 	ctx context.Context, route *v1alpha1.Route, revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
-	revisionClient := c.ElaClientSet.ServingV1alpha1().Revisions(route.Namespace)
+	revisionClient := c.ServingClientSet.ServingV1alpha1().Revisions(route.Namespace)
 
 	// Validate revision if it already has a route label
 	for _, rev := range revMap {
@@ -569,7 +557,7 @@ func (c *Controller) setLabelForGivenRevisions(
 func (c *Controller) deleteLabelForOutsideOfGivenConfigurations(
 	ctx context.Context, route *v1alpha1.Route, configMap map[string]*v1alpha1.Configuration) error {
 	logger := logging.FromContext(ctx)
-	configClient := c.ElaClientSet.ServingV1alpha1().Configurations(route.Namespace)
+	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(route.Namespace)
 	// Get Configurations set as traffic target before this sync.
 	oldConfigsList, err := configClient.List(
 		metav1.ListOptions{
@@ -599,7 +587,7 @@ func (c *Controller) deleteLabelForOutsideOfGivenConfigurations(
 func (c *Controller) deleteLabelForOutsideOfGivenRevisions(
 	ctx context.Context, route *v1alpha1.Route, revMap map[string]*v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
-	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(route.Namespace)
+	revClient := c.ServingClientSet.ServingV1alpha1().Revisions(route.Namespace)
 
 	oldRevList, err := revClient.List(
 		metav1.ListOptions{
@@ -730,7 +718,7 @@ func (c *Controller) computeEmptyRevisionRoutes(
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
 	elaNS := controller.GetElaNamespaceName(ns)
-	revClient := c.ElaClientSet.ServingV1alpha1().Revisions(ns)
+	revClient := c.ServingClientSet.ServingV1alpha1().Revisions(ns)
 	revRoutes := []RevisionRoute{}
 	for _, tt := range route.Spec.Traffic {
 		configName := tt.ConfigurationName
@@ -767,7 +755,7 @@ func (c *Controller) createOrUpdateRouteRules(ctx context.Context, route *v1alph
 	logger := logging.FromContext(ctx)
 	// grab a client that's specific to RouteRule.
 	ns := route.Namespace
-	routeClient := c.ElaClientSet.ConfigV1alpha2().RouteRules(ns)
+	routeClient := c.ServingClientSet.ConfigV1alpha2().RouteRules(ns)
 	if routeClient == nil {
 		logger.Errorf("Failed to create resource client")
 		return nil, fmt.Errorf("Couldn't get a routeClient")
@@ -846,7 +834,7 @@ func (c *Controller) createOrUpdateRouteRules(ctx context.Context, route *v1alph
 func (c *Controller) updateStatus(ctx context.Context, route *v1alpha1.Route) (*v1alpha1.Route, error) {
 	logger := logging.FromContext(ctx)
 
-	routeClient := c.ElaClientSet.ServingV1alpha1().Routes(route.Namespace)
+	routeClient := c.ServingClientSet.ServingV1alpha1().Routes(route.Namespace)
 	existing, err := routeClient.Get(route.Name, metav1.GetOptions{})
 	if err != nil {
 		logger.Warn("Failed to update route status", zap.Error(err))
@@ -928,7 +916,7 @@ func (c *Controller) consolidateTrafficTargets(ctx context.Context, route *v1alp
 func (c *Controller) removeOutdatedRouteRules(ctx context.Context, u *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 	ns := u.Namespace
-	routeClient := c.ElaClientSet.ConfigV1alpha2().RouteRules(ns)
+	routeClient := c.ServingClientSet.ConfigV1alpha2().RouteRules(ns)
 	if routeClient == nil {
 		logger.Error("Failed to create resource client")
 		return errors.New("Couldn't get a routeClient")
@@ -1013,7 +1001,7 @@ func (c *Controller) SyncIngress(ingress *v1beta1.Ingress) {
 		}
 	}
 	ns := ingress.Namespace
-	routeClient := c.ElaClientSet.ServingV1alpha1().Routes(ns)
+	routeClient := c.ServingClientSet.ServingV1alpha1().Routes(ns)
 	route, err := routeClient.Get(routeName, metav1.GetOptions{})
 	if err != nil {
 		c.Logger.Error(

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -192,13 +192,14 @@ func newTestController(t *testing.T, elaObjects ...runtime.Object) (
 
 	controller = NewController(
 		ctrl.Options{
-			kubeClient,
-			elaClient,
-			testLogger,
+			KubeClientSet:    kubeClient,
+			ServingClientSet: elaClient,
+			Logger:           zap.NewNop().Sugar(),
 		},
-		kubeInformer,
-		elaInformer,
-		servingSystemInformer,
+		elaInformer.Serving().V1alpha1().Routes(),
+		elaInformer.Serving().V1alpha1().Configurations(),
+		kubeInformer.Extensions().V1beta1().Ingresses(),
+		servingSystemInformer.Core().V1().ConfigMaps(),
 		&rest.Config{},
 		k8sflag.Bool("enable-scale-to-zero", false),
 	).(*Controller)

--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -343,7 +343,7 @@ func TestReconcile(t *testing.T) {
 					KubeClientSet:    fakekubeclientset.NewSimpleClientset(),
 					ServingClientSet: client,
 					Logger:           zap.NewNop().Sugar(),
-				}, controllerAgentName, "Services", nil),
+				}, controllerAgentName, "Services"),
 				serviceLister:       tt.fields.s,
 				configurationLister: tt.fields.c,
 				routeLister:         tt.fields.r,
@@ -430,11 +430,16 @@ func TestNew(t *testing.T) {
 	kubeClient := fakekubeclientset.NewSimpleClientset()
 	servingClient := fakeclientset.NewSimpleClientset()
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
+
+	serviceInformer := servingInformer.Serving().V1alpha1().Services()
+	routeInformer := servingInformer.Serving().V1alpha1().Routes()
+	configurationInformer := servingInformer.Serving().V1alpha1().Configurations()
+
 	_ = NewController(controller.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		Logger:           zap.NewNop().Sugar(),
-	}, servingInformer, &rest.Config{})
+	}, serviceInformer, configurationInformer, routeInformer, &rest.Config{})
 }
 
 var ignoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {


### PR DESCRIPTION
This change hoists the creation of our informers into our controller's main.go and passes into each controller the set of informers it uses.  This enables us to move the logic to wait for the informers to sync into main.go as well, and (hopefully) make it harder for folks to get wrong.

This also moves `BuildClientSet` into `controller.Options` alongside its siblings and renames `ElaClientSet` to `ServingClientSet`.