### PR TITLE
Add new scaling-config configMap to release-lite.yaml

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -161,6 +161,7 @@ ko resolve -R -f config/monitoring/100-common \
     -f third_party/config/monitoring/common/istio \
     -f third_party/config/monitoring/common/kubernetes/kube-state-metrics \
     -f third_party/config/monitoring/common/prometheus-operator \
+    -f config/monitoring/150-elasticsearch-prod/100-scaling-configmap.yaml \
     -f config/monitoring/200-common/100-fluentd.yaml \
     -f config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml \
     -f config/monitoring/200-common/100-grafana-dash-knative.yaml \


### PR DESCRIPTION
## Proposed Changes

  * Add new scaling-config configMap to release-lite.yaml
  * Grafana pod fail to start without it
  * This new configMap was added in #1073 

**Release Note**
```release-note
NONE
```
