### PR TITLE
Do not sample logs

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -23,10 +23,6 @@ data:
     {
       "level": "info",
       "development": false,
-      "sampling": {
-        "initial": 100,
-        "thereafter": 100
-      },
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
       "encoding": "json",


### PR DESCRIPTION
Logs are essential to serviceability and the default logging configuration should preserve all logs.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
The logging configuration no longer samples logs.
```
