### PR TITLE
Update minikube docs post rename

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -99,19 +99,33 @@ Once you reach this point you are ready to do a full build and deploy as describ
 
 ## Starting Knative Serving
 
-Once you've [setup your development environment](#getting-started), stand up `Knative Serving` with:
+Once you've [setup your development environment](#getting-started), stand up
+`Knative Serving`:
 
-### Deploy Istio
+1. [Setup cluster admin](#setup-cluster-admin)
+1. [Deploy istio](#deploy-istio)
+1. [Deploy build](#deploy-build)
+1. [Deploy Knative Serving](#deploy-knative-serving)
+1. [Enable log and metric collection](#enable-log-and-metric-collection)
+
+### Setup cluster admin
+
+Your `$K8S_USER_OVERRIDE` must be a cluster admin to perform
+the setup needed for Knative:
 
 ```shell
 kubectl create clusterrolebinding cluster-admin-binding \
   --clusterrole=cluster-admin \
   --user="${K8S_USER_OVERRIDE}"
+```
 
+### Deploy Istio
+
+```shell
 kubectl apply -f ./third_party/istio-0.8.0/istio.yaml
 ```
 
-Then label namespaces with `istio-injection=enabled`:
+Optionally label namespaces with `istio-injection=enabled`:
 
 ```shell
 kubectl label namespace default istio-injection=enabled


### PR DESCRIPTION
The docs for setting up minikube were using the namespaces and
resource names from elafros instead of knative. The naming changed
slightly, e.g. a knative controller is now called `controller`
instead of `knative-serving-controller`, so one of the loops had
to be broken into 2 statements.

Added steps about redeploying pods after setting up GCR
secrets b/c there is a chicken and egg problem where the namespaces
must exist before you can setup the secrets, but the secrets must
exist before the images can be pulled.

The PR that enabled `MutatingAdmissionWebhook` by default
(kubernetes/minikube#2547) was merged, but
the latest minikube (0.28.0) still did not enable this option
by default b/c providing any arugments overrides all of the defaults,
so we must still set it explicitly.

Made it clear in the setting up knative serving docs that the cluster
admin binding is required, not just for istio.

## Proposed Changes

  * Update minikube and GCR for minikube docs

```release-note
NONE
```
