### PR TITLE
Start migrating the Revision controller to level-based Reconciliation.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -342,7 +342,7 @@
     "pkg/client/informers/externalversions/internalinterfaces",
     "pkg/client/listers/build/v1alpha1"
   ]
-  revision = "5127da35831f0c56d234e23ff087e9caf77d75e7"
+  revision = "5dba97ea172464d6459c393330ffba2152ec78dd"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -954,6 +954,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9794defec7ac7f7e8d21464a8bbd7e943b3bda0dfa0210cc2118357e889533e5"
+  inputs-digest = "b720a1edf1cc92482948ff4da72dea0c14d3c05fa442af00ae84035ebdb46cb4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,8 +50,8 @@ required = [
 
 [[constraint]]
   name = "github.com/knative/build"
-  # HEAD as of 2018-06-15
-  revision = "5127da35831f0c56d234e23ff087e9caf77d75e7"
+  # HEAD as of 2018-06-18
+  revision = "5dba97ea172464d6459c393330ffba2152ec78dd"
 
 [[constraint]]
   name = "github.com/google/go-containerregistry"

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -39,104 +39,79 @@ func TestIsReady(t *testing.T) {
 		name    string
 		status  RevisionStatus
 		isReady bool
-	}{
-		{
-			name:    "empty status should not be ready",
-			status:  RevisionStatus{},
-			isReady: false,
+	}{{
+		name:    "empty status should not be ready",
+		status:  RevisionStatus{},
+		isReady: false,
+	}, {
+		name: "Different condition type should not be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type:   RevisionConditionBuildSucceeded,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "Different condition type should not be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type:   RevisionConditionBuildSucceeded,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "False condition status should not be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type:   RevisionConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "False condition status should not be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type:   RevisionConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "Unknown condition status should not be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type:   RevisionConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
 		},
-		{
-			name: "Unknown condition status should not be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type:   RevisionConditionReady,
-						Status: corev1.ConditionUnknown,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "Missing condition status should not be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type: RevisionConditionReady,
+			}},
 		},
-		{
-			name: "Missing condition status should not be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type: RevisionConditionReady,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "True condition status should be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type:   RevisionConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "True condition status should be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type:   RevisionConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: true,
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status should be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type:   RevisionConditionBuildSucceeded,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   RevisionConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "Multiple conditions with ready status should be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type:   RevisionConditionBuildSucceeded,
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   RevisionConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: true,
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status false should not be ready",
+		status: RevisionStatus{
+			Conditions: []RevisionCondition{{
+				Type:   RevisionConditionBuildSucceeded,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   RevisionConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "Multiple conditions with ready status false should not be ready",
-			status: RevisionStatus{
-				Conditions: []RevisionCondition{
-					{
-						Type:   RevisionConditionBuildSucceeded,
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   RevisionConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isReady: false,
-		},
-	}
+		isReady: false,
+	}}
 
 	for _, tc := range cases {
 		if e, a := tc.isReady, tc.status.IsReady(); e != a {
@@ -233,25 +208,39 @@ func TestTypicalFlowWithBuild(t *testing.T) {
 	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
 
-	r.Status.MarkBuilding()
+	// Empty BuildStatus keeps things as-is.
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{})
+	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
+
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:   buildv1alpha1.BuildSucceeded,
+			Status: corev1.ConditionUnknown,
+		}},
+	})
 	want := "Building"
 	if got := checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t); got == nil || got.Reason != want {
-		t.Errorf("MarkBuilding = %v, wanted %v", got, want)
+		t.Errorf("PropagateBuildStatus(Unknown) = %v, wanted %v", got, want)
 	}
 	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
 	if got := checkConditionOngoingRevision(r.Status, RevisionConditionReady, t); got == nil || got.Reason != want {
-		t.Errorf("MarkBuilding = %v, wanted %v", got, want)
+		t.Errorf("PropagateBuildStatus(Unknown) = %v, wanted %v", got, want)
 	}
 
-	r.Status.MarkBuildSucceeded()
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:   buildv1alpha1.BuildSucceeded,
+			Status: corev1.ConditionTrue,
+		}},
+	})
 	checkConditionSucceededRevision(r.Status, RevisionConditionBuildSucceeded, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
-	want = "" // Should be cleared.
-	if got := checkConditionOngoingRevision(r.Status, RevisionConditionReady, t); got == nil || got.Reason != want {
-		t.Errorf("MarkBuildSucceeded = %v, wanted %v", got, want)
-	}
+	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
 
 	// All of these conditions should get this status.
 	want = "TheReason"
@@ -311,18 +300,72 @@ func TestTypicalFlowWithBuildFailure(t *testing.T) {
 	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
 
-	r.Status.MarkBuilding()
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:   buildv1alpha1.BuildSucceeded,
+			Status: corev1.ConditionUnknown,
+		}},
+	})
 	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
 	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
 
 	wantReason, wantMessage := "this is the reason", "and this the message"
