### PR TITLE
Prefix the logs with test names for better observability of test logs.

### DIFF
--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -41,7 +41,7 @@ func TestActiveEndpoint_Active_StaysActive(t *testing.T) {
 	k8s, kna := fakeClients()
 	kna.ServingV1alpha1().Revisions(testNamespace).Create(newRevisionBuilder().build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
-	a := NewRevisionActivator(k8s, kna, TestLogger())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
 
 	got, status, err := a.ActiveEndpoint(testNamespace, testRevision)
 
@@ -64,7 +64,7 @@ func TestActiveEndpoint_Reserve_BecomesActive(t *testing.T) {
 			withServingState(v1alpha1.RevisionServingStateReserve).
 			build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
-	a := NewRevisionActivator(k8s, kna, TestLogger())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
 
 	got, status, err := a.ActiveEndpoint(testNamespace, testRevision)
 
@@ -92,7 +92,7 @@ func TestActiveEndpoint_Retired_StaysRetiredWithError(t *testing.T) {
 			withServingState(v1alpha1.RevisionServingStateRetired).
 			build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
-	a := NewRevisionActivator(k8s, kna, TestLogger())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
 
 	got, status, err := a.ActiveEndpoint(testNamespace, testRevision)
 
@@ -121,7 +121,7 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 			withReady(false).
 			build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
-	a := NewRevisionActivator(k8s, kna, TestLogger())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
 
 	ch := make(chan activationResult)
 	go func() {
@@ -167,7 +167,7 @@ func TestActiveEndpoint_Reserve_ReadyTimeoutWithError(t *testing.T) {
 			withReady(false).
 			build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
-	a := NewRevisionActivator(k8s, kna, TestLogger())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
 	a.(*revisionActivator).readyTimout = 200 * time.Millisecond
 
 	ch := make(chan activationResult)

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -315,14 +315,14 @@ func (a *Autoscaler) recordLinearSeries(test *testing.T, now time.Time, s linear
 				PodName:                   fmt.Sprintf("pod-%v", j),
 				AverageConcurrentRequests: float64(point),
 			}
-			a.Record(TestContextWithLogger(), stat)
+			a.Record(TestContextWithLogger(test), stat)
 		}
 	}
 	return now
 }
 
 func (a *Autoscaler) expectScale(t *testing.T, now time.Time, expectScale int32, expectOk bool) {
-	scale, ok := a.Scale(TestContextWithLogger(), now)
+	scale, ok := a.Scale(TestContextWithLogger(t), now)
 	if ok != expectOk {
 		t.Errorf("Unexpected autoscale decison. Expected %v. Got %v.", expectOk, ok)
 	}

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -432,7 +432,7 @@ func TestReconcile(t *testing.T) {
 					KubeClientSet:    kubeClient,
 					BuildClientSet:   buildClient,
 					ServingClientSet: client,
-					Logger:           TestLogger(),
+					Logger:           TestLogger(t),
 				}, controllerAgentName, "Configurations"),
 				configurationLister: tt.fields.c,
 				revisionLister:      tt.fields.r,

--- a/pkg/controller/configuration/queueing_test.go
+++ b/pkg/controller/configuration/queueing_test.go
@@ -86,7 +86,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 	}
 }
 
-func newTestController(servingObjects ...runtime.Object) (
+func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	kubeClient *fakekubeclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
 	controller *Controller,
@@ -110,7 +110,7 @@ func newTestController(servingObjects ...runtime.Object) (
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			BuildClientSet:   fakebuildclientset.NewSimpleClientset(),
-			Logger:           TestLogger(),
+			Logger:           TestLogger(t),
 		},
 		servingInformer.Serving().V1alpha1().Configurations(),
 		servingInformer.Serving().V1alpha1().Revisions(),
@@ -125,7 +125,7 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 	// because ObjectTracker doesn't fire watches in the 1.9 client. When we
 	// upgrade to 1.10 we can remove the config argument here and instead use the
 	// Create() method.
-	_, servingClient, controller, kubeInformer, servingInformer := newTestController(config)
+	_, servingClient, controller, kubeInformer, servingInformer := newTestController(t, config)
 
 	h := hooks.NewHooks()
 

--- a/pkg/controller/revision/queueing_test.go
+++ b/pkg/controller/revision/queueing_test.go
@@ -40,7 +40,9 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	// because ObjectTracker doesn't fire watches in the 1.9 client. When we
 	// upgrade to 1.10 we can remove the config argument here and instead use the
 	// Create() method.
-	kubeClient, _, _, _, controller, kubeInformer, buildInformer, servingInformer, servingSystemInformer, vpaInformer := newTestController(rev)
+	kubeClient, _, _, _, controller, kubeInformer, buildInformer,
+		servingInformer, servingSystemInformer, vpaInformer :=
+		newTestController(t, rev)
 
 	h := NewHooks()
 

--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -351,7 +351,7 @@ func TestReconcile(t *testing.T) {
 				Base: controller.NewBase(controller.Options{
 					KubeClientSet:    fakekubeclientset.NewSimpleClientset(),
 					ServingClientSet: client,
-					Logger:           TestLogger(),
+					Logger:           TestLogger(t),
 				}, controllerAgentName, "Services"),
 				serviceLister:       tt.fields.s,
 				configurationLister: tt.fields.c,
@@ -443,7 +443,7 @@ func TestNew(t *testing.T) {
 	c := NewController(controller.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
-		Logger:           TestLogger(),
+		Logger:           TestLogger(t),
 	}, serviceInformer, configurationInformer, routeInformer)
 
 	if c == nil {

--- a/pkg/logging/testing/util.go
+++ b/pkg/logging/testing/util.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"context"
 	"sync"
+	"testing"
 
 	"github.com/knative/serving/pkg/logging"
 	"go.uber.org/zap"
@@ -30,7 +31,7 @@ var (
 )
 
 // TestLogger gets a logger to use in unit and end to end tests
-func TestLogger() *zap.SugaredLogger {
+func TestLogger(t *testing.T) *zap.SugaredLogger {
 	testLoggerMux.Lock()
 	defer testLoggerMux.Unlock()
 
@@ -43,10 +44,10 @@ func TestLogger() *zap.SugaredLogger {
 		testLogger = logger.Sugar()
 	}
 
-	return testLogger
+	return testLogger.Named(t.Name())
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests
-func TestContextWithLogger() context.Context {
-	return logging.WithLogger(context.TODO(), TestLogger())
+func TestContextWithLogger(t *testing.T) context.Context {
+	return logging.WithLogger(context.TODO(), TestLogger(t))
 }

--- a/pkg/webhook/configuration_test.go
+++ b/pkg/webhook/configuration_test.go
@@ -30,13 +30,13 @@ import (
 func TestValidConfigurationAllowed(t *testing.T) {
 	configuration := createConfiguration(testGeneration, testConfigurationName)
 
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err != nil {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err != nil {
 		t.Fatalf("Expected allowed. Failed with %s", err)
 	}
 }
 
 func TestEmptyConfigurationNotAllowed(t *testing.T) {
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, nil, nil); err != errInvalidConfigurationInput {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, nil, nil); err != errInvalidConfigurationInput {
 		t.Fatalf("Expected: %s. Failed with %s", errInvalidConfigurationInput, err)
 	}
 }
@@ -50,7 +50,7 @@ func TestEmptySpecInConfigurationNotAllowed(t *testing.T) {
 		Spec: v1alpha1.ConfigurationSpec{},
 	}
 
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err != errEmptySpecInConfiguration {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err != errEmptySpecInConfiguration {
 		t.Fatalf("Expected: %s. Failed with %s", errEmptySpecInConfiguration, err)
 	}
 }
@@ -67,7 +67,7 @@ func TestEmptyTemplateInSpecNotAllowed(t *testing.T) {
 		},
 	}
 
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err != errEmptyRevisionTemplateInSpec {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err != errEmptyRevisionTemplateInSpec {
 		t.Fatalf("Expected: %s. Failed with %s", errEmptyRevisionTemplateInSpec, err)
 	}
 }
@@ -88,7 +88,7 @@ func TestEmptyContainerNotAllowed(t *testing.T) {
 		},
 	}
 
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err != errEmptyContainerInRevisionTemplate {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err != errEmptyContainerInRevisionTemplate {
 		t.Fatalf("Expected: %v. Failed with %v", errEmptyRevisionTemplateInSpec, err)
 	}
 }
@@ -113,7 +113,7 @@ func TestServingStateNotAllowed(t *testing.T) {
 		},
 	}
 	expected := fmt.Sprintf("The configuration spec must not set the field(s): revisionTemplate.spec.servingState")
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err == nil || err.Error() != expected {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err == nil || err.Error() != expected {
 		t.Fatalf("Result of ValidateConfiguration function: %s. Expected: %s.", err, expected)
 	}
 }
@@ -158,17 +158,17 @@ func TestUnwantedFieldInContainerNotAllowed(t *testing.T) {
 		"revisionTemplate.spec.container.lifecycle",
 	}
 	expected := fmt.Sprintf("The configuration spec must not set the field(s): %s", strings.Join(unwanted, ", "))
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err == nil || err.Error() != expected {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err == nil || err.Error() != expected {
 		t.Fatalf("Expected: %s. Failed with %s", expected, err)
 	}
 	configuration.Spec.RevisionTemplate.Spec.Container.Name = ""
 	expected = fmt.Sprintf("The configuration spec must not set the field(s): %s", strings.Join(unwanted[1:], ", "))
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err == nil || err.Error() != expected {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err == nil || err.Error() != expected {
 		t.Fatalf("Expected: %s. Failed with %s", expected, err)
 	}
 	configuration.Spec.RevisionTemplate.Spec.Container.Resources = corev1.ResourceRequirements{}
 	expected = fmt.Sprintf("The configuration spec must not set the field(s): %s", strings.Join(unwanted[2:], ", "))
-	if err := ValidateConfiguration(TestContextWithLogger())(nil, &configuration, &configuration); err == nil || err.Error() != expected {
+	if err := ValidateConfiguration(TestContextWithLogger(t))(nil, &configuration, &configuration); err == nil || err.Error() != expected {
 		t.Fatalf("Expected: %s. Failed with %s", expected, err)
 	}
 }

--- a/pkg/webhook/route_test.go
+++ b/pkg/webhook/route_test.go
@@ -45,7 +45,7 @@ func TestValidRouteWithTrafficAllowed(t *testing.T) {
 		Percent:           50,
 	}})
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != nil {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != nil {
 		t.Fatalf("Expected allowed, but failed with: %s.", err)
 	}
 }
@@ -53,7 +53,7 @@ func TestValidRouteWithTrafficAllowed(t *testing.T) {
 func TestEmptyTrafficTargetWithoutTrafficAllowed(t *testing.T) {
 	route := createRouteWithTraffic(nil)
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != nil {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != nil {
 		t.Fatalf("Expected allowed, but failed with: %s.", err)
 	}
 }
@@ -66,7 +66,7 @@ func TestNoneRouteTypeForOldResourceNotAllowed(t *testing.T) {
 		},
 	}
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &revision, &revision); err != errInvalidRouteInput {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &revision, &revision); err != errInvalidRouteInput {
 		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRouteInput, err)
 	}
 }
@@ -79,7 +79,7 @@ func TestNoneRouteTypeForNewResourceNotAllowed(t *testing.T) {
 		},
 	}
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, nil, &revision); err != errInvalidRouteInput {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, nil, &revision); err != errInvalidRouteInput {
 		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRouteInput, err)
 	}
 }
