### PR TITLE
Remove redundant testing from revision_test.go

### DIFF
--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
@@ -36,7 +35,6 @@ import (
 	. "github.com/knative/serving/pkg/logging/testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
 	buildinformers "github.com/knative/build/pkg/client/informers/externalversions"
@@ -47,12 +45,10 @@ import (
 	ctrl "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/controller/revision/resources"
-	"github.com/knative/serving/pkg/queue"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	fakevpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
 	vpainformers "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions"
 
@@ -60,7 +56,6 @@ import (
 
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
-	kubetesting "k8s.io/client-go/testing"
 
 	. "github.com/knative/serving/pkg/controller/testing"
 )
@@ -79,23 +74,6 @@ func getTestReadyEndpoints(revName string) *corev1.Endpoints {
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", revName),
-			Namespace: testNamespace,
-			Labels: map[string]string{
-				serving.RevisionLabelKey: revName,
-			},
-		},
-		Subsets: []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{
-				IP: "123.456.78.90",
-			}},
-		}},
-	}
-}
-
-func getTestAuxiliaryReadyEndpoints(revName string) *corev1.Endpoints {
-	return &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-auxiliary", revName),
 			Namespace: testNamespace,
 			Labels: map[string]string{
 				serving.RevisionLabelKey: revName,
@@ -330,311 +308,6 @@ func (r *fixedResolver) Resolve(deploy *appsv1.Deployment) error {
 	return nil
 }
 
-func TestCreateRevCreatesStuff(t *testing.T) {
-	controllerConfig := getTestControllerConfig()
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestControllerWithConfig(t, controllerConfig)
-
-	// Resolve image references to this "digest"
-	digest := "foo@sha256:deadbeef"
-	controller.resolver = &fixedResolver{digest}
-
-	rev := getTestRevision()
-	config := getTestConfiguration()
-	rev.OwnerReferences = append(
-		rev.OwnerReferences,
-		*ctrl.NewControllerRef(config),
-	)
-
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// This function is used to verify pass through of container environment
-	// variables.
-	checkEnv := func(env []corev1.EnvVar, name, value, fieldPath string) {
-		nameFound := false
-		for _, e := range env {
-			if e.Name == name {
-				nameFound = true
-				if value != "" && e.Value != value {
-					t.Errorf("Incorrect environment variable %s. Expected value %s. Got %s.", name, value, e.Value)
-				}
-				if fieldPath != "" {
-					if vf := e.ValueFrom; vf == nil {
-						t.Errorf("Incorrect environment variable %s. Missing value source.", name)
-					} else if fr := vf.FieldRef; fr == nil {
-						t.Errorf("Incorrect environment variable %s. Missing field ref.", name)
-					} else if fr.FieldPath != fieldPath {
-						t.Errorf("Incorrect environment variable %s. Expected field path %s. Got %s.",
-							name, fr.FieldPath, fieldPath)
-					}
-				}
-			}
-		}
-		if !nameFound {
-			t.Errorf("Missing environment variable %s", name)
-		}
-	}
-
-	// Look for the revision deployment.
-	expectedDeploymentName := fmt.Sprintf("%s-deployment", rev.Name)
-	deployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(expectedDeploymentName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get serving deployment: %v", err)
-	}
-
-	if len(deployment.OwnerReferences) != 1 && rev.Name != deployment.OwnerReferences[0].Name {
-		t.Errorf("expected owner references to have 1 ref with name %s", rev.Name)
-	}
-
-	foundQueueProxy := false
-	foundServingContainer := false
-	foundFluentdProxy := false
-	expectedPreStop := &corev1.Handler{
-		HTTPGet: &corev1.HTTPGetAction{
-			Port: intstr.FromInt(queue.RequestQueueAdminPort),
-			Path: queue.RequestQueueQuitPath,
-		},
-	}
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		// Our fixedResolver will replace all image references with "digest".
-		if container.Image != digest {
-			t.Errorf("container.Image = %v, want %v", container.Image, digest)
-		}
-		if container.Name == "queue-proxy" {
-			foundQueueProxy = true
-			checkEnv(container.Env, "SERVING_NAMESPACE", testNamespace, "")
-			checkEnv(container.Env, "SERVING_CONFIGURATION", config.Name, "")
-			checkEnv(container.Env, "SERVING_REVISION", rev.Name, "")
-			checkEnv(container.Env, "SERVING_POD", "", "metadata.name")
-			checkEnv(container.Env, "SERVING_AUTOSCALER", ctrl.GetRevisionAutoscalerName(rev), "")
-			checkEnv(container.Env, "SERVING_AUTOSCALER_PORT", strconv.Itoa(resources.AutoscalerPort), "")
-			checkEnv(container.Env, "SERVING_LOGGING_CONFIG", controller.getLoggingConfig().LoggingConfig, "")
-			checkEnv(container.Env, "SERVING_LOGGING_LEVEL", controller.getLoggingConfig().LoggingLevel["queueproxy"], "")
-			if diff := cmp.Diff(expectedPreStop, container.Lifecycle.PreStop); diff != "" {
-				t.Errorf("Unexpected PreStop diff in container %q (-want +got): %v", container.Name, diff)
-			}
-
-			expectedArgs := []string{
-				fmt.Sprintf("-concurrencyQuantumOfTime=%v", controller.getAutoscalerConfig().ConcurrencyQuantumOfTime),
-				fmt.Sprintf("-concurrencyModel=%v", rev.Spec.ConcurrencyModel),
-			}
-			if diff := cmp.Diff(expectedArgs, container.Args); diff != "" {
-				t.Errorf("Unexpected args diff in container %q (-want +got): %v", container.Name, diff)
-			}
-		}
-		if container.Name == resources.UserContainerName {
-			foundServingContainer = true
-			// verify that the ReadinessProbe has our port.
-			if container.ReadinessProbe.Handler.HTTPGet.Port != intstr.FromInt(queue.RequestQueuePort) {
-				t.Errorf("Expect ReadinessProbe handler to have port %d, saw %v",
-					queue.RequestQueuePort, container.ReadinessProbe.Handler.HTTPGet.Port)
-			}
-			if diff := cmp.Diff(expectedPreStop, container.Lifecycle.PreStop); diff != "" {
-				t.Errorf("Unexpected PreStop diff in container %q (-want +got): %v", container.Name, diff)
-			}
-		}
-		if container.Name == "fluentd-proxy" {
-			foundFluentdProxy = true
-			checkEnv(container.Env, "SERVING_NAMESPACE", testNamespace, "")
-			checkEnv(container.Env, "SERVING_REVISION", rev.Name, "")
-			checkEnv(container.Env, "SERVING_CONFIGURATION", config.Name, "")
-			checkEnv(container.Env, "SERVING_CONTAINER_NAME", "user-container", "")
-			checkEnv(container.Env, "SERVING_POD_NAME", "", "metadata.name")
-		}
-	}
-	if !foundQueueProxy {
-		t.Error("Missing queue-proxy container")
-	}
-	if !foundFluentdProxy {
-		t.Error("Missing fluentd-proxy container")
-	}
-	if !foundServingContainer {
-		t.Errorf("Missing %q container", resources.UserContainerName)
-	}
-	expectedLabels := sumMaps(
-		rev.Labels,
-		map[string]string{
-			serving.RevisionLabelKey: rev.Name,
-			serving.RevisionUID:      string(rev.UID),
-			resources.AppLabelKey:    rev.Name,
-		},
-	)
-	expectedAnnotations := rev.Annotations
-	expectedPodSpecAnnotations := sumMaps(
-		rev.Annotations,
-		map[string]string{"sidecar.istio.io/inject": "true"},
-	)
-
-	if labels := deployment.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedLabels) {
-		t.Errorf("Labels not set correctly on deployment: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	if labels := deployment.Spec.Template.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedLabels) {
-		t.Errorf("Label not set correctly in pod template: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	if annotations := deployment.ObjectMeta.Annotations; !reflect.DeepEqual(annotations, expectedAnnotations) {
-		t.Errorf("Annotations not set correctly on deployment: expected %v got %v.",
-			expectedAnnotations, annotations)
-	}
-	if annotations := deployment.Spec.Template.ObjectMeta.Annotations; !reflect.DeepEqual(annotations, expectedPodSpecAnnotations) {
-		t.Errorf("Annotations not set correctly in pod template: expected %v got %v.",
-			expectedPodSpecAnnotations, annotations)
-	}
-
-	// Look for the revision service.
-	expectedServiceName := fmt.Sprintf("%s-service", rev.Name)
-	service, err := kubeClient.CoreV1().Services(testNamespace).Get(expectedServiceName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get revision service: %v", err)
-	}
-	// The revision service should be owned by rev.
-	expectedRefs := []metav1.OwnerReference{{
-		APIVersion: "serving.knative.dev/v1alpha1",
-		Kind:       "Revision",
-		Name:       rev.Name,
-		UID:        rev.UID,
-	}}
-
-	if diff := cmp.Diff(expectedRefs, service.OwnerReferences, cmpopts.IgnoreFields(expectedRefs[0], "Controller", "BlockOwnerDeletion")); diff != "" {
-		t.Errorf("Unexpected service owner refs diff (-want +got): %v", diff)
-	}
-	if labels := service.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedLabels) {
-		t.Errorf("Label not set correctly for revision service: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	if annotations := service.ObjectMeta.Annotations; !reflect.DeepEqual(annotations, expectedAnnotations) {
-		t.Errorf("Annotations not set correctly for revision service: expected %v got %v.",
-			expectedAnnotations, annotations)
-	}
-
-	// Look for the autoscaler deployment.
-	expectedAutoscalerName := fmt.Sprintf("%s-autoscaler", rev.Name)
-	expectedAutoscalerLabels := sumMaps(
-		expectedLabels,
-		map[string]string{serving.AutoscalerLabelKey: expectedAutoscalerName},
-	)
-	expectedAutoscalerPodSpecAnnotations := sumMaps(
-		rev.Annotations,
-		map[string]string{"sidecar.istio.io/inject": "true"},
-	)
-
-	asDeployment, err := kubeClient.AppsV1().Deployments(pkg.GetServingSystemNamespace()).Get(expectedAutoscalerName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get autoscaler deployment: %v", err)
-	}
-	if labels := asDeployment.Spec.Template.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedAutoscalerLabels) {
-		t.Errorf("Label not set correctly in autoscaler pod template: expected %v got %v.",
-			expectedAutoscalerLabels, labels)
-	}
-	if annotations := asDeployment.Spec.Template.ObjectMeta.Annotations; !reflect.DeepEqual(annotations, expectedAutoscalerPodSpecAnnotations) {
-		t.Errorf("Annotations not set correctly in autoscaler pod template: expected %v got %v.",
-			expectedAutoscalerPodSpecAnnotations, annotations)
-	}
-	// Check the autoscaler deployment environment variables and arguments
-	foundAutoscaler := false
-	for _, container := range asDeployment.Spec.Template.Spec.Containers {
-		if container.Name == "autoscaler" {
-			foundAutoscaler = true
-			checkEnv(container.Env, "SERVING_NAMESPACE", testNamespace, "")
-			checkEnv(container.Env, "SERVING_DEPLOYMENT", expectedDeploymentName, "")
-			checkEnv(container.Env, "SERVING_CONFIGURATION", config.Name, "")
-			checkEnv(container.Env, "SERVING_REVISION", rev.Name, "")
-			checkEnv(container.Env, "SERVING_AUTOSCALER_PORT", strconv.Itoa(resources.AutoscalerPort), "")
-			if got, want := len(container.VolumeMounts), 2; got != want {
-				t.Errorf("Unexpected number of volume mounts: got: %v, want: %v", got, want)
-			} else {
-				if got, want := container.VolumeMounts[0].MountPath, "/etc/config-autoscaler"; got != want {
-					t.Errorf("Unexpected volume mount path: got: %v, want: %v", got, want)
-				}
-				if got, want := container.VolumeMounts[1].MountPath, "/etc/config-logging"; got != want {
-					t.Errorf("Unexpected volume mount path: got: %v, want: %v", got, want)
-				}
-			}
-
-			expectedArgs := []string{
-				fmt.Sprintf("-concurrencyModel=%v", rev.Spec.ConcurrencyModel),
-			}
-			if diff := cmp.Diff(expectedArgs, container.Args); diff != "" {
-				t.Errorf("Unexpected args diff in container %q (-want +got): %v", container.Name, diff)
-			}
-
-			break
-		}
-	}
-	if !foundAutoscaler {
-		t.Error("Missing autoscaler")
-	}
-
-	// Validate the config volumes for auto scaler
-	if got, want := len(asDeployment.Spec.Template.Spec.Volumes), 2; got != want {
-		t.Errorf("Unexpected number of volumes: got: %v, want: %v", got, want)
-	} else {
-		if got, want := asDeployment.Spec.Template.Spec.Volumes[0].ConfigMap.LocalObjectReference.Name, "config-autoscaler"; got != want {
-			t.Errorf("Unexpected configmap reference: got: %v, want: %v", got, want)
-		}
-		if got, want := asDeployment.Spec.Template.Spec.Volumes[1].ConfigMap.LocalObjectReference.Name, "config-logging"; got != want {
-			t.Errorf("Unexpected configmap reference: got: %v, want: %v", got, want)
-		}
-	}
-
-	// Look for the autoscaler service.
-	asService, err := kubeClient.CoreV1().Services(pkg.GetServingSystemNamespace()).Get(expectedAutoscalerName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get autoscaler service: %v", err)
-	}
-	// The autoscaler service should also be owned by rev.
-	if diff := cmp.Diff(expectedRefs, asService.OwnerReferences, cmpopts.IgnoreFields(expectedRefs[0], "Controller", "BlockOwnerDeletion")); diff != "" {
-		t.Errorf("Unexpected service owner refs diff (-want +got): %v", diff)
-	}
-	if labels := asService.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedAutoscalerLabels) {
-		t.Errorf("Label not set correctly autoscaler service: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	if annotations := asService.ObjectMeta.Annotations; !reflect.DeepEqual(annotations, expectedAnnotations) {
-		t.Errorf("Annotations not set correctly autoscaler service: expected %v got %v.",
-			expectedAnnotations, annotations)
-	}
-
-	rev, err = servingClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
-	}
-
-	// Look for the config map.
-	configMap, err := kubeClient.CoreV1().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get config map: %v", err)
-	}
-	// The config map should also be owned by rev.
-	if diff := cmp.Diff(expectedRefs, configMap.OwnerReferences, cmpopts.IgnoreFields(expectedRefs[0], "Controller", "BlockOwnerDeletion")); diff != "" {
-		t.Errorf("Unexpected config map owner refs diff (-want +got): %v", diff)
-	}
-	fluentdConfigSource := makeFullFluentdConfig(testFluentdSidecarOutputConfig)
-	if got, want := configMap.Data["varlog.conf"], fluentdConfigSource; got != want {
-		t.Errorf("Fluent config file not set correctly config map: expected %v got %v.",
-			want, got)
-	}
-
-	rev, err = servingClient.ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
-	}
-
-	// Ensure that the Revision status is updated.
-	for _, ct := range []v1alpha1.RevisionConditionType{"Ready"} {
-		got := rev.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionUnknown,
-			Reason:             "Deploying",
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-}
-
 type errorResolver struct {
 	error string
 }
