### PR TITLE
Add test coverage for webhook(cert file) pkg

### DIFF
--- a/pkg/webhook/certs_test.go
+++ b/pkg/webhook/certs_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Pivotal Software, Inc. All Rights Reserved.
+Copyright 2018 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
## Proposed Changes

  * Added test coverage to certs file under webhook package
  * I will follow up with another PR for webhook.go file test coverage.
  * Corresponding [issue](https://github.com/knative/serving/issues/1255)
## Questions
  * Do you have any recommendations or patterns on testing this type of file(Very thin wrapper around Go functions)?



