### PR TITLE
This changes from `demo-domain.com` to `example.com`.

### DIFF
--- a/config/config-domain.yaml
+++ b/config/config-domain.yaml
@@ -19,11 +19,12 @@ metadata:
   namespace: knative-serving
 data:
   # These are example settings of domain.
-  # prod-domain.com will be used for routes having app=prod.
-  prod-domain.com: |
-    selector:
-      app: prod
+  # example.org will be used for routes having app=prod.
+  # example.org: |
+  #   selector:
+  #     app: prod
+
   # Default value for domain, for routes that does not have app=prod labels.
   # Although it will match all routes, it is the least-specific rule so it
   # will only be used if no other domain matches.
-  demo-domain.com: |
+  example.com: |

--- a/sample/buildpack-function/README.md
+++ b/sample/buildpack-function/README.md
@@ -56,7 +56,7 @@ To access this service via `curl`, we first need to determine its ingress addres
 ```shell
 $ watch kubectl get ing
 NAME                             HOSTS                                        ADDRESS   PORTS   AGE
-buildpack-function-ingress   buildpack-function.default.demo-domain.com   0.0.0.0   80      3m
+buildpack-function-ingress   buildpack-function.default.example.com   0.0.0.0   80      3m
 ```
 
 Once the `ADDRESS` gets assigned to the cluster, you can run:

--- a/sample/knative-routing/README.md
+++ b/sample/knative-routing/README.md
@@ -56,14 +56,14 @@ You should see 2 Ingress objects:
 
 ```
 NAME                                 HOSTS                                                                                         ADDRESS        PORTS
-login-service-knative-ingress     login-service.default.demo-domain.com,*.login-service.default.demo-domain.com    35.237.65.249      80
-search-service-knative-ingress    search-service.default.demo-domain.com,*.search-service.default.demo-domain.com   35.237.65.249      80
+login-service-knative-ingress     login-service.default.example.com,*.login-service.default.example.com    35.237.65.249      80
+search-service-knative-ingress    search-service.default.example.com,*.search-service.default.example.com   35.237.65.249      80
 ```
 The login-service-knative-ingress and search-service-knative-ingress are Ingresses corresponding to "Login" service and "Search" service.
 
 You can directly access "Search" service by running
 ```shell
-curl http://35.237.65.249 --header "Host:search-service.default.demo-domain.com"
+curl http://35.237.65.249 --header "Host:search-service.default.example.com"
 ```
 You should see
 ```

--- a/sample/knative-routing/routing.yaml
+++ b/sample/knative-routing/routing.yaml
@@ -52,12 +52,12 @@ spec:
   rewrite:
     # Rewrite the original host header to the host header of Search service
     # in order to redirect requests to Search service.
-    authority: search-service.default.demo-domain.com
+    authority: search-service.default.example.com
   route:
   - destination:
       # istio-ingress is the k8s service created by Istio as the actual entry of all traffic incoming to the cluster.
       # Basically here we redirect the request to the cluster entry again with updated header
-      # "search-service.default.demo-domain.com" so the request will eventually be directed to Search service.
+      # "search-service.default.example.com" so the request will eventually be directed to Search service.
       name: istio-ingress
       namespace: istio-system
     weight: 100
@@ -82,11 +82,11 @@ spec:
   rewrite:
     # Rewrite the original host header to the host header of Login service
     # in order to redirect requests to Login service.
-    authority: login-service.default.demo-domain.com
+    authority: login-service.default.example.com
   route:
     # istio-ingress is the k8s service created by Istio as the actual entry of all traffic incoming to the cluster.
     # Basically here we redirect the request to the cluster entry again with updated header
-    # "login-service.default.demo-domain.com" so the request will eventually be directed to Login service. 
+    # "login-service.default.example.com" so the request will eventually be directed to Login service. 
   - destination:
       name: istio-ingress
       namespace: istio-system

--- a/sample/stock-rest-app/README.md
+++ b/sample/stock-rest-app/README.md
@@ -59,7 +59,7 @@ When the ingress is ready, you'll see an IP address in the ADDRESS field:
 
 ```
 NAME                                 HOSTS                     ADDRESS   PORTS     AGE
-stock-route-example-ingress   stock-route-example.default.demo-domain.com   35.185.44.102   80        1m
+stock-route-example-ingress   stock-route-example.default.example.com   35.185.44.102   80        1m
 ```
 
 Once the `ADDRESS` gets assigned to the cluster, you can run:

--- a/test/README.md
+++ b/test/README.md
@@ -193,7 +193,7 @@ go test -v -tags=e2e -count=1 ./test/e2e --dockerrepo gcr.myhappyproject
 
 If you set up your cluster using [the getting started
 docs](/DEVELOPMENT.md#getting-started), Routes created in the test will
-use the domain `demo-domain.com`, unless the route has label `app=prod` in which
+use the domain `example.com`, unless the route has label `app=prod` in which
 case they will use the domain `prod-domain.com`.  Since these domains will not be
 resolvable to deployments in your test cluster, in order to make a request
 against the endpoint, the test use the IP assigned to the istio `*-ingress`


### PR DESCRIPTION
We don't own `demo-domain.com`, so configuring it by default presents an abundance of problems.  `example.com` is the canonical placeholder domain, so we will configure that by default.

In the future we will very likely change this to a sane default that will automatically work with intra-cluster DNS, but until then this seems like the most reasonable default.

Fixes: https://github.com/knative/serving/issues/1365

FYI @rgregg @grantr @vaikas-google @mchmarny 