### PR TITLE
Make the fluentd ConfigMap a more conventional resource.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -136,8 +136,9 @@ func main() {
 	revisionInformer := servingInformerFactory.Serving().V1alpha1().Revisions()
 	buildInformer := buildInformerFactory.Build().V1alpha1().Builds()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
-	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
 	coreServiceInformer := kubeInformerFactory.Core().V1().Services()
+	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
+	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	virtualServiceInformer := servingInformerFactory.Networking().V1alpha3().VirtualServices()
 	vpaInformer := vpaInformerFactory.Poc().V1alpha1().VerticalPodAutoscalers()
 
@@ -157,6 +158,7 @@ func main() {
 			deploymentInformer,
 			coreServiceInformer,
 			endpointsInformer,
+			configMapInformer,
 			vpaInformer,
 			&revControllerConfig,
 		),
@@ -196,8 +198,9 @@ func main() {
 		buildInformer.Informer().HasSynced,
 		deploymentInformer.Informer().HasSynced,
 		coreServiceInformer.Informer().HasSynced,
-		virtualServiceInformer.Informer().HasSynced,
 		endpointsInformer.Informer().HasSynced,
+		configMapInformer.Informer().HasSynced,
+		virtualServiceInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
 			logger.Fatalf("failed to wait for cache at index %v to sync", i)

--- a/pkg/controller/revision/queueing_test.go
+++ b/pkg/controller/revision/queueing_test.go
@@ -198,6 +198,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 		kubeInformer.Apps().V1().Deployments(),
 		kubeInformer.Core().V1().Services(),
 		kubeInformer.Core().V1().Endpoints(),
+		kubeInformer.Core().V1().ConfigMaps(),
 		vpaInformer.Poc().V1alpha1().VerticalPodAutoscalers(),
 		controllerConfig,
 	)

--- a/pkg/controller/revision/resources/fluentd.go
+++ b/pkg/controller/revision/resources/fluentd.go
@@ -14,11 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package revision
+package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/serving/pkg/controller/revision/config"
+	"github.com/knative/serving/pkg/controller/revision/resources/names"
 )
 
 // fluentdSidecarPreOutputConfig defines source and filter configurations for
@@ -60,23 +65,18 @@ const fluentdSidecarPreOutputConfig = `
 
 `
 
-const fluentdConfigMapName = "fluentd-varlog-config"
-
-// MakeFluentdConfigMap creates a ConfigMap that gets mounted for fluentd
-// container on the pod.
-func MakeFluentdConfigMap(
-	namespace string, fluentdSidecarOutputConfig string) *corev1.ConfigMap {
+func MakeFluentdConfigMap(rev *v1alpha1.Revision, observabilityConfig *config.Observability) *corev1.ConfigMap {
+	varlogConf := fluentdSidecarPreOutputConfig + observabilityConfig.FluentdSidecarOutputConfig
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fluentdConfigMapName,
-			Namespace: namespace,
+			Name:            names.FluentdConfigMap(rev),
+			Namespace:       rev.Namespace,
+			Labels:          makeLabels(rev),
+			Annotations:     makeAnnotations(rev),
+			OwnerReferences: []metav1.OwnerReference{*controller.NewControllerRef(rev)},
 		},
 		Data: map[string]string{
-			"varlog.conf": makeFullFluentdConfig(fluentdSidecarOutputConfig),
+			"varlog.conf": varlogConf,
 		},
 	}
-}
-
-func makeFullFluentdConfig(fluentdSidecarOutputConfig string) string {
-	return fluentdSidecarPreOutputConfig + fluentdSidecarOutputConfig
 }