@@ -652,10 +325,7 @@ func TestResolutionFailed(t *testing.T) {
 
 	rev := getTestRevision()
 	config := getTestConfiguration()
-	rev.OwnerReferences = append(
-		rev.OwnerReferences,
-		*ctrl.NewControllerRef(config),
-	)
+	rev.OwnerReferences = append(rev.OwnerReferences, *ctrl.NewControllerRef(config))
 
 	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
 
@@ -680,57 +350,7 @@ func TestResolutionFailed(t *testing.T) {
 	}
 }
 
-func TestCreateRevDoesNotSetUpFluentdSidecarIfVarLogCollectionDisabled(t *testing.T) {
-	controllerConfig := getTestControllerConfig()
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestControllerWithConfig(t, controllerConfig, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: pkg.GetServingSystemNamespace(),
-			Name:      ctrl.GetObservabilityConfigMapName(),
-		},
-		Data: map[string]string{
-			"logging.enable-var-log-collection": "false",
-		},
-	})
-
-	rev := getTestRevision()
-	config := getTestConfiguration()
-	rev.OwnerReferences = append(
-		rev.OwnerReferences,
-		*ctrl.NewControllerRef(config),
-	)
-
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Look for the revision deployment.
-	expectedDeploymentName := fmt.Sprintf("%s-deployment", rev.Name)
-	deployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(expectedDeploymentName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get serving deployment: %v", err)
-	}
-
-	if len(deployment.OwnerReferences) != 1 && rev.Name != deployment.OwnerReferences[0].Name {
-		t.Errorf("expected owner references to have 1 ref with name %s", rev.Name)
-	}
-
-	// Check the revision deployment fluentd proxy
-	foundFluentdProxy := false
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == "fluentd-proxy" {
-			foundFluentdProxy = true
-			break
-		}
-	}
-	if foundFluentdProxy {
-		t.Error("fluentd-proxy container shouldn't be set up")
-	}
-
-	// Look for the config map.
-	_, err = kubeClient.CoreV1().ConfigMaps(testNamespace).Get(fluentdConfigMapName, metav1.GetOptions{})
-	if !apierrs.IsNotFound(err) {
-		t.Fatalf("The ConfigMap %s shouldn't exist: %v", fluentdConfigMapName, err)
-	}
-}
-
+// TODO(mattmoor): Add fluentd table testing.
 func TestCreateRevUpdateConfigMap_NewData(t *testing.T) {
 	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
 	rev := getTestRevision()
@@ -760,6 +380,7 @@ func TestCreateRevUpdateConfigMap_NewData(t *testing.T) {
 	}
 }
 
