### PR TITLE
use default bool for enable-var-log-collection

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -22,8 +22,9 @@ data:
 
   # Static parameters:
 
-  # A fluentd sidecar will be set up to collect var log if this flag is true.
-  logging.enable-var-log-collection: "true"
+  # enable-var-log-collection defaults to false. A fluentd sidecar
+  # will be set up to collect var log if this flag is true.
+  logging.enable-var-log-collection: "false"
 
   # The fluentd sidecar image used to collect logs from /var/log as a sidecar.
   # Must be presented if logging.enable-var-log-collection is true.


### PR DESCRIPTION
`enable-var-log-collection` defaults to `false`. Once turned on, logging sidecars are created, causing pod startup latency increase.

This change reduces startup latency from ~14 seconds to ~3 seconds on a cold start.

thanks @markusthoemmes for his inspiration in investigating latency.

Restore default and add more comments

Fixes #

## Proposed Changes

  * 
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Comment out logging.enable-var-log-collection config for controller.
```