@@ -89,7 +89,7 @@ func TestEmptyRevisionAndConfigurationInOneTargetNotAllowed(t *testing.T) {
 		Percent: 100,
 	}})
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != errInvalidRevisions {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != errInvalidRevisions {
 		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRevisions, err)
 	}
 }
@@ -101,7 +101,7 @@ func TestBothRevisionAndConfigurationInOneTargetNotAllowed(t *testing.T) {
 		Percent:           100,
 	}})
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != errInvalidRevisions {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != errInvalidRevisions {
 		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidRevisions, err)
 	}
 }
@@ -112,7 +112,7 @@ func TestNegativeTargetPercentNotAllowed(t *testing.T) {
 		Percent:      -20,
 	}})
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != errNegativeTargetPercent {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != errNegativeTargetPercent {
 		t.Fatalf("Expected: %s. Failed with: %s.", errNegativeTargetPercent, err)
 	}
 }
@@ -125,7 +125,7 @@ func TestNotAllowedIfTrafficPercentSumIsNot100(t *testing.T) {
 		Percent:           50,
 	}})
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != errInvalidTargetPercentSum {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != errInvalidTargetPercentSum {
 		t.Fatalf("Expected: %s. Failed with: %s.", errInvalidTargetPercentSum, err)
 	}
 }