+// TODO(mattmoor): Add fluentd table testing.
 func TestCreateRevUpdateConfigMap_NewRevOwnerReference(t *testing.T) {
 	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
 	rev := getTestRevision()
@@ -794,36 +415,7 @@ func TestCreateRevUpdateConfigMap_NewRevOwnerReference(t *testing.T) {
 	}
 }
 
-func TestCreateRevWithWithLoggingURL(t *testing.T) {
-	controllerConfig := getTestControllerConfig()
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestControllerWithConfig(t, controllerConfig, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: pkg.GetServingSystemNamespace(),
-			Name:      ctrl.GetObservabilityConfigMapName(),
-		},
-		Data: map[string]string{
-			"logging.enable-var-log-collection":     "true",
-			"logging.fluentd-sidecar-image":         testFluentdImage,
-			"logging.fluentd-sidecar-output-config": testFluentdSidecarOutputConfig,
-			"logging.revision-url-template":         "http://logging.test.com?filter=${REVISION_UID}",
-		},
-	})
-	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-	rev := getTestRevision()
-
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	createdRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
-	}
-
-	expectedLoggingURL := fmt.Sprintf("http://logging.test.com?filter=%s", rev.UID)
-	if createdRev.Status.LogURL != expectedLoggingURL {
-		t.Errorf("Created revision does not have a logging URL: expected: %s, got: %s", expectedLoggingURL, createdRev.Status.LogURL)
-	}
-}
-
+// TODO(mattmoor): Add VPA table testing
 func TestCreateRevWithVPA(t *testing.T) {
 	controllerConfig := getTestControllerConfig()
 	kubeClient, _, servingClient, vpaClient, controller, kubeInformer, _, servingInformer, _, _ := newTestControllerWithConfig(t, controllerConfig, &corev1.ConfigMap{
@@ -866,6 +458,7 @@ func TestCreateRevWithVPA(t *testing.T) {
 	}
 }
 
+// TODO(mattmoor): add coverage of a Reconcile fixing a stale logging URL
 func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 	controllerConfig := getTestControllerConfig()
 	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestControllerWithConfig(t, controllerConfig, &corev1.ConfigMap{
@@ -911,200 +504,7 @@ func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 	}
 }
 
-func TestCreateRevPreservesAppLabel(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-	rev.Labels["app"] = "app-label-that-should-stay-unchanged"
-	servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
-
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev, deployment, service := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	expectedLabels := sumMaps(
-		rev.Labels,
-		map[string]string{
-			serving.RevisionLabelKey: rev.Name,
-			serving.RevisionUID:      string(rev.UID),
-		},
-	)
-	if labels := deployment.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedLabels) {
-		t.Errorf("Labels not set correctly on deployment: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	if labels := deployment.Spec.Template.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedLabels) {
-		t.Errorf("Label not set correctly in pod template: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	if labels := service.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedLabels) {
-		t.Errorf("Label not set correctly for revision service: expected %v got %v.",
-			expectedLabels, labels)
-	}
-	// Look for the autoscaler deployment.
-	expectedAutoscalerName := fmt.Sprintf("%s-autoscaler", rev.Name)
-	expectedAutoscalerLabels := sumMaps(
-		expectedLabels,
-		map[string]string{serving.AutoscalerLabelKey: expectedAutoscalerName},
-	)
-	asDeployment, err := kubeClient.AppsV1().Deployments(pkg.GetServingSystemNamespace()).Get(expectedAutoscalerName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get autoscaler deployment: %v", err)
-	}
-	if labels := asDeployment.Spec.Template.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedAutoscalerLabels) {
-		t.Errorf("Label not set correctly in autoscaler pod template: expected %v got %v.",
-			expectedAutoscalerLabels, labels)
-	}
-	// Look for the autoscaler service.
-	asService, err := kubeClient.CoreV1().Services(pkg.GetServingSystemNamespace()).Get(expectedAutoscalerName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get autoscaler service: %v", err)
-	}
-	if labels := asService.ObjectMeta.Labels; !reflect.DeepEqual(labels, expectedAutoscalerLabels) {
-		t.Errorf("Label not set correctly autoscaler service: expected %v got %v.",
-			expectedLabels, labels)
-	}
-}
-
-func TestCreateRevWithBuildNameWaits(t *testing.T) {
-	kubeClient, buildClient, servingClient, _, controller, kubeInformer, buildInformer, servingInformer, _, _ := newTestController(t)
-	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-
-	bld := &buildv1alpha1.Build{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
-			Name:      "foo",
-		},
-		Spec: buildv1alpha1.BuildSpec{
-			Steps: []corev1.Container{{
-				Name:    "nop",
-				Image:   "busybox:latest",
-				Command: []string{"/bin/sh"},
-				Args:    []string{"-c", "echo Hello"},
-			}},
-		},
-		Status: buildv1alpha1.BuildStatus{
-			Conditions: []buildv1alpha1.BuildCondition{{
-				Type:   buildv1alpha1.BuildSucceeded,
-				Status: corev1.ConditionUnknown,
-			}},
-		},
-	}
-	buildClient.BuildV1alpha1().Builds(testNamespace).Create(bld)
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	buildInformer.Build().V1alpha1().Builds().Informer().GetIndexer().Add(bld)
-
-	rev := getTestRevision()
-	// Direct the Revision to wait for this build to complete.
-	rev.Spec.BuildName = bld.Name
-
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	waitRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
-	}
-
-	// Ensure that the Revision status is updated.
-	for _, ct := range []v1alpha1.RevisionConditionType{"BuildSucceeded", "Ready"} {
-		got := waitRev.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionUnknown,
-			Reason:             "Building",
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-}
-
-func TestCreateRevWithFailedBuildNameFails(t *testing.T) {
-	kubeClient, buildClient, servingClient, _, controller, kubeInformer, buildInformer, servingInformer, _, _ := newTestController(t)
-	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-
-	reason := "Foo"
-	errMessage := "a long human-readable error message."
-
-	h := NewHooks()
-	// Look for the build failure event. Events are delivered asynchronously so
-	// we need to use hooks here.
-	h.OnCreate(&kubeClient.Fake, "events", ExpectWarningEventDelivery(t, errMessage))
-
-	bld := &buildv1alpha1.Build{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
-			Name:      "foo",
-		},
-		Spec: buildv1alpha1.BuildSpec{
-			Steps: []corev1.Container{{
-				Name:    "nop",
-				Image:   "busybox:latest",
-				Command: []string{"/bin/sh"},
-				Args:    []string{"-c", "echo Hello"},
-			}},
-		},
-	}
-	buildClient.BuildV1alpha1().Builds(testNamespace).Create(bld)
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	buildInformer.Build().V1alpha1().Builds().Informer().GetIndexer().Add(bld)
-
-	rev := getTestRevision()
-	// Direct the Revision to wait for this build to complete.
-	rev.Spec.BuildName = bld.Name
-	rev = createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// After the initial update to the revision, we should be
-	// watching for this build to complete, so make it complete, but
-	// with a failure.
-	bld.Status = buildv1alpha1.BuildStatus{
-		Conditions: []buildv1alpha1.BuildCondition{{
-			Type:    buildv1alpha1.BuildSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  reason,
-			Message: errMessage,
-		}},
-	}
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	buildInformer.Build().V1alpha1().Builds().Informer().GetIndexer().Add(bld)
-
-	controller.EnqueueBuildTrackers(bld)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	failedRev, _, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	failedRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
-	}
-
-	// The next update we receive should tell us that the build failed,
-	// and surface the reason and message from that failure in our own
-	// status.
-	for _, ct := range []v1alpha1.RevisionConditionType{"BuildSucceeded", "Ready"} {
-		got := failedRev.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionFalse,
-			Reason:             reason,
-			Message:            errMessage,
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-
-	// Wait for events to be delivered.
-	if err := h.WaitForHooks(3 * time.Second); err != nil {
-		t.Error(err)
-	}
-}
-
+// TODO(mattmoor): Remove when we have coverage of EnqueueBuildTrackers
 func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 	kubeClient, buildClient, servingClient, _, controller, kubeInformer, buildInformer, servingInformer, _, _ := newTestController(t)
 
