### PR TITLE
Integration tests to retry on TCP dial timeout too

### DIFF
--- a/test/request.go
+++ b/test/request.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"time"
 
@@ -52,6 +53,10 @@ func waitForRequestToDomainState(logger *zap.SugaredLogger, address string, spoo
 	err = wait.PollImmediate(requestInterval, requestTimeout, func() (bool, error) {
 		resp, err := h.Do(req)
 		if err != nil {
+			if err, ok := err.(net.Error); ok && err.Timeout() {
+				logger.Infof("Retrying for TCP timeout %v", err)
+				return false, nil
+			}
 			return true, err
 		}
 


### PR DESCRIPTION
Looks like in many cases the log shows that connection failed after 1ms

```
I0630 13:48:19.842] info	TestRouteCreation	test/request.go:106	Wait for the endpoint to be up and handling requests I0630 13:48:19.843] 
---
FAIL: TestRouteCreation (80.27s) 
I0630 13:48:19.843] route_test.go:89: The endpoint for Route pizzaplanetbnuyrqnq at domain pizzaplanetbnuyrqnq.pizzaplanet.example.com didn't serve the expected text "What a spaceport!": Get http://35.232.247.95: dial tcp 35.232.247.95:80: i/o timeout
```

The attempt was made @ 13:48.19.842, the error happens at 13:48.19.843.

This adds a retry.