### PR TITLE
Update global metric logger to be contextual

### DIFF
--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -53,12 +53,11 @@ _See [e2e_flags.go](./e2e_flags.go)._
 option](README.md#output-verbose-logs), debug logs will be emitted to stdout.
 
 We are using [Knative logging library](/pkg/logging) for structured logging, it is built on top of [zap](https://github.com/uber-go/zap).
-Tests can initialize loggers with `test.Logger.Named`:
+Tests should initialize the global logger to use a test specifc context with `test.GetContextLogger`:
 
 ```go
-// The convention is for the name of the logger to match the name
-// of the test.
-logger := test.Logger.Named("TestHelloWorld")
+// The convention is for the name of the logger to match the name of the test.
+test.GetContextLogger("TestHelloWorld")
 ```
 
 Logs can then be emitted using the `logger` object which is required by
@@ -90,8 +89,6 @@ ctx, span := trace.StartSpan(context.Background(), "MyMetric")
   functions](#check-knative-serving-resources).
 * The traces are emitted by [a custom metric exporter](./logging.go)
   that uses the global logger instance.
-
-TODO(bobcatfish): Either make the test case specific named loggers global or update the metric exporter to use the named loggers.
 
 #### Metric format
 

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -150,7 +150,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	clients := setup(t)
 
 	// add test case specific name to its own logger
-	logger := test.Logger.Named("TestBlueGreenRoute")
+	logger := test.GetContextLogger("TestBlueGreenRoute")
 
 	var imagePaths []string
 	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -147,8 +147,8 @@ func tearDown(clients *test.Clients, names test.ResourceNames) {
 func TestRouteCreation(t *testing.T) {
 	clients := setup(t)
 
-	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestRouteCreation")
+	//add test case specific name to its own logger
+	logger := test.GetContextLogger("TestRouteCreation")
 
 	var imagePaths []string
 	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -126,7 +126,7 @@ func TestRunLatestService(t *testing.T) {
 	clients := setup(t)
 
 	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestRunLatestService")
+	logger := test.GetContextLogger("TestRunLatestService")
 
 	var imagePaths []string
 	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -111,8 +111,8 @@ func tearDown(clients *test.Clients, names test.ResourceNames, logger *zap.Sugar
 }
 
 func TestAutoscaleUpDownUp(t *testing.T) {
-	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestAutoscaleUpDownUp")
+	//add test case specific name to its own logger
+	logger := test.GetContextLogger("TestAutoscaleUpDownUp")
 
 	clients := setup(t, logger)
 	imagePath := strings.Join(

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -32,7 +32,7 @@ func TestBuildAndServe(t *testing.T) {
 	clients := Setup(t)
 
 	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestBuildAndServe")
+	logger := test.GetContextLogger("TestBuildAndServe")
 
 	imagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
 
@@ -102,7 +102,7 @@ func TestBuildFailure(t *testing.T) {
 	clients := Setup(t)
 
 	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestBuildFailure")
+	logger := test.GetContextLogger("TestBuildFailure")
 
 	logger.Infof("Creating a new Configuration with failing build")
 	names := test.ResourceNames{

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -43,8 +43,8 @@ func TestContainerErrorMsg(t *testing.T) {
 	//t.Skip("Skipping until https://github.com/knative/serving/issues/1240 is closed")
 	clients := Setup(t)
 
-	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestContainerErrorMsg")
+	//add test case specific name to its own logger
+	logger := test.GetContextLogger("TestContainerErrorMsg")
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -61,8 +61,8 @@ func cleanup(yamlFilename string, logger *zap.SugaredLogger) {
 }
 
 func TestHelloWorldFromShell(t *testing.T) {
-	// Add test case specific name to its own logger
-	logger := test.Logger.Named("TestHelloWorldFromShell")
+	//add test case specific name to its own logger
+	logger := test.GetContextLogger("TestHelloWorldFromShell")
 
 	imagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
 

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -33,8 +33,8 @@ const (
 func TestHelloWorld(t *testing.T) {
 	clients := Setup(t)
 
-	// Add test case specific name to its own logger.
-	logger := test.Logger.Named("TestHelloWorld")
+	//add test case specific name to its own logger
+	logger := test.GetContextLogger("TestHelloWorld")
 
 	var imagePath string
 	imagePath = strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")


### PR DESCRIPTION
~Passing around a logger object is a good pattern, however it makes the interface to the test library methods more cluttered. It is also a good practice to avoid logging in libraries, however in our tests we actively want the libraries to log for us to provide context for debugging, which leads me (and maybe @jonjohnsonjr?) to the conclusion that test libraries really are a special case, and it might not be totally evil to have a global logging object.~

Initially this was an experiment to use a global logging object, for
2 reasons:
1. The opencensus metrics exporter has no choice but to be global
2. It clutters up the function signatures a bit

After that experiment I have decided that it is not a good idea to
use a global logger because:
1. It promotes bad practices
2. What if we ever want to write tests FOR our test libraries? (if they
   become sophisticated enough) And this _may_ lead to some of these
   libs one day being actual libraries, in which case they should follow
   best practices for libraries.

So instead I have updated the metrics emitter to also be contextual, and
sadly there is no way to avoid it being global :(

This changes the output of metrics b/c the context will be included as
well.

Previous output:

```
info	TestBlueGreenRoute	conformance/blue_green_test.go:188	Since the Configuration was updated a new Revision will be created and the Configuration will be updated
info	test/logging.go:64	metric WaitForConfigurationState/prodarwmlxlg/ConfigurationUpdatedWithRevision 1532038661515264014 1532038661611044911 95.780897ms
info	TestBlueGreenRoute	conformance/blue_green_test.go:195	Waiting for revision "prodarwmlxlg-00001" to be ready
info	test/logging.go:64	metric WaitForRevision/prodarwmlxlg-00001/RevisionIsReady 1532038661611154885 1532038665787220418 4.176065533s
info	TestBlueGreenRoute	conformance/blue_green_test.go:199	Waiting for revision "prodarwmlxlg-00002" to be ready
```

New output:

```
info	TestBlueGreenRoute	conformance/blue_green_test.go:195	Waiting for revision "prodbikgknnx-00001" to be ready
info	TestBlueGreenRoute	test/logging.go:64	metric WaitForRevision/prodbikgknnx-00001/RevisionIsReady 1532042663872700584 1532042669022228353 5.149527769s
info	TestBlueGreenRoute	conformance/blue_green_test.go:199	Waiting for revision "prodbikgknnx-00002" to be ready
info	TestBlueGreenRoute	test/logging.go:64	metric WaitForRevision/prodbikgknnx-00002/RevisionIsReady 1532042669022329733 1532042669098558396 76.228663ms
```

A possible future modification would be to create structs for some of
these libs and initialize those structs with a logger object so the
function signatures do not include a logger.

## Proposed Changes
  * Use a context specific logger for emitting metrics

```release-note
NONE
```
