### PR TITLE
Add support to emitting metrics when running E2E tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -139,7 +139,9 @@ function dump_stack_info() {
 function run_e2e_tests() {
   header "Running tests in $1"
   kubectl create namespace $2
-  report_go_test -v -tags=e2e ./test/$1 -dockerrepo gcr.io/elafros-e2e-tests/$3
+  local options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test -v -tags=e2e -count=1 ./test/$1 -dockerrepo gcr.io/elafros-e2e-tests/$3 ${options}
   local result=$?
   [[ ${result} -ne 0 ]] && dump_stack_info
   return ${result}
@@ -149,15 +151,31 @@ function run_e2e_tests() {
 
 cd ${SERVING_ROOT_DIR}
 
-# Show help if bad arguments are passed.
-if [[ -n $1 && $1 != "--run-tests" ]]; then
-  echo "usage: $0 [--run-tests]"
-  exit 1
-fi
+RUN_TESTS=0
+EMIT_METRICS=0
+for parameter in $@; do
+  case $parameter in
+    --run-tests)
+      RUN_TESTS=1
+      shift
+      ;;
+    --emit-metrics)
+      EMIT_METRICS=1
+      shift
+      ;;
+    *)
+      echo "error: unknown option ${parameter}"
+      echo "usage: $0 [--run-tests][--emit-metrics]"
+      exit 1
+      ;;
+  esac
+done
+readonly RUN_TESTS
+readonly EMIT_METRICS
 
-# No argument provided, create the test cluster.
+# Create the test cluster if not running tests.
 
-if [[ -z $1 ]]; then
+if (( ! RUN_TESTS )); then
   header "Creating test cluster"
   # Smallest cluster required to run the end-to-end-tests
   CLUSTER_CREATION_ARGS=(
@@ -184,13 +202,15 @@ if [[ -z $1 ]]; then
   export K8S_CLUSTER_OVERRIDE=
   # Assume test failed (see more details at the end of this script).
   echo -n "1"> ${TEST_RESULT_FILE}
+  test_cmd_args="--run-tests"
+  (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
   kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
     --extract "gke-${SERVING_GKE_VERSION}" \
     --gcp-node-image ${SERVING_GKE_IMAGE} \
     --test-cmd "${SCRIPT_CANONICAL_PATH}" \
-    --test-cmd-args --run-tests
+    --test-cmd-args "${test_cmd_args}"
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.
@@ -217,7 +237,7 @@ if [[ -z $1 ]]; then
   exit $result
 fi
 
-# --run-tests passed as first argument, run the tests.
+# --run-tests passed, run the tests.
 
 # Fail fast during setup.
 set -o errexit

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -55,31 +55,62 @@ function unit_tests() {
 function integration_tests() {
   # Make sure environment variables are intact.
   restore_override_vars
-  ./test/e2e-tests.sh
+  local options=""
+  (( EMIT_METRICS )) && options="--emit-metrics"
+  ./test/e2e-tests.sh ${options}
 }
 
 # Script entry point.
 
-# Parse script argument:
+# Parse script arguments:
 # --all-tests or no arguments: run all tests
 # --build-tests: run only the build tests
 # --unit-tests: run only the unit tests
 # --integration-tests: run only the integration tests
+# --emit-metrics: emit metrics when running the E2E tests
 RUN_BUILD_TESTS=0
 RUN_UNIT_TESTS=0
 RUN_INTEGRATION_TESTS=0
-[[ -z "$1" || "$1" == "--all-tests" ]] && RUN_BUILD_TESTS=1 && RUN_UNIT_TESTS=1 && RUN_INTEGRATION_TESTS=1
-[[ "$1" == "--build-tests" ]] && RUN_BUILD_TESTS=1
-[[ "$1" == "--unit-tests" ]] && RUN_UNIT_TESTS=1
-[[ "$1" == "--integration-tests" ]] && RUN_INTEGRATION_TESTS=1
+EMIT_METRICS=0
+
+all_parameters=$@
+[[ -z $1 ]] && all_parameters="--all-tests"
+
+for parameter in ${all_parameters}; do
+  case $parameter in
+    --all-tests)
+      RUN_BUILD_TESTS=1
+      RUN_UNIT_TESTS=1
+      RUN_INTEGRATION_TESTS=1
+      shift
+      ;;
+    --build-tests)
+      RUN_BUILD_TESTS=1
+      shift
+      ;;
+    --unit-tests)
+      RUN_UNIT_TESTS=1
+      shift
+      ;;
+    --integration-tests)
+      RUN_INTEGRATION_TESTS=1
+      shift
+      ;;
+    --emit-metrics)
+      EMIT_METRICS=1
+      shift
+      ;;
+    *)
+      echo "error: unknown option ${parameter}"
+      exit 1
+      ;;
+  esac
+done
+
 readonly RUN_BUILD_TESTS
 readonly RUN_UNIT_TESTS
 readonly RUN_INTEGRATION_TESTS
-
-if ! (( RUN_BUILD_TESTS+RUN_UNIT_TESTS+RUN_INTEGRATION_TESTS )); then
-  echo "error: unknown argument $1";
-  exit 1
-fi
+readonly EMIT_METRICS
 
 cd ${SERVING_ROOT_DIR}
 


### PR DESCRIPTION
Make `presubmit-tests.sh` accept `--emit-metrics`, and pass it to `e2e-tests.sh` (which in turn will run E2E tests with `--emitmetrics`).

Currently only the E2E tests emit metrics, so unit tests are untouched.

Addresses #1394.