@@ -1187,184 +587,7 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 	}
 }
 
-func TestCreateRevWithProgressDeadlineSecondsStuff(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-
-	rev := getTestRevision()
-
-	revClient.Create(rev)
-
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev, deployment, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	if len(deployment.OwnerReferences) != 1 && rev.Name != deployment.OwnerReferences[0].Name {
-		t.Errorf("expected owner references to have 1 ref with name %s", rev.Name)
-	}
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev2Inspect, _, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	for _, ct := range []v1alpha1.RevisionConditionType{"Ready"} {
-		got := rev2Inspect.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionUnknown,
-			Reason:             "Deploying",
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-}
-
-// TODO(mattmoor): This is meant to test the checkAndUpdateDeployment logic in the,
-// Revision controller.  However, this logic is commented out because in practice it
-// fights with the defaulting logic for a Deployment.
-// func TestDeploymentReconciliation(t *testing.T) {
-// 	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-// 	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-
-// 	rev := getTestRevision()
-
-// 	revClient.Create(rev)
-
-// 	// Since Reconcile looks in the lister, we need to add it to the informer
-// 	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
-// 	controller.Reconcile(KeyOrDie(rev))
-
-// 	// Make sure that the changes from the Reconcile are reflected in our Informers.
-// 	rev, deployment, service := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-// 	makeBackingEndpoints(t, kubeClient, kubeInformer, service)
-
-// 	// First make a change that we don't expect the Revision controller to reconcile.
-// 	var tmp int32 = 37
-// 	deployment.Spec.Replicas = &tmp
-// 	// Then create a copy to compare against.
-// 	want := deployment.DeepCopy()
-// 	// Lastly, make an edit we expect the controller to revert.
-// 	deployment.Spec.Template.Spec.Containers[0].Image = "busybox"
-
-// 	kubeInformer.Apps().V1().Deployments().Informer().GetIndexer().Add(deployment)
-
-// 	controller.Reconcile(KeyOrDie(rev))
-
-// 	// Make sure that the changes from the Reconcile are reflected in our Informers.
-// 	rev2Inspect, got, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-// 	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-// 		t.Errorf("Unexpected deployment diff (-want +got): %v", diff)
-// 	}
-// 	for _, ct := range []v1alpha1.RevisionConditionType{"Ready"} {
-// 		got := rev2Inspect.Status.GetCondition(ct)
-// 		want := &v1alpha1.RevisionCondition{
-// 			Type:               ct,
-// 			Status:             corev1.ConditionUnknown,
-// 			Reason:             "Updating",
-// 			LastTransitionTime: got.LastTransitionTime,
-// 		}
-// 		if diff := cmp.Diff(want, got); diff != "" {
-// 			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-// 		}
-// 	}
-// }
-
-func TestReconciliation(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-
-	rev := getTestRevision()
-
-	revClient.Create(rev)
-
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev, _, service := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-	makeBackingEndpoints(kubeClient, kubeInformer, service)
-
-	want := service.DeepCopy()
-	// Make an edit we expect the controller to revert.
-	service.Spec.Selector = map[string]string{
-		"not-the": "same",
-	}
-
-	kubeInformer.Core().V1().Services().Informer().GetIndexer().Add(service)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev2Inspect, _, got := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Unexpected service diff (-want +got): %v", diff)
-	}
-	for _, ct := range []v1alpha1.RevisionConditionType{"Ready"} {
-		got := rev2Inspect.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionUnknown,
-			Reason:             "Updating",
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-}
-
-func TestCreateRevWithProgressDeadlineExceeded(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
-
-	rev := getTestRevision()
-
-	revClient.Create(rev)
-
-	// Since Reconcile looks in the lister, we need to add it to the informer
-	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev, deployment, service := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-	makeBackingEndpoints(kubeClient, kubeInformer, service)
-
-	if len(deployment.OwnerReferences) != 1 && rev.Name != deployment.OwnerReferences[0].Name {
-		t.Errorf("expected owner references to have 1 ref with name %s", rev.Name)
-	}
-
-	// set ProgressDeadlineSeconds on Dep spec
-	deployment.Status.Conditions = []appsv1.DeploymentCondition{{
-		Type:   appsv1.DeploymentProgressing,
-		Status: corev1.ConditionFalse,
-		Reason: "ProgressDeadlineExceeded",
-	}}
-	kubeInformer.Apps().V1().Deployments().Informer().GetIndexer().Add(deployment)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev2Inspect, _, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	for _, ct := range []v1alpha1.RevisionConditionType{"Ready"} {
-		got := rev2Inspect.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionFalse,
-			Reason:             "ProgressDeadlineExceeded",
-			Message:            "Unable to create pods for more than 120 seconds.",
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-}
-
+// TODO(mattmoor): Remove when we have coverage of EnqueueEndpointsRevision
 func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
 	rev := getTestRevision()
@@ -1418,216 +641,7 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 	}
 }
 
