### PR TITLE
Use compact lists.

### DIFF
--- a/pkg/controller/revision/autoscaler.go
+++ b/pkg/controller/revision/autoscaler.go
@@ -95,56 +95,45 @@ func MakeServingAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage str
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						corev1.Container{
-							Name:  "autoscaler",
-							Image: autoscalerImage,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceName("cpu"): resource.MustParse("25m"),
-								},
-							},
-							Ports: []corev1.ContainerPort{{
-								Name:          "autoscaler-port",
-								ContainerPort: autoscalerPort,
-							}},
-							Env: []corev1.EnvVar{
-								{
-									Name:  "ELA_NAMESPACE",
-									Value: rev.Namespace,
-								},
-								{
-									Name:  "ELA_DEPLOYMENT",
-									Value: controller.GetRevisionDeploymentName(rev),
-								},
-								{
-									Name:  "ELA_CONFIGURATION",
-									Value: configName,
-								},
-								{
-									Name:  "ELA_REVISION",
-									Value: rev.Name,
-								},
-								{
-									Name:  "ELA_AUTOSCALER_PORT",
-									Value: strconv.Itoa(autoscalerPort),
-								},
-							},
-							Args: []string{
-								fmt.Sprintf("-concurrencyModel=%v", rev.Spec.ConcurrencyModel),
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								corev1.VolumeMount{
-									Name:      autoscalerConfigName,
-									MountPath: "/etc/config-autoscaler",
-								},
-								corev1.VolumeMount{
-									Name:      loggingConfigName,
-									MountPath: "/etc/config-logging",
-								},
+					Containers: []corev1.Container{{
+						Name:  "autoscaler",
+						Image: autoscalerImage,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName("cpu"): resource.MustParse("25m"),
 							},
 						},
-					},
+						Ports: []corev1.ContainerPort{{
+							Name:          "autoscaler-port",
+							ContainerPort: autoscalerPort,
+						}},
+						Env: []corev1.EnvVar{{
+							Name:  "ELA_NAMESPACE",
+							Value: rev.Namespace,
+						}, {
+							Name:  "ELA_DEPLOYMENT",
+							Value: controller.GetRevisionDeploymentName(rev),
+						}, {
+							Name:  "ELA_CONFIGURATION",
+							Value: configName,
+						}, {
+							Name:  "ELA_REVISION",
+							Value: rev.Name,
+						}, {
+							Name:  "ELA_AUTOSCALER_PORT",
+							Value: strconv.Itoa(autoscalerPort),
+						}},
+						Args: []string{
+							fmt.Sprintf("-concurrencyModel=%v", rev.Spec.ConcurrencyModel),
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      autoscalerConfigName,
+							MountPath: "/etc/config-autoscaler",
+						}, {
+							Name:      loggingConfigName,
+							MountPath: "/etc/config-logging",
+						}},
+					}},
 					ServiceAccountName: "autoscaler",
 					Volumes:            []corev1.Volume{autoscalerConfigVolume, loggingConfigVolume},
 				},
@@ -165,13 +154,11 @@ func MakeServingAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 			OwnerReferences: []metav1.OwnerReference{*controller.NewRevisionControllerRef(rev)},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "autoscaler-port",
-					Port:       int32(autoscalerPort),
-					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: autoscalerPort},
-				},
-			},
+			Ports: []corev1.ServicePort{{
+				Name:       "autoscaler-port",
+				Port:       int32(autoscalerPort),
+				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: autoscalerPort},
+			}},
 			Type: "NodePort",
 			Selector: map[string]string{
 				serving.AutoscalerLabelKey: controller.GetRevisionAutoscalerName(rev),

--- a/pkg/controller/revision/pod.go
+++ b/pkg/controller/revision/pod.go
@@ -164,46 +164,36 @@ func MakeServingPodSpec(rev *v1alpha1.Revision, controllerConfig *ControllerConf
 					corev1.ResourceName("cpu"): resource.MustParse(fluentdContainerCPU),
 				},
 			},
