### PR TITLE
Removes 503 as a retryable status code in tests

### DIFF
--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -63,8 +63,9 @@ func updateServiceWithImage(clients *test.Clients, names test.ResourceNames, ima
 
 // Shamelessly cribbed from route_test. We expect the Route and Configuration to be ready if the Service is ready.
 func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clients *test.Clients, names test.ResourceNames, routeDomain, expectedText string) {
+	expectedEndpointState := test.NewExpectedEndpointstate(routeDomain)
 	// TODO(#1178): Remove "Wait" from all checks below this point.
-	err := test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, routeDomain, test.EventuallyMatchesBody(expectedText), "WaitForEndpointToServeText")
+	err := test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, expectedEndpointState, test.EventuallyMatchesBody(expectedText), "WaitForEndpointToServeText")
 	if err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, routeDomain, expectedText, err)
 	}

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -57,7 +57,8 @@ func TestHelloWorld(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	err = test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, domain, test.MatchesBody(helloWorldExpectedOutput), "HelloWorldServesText")
+	expectedEndpointState := test.NewExpectedEndpointstate(domain)
+	err = test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, expectedEndpointState, test.MatchesBody(helloWorldExpectedOutput), "HelloWorldServesText")
 	if err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}


### PR DESCRIPTION
Given that the activator now has retry logic (#1226) and we have a temporary workaround for Istio's spurious 503's (#785), we should remove the `503` as a possible retry-able code.

Note: 503's are still allowed for newly created revisions