### PR TITLE
Do not log in log library

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -103,7 +103,11 @@ func (a *activationHandler) handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	logger := logging.NewLoggerFromDefaultConfigMap("loglevel.activator").Named("activator")
+
+	var logger *zap.SugaredLogger
+	if logger, err := logging.NewDefaultConfigMapLogger(logging.DefaultLoggingConfigPath, "activator"); err != nil {
+		logger.Errorf("Error initializing logger: %s", err)
+	}
 	defer logger.Sync()
 
 	logger.Info("Starting the knative activator")

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -230,7 +230,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	logger = logging.NewLoggerFromDefaultConfigMap("loglevel.autoscaler").Named("autoscaler")
+
+	var logger *zap.SugaredLogger
+	if logger, err := logging.NewDefaultConfigMapLogger(logging.DefaultLoggingConfigPath, "autoscaler"); err != nil {
+		logger.Errorf("Error initializing logger: %s", err)
+	}
 	defer logger.Sync()
 
 	initEnv()

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/knative/serving/pkg"
 	"github.com/knative/serving/pkg/configmap"
+	"go.uber.org/zap"
 
 	"github.com/josephburnett/k8sflag/pkg/k8sflag"
 	"github.com/knative/serving/pkg/controller"
@@ -76,7 +77,11 @@ var (
 
 func main() {
 	flag.Parse()
-	logger := logging.NewLoggerFromDefaultConfigMap("loglevel.controller").Named("controller")
+
+	var logger *zap.SugaredLogger
+	if logger, err := logging.NewDefaultConfigMapLogger(logging.DefaultLoggingConfigPath, "controller"); err != nil {
+		logger.Errorf("Error initializing logger: %s", err)
+	}
 	defer logger.Sync()
 
 	if loggingEnableVarLogCollection.Get() {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -262,9 +262,20 @@ func setupAdminHandlers(server *http.Server) {
 	server.ListenAndServe()
 }
 
+func initializeLogging() *zap.SugaredLogger {
+	configJSON := os.Getenv("SERVING_LOGGING_CONFIG")
+	levelOverride := os.Getenv("SERVING_LOGGING_LEVEL")
+	genericLogger, err := logging.NewLogger(configJSON, levelOverride)
+	logger = genericLogger.Named("queueproxy")
+	if err != nil {
+		logger.Errorf("Error initializing logger: %s", err)
+	}
+	return logger
+}
+
 func main() {
 	flag.Parse()
-	logger = logging.NewLogger(os.Getenv("SERVING_LOGGING_CONFIG"), os.Getenv("SERVING_LOGGING_LEVEL")).Named("queueproxy")
+	logger = initializeLogging()
 	defer logger.Sync()
 
 	initEnv()

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -31,7 +31,11 @@ import (
 
 func main() {
 	flag.Parse()
-	logger := logging.NewLoggerFromDefaultConfigMap("loglevel.webhook").Named("webhook")
+
+	var logger *zap.SugaredLogger
+	if logger, err := logging.NewDefaultConfigMapLogger(logging.DefaultLoggingConfigPath, "webhook"); err != nil {
+		logger.Errorf("Error initializing logger: %s", err)
+	}
 	defer logger.Sync()
 
 	logger.Info("Starting the Configuration Webhook")

--- a/test/logging.go
+++ b/test/logging.go
@@ -85,7 +85,11 @@ func newLogger(logLevel string) *zap.SugaredLogger {
 	  }
 	}`
 	configJSON := fmt.Sprintf(configJSONTemplate, logLevel)
-	return logging.NewLogger(string(configJSON), logLevel)
+	logger, err := logging.NewLogger(configJSON, logLevel)
+	if err != nil {
+		logger.Errorf("Error initializing logger: %s", err)
+	}
+	return logger
 }
 
 func initializeMetricExporter() {


### PR DESCRIPTION
Okay this is a lot repeated code, but hear me out! When you log in
a library, it means the caller has no control over whether those
logs are emitted or not - case in point, the e2e tests are using this
library, and now they dump the json config and log level at the
beginning of every test, which we don't want and can't control.

This commit changes the `logging` lib such that it's the caller's
responsibility to decide whether to log or not.

* Also open to ideas that involve less code duplication, e.g. a(nother) wrapper that logs, such that the interface includes functions which log and functions which do not log.)
* Another option is to have the e2e tests use `zap` directly instead of using the knative `logging` lib.)

This is what the test output looks like before this change, in verbose mode:
![image](https://user-images.githubusercontent.com/432502/41945037-eea1567e-795f-11e8-888c-f03246dd0a53.png)

In the default mode:
![image](https://user-images.githubusercontent.com/432502/41945055-0a19740e-7960-11e8-9da7-82d0279cad31.png)

## Proposed Changes

  * Remove code that actual logs from the log library
  * Update users of the log library to log info about initializing the logger

```release-note
NONE
```
