### PR TITLE
Avoid a dependency cycle.

### DIFF
--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
-	revisionresources "github.com/knative/serving/pkg/controller/revision/resources"
+	revisionresourcenames "github.com/knative/serving/pkg/controller/revision/resources/names"
 	"github.com/knative/serving/pkg/logging/logkey"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,7 +118,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) (end Endpoint
 
 	// Get the revision endpoint
 	services := r.kubeClient.CoreV1().Services(revision.GetNamespace())
-	serviceName := revisionresources.K8sServiceName(revision)
+	serviceName := revisionresourcenames.K8sService(revision)
 	svc, err := services.Get(serviceName, metav1.GetOptions{})
 	if err != nil {
 		return internalError("Unable to get service %s for revision: %v",

--- a/pkg/controller/revision/resources/autoscaler.go
+++ b/pkg/controller/revision/resources/autoscaler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/resources/names"
 	"github.com/knative/serving/pkg/logging"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -100,7 +101,7 @@ func MakeAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string, re
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            AutoscalerName(rev),
+			Name:            names.Autoscaler(rev),
 			Namespace:       pkg.GetServingSystemNamespace(),
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),
@@ -125,7 +126,7 @@ func MakeAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string, re
 							Value: rev.Namespace,
 						}, {
 							Name:  "SERVING_DEPLOYMENT",
-							Value: DeploymentName(rev),
+							Value: names.Deployment(rev),
 						}, {
 							Name:  "SERVING_CONFIGURATION",
 							Value: configName,
@@ -153,7 +154,7 @@ func MakeAutoscalerDeployment(rev *v1alpha1.Revision, autoscalerImage string, re
 func MakeAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            AutoscalerName(rev),
+			Name:            names.Autoscaler(rev),
 			Namespace:       pkg.GetServingSystemNamespace(),
 			Labels:          makeAutoScalerLabels(rev),
 			Annotations:     makeAnnotations(rev),
@@ -163,7 +164,7 @@ func MakeAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 			Ports: autoscalerServicePorts,
 			Type:  "NodePort",
 			Selector: map[string]string{
-				serving.AutoscalerLabelKey: AutoscalerName(rev),
+				serving.AutoscalerLabelKey: names.Autoscaler(rev),
 			},
 		},
 	}
@@ -173,6 +174,6 @@ func MakeAutoscalerService(rev *v1alpha1.Revision) *corev1.Service {
 // service and deployment specs for autoscaler.
 func makeAutoScalerLabels(rev *v1alpha1.Revision) map[string]string {
 	labels := makeLabels(rev)
-	labels[serving.AutoscalerLabelKey] = AutoscalerName(rev)
+	labels[serving.AutoscalerLabelKey] = names.Autoscaler(rev)
 	return labels
 }

--- a/pkg/controller/revision/resources/deploy.go
+++ b/pkg/controller/revision/resources/deploy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/revision/config"
+	"github.com/knative/serving/pkg/controller/revision/resources/names"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 
@@ -204,7 +205,7 @@ func MakeDeployment(rev *v1alpha1.Revision,
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            DeploymentName(rev),
+			Name:            names.Deployment(rev),
 			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),

--- a/pkg/controller/revision/resources/names/doc.go
+++ b/pkg/controller/revision/resources/names/doc.go
@@ -14,24 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
-
-import (
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-)
-
-func DeploymentName(rev *v1alpha1.Revision) string {
-	return rev.Name + "-deployment"
-}
-
-func AutoscalerName(rev *v1alpha1.Revision) string {
-	return rev.Name + "-autoscaler"
-}
-
-func VPAName(rev *v1alpha1.Revision) string {
-	return rev.Name + "-vpa"
-}
-
-func K8sServiceName(rev *v1alpha1.Revision) string {
-	return rev.Name + "-service"
-}
+// Package names holds simple functions for synthesizing resource names.
+package names

--- a/pkg/controller/revision/resources/names/names.go
+++ b/pkg/controller/revision/resources/names/names.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+func Deployment(rev *v1alpha1.Revision) string {
+	return rev.Name + "-deployment"
+}
+
+func Autoscaler(rev *v1alpha1.Revision) string {
+	return rev.Name + "-autoscaler"
+}
+
+func VPA(rev *v1alpha1.Revision) string {
+	return rev.Name + "-vpa"
+}
+
+func K8sService(rev *v1alpha1.Revision) string {
+	return rev.Name + "-service"
+}

--- a/pkg/controller/revision/resources/names/names_test.go
+++ b/pkg/controller/revision/resources/names/names_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+func TestNamer(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *v1alpha1.Revision
+		f    func(*v1alpha1.Revision) string
+		want string
+	}{{
+		name: "Deployment",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		f:    Deployment,
+		want: "foo-deployment",
+	}, {
+		name: "Autoscaler",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+		f:    Autoscaler,
+		want: "bar-autoscaler",
+	}, {
+		name: "VPA",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "baz",
+			},
+		},
+		f:    VPA,
+		want: "baz-vpa",
+	}, {
+		name: "K8sService",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blah",
+			},
+		},
+		f:    K8sService,
+		want: "blah-service",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.f(test.rev)
+			if got != test.want {
+				t.Errorf("%s() = %v, wanted %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/revision/resources/queue.go
+++ b/pkg/controller/revision/resources/queue.go
@@ -23,6 +23,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller/revision/config"
+	"github.com/knative/serving/pkg/controller/revision/resources/names"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
@@ -83,7 +84,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 	if controllerConfig.AutoscalerImage == "" {
 		autoscalerAddress = "autoscaler"
 	} else {
-		autoscalerAddress = AutoscalerName(rev)
+		autoscalerAddress = names.Autoscaler(rev)
 	}
 
 	return &corev1.Container{

--- a/pkg/controller/revision/resources/service.go
+++ b/pkg/controller/revision/resources/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/resources/names"
 	"github.com/knative/serving/pkg/queue"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,7 @@ var (
 func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            K8sServiceName(rev),
+			Name:            names.K8sService(rev),
 			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),

--- a/pkg/controller/revision/resources/vpa.go
+++ b/pkg/controller/revision/resources/vpa.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
@@ -65,7 +66,7 @@ var (
 func MakeVPA(rev *v1alpha1.Revision) *vpa.VerticalPodAutoscaler {
 	return &vpa.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            VPAName(rev),
+			Name:            names.VPA(rev),
 			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -33,6 +33,7 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/controller/revision/resources"
+	resourcenames "github.com/knative/serving/pkg/controller/revision/resources/names"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/logging/logkey"
 	"go.uber.org/zap"
@@ -366,7 +367,7 @@ func (c *Controller) EnqueueEndpointsRevision(obj interface{}) {
 
 func (c *Controller) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revision) error {
 	ns := controller.GetServingNamespaceName(rev.Namespace)
-	deploymentName := resources.DeploymentName(rev)
+	deploymentName := resourcenames.Deployment(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.Deployment, deploymentName))
 
 	deployment, getDepErr := c.deploymentLister.Deployments(ns).Get(deploymentName)
@@ -494,7 +495,7 @@ func (c *Controller) deleteDeployment(ctx context.Context, deployment *appsv1.De
 
 func (c *Controller) reconcileService(ctx context.Context, rev *v1alpha1.Revision) error {
 	ns := controller.GetServingNamespaceName(rev.Namespace)
-	serviceName := resources.K8sServiceName(rev)
+	serviceName := resourcenames.K8sService(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.KubernetesService, serviceName))
 
 	rev.Status.ServiceName = serviceName
@@ -698,7 +699,7 @@ func (c *Controller) reconcileAutoscalerService(ctx context.Context, rev *v1alph
 	}
 
 	ns := pkg.GetServingSystemNamespace()
-	serviceName := resources.AutoscalerName(rev)
+	serviceName := resourcenames.Autoscaler(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.KubernetesService, serviceName))
 
 	service, err := c.serviceLister.Services(ns).Get(serviceName)
@@ -763,7 +764,7 @@ func (c *Controller) reconcileAutoscalerDeployment(ctx context.Context, rev *v1a
 	}
 
 	ns := pkg.GetServingSystemNamespace()
-	deploymentName := resources.AutoscalerName(rev)
+	deploymentName := resourcenames.Autoscaler(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.Deployment, deploymentName))
 
 	deployment, getDepErr := c.deploymentLister.Deployments(ns).Get(deploymentName)
@@ -831,7 +832,7 @@ func (c *Controller) reconcileVPA(ctx context.Context, rev *v1alpha1.Revision) e
 	}
 
 	ns := controller.GetServingNamespaceName(rev.Namespace)
-	vpaName := resources.VPAName(rev)
+	vpaName := resourcenames.VPA(rev)
 
 	// TODO(mattmoor): Switch to informer lister once it can reliably be sunk.
 	vpa, err := c.vpaClient.PocV1alpha1().VerticalPodAutoscalers(ns).Get(vpaName, metav1.GetOptions{})


### PR DESCRIPTION
Having resource names alongside the resource creation created a dependency cycle in the forthcoming multi-tenant autoscaler work.

The autoscaler needs to be able to use the `name.Deployment` method to determine the names of a `Revision`'s `Deployment` resources, but (currently) the way we `MakeDeployment` (specifically the queue container) depends on `autoscaler.Config`.

Naming seemed like a relatively self-contained piece to break off to cut this cycle.  This does that for the Revision controller.

cc @tcnghia @jonjohnsonjr 