### PR TITLE
Increase timeouts for conformance tests

### DIFF
--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	interval = 1 * time.Second
-	timeout  = 2 * time.Minute
+	timeout  = 5 * time.Minute
 )
 
 // WaitForRouteState polls the status of the Route called name from client every

--- a/test/request.go
+++ b/test/request.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	requestInterval = 1 * time.Second
-	requestTimeout  = 1 * time.Minute
+	requestTimeout  = 5 * time.Minute
 )
 
 func waitForRequestToDomainState(address string, spoofDomain string, retryableCodes []int, inState func(body string) (bool, error)) error {


### PR DESCRIPTION
About 25% of the time the conformance tests take more than 2 minutes to finish, and thus fail (the test timeout is currently 2 minutes). This is a source of flakiness for these tests.

At this point I don't know if this is Knative fault ("too slow") or the test's fault ("too optimistic"). At some point back in time, 2 minutes probably was more than enough time for the tests to run (the author even mentioned that the tests were slow, because they were taking about 1 minute to run).

In any case, this should reduce the test flakiness and help us focus or spot other sources of flakiness until the right solution is in place.

Note that this is a temporary workaround, until https://github.com/knative/serving/issues/1273 is properly closed.