### PR TITLE
Propagate unknown conditions to Service

### DIFF
--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -209,8 +209,8 @@ func (ss *ServiceStatus) PropagateConfigurationStatus(cs ConfigurationStatus) {
 		return
 	}
 	sct := []ServiceConditionType{ServiceConditionConfigurationReady}
-	// If the underlying Configuration reported failure, then bubble it up.
-	if cc.Status == corev1.ConditionFalse {
+	// If the underlying Configuration reported not ready, then bubble it up.
+	if cc.Status != corev1.ConditionTrue {
 		sct = append(sct, ServiceConditionReady)
 	}
 	for _, cond := range sct {
@@ -232,8 +232,8 @@ func (ss *ServiceStatus) PropagateRouteStatus(rs RouteStatus) {
 		return
 	}
 	sct := []ServiceConditionType{ServiceConditionRouteReady}
-	// If the underlying Route reported failure, then bubble it up.
-	if rc.Status == corev1.ConditionFalse {
+	// If the underlying Route reported not ready, then bubble it up.
+	if rc.Status != corev1.ConditionTrue {
 		sct = append(sct, ServiceConditionReady)
 	}
 	for _, cond := range sct {


### PR DESCRIPTION
If a route or config ready condition becomes unknown, that should bubble
up to the service ready condition.

Fixes #1222 