### PR TITLE
Add first Service conformance test

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -31,6 +31,7 @@ type Clients struct {
 	Routes    servingtyped.RouteInterface
 	Configs   servingtyped.ConfigurationInterface
 	Revisions servingtyped.RevisionInterface
+	Services  servingtyped.ServiceInterface
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
@@ -55,6 +56,7 @@ func NewClients(configPath string, clusterName string, namespace string) (*Clien
 	clients.Routes = cs.ServingV1alpha1().Routes(namespace)
 	clients.Configs = cs.ServingV1alpha1().Configurations(namespace)
 	clients.Revisions = cs.ServingV1alpha1().Revisions(namespace)
+	clients.Services = cs.ServingV1alpha1().Services(namespace)
 
 	return clients, nil
 }

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -99,7 +99,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 
 	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
 	logger.Infof("The Revision will be marked as Ready when it can serve traffic")
-	err = test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady(names.Revision))
+	err = test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady())
 	if err != nil {
 		t.Fatalf("Revision %s did not become ready to serve traffic: %v", names.Revision, err)
 	}
@@ -111,7 +111,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
 	}
 	logger.Infof("Updates the Route to route traffic to the Revision")
-	err = test.CheckRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names.Route, names.Revision))
+	err = test.CheckRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names))
 	if err != nil {
 		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
@@ -156,6 +156,7 @@ func TestRouteCreation(t *testing.T) {
 	var names test.ResourceNames
 	names.Config = test.AppendRandomString("prod", logger)
 	names.Route = test.AppendRandomString("pizzaplanet", logger)
+	names.TrafficTarget = test.AppendRandomString("pizzaplanet", logger)
 
 	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
 	defer tearDown(clients, names)

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -1,0 +1,185 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/test"
+	"github.com/mattbaird/jsonpatch"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func tearDownService(clients *test.Clients, names test.ResourceNames) {
+	if clients != nil {
+		if clients.Services != nil {
+			clients.Services.Delete(names.Service, nil)
+		}
+	}
+}
+
+func updateServiceWithImage(clients *test.Clients, names test.ResourceNames, imagePath string) error {
+	patches := []jsonpatch.JsonPatchOperation{
+		jsonpatch.JsonPatchOperation{
+			Operation: "replace",
+			Path:      "/spec/runLatest/configuration/revisionTemplate/spec/container/image",
+			Value:     imagePath,
+		},
+	}
+	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		return err
+	}
+	newService, err := clients.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
+	if err != nil {
+		return err
+	}
+	if newService.Spec.Generation != int64(2) {
+		return fmt.Errorf("The spec was updated so the Generation should be 2 but it was actually %d", newService.Spec.Generation)
+	}
+	return nil
+}
+
+// Shamelessly cribbed from route_test. We expect the Route and Configuration to be ready if the Service is ready.
+func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clients *test.Clients, names test.ResourceNames, routeDomain, expectedText string) {
+	// TODO(#1178): Remove "Wait" from all checks below this point.
+	err := test.WaitForEndpointState(clients.Kube, logger, test.Flags.ResolvableDomain, routeDomain, namespaceName, names.Route, func(body string) (bool, error) {
+		return body == expectedText, nil
+	}, "WaitForEndpointToServeText")
+	if err != nil {
+		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, routeDomain, expectedText, err)
+	}
+
+	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
+	logger.Info("The Revision will be marked as Ready when it can serve traffic")
+	if err := test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady()); err != nil {
+		t.Fatalf("Revision %s did not become ready to serve traffic: %v", names.Revision, err)
+	}
+
+	logger.Info("The Service's latestReadyRevisionName should match the Configuration's")
+	err = test.CheckConfigurationState(clients.Configs, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+		return c.Status.LatestReadyRevisionName == names.Revision, nil
+	})
+	if err != nil {
+		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v\n", names.Config, names.Revision, err)
+	}
+
+	logger.Info("Updates the Route to route traffic to the Revision")
+	if err := test.CheckRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names)); err != nil {
+		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
+	}
+
+	// TODO(#1381): Check labels and annotations.
+}
+
+func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	var revisionName string
+	err := test.WaitForServiceState(clients.Services, names.Service, func(s *v1alpha1.Service) (bool, error) {
+		if s.Status.LatestCreatedRevisionName != names.Revision {
+			revisionName = s.Status.LatestCreatedRevisionName
+			return true, nil
+		}
+		return false, nil
+	}, "ServiceUpdatedWithRevision")
+	return revisionName, err
+}
+
+func waitForServiceDomain(clients *test.Clients, names test.ResourceNames) (string, error) {
+	var routeDomain string
+	err := test.WaitForServiceState(clients.Services, names.Service, func(s *v1alpha1.Service) (bool, error) {
+		if s.Status.Domain != "" {
+			routeDomain = s.Status.Domain
+			return true, nil
+		}
+		return false, nil
+	}, "ServiceUpdatedWithDomain")
+	return routeDomain, err
+}
+
+func TestRunLatestService(t *testing.T) {
+	clients := setup(t)
+
+	//add test case specific name to its own logger
+	logger := test.Logger.Named("TestRunLatestService")
+
+	var imagePaths []string
+	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))
+	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image2}, "/"))
+
+	var names test.ResourceNames
+	names.Service = test.AppendRandomString("pizzaplanet-service", logger)
+
+	defer tearDownService(clients, names)
+	test.CleanupOnInterrupt(func() { tearDownService(clients, names) }, logger)
+
+	logger.Info("Creating a new Service")
+	svc, err := clients.Services.Create(test.LatestService(namespaceName, names, imagePaths[0]))
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+	names.Route = controller.GetServiceRouteName(svc)
+	names.Config = controller.GetServiceConfigurationName(svc)
+
+	logger.Info("The Service will be updated with the name of the Revision once it is created")
+	revisionName, err := waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+	}
+	names.Revision = revisionName
+
+	logger.Info("The Service will be updated with the domain of the Route once it is created")
+	routeDomain, err := waitForServiceDomain(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the new route: %v", names.Service, err)
+	}
+
+	logger.Info("When the Service reports as Ready, everything should be ready.")
+	if err := test.WaitForServiceState(clients.Services, names.Service, test.IsServiceReady(), "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "What a spaceport!")
+
+	logger.Info("Updating the Service to use a different image")
+	if err := updateServiceWithImage(clients, names, imagePaths[1]); err != nil {
+		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, imagePaths[1], err)
+	}
+
+	logger.Info("Since the Service was updated a new Revision will be created and the Service will be updated")
+	revisionName, err = waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, image2, err)
+	}
+	names.Revision = revisionName
+
+	logger.Info("When the Service reports as Ready, everything should be ready.")
+	if err := test.WaitForServiceState(clients.Services, names.Service, test.IsServiceReady(), "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "Re-energize yourself with a slice of pepperoni!")
+}
+
+// TODO(jonjohnsonjr): LatestService roads less traveled.
+// TODO(jonjohnsonjr): PinnedService happy path.
+// TODO(jonjohnsonjr): PinnedService roads less traveled.
+// TODO(jonjohnsonjr): Examples of deploying from source.