@@ -141,7 +141,7 @@ func TestNotAllowedIfTrafficNamesNotUnique(t *testing.T) {
 		Percent:           50,
 	}})
 
-	if err := ValidateRoute(TestContextWithLogger())(nil, &route, &route); err != errTrafficTargetsNotUnique {
+	if err := ValidateRoute(TestContextWithLogger(t))(nil, &route, &route); err != errTrafficTargetsNotUnique {
 		t.Fatalf("Expected: %s. Failed with: %s.", errTrafficTargetsNotUnique, err)
 	}
 }

--- a/pkg/webhook/service_test.go
+++ b/pkg/webhook/service_test.go
@@ -27,7 +27,7 @@ func TestEmptySpec(t *testing.T) {
 	s := v1alpha1.Service{
 		Spec: v1alpha1.ServiceSpec{},
 	}
-	err := ValidateService(TestContextWithLogger())(nil, &s, &s)
+	err := ValidateService(TestContextWithLogger(t))(nil, &s, &s)
 	if err == nil {
 		t.Errorf("Expected failure, but succeeded with: %+v", s)
 	}
@@ -44,7 +44,7 @@ func TestRunLatest(t *testing.T) {
 			},
 		},
 	}
-	if err := ValidateService(TestContextWithLogger())(nil, &s, &s); err != nil {
+	if err := ValidateService(TestContextWithLogger(t))(nil, &s, &s); err != nil {
 		t.Errorf("Expected success, but failed with: %s", err)
 	}
 }
