### PR TITLE
Update samples to no longer refers to K8s Ingresses.

### DIFF
--- a/sample/autoscale/README.md
+++ b/sample/autoscale/README.md
@@ -29,13 +29,13 @@ kubectl apply -f sample/autoscale/sample.yaml
 
 ```
 
-Export your Ingress IP as SERVICE_IP.
+Export your ingress IP as SERVICE_IP.
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the ingress Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route autoscale-route -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 

--- a/sample/buildpack-app/README.md
+++ b/sample/buildpack-app/README.md
@@ -55,21 +55,21 @@ Once the `BuildComplete` status becomes `True` the resources will start getting 
 
 To access this service via `curl`, we first need to determine its ingress address:
 ```shell
-$ watch kubectl get ing
-NAME                             HOSTS                          ADDRESS    PORTS     AGE
-buildpack-sample-app-ingress buildpack-app.example.com                 80        3m
+$ watch kubectl get svc knative-ingressgateway -n istio-system
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 Once the `ADDRESS` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route buildpack-sample-app -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 
-# Curl the Ingress IP "as-if" DNS were properly configured.
+# Curl the ingress IP "as-if" DNS were properly configured.
 $ curl --header "Host: $SERVICE_HOST" http://${SERVICE_IP}/
 [response]
 ```

--- a/sample/buildpack-function/README.md
+++ b/sample/buildpack-function/README.md
@@ -54,22 +54,22 @@ Once the `BuildComplete` status becomes `True` the resources will start getting 
 
 To access this service via `curl`, we first need to determine its ingress address:
 ```shell
-$ watch kubectl get ing
-NAME                             HOSTS                                        ADDRESS   PORTS   AGE
-buildpack-function-ingress   buildpack-function.default.example.com   0.0.0.0   80      3m
+watch kubectl get svc knative-ingressgateway -n istio-system
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
-Once the `ADDRESS` gets assigned to the cluster, you can run:
+Once the `EXTERNAL-IP` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 $ export SERVICE_HOST=`kubectl get route buildpack-function -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 $ export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 
 
-# Curl the Ingress IP "as-if" DNS were properly configured.
+# Curl the ingress IP "as-if" DNS were properly configured.
 $ curl http://${SERVICE_IP}/ -H "Host: $SERVICE_HOST" -H "Content-Type: application/json" -d "33"
 [response]
 ```

--- a/sample/gitwebhook/README.md
+++ b/sample/gitwebhook/README.md
@@ -47,14 +47,14 @@ kubectl get revisions -o yaml
 ```
 
 To make this service accessible to github, we first need to determine its ingress address
-(might have to wait a little while until 'ADDRESS' gets assigned):
+(might have to wait a little while until `EXTERNAL-IP` gets assigned):
 ```shell
