### PR TITLE
Add support for emitting metrics from tests.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -48,11 +48,27 @@ go test -v -tags=e2e -count=1 ./test/conformance
 go test -v -tags=e2e -count=1 ./test/e2e
 ```
 
+### One test case
+
 To run one e2e test case, e.g. TestAutoscaleUpDownUp, use [the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e -run ^TestAutoscaleUpDownUp$
 ```
+
+### Environment requirements
+
+These tests require:
+
+1. [A running `Knative Serving` cluster.](/DEVELOPMENT.md#getting-started)
+2. The namespaces `pizzaplanet` and `noodleburg`:
+    ```bash
+    kubectl create namespace pizzaplanet
+    kubectl create namespace noodleburg
+    ```
+3. A docker repo containing [the test images](#test-images)
+
+### Flags
 
 * By default the e2e tests against the current cluster in `~/.kube/config`
   using the environment specified in [your environment variables](/DEVELOPMENT.md#environment-setup).
@@ -77,18 +93,6 @@ your only option is to use a domain which will resolve to the IP of the running 
 go test -v -tags=e2e -count=1 ./test/conformance --resolvabledomain
 go test -v -tags=e2e -count=1 ./test/e2e --resolvabledomain
 ```
-
-### Environment requirements
-
-These tests require:
-
-1. [A running `Knative Serving` cluster.](/DEVELOPMENT.md#getting-started)
-2. The namespaces `pizzaplanet` and `noodleburg`:
-    ```bash
-    kubectl create namespace pizzaplanet
-    kubectl create namespace noodleburg
-    ```
-3. A docker repo containing [the test images](#test-images)
 
 ## Test images
 
@@ -132,7 +136,8 @@ Tests importing [`github.com/knative/serving/test`](adding_tests.md#test-library
 * [`--cluster`](#specifying-cluster)
 * [`--dockerrepo`](#overriding-docker-repo)
 * [`--resolvabledomain`](#using-a-resolvable-domain)
-* [`--logverbose`](#output-verbose-log)
+* [`--logverbose`](#output-verbose-logs)
+* [`--emitmetrics`](#emit-metrics)
 
 ### Specifying kubeconfig
 
@@ -166,7 +171,7 @@ The current cluster names can be obtained by running:
 kubectl config get-clusters
 ```
 
-#### Overridding docker repo
+### Overridding docker repo
 
 The `--dockerrepo` argument lets you specify the docker repo from which images used
 by your tests should be pulled. This will default to the value
@@ -178,7 +183,7 @@ go test -v -tags=e2e -count=1 ./test/conformance --dockerrepo gcr.myhappyproject
 go test -v -tags=e2e -count=1 ./test/e2e --dockerrepo gcr.myhappyproject
 ```
 
-#### Using a resolvable domain
+### Using a resolvable domain
 
 If you set up your cluster using [the getting started
 docs](/DEVELOPMENT.md#getting-started), Routes created in the test will
@@ -192,10 +197,18 @@ If you have configured your cluster to use a resolvable domain, you can use the
 `--resolvabledomain` flag to indicate that the test should make requests directly against
 `Route.Status.Domain` and does not need to spoof the `Host`.
 
-#### Output verbose log
+### Output verbose logs
 
 The `--logverbose` argument lets you see verbose test logs and k8s logs.
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e --logverbose
 ```
+
+### Emit metrics
+
+Running tests with the `--emitmetrics` argument will cause latency metrics to be emitted by
+the tests.
+
+* To add additional metrics to a test, see [emitting metrics](adding_tests.md#emit-metrics).
+* For more info on the format of the metrics, see [metric format](adding_tests.md#metric-format).

--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -24,7 +24,8 @@ you can use in your tests.
 You can:
 
 * [Use common test flags](#use-common-test-flags)
-* [Output log](#output-log)
+* [Output logs](#output-logs)
+* [Emit metrics](#emit-metrics)
 * [Get access to client objects](#get-access-to-client-objects)
 * [Make requests against deployed services](#make-requests-against-deployed-services)
 * [Check Knative Serving resources](#check-knative-serving-resources)
@@ -46,26 +47,75 @@ imagePath := strings.Join([]string{test.Flags.DockerRepo, image}, "/"))
 
 _See [e2e_flags.go](./e2e_flags.go)._
 
-### Output log
+### Output logs
+
+[When tests are run with `--logverbose`
+option](README.md#output-verbose-logs), debug logs will be emitted to stdout.
 
 We are using [Knative logging library](/pkg/logging) for structured logging, it is built on top of [zap](https://github.com/uber-go/zap).
-All test case should define its own logger with test case name as logger name, and pass it around; this way, all output from the test case will be tagged by same logger name.
-Pls see below for sample code from test case [`TestHelloWorld`](./e2e/helloworld_test.go).
-
-To output debug log, use `logger.Debug()`. Pls _see [errorcondition_test.go](./e2e/errorcondition_test.go)._ for an example of `logger.Debug()` call.
-When tests are run with `--logverbose` option, debug log will show.
+Tests can initialize loggers with `test.Logger.Named`:
 
 ```go
-func TestHelloWorld(t *testing.T) {
-    clients := Setup(t)
-    //add test case specific name to its own logger
-    logger := test.Logger.Named("TestHelloWorld")
-    var imagePath string
-    imagePath = strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
-    logger.Infof("Creating a new Route and Configuration")
-    ...
-}
+// The convention is for the name of the logger to match the name
+// of the test.
+logger := test.Logger.Named("TestHelloWorld")
 ```
+
+Logs can then be emitted using the `logger` object which is required by
+many functions in the test library. To emit logs:
+
+```go
+logger.Infof("Creating a new Route %s and Configuration %s", route, configuration)
+logger.Debugf("The LogURL is %s, not yet verifying", logURL)
+```
+
+_See [logging.go](./logging.go)._
+
+### Emit metrics
+
+You can emit metrics from your tests using [the opencensus
+library](https://github.com/census-instrumentation/opencensus-go), which [is being
+used inside Knative as well](/docs/telemetry.md). These metrics will be emitted by
+the test if the test is run with [the `--emitmetrics` option](README.md#emit-metrics).
+
+You can record arbitrary metrics with
+[`stats.Record`](https://github.com/census-instrumentation/opencensus-go#stats) or
+measure latency with [`trace.StartSpan`](https://github.com/census-instrumentation/opencensus-go#traces):
+
+```go
+ctx, span := trace.StartSpan(context.Background(), "MyMetric")
+```
+
+* These traces will be emitted automatically by [the generic crd polling
+  functions](#check-knative-serving-resources).
+* The traces are emitted by [a custom metric exporter](./logging.go)
+  that uses the global logger instance.
+
+TODO(bobcatfish): Either make the test case specific named loggers global or update the metric exporter to use the named loggers.
+
+#### Metric format
+
+When a `trace` metric is emitted, the format is `metric name startTime endTime duration`. The name
+of the metric is arbitrary and can be any string. The values are:
+
+* "metric" - Indicates this log is a metric
+* name - Arbitrary string indentifying the metric. TODO(#1379) determine metric format
+* startTime - Unix time in nanoseconds when measurement started
+* endTime - Unix time in nanoseconds when measurement ended
+* duration - The difference in ms between the startTime and endTime
+
+For example:
+
+```bash
+metric WaitForConfigurationState/prodxiparjxt/ConfigurationUpdatedWithRevision 1529980772357637397 1529980772431586609 73.949212ms
+```
+
+_The [`Wait` methods](#check-knative-serving-resources) (which poll resources) will
+prefix the metric names with the name of the function, and if applicable, the name of the resource,
+separated by `/`. In the example above, `WaitForConfigurationState` is the name of
+the function, and `prodxiparjxt` is the name of the configuration resource being polled.
+`ConfigurationUpdatedWithRevision` is the string passed to `WaitForConfigurationState` by
+the caller to identify what state is being polled for._
 
 ### Get access to client objects
 
@@ -152,8 +202,10 @@ err := test.WaitForConfigurationState(clients.Configs, configName, func(c *v1alp
         return true, nil
     }
     return false, nil
-})
+}, "ConfigurationUpdatedWithRevision")
 ```
+
+_[Metrics will be emitted](#emit-metrics) for these `Wait` method tracking how long test poll for._
 
 We also have `Check*` variants of many of these methods with identical signatures, same example:
 
@@ -168,11 +220,11 @@ err := test.CheckConfigurationState(clients.Configs, configName, func(c *v1alpha
 })
 ```
 
-_See [crd_checks.go](./crd_checks.go)._
+_See [crd_checks.go](./crd_checks.go) and [kube_checks.go](./kube_checks.go)._
 
 ### Verify resource state transitions
 
-To use the [polling functions](#poll-knative-serving-resources) you must provide a function to check the
+To use the [check functions](#check-knative-serving-resources) you must provide a function to check the
 state. Some of the expected transition states (as defined in [the Knative Serving spec](/docs/spec/spec.md))
 are expressed in functions in [states.go](./states.go).
 

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -19,9 +19,10 @@ package conformance
 
 import (
 	"fmt"
-	"go.uber.org/zap"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
 
 	"encoding/json"
 
@@ -78,7 +79,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 		} else {
 			return cond.Status == corev1.ConditionTrue, nil
 		}
-	})
+	}, "RouteIsReady")
 	if err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic to Revision %s: %v", names.Route, names.Revision, err)
 	}
@@ -91,7 +92,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 	}
 	err = test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, updatedRoute.Status.Domain, namespaceName, names.Route, func(body string) (bool, error) {
 		return body == expectedText, nil
-	})
+	}, "WaitForEndpointToServeText")
 	if err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, updatedRoute.Status.Domain, expectedText, err)
 	}
@@ -124,7 +125,7 @@ func getNextRevisionName(clients *test.Clients, names test.ResourceNames) (strin
 			return true, nil
 		}
 		return false, nil
-	})
+	}, "ConfigurationUpdatedWithRevision")
 	return newRevisionName, err
 }
 

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -19,11 +19,13 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	elatyped "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	"go.opencensus.io/trace"
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -37,8 +39,13 @@ const (
 
 // WaitForRouteState polls the status of the Route called name from client every
 // interval until inState returns `true` indicating it is done, returns an
-// error or timeout.
-func WaitForRouteState(client elatyped.RouteInterface, name string, inState func(r *v1alpha1.Route) (bool, error)) error {
+// error or timeout. desc will be used to name the metric that is emitted to
+// track how long it took for name to get into the state checked by inState.
+func WaitForRouteState(client elatyped.RouteInterface, name string, inState func(r *v1alpha1.Route) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForRouteState/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		r, err := client.Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -66,8 +73,13 @@ func CheckRouteState(client elatyped.RouteInterface, name string, inState func(r
 
 // WaitForConfigurationState polls the status of the Configuration called name
 // from client every interval until inState returns `true` indicating it
-// is done, returns an error or timeout.
-func WaitForConfigurationState(client elatyped.ConfigurationInterface, name string, inState func(c *v1alpha1.Configuration) (bool, error)) error {
+// is done, returns an error or timeout. desc will be used to name the metric
+// that is emitted to track how long it took for name to get into the state checked by inState.
+func WaitForConfigurationState(client elatyped.ConfigurationInterface, name string, inState func(c *v1alpha1.Configuration) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForConfigurationState/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		c, err := client.Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -95,8 +107,13 @@ func CheckConfigurationState(client elatyped.ConfigurationInterface, name string
 
 // WaitForRevisionState polls the status of the Revision called name
 // from client every interval until inState returns `true` indicating it
-// is done, returns an error or timeout.
-func WaitForRevisionState(client elatyped.RevisionInterface, name string, inState func(r *v1alpha1.Revision) (bool, error)) error {
+// is done, returns an error or timeout. desc will be used to name the metric
+// that is emitted to track how long it took for name to get into the state checked by inState.
+func WaitForRevisionState(client elatyped.RevisionInterface, name string, inState func(r *v1alpha1.Revision) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForRevision/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		r, err := client.Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -124,8 +141,13 @@ func CheckRevisionState(client elatyped.RevisionInterface, name string, inState 
 
 // WaitForIngressState polls the status of the Ingress called name
 // from client every interval until inState returns `true` indicating it
-// is done, returns an error or timeout.
-func WaitForIngressState(client v1beta1.IngressInterface, name string, inState func(r *apiv1beta1.Ingress) (bool, error)) error {
+// is done, returns an error or timeout. desc will be used to name the metric
+// that is emitted to track how long it took for name to get into the state checked by inState.
+func WaitForIngressState(client v1beta1.IngressInterface, name string, inState func(r *apiv1beta1.Ingress) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForIngressState/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		i, err := client.Get(name, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -18,14 +18,15 @@ limitations under the License.
 package e2e
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	"go.uber.org/zap"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"testing"
 )
 
 const (
@@ -66,7 +67,8 @@ func generateTrafficBurst(clients *test.Clients, logger *zap.SugaredLogger, name
 				domain,
 				NamespaceName,
 				names.Route,
-				isExpectedOutput())
+				isExpectedOutput(),
+				"MakingConcurrentRequests")
 			concurrentRequests <- true
 		}()
 	}
@@ -135,7 +137,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		names.Route,
 		func(r *v1alpha1.Route) (bool, error) {
 			return r.Status.IsReady(), nil
-		})
+		}, "RouteIsReady")
 	if err != nil {
 		t.Fatalf(`The Route %s was not marked as Ready to serve traffic:
 			 %v`, names.Route, err)
@@ -162,7 +164,8 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		domain,
 		NamespaceName,
 		names.Route,
-		isExpectedOutput())
+		isExpectedOutput(),
+		"CheckingEndpointAfterUpdating")
 	if err != nil {
 		t.Fatalf(`The endpoint for Route %s at domain %s didn't serve
 			 the expected text \"%v\": %v`,
@@ -175,7 +178,8 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	err = test.WaitForDeploymentState(
 		clients.Kube.ExtensionsV1beta1().Deployments(NamespaceName),
 		deploymentName,
-		isDeploymentScaledUp())
+		isDeploymentScaledUp(),
+		"DeploymentIsScaledUp")
 	if err != nil {
 		logger.Fatalf(`Unable to observe the Deployment named %s scaling
 			   up. %s`, deploymentName, err)
@@ -196,7 +200,8 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	err = test.WaitForDeploymentState(
 		clients.Kube.ExtensionsV1beta1().Deployments(NamespaceName),
 		deploymentName,
-		isDeploymentScaledToZero())
+		isDeploymentScaledToZero(),
+		"DeploymentScaledToZero")
 	if err != nil {
 		logger.Fatalf(`Unable to observe the Deployment named %s scaling
 		           down. %s`, deploymentName, err)
@@ -210,7 +215,8 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		pc,
 		func(p *v1.PodList) (bool, error) {
 			return len(p.Items) == 0, nil
-		})
+		},
+		"WaitForAvailablePods")
 
 	logger.Infof("Scaled down, resetting ScaleToZeroThreshold.")
 	setScaleToZeroThreshold(clients, initialScaleToZeroThreshold)
@@ -220,7 +226,8 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	err = test.WaitForDeploymentState(
 		clients.Kube.ExtensionsV1beta1().Deployments(NamespaceName),
 		deploymentName,
-		isDeploymentScaledUp())
+		isDeploymentScaledUp(),
+		"DeploymentScaledUp")
 	if err != nil {
 		logger.Fatalf(`Unable to observe the Deployment named %s scaling
 			   up. %s`, deploymentName, err)

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -20,13 +20,14 @@ package e2e
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/google/go-containerregistry/v1/remote"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"testing"
 )
 
 const (
@@ -71,7 +72,7 @@ func TestContainerErrorMsg(t *testing.T) {
 			return true, errors.New(s)
 		}
 		return false, nil
-	})
+	}, "ContainerImageNotPresent")
 
 	if err != nil {
 		t.Fatalf("Failed to validate configuration state: %s", err)
@@ -93,7 +94,7 @@ func TestContainerErrorMsg(t *testing.T) {
 				revisionName, containerMissing, manifestUnknown, cond.Reason, cond.Message)
 		}
 		return false, nil
-	})
+	}, "ImagePathInvalid")
 
 	if err != nil {
 		t.Fatalf("Failed to validate revision state: %s", err)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -18,12 +18,13 @@ limitations under the License.
 package e2e
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"testing"
 )
 
 const (
@@ -60,7 +61,7 @@ func TestHelloWorld(t *testing.T) {
 		} else {
 			return cond.Status == corev1.ConditionTrue, nil
 		}
-	})
+	}, "RouteIsReady")
 	if err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
 	}
