### PR TITLE
Also build stuff in //test in presubmit-tests.sh

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -38,7 +38,8 @@ function cleanup() {
 
 function build_tests() {
   header "Running build tests"
-  go build ./cmd/... ./sample/... ./pkg/... ./test/...
+  go build ./cmd/... ./sample/... ./pkg/...
+  go build -tags=e2e ./test/...
   # kubekins images don't have dep installed by default
   go get -u github.com/golang/dep/cmd/dep
   ./hack/verify-codegen.sh


### PR DESCRIPTION
Let's avoid errors like https://gubernator-internal.googleplex.com/build/ela-prow/pr-logs/pull/knative_serving/1349/pull-knative-serving-integration-tests/880/