-func TestDoNotUpdateRevIfRevIsAlreadyReady(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Create endpoints owned by this Revision.
-	endpoints := getTestReadyEndpoints(rev.Name)
-	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Add(endpoints)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	rev, _, _ = addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	// No revision updates.
-	servingClient.Fake.PrependReactor("update", "revisions",
-		func(a kubetesting.Action) (bool, runtime.Object, error) {
-			t.Error("Revision was updated unexpectedly")
-			return true, nil, nil
-		},
-	)
-
-	controller.Reconcile(KeyOrDie(rev))
-}
-
-func TestMarkRevAsFailedIfEndpointHasNoAddressesAfterSomeDuration(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-
-	rev = createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	creationTime := time.Now().Add(-10 * time.Minute)
-	rev.ObjectMeta.CreationTimestamp = metav1.NewTime(creationTime)
-	for i := range rev.Status.Conditions {
-		rev.Status.Conditions[i].LastTransitionTime = rev.ObjectMeta.CreationTimestamp
-	}
-
-	updateRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Create endpoints owned by this Revision.
-	endpoints := getTestNotReadyEndpoints(rev.Name)
-
-	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Add(endpoints)
-	controller.Reconcile(KeyOrDie(rev))
-
-	// Make sure that the changes from the Reconcile are reflected in our Informers.
-	currentRev, _, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
-
-	for _, ct := range []v1alpha1.RevisionConditionType{"ResourcesAvailable", "Ready"} {
-		got := currentRev.Status.GetCondition(ct)
-		want := &v1alpha1.RevisionCondition{
-			Type:               ct,
-			Status:             corev1.ConditionFalse,
-			Reason:             "ServiceTimeout",
-			Message:            "Timed out waiting for a service endpoint to become ready",
-			LastTransitionTime: got.LastTransitionTime,
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
-		}
-	}
-}
-
-func TestAuxiliaryEndpointDoesNotUpdateRev(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Create endpoints owned by this Revision.
-	endpoints := getTestAuxiliaryReadyEndpoints(rev.Name)
-
-	// No revision updates.
-	servingClient.Fake.PrependReactor("update", "revisions",
-		func(a kubetesting.Action) (bool, runtime.Object, error) {
-			t.Error("Revision was updated unexpectedly")
-			return true, nil, nil
-		},
-	)
-
-	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Add(endpoints)
-	controller.Reconcile(KeyOrDie(rev))
-}
-
-func TestActiveToRetiredRevisionDeletesStuff(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-
-	// Create revision and verify that the k8s resources are created as
-	// appropriate.
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Now, update the revision serving state to Retired, and force another
-	// run of the controller.
-	rev.Spec.ServingState = v1alpha1.RevisionServingStateRetired
-	updateRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Expect the deployment to be gone.
-	expectedDeploymentName := fmt.Sprintf("%s-deployment", rev.Name)
-	deployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(expectedDeploymentName, metav1.GetOptions{})
-	if err == nil {
-		t.Fatalf("Expected serving deployment to be missing but it was really here: %v", deployment)
-	}
-}
-
-func TestActiveToReserveRevisionDeactivateDeployment(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-
-	// Create revision and verify that the k8s resources are created as
-	// appropriate.
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Now, update the revision serving state to Reserve, and force another
-	// run of the controller.
-	rev.Spec.ServingState = v1alpha1.RevisionServingStateReserve
-	updateRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Expect the deployment to be there.
-	deploymentName := ctrl.GetRevisionDeploymentName(rev)
-	deployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(deploymentName, metav1.GetOptions{})
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			t.Fatalf("Expected k8s deployment to be there but it was gone: %s/%s", testNamespace, deploymentName)
-		}
-		t.Fatalf("There was an error to get the deployment %s while it exists", deploymentName)
-	}
-	if *deployment.Spec.Replicas != 0 {
-		t.Fatalf("Expected k8s deployment to have %v replicas but got %v replicas.", 0, *deployment.Spec.Replicas)
-	}
-
-	// Expect the autoscaler deployment to be there.
-	deploymentName = ctrl.GetRevisionAutoscalerName(rev)
-	_, err = kubeClient.AppsV1().Deployments(pkg.GetServingSystemNamespace()).Get(deploymentName, metav1.GetOptions{})
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			t.Fatalf("Expected autoscaler k8s deployment to be there but it was gone: %s/%s", testNamespace, deploymentName)
-		}
-		t.Fatalf("There was an error to get the autoscaler deployment %s while it exists", deploymentName)
-	}
-	if *deployment.Spec.Replicas != 0 {
-		t.Fatalf("Expected k8s deployment to have %v replicas but got %v replicas.", 0, *deployment.Spec.Replicas)
-	}
-}
-
-func TestRetiredToActiveRevisionCreatesStuff(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-
-	// Create revision. The k8s resources should not be created.
-	rev.Spec.ServingState = v1alpha1.RevisionServingStateRetired
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Expect the deployment to be gone.
-	expectedDeploymentName := fmt.Sprintf("%s-deployment", rev.Name)
-	deployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(expectedDeploymentName, metav1.GetOptions{})
-	if err == nil {
-		t.Fatalf("Expected serving deployment to be missing but it was really here: %v", deployment)
-	}
-
-	// Now, update the revision serving state to Active, and force another
-	// run of the controller.
-	rev.Spec.ServingState = v1alpha1.RevisionServingStateActive
-	updateRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	// Expect the resources to be created.
-	_, err = kubeClient.AppsV1().Deployments(testNamespace).Get(expectedDeploymentName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get serving deployment: %v", err)
-	}
-}
-
-func TestReserveToActiveRevisionCreatesStuff(t *testing.T) {
-	kubeClient, _, servingClient, _, controller, kubeInformer, _, servingInformer, _, _ := newTestController(t)
-	rev := getTestRevision()
-
-	// Create revision. Two deployments should be created with 0 replicas.
-	rev.Spec.ServingState = v1alpha1.RevisionServingStateReserve
-	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	checkZeroReplicas := func(deploymentName string, ns string) {
-		deployment, err := kubeClient.AppsV1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Expected deployment %v to be there with zero replicas but it is missing: %v", deploymentName, err)
-		}
-		if *deployment.Spec.Replicas != 0 {
-			t.Fatalf("Expected deployment %v to have %v replicas but got %v replicas.", deploymentName, 0, *deployment.Spec.Replicas)
-		}
-	}
-
-	checkZeroReplicas(ctrl.GetRevisionDeploymentName(rev), testNamespace)
-	checkZeroReplicas(ctrl.GetRevisionAutoscalerName(rev), pkg.GetServingSystemNamespace())
-
-	// Now, update the revision serving state to Active, and force another
-	// run of the controller.
-	rev.Spec.ServingState = v1alpha1.RevisionServingStateActive
-	updateRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
-
-	checkNonZeroReplicas := func(deploymentName string, ns string) {
-		deployment, err := kubeClient.AppsV1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Expected to have deployment %v with more than zero replicas but it is missing: %v", deploymentName, err)
-		}
-		if *deployment.Spec.Replicas == 0 {
-			t.Fatalf("Expected deployment %v to have more than 0 replicas but got %v replicas.", deploymentName, *deployment.Spec.Replicas)
-		}
-	}
-	checkNonZeroReplicas(ctrl.GetRevisionDeploymentName(rev), testNamespace)
-	checkNonZeroReplicas(ctrl.GetRevisionAutoscalerName(rev), pkg.GetServingSystemNamespace())
-}
-
+// TODO(mattmoor): Remove once we have table testing with the autoscaler configured so that it doesn't use single-tenant autoscaling.
 func TestNoAutoscalerImageCreatesNoAutoscalers(t *testing.T) {
 	controllerConfig := getTestControllerConfig()
 	controllerConfig.AutoscalerImage = ""
@@ -1657,6 +671,7 @@ func TestNoAutoscalerImageCreatesNoAutoscalers(t *testing.T) {
 	}
 }
 
+// This covers *error* paths in receiveNetworkConfig, since "" is not a valid value.
 func TestIstioOutboundIPRangesInjection(t *testing.T) {
 	var annotations map[string]string
 
@@ -1686,6 +701,7 @@ func TestIstioOutboundIPRangesInjection(t *testing.T) {
 	}
 }
 
+// TODO(mattmoor): Add table testing that varies the replica counts of Deployments.
 func TestReconcileReplicaCount(t *testing.T) {
 	kubeClient, _, elaClient, _, controller, kubeInformer, _, elaInformer, _, _ := newTestController(t)
 	rev := getTestRevision()


### PR DESCRIPTION
This removes test cases from revision_test.go that are redundant with coverage provided by table_test.go or (much lighter) tests in the `resources` package.

This also sprinkles TODOs throughout revision_test.go highlighting what we need coverage of to remove several remaining functions.

It is notable that by "coverage" I mean functional coverage and not strictly block coverage.