-$ watch kubectl get ingress
-NAME                                 HOSTS                     ADDRESS        PORTS     AGE
-git-webhook-ingress              demostuff.aikas.org       35.202.30.59   80        14s
+watch kubectl get svc knative-ingressgateway -n istio-system
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
-Once the `ADDRESS` gets assigned to the cluster, you need to assign a DNS name for that IP address.
+Once the `EXTERNAL-IP` gets assigned to the cluster, you need to assign a DNS name for that IP address.
 [Using GCP DNS](https://support.google.com/domains/answer/3290350)
 
 So, you'd need to create an A record for demostuff.aikas.org pointing to 35.202.30.59.

--- a/sample/grpc-ping/README.md
+++ b/sample/grpc-ping/README.md
@@ -37,10 +37,10 @@ kubectl apply -f sample/grpc-ping/sample.yaml
 1. Fetch the created ingress hostname and IP.
 
 ```
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route grpc-ping -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 

--- a/sample/helloworld/README.md
+++ b/sample/helloworld/README.md
@@ -52,28 +52,28 @@ kubectl get revisions -o yaml
 
 To access this service via `curl`, we first need to determine its ingress address:
 ```shell
-watch kubectl get ingress
+watch kubectl get svc knative-ingressgateway -n istio-system
 ```
 
-When the ingress is ready, you'll see an IP address in the ADDRESS field:
+When the service is ready, you'll see an IP address in the `EXTERNAL-IP` field:
 
 ```
-NAME                                 HOSTS                     ADDRESS   PORTS     AGE
-route-example-ingress   demo.myhost.net             80        14s
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
-Once the `ADDRESS` gets assigned to the cluster, you can run:
+Once the `EXTERNAL-IP` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route route-example -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+your services will never get an external IP address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
 export SERVICE_IP=$(kubectl get po -l knative=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')

--- a/sample/private-repos/README.md
+++ b/sample/private-repos/README.md
@@ -157,7 +157,7 @@ As with the other demos, you can confirm that things work by capturing the IP
 of the ingress endpoint:
 
 ```
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route private-repos \
   -o jsonpath="{.status.domain}"`
 
@@ -165,7 +165,7 @@ export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jso
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+your services will never get an external IP address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
 export SERVICE_IP=$(kubectl get po -l knative=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')

--- a/sample/pythonsimple/README.md
+++ b/sample/pythonsimple/README.md
@@ -47,30 +47,30 @@ kubectl get revisions -o yaml
 
 ```
 
-To access this service via `curl`, we first need to determine its ingress address:
+To access this service via `curl`, we first need to determine the ingress address:
 ```shell
-watch kubectl get ingress
+watch kubectl get svc knative-ingressgateway -n istio-system
 ```
 
-When the ingress is ready, you'll see an IP address in the ADDRESS field:
+When that service is ready, you'll see an IP address in the `EXTERNAL-IP` field:
 
 ```
-NAME                                 HOSTS                     ADDRESS   PORTS     AGE
-route-python-example-ingress   demo.myhost.net             80        14s
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
-Once the `ADDRESS` gets assigned to the cluster, you can run:
+Once the `EXTERNAL-IP` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route route-python-example -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+your services will never get an external IP address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
 export SERVICE_IP=$(kubectl get po -l knative=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')

--- a/sample/service/README.md
+++ b/sample/service/README.md
@@ -55,30 +55,30 @@ kubectl get revisions -o yaml
 
 ```
 
-To access this service via `curl`, we first need to determine its ingress address:
+To access this service via `curl`, we first need to determine the ingress address:
 ```shell
-watch kubectl get ingress
+kubectl get svc knative-ingressgateway -n istio-system
 ```
 
-When the ingress is ready, you'll see an IP address in the ADDRESS field:
+When the service is ready, you'll see an IP address in the `EXTERNAL-IP` field:
 
 ```
-NAME                                 HOSTS                     ADDRESS   PORTS     AGE
-service-example-ingress   demo.myhost.net             80        14s
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
-Once the `ADDRESS` gets assigned to the cluster, you can run:
+Once the `EXTERNAL-IP` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route service-example -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+your services will never get an external IP address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
 export SERVICE_IP=$(kubectl get po -l knative=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')

--- a/sample/stock-rest-app/README.md
+++ b/sample/stock-rest-app/README.md
@@ -52,28 +52,28 @@ kubectl get revisions -o yaml
 
 To access this service via `curl`, we first need to determine its ingress address:
 ```shell
-watch kubectl get ingress
+watch get svc knative-ingressgateway -n istio-system
 ```
 
-When the ingress is ready, you'll see an IP address in the ADDRESS field:
+When the service is ready, you'll see an IP address in the EXTERNAL-IP field:
 
 ```
-NAME                                 HOSTS                     ADDRESS   PORTS     AGE
-stock-route-example-ingress   stock-route-example.default.example.com   35.185.44.102   80        1m
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 Once the `ADDRESS` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the host name into an environment variable.
 export SERVICE_HOST=`kubectl get route stock-route-example -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+your services will never get an external IP address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
 export SERVICE_IP=$(kubectl get po -l knative=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')

--- a/sample/telemetrysample/README.md
+++ b/sample/telemetrysample/README.md
@@ -52,21 +52,21 @@ kubectl get revisions -o yaml
 
 To access this service via `curl`, we first need to determine its ingress address:
 ```shell
-watch kubectl get ingress
-NAME                                 HOSTS                     ADDRESS   PORTS     AGE
-telemetrysample-route-ingress   telemetrysample.myhost.net             80        14s
+watch kubectl get svc knative-ingressgateway -n istio-system
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
-Once the `ADDRESS` gets assigned to the cluster, you can run:
+Once the `EXTERNAL-IP` gets assigned to the cluster, you can run:
 
 ```shell
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route telemetrysample-route -o jsonpath="{.status.domain}"`
 
-# Put the Ingress IP into an environment variable.
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 
-# Curl the Ingress IP "as-if" DNS were properly configured.
+# Curl the ingress IP "as-if" DNS were properly configured.
 curl --header "Host:$SERVICE_HOST" http://${SERVICE_IP}
 Hello World!
 ```

--- a/sample/thumbnailer/README.md
+++ b/sample/thumbnailer/README.md
@@ -117,7 +117,9 @@ Once `BuildComplete` has a `status: "True"`, the revision will get deployed as i
 To confirm that the app deployed, you can check for the Knative Serving service using `kubectl`. First, is there an ingress service:
 
 ```
-kubectl get ing
+kubectl get svc knative-ingressgateway -n istio-system
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 Sometimes the newly deployed app may take few seconds to initialize. You can check its status like this
@@ -129,14 +131,15 @@ kubectl -n default get pods
 The Knative Serving ingress service will automatically be assigned an IP so let's capture that IP so we can use it in subsequent `curl` commands
 
 ```
-# Put the Ingress Host name into an environment variable.
+# Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route thumb -o jsonpath="{.status.domain}"`
 
+# Put the ingress IP into an environment variable.
 export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
-your ingress will never get an address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
+your services will never get an external IP address. In that case, use the istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
 export SERVICE_IP=$(kubectl get po -l knative=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')


### PR DESCRIPTION
This excludes the `knative-routing` sample, which will need a more involved update.

Fixes #1446 