### PR TITLE
Cleanup e2e-tests.sh

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -148,17 +148,7 @@ function run_smoke_test() {
   # Building the sample image using docker takes about 20 minutes (June 2018)
   # when running the tests on prow, compared to 1 minute on a workstation.
   # Thus we use a prebuilt image stored in GCR when running on Prow.
-  # TODO(adrcunha): Use a single approach here.
-  if (( IS_PROW )); then
-    local IMAGE="gcr.io/elafros-e2e-tests/ela-e2e-test/sample/helloworld"
-  else
-    local IMAGE="${KO_DOCKER_REPO}/smoke/helloworld"
-    docker build \
-      --build-arg SAMPLE=helloworld \
-      --tag ${IMAGE} \
-      --file=sample/Dockerfile.golang .
-    docker push "${IMAGE}"
-  fi
+  local IMAGE="gcr.io/elafros-e2e-tests/ela-e2e-test/sample/helloworld"
   sed "s@github.com/knative/serving/sample/helloworld@${IMAGE}@g" \
     sample/helloworld/sample.yaml > ${YAML}
   kubectl apply -f ${YAML}
@@ -261,6 +251,7 @@ if [[ -z $1 ]]; then
   region="$(gcloud compute zones list --filter=name=${E2E_CLUSTER_ZONE} --format='value(region)')"
   if [[ -n "${target_pools}" ]]; then
     echo "Found leaked target pools, deleting"
+    gcloud compute forwarding-rules delete -q --project=${gcp_project} --region=${region} ${target_pools}
     gcloud compute target-pools delete -q --project=${gcp_project} --region=${region} ${target_pools}
   fi
   if [[ -n "${http_health_checks}" ]]; then

--- a/test/library.sh
+++ b/test/library.sh
@@ -81,7 +81,7 @@ function delete_gcr_images() {
 function wait_until_pods_running() {
   echo -n "Waiting until all pods in namespace $1 are up"
   for i in {1..150}; do  # timeout after 5 minutes
-    local pods="$(kubectl get pods -n $1 | grep -v NAME)"
+    local pods="$(kubectl get pods -n $1 2>/dev/null | grep -v NAME)"
     local not_running=$(echo "${pods}" | grep -v Running | wc -l)
     if [[ -n "${pods}" && ${not_running} == 0 ]]; then
       echo -e "\nAll pods are up:"


### PR DESCRIPTION
* use a single approach (prebuilt image) for the shell "hello world" tests;
* delete leaked forwarding rules on test cluster shutdown;
* remove noise ("resource not found" message) when waiting for pods to come up;

Fixes #959.