### PR TITLE
Separate the Revision controller configs into a subpackage.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -43,6 +43,7 @@ import (
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/controller/configuration"
 	"github.com/knative/serving/pkg/controller/revision"
+	revisionconfig "github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/controller/route"
 	"github.com/knative/serving/pkg/controller/service"
 	"github.com/knative/serving/pkg/signals"
@@ -113,7 +114,7 @@ func main() {
 		time.Minute*5, pkg.GetServingSystemNamespace(), nil)
 	vpaInformerFactory := vpainformers.NewSharedInformerFactory(vpaClient, time.Second*30)
 
-	revControllerConfig := revision.ControllerConfig{
+	revControllerConfig := revisionconfig.Controller{
 		AutoscalerImage:                autoscalerImage,
 		QueueSidecarImage:              queueSidecarImage,
 		RegistriesSkippingTagResolving: toStringSet(registriesSkippingTagResolving, ","),

--- a/pkg/controller/revision/config/controller.go
+++ b/pkg/controller/revision/config/controller.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// Controller includes the configurations for the controller.
+type Controller struct {
+	// AutoscalerImage is the name of the image used for the autoscaler pod.
+	AutoscalerImage string
+
+	// QueueSidecarImage is the name of the image used for the queue sidecar
+	// injected into the revision pod
+	QueueSidecarImage string
+
+	// Repositories for which tag to digest resolving should be skipped
+	RegistriesSkippingTagResolving map[string]struct{}
+}

--- a/pkg/controller/revision/config/doc.go
+++ b/pkg/controller/revision/config/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config holds the typed objects that define the schemas for
+// assorted ConfigMap objects on which the Revision controller depends.
+package config

--- a/pkg/controller/revision/config/network.go
+++ b/pkg/controller/revision/config/network.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package revision
+package config
 
 import (
 	"net"
@@ -29,9 +29,9 @@ const (
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 )
 
-// NetworkConfig contains the networking configuration defined in the
+// Network contains the networking configuration defined in the
 // network config map.
-type NetworkConfig struct {
+type Network struct {
 	// IstioOutboundIPRange specifies the IP ranges to intercept
 	// by Istio sidecar.
 	IstioOutboundIPRanges string
@@ -51,9 +51,9 @@ func validateOutboundIPRanges(s string) error {
 	return nil
 }
 
-// NewNetworkConfigFromConfigMap creates a NewNetworkConfig from the supplied ConfigMap
-func NewNetworkConfigFromConfigMap(configMap *corev1.ConfigMap) (*NetworkConfig, error) {
-	nc := &NetworkConfig{}
+// NewNetworkFromConfigMap creates a Network from the supplied ConfigMap
+func NewNetworkFromConfigMap(configMap *corev1.ConfigMap) (*Network, error) {
+	nc := &Network{}
 	if ipr, ok := configMap.Data[IstioOutboundIPRangesKey]; !ok {
 		// It is OK for this to be absent, we will elide the annotation.
 	} else if err := validateOutboundIPRanges(ipr); err != nil {

--- a/pkg/controller/revision/config/network_test.go
+++ b/pkg/controller/revision/config/network_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package revision
+package config
 
 import (
 	"fmt"
@@ -28,29 +28,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNewNetworkConfigNoEntry(t *testing.T) {
-	c, err := NewNetworkConfigFromConfigMap(&corev1.ConfigMap{
+func TestNewNetworkNoEntry(t *testing.T) {
+	c, err := NewNetworkFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pkg.GetServingSystemNamespace(),
 			Name:      controller.GetNetworkConfigMapName(),
 		},
 	})
 	if err != nil {
-		t.Errorf("NewNetworkConfigFromConfigMap() = %v", err)
+		t.Errorf("NewNetworkFromConfigMap() = %v", err)
 	}
 	if len(c.IstioOutboundIPRanges) > 0 {
 		t.Error("Expected an empty value when config map doesn't have the entry.")
 	}
 }
 
-func TestNewNetworkConfig(t *testing.T) {
+func TestNewNetwork(t *testing.T) {
 	validList := []string{
 		"10.10.10.0/24",                                // Valid single outbound IP range
 		"10.10.10.0/24,10.240.10.0/14,192.192.10.0/16", // Valid multiple outbound IP ranges
 		"*",
 	}
 	for _, want := range validList {
-		c, err := NewNetworkConfigFromConfigMap(&corev1.ConfigMap{
+		c, err := NewNetworkFromConfigMap(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: pkg.GetServingSystemNamespace(),
 				Name:      controller.GetNetworkConfigMapName(),
@@ -60,7 +60,7 @@ func TestNewNetworkConfig(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Errorf("NewNetworkConfigFromConfigMap() = %v", err)
+			t.Errorf("NewNetworkFromConfigMap() = %v", err)
 		}
 		if c.IstioOutboundIPRanges != want {
 			t.Errorf("Want %v, got %v", want, c.IstioOutboundIPRanges)
@@ -68,7 +68,7 @@ func TestNewNetworkConfig(t *testing.T) {
 	}
 }
 
-func TestBadNetworkConfig(t *testing.T) {
+func TestBadNetwork(t *testing.T) {
 	invalidList := []string{
 		"",                       // Empty input should generate no annotation
 		"10.10.10.10/33",         // Invalid outbound IP range
@@ -82,7 +82,7 @@ func TestBadNetworkConfig(t *testing.T) {
 		"this is not an IP range",
 	}
 	for _, invalid := range invalidList {
-		c, err := NewNetworkConfigFromConfigMap(&corev1.ConfigMap{
+		c, err := NewNetworkFromConfigMap(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: pkg.GetServingSystemNamespace(),
 				Name:      controller.GetNetworkConfigMapName(),
@@ -92,12 +92,12 @@ func TestBadNetworkConfig(t *testing.T) {
 			},
 		})
 		if err == nil {
-			t.Errorf("NewNetworkConfigFromConfigMap() = %v, wanted error", c)
+			t.Errorf("NewNetworkFromConfigMap() = %v, wanted error", c)
 		}
 	}
 }
 
-func TestOurNetworkConfig(t *testing.T) {
+func TestOurNetwork(t *testing.T) {
 	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", controller.GetNetworkConfigMapName()))
 	if err != nil {
 		t.Errorf("ReadFile() = %v", err)
@@ -106,7 +106,7 @@ func TestOurNetworkConfig(t *testing.T) {
 	if err := yaml.Unmarshal(b, &cm); err != nil {
 		t.Errorf("yaml.Unmarshal() = %v", err)
 	}
-	if _, err := NewNetworkConfigFromConfigMap(&cm); err != nil {
-		t.Errorf("NewNetworkConfigFromConfigMap() = %v", err)
+	if _, err := NewNetworkFromConfigMap(&cm); err != nil {
+		t.Errorf("NewNetworkFromConfigMap() = %v", err)
 	}
 }

--- a/pkg/controller/revision/config/observability.go
+++ b/pkg/controller/revision/config/observability.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package revision
+package config
 
 import (
 	"fmt"
@@ -23,8 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ObservabilityConfig contains the configuration defined in the observability ConfigMap.
-type ObservabilityConfig struct {
+// Observability contains the configuration defined in the observability ConfigMap.
+type Observability struct {
 	// EnableVarLogCollection dedicates whether to set up a fluentd sidecar to
 	// collect logs under /var/log/.
 	EnableVarLogCollection bool
@@ -44,9 +44,9 @@ type ObservabilityConfig struct {
 	LoggingURLTemplate string
 }
 
-// NewObservabilityConfigFromConfigMap creates a ObservabilityConfig from the supplied ConfigMap
-func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*ObservabilityConfig, error) {
-	oc := &ObservabilityConfig{}
+// NewObservabilityFromConfigMap creates a Observability from the supplied ConfigMap
+func NewObservabilityFromConfigMap(configMap *corev1.ConfigMap) (*Observability, error) {
+	oc := &Observability{}
 	if evlc, ok := configMap.Data["logging.enable-var-log-collection"]; ok {
 		oc.EnableVarLogCollection = (strings.ToLower(evlc) == "true")
 	}

--- a/pkg/controller/revision/config/observability_test.go
+++ b/pkg/controller/revision/config/observability_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package revision
+package config
 
 import (
 	"fmt"
@@ -28,15 +28,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNewObservabilityConfigNoEntry(t *testing.T) {
-	c, err := NewObservabilityConfigFromConfigMap(&corev1.ConfigMap{
+func TestNewObservabilityNoEntry(t *testing.T) {
+	c, err := NewObservabilityFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pkg.GetServingSystemNamespace(),
 			Name:      controller.GetObservabilityConfigMapName(),
 		},
 	})
 	if err != nil {
-		t.Fatalf("NewObservabilityConfigFromConfigMap() = %v", err)
+		t.Fatalf("NewObservabilityFromConfigMap() = %v", err)
 	}
 	if got, want := c.EnableVarLogCollection, false; got != want {
 		t.Errorf("EnableVarLogCollection = %v, want %v", got, want)
@@ -46,8 +46,8 @@ func TestNewObservabilityConfigNoEntry(t *testing.T) {
 	}
 }
 
-func TestNewObservabilityConfigNoSidecar(t *testing.T) {
-	c, err := NewObservabilityConfigFromConfigMap(&corev1.ConfigMap{
+func TestNewObservabilityNoSidecar(t *testing.T) {
+	c, err := NewObservabilityFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pkg.GetServingSystemNamespace(),
 			Name:      controller.GetObservabilityConfigMapName(),
@@ -57,15 +57,15 @@ func TestNewObservabilityConfigNoSidecar(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatalf("NewObservabilityConfigFromConfigMap() = %v, want error", c)
+		t.Fatalf("NewObservabilityFromConfigMap() = %v, want error", c)
 	}
 }
 
-func TestNewObservabilityConfig(t *testing.T) {
+func TestNewObservability(t *testing.T) {
 	wantFSI := "gcr.io/log-stuff/fluentd:latest"
 	wantFSOC := "the-config"
 	wantLUT := "https://logging.io"
-	c, err := NewObservabilityConfigFromConfigMap(&corev1.ConfigMap{
+	c, err := NewObservabilityFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pkg.GetServingSystemNamespace(),
 			Name:      controller.GetObservabilityConfigMapName(),
@@ -78,7 +78,7 @@ func TestNewObservabilityConfig(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("NewObservabilityConfigFromConfigMap() = %v", err)
+		t.Fatalf("NewObservabilityFromConfigMap() = %v", err)
 	}
 	if got := c.FluentdSidecarImage; got != wantFSI {
 		t.Errorf("FluentdSidecarImage = %v, want %v", got, wantFSI)
@@ -91,7 +91,7 @@ func TestNewObservabilityConfig(t *testing.T) {
 	}
 }
 
-func TestOurObservabilityConfig(t *testing.T) {
+func TestOurObservability(t *testing.T) {
 	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", controller.GetObservabilityConfigMapName()))
 	if err != nil {
 		t.Errorf("ReadFile() = %v", err)
@@ -100,7 +100,7 @@ func TestOurObservabilityConfig(t *testing.T) {
 	if err := yaml.Unmarshal(b, &cm); err != nil {
 		t.Errorf("yaml.Unmarshal() = %v", err)
 	}
-	if _, err := NewObservabilityConfigFromConfigMap(&cm); err != nil {
-		t.Errorf("NewObservabilityConfigFromConfigMap() = %v", err)
+	if _, err := NewObservabilityFromConfigMap(&cm); err != nil {
+		t.Errorf("NewObservabilityFromConfigMap() = %v", err)
 	}
 }

--- a/pkg/controller/revision/config/testdata/config-network.yaml
+++ b/pkg/controller/revision/config/testdata/config-network.yaml
@@ -1,0 +1,1 @@
+../../../../../config/config-network.yaml

--- a/pkg/controller/revision/config/testdata/config-observability.yaml
+++ b/pkg/controller/revision/config/testdata/config-observability.yaml
@@ -1,0 +1,1 @@
+../../../../../config/config-observability.yaml

--- a/pkg/controller/revision/pod.go
+++ b/pkg/controller/revision/pod.go
@@ -20,6 +20,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 
@@ -74,7 +75,7 @@ func hasHTTPPath(p *corev1.Probe) bool {
 }
 
 // MakeServingPodSpec creates a pod spec.
-func MakeServingPodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observabilityConfig *ObservabilityConfig, autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *corev1.PodSpec {
+func MakeServingPodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observabilityConfig *config.Observability, autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.PodSpec {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name
@@ -202,8 +203,8 @@ func MakeServingPodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 
 // MakeServingDeployment creates a deployment.
 func MakeServingDeployment(rev *v1alpha1.Revision,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig, replicaCount int32) *appsv1.Deployment {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller, replicaCount int32) *appsv1.Deployment {
 
 	podTemplateAnnotations := MakeServingResourceAnnotations(rev)
 	podTemplateAnnotations[sidecarIstioInjectAnnotation] = "true"

--- a/pkg/controller/revision/queue.go
+++ b/pkg/controller/revision/queue.go
@@ -23,6 +23,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +33,7 @@ import (
 )
 
 // MakeServingQueueContainer creates the container spec for queue sidecar.
-func MakeServingQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *corev1.Container {
+func MakeServingQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.Container {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name

--- a/pkg/controller/revision/queueing_test.go
+++ b/pkg/controller/revision/queueing_test.go
@@ -30,6 +30,7 @@ import (
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/configmap"
 	ctrl "github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/logging"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -110,8 +111,8 @@ func getTestRevision() *v1alpha1.Revision {
 	}
 }
 
-func getTestControllerConfig() *ControllerConfig {
-	return &ControllerConfig{
+func getTestControllerConfig() *config.Controller {
+	return &config.Controller{
 		QueueSidecarImage: testQueueImage,
 		AutoscalerImage:   testAutoscalerImage,
 	}

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -45,6 +45,7 @@ import (
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	ctrl "github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/queue"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -133,7 +134,7 @@ func sumMaps(a map[string]string, b map[string]string) map[string]string {
 	return summedMap
 }
 
-func newTestControllerWithConfig(t *testing.T, controllerConfig *ControllerConfig, configs ...*corev1.ConfigMap) (
+func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controller, configs ...*corev1.ConfigMap) (
 	kubeClient *fakekubeclientset.Clientset,
 	buildClient *fakebuildclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
@@ -1776,7 +1777,7 @@ func getPodAnnotationsForConfig(t *testing.T, configMapValue string, configAnnot
 			Namespace: pkg.GetServingSystemNamespace(),
 		},
 		Data: map[string]string{
-			IstioOutboundIPRangesKey: configMapValue,
+			config.IstioOutboundIPRangesKey: configMapValue,
 		}})
 
 	rev := getTestRevision()

--- a/pkg/controller/revision/table_test.go
+++ b/pkg/controller/revision/table_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/logging"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,9 +36,9 @@ import (
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestReconcile(t *testing.T) {
-	networkConfig := &NetworkConfig{IstioOutboundIPRanges: "*"}
+	networkConfig := &config.Network{IstioOutboundIPRanges: "*"}
 	loggingConfig := &logging.Config{}
-	observabilityConfig := &ObservabilityConfig{
+	observabilityConfig := &config.Observability{
 		LoggingURLTemplate: "http://logger.io/${REVISION_UID}",
 	}
 	autoscalerConfig := &autoscaler.Config{}
@@ -1242,8 +1243,8 @@ func build(namespace, name string, conds ...buildv1alpha1.BuildCondition) *build
 
 // The input signatures of these functions should be kept in sync for readability.
 func getRev(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *v1alpha1.Revision {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *v1alpha1.Revision {
 	return &v1alpha1.Revision{
 		ObjectMeta: om(namespace, name),
 		Spec: v1alpha1.RevisionSpec{
@@ -1254,8 +1255,8 @@ func getRev(namespace, name string, servingState v1alpha1.RevisionServingStateTy
 }
 
 func getDeploy(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *appsv1.Deployment {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *appsv1.Deployment {
 
 	var replicaCount int32 = 1
 	if servingState == v1alpha1.RevisionServingStateReserve {
@@ -1268,8 +1269,8 @@ func getDeploy(namespace, name string, servingState v1alpha1.RevisionServingStat
 }
 
 func getService(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *corev1.Service {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.Service {
 
 	rev := getRev(namespace, name, servingState, image, loggingConfig, networkConfig, observabilityConfig,
 		autoscalerConfig, controllerConfig)
@@ -1277,8 +1278,8 @@ func getService(namespace, name string, servingState v1alpha1.RevisionServingSta
 }
 
 func getEndpoints(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *corev1.Endpoints {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.Endpoints {
 
 	service := getService(namespace, name, servingState, image, loggingConfig, networkConfig, observabilityConfig,
 		autoscalerConfig, controllerConfig)
@@ -1291,8 +1292,8 @@ func getEndpoints(namespace, name string, servingState v1alpha1.RevisionServingS
 }
 
 func getASDeploy(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *appsv1.Deployment {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *appsv1.Deployment {
 
 	var replicaCount int32 = 1
 	if servingState == v1alpha1.RevisionServingStateReserve {
@@ -1304,8 +1305,8 @@ func getASDeploy(namespace, name string, servingState v1alpha1.RevisionServingSt
 }
 
 func getASService(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *corev1.Service {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.Service {
 
 	rev := getRev(namespace, name, servingState, image, loggingConfig, networkConfig, observabilityConfig,
 		autoscalerConfig, controllerConfig)
@@ -1313,8 +1314,8 @@ func getASService(namespace, name string, servingState v1alpha1.RevisionServingS
 }
 
 func getASEndpoints(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,
-	loggingConfig *logging.Config, networkConfig *NetworkConfig, observabilityConfig *ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, controllerConfig *ControllerConfig) *corev1.Endpoints {
+	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.Endpoints {
 
 	service := getASService(namespace, name, servingState, image, loggingConfig, networkConfig, observabilityConfig,
 		autoscalerConfig, controllerConfig)

--- a/pkg/controller/revision/testdata/config-network.yaml
+++ b/pkg/controller/revision/testdata/config-network.yaml
@@ -1,1 +1,0 @@
-../../../../config/config-network.yaml

--- a/pkg/controller/revision/testdata/config-observability.yaml
+++ b/pkg/controller/revision/testdata/config-observability.yaml
@@ -1,1 +1,0 @@
-../../../../config/config-observability.yaml


### PR DESCRIPTION
As a precursor to moving all fo the MakeFoo methods into a resources subpackage of `pkg/controller/revision`, this moves the assorted "configs" on which they depend (currently a part of the revision package monolith) into a "config" subpackage.
