### PR TITLE
Move resource synthesis for Route into resources package.

### DIFF
--- a/pkg/controller/route/cruds.go
+++ b/pkg/controller/route/cruds.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/knative/serving/pkg/apis/istio/v1alpha3"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/controller/route/istio"
+	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/logging"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +56,7 @@ func (c *Controller) reconcileVirtualService(ctx context.Context, route *v1alpha
 
 func (c *Controller) reconcilePlaceholderService(ctx context.Context, route *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
-	service := istio.MakeRouteK8SService(route)
+	service := resources.MakeK8sService(route)
 	if _, err := c.KubeClientSet.CoreV1().Services(route.Namespace).Create(service); err != nil {
 		if apierrs.IsAlreadyExists(err) {
 			// Service already exist.

--- a/pkg/controller/route/cruds_test.go
+++ b/pkg/controller/route/cruds_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/serving/pkg/apis/istio/v1alpha3"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/controller/route/istio"
+	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/controller/route/traffic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -91,5 +91,5 @@ func newTestVirtualService(r *v1alpha1.Route) *v1alpha3.VirtualService {
 			},
 			Active: true,
 		}}}}
-	return istio.MakeVirtualService(r, tc)
+	return resources.MakeVirtualService(r, tc)
 }

--- a/pkg/controller/route/resources/doc.go
+++ b/pkg/controller/route/resources/doc.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This package contains code that builds Istio CRDs to be use by the
-route controller for configuring an Istio mesh for Routes.
-*/
-
-package istio
+// Package resources holds simple functions for synthesizing child resources
+// from a Route resource and any relevant Route controller configuration.
+package resources

--- a/pkg/controller/route/resources/service.go
+++ b/pkg/controller/route/resources/service.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package istio
+package resources
 
 import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -24,10 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MakeRouteK8SService creates a Service that targets nothing, owned
+// MakeK8sService creates a Service that targets nothing, owned
 // by the provided v1alpha1.Route.  The purpose of this service is to
 // provide a domain name for Istio routing.
-func MakeRouteK8SService(route *v1alpha1.Route) *corev1.Service {
+func MakeK8sService(route *v1alpha1.Route) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controller.GetServingK8SServiceNameForRoute(route),
@@ -38,12 +38,10 @@ func MakeRouteK8SService(route *v1alpha1.Route) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name: PortName,
-					Port: PortNumber,
-				},
-			},
+			Ports: []corev1.ServicePort{{
+				Name: PortName,
+				Port: PortNumber,
+			}},
 		},
 	}
 }

--- a/pkg/controller/route/resources/service_test.go
+++ b/pkg/controller/route/resources/service_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package istio
+package resources
 
 import (
 	"testing"
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestMakeRouteK8SService_ValidSpec(t *testing.T) {
+func TestMakeK8SService_ValidSpec(t *testing.T) {
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -42,13 +42,13 @@ func TestMakeRouteK8SService_ValidSpec(t *testing.T) {
 			Port: 80,
 		}},
 	}
-	spec := MakeRouteK8SService(r).Spec
+	spec := MakeK8sService(r).Spec
 	if diff := cmp.Diff(expectedSpec, spec); diff != "" {
 		t.Errorf("Unexpected ServiceSpec (-want +got): %v", diff)
 	}
 }
 
-func TestMakeRouteK8SService_ValidMeta(t *testing.T) {
+func TestMakeK8sService_ValidMeta(t *testing.T) {
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -66,7 +66,7 @@ func TestMakeRouteK8SService_ValidMeta(t *testing.T) {
 			*controller.NewRouteControllerRef(r),
 		},
 	}
-	meta := MakeRouteK8SService(r).ObjectMeta
+	meta := MakeK8sService(r).ObjectMeta
 	if diff := cmp.Diff(expectedMeta, meta); diff != "" {
 		t.Errorf("Unexpected Metadata (-want +got): %v", diff)
 	}

--- a/pkg/controller/route/resources/virtual_service.go
+++ b/pkg/controller/route/resources/virtual_service.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package istio
+package resources
 
 import (
 	"fmt"

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -32,7 +32,7 @@ import (
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
-	"github.com/knative/serving/pkg/controller/route/istio"
+	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/controller/route/traffic"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/logging/logkey"
@@ -188,7 +188,7 @@ func (c *Controller) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 		return r, targetErr
 	}
 	logger.Info("All referred targets are routable.  Creating Istio VirtualService.")
-	if err := c.reconcileVirtualService(ctx, r, istio.MakeVirtualService(r, t)); err != nil {
+	if err := c.reconcileVirtualService(ctx, r, resources.MakeVirtualService(r, t)); err != nil {
 		return r, err
 	}
 	logger.Info("VirtualService created, marking AllTrafficAssigned with traffic information.")

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -53,7 +53,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/knative/serving/pkg/controller/route/istio"
+	"github.com/knative/serving/pkg/controller/route/resources"
 	. "github.com/knative/serving/pkg/controller/testing"
 )
 
@@ -397,7 +397,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 			AppendHeaders: map[string]string{
 				ctrl.GetRevisionHeaderName():      "test-rev",
 				ctrl.GetRevisionHeaderNamespace(): testNamespace,
-				istio.EnvoyTimeoutHeader:          istio.DefaultEnvoyTimeoutMs,
+				resources.EnvoyTimeoutHeader:      resources.DefaultEnvoyTimeoutMs,
 			},
 		}},
 	}
@@ -564,7 +564,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			AppendHeaders: map[string]string{
 				ctrl.GetRevisionHeaderName():      "test-rev",
 				ctrl.GetRevisionHeaderNamespace(): testNamespace,
-				istio.EnvoyTimeoutHeader:          istio.DefaultEnvoyTimeoutMs,
+				resources.EnvoyTimeoutHeader:      resources.DefaultEnvoyTimeoutMs,
 			},
 		}},
 	}


### PR DESCRIPTION
This mostly is a rename of the `istio` package to be consistent with the other controllers moving this same direction.