### PR TITLE
Correct the UpdateFunc callbacks for the Service controller.

### DIFF
--- a/pkg/controller/service/service.go
+++ b/pkg/controller/service/service.go
@@ -76,7 +76,7 @@ func NewController(
 		FilterFunc: controller.Filter("Service"),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.EnqueueControllerOf,
-			UpdateFunc: controller.PassNew(c.Enqueue),
+			UpdateFunc: controller.PassNew(c.EnqueueControllerOf),
 		},
 	})
 
@@ -84,7 +84,7 @@ func NewController(
 		FilterFunc: controller.Filter("Service"),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.EnqueueControllerOf,
-			UpdateFunc: controller.PassNew(c.Enqueue),
+			UpdateFunc: controller.PassNew(c.EnqueueControllerOf),
 		},
 	})
 


### PR DESCRIPTION
Same bug I fixed in the Configuration controller, I must have copy/pasted it here.  Caught it before copy/pasting into Revision 🎉 

I think this explains why Service felt strangely slow to reach `Ready: True` during the empathy session.