### PR TITLE
Clean up formatting in `pkg/webhook`

### DIFF
--- a/pkg/webhook/revision.go
+++ b/pkg/webhook/revision.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/logging"
-	"github.com/google/go-cmp/cmp"
 	"github.com/mattbaird/jsonpatch"
 )
 

--- a/pkg/webhook/route_test.go
+++ b/pkg/webhook/route_test.go
@@ -36,17 +36,13 @@ func createRouteWithTraffic(trafficTargets []v1alpha1.TrafficTarget) v1alpha1.Ro
 }
 
 func TestValidRouteWithTrafficAllowed(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: "test-configuration-1",
-				Percent:           50,
-			},
-			v1alpha1.TrafficTarget{
-				ConfigurationName: "test-configuration-2",
-				Percent:           50,
-			},
-		})
+	route := createRouteWithTraffic([]v1alpha1.TrafficTarget{{
+		ConfigurationName: "test-configuration-1",
+		Percent:           50,
+	}, {
+		ConfigurationName: "test-configuration-2",
+		Percent:           50,
+	}})
 
 	if err := ValidateRoute(testCtx)(nil, &route, &route); err != nil {
 		t.Fatalf("Expected allowed, but failed with: %s.", err)
@@ -70,8 +66,7 @@ func TestNoneRouteTypeForOldResourceNotAllowed(t *testing.T) {
 	}
 
 	if err := ValidateRoute(testCtx)(nil, &revision, &revision); err != errInvalidRouteInput {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errInvalidRouteInput, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRouteInput, err)
 	}
 }
 
