### PR TITLE
Make package name consistent with dir (again).

### DIFF
--- a/pkg/client/informers/externalversions/istio/interface.go
+++ b/pkg/client/informers/externalversions/istio/interface.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package config
+package istio
 
 import (
 	internalinterfaces "github.com/knative/serving/pkg/client/informers/externalversions/internalinterfaces"


### PR DESCRIPTION
The name of the dir that `interface.go` is in and the package
it declares are inconsistent, which can cause problems with tools that
expect these to be consistent.

(This was originally fixed in #691 but managed to creep back in via #733.)


## Proposed Changes
  * Change the config package to be istio

```release-note
The package declared by `pkg/client/informers/externalversions/istio/interface.go` is now `istio` instead of `config`.
```
