### PR TITLE
README update on how to set up DNS

### DIFF
--- a/sample/helloworld/README.md
+++ b/sample/helloworld/README.md
@@ -166,7 +166,7 @@ data:
 2. Apply updated domain configuration.
 
   ```shell
-  ko apply -f config/
+  kubectl apply -f config/config-domain.yaml
   ```
 
 3. [Deploy app normally](#Setup). When the ingress is ready, you'll see customized domain in HOSTS field together with assigned IP address.


### PR DESCRIPTION
Fixes #562

Added content on how to set up DNS for custom domain deployment. 
Starting with HelloWorld app, once I get feedback on the content, we can add referencing links to rest of sample app. 