@@ -55,7 +55,7 @@ func TestRunLatestWithMissingConfiguration(t *testing.T) {
 			RunLatest: &v1alpha1.RunLatestType{},
 		},
 	}
-	err := ValidateService(TestContextWithLogger())(nil, &s, &s)
+	err := ValidateService(TestContextWithLogger(t))(nil, &s, &s)
 	if err == nil {
 		t.Errorf("Expected failure, but succeeded with: %+v", s)
 	}
@@ -75,7 +75,7 @@ func TestPinned(t *testing.T) {
 		},
 	}
 
-	if err := ValidateService(TestContextWithLogger())(nil, &s, &s); err != nil {
+	if err := ValidateService(TestContextWithLogger(t))(nil, &s, &s); err != nil {
 		t.Errorf("Expected success, but failed with: %s", err)
 	}
 }
@@ -88,7 +88,7 @@ func TestPinnedFailsWithNoRevisionName(t *testing.T) {
 			},
 		},
 	}
-	err := ValidateService(TestContextWithLogger())(nil, &s, &s)
+	err := ValidateService(TestContextWithLogger(t))(nil, &s, &s)
 	if err == nil {
 		t.Errorf("Expected failure, but succeeded with: %+v", s)
 	}
@@ -105,7 +105,7 @@ func TestPinnedFailsWithNoConfiguration(t *testing.T) {
 			},
 		},
 	}
-	err := ValidateService(TestContextWithLogger())(nil, &s, &s)
+	err := ValidateService(TestContextWithLogger(t))(nil, &s, &s)
 	if err == nil {
 		t.Errorf("Expected failure, but succeeded with: %+v", s)
 	}
@@ -127,7 +127,7 @@ func TestPinnedSetsDefaults(t *testing.T) {
 	s.Spec.Pinned.Configuration.RevisionTemplate.Spec.ConcurrencyModel = ""
 
 	var patches []jsonpatch.JsonPatchOperation
-	if err := SetServiceDefaults(TestContextWithLogger())(&patches, &s); err != nil {
+	if err := SetServiceDefaults(TestContextWithLogger(t))(&patches, &s); err != nil {
 		t.Errorf("Expected success, but failed with: %s", err)
 	}
 
@@ -157,7 +157,7 @@ func TestLatestSetsDefaults(t *testing.T) {
 	s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.ConcurrencyModel = ""
 
 	var patches []jsonpatch.JsonPatchOperation
-	if err := SetServiceDefaults(TestContextWithLogger())(&patches, &s); err != nil {
+	if err := SetServiceDefaults(TestContextWithLogger(t))(&patches, &s); err != nil {
 		t.Errorf("Expected success, but failed with: %s", err)
 	}
 


### PR DESCRIPTION
Prefix the logs with test names for better observability of test logs.