### PR TITLE
Remove GetServingNamespaceName.

### DIFF
--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -24,13 +24,6 @@ func GetK8sServiceFullname(name string, namespace string) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace)
 }
 
-// Various functions for naming the resources for consistency
-func GetServingNamespaceName(ns string) string {
-	// We create resources in the same namespace as the Knative Serving resources by default.
-	// TODO(mattmoor): Expose a knob for creating resources in an alternate namespace.
-	return ns
-}
-
 func GetServingK8SServiceNameForObj(name string) string {
 	return name + "-service"
 }

--- a/pkg/controller/revision/resources/deploy.go
+++ b/pkg/controller/revision/resources/deploy.go
@@ -206,7 +206,7 @@ func MakeDeployment(rev *v1alpha1.Revision,
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            names.Deployment(rev),
-			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
+			Namespace:       rev.Namespace,
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),
 			OwnerReferences: []metav1.OwnerReference{*controller.NewControllerRef(rev)},

--- a/pkg/controller/revision/resources/service.go
+++ b/pkg/controller/revision/resources/service.go
@@ -42,7 +42,7 @@ func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            names.K8sService(rev),
-			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
+			Namespace:       rev.Namespace,
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),
 			OwnerReferences: []metav1.OwnerReference{*controller.NewControllerRef(rev)},

--- a/pkg/controller/revision/resources/vpa.go
+++ b/pkg/controller/revision/resources/vpa.go
@@ -67,7 +67,7 @@ func MakeVPA(rev *v1alpha1.Revision) *vpa.VerticalPodAutoscaler {
 	return &vpa.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            names.VPA(rev),
-			Namespace:       controller.GetServingNamespaceName(rev.Namespace),
+			Namespace:       rev.Namespace,
 			Labels:          makeLabels(rev),
 			Annotations:     makeAnnotations(rev),
 			OwnerReferences: []metav1.OwnerReference{*controller.NewControllerRef(rev)},

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -366,7 +366,7 @@ func (c *Controller) EnqueueEndpointsRevision(obj interface{}) {
 }
 
 func (c *Controller) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revision) error {
-	ns := controller.GetServingNamespaceName(rev.Namespace)
+	ns := rev.Namespace
 	deploymentName := resourcenames.Deployment(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.Deployment, deploymentName))
 
@@ -494,7 +494,7 @@ func (c *Controller) deleteDeployment(ctx context.Context, deployment *appsv1.De
 }
 
 func (c *Controller) reconcileService(ctx context.Context, rev *v1alpha1.Revision) error {
-	ns := controller.GetServingNamespaceName(rev.Namespace)
+	ns := rev.Namespace
 	serviceName := resourcenames.K8sService(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.KubernetesService, serviceName))
 
@@ -831,7 +831,7 @@ func (c *Controller) reconcileVPA(ctx context.Context, rev *v1alpha1.Revision) e
 		return nil
 	}
 
-	ns := controller.GetServingNamespaceName(rev.Namespace)
+	ns := rev.Namespace
 	vpaName := resourcenames.VPA(rev)
 
 	// TODO(mattmoor): Switch to informer lister once it can reliably be sunk.

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -260,7 +260,7 @@ func addResourcesToInformers(t *testing.T,
 	haveBuild := rev.Spec.BuildName != ""
 	inActive := rev.Spec.ServingState != "Active"
 
-	ns := ctrl.GetServingNamespaceName(rev.Namespace)
+	ns := rev.Namespace
 
 	deploymentName := resourcenames.Deployment(rev)
 	deployment, err := kubeClient.AppsV1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})


### PR DESCRIPTION
This removes the `GetServingNamespaceName` function, which is currently identity (with TODO).  The idea behind this identity function (with TODO) was that we might later want to enable operators to shift resource creation into a separate namespace.  However, our usage of this function has grown inconsistent, and implementing such a change faces many steeper obstacles than bringing this function back.  So for now I'm biasing towards keeping the code lean and consistent and removing it.

The reason we use same-namespace today is that many K8s abstractions we want to integrate require this namespace colocation.  Allowing the user to specify serviceaccount, configmap references, secret references, ... only work when the Pods we push those references into operate in the same namespace as the knative/serving resources.  e.g. Currently this is our only mechanism for supplying a Revision `imagePullSecrets`.

The main piece of knowledge that I've gained since leaving the TODO is that OwnerReferences (and cascaded deletions) are scoped to same-namespace.  This happens to work cross-namespace now, but we need to stop relying on that (bug not feature), see: https://github.com/knative/serving/issues/1259.

cc @evankanderson @vaikas-google 