### PR TITLE
Move the Route controller's DomainConfig to config.Domain.

### DIFF
--- a/pkg/controller/route/config/doc.go
+++ b/pkg/controller/route/config/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config holds the typed objects that define the schemas for
+// assorted ConfigMap objects on which the Route controller depends.
+package config

--- a/pkg/controller/route/config/domain.go
+++ b/pkg/controller/route/config/domain.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package route
+package config
 
 import (
 	"fmt"
@@ -45,9 +45,9 @@ func (s *LabelSelector) Matches(labels map[string]string) bool {
 	return true
 }
 
-// DomainConfig maps domains to routes by matching the domain's
+// Domain maps domains to routes by matching the domain's
 // label selectors to the route's labels.
-type DomainConfig struct {
+type Domain struct {
 	// Domains map from domain to label selector.  If a route has
 	// labels matching a particular selector, it will use the
 	// corresponding domain.  If multiple selectors match, we choose
@@ -55,9 +55,9 @@ type DomainConfig struct {
 	Domains map[string]*LabelSelector
 }
 
-// NewDomainConfigFromConfigMap creates a DomainConfig from the supplied ConfigMap
-func NewDomainConfigFromConfigMap(configMap *corev1.ConfigMap) (*DomainConfig, error) {
-	c := DomainConfig{Domains: map[string]*LabelSelector{}}
+// NewDomainFromConfigMap creates a Domain from the supplied ConfigMap
+func NewDomainFromConfigMap(configMap *corev1.ConfigMap) (*Domain, error) {
+	c := Domain{Domains: map[string]*LabelSelector{}}
 	hasDefault := false
 	for k, v := range configMap.Data {
 		labelSelector := LabelSelector{}
@@ -79,7 +79,7 @@ func NewDomainConfigFromConfigMap(configMap *corev1.ConfigMap) (*DomainConfig, e
 // LookupDomainForLabels returns a domain given a set of labels.
 // Since we reject configuration without a default domain, this should
 // always return a value.
-func (c *DomainConfig) LookupDomainForLabels(labels map[string]string) string {
+func (c *Domain) LookupDomainForLabels(labels map[string]string) string {
 	domain := ""
 	specificity := -1
 

--- a/pkg/controller/route/config/domain_test.go
+++ b/pkg/controller/route/config/domain_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package route
+package config
 
 import (
 	"fmt"
@@ -60,7 +60,7 @@ func TestSelectorMatches(t *testing.T) {
 }
 
 func TestNewConfigNoEntry(t *testing.T) {
-	_, err := NewDomainConfigFromConfigMap(&corev1.ConfigMap{
+	_, err := NewDomainFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pkg.GetServingSystemNamespace(),
 			Name:      controller.GetDomainConfigMapName(),
@@ -71,8 +71,23 @@ func TestNewConfigNoEntry(t *testing.T) {
 	}
 }
 
+func TestNewConfigBadYaml(t *testing.T) {
+	c, err := NewDomainFromConfigMap(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pkg.GetServingSystemNamespace(),
+			Name:      controller.GetDomainConfigMapName(),
+		},
+		Data: map[string]string{
+			"default.com": "bad: yaml: all: day",
+		},
+	})
+	if err == nil {
+		t.Errorf("NewDomainFromConfigMap() = %v, wanted error", c)
+	}
+}
+
 func TestNewConfig(t *testing.T) {
-	expectedConfig := DomainConfig{
+	expectedConfig := Domain{
 		Domains: map[string]*LabelSelector{
 			"test-domain.foo.com": {
 				Selector: map[string]string{
@@ -88,7 +103,7 @@ func TestNewConfig(t *testing.T) {
 			"default.com": {},
 		},
 	}
-	c, err := NewDomainConfigFromConfigMap(&corev1.ConfigMap{
+	c, err := NewDomainFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pkg.GetServingSystemNamespace(),
 			Name:      controller.GetDomainConfigMapName(),
@@ -108,7 +123,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestLookupDomainForLabels(t *testing.T) {
-	config := DomainConfig{
+	config := Domain{
 		Domains: map[string]*LabelSelector{
 			"test-domain.foo.com": {
 				Selector: map[string]string{
@@ -162,7 +177,7 @@ func TestLookupDomainForLabels(t *testing.T) {
 	}
 }
 
-func TestOurDomainConfig(t *testing.T) {
+func TestOurDomain(t *testing.T) {
 	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", controller.GetDomainConfigMapName()))
 	if err != nil {
 		t.Errorf("ReadFile() = %v", err)
@@ -171,7 +186,7 @@ func TestOurDomainConfig(t *testing.T) {
 	if err := yaml.Unmarshal(b, &cm); err != nil {
 		t.Errorf("yaml.Unmarshal() = %v", err)
 	}
-	if _, err := NewDomainConfigFromConfigMap(&cm); err != nil {
-		t.Errorf("NewDomainConfigFromConfigMap() = %v", err)
+	if _, err := NewDomainFromConfigMap(&cm); err != nil {
+		t.Errorf("NewDomainFromConfigMap() = %v", err)
 	}
 }

--- a/pkg/controller/route/config/testdata/config-domain.yaml
+++ b/pkg/controller/route/config/testdata/config-domain.yaml
@@ -1,0 +1,1 @@
+../../../../../config/config-domain.yaml

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -32,6 +32,7 @@ import (
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/route/config"
 	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/controller/route/traffic"
 	"github.com/knative/serving/pkg/logging"
@@ -52,7 +53,7 @@ type Controller struct {
 
 	// Domain configuration could change over time and access to domainConfig
 	// must go through domainConfigMutex
-	domainConfig      *DomainConfig
+	domainConfig      *config.Domain
 	domainConfigMutex sync.Mutex
 }
 
@@ -232,7 +233,7 @@ func loggerWithRouteInfo(logger *zap.SugaredLogger, ns string, name string) *zap
 	return logger.With(zap.String(logkey.Namespace, ns), zap.String(logkey.Route, name))
 }
 
-func (c *Controller) getDomainConfig() *DomainConfig {
+func (c *Controller) getDomainConfig() *config.Domain {
 	c.domainConfigMutex.Lock()
 	defer c.domainConfigMutex.Unlock()
 	return c.domainConfig
@@ -244,7 +245,7 @@ func (c *Controller) routeDomain(route *v1alpha1.Route) string {
 }
 
 func (c *Controller) receiveDomainConfig(configMap *corev1.ConfigMap) {
-	newDomainConfig, err := NewDomainConfigFromConfigMap(configMap)
+	newDomainConfig, err := config.NewDomainFromConfigMap(configMap)
 	if err != nil {
 		c.Logger.Error("Failed to parse the new config map. Previous config map will be used.",
 			zap.Error(err))

--- a/pkg/controller/route/testdata/config-domain.yaml
+++ b/pkg/controller/route/testdata/config-domain.yaml
@@ -1,1 +1,0 @@
-../../../../config/config-domain.yaml


### PR DESCRIPTION
This is mostly for symmetry with the Revision controller.