-			Env: []corev1.EnvVar{
-				{
-					Name:  "FLUENTD_ARGS",
-					Value: "--no-supervisor -q",
-				},
-				{
-					Name:  "ELA_CONTAINER_NAME",
-					Value: userContainerName,
-				},
-				{
-					Name:  "ELA_CONFIGURATION",
-					Value: configName,
-				},
-				{
-					Name:  "ELA_REVISION",
-					Value: rev.Name,
-				},
-				{
-					Name:  "ELA_NAMESPACE",
-					Value: rev.Namespace,
-				},
-				{
-					Name: "ELA_POD_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.name",
-						},
+			Env: []corev1.EnvVar{{
+				Name:  "FLUENTD_ARGS",
+				Value: "--no-supervisor -q",
+			}, {
+				Name:  "ELA_CONTAINER_NAME",
+				Value: userContainerName,
+			}, {
+				Name:  "ELA_CONFIGURATION",
+				Value: configName,
+			}, {
+				Name:  "ELA_REVISION",
+				Value: rev.Name,
+			}, {
+				Name:  "ELA_NAMESPACE",
+				Value: rev.Namespace,
+			}, {
+				Name: "ELA_POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
 					},
 				},
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      varLogVolumeName,
-					MountPath: "/var/log/revisions",
-				},
-				{
-					Name:      fluentdConfigMapVolumeName,
-					MountPath: "/etc/fluent/config.d",
-				},
-			},
+			}},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      varLogVolumeName,
+				MountPath: "/var/log/revisions",
+			}, {
+				Name:      fluentdConfigMapVolumeName,
+				MountPath: "/etc/fluent/config.d",
+			}},
 		}
 
 		podSpec.Containers = append(podSpec.Containers, fluentdContainer)

--- a/pkg/controller/revision/queue.go
+++ b/pkg/controller/revision/queue.go
@@ -45,17 +45,14 @@ func MakeServingQueueContainer(rev *v1alpha1.Revision, controllerConfig *Control
 				corev1.ResourceName("cpu"): resource.MustParse(queueContainerCPU),
 			},
 		},
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          queue.RequestQueuePortName,
-				ContainerPort: int32(queue.RequestQueuePort),
-			},
+		Ports: []corev1.ContainerPort{{
+			Name:          queue.RequestQueuePortName,
+			ContainerPort: int32(queue.RequestQueuePort),
+		}, {
 			// Provides health checks and lifecycle hooks.
-			{
-				Name:          queue.RequestQueueAdminPortName,
-				ContainerPort: int32(queue.RequestQueueAdminPort),
-			},
-		},
+			Name:          queue.RequestQueueAdminPortName,
+			ContainerPort: int32(queue.RequestQueueAdminPort),
+		}},
 		// This handler (1) marks the service as not ready and (2)
 		// adds a small delay before the container is killed.
 		Lifecycle: &corev1.Lifecycle{
@@ -83,43 +80,34 @@ func MakeServingQueueContainer(rev *v1alpha1.Revision, controllerConfig *Control
 			fmt.Sprintf("-concurrencyQuantumOfTime=%v", controllerConfig.AutoscaleConcurrencyQuantumOfTime.Get()),
 			fmt.Sprintf("-concurrencyModel=%v", rev.Spec.ConcurrencyModel),
 		},
-		Env: []corev1.EnvVar{
-			{
-				Name:  "ELA_NAMESPACE",
-				Value: rev.Namespace,
-			},
-			{
-				Name:  "ELA_CONFIGURATION",
-				Value: configName,
-			},
-			{
-				Name:  "ELA_REVISION",
-				Value: rev.Name,
-			},
-			{
-				Name:  "ELA_AUTOSCALER",
-				Value: controller.GetRevisionAutoscalerName(rev),
-			},
-			{
-				Name:  "ELA_AUTOSCALER_PORT",
-				Value: strconv.Itoa(autoscalerPort),
-			},
-			{
-				Name: "ELA_POD",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.name",
-					},
+		Env: []corev1.EnvVar{{
+			Name:  "ELA_NAMESPACE",
+			Value: rev.Namespace,
+		}, {
+			Name:  "ELA_CONFIGURATION",
+			Value: configName,
+		}, {
+			Name:  "ELA_REVISION",
+			Value: rev.Name,
+		}, {
+			Name:  "ELA_AUTOSCALER",
+			Value: controller.GetRevisionAutoscalerName(rev),
+		}, {
+			Name:  "ELA_AUTOSCALER_PORT",
+			Value: strconv.Itoa(autoscalerPort),
+		}, {
+			Name: "ELA_POD",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
 				},
 			},
-			{
-				Name:  "ELA_LOGGING_CONFIG",
-				Value: controllerConfig.QueueProxyLoggingConfig,
-			},
-			{
-				Name:  "ELA_LOGGING_LEVEL",
-				Value: controllerConfig.QueueProxyLoggingLevel,
-			},
-		},
+		}, {
+			Name:  "ELA_LOGGING_CONFIG",
+			Value: controllerConfig.QueueProxyLoggingConfig,
+		}, {
+			Name:  "ELA_LOGGING_LEVEL",
+			Value: controllerConfig.QueueProxyLoggingLevel,
+		}},
 	}
 }

