### PR TITLE
Allow in-cluster connections to a route's service

### DIFF
--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -80,6 +80,10 @@ func GetServingK8SServiceFullnameForRoute(u *v1alpha1.Route) string {
 	return GetK8SServiceFullname(GetServingK8SServiceNameForRoute(u), u.Namespace)
 }
 
+func GetServingK8SServiceShortnameForRoute(u *v1alpha1.Route) string {
+	return fmt.Sprintf("%s.%s", GetServingK8SServiceNameForRoute(u), u.Namespace)
+}
+
 func GetServiceConfigurationName(u *v1alpha1.Service) string {
 	return u.Name
 }

--- a/pkg/controller/route/istio/service.go
+++ b/pkg/controller/route/istio/service.go
@@ -44,7 +44,6 @@ func MakeRouteK8SService(route *v1alpha1.Route) *corev1.Service {
 					Port: PortNumber,
 				},
 			},
-			ClusterIP: "None",
 		},
 	}
 }

--- a/pkg/controller/route/istio/service_test.go
+++ b/pkg/controller/route/istio/service_test.go
@@ -41,7 +41,6 @@ func TestMakeRouteK8SService_ValidSpec(t *testing.T) {
 			Name: "http",
 			Port: 80,
 		}},
-		ClusterIP: "None",
 	}
 	spec := MakeRouteK8SService(r).Spec
 	if diff := cmp.Diff(expectedSpec, spec); diff != "" {

--- a/pkg/controller/route/istio/virtual_service.go
+++ b/pkg/controller/route/istio/virtual_service.go
@@ -67,6 +67,8 @@ func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.Revi
 			domain,
 			// Traffic from inside the cluster will use the FQDN of the Route's headless Service.
 			controller.GetServingK8SServiceFullnameForRoute(u),
+			controller.GetServingK8SServiceShortnameForRoute(u),
+			controller.GetServingK8SServiceNameForRoute(u),
 		},
 	}
 	names := []string{}
@@ -86,7 +88,12 @@ func getRouteDomains(targetName string, u *v1alpha1.Route, domain string) []stri
 	if targetName == "" {
 		// Nameless traffic targets correspond to two domains: the Route.Status.Domain, and also the FQDN
 		// of the Route's headless Service.
-		return []string{domain, controller.GetServingK8SServiceFullnameForRoute(u)}
+		return []string{
+			domain,
+			controller.GetServingK8SServiceFullnameForRoute(u),
+			controller.GetServingK8SServiceShortnameForRoute(u),
+			controller.GetServingK8SServiceNameForRoute(u),
+		}
 	}
 	// Named traffic targets correspond to a subdomain of the Route.Status.Domain.
 	return []string{fmt.Sprintf("%s.%s", targetName, domain)}

--- a/pkg/controller/route/istio/virtual_service_test.go
+++ b/pkg/controller/route/istio/virtual_service_test.go
@@ -74,6 +74,8 @@ func TestMakeVirtualServiceSpec_CorrectSpec(t *testing.T) {
 			"*.domain.com",
 			"domain.com",
 			"test-route-service.test-ns.svc.cluster.local",
+			"test-route-service.test-ns",
+			"test-route-service",
 		},
 	}
 	routes := MakeVirtualService(r, &traffic.TrafficConfig{Targets: targets}).Spec
@@ -114,6 +116,10 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Authority: &v1alpha3.StringMatch{Exact: "domain.com"},
 		}, {
 			Authority: &v1alpha3.StringMatch{Exact: "test-route-service.test-ns.svc.cluster.local"},
+		}, {
+			Authority: &v1alpha3.StringMatch{Exact: "test-route-service.test-ns"},
+		}, {
+			Authority: &v1alpha3.StringMatch{Exact: "test-route-service"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -153,7 +159,12 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		},
 	}
 	base := "domain.com"
-	expected := []string{base, "test-route-service.test-ns.svc.cluster.local"}
+	expected := []string{
+		base,
+		"test-route-service.test-ns.svc.cluster.local",
+		"test-route-service.test-ns",
+		"test-route-service",
+	}
 	domains := getRouteDomains("", r, base)
 	if diff := cmp.Diff(expected, domains); diff != "" {
 		t.Errorf("Unexpected domains  (-want +got): %v", diff)

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -275,6 +275,8 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 	}
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	clusterDomain := "test-route-service.test.svc.cluster.local"
+	serviceShortName := "test-route-service.test"
+	serviceName := "test-route-service"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -288,12 +290,18 @@ func TestCreateRouteCreatesStuff(t *testing.T) {
 			"*." + domain,
 			domain,
 			clusterDomain,
+			serviceShortName,
+			serviceName,
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceShortName},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceName},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -371,6 +379,8 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	}
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	clusterDomain := "test-route-service.test.svc.cluster.local"
+	serviceShortName := "test-route-service.test"
+	serviceName := "test-route-service"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -384,12 +394,18 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 			"*." + domain,
 			domain,
 			clusterDomain,
+			serviceShortName,
+			serviceName,
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceShortName},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceName},
 			}},
 			Route: []v1alpha3.DestinationWeight{getActivatorDestinationWeight(100)},
 			AppendHeaders: map[string]string{
@@ -447,6 +463,8 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	clusterDomain := "test-route-service.test.svc.cluster.local"
+	serviceShortName := "test-route-service.test"
+	serviceName := "test-route-service"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -460,12 +478,18 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 			"*." + domain,
 			domain,
 			clusterDomain,
+			serviceShortName,
+			serviceName,
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceShortName},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceName},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -534,6 +558,8 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	clusterDomain := "test-route-service.test.svc.cluster.local"
+	serviceShortName := "test-route-service.test"
+	serviceName := "test-route-service"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -547,12 +573,18 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			"*." + domain,
 			domain,
 			clusterDomain,
+			serviceShortName,
+			serviceName,
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceShortName},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceName},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -632,6 +664,8 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	clusterDomain := "test-route-service.test.svc.cluster.local"
+	serviceShortName := "test-route-service.test"
+	serviceName := "test-route-service"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -645,12 +679,18 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			"*." + domain,
 			domain,
 			clusterDomain,
+			serviceShortName,
+			serviceName,
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceShortName},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceName},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -733,6 +773,8 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 	}
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	clusterDomain := "test-route-service.test.svc.cluster.local"
+	serviceShortName := "test-route-service.test"
+	serviceName := "test-route-service"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -746,12 +788,18 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			"*." + domain,
 			domain,
 			clusterDomain,
+			serviceShortName,
+			serviceName,
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceShortName},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: serviceName},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{


### PR DESCRIPTION
- remove the `ClusterIP: "None"` from the route's service so that the service will be resolvable.
- add service shortnames `{name}` and `{name}.{namespace}` to the route's virtual service.

In testing, accessing the service via the fqdn (`{name}.{ns}.svc.cluster.local`) works, but the short names do not. Adding them here since it shouldn't cause issues and may be an Istio issue we can resolve.

Refs #1415

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Routes are now accessible from inside the cluster via `{route}-service.{ns}.svc.cluster.local`
```

/assign @tcnghia 