### PR TITLE
Rename namespace to knative-serving

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,7 +139,7 @@ ko apply -f config/
 
 You can see things running with:
 ```shell
-kubectl -n knative-serving-system get pods
+kubectl -n knative-serving get pods
 NAME                                READY     STATUS    RESTARTS   AGE
 controller-77897cc687-vp27q   1/1       Running   0          16s
 webhook-5cb5cfc667-k7mcg      1/1       Running   0          16s
@@ -148,7 +148,7 @@ webhook-5cb5cfc667-k7mcg      1/1       Running   0          16s
 You can access the Knative Serving Controller's logs with:
 
 ```shell
-kubectl -n knative-serving-system logs $(kubectl -n knative-serving-system get pods -l app=controller -o name)
+kubectl -n knative-serving logs $(kubectl -n knative-serving get pods -l app=controller -o name)
 ```
 
 If you're using a GCP project to host your Kubernetes cluster, it's good to check the

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -15,6 +15,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: knative-serving-system
+  name: knative-serving
   labels:
     istio-injection: enabled

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -16,11 +16,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller
-  namespace: knative-serving-system
+  namespace: knative-serving
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: autoscaler
-  namespace: knative-serving-system
+  namespace: knative-serving
 

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: controller
-    namespace: knative-serving-system
+    namespace: knative-serving
 roleRef:
   kind: ClusterRole
   name: knative-serving-admin
@@ -32,7 +32,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: autoscaler
-    namespace: knative-serving-system
+    namespace: knative-serving
 roleRef:
   kind: ClusterRole
   name: knative-serving-write

--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: activator-service
-  namespace: knative-serving-system
+  namespace: knative-serving
   labels:
     app: activator
 spec:

--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: controller
   name: controller
-  namespace: knative-serving-system
+  namespace: knative-serving
 spec:
   ports:
   - name: metrics

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     role: webhook
   name: webhook
-  namespace: knative-serving-system
+  namespace: knative-serving
 spec:
   ports:
     - port: 443

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: activator
-  namespace: knative-serving-system
+  namespace: knative-serving
 spec:
   # TODO: Increase the replicas
   # https://github.com/knative/serving/issues/695

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-autoscaler
-  namespace: knative-serving-system
+  namespace: knative-serving
 data:
   # Static parameters:
 

--- a/config/config-domain.yaml
+++ b/config/config-domain.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-domain
-  namespace: knative-serving-system
+  namespace: knative-serving
 data:
   # These are example settings of domain.
   # prod-domain.com will be used for routes having app=prod.

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
-  namespace: knative-serving-system
+  namespace: knative-serving
 data:
   # Common configuration for all Knative codebase
   zap-logger-config: |

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-network
-  namespace: knative-serving-system
+  namespace: knative-serving
 data:
   # Specifies the IP ranges that Istio sidecar will intercept.
   # Replace this with the IP ranges of your cluster (see below for some examples).

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: knative-serving-system
+  namespace: knative-serving
 data:
   # LOGGING CONFIGURATION
 

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: controller
-  namespace: knative-serving-system
+  namespace: knative-serving
 spec:
   replicas: 1
   template:

--- a/config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml
+++ b/config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml
@@ -80,10 +80,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"knative-serving-system\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"knative-serving\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "knative-serving-system",
+              "legendFormat": "knative-serving",
               "refId": "A"
             },
             {
@@ -205,10 +205,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"knative-serving-system\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"knative-serving\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "knative-serving-system",
+              "legendFormat": "knative-serving",
               "refId": "A"
             },
             {
@@ -330,7 +330,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace!~\"knative-serving-system|monitoring|build-system|istio-system|kube-system|kube-public|^$\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace!~\"knative-serving|monitoring|build-system|istio-system|kube-system|kube-public|^$\"}[1m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -338,7 +338,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"knative-serving-system|monitoring|build-system|istio-system|kube-system|kube-public\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"knative-serving|monitoring|build-system|istio-system|kube-system|kube-public\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Control plane",
@@ -421,7 +421,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace!~\"knative-serving-system|monitoring|build-system|istio-system|kube-system|kube-public|^$\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace!~\"knative-serving|monitoring|build-system|istio-system|kube-system|kube-public|^$\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -429,7 +429,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=~\"knative-serving-system|monitoring|build-system|istio-system|kube-system|kube-public\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace=~\"knative-serving|monitoring|build-system|istio-system|kube-system|kube-public\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Control plane",

--- a/config/monitoring/200-common/300-prometheus/100-scrape-config.yaml
+++ b/config/monitoring/200-common/300-prometheus/100-scrape-config.yaml
@@ -39,7 +39,7 @@ data:
         regex: .+
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: knative-serving-system;autoscaler-port
+        regex: knative-serving;autoscaler-port
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: webhook
-  namespace: knative-serving-system
+  namespace: knative-serving
 spec:
   replicas: 1
   template:

--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -171,7 +171,7 @@ For example, use these steps to allow Minikube to pull Knative Serving and Build
 from GCR as published in our development flow (`ko apply -f config/`).
 _This is only necessary if you are not using public Knative Serving and Build images._
 
-1.  Create a Kubernetes secret in the `knative-serving-system` and `build-system` namespace:
+1.  Create a Kubernetes secret in the `knative-serving` and `build-system` namespace:
 
     ```shell
     for prefix in ela build; do

