### PR TITLE
Add link to Serving Resource Types overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ You can choose to install individual Knative components following the
 instructions in each repo, or install a pre-built suite of components
 by following the instructions at https://github.com/knative/install.
 
+Read an [overview of the Knative Serving resource types](https://github.com/knative/serving/blob/master/docs/spec/overview.md#resource-types).
+
 
 # Who is Knative for?
 


### PR DESCRIPTION
Understanding the Knative Serving resource model is quite important to get started. Add a link to the existing overview.