### PR TITLE
Stop helloworld sample logging readiness probe requests (#1353)

### DIFF
--- a/sample/helloworld/sample.yaml
+++ b/sample/helloworld/sample.yaml
@@ -31,8 +31,7 @@ spec:
           - name: TARGET
             value: shiniestnewestversion
         readinessProbe:
-          httpGet:
-            path: /
+          tcpSocket:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3


### PR DESCRIPTION
* Replace HTTP readiness probe with TCP readiness probe

Fixes #1353 

## Proposed Changes

  * Replace helloworld sample's HTTP readiness probe with a TCP readiness probe
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
