### PR TITLE
Disallow lifecycle hooks for user containers

### DIFF
--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -118,6 +118,9 @@ func validateContainer(container corev1.Container) error {
 	if len(container.VolumeMounts) > 0 {
 		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.volumeMounts")
 	}
+	if container.Lifecycle != nil {
+		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.lifecycle")
+	}
 	if len(ignoredFields) > 0 {
 		// Complain about all ignored fields so that user can remove them all at once.
 		return errDisallowedFields(strings.Join(ignoredFields, ", "))

--- a/pkg/webhook/configuration_test.go
+++ b/pkg/webhook/configuration_test.go
@@ -133,6 +133,7 @@ func TestUnwantedFieldInContainerNotAllowed(t *testing.T) {
 			MountPath: "mount/path",
 			Name:      "name",
 		}},
+		Lifecycle: &corev1.Lifecycle{},
 	}
 	configuration := v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -153,6 +154,7 @@ func TestUnwantedFieldInContainerNotAllowed(t *testing.T) {
 		"revisionTemplate.spec.container.resources",
 		"revisionTemplate.spec.container.ports",
 		"revisionTemplate.spec.container.volumeMounts",
+		"revisionTemplate.spec.container.lifecycle",
 	}
 	expected := fmt.Sprintf("The configuration spec must not set the field(s): %s", strings.Join(unwanted, ", "))
 	if err := ValidateConfiguration(testCtx)(nil, &configuration, &configuration); err == nil || err.Error() != expected {


### PR DESCRIPTION
[#687](https://github.com/knative/serving/issues/687)

Co-authored-by: Tanzeeb Khalili <tkhalili@pivotal.io>

Fixes #687 


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
