### PR TITLE
Replace nop logger in tests with the development logger

### DIFF
--- a/pkg/controller/route/cruds_test.go
+++ b/pkg/controller/route/cruds_test.go
@@ -24,11 +24,12 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/controller/route/traffic"
+	. "github.com/knative/serving/pkg/logging/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestReconcileVirtualService_Insert(t *testing.T) {
-	_, elaClient, c, _, _, _ := newTestController()
+	_, elaClient, c, _, _, _ := newTestController(t)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -40,7 +41,7 @@ func TestReconcileVirtualService_Insert(t *testing.T) {
 		Status: v1alpha1.RouteStatus{Domain: "foo.com"},
 	}
 	vs := newTestVirtualService(r)
-	if err := c.reconcileVirtualService(testCtx, r, vs); err != nil {
+	if err := c.reconcileVirtualService(TestContextWithLogger(t), r, vs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if created, err := elaClient.NetworkingV1alpha3().VirtualServices(vs.Namespace).Get(vs.Name, metav1.GetOptions{}); err != nil {
@@ -51,7 +52,7 @@ func TestReconcileVirtualService_Insert(t *testing.T) {
 }
 
 func TestReconcileVirtualService_Update(t *testing.T) {
-	_, elaClient, c, _, _, _ := newTestController()
+	_, elaClient, c, _, _, _ := newTestController(t)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -62,12 +63,12 @@ func TestReconcileVirtualService_Update(t *testing.T) {
 		},
 	}
 	vs := newTestVirtualService(r)
-	if err := c.reconcileVirtualService(testCtx, r, vs); err != nil {
+	if err := c.reconcileVirtualService(TestContextWithLogger(t), r, vs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	r.Status.Domain = "bar.com"
 	vs2 := newTestVirtualService(r)
-	if err := c.reconcileVirtualService(testCtx, r, vs2); err != nil {
+	if err := c.reconcileVirtualService(TestContextWithLogger(t), r, vs2); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if updated, err := elaClient.NetworkingV1alpha3().VirtualServices(vs.Namespace).Get(vs.Name, metav1.GetOptions{}); err != nil {

--- a/pkg/controller/route/queueing_test.go
+++ b/pkg/controller/route/queueing_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/knative/serving/pkg/configmap"
 	ctrl "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/route/config"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +34,7 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
 	. "github.com/knative/serving/pkg/controller/testing"
+	. "github.com/knative/serving/pkg/logging/testing"
 )
 
 /* TODO tests:
@@ -85,7 +85,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,
-			Logger:           zap.NewNop().Sugar(),
+			Logger:           TestLogger(t),
 		},
 		servingInformer.Serving().V1alpha1().Routes(),
 		servingInformer.Serving().V1alpha1().Configurations(),

--- a/pkg/controller/route/traffic/traffic_test.go
+++ b/pkg/controller/route/traffic/traffic_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package traffic
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -27,8 +26,6 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	clientv1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
-	"github.com/knative/serving/pkg/logging"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,11 +35,6 @@ const (
 	testNamespace       string = "test"
 	defaultDomainSuffix string = "test-domain.dev"
 	prodDomainSuffix    string = "prod-domain.com"
-)
-
-var (
-	testLogger = zap.NewNop().Sugar()
-	testCtx    = logging.WithLogger(context.Background(), testLogger)
 )
 
 // A simple fixed Configuration/Revision layout for testing.


### PR DESCRIPTION
Replace the nop logger in test setup with development logger in order to see controller logs in unit tests.
