### PR TITLE
Experimental flag guard infrastructure

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -50,6 +50,8 @@ spec:
           mountPath: /etc/config-autoscaler
         - name: config-logging
           mountPath: /etc/config-logging
+        - name: config-experiments
+          mountPath: /etc/config-experiments
       volumes:
         - name: config-autoscaler
           configMap:
@@ -57,3 +59,7 @@ spec:
         - name: config-logging
           configMap:
             name: config-logging
+        - name: config-experiments
+          configMap:
+            name: config-experiments
+            optional: true

--- a/config/experiments/config-experiments.yaml
+++ b/config/experiments/config-experiments.yaml
@@ -1,0 +1,27 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-experiments
+  namespace: knative-serving
+data:
+  # New experiments are added here. For example:
+  # autoscaler.enable-my-experiment: "true"

--- a/pkg/controller/revision/autoscaler.go
+++ b/pkg/controller/revision/autoscaler.go
@@ -67,6 +67,19 @@ func MakeServingAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage str
 		},
 	}
 
+	const experimentsConfigName = "config-experiments"
+	experimentsConfigVolume := corev1.Volume{
+		Name: experimentsConfigName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: experimentsConfigName,
+				},
+				Optional: func() *bool { b := true; return &b }(),
+			},
+		},
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            controller.GetRevisionAutoscalerName(rev),
@@ -121,10 +134,13 @@ func MakeServingAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage str
 						}, {
 							Name:      loggingConfigName,
 							MountPath: "/etc/config-logging",
+						}, {
+							Name:      experimentsConfigName,
+							MountPath: "/etc/config-experiments",
 						}},
 					}},
 					ServiceAccountName: "autoscaler",
-					Volumes:            []corev1.Volume{autoscalerConfigVolume, loggingConfigVolume},
+					Volumes:            []corev1.Volume{autoscalerConfigVolume, loggingConfigVolume, experimentsConfigVolume},
 				},
 			},
 		},

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -672,13 +672,16 @@ func TestCreateRevCreatesStuff(t *testing.T) {
 			checkEnv(container.Env, "SERVING_CONFIGURATION", config.Name, "")
 			checkEnv(container.Env, "SERVING_REVISION", rev.Name, "")
 			checkEnv(container.Env, "SERVING_AUTOSCALER_PORT", strconv.Itoa(autoscalerPort), "")
-			if got, want := len(container.VolumeMounts), 2; got != want {
+			if got, want := len(container.VolumeMounts), 3; got != want {
 				t.Errorf("Unexpected number of volume mounts: got: %v, want: %v", got, want)
 			} else {
 				if got, want := container.VolumeMounts[0].MountPath, "/etc/config-autoscaler"; got != want {
 					t.Errorf("Unexpected volume mount path: got: %v, want: %v", got, want)
 				}
 				if got, want := container.VolumeMounts[1].MountPath, "/etc/config-logging"; got != want {
+					t.Errorf("Unexpected volume mount path: got: %v, want: %v", got, want)
+				}
+				if got, want := container.VolumeMounts[2].MountPath, "/etc/config-experiments"; got != want {
 					t.Errorf("Unexpected volume mount path: got: %v, want: %v", got, want)
 				}
 			}


### PR DESCRIPTION
Adds dedicated experimental flag guarding. This will pave the way for
making an e2e test dashboard that can continuously test our experiments
without the need to turn them on at HEAD.

To use:

Create a flag in config/experiments/config-experiments.yaml. For
instance,

```yaml
data:
  autoscaler.enable-my-experiment: "true"
```

Then, in the binary you would like to flag guard:

```golang
	var (
         experimentalFlagSet = k8sflag.NewFlagSet("/etc/config-experiments")

	 enableMyExperiment =
	 experimentalFlagSet.Bool("autoscaler.enable-my-experiment", false)
	 ...
	 )
	 ...

	 # If my experiment is enabled, run my new code path
	 if enableMyExperiment.Get() {
		# my new feature
	 }
	 ...
```
That's it. To enable experiments, simply run 
`ko apply -f
config/experiments/config-experiments.yaml` before running `ko apply -f
config/`

## Proposed Changes

 * Adding new configMap, config-experiments
 * Mounting a new optional volume for the new configMap.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
