### PR TITLE
Fix ingress timeout detection in "hello world" shell test.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -168,8 +168,9 @@ function run_smoke_test() {
     sleep 2
   done
   echo
-  if [[ -z ${service_host} ]]; then
-    echo "FAILED -- No ingress found"
+  if [[ -z "${service_host}" || -z "${service_ip}" ]]; then
+    # service_host or service_ip might contain a useful error, dump it.
+    echo "FAILED -- No ingress found. ${service_host}${service_ip}"
     kubectl delete -f ${YAML}
     return 1
   fi


### PR DESCRIPTION
`$service_host` contains an error message, thus failure checking must assert against `$service_ip` being empty as well, just like the opposite check in line 163.