### PR TITLE
Exclude gRPC sample dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,6 +30,9 @@ required = [
   "github.com/google/go-containerregistry/cmd/ko",
 ]
 
+ignored = [
+  "github.com/knative/serving/sample/grpc-ping*",
+]
 
 # Use HEAD (2018-04-21) to pick up:
 # https://github.com/spf13/cobra/pull/662


### PR DESCRIPTION
Authored by Brenda Chan brchan@pivotal.io

Checked in by josephburnett79@gmail.com because the CLA bot is misbehaving.
Original pull request: https://github.com/knative/serving/pull/1352

Fixes #1342

**Release Note**
```release-note
NONE
```