@@ -84,91 +79,68 @@ func TestNoneRouteTypeForNewResourceNotAllowed(t *testing.T) {
 	}
 
 	if err := ValidateRoute(testCtx)(nil, nil, &revision); err != errInvalidRouteInput {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errInvalidRouteInput, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRouteInput, err)
 	}
 }
 
 func TestEmptyRevisionAndConfigurationInOneTargetNotAllowed(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				Percent: 100,
-			},
-		})
+	route := createRouteWithTraffic([]v1alpha1.TrafficTarget{{
+		Percent: 100,
+	}})
 
 	if err := ValidateRoute(testCtx)(nil, &route, &route); err != errInvalidRevisions {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errInvalidRevisions, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRevisions, err)
 	}
 }
 
 func TestBothRevisionAndConfigurationInOneTargetNotAllowed(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName:      testRevisionName,
-				ConfigurationName: testConfigurationName,
-				Percent:           100,
-			},
-		})
+	route := createRouteWithTraffic([]v1alpha1.TrafficTarget{{
+		RevisionName:      testRevisionName,
+		ConfigurationName: testConfigurationName,
+		Percent:           100,
+	}})
 
 	if err := ValidateRoute(testCtx)(nil, &route, &route); err != errInvalidRevisions {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errInvalidRevisions, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRevisions, err)
 	}
 }
 
 func TestNegativeTargetPercentNotAllowed(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				RevisionName: testRevisionName,
-				Percent:      -20,
-			},
-		})
+	route := createRouteWithTraffic([]v1alpha1.TrafficTarget{{
+		RevisionName: testRevisionName,
+		Percent:      -20,
+	}})
 
 	if err := ValidateRoute(testCtx)(nil, &route, &route); err != errNegativeTargetPercent {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errNegativeTargetPercent, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errNegativeTargetPercent, err)
 	}
 }
 
 func TestNotAllowedIfTrafficPercentSumIsNot100(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				ConfigurationName: "test-configuration-1",
-			},
-			v1alpha1.TrafficTarget{
-				ConfigurationName: "test-configuration-2",
-				Percent:           50,
-			},
-		})
+	route := createRouteWithTraffic([]v1alpha1.TrafficTarget{{
+		ConfigurationName: "test-configuration-1",
+	}, {
+		ConfigurationName: "test-configuration-2",
+		Percent:           50,
+	}})
 
 	if err := ValidateRoute(testCtx)(nil, &route, &route); err != errInvalidTargetPercentSum {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errInvalidTargetPercentSum, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidTargetPercentSum, err)
 	}
 }
 
 func TestNotAllowedIfTrafficNamesNotUnique(t *testing.T) {
-	route := createRouteWithTraffic(
-		[]v1alpha1.TrafficTarget{
-			v1alpha1.TrafficTarget{
-				Name:              "test",
-				ConfigurationName: "test-configuration-1",
-				Percent:           50,
-			},
-			v1alpha1.TrafficTarget{
-				Name:              "test",
-				ConfigurationName: "test-configuration-2",
-				Percent:           50,
-			},
-		})
+	route := createRouteWithTraffic([]v1alpha1.TrafficTarget{{
+		Name:              "test",
+		ConfigurationName: "test-configuration-1",
+		Percent:           50,
+	}, {
+		Name:              "test",
+		ConfigurationName: "test-configuration-2",
+		Percent:           50,
+	}})
 
 	if err := ValidateRoute(testCtx)(nil, &route, &route); err != errTrafficTargetsNotUnique {
-		t.Fatalf(
-			"Expected: %s. Failed with: %s.", errTrafficTargetsNotUnique, err)
+		t.Fatalf("Expected: %s. Failed with: %s.", errTrafficTargetsNotUnique, err)
 	}
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -212,21 +212,21 @@ func NewAdmissionController(client kubernetes.Interface, options ControllerOptio
 		client:  client,
 		options: options,
 		handlers: map[string]GenericCRDHandler{
-			"Revision": GenericCRDHandler{
+			"Revision": {
 				Factory:   &v1alpha1.Revision{},
 				Defaulter: SetRevisionDefaults(ctx),
 				Validator: ValidateRevision(ctx),
 			},
-			"Configuration": GenericCRDHandler{
+			"Configuration": {
 				Factory:   &v1alpha1.Configuration{},
 				Defaulter: SetConfigurationDefaults(ctx),
 				Validator: ValidateConfiguration(ctx),
 			},
-			"Route": GenericCRDHandler{
+			"Route": {
 				Factory:   &v1alpha1.Route{},
 				Validator: ValidateRoute(ctx),
 			},
-			"Service": GenericCRDHandler{
+			"Service": {
 				Factory:   &v1alpha1.Service{},
 				Defaulter: SetServiceDefaults(ctx),
 				Validator: ValidateService(ctx),
@@ -321,29 +321,27 @@ func (ac *AdmissionController) register(
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ac.options.WebhookName,
 		},
-		Webhooks: []admissionregistrationv1beta1.Webhook{
-			{
-				Name: ac.options.WebhookName,
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-					Operations: []admissionregistrationv1beta1.OperationType{
-						admissionregistrationv1beta1.Create,
-						admissionregistrationv1beta1.Update,
-					},
-					Rule: admissionregistrationv1beta1.Rule{
-						APIGroups:   []string{serving.GroupName},
-						APIVersions: []string{knativeAPIVersion},
-						Resources:   resources,
-					},
-				}},
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-					Service: &admissionregistrationv1beta1.ServiceReference{
-						Namespace: ac.options.ServiceNamespace,
-						Name:      ac.options.ServiceName,
-					},
-					CABundle: caCert,
+		Webhooks: []admissionregistrationv1beta1.Webhook{{
+			Name: ac.options.WebhookName,
+			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+				Operations: []admissionregistrationv1beta1.OperationType{
+					admissionregistrationv1beta1.Create,
+					admissionregistrationv1beta1.Update,
 				},
+				Rule: admissionregistrationv1beta1.Rule{
+					APIGroups:   []string{serving.GroupName},
+					APIVersions: []string{knativeAPIVersion},
+					Resources:   resources,
+				},
+			}},
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
+					Namespace: ac.options.ServiceNamespace,
+					Name:      ac.options.ServiceName,
+				},
+				CABundle: caCert,
 			},
-		},
+		}},
 	}
 
 	// Set the owner to our deployment

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -182,21 +182,17 @@ func TestValidConfigurationEnvChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createConfiguration(testGeneration, testConfigurationName)
 	new := createConfiguration(testGeneration, testConfigurationName)
-	new.Spec.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{
-		corev1.EnvVar{
-			Name:  envVarName,
-			Value: "different",
-		},
-	}
+	new.Spec.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{{
+		Name:  envVarName,
+		Value: "different",
+	}}
 	resp := ac.admit(testCtx, createUpdateConfiguration(&old, &new))
 	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{
-		jsonpatch.JsonPatchOperation{
-			Operation: "replace",
-			Path:      "/spec/generation",
-			Value:     2,
-		},
-	})
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/spec/generation",
+		Value:     2,
+	}})
 }
 
 func TestInvalidNewRouteNameFails(t *testing.T) {
@@ -269,21 +265,17 @@ func TestValidRouteChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createRoute(1, testRouteName)
 	new := createRoute(1, testRouteName)
-	new.Spec.Traffic = []v1alpha1.TrafficTarget{
-		v1alpha1.TrafficTarget{
-			RevisionName: testRevisionName,
-			Percent:      100,
-		},
-	}
+	new.Spec.Traffic = []v1alpha1.TrafficTarget{{
+		RevisionName: testRevisionName,
+		Percent:      100,
+	}}
 	resp := ac.admit(testCtx, createUpdateRoute(&old, &new))
 	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{
-		jsonpatch.JsonPatchOperation{
-			Operation: "replace",
-			Path:      "/spec/generation",
-			Value:     2,
-		},
-	})
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/spec/generation",
+		Value:     2,
+	}})
 }
 
 func TestValidNewRevisionObject(t *testing.T) {
@@ -301,18 +293,15 @@ func TestValidNewRevisionObject(t *testing.T) {
 	req.Object.Raw = marshaled
 	resp := ac.admit(testCtx, req)
 	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{
-		jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      "/spec/generation",
-			Value:     1,
-		},
-		jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      "/spec/servingState",
-			Value:     v1alpha1.RevisionServingStateActive,
-		},
-	})
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/generation",
+		Value:     1,
+	}, {
+		Operation: "add",
+		Path:      "/spec/servingState",
+		Value:     v1alpha1.RevisionServingStateActive,
+	}})
 }
 
 func TestValidRevisionUpdates(t *testing.T) {
@@ -339,13 +328,11 @@ func TestValidRevisionUpdates(t *testing.T) {
 	req.Object.Raw = marshaled
 	resp := ac.admit(testCtx, req)
 	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{
-		jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      "/spec/generation",
-			Value:     1,
-		},
-	})
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/generation",
+		Value:     1,
+	}})
 }
 
 func TestInvalidRevisionUpdate(t *testing.T) {
@@ -435,21 +422,17 @@ func TestValidServiceEnvChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createServicePinned(testGeneration, testServiceName)
 	new := createServicePinned(testGeneration, testServiceName)
-	new.Spec.Pinned.Configuration.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{
-		corev1.EnvVar{
-			Name:  envVarName,
-			Value: "different",
-		},
-	}
+	new.Spec.Pinned.Configuration.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{{
+		Name:  envVarName,
+		Value: "different",
+	}}
 	resp := ac.admit(testCtx, createUpdateService(&old, &new))
 	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{
-		jsonpatch.JsonPatchOperation{
-			Operation: "replace",
-			Path:      "/spec/generation",
-			Value:     2,
-		},
-	})
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/spec/generation",
+		Value:     2,
+	}})
 }
 
 func TestValidWebhook(t *testing.T) {
@@ -468,13 +451,11 @@ func TestUpdatingWebhook(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ac.options.WebhookName,
 		},
-		Webhooks: []admissionregistrationv1beta1.Webhook{
-			{
-				Name:         ac.options.WebhookName,
-				Rules:        []admissionregistrationv1beta1.RuleWithOperations{{}},
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{},
-			},
-		},
+		Webhooks: []admissionregistrationv1beta1.Webhook{{
+			Name:         ac.options.WebhookName,
+			Rules:        []admissionregistrationv1beta1.RuleWithOperations{{}},
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{},
+		}},
 	}
 
 	createDeployment(ac)
@@ -706,13 +687,11 @@ func createRoute(generation int64, routeName string) v1alpha1.Route {
 		},
 		Spec: v1alpha1.RouteSpec{
 			Generation: generation,
-			Traffic: []v1alpha1.TrafficTarget{
-				v1alpha1.TrafficTarget{
-					Name:         "test-traffic-target",
-					RevisionName: testRevisionName,
-					Percent:      100,
-				},
-			},
+			Traffic: []v1alpha1.TrafficTarget{{
+				Name:         "test-traffic-target",
+				RevisionName: testRevisionName,
+				Percent:      100,
+			}},
 		},
 	}
 }


### PR DESCRIPTION
`gofmt -s` on `pkg/webhook`, collapsing list syntax, and other trivial cleanups to try and reduce excessive indentation.