### PR TITLE
Don't dump project info on E2E test failure

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -114,10 +114,6 @@ function dump_stack_info() {
   echo "***           TEST FAILED           ***"
   echo "***    Start of information dump    ***"
   echo "***************************************"
-  if (( IS_PROW )) || [[ $PROJECT_ID != "" ]]; then
-    echo ">>> Project info:"
-    gcloud compute project-info describe
-  fi
   echo ">>> All resources:"
   kubectl get all --all-namespaces
   echo ">>> Services:"


### PR DESCRIPTION
The information is not relevant anymore for test debugging. Furthermore dumping the project info also leaks some of its keys.