### PR TITLE
Add coverage for Route controller failure paths.

### DIFF
--- a/pkg/controller/route/cruds.go
+++ b/pkg/controller/route/cruds.go
@@ -106,12 +106,8 @@ func (c *Controller) reconcilePlaceholderService(ctx context.Context, route *v1a
 // Update the Status of the route.  Caller is responsible for checking
 // for semantic differences before calling.
 func (c *Controller) updateStatus(ctx context.Context, route *v1alpha1.Route) (*v1alpha1.Route, error) {
-	logger := logging.FromContext(ctx)
-
 	existing, err := c.routeLister.Routes(route.Namespace).Get(route.Name)
 	if err != nil {
-		logger.Warn("Failed to update route status", zap.Error(err))
-		c.Recorder.Eventf(route, corev1.EventTypeWarning, "UpdateFailed", "Failed to get current status for route %q: %v", route.Name, err)
 		return nil, err
 	}
 	// If there's nothing to update, just return.
@@ -122,8 +118,6 @@ func (c *Controller) updateStatus(ctx context.Context, route *v1alpha1.Route) (*
 	// TODO: for CRD there's no updatestatus, so use normal update.
 	updated, err := c.ServingClientSet.ServingV1alpha1().Routes(route.Namespace).Update(existing)
 	if err != nil {
-		logger.Warn("Failed to update route status", zap.Error(err))
-		c.Recorder.Eventf(route, corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for route %q: %v", route.Name, err)
 		return nil, err
 	}
 

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -156,6 +156,9 @@ func (c *Controller) Reconcile(key string) error {
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 	} else if _, err := c.updateStatus(ctx, route); err != nil {
+		logger.Warn("Failed to update route status", zap.Error(err))
+		c.Recorder.Eventf(route, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update status for route %q: %v", route.Name, err)
 		return err
 	}
 	return err

--- a/pkg/controller/testing/reactions.go
+++ b/pkg/controller/testing/reactions.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// InduceFailure is used in conjunction with TableTest's WithReactors field.
+// Tests that want to induce a failure in a row of a TableTest would add:
+//   WithReactors: []clientgotesting.ReactionFunc{
+//      // Makes calls to create revisions return an error.
+//      InduceFailure("create", "revisions"),
+//   },
+func InduceFailure(verb, resource string) clientgotesting.ReactionFunc {
+	return func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		if !action.Matches(verb, resource) {
+			return false, nil, nil
+		}
+		return true, nil, fmt.Errorf("inducing failure for %s %s", action.GetVerb(), action.GetResource().Resource)
+	}
+}


### PR DESCRIPTION
This introduces new functionality to our `TableTest` to enable a `Row` to provide `clientgotesting.ReactionFunc`s to induce failures during API requests through the fake clients.  For example:

```go
    // Induce a failure creating revisions.
    WantErr: true,
    WithReactors: []clientgotesting.ReactionFunc{
        InduceFailure("create", "revisions"),
    },
```

Fixes: https://github.com/knative/serving/issues/1501