### PR TITLE
Remove linefeeds from log messages

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -107,7 +107,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 		return c.Status.LatestReadyRevisionName == names.Revision, nil
 	})
 	if err != nil {
-		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v\n", names.Config, names.Revision, err)
+		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
 	}
 	logger.Infof("Updates the Route to route traffic to the Revision")
 	err = test.CheckRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names.Route, names.Revision))

--- a/test/crd.go
+++ b/test/crd.go
@@ -88,9 +88,9 @@ var once sync.Once
 
 func initSeed(logger *zap.SugaredLogger) func() {
 	return func() {
-	seed := time.Now().UTC().UnixNano()
-	logger.Infof("Seeding rand.Rand with %v\n", seed)
-	r = rand.New(rand.NewSource(seed))
+		seed := time.Now().UTC().UnixNano()
+		logger.Infof("Seeding rand.Rand with %v", seed)
+		r = rand.New(rand.NewSource(seed))
 	}
 }
 

--- a/test/request.go
+++ b/test/request.go
@@ -55,7 +55,7 @@ func waitForRequestToDomainState(logger *zap.SugaredLogger, address string, spoo
 		if resp.StatusCode != 200 {
 			for _, code := range retryableCodes {
 				if resp.StatusCode == code {
-					logger.Infof("Retrying for code %v\n", resp.StatusCode)
+					logger.Infof("Retrying for code %v", resp.StatusCode)
 					return false, nil
 				}
 			}


### PR DESCRIPTION
It's unnecessary and adds an annoying blank line to the output. :stuck_out_tongue_closed_eyes: 

Bonus: fix indentation in `initSeed`.