@@ -70,7 +71,7 @@ func TestHelloWorld(t *testing.T) {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 	domain := route.Status.Domain
-	err = test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, domain, NamespaceName, names.Route, isHelloWorldExpectedOutput())
+	err = test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, domain, NamespaceName, names.Route, isHelloWorldExpectedOutput(), "HelloWorldServesText")
 	if err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -3,9 +3,7 @@ Copyright 2018 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,12 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// kube_polling contains functions which poll Kubernetes objects until
+// kube_checks contains functions which poll Kubernetes objects until
 // they get into the state desired by the caller or time out.
 
 package test
 
 import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/trace"
 	corev1 "k8s.io/api/core/v1"
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,9 +31,13 @@ import (
 
 // WaitForDeploymentState polls the status of the Deployment called name
 // from client every interval until inState returns `true` indicating it
-// is done, returns an error or timeout.
-func WaitForDeploymentState(client v1beta1.DeploymentInterface, name string,
-	inState func(d *apiv1beta1.Deployment) (bool, error)) error {
+// is done, returns an error or timeout. desc will be used to name the metric
+// that is emitted to track how long it took for name to get into the state checked by inState.
+func WaitForDeploymentState(client v1beta1.DeploymentInterface, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		d, err := client.Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -43,9 +49,13 @@ func WaitForDeploymentState(client v1beta1.DeploymentInterface, name string,
 
 // WaitForPodListState polls the status of the PodList
 // from client every interval until inState returns `true` indicating it
-// is done, returns an error or timeout.
-func WaitForPodListState(client v1.PodInterface,
-	inState func(p *corev1.PodList) (bool, error)) error {
+// is done, returns an error or timeout. desc will be used to name the metric
+// that is emitted to track how long it took to get into the state checked by inState.
+func WaitForPodListState(client v1.PodInterface, inState func(p *corev1.PodList) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForPodListState/%s", desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		p, err := client.List(metav1.ListOptions{})
 		if err != nil {

--- a/test/logging.go
+++ b/test/logging.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// logging.go contains the logic to configure and interact with the
+// logging and metrics libraries.
+
+package test
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/knative/serving/pkg/logging"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
+)
+
+const (
+	// VerboseLogLevel defines verbose log level as 10
+	VerboseLogLevel glog.Level = 10
+
+	// 1 second was chosen arbitrarily
+	metricViewReportingPeriod = 1 * time.Second
+)
+
+// Logger is to be used by test cases for logging and is also used
+// for emitting metrics.
+var Logger *zap.SugaredLogger
+
+// ZapMetricExporter is a stats and trace exporter that logs the
+// exported data to the provided (probably test specific) zap logger.
+// It conforms to the view.Exporter and trace.Exporter interfaces.
+type ZapMetricExporter struct {
+	logger *zap.SugaredLogger
+}
+
+// ExportView will emit the view data vd (i.e. the stats that have been
+// recorded) to the zap logger.
+func (e *ZapMetricExporter) ExportView(vd *view.Data) {
+	// We are not curretnly consuming these metrics, so for now we'll juse
+	// dump the view.Data object as is.
+	e.logger.Info(vd)
+}
+
+// ExportSpan will emit the trace data to the zap logger.
+func (e *ZapMetricExporter) ExportSpan(vd *trace.SpanData) {
+	duration := vd.EndTime.Sub(vd.StartTime)
+	// We will start the log entry with `metric` to identify it as a metric for parsing
+	e.logger.Infof("metric %s %d %d %s", vd.Name, vd.StartTime.UnixNano(), vd.EndTime.UnixNano(), duration)
+}
+
+func newLogger(logLevel string) *zap.SugaredLogger {
+	configJSONTemplate := `{
+	  "level": "%s",
+	  "encoding": "console",
+	  "outputPaths": ["stdout"],
+	  "errorOutputPaths": ["stderr"],
+	  "encoderConfig": {
+	    "messageKey": "message",
+			"levelKey": "level",
+			"nameKey": "logger",
+			"callerKey": "caller",
+			"messageKey": "msg",
+      "stacktraceKey": "stacktrace",
+      "lineEnding": "",
+      "levelEncoder": "",
+      "timeEncoder": "",
+      "durationEncoder": "",
+      "callerEncoder": ""
+	  }
+	}`
+	configJSON := fmt.Sprintf(configJSONTemplate, logLevel)
+	return logging.NewLogger(string(configJSON), logLevel)
+}
+
+func initializeMetricExporter() {
+	exporter := &ZapMetricExporter{logger: Logger}
+	view.RegisterExporter(exporter)
+	trace.RegisterExporter(exporter)
+
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	view.SetReportingPeriod(metricViewReportingPeriod)
+}
+
+func initializeLogger(logVerbose bool) {
+	logLevel := "info"
+	if logVerbose {
+		// Both gLog and "go test" use -v flag. The code below is a work around so that we can still set v value for gLog
+		flag.StringVar(&logLevel, "logLevel", fmt.Sprint(VerboseLogLevel), "verbose log level")
+		flag.Lookup("v").Value.Set(logLevel)
+		glog.Infof("Logging set to verbose mode with logLevel %d", VerboseLogLevel)
+
+		logLevel = "debug"
+	}
+	Logger = newLogger(logLevel)
+}

--- a/test/request.go
+++ b/test/request.go
@@ -18,15 +18,18 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"io/ioutil"
+	"net/http"
+	"time"
+
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"net/http"
-	"time"
 )
 
 const (
@@ -70,8 +73,14 @@ func waitForRequestToDomainState(logger *zap.SugaredLogger, address string, spoo
 
 // WaitForEndpointState will poll an endpoint until inState indicates the state is achieved. If resolvableDomain
 // is false, it will use kubeClientset to look up the ingress (named based on routeName) in the namespace namespaceName,
-// and spoof domain in the request heaers, otherwise it will make the request directly to domain.
-func WaitForEndpointState(kubeClientset *kubernetes.Clientset, logger *zap.SugaredLogger, resolvableDomain bool, domain string, namespaceName string, routeName string, inState func(body string) (bool, error)) error {
+// and spoof domain in the request headers, otherwise it will make the request directly to domain.
+// desc will be used to name the metric that is emitted to track how long it took for the domain to get into the state checked by inState.
+// Commas in `desc` must be escaped.
+func WaitForEndpointState(kubeClientset *kubernetes.Clientset, logger *zap.SugaredLogger, resolvableDomain bool, domain string, namespaceName string, routeName string, inState func(body string) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForEndpointState/%s", desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
 	var endpoint, spoofDomain string
 
 	// If the domain that the Route controller is configured to assign to Route.Status.Domain


### PR DESCRIPTION
We want to track latency over time by emitting this information from
our end to end tests.

In this change we use opencensus metric collection to collect and
export metrics to the zap logger. The `Wait` (aka polling) functions
used by the end to end tests will automatically emit these metrics,
identified by a string provided by the caller.

These metrics will be emitted if an end to end test is run with
`--emitmetrics`.

Some choices made in this implementation, which I'd be very interested
to hear some opinions about:
* The metric tracker is global, effectively making the logger global,
  which is contrary to the current logger interface (it must be
  passed around)
* The fact that the caller can provide any string is a bit weird,
  but also the metric is not meaningful without some context.

Fixes #1008 

```release-note
NONE
```
