### PR TITLE
Remove k8s downloaded by kubetest once e2e tests finishes

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -97,6 +97,8 @@ function teardown() {
     gcloud container images list --repository=${DOCKER_REPO_OVERRIDE}
     delete_gcr_images ${DOCKER_REPO_OVERRIDE}
   else
+    # Delete the kubernetes source downloaded by kubetest
+    rm -fr kubernetes kubernetes.tar.gz
     restore_override_vars
   fi
 }


### PR DESCRIPTION
k8s is downloaded every time kubetest is called, so keeping it won't speed up the test. Remove it when running the test locally to save disk space and reduce clutter.