### PR TITLE
Don't fail fast when running all presubmit tests

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,9 +21,6 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
-set -o errexit
-set -o pipefail
-
 # Extensions or file patterns that don't require presubmit tests
 readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS)
 


### PR DESCRIPTION
Now that all individual test results are reported (#1154), we want `presubmit-tests.sh` to really run all tests unless specified otherwise, so we get all results in http://testgrid/knative-serving#continuous.