### PR TITLE
Remove the "stutter" from autoscaler.NewAutoscaler.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -112,7 +112,7 @@ func runAutoscaler() {
 		PanicWindow:          *autoscaleFlagSet.Duration("panic-window", nil, k8sflag.Required).Get(),
 		ScaleToZeroThreshold: *autoscaleFlagSet.Duration("scale-to-zero-threshold", nil, k8sflag.Required).Get(),
 	}
-	a := autoscaler.NewAutoscaler(config, statsReporter)
+	a := autoscaler.New(config, statsReporter)
 	ticker := time.NewTicker(2 * time.Second)
 	ctx := logging.WithLogger(context.TODO(), logger)
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -132,8 +132,8 @@ type Autoscaler struct {
 	reporter     StatsReporter
 }
 
-// NewAutoscaler creates a new instance of autoscaler
-func NewAutoscaler(config Config, reporter StatsReporter) *Autoscaler {
+// New creates a new instance of autoscaler
+func New(config Config, reporter StatsReporter) *Autoscaler {
 	return &Autoscaler{
 		Config:   config,
 		stats:    make(map[statKey]Stat),

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -302,7 +302,7 @@ func newTestAutoscaler(targetConcurrency float64) *Autoscaler {
 		PanicWindow:          panicWindow,
 		ScaleToZeroThreshold: scaleToZeroThreshold,
 	}
-	return NewAutoscaler(config, &mockReporter{})
+	return New(config, &mockReporter{})
 }
 
 // Record a data point every second, for every pod, for duration of the


### PR DESCRIPTION
Stylistically, Go prefers leveraging the package name to qualify things and biases away from repetitious names like this.