### PR TITLE
Literally just s/Ela/Serving/g

### DIFF
--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -115,7 +115,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) (end Endpoint
 
 	// Get the revision endpoint
 	services := r.kubeClient.CoreV1().Services(revision.GetNamespace())
-	serviceName := controller.GetElaK8SServiceNameForRevision(revision)
+	serviceName := controller.GetServingK8SServiceNameForRevision(revision)
 	svc, err := services.Get(serviceName, metav1.GetOptions{})
 	if err != nil {
 		return internalError("Unable to get service %s for revision %s/%s: %v",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -81,7 +81,7 @@ type Base struct {
 	// KubeClientSet allows us to talk to the k8s for core APIs
 	KubeClientSet kubernetes.Interface
 
-	// ServingClientSet allows us to configure Ela objects
+	// ServingClientSet allows us to configure Serving objects
 	ServingClientSet clientset.Interface
 
 	// BuildClientSet allows us to configure Build objects

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -39,7 +39,7 @@ func GetNetworkConfigMapName() string {
 }
 
 // Various functions for naming the resources for consistency
-func GetElaNamespaceName(ns string) string {
+func GetServingNamespaceName(ns string) string {
 	// We create resources in the same namespace as the Knative Serving resources by default.
 	// TODO(mattmoor): Expose a knob for creating resources in an alternate namespace.
 	return ns
@@ -60,15 +60,15 @@ func GetRouteRuleName(u *v1alpha1.Route, tt *v1alpha1.TrafficTarget) string {
 	return u.Name + "-istio"
 }
 
-func GetElaK8SIngressName(u *v1alpha1.Route) string {
+func GetServingK8SIngressName(u *v1alpha1.Route) string {
 	return u.Name + "-ingress"
 }
 
-func GetElaK8SServiceNameForRevision(u *v1alpha1.Revision) string {
+func GetServingK8SServiceNameForRevision(u *v1alpha1.Revision) string {
 	return u.Name + "-service"
 }
 
-func GetElaK8SServiceName(u *v1alpha1.Route) string {
+func GetServingK8SServiceName(u *v1alpha1.Route) string {
 	return u.Name + "-service"
 }
 
@@ -80,7 +80,7 @@ func GetServiceRouteName(u *v1alpha1.Service) string {
 	return u.Name
 }
 
-func GetElaK8SActivatorServiceName() string {
+func GetServingK8SActivatorServiceName() string {
 	return "activator-service"
 }
 
@@ -93,7 +93,7 @@ func GetRevisionHeaderNamespace() string {
 }
 
 func GetOrCreateRevisionNamespace(ctx context.Context, ns string, c clientset.Interface) (string, error) {
-	return GetOrCreateNamespace(ctx, GetElaNamespaceName(ns), c)
+	return GetOrCreateNamespace(ctx, GetServingNamespaceName(ns), c)
 }
 
 func GetOrCreateNamespace(ctx context.Context, namespace string, c clientset.Interface) (string, error) {

--- a/pkg/controller/revision/autoscaler.go
+++ b/pkg/controller/revision/autoscaler.go
@@ -32,9 +32,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// MakeElaAutoscalerDeployment creates the deployment of the
+// MakeServingAutoscalerDeployment creates the deployment of the
 // autoscaler for a particular revision.
-func MakeElaAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string) *appsv1.Deployment {
+func MakeServingAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string) *appsv1.Deployment {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name
@@ -45,7 +45,7 @@ func MakeElaAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string)
 		MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 	}
 
-	annotations := MakeElaResourceAnnotations(rev)
+	annotations := MakeServingResourceAnnotations(rev)
 	annotations[sidecarIstioInjectAnnotation] = "true"
 
 	replicas := int32(1)
@@ -78,20 +78,20 @@ func MakeElaAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            controller.GetRevisionAutoscalerName(rev),
 			Namespace:       pkg.GetServingSystemNamespace(),
-			Labels:          MakeElaResourceLabels(rev),
-			Annotations:     MakeElaResourceAnnotations(rev),
+			Labels:          MakeServingResourceLabels(rev),
+			Annotations:     MakeServingResourceAnnotations(rev),
 			OwnerReferences: []metav1.OwnerReference{*controller.NewRevisionControllerRef(rev)},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
-			Selector: MakeElaResourceSelector(rev),
+			Selector: MakeServingResourceSelector(rev),
 			Strategy: appsv1.DeploymentStrategy{
 				Type:          "RollingUpdate",
 				RollingUpdate: &rollingUpdateConfig,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      makeElaAutoScalerLabels(rev),
+					Labels:      makeServingAutoScalerLabels(rev),
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
@@ -153,15 +153,15 @@ func MakeElaAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string)
 	}
 }
 
-// MakeElaAutoscalerService returns a service for the autoscaler of
+// MakeServingAutoscalerService returns a service for the autoscaler of
 // the given revision.
-func MakeElaAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
+func MakeServingAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            controller.GetRevisionAutoscalerName(rev),
 			Namespace:       pkg.GetServingSystemNamespace(),
-			Labels:          makeElaAutoScalerLabels(rev),
-			Annotations:     MakeElaResourceAnnotations(rev),
+			Labels:          makeServingAutoScalerLabels(rev),
+			Annotations:     MakeServingResourceAnnotations(rev),
 			OwnerReferences: []metav1.OwnerReference{*controller.NewRevisionControllerRef(rev)},
 		},
 		Spec: corev1.ServiceSpec{
@@ -180,10 +180,10 @@ func MakeElaAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 	}
 }
 
-// makeElaAutoScalerLabels constructs the labels we will apply to
+// makeServingAutoScalerLabels constructs the labels we will apply to
 // service and deployment specs for autoscaler.
-func makeElaAutoScalerLabels(rev *v1alpha1.Revision) map[string]string {
-	labels := MakeElaResourceLabels(rev)
+func makeServingAutoScalerLabels(rev *v1alpha1.Revision) map[string]string {
+	labels := MakeServingResourceLabels(rev)
 	labels[serving.AutoscalerLabelKey] = controller.GetRevisionAutoscalerName(rev)
 	return labels
 }

--- a/pkg/controller/revision/queue.go
+++ b/pkg/controller/revision/queue.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// MakeElaQueueContainer creates the container spec for queue sidecar.
-func MakeElaQueueContainer(rev *v1alpha1.Revision, controllerConfig *ControllerConfig) *corev1.Container {
+// MakeServingQueueContainer creates the container spec for queue sidecar.
+func MakeServingQueueContainer(rev *v1alpha1.Revision, controllerConfig *ControllerConfig) *corev1.Container {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name

--- a/pkg/controller/revision/resource.go
+++ b/pkg/controller/revision/resource.go
@@ -24,8 +24,8 @@ import (
 
 const appLabelKey = "app"
 
-// MakeElaResourceLabels constructs the labels we will apply to K8s resources.
-func MakeElaResourceLabels(revision *v1alpha1.Revision) map[string]string {
+// MakeServingResourceLabels constructs the labels we will apply to K8s resources.
+func MakeServingResourceLabels(revision *v1alpha1.Revision) map[string]string {
 	labels := make(map[string]string, len(revision.ObjectMeta.Labels)+2)
 	labels[serving.RevisionLabelKey] = revision.Name
 	labels[serving.RevisionUID] = string(revision.UID)
@@ -42,14 +42,14 @@ func MakeElaResourceLabels(revision *v1alpha1.Revision) map[string]string {
 	return labels
 }
 
-// MakeElaResourceSelector constructs the Selector we will apply to K8s resources.
-func MakeElaResourceSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
-	return &metav1.LabelSelector{MatchLabels: MakeElaResourceLabels(revision)}
+// MakeServingResourceSelector constructs the Selector we will apply to K8s resources.
+func MakeServingResourceSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: MakeServingResourceLabels(revision)}
 }
 
-// MakeElaResourceAnnotations creates the annotations we will apply to
+// MakeServingResourceAnnotations creates the annotations we will apply to
 // child resource of the given revision.
-func MakeElaResourceAnnotations(revision *v1alpha1.Revision) map[string]string {
+func MakeServingResourceAnnotations(revision *v1alpha1.Revision) map[string]string {
 	annotations := make(map[string]string, len(revision.ObjectMeta.Annotations)+1)
 	for k, v := range revision.ObjectMeta.Annotations {
 		annotations[k] = v

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -385,7 +385,7 @@ func TestCreateRevCreatesStuff(t *testing.T) {
 	}
 
 	foundQueueProxy := false
-	foundElaContainer := false
+	foundServingContainer := false
 	foundFluentdProxy := false
 	expectedPreStop := &corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
@@ -421,7 +421,7 @@ func TestCreateRevCreatesStuff(t *testing.T) {
 			}
 		}
 		if container.Name == userContainerName {
-			foundElaContainer = true
+			foundServingContainer = true
 			// verify that the ReadinessProbe has our port.
 			if container.ReadinessProbe.Handler.HTTPGet.Port != intstr.FromInt(queue.RequestQueuePort) {
 				t.Errorf("Expect ReadinessProbe handler to have port %d, saw %v",
@@ -446,7 +446,7 @@ func TestCreateRevCreatesStuff(t *testing.T) {
 	if !foundFluentdProxy {
 		t.Error("Missing fluentd-proxy container")
 	}
-	if !foundElaContainer {
+	if !foundServingContainer {
 		t.Errorf("Missing %q container", userContainerName)
 	}
 	expectedLabels := sumMaps(

--- a/pkg/controller/revision/service.go
+++ b/pkg/controller/revision/service.go
@@ -35,10 +35,10 @@ var servicePort = 80
 func MakeRevisionK8sService(rev *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            controller.GetElaK8SServiceNameForRevision(rev),
-			Namespace:       controller.GetElaNamespaceName(rev.Namespace),
-			Labels:          MakeElaResourceLabels(rev),
-			Annotations:     MakeElaResourceAnnotations(rev),
+			Name:            controller.GetServingK8SServiceNameForRevision(rev),
+			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
+			Labels:          MakeServingResourceLabels(rev),
+			Annotations:     MakeServingResourceAnnotations(rev),
 			OwnerReferences: []metav1.OwnerReference{*controller.NewRevisionControllerRef(rev)},
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/controller/route/ingress.go
+++ b/pkg/controller/route/ingress.go
@@ -42,7 +42,7 @@ func MakeRouteIngress(route *v1alpha1.Route) *v1beta1.Ingress {
 
 	path := v1beta1.HTTPIngressPath{
 		Backend: v1beta1.IngressBackend{
-			ServiceName: controller.GetElaK8SServiceName(route),
+			ServiceName: controller.GetServingK8SServiceName(route),
 			ServicePort: intstr.IntOrString{Type: intstr.String, StrVal: "http"},
 		},
 	}
@@ -62,7 +62,7 @@ func MakeRouteIngress(route *v1alpha1.Route) *v1beta1.Ingress {
 
 	return &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.GetElaK8SIngressName(route),
+			Name:      controller.GetServingK8SIngressName(route),
 			Namespace: route.Namespace,
 			Annotations: map[string]string{
 				"kubernetes.io/ingress.class": "istio",

--- a/pkg/controller/route/istio_route.go
+++ b/pkg/controller/route/istio_route.go
@@ -36,7 +36,7 @@ func makeIstioRouteSpec(u *v1alpha1.Route, tt *v1alpha1.TrafficTarget, ns string
 	}
 	spec := istiov1alpha2.RouteRuleSpec{
 		Destination: istiov1alpha2.IstioService{
-			Name:      controller.GetElaK8SServiceName(u),
+			Name:      controller.GetServingK8SServiceName(u),
 			Namespace: ns,
 		},
 		Match: istiov1alpha2.Match{

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -325,7 +325,7 @@ func (c *Controller) reconcilePlaceholderService(ctx context.Context, route *v1a
 func (c *Controller) reconcileIngress(ctx context.Context, route *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 	ingressNamespace := route.Namespace
-	ingressName := controller.GetElaK8SIngressName(route)
+	ingressName := controller.GetServingK8SIngressName(route)
 	ingress := MakeRouteIngress(route)
 	ingressClient := c.KubeClientSet.ExtensionsV1beta1().Ingresses(ingressNamespace)
 	existing, err := ingressClient.Get(ingressName, metav1.GetOptions{})
@@ -631,7 +631,7 @@ func (c *Controller) computeRevisionRoutes(
 	// The total percent of all inactive revisions.
 	totalInactivePercent := 0
 	ns := route.Namespace
-	elaNS := controller.GetElaNamespaceName(ns)
+	elaNS := controller.GetServingNamespaceName(ns)
 	ret := []RevisionRoute{}
 
 	for _, tt := range route.Spec.Traffic {
@@ -697,9 +697,9 @@ func (c *Controller) computeRevisionRoutes(
 	// Once migration to Istio Gateway completes, we should change this back so that activator
 	// is added to the list only if its weight is positive
 	activatorRoute := RevisionRoute{
-		Name:         controller.GetElaK8SActivatorServiceName(),
+		Name:         controller.GetServingK8SActivatorServiceName(),
 		RevisionName: inactiveRev,
-		Service:      controller.GetElaK8SActivatorServiceName(),
+		Service:      controller.GetServingK8SActivatorServiceName(),
 		Namespace:    pkg.GetServingSystemNamespace(),
 		Weight:       totalInactivePercent,
 	}
@@ -719,7 +719,7 @@ func (c *Controller) computeEmptyRevisionRoutes(
 	revMap map[string]*v1alpha1.Revision) ([]RevisionRoute, error) {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-	elaNS := controller.GetElaNamespaceName(ns)
+	elaNS := controller.GetServingNamespaceName(ns)
 	revClient := c.ServingClientSet.ServingV1alpha1().Revisions(ns)
 	revRoutes := []RevisionRoute{}
 	for _, tt := range route.Spec.Traffic {

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -154,7 +154,7 @@ func getTestRevisionForConfig(config *v1alpha1.Configuration) *v1alpha1.Revision
 func getActivatorDestinationWeight(w int) v1alpha2.DestinationWeight {
 	return v1alpha2.DestinationWeight{
 		Destination: v1alpha2.IstioService{
-			Name:      ctrl.GetElaK8SActivatorServiceName(),
+			Name:      ctrl.GetServingK8SActivatorServiceName(),
 			Namespace: pkg.GetServingSystemNamespace(),
 		},
 		Weight: w,
@@ -1373,7 +1373,7 @@ func TestUpdateRouteDomainWhenRouteLabelChanges(t *testing.T) {
 		}
 
 		// Confirms that the ingress is updated in tandem with the route.
-		ingress, _ := ingressClient.Get(ctrl.GetElaK8SIngressName(route), metav1.GetOptions{})
+		ingress, _ := ingressClient.Get(ctrl.GetServingK8SIngressName(route), metav1.GetOptions{})
 
 		expectedHost := route.Status.Domain
 		expectedWildcardHost := fmt.Sprintf("*.%s", route.Status.Domain)
@@ -1447,7 +1447,7 @@ func TestUpdateRouteWhenConfigurationChanges(t *testing.T) {
 		RevisionName: rev.Name,
 		Percent:      100,
 	}, {
-		Name:    ctrl.GetElaK8SActivatorServiceName(),
+		Name:    ctrl.GetServingK8SActivatorServiceName(),
 		Percent: 0,
 	}}
 	if diff := cmp.Diff(expectedTrafficTargets, route.Status.Traffic); diff != "" {
@@ -1523,7 +1523,7 @@ func TestUpdateIngressEventUpdateRouteStatus(t *testing.T) {
 
 	// Before ingress has an IP address, route isn't marked as Ready.
 	ingressClient := kubeClient.ExtensionsV1beta1().Ingresses(route.Namespace)
-	ingress, _ := ingressClient.Get(ctrl.GetElaK8SIngressName(route), metav1.GetOptions{})
+	ingress, _ := ingressClient.Get(ctrl.GetServingK8SIngressName(route), metav1.GetOptions{})
 	controller.SyncIngress(ingress)
 
 	newRoute, _ := routeClient.Get(route.Name, metav1.GetOptions{})
@@ -1655,7 +1655,7 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 		if route.Status.Domain != expectedDomain {
 			t.Errorf("Expected domain %q but saw %q", expectedDomain, route.Status.Domain)
 		}
-		ingress, _ := ingressClient.Get(ctrl.GetElaK8SIngressName(route), metav1.GetOptions{})
+		ingress, _ := ingressClient.Get(ctrl.GetServingK8SIngressName(route), metav1.GetOptions{})
 		expectedHost := route.Status.Domain
 		expectedWildcardHost := fmt.Sprintf("*.%s", route.Status.Domain)
 		if ingress.Spec.Rules[0].Host != expectedHost {

--- a/pkg/controller/route/service.go
+++ b/pkg/controller/route/service.go
@@ -33,7 +33,7 @@ var servicePort = 80
 func MakeRouteK8SService(route *v1alpha1.Route) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.GetElaK8SServiceName(route),
+			Name:      controller.GetServingK8SServiceName(route),
 			Namespace: route.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*controller.NewRouteControllerRef(route),

--- a/pkg/controller/service/resource.go
+++ b/pkg/controller/service/resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
-// MakeElaResourceLabels constructs the labels we will apply to Route and Configuration
+// MakeServingResourceLabels constructs the labels we will apply to Route and Configuration
 // resources.
-func MakeElaResourceLabels(s *v1alpha1.Service) map[string]string {
+func MakeServingResourceLabels(s *v1alpha1.Service) map[string]string {
 	labels := make(map[string]string, len(s.ObjectMeta.Labels)+1)
 	labels[serving.ServiceLabelKey] = s.Name
 

--- a/pkg/controller/service/service_configuration.go
+++ b/pkg/controller/service/service_configuration.go
@@ -34,7 +34,7 @@ func MakeServiceConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuratio
 			OwnerReferences: []metav1.OwnerReference{
 				*controller.NewServiceControllerRef(service),
 			},
-			Labels: MakeElaResourceLabels(service),
+			Labels: MakeServingResourceLabels(service),
 		},
 	}
 

--- a/pkg/controller/service/service_route.go
+++ b/pkg/controller/service/service_route.go
@@ -32,7 +32,7 @@ func MakeServiceRoute(service *v1alpha1.Service) *v1alpha1.Route {
 			OwnerReferences: []metav1.OwnerReference{
 				*controller.NewServiceControllerRef(service),
 			},
-			Labels: MakeElaResourceLabels(service),
+			Labels: MakeServingResourceLabels(service),
 		},
 	}
 


### PR DESCRIPTION
I noticed a number of helpers in `./pkg/controller` still had `Ela` in their names, this literally replaces that substring across `./pkg/controller` and fixes one collateral breakage in `./pkg/activator`.

cc @josephburnett 