--- a/pkg/controller/revision/service.go
+++ b/pkg/controller/revision/service.go
@@ -42,13 +42,11 @@ func MakeRevisionK8sService(rev *v1alpha1.Revision) *corev1.Service {
 			OwnerReferences: []metav1.OwnerReference{*controller.NewRevisionControllerRef(rev)},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:       httpServicePortName,
-					Port:       int32(servicePort),
-					TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: queue.RequestQueuePortName},
-				},
-			},
+			Ports: []corev1.ServicePort{{
+				Name:       httpServicePortName,
+				Port:       int32(servicePort),
+				TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: queue.RequestQueuePortName},
+			}},
 			Type: "NodePort",
 			Selector: map[string]string{
 				serving.RevisionLabelKey: rev.Name,

--- a/pkg/controller/revision/vpa.go
+++ b/pkg/controller/revision/vpa.go
@@ -13,7 +13,7 @@ func MakeVpa(rev *v1alpha1.Revision) *vpa.VerticalPodAutoscaler {
 	return &vpa.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        controller.GetRevisionVpaName(rev),
-			Namespace:   rev.Namespace,
+			Namespace:   controller.GetServingNamespaceName(rev.Namespace),
 			Labels:      MakeServingResourceLabels(rev),
 			Annotations: MakeServingResourceAnnotations(rev),
 		},
@@ -25,40 +25,35 @@ func MakeVpa(rev *v1alpha1.Revision) *vpa.VerticalPodAutoscaler {
 				UpdateMode: vpa.UpdateModeAuto,
 			},
 			ResourcePolicy: vpa.PodResourcePolicy{
-				ContainerPolicies: []vpa.ContainerResourcePolicy{
-					vpa.ContainerResourcePolicy{
-						Name: userContainerName,
-						Mode: vpa.ContainerScalingModeOn,
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceName("cpu"):    resource.MustParse(userContainerMaxCPU),
-							corev1.ResourceName("memory"): resource.MustParse(userContainerMaxMemory),
-						},
+				ContainerPolicies: []vpa.ContainerResourcePolicy{{
+					Name: userContainerName,
+					Mode: vpa.ContainerScalingModeOn,
+					MaxAllowed: corev1.ResourceList{
+						corev1.ResourceName("cpu"):    resource.MustParse(userContainerMaxCPU),
+						corev1.ResourceName("memory"): resource.MustParse(userContainerMaxMemory),
 					},
-					vpa.ContainerResourcePolicy{
-						Name: queueContainerName,
-						Mode: vpa.ContainerScalingModeOn,
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceName("cpu"):    resource.MustParse(queueContainerMaxCPU),
-							corev1.ResourceName("memory"): resource.MustParse(queueContainerMaxMemory),
-						},
+				}, {
+					Name: queueContainerName,
+					Mode: vpa.ContainerScalingModeOn,
+					MaxAllowed: corev1.ResourceList{
+						corev1.ResourceName("cpu"):    resource.MustParse(queueContainerMaxCPU),
+						corev1.ResourceName("memory"): resource.MustParse(queueContainerMaxMemory),
 					},
-					vpa.ContainerResourcePolicy{
-						Name: fluentdContainerName,
-						Mode: vpa.ContainerScalingModeOn,
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceName("cpu"):    resource.MustParse(fluentdContainerMaxCPU),
-							corev1.ResourceName("memory"): resource.MustParse(fluentdContainerMaxMemory),
-						},
+				}, {
+					Name: fluentdContainerName,
+					Mode: vpa.ContainerScalingModeOn,
+					MaxAllowed: corev1.ResourceList{
+						corev1.ResourceName("cpu"):    resource.MustParse(fluentdContainerMaxCPU),
+						corev1.ResourceName("memory"): resource.MustParse(fluentdContainerMaxMemory),
 					},
-					vpa.ContainerResourcePolicy{
-						Name: envoyContainerName,
-						Mode: vpa.ContainerScalingModeOn,
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceName("cpu"):    resource.MustParse(envoyContainerMaxCPU),
-							corev1.ResourceName("memory"): resource.MustParse(envoyContainerMaxMemory),
-						},
+				}, {
+					Name: envoyContainerName,
+					Mode: vpa.ContainerScalingModeOn,
+					MaxAllowed: corev1.ResourceList{
+						corev1.ResourceName("cpu"):    resource.MustParse(envoyContainerMaxCPU),
+						corev1.ResourceName("memory"): resource.MustParse(envoyContainerMaxMemory),
 					},
-				},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
This changes every literal I could find to use the compact notation discussed in #golang.

I also noticed that VPA wasn't using our GetServingNamespaceName helper, so I changed that as well.

cc @josephburnett 