### PR TITLE
Add coverage of Service controller failure paths.

### DIFF
--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -300,6 +300,263 @@ func TestReconcile(t *testing.T) {
 		},
 		Key:     "foo/bad-config-update",
 		WantErr: true,
+	}, {
+		Name: "runLatest - route creation failure",
+		// Induce a failure during route creation
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "routes"),
+		},
+		Listers: Listers{
+			Service: &ServiceLister{
+				Items: []*v1alpha1.Service{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "create-route-failure",
+						Namespace: "foo",
+					},
+					Spec: v1alpha1.ServiceSpec{
+						RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+					},
+				}},
+			},
+		},
+		Key: "foo/create-route-failure",
+		WantCreates: []metav1.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: com("foo", "create-route-failure", or("create-route-failure")),
+				Spec:       configSpec,
+			},
+			&v1alpha1.Route{
+				ObjectMeta: com("foo", "create-route-failure", or("create-route-failure")),
+				Spec:       runLatestSpec("create-route-failure"),
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &v1alpha1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "create-route-failure",
+					Namespace: "foo",
+				},
+				Spec: v1alpha1.ServiceSpec{
+					RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+				},
+				Status: v1alpha1.ServiceStatus{
+					Conditions: []v1alpha1.ServiceCondition{{
+						Type:   v1alpha1.ServiceConditionReady,
+						Status: corev1.ConditionUnknown,
+					}, {
+						Type:   v1alpha1.ServiceConditionConfigurationsReady,
+						Status: corev1.ConditionUnknown,
+					}, {
+						Type:   v1alpha1.ServiceConditionRoutesReady,
+						Status: corev1.ConditionUnknown,
+					}},
+				},
+			},
+		}},
+	}, {
+		Name: "runLatest - configuration creation failure",
+		// Induce a failure during configuration creation
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "configurations"),
+		},
+		Listers: Listers{
+			Service: &ServiceLister{
+				Items: []*v1alpha1.Service{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "create-config-failure",
+						Namespace: "foo",
+					},
+					Spec: v1alpha1.ServiceSpec{
+						RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+					},
+				}},
+			},
+		},
+		Key: "foo/create-config-failure",
+		WantCreates: []metav1.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: com("foo", "create-config-failure", or("create-config-failure")),
+				Spec:       configSpec,
+			},
+			// We don't get to creating the Route.
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &v1alpha1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "create-config-failure",
+					Namespace: "foo",
+				},
+				Spec: v1alpha1.ServiceSpec{
+					RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+				},
+				Status: v1alpha1.ServiceStatus{
+					Conditions: []v1alpha1.ServiceCondition{{
+						Type:   v1alpha1.ServiceConditionReady,
+						Status: corev1.ConditionUnknown,
+					}, {
+						Type:   v1alpha1.ServiceConditionConfigurationsReady,
+						Status: corev1.ConditionUnknown,
+					}, {
+						Type:   v1alpha1.ServiceConditionRoutesReady,
+						Status: corev1.ConditionUnknown,
+					}},
+				},
+			},
+		}},
+	}, {
+		Name: "runLatest - update route failure",
+		// Induce a failure updating the route
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "routes"),
+		},
+		Listers: Listers{
+			Service: &ServiceLister{
+				Items: []*v1alpha1.Service{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "update-route-failure",
+						Namespace: "foo",
+					},
+					Spec: v1alpha1.ServiceSpec{
+						RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+					},
+					Status: v1alpha1.ServiceStatus{
+						Conditions: []v1alpha1.ServiceCondition{{
+							Type:   v1alpha1.ServiceConditionReady,
+							Status: corev1.ConditionUnknown,
+						}, {
+							Type:   v1alpha1.ServiceConditionConfigurationsReady,
+							Status: corev1.ConditionUnknown,
+						}, {
+							Type:   v1alpha1.ServiceConditionRoutesReady,
+							Status: corev1.ConditionUnknown,
+						}},
+					},
+				}},
+			},
+			// Update the skeletal Config/Route to have the appropriate {Config,Route}Specs
+			Route: &RouteLister{
+				Items: []*v1alpha1.Route{{ObjectMeta: om("foo", "update-route-failure")}},
+			},
+			Configuration: &ConfigurationLister{
+				Items: []*v1alpha1.Configuration{{ObjectMeta: om("foo", "update-route-failure")}},
+			},
+		},
+		Key: "foo/update-route-failure",
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &v1alpha1.Configuration{
+				ObjectMeta: om("foo", "update-route-failure"),
+				Spec:       configSpec,
+			},
+		}, {
+			Object: &v1alpha1.Route{
+				ObjectMeta: om("foo", "update-route-failure"),
+				Spec:       runLatestSpec("update-route-failure"),
+			},
+		}},
+	}, {
+		Name: "runLatest - update config failure",
+		// Induce a failure updating the config
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "configurations"),
+		},
+		Listers: Listers{
+			Service: &ServiceLister{
+				Items: []*v1alpha1.Service{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "update-config-failure",
+						Namespace: "foo",
+					},
+					Spec: v1alpha1.ServiceSpec{
+						RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+					},
+					Status: v1alpha1.ServiceStatus{
+						Conditions: []v1alpha1.ServiceCondition{{
+							Type:   v1alpha1.ServiceConditionReady,
+							Status: corev1.ConditionUnknown,
+						}, {
+							Type:   v1alpha1.ServiceConditionConfigurationsReady,
+							Status: corev1.ConditionUnknown,
+						}, {
+							Type:   v1alpha1.ServiceConditionRoutesReady,
+							Status: corev1.ConditionUnknown,
+						}},
+					},
+				}},
+			},
+			// Update the skeletal Config/Route to have the appropriate {Config,Route}Specs
+			Route: &RouteLister{
+				Items: []*v1alpha1.Route{{ObjectMeta: om("foo", "update-config-failure")}},
+			},
+			Configuration: &ConfigurationLister{
+				Items: []*v1alpha1.Configuration{{ObjectMeta: om("foo", "update-config-failure")}},
+			},
+		},
+		Key: "foo/update-config-failure",
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &v1alpha1.Configuration{
+				ObjectMeta: om("foo", "update-config-failure"),
+				Spec:       configSpec,
+			},
+			// We don't get to updating the Route.
+		}},
+	}, {
+		Name: "runLatest - failure updating service status",
+		// Induce a failure updating the service status.
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "services"),
+		},
+		Listers: Listers{
+			Service: &ServiceLister{
+				Items: []*v1alpha1.Service{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "run-latest",
+						Namespace: "foo",
+					},
+					Spec: v1alpha1.ServiceSpec{
+						RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+					},
+				}},
+			},
+		},
+		Key: "foo/run-latest",
+		WantCreates: []metav1.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: com("foo", "run-latest", or("run-latest")),
+				Spec:       configSpec,
+			},
+			&v1alpha1.Route{
+				ObjectMeta: com("foo", "run-latest", or("run-latest")),
+				Spec:       runLatestSpec("run-latest"),
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &v1alpha1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "run-latest",
+					Namespace: "foo",
+				},
+				Spec: v1alpha1.ServiceSpec{
+					RunLatest: &v1alpha1.RunLatestType{Configuration: configSpec},
+				},
+				Status: v1alpha1.ServiceStatus{
+					Conditions: []v1alpha1.ServiceCondition{{
+						Type:   v1alpha1.ServiceConditionReady,
+						Status: corev1.ConditionUnknown,
+					}, {
+						Type:   v1alpha1.ServiceConditionConfigurationsReady,
+						Status: corev1.ConditionUnknown,
+					}, {
+						Type:   v1alpha1.ServiceConditionRoutesReady,
+						Status: corev1.ConditionUnknown,
+					}},
+				},
+			},
+		}},
 	}}
 
 	table.Test(t, func(listers *Listers, opt controller.Options) controller.Interface {


### PR DESCRIPTION
This builds on #1501 to add coverage to the failure paths in the Service controller.

WIP until https://github.com/knative/serving/pull/1508 lands