--- a/test/crd.go
+++ b/test/crd.go
@@ -21,17 +21,20 @@ import (
 	"math/rand"
 	"sync"
 	"time"
-	"go.uber.org/zap"
+
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ResourceNames holds names of related Config, Route and Revision objects.
+// ResourceNames holds names of various resources.
 type ResourceNames struct {
-	Config   string
-	Route    string
-	Revision string
+	Config        string
+	Route         string
+	Revision      string
+	Service       string
+	TrafficTarget string
 }
 
 // Route returns a Route object in namespace using the route and configuration
@@ -45,7 +48,7 @@ func Route(namespace string, names ResourceNames) *v1alpha1.Route {
 		Spec: v1alpha1.RouteSpec{
 			Traffic: []v1alpha1.TrafficTarget{
 				v1alpha1.TrafficTarget{
-					Name:              names.Route,
+					Name:              names.TrafficTarget,
 					ConfigurationName: names.Config,
 					Percent:           100,
 				},
@@ -67,6 +70,30 @@ func Configuration(namespace string, names ResourceNames, imagePath string) *v1a
 				Spec: v1alpha1.RevisionSpec{
 					Container: corev1.Container{
 						Image: imagePath,
+					},
+				},
+			},
+		},
+	}
+}
+
+// LatestService returns a RunLatest Service object in namespace with the name names.Service
+// that uses the image specifed by imagePath.
+func LatestService(namespace string, names ResourceNames, imagePath string) *v1alpha1.Service {
+	return &v1alpha1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      names.Service,
+		},
+		Spec: v1alpha1.ServiceSpec{
+			RunLatest: &v1alpha1.RunLatestType{
+				Configuration: v1alpha1.ConfigurationSpec{
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: v1alpha1.RevisionSpec{
+							Container: corev1.Container{
+								Image: imagePath,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This currently just tests the RunLatest happy path, that is:

* Create a RunLatest Service.
* Wait for Service's LatestCreatedRevisionName to be populated (from Configuration).
* Wait for Service's Domain to be populated (from Route).
* Wait for Service to be Ready.
* Assert that we get the appropriate response.
* Update Service to change Configuration, pointing to new image.
* Wait for Service's LatestCreatedRevisionName to change (from Configuration).
* Wait for Service to be Ready.
* Assert that we get the appropriate NEW response.

This also fixes a perceived bug in AllRouteTrafficAtRevision, which
seemed to not handle multiple traffic targets at all.

ref #591

@bobcatfish see ctrl+f "TODO(reviewer)" for some things you might have opinions about.
