### PR TITLE
Fixes activator retry for HTTP POST

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -98,7 +98,7 @@ func (rrt retryRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) 
 		time.Sleep(retryInterval)
 
 		// The request body cannot be read multiple times for retries.
-		// The workaround is to clone the request body into a byte array
+		// The workaround is to clone the request body into a byte reader
 		// so the body can be read multiple times.
 		if r.Body != nil {
 			reqBody.Seek(0, io.SeekStart)


### PR DESCRIPTION
Co-authored-by: Dave Protasowski <dprotaso@gmail.com>

Related issue #898

We were using the sample/buildpack-functions app and scaling from 0->1 and were getting a 503 response and `upstream connect error or disconnect/reset before headers`. This was due to the activator not going through it's retry logic and the code would panic on https://github.com/knative/serving/blob/master/cmd/activator/main.go#L69 since the response body was nil.