### PR TITLE
Remove ClusterIP=None specification in Route's service

### DIFF
--- a/pkg/controller/route/istio/service.go
+++ b/pkg/controller/route/istio/service.go
@@ -24,9 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MakeRouteK8SService creates a Service that targets nothing, owned by the provided v1alpha1.Route.  The purpose of
-// this service is to provide a FQDN for Istio routing.  Since Istio does not provide IP address routing, a ClusterIP is
-// useless here.  As a result we assign ClusterIP: "None" for this Service to avoid redundant IP assignment.
+// MakeRouteK8SService creates a Service that targets nothing, owned
+// by the provided v1alpha1.Route.  The purpose of this service is to
+// provide a domain name for Istio routing.
 func MakeRouteK8SService(route *v1alpha1.Route) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -44,7 +44,6 @@ func MakeRouteK8SService(route *v1alpha1.Route) *corev1.Service {
 					Port: PortNumber,
 				},
 			},
-			ClusterIP: "None",
 		},
 	}
 }

--- a/pkg/controller/route/istio/service_test.go
+++ b/pkg/controller/route/istio/service_test.go
@@ -41,7 +41,6 @@ func TestMakeRouteK8SService_ValidSpec(t *testing.T) {
 			Name: "http",
 			Port: 80,
 		}},
-		ClusterIP: "None",
 	}
 	spec := MakeRouteK8SService(r).Spec
 	if diff := cmp.Diff(expectedSpec, spec); diff != "" {


### PR DESCRIPTION
In #1228 we allowed the usage of cluster local domain name, but we incorrectly specified "ClusterIP: None" for the route's placeholder service.  Thanks @scothis for noticing.  @scothis opened PR #1423, but he's on vacation so I talked to him to replace it with this PR instead.