--- a/docs/resources-overview.md
+++ b/docs/resources-overview.md
@@ -19,9 +19,9 @@ There are two primary components to the Knative Serving system. The first is a c
 
 The controller processes a series of state changes in order to move the system from its current, actual state to the state desired by the user.
 
-All of the Knative Serving components are deployed into the `knative-serving-system` namespace. You can see the various objects in this namespace by running `kubectl -n knative-serving-system get all` ([minus some admin-level resources like service accounts](https://github.com/kubernetes/kubectl/issues/151)). To see only objects of a specific type, for example to see the webhook and controller deployments inside Knative Serving, you can run `kubectl -n knative-serving-system get deployments`.
+All of the Knative Serving components are deployed into the `knative-serving` namespace. You can see the various objects in this namespace by running `kubectl -n knative-serving get all` ([minus some admin-level resources like service accounts](https://github.com/kubernetes/kubectl/issues/151)). To see only objects of a specific type, for example to see the webhook and controller deployments inside Knative Serving, you can run `kubectl -n knative-serving get deployments`.
 
-The Knative Serving controller creates Kubernetes, Istio, and Build CRD resources when Knative Serving resources are created and updated. These sub-resources will be created in the same namespace as their parent Knative Serving resource, _not_ the `knative-serving-system` namespace.
+The Knative Serving controller creates Kubernetes, Istio, and Build CRD resources when Knative Serving resources are created and updated. These sub-resources will be created in the same namespace as their parent Knative Serving resource, _not_ the `knative-serving` namespace.
 
 ## Kubernetes Resource Configs
 
@@ -49,12 +49,12 @@ To view all of the custom resource definitions created, run `kubectl get customr
 
 ### Deployments
 
-View the Knative Serving specific deployments by running `kubectl -n knative-serving-system get deployments`. These deployments will ensure that the correct number of pods are running for that specific deployment.
+View the Knative Serving specific deployments by running `kubectl -n knative-serving get deployments`. These deployments will ensure that the correct number of pods are running for that specific deployment.
 
 For example, given:
 
 ```
-$ kubectl -n knative-serving-system get deployments
+$ kubectl -n knative-serving get deployments
 NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 controller   1         1         1            1           6m
 webhook      1         1         1            1           6m
@@ -63,7 +63,7 @@ webhook      1         1         1            1           6m
 Based on the desired state shown above, we expect there to be a single pod running for each of the deployments shown above. We can verify this by running and seeing similar output as shown below:
 
 ```
-$ kubectl -n knative-serving-system get pods
+$ kubectl -n knative-serving get pods
 NAME                              READY     STATUS    RESTARTS   AGE
 controller-5bfb798f96-2zjnf   1/1       Running   0          9m
 webhook-64c459569b-v5npx      1/1       Running   0          8m
@@ -73,6 +73,6 @@ Similarly, you can run the same commands in the build-crd (`build-system`) and i
 
 ### Service Accounts and RBAC policies
 
-To view the service accounts configured for Knative Serving, run `kubectl -n knative-serving-system get serviceaccounts`.
+To view the service accounts configured for Knative Serving, run `kubectl -n knative-serving get serviceaccounts`.
 
 To view all cluster role bindings, run `kubectl get clusterrolebindings`. Unfortunately there is currently no mechanism to fetch the cluster role bindings that are tied to a service account.

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -69,7 +69,7 @@ kubectl label namespace default istio-injection=enabled
 header "Installing Knative Serving"
 kubectl apply -f ${SERVING_RELEASE}
 
-wait_until_pods_running knative-serving-system
+wait_until_pods_running knative-serving
 wait_until_pods_running build-system
 
 header "Knative Serving deployed successfully to ${K8S_CLUSTER_NAME}"

--- a/hack/diagnose-me.sh
+++ b/hack/diagnose-me.sh
@@ -49,7 +49,7 @@ run_test() {
       ;;
     webhook_running)
       printf "Knative Serving webhook is installed"
-      test_cmd="kubectl get pods -n knative-serving-system -l app=webhook -o jsonpath={.items[].status.phase}"
+      test_cmd="kubectl get pods -n knative-serving -l app=webhook -o jsonpath={.items[].status.phase}"
       expected_result="Running"
       test_command "$test_cmd" "$expected_result"
       ;;
@@ -70,12 +70,12 @@ run_test() {
 
       printf "* configured with correct namespace"
       test_cmd="kubectl get mutatingwebhookconfiguration webhook.knative.dev -o jsonpath={.webhooks[].clientConfig.service.namespace}"
-      expected_result="knative-serving-system"
+      expected_result="knative-serving"
       test_command "$test_cmd" "$expected_result"
       ;;
     controllers_running)
       printf "Knative Serving controllers are running"
-      test_cmd="kubectl get pods -n knative-serving-system -l app=controller -o jsonpath={.items[].status.phase}"
+      test_cmd="kubectl get pods -n knative-serving -l app=controller -o jsonpath={.items[].status.phase}"
       expected_result="Running"
       test_command "$test_cmd" "$expected_result"
       ;;

--- a/install/CONFIG.md
+++ b/install/CONFIG.md
@@ -4,7 +4,7 @@
 
 Different domain suffixes can be configured based on the route labels.  In order
 to do this, update the config map named `config-domain` in the namespace
-`knative-serving-system`.
+`knative-serving`.
 
 In that config map, each entry maps a domain name to an equality-based label
 selector.  If your route has labels that meet all requirement of the selector it
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-domain
-  namespace: knative-serving-system
+  namespace: knative-serving
 data:
   prod.domain.com: |
     selector:

--- a/pkg/names.go
+++ b/pkg/names.go
@@ -19,5 +19,5 @@ package pkg
 // GetServingSystemNamespace returns the namespace where
 // serving controllers are deployed to.
 func GetServingSystemNamespace() string {
-	return "knative-serving-system"
+	return "knative-serving"
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -131,7 +131,7 @@ function dump_stack_info() {
   echo ">>> Ingress:"
   kubectl get ingress --all-namespaces
   echo ">>> Knative Serving controller log:"
-  kubectl logs $(get_ela_pod controller) -n knative-serving-system
+  kubectl logs $(get_ela_pod controller) -n knative-serving
   echo "***************************************"
   echo "***           TEST FAILED           ***"
   echo "***     End of information dump     ***"
@@ -323,7 +323,7 @@ create_everything
 set +o errexit
 set +o pipefail
 
-wait_until_pods_running knative-serving-system
+wait_until_pods_running knative-serving
 abort_if_failed
 
 # Ensure we have a minimum working cluster.

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -78,7 +78,7 @@ func generateTrafficBurst(clients *test.Clients, names test.ResourceNames, num i
 }
 
 func getAutoscalerConfigMap(clients *test.Clients) (*v1.ConfigMap, error) {
-	return clients.Kube.CoreV1().ConfigMaps("knative-serving-system").Get("config-autoscaler", metav1.GetOptions{})
+	return clients.Kube.CoreV1().ConfigMaps("knative-serving").Get("config-autoscaler", metav1.GetOptions{})
 }
 
 func setScaleToZeroThreshold(clients *test.Clients, threshold string) error {
@@ -87,7 +87,7 @@ func setScaleToZeroThreshold(clients *test.Clients, threshold string) error {
 		return err
 	}
 	configMap.Data["scale-to-zero-threshold"] = threshold
-	_, err = clients.Kube.CoreV1().ConfigMaps("knative-serving-system").Update(configMap)
+	_, err = clients.Kube.CoreV1().ConfigMaps("knative-serving").Update(configMap)
 	return err
 }
 

--- a/test/library.sh
+++ b/test/library.sh
@@ -99,7 +99,7 @@ function wait_until_pods_running() {
 # Returns the name of the Knative Serving pod of the given app.
 # Parameters: $1 - Knative Serving app name.
 function get_ela_pod() {
-  kubectl get pods -n knative-serving-system --selector=app=$1 --output=jsonpath="{.items[0].metadata.name}"
+  kubectl get pods -n knative-serving --selector=app=$1 --output=jsonpath="{.items[0].metadata.name}"
 }
 
 # Sets the given user as cluster admin.


### PR DESCRIPTION
Fixes #

## Proposed Changes

  *  Rename namespace to `knative-serving`
  *  using -system suffix makes sense when using a single namespace
  *  since Knative has multiple namespaces, prefer to use `knative-serving` and `knative-eventing`  

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Namespace is renamed from knative-serving-system to knative-serving
```
