### PR TITLE
Restrict resolution to the user container.

### DIFF
--- a/pkg/controller/revision/resolve.go
+++ b/pkg/controller/revision/resolve.go
@@ -48,6 +48,12 @@ func (r *digestResolver) Resolve(deploy *appsv1.Deployment) error {
 	}
 
 	for i := range pod.Containers {
+		if pod.Containers[i].Name != userContainerName {
+			// We skip our sidecars, which should largely already be digests unless
+			// folks are iterating with `ko apply -L -f config`, where tag-to-digest
+			// resolution will fail.
+			continue
+		}
 		if _, err := name.NewDigest(pod.Containers[i].Image, name.WeakValidation); err == nil {
 			// Already a digest
 			continue

--- a/pkg/controller/revision/resolve_test.go
+++ b/pkg/controller/revision/resolve_test.go
@@ -164,6 +164,7 @@ func TestResolve(t *testing.T) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: svcacct,
 					Containers: []corev1.Container{{
+						Name:  userContainerName,
 						Image: tag.String(),
 					}},
 				},
@@ -202,6 +203,7 @@ func TestResolveWithDigest(t *testing.T) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "default",
 					Containers: []corev1.Container{{
+						Name:  userContainerName,
 						Image: "ubuntu@sha256:e7def0d56013d50204d73bb588d99e0baa7d69ea1bc1157549b898eb67287612",
 					}},
 				},
@@ -236,6 +238,7 @@ func TestResolveWithBadTag(t *testing.T) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "default",
 					Containers: []corev1.Container{{
+						Name: userContainerName,
 						// Invalid character
 						Image: "ubuntu%latest",
 					}},
@@ -286,6 +289,7 @@ func TestResolveWithPingFailure(t *testing.T) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: svcacct,
 					Containers: []corev1.Container{{
+						Name:  userContainerName,
 						Image: tag.String(),
 					}},
 				},
@@ -335,6 +339,7 @@ func TestResolveWithManifestFailure(t *testing.T) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: svcacct,
 					Containers: []corev1.Container{{
+						Name:  userContainerName,
 						Image: tag.String(),
 					}},
 				},
@@ -359,6 +364,7 @@ func TestResolveNoAccess(t *testing.T) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "default",
 					Containers: []corev1.Container{{
+						Name:  userContainerName,
 						Image: "ubuntu:latest",
 					}},
 				},


### PR DESCRIPTION
This enables sidecars that have been loaded directly into the Docker daemon (e.g. `ko apply -L`).
