### PR TITLE
Replace concurrencyModel with instanceMaxRequestConcurrency.

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -181,8 +181,8 @@ spec:
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
 
-      # +optional concurrency strategy.  Defaults to Multi.
-      concurrencyModel: ...
+      # +optional max request concurrency per instance.  Defaults to `0` (system decides).
+      instanceMaxRequestConcurrency: ...
       # +optional. max time the instance is allowed for responding to a request
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as.
@@ -256,10 +256,15 @@ spec:
   # scaling to/from 0.
   servingState: Active | Reserve | Retired
 
-  # Some function or server frameworks or application code may be written to
-  # expect that each request will be granted a single-tenant process to run
-  # (i.e. that the request code is run single-threaded).
-  concurrencyModel: Single | Multi
+  # Some function or server frameworks or application code may be
+  # written to expect that each request will be granted a single-tenant
+  # process to run (i.e. that the request code is run
+  # single-threaded). An instanceMaxRequestConcurrency value of `1` will
+  # guarantee that only one request is handled at a time by a given
+  # instance of the Revision container. A value of `2` or more will
+  # limit request concurrency to that value.  A value of `0` means the
+  # system should decide.
+  instanceMaxRequestConcurrency: 0 | 1 | 2-N
 
   # NYI: https://github.com/knative/serving/issues/457
   # Many higher-level systems impose a per-request response deadline.
@@ -331,7 +336,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
-      concurrencyModel: ...
+      instanceMaxRequestConcurrency: ... # Optional
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as
   # Example, only one of runLatest or pinned can be set in practice.
@@ -353,7 +358,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
-      concurrencyModel: ...
+      instanceMaxRequestConcurrency: ... # Optional
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as
 status:

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -182,7 +182,7 @@ spec:
         readinessProbe: ...  # Optional
 
       # +optional max request concurrency per instance.  Defaults to `0` (system decides).
-      instanceMaxRequestConcurrency: ...
+      instanceConcurrency: ...
       # +optional. max time the instance is allowed for responding to a request
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as.
@@ -259,12 +259,12 @@ spec:
   # Some function or server frameworks or application code may be
   # written to expect that each request will be granted a single-tenant
   # process to run (i.e. that the request code is run
-  # single-threaded). An instanceMaxRequestConcurrency value of `1` will
+  # single-threaded). An instanceConcurrency value of `1` will
   # guarantee that only one request is handled at a time by a given
   # instance of the Revision container. A value of `2` or more will
   # limit request concurrency to that value.  A value of `0` means the
   # system should decide.
-  instanceMaxRequestConcurrency: 0 | 1 | 2-N
+  instanceConcurrency: 0 | 1 | 2-N
 
   # NYI: https://github.com/knative/serving/issues/457
   # Many higher-level systems impose a per-request response deadline.
@@ -336,7 +336,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
-      instanceMaxRequestConcurrency: ... # Optional
+      instanceConcurrency: ... # Optional
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as
   # Example, only one of runLatest or pinned can be set in practice.
@@ -358,7 +358,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
-      instanceMaxRequestConcurrency: ... # Optional
+      instanceConcurrency: ... # Optional
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as
 status:

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -91,7 +91,7 @@ const (
 	RevisionRequestConcurrencyModelMulti RevisionRequestConcurrencyModelType = "Multi"
 )
 
-type RevisionInstanceRequestMaxConcurrencyType int64
+type RevisionInstanceConcurrencyType int64
 
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
@@ -116,13 +116,13 @@ type RevisionSpec struct {
 	// +optional
 	ConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
 
-	// InstanceMaxRequestConcurrency specifies the maximum allowed
+	// InstanceConcurrency specifies the maximum allowed
 	// in-flight (concurrent) requests per instance of the Revision
 	// container. Defaults to `0` which means the system should
 	// decide. This field replaces ConcurrencyModel. A value of `1`
 	// is equivalent to `Single` and `0` is equivalent to `Multi`.
 	// +optional
-	InstanceMaxRequestConcurrency RevisionInstanceRequestMaxConcurrencyType `json:"instanceMaxConcurrency,omitempty"`
+	InstanceConcurrency RevisionInstanceConcurrencyType `json:"instanceConcurrency,omitempty"`
 
 	// ServiceAccountName holds the name of the Kubernetes service account
 	// as which the underlying K8s resources should be run. If unspecified

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -77,6 +77,7 @@ const (
 
 // RevisionRequestConcurrencyModelType is an enumeration of the
 // concurrency models supported by a Revision.
+// Deprecated in favor of InstanceMaxRequestConcurrency.
 type RevisionRequestConcurrencyModelType string
 
 const (
@@ -89,6 +90,8 @@ const (
 	// Container.
 	RevisionRequestConcurrencyModelMulti RevisionRequestConcurrencyModelType = "Multi"
 )
+
+type RevisionInstanceRequestMaxConcurrencyType int64
 
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
@@ -109,8 +112,17 @@ type RevisionSpec struct {
 	// ConcurrencyModel specifies the desired concurrency model
 	// (Single or Multi) for the
 	// Revision. Defaults to Multi.
+	// Deprecated in favor of InstanceMaxRequestConcurrency.
 	// +optional
 	ConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
+
+	// InstanceMaxRequestConcurrency specifies the maximum allowed
+	// in-flight (concurrent) requests per instance of the Revision
+	// container. Defaults to `0` which means the system should
+	// decide. This field replaces ConcurrencyModel. A value of `1`
+	// is equivalent to `Single` and `0` is equivalent to `Multi`.
+	// +optional
+	InstanceMaxRequestConcurrency RevisionInstanceRequestMaxConcurrencyType `json:"instanceMaxConcurrency,omitempty"`
 
 	// ServiceAccountName holds the name of the Kubernetes service account
 	// as which the underlying K8s resources should be run. If unspecified


### PR DESCRIPTION
API change for #1105

## Proposed Changes

  * replace `concurrencyModel` with `instanceMaxRequestConcurrency`

**Release Note**
```release-note
* The Revision field `concurrencyModel` has been deprecated in favor of `instanceMaxRequestConcurrency` and will be removed.
```