--- a/pkg/controller/revision/resources/fluentd_test.go
+++ b/pkg/controller/revision/resources/fluentd_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/controller/revision/config"
+)
+
+func TestMakeFluentdConfigMap(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *v1alpha1.Revision
+		oc   *config.Observability
+		want *corev1.ConfigMap
+	}{{
+		name: "empty config",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+			},
+		},
+		oc: &config.Observability{},
+		want: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar-fluentd",
+				Labels: map[string]string{
+					serving.RevisionLabelKey: "bar",
+					serving.RevisionUID:      "1234",
+					AppLabelKey:              "bar",
+				},
+				Annotations: map[string]string{},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					Kind:               "Revision",
+					Name:               "bar",
+					UID:                "1234",
+					Controller:         &boolTrue,
+					BlockOwnerDeletion: &boolTrue,
+				}},
+			},
+			Data: map[string]string{
+				"varlog.conf": fluentdSidecarPreOutputConfig,
+			},
+		},
+	}, {
+		name: "non-empty config",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+			},
+		},
+		oc: &config.Observability{
+			FluentdSidecarOutputConfig: "foo bar config",
+		},
+		want: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar-fluentd",
+				Labels: map[string]string{
+					serving.RevisionLabelKey: "bar",
+					serving.RevisionUID:      "1234",
+					AppLabelKey:              "bar",
+				},
+				Annotations: map[string]string{},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					Kind:               "Revision",
+					Name:               "bar",
+					UID:                "1234",
+					Controller:         &boolTrue,
+					BlockOwnerDeletion: &boolTrue,
+				}},
+			},
+			Data: map[string]string{
+				"varlog.conf": fluentdSidecarPreOutputConfig + "foo bar config",
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := MakeFluentdConfigMap(test.rev, test.oc)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("MakeDeployment (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/revision/resources/names/names.go
+++ b/pkg/controller/revision/resources/names/names.go
@@ -35,3 +35,7 @@ func VPA(rev *v1alpha1.Revision) string {
 func K8sService(rev *v1alpha1.Revision) string {
 	return rev.Name + "-service"
 }
+
+func FluentdConfigMap(rev *v1alpha1.Revision) string {
+	return rev.Name + "-fluentd"
+}

--- a/pkg/controller/revision/resources/names/names_test.go
+++ b/pkg/controller/revision/resources/names/names_test.go
@@ -66,6 +66,15 @@ func TestNamer(t *testing.T) {
 		},
 		f:    K8sService,
 		want: "blah-service",
+	}, {
+		name: "FluentdConfigMap",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bazinga",
+			},
+		},
+		f:    FluentdConfigMap,
+		want: "bazinga-fluentd",
 	}}
 
 	for _, test := range tests {

--- a/pkg/controller/testing/listers.go
+++ b/pkg/controller/testing/listers.go
@@ -341,3 +341,41 @@ func (r *nsK8sServiceLister) Get(name string) (*corev1.Service, error) {
 	}
 	return nil, errors.NewNotFound(schema.GroupResource{}, name)
 }
+
+// ConfigMapLister is a lister.ConfigMapLister fake for testing.
+type ConfigMapLister struct {
+	Err   error
+	Items []*corev1.ConfigMap
+}
+
+// Assert that our fake implements the interface it is faking.
+var _ corev1listers.ConfigMapLister = (*ConfigMapLister)(nil)
+
+func (r *ConfigMapLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	return r.Items, r.Err
+}
+
+func (r *ConfigMapLister) ConfigMaps(namespace string) corev1listers.ConfigMapNamespaceLister {
+	return &nsConfigMapLister{r: r, ns: namespace}
+}
+
+type nsConfigMapLister struct {
+	r  *ConfigMapLister
+	ns string
+}
+
+// Assert that our fake implements the interface it is faking.
+var _ corev1listers.ConfigMapNamespaceLister = (*nsConfigMapLister)(nil)
+
+func (r *nsConfigMapLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	return r.r.Items, r.r.Err
+}
+
+func (r *nsConfigMapLister) Get(name string) (*corev1.ConfigMap, error) {
+	for _, s := range r.r.Items {
+		if s.Name == name && r.ns == s.Namespace {
+			return s, nil
+		}
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{}, name)
+}

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -50,6 +50,7 @@ type Listers struct {
 	Deployment *DeploymentLister
 	K8sService *K8sServiceLister
 	Endpoints  *EndpointsLister
+	ConfigMap  *ConfigMapLister
 }
 
 func (f *Listers) GetServiceLister() *ServiceLister {
@@ -108,6 +109,13 @@ func (f *Listers) GetEndpointsLister() *EndpointsLister {
 	return f.Endpoints
 }
 
+func (f *Listers) GetConfigMapLister() *ConfigMapLister {
+	if f.ConfigMap == nil {
+		return &ConfigMapLister{}
+	}
+	return f.ConfigMap
+}
+
 func (f *Listers) GetKubeObjects() []runtime.Object {
 	var kubeObjs []runtime.Object
 	for _, r := range f.GetDeploymentLister().Items {
@@ -117,6 +125,9 @@ func (f *Listers) GetKubeObjects() []runtime.Object {
 		kubeObjs = append(kubeObjs, r)
 	}
 	for _, r := range f.GetEndpointsLister().Items {
+		kubeObjs = append(kubeObjs, r)
+	}
+	for _, r := range f.GetConfigMapLister().Items {
 		kubeObjs = append(kubeObjs, r)
 	}
 	return kubeObjs


### PR DESCRIPTION
This makes the handling of the Fluentd ConfigMap in the Revision controller more like the other resources (1:1 with Revision).
 * Naming is handled by `pkg/controller/revision/resources/names`
 * Creating of our "desired" ConfigMap is done through `pkg/controller/revision/resources`
 * The reconciliation in `pkg/controller/revision/revision.go` follows the pattern:

```
  got, err := lister.Things(namespace).Get(name)
  if IsNotFound(err) {
    want := resources.MakeThing(rev)
    got, err = client.Create(want)
    if err != nil {
      return err
    }
  } else if err != nil {
    return err
  } else {
    want := resources.MakeThing(rev)
    if !equality.Semantic.DeepEqual(got, want) {
      got.Spec = want.Spec
      got, err = client.Update(got)
      if err != nil {
        return err
      }
    }
  }

  // Optionally propagate status based on the state of "got"
```

Fixes: https://github.com/knative/serving/issues/1474