-	r.Status.MarkBuildFailed(&buildv1alpha1.BuildCondition{
-		Type:    buildv1alpha1.BuildSucceeded,
-		Status:  corev1.ConditionFalse,
-		Reason:  wantReason,
-		Message: wantMessage,
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:    buildv1alpha1.BuildSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  wantReason,
+			Message: wantMessage,
+		}},
+	})
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionBuildSucceeded, t); got == nil {
+		t.Errorf("MarkBuildFailed = nil, wanted %v", wantReason)
+	} else if got.Reason != wantReason {
+		t.Errorf("MarkBuildFailed = %v, wanted %v", got.Reason, wantReason)
+	} else if got.Message != wantMessage {
+		t.Errorf("MarkBuildFailed = %v, wanted %v", got.Reason, wantMessage)
+	}
+	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionReady, t); got == nil {
+		t.Errorf("MarkBuildFailed = nil, wanted %v", wantReason)
+	} else if got.Reason != wantReason {
+		t.Errorf("MarkBuildFailed = %v, wanted %v", got.Reason, wantReason)
+	} else if got.Message != wantMessage {
+		t.Errorf("MarkBuildFailed = %v, wanted %v", got.Reason, wantMessage)
+	}
+}
+
+func TestTypicalFlowWithBuildInvalid(t *testing.T) {
+	r := &Revision{}
+	r.Status.InitializeConditions()
+	r.Status.InitializeBuildCondition()
+	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
+
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:   buildv1alpha1.BuildSucceeded,
+			Status: corev1.ConditionUnknown,
+		}},
+	})
+	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
+
+	wantReason, wantMessage := "this is the reason", "and this the message"
+	r.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:    buildv1alpha1.BuildInvalid,
+			Status:  corev1.ConditionTrue,
+			Reason:  wantReason,
+			Message: wantMessage,
+		}},
 	})
 	if got := checkConditionFailedRevision(r.Status, RevisionConditionBuildSucceeded, t); got == nil {
 		t.Errorf("MarkBuildFailed = nil, wanted %v", wantReason)

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -523,11 +523,13 @@ func TestMarkConfigurationStatusWhenLatestRevisionIsNotReady(t *testing.T) {
 	revision := revList.Items[0].DeepCopy()
 
 	// mark the revision not ready with the status
-	revision.Status.MarkBuildFailed(&buildv1alpha1.BuildCondition{
-		Type:    buildv1alpha1.BuildSucceeded,
-		Status:  corev1.ConditionFalse,
-		Reason:  "StepFailed",
-		Message: "Build step failed with error",
+	revision.Status.PropagateBuildStatus(buildv1alpha1.BuildStatus{
+		Conditions: []buildv1alpha1.BuildCondition{{
+			Type:    buildv1alpha1.BuildSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  "StepFailed",
+			Message: "Build step failed with error",
+		}},
 	})
 
 	// Since Reconcile looks in the lister, we need to add it to the informer

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -152,7 +152,7 @@ func (c *Base) Enqueue(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	c.WorkQueue.AddRateLimited(key)
+	c.EnqueueKey(key)
 }
 
 // EnqueueControllerOf takes a resource, identifies its controller resource, and
@@ -170,8 +170,13 @@ func (c *Base) EnqueueControllerOf(obj interface{}) {
 	// If we can determine the controller ref of this object, then
 	// add that object to our workqueue.
 	if owner := metav1.GetControllerOf(object); owner != nil {
-		c.WorkQueue.AddRateLimited(object.GetNamespace() + "/" + owner.Name)
+		c.EnqueueKey(object.GetNamespace() + "/" + owner.Name)
 	}
+}
+
+// EnqueueKey takes a namespace/name string and puts it onto the work queue.
+func (c *Base) EnqueueKey(key string) {
+	c.WorkQueue.AddRateLimited(key)
 }
 
 // RunController will set up the event handlers for types we are interested in, as well

--- a/pkg/controller/revision/buildtracker.go
+++ b/pkg/controller/revision/buildtracker.go
@@ -18,7 +18,6 @@ package revision
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
@@ -29,14 +28,6 @@ type key string
 
 func getKey(namespace, name string) key {
 	return key(fmt.Sprintf("%s/%s", namespace, name))
-}
-
-func splitKey(k key) (string, string) {
-	parts := strings.Split(string(k), "/")
-	if len(parts) != 2 {
-		panic("key type invariant violated.")
-	}
-	return parts[0], parts[1]
 }
 
 type set map[key]struct{}

--- a/vendor/github.com/knative/build/pkg/apis/build/v1alpha1/build_types.go
+++ b/vendor/github.com/knative/build/pkg/apis/build/v1alpha1/build_types.go
@@ -192,6 +192,15 @@ type BuildList struct {
 	Items []Build `json:"items"`
 }
 
+func (bs *BuildStatus) GetCondition(t BuildConditionType) *BuildCondition {
+	for _, cond := range bs.Conditions {
+		if cond.Type == t {
+			return &cond
+		}
+	}
+	return nil
+}
+
 func (b *BuildStatus) SetCondition(newCond *BuildCondition) {
 	if newCond == nil {
 		return


### PR DESCRIPTION
This moves the very first part of the Revision controller's reconciliation to be level-based.  When a Revision has an associated Build, the Revision fetches the state of that Build and incorporates its status into its own.  Then, depending on the result of the Build, it proceeds with the reconciliation of other resources.  In a pivot to being more level-based, when Build events trigger we `Enqueue` the Revisions to reconcile instead of directly processing the events.

This also imports a new version of Build that exposes `GetCondition` on Build.

cc @grantr @vaikas-google 

