### PR TITLE
Fixes #1269

### DIFF
--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -70,7 +70,7 @@ func NewController(
 		FilterFunc: controller.Filter("Configuration"),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.EnqueueControllerOf,
-			UpdateFunc: controller.PassNew(c.Enqueue),
+			UpdateFunc: controller.PassNew(c.EnqueueControllerOf),
 		},
 	})
 	return c


### PR DESCRIPTION
This fixes what we enqueue in the Configuration controller when Revision *update* events occur.  We were mistakenly enqueuing the Revision, when we should have been enqueuing its controller resource: the Configuration.

Fixes: https://github.com/knative/serving/issues/1269