### PR TITLE
This makes our lister fakes properly filter List calls.

### DIFF
--- a/pkg/controller/route/table_test.go
+++ b/pkg/controller/route/table_test.go
@@ -982,10 +982,6 @@ func TestReconcile(t *testing.T) {
 			resources.MakeK8sService(simpleRunLatest("default", "missing-revision-direct", "config", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			// TODO(#1496): Even without adding the label we see an update because of #1496
-			// (we remove the non-existent label).
-			Object: simpleReadyConfig("default", "config"),
-		}, {
 			Object: simplePinned("default", "missing-revision-direct", "not-found", &v1alpha1.RouteStatus{
 				Domain: "missing-revision-direct.default.example.com",
 				Conditions: []v1alpha1.RouteCondition{{
@@ -1071,17 +1067,14 @@ func TestReconcile(t *testing.T) {
 			resources.MakeK8sService(simpleRunLatest("default", "pinned-becomes-ready", "config", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			// TODO(#1496): Even without adding the label we see an update because of #1496
-			// (we remove the non-existent label).
-			Object: simpleReadyConfig("default", "config"),
 			// TODO(#1495): The parent configuration isn't labeled because it's established through
 			// labels instead of owner references.
-			// addConfigLabel(
+			// Object: addConfigLabel(
 			// 	simpleReadyConfig("default", "config"),
 			// 	// The Route controller attaches our label to this Configuration.
 			// 	"serving.knative.dev/route", "pinned-becomes-ready",
 			// ),
-		}, {
+			// }, {
 			Object: simplePinned("default", "pinned-becomes-ready",
 				// Use the config's revision name.
 				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName, &v1alpha1.RouteStatus{
@@ -1412,7 +1405,11 @@ func TestReconcile(t *testing.T) {
 			resources.MakeK8sService(simpleRunLatest("default", "addlabel-config-failure", "blue", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleReadyConfig("default", "blue"),
+			Object: addConfigLabel(
+				simpleReadyConfig("default", "green"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "addlabel-config-failure",
+			),
 		}},
 		Key: "default/addlabel-config-failure",
 	}}

--- a/pkg/controller/testing/listers.go
+++ b/pkg/controller/testing/listers.go
@@ -41,8 +41,13 @@ type ServiceLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.ServiceLister = (*ServiceLister)(nil)
 
-func (r *ServiceLister) List(selector labels.Selector) ([]*v1alpha1.Service, error) {
-	return r.Items, r.Err
+func (r *ServiceLister) List(selector labels.Selector) (results []*v1alpha1.Service, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *ServiceLister) Services(namespace string) listers.ServiceNamespaceLister {
@@ -57,8 +62,13 @@ type nsServiceLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.ServiceNamespaceLister = (*nsServiceLister)(nil)
 
-func (r *nsServiceLister) List(selector labels.Selector) ([]*v1alpha1.Service, error) {
-	return r.r.Items, r.r.Err
+func (r *nsServiceLister) List(selector labels.Selector) (results []*v1alpha1.Service, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsServiceLister) Get(name string) (*v1alpha1.Service, error) {
@@ -79,8 +89,13 @@ type RouteLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.RouteLister = (*RouteLister)(nil)
 
-func (r *RouteLister) List(selector labels.Selector) ([]*v1alpha1.Route, error) {
-	return r.Items, r.Err
+func (r *RouteLister) List(selector labels.Selector) (results []*v1alpha1.Route, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *RouteLister) Routes(namespace string) listers.RouteNamespaceLister {
@@ -95,8 +110,13 @@ type nsRouteLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.RouteNamespaceLister = (*nsRouteLister)(nil)
 
-func (r *nsRouteLister) List(selector labels.Selector) ([]*v1alpha1.Route, error) {
-	return r.r.Items, r.r.Err
+func (r *nsRouteLister) List(selector labels.Selector) (results []*v1alpha1.Route, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsRouteLister) Get(name string) (*v1alpha1.Route, error) {
@@ -117,8 +137,13 @@ type ConfigurationLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.ConfigurationLister = (*ConfigurationLister)(nil)
 
-func (r *ConfigurationLister) List(selector labels.Selector) ([]*v1alpha1.Configuration, error) {
-	return r.Items, r.Err
+func (r *ConfigurationLister) List(selector labels.Selector) (results []*v1alpha1.Configuration, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *ConfigurationLister) Configurations(namespace string) listers.ConfigurationNamespaceLister {
@@ -133,8 +158,13 @@ type nsConfigurationLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.ConfigurationNamespaceLister = (*nsConfigurationLister)(nil)
 
-func (r *nsConfigurationLister) List(selector labels.Selector) ([]*v1alpha1.Configuration, error) {
-	return r.r.Items, r.r.Err
+func (r *nsConfigurationLister) List(selector labels.Selector) (results []*v1alpha1.Configuration, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsConfigurationLister) Get(name string) (*v1alpha1.Configuration, error) {
@@ -155,8 +185,13 @@ type RevisionLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.RevisionLister = (*RevisionLister)(nil)
 
-func (r *RevisionLister) List(selector labels.Selector) ([]*v1alpha1.Revision, error) {
-	return r.Items, r.Err
+func (r *RevisionLister) List(selector labels.Selector) (results []*v1alpha1.Revision, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *RevisionLister) Revisions(namespace string) listers.RevisionNamespaceLister {
@@ -171,8 +206,13 @@ type nsRevisionLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ listers.RevisionNamespaceLister = (*nsRevisionLister)(nil)
 
-func (r *nsRevisionLister) List(selector labels.Selector) ([]*v1alpha1.Revision, error) {
-	return r.r.Items, r.r.Err
+func (r *nsRevisionLister) List(selector labels.Selector) (results []*v1alpha1.Revision, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsRevisionLister) Get(name string) (*v1alpha1.Revision, error) {
@@ -193,8 +233,13 @@ type BuildLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ buildlisters.BuildLister = (*BuildLister)(nil)
 
-func (r *BuildLister) List(selector labels.Selector) ([]*buildv1alpha1.Build, error) {
-	return r.Items, r.Err
+func (r *BuildLister) List(selector labels.Selector) (results []*buildv1alpha1.Build, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *BuildLister) Builds(namespace string) buildlisters.BuildNamespaceLister {
@@ -209,8 +254,13 @@ type nsBuildLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ buildlisters.BuildNamespaceLister = (*nsBuildLister)(nil)
 
-func (r *nsBuildLister) List(selector labels.Selector) ([]*buildv1alpha1.Build, error) {
-	return r.r.Items, r.r.Err
+func (r *nsBuildLister) List(selector labels.Selector) (results []*buildv1alpha1.Build, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsBuildLister) Get(name string) (*buildv1alpha1.Build, error) {
@@ -231,15 +281,20 @@ type DeploymentLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ appsv1listers.DeploymentLister = (*DeploymentLister)(nil)
 
-func (r *DeploymentLister) List(selector labels.Selector) ([]*appsv1.Deployment, error) {
-	return r.Items, r.Err
+func (r *DeploymentLister) List(selector labels.Selector) (results []*appsv1.Deployment, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *DeploymentLister) Deployments(namespace string) appsv1listers.DeploymentNamespaceLister {
 	return &nsDeploymentLister{r: r, ns: namespace}
 }
 
-func (r *DeploymentLister) GetDeploymentsForReplicaSet(rs *appsv1.ReplicaSet) ([]*appsv1.Deployment, error) {
+func (r *DeploymentLister) GetDeploymentsForReplicaSet(rs *appsv1.ReplicaSet) (results []*appsv1.Deployment, err error) {
 	return nil, fmt.Errorf("unimplemented GetDeploymentsForReplicaSet(%v)", rs)
 }
 
@@ -251,8 +306,13 @@ type nsDeploymentLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ appsv1listers.DeploymentNamespaceLister = (*nsDeploymentLister)(nil)
 
-func (r *nsDeploymentLister) List(selector labels.Selector) ([]*appsv1.Deployment, error) {
-	return r.r.Items, r.r.Err
+func (r *nsDeploymentLister) List(selector labels.Selector) (results []*appsv1.Deployment, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsDeploymentLister) Get(name string) (*appsv1.Deployment, error) {
@@ -273,8 +333,13 @@ type EndpointsLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ corev1listers.EndpointsLister = (*EndpointsLister)(nil)
 
-func (r *EndpointsLister) List(selector labels.Selector) ([]*corev1.Endpoints, error) {
-	return r.Items, r.Err
+func (r *EndpointsLister) List(selector labels.Selector) (results []*corev1.Endpoints, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *EndpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
@@ -289,8 +354,13 @@ type nsEndpointsLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ corev1listers.EndpointsNamespaceLister = (*nsEndpointsLister)(nil)
 
-func (r *nsEndpointsLister) List(selector labels.Selector) ([]*corev1.Endpoints, error) {
-	return r.r.Items, r.r.Err
+func (r *nsEndpointsLister) List(selector labels.Selector) (results []*corev1.Endpoints, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsEndpointsLister) Get(name string) (*corev1.Endpoints, error) {
@@ -311,15 +381,20 @@ type K8sServiceLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ corev1listers.ServiceLister = (*K8sServiceLister)(nil)
 
-func (r *K8sServiceLister) List(selector labels.Selector) ([]*corev1.Service, error) {
-	return r.Items, r.Err
+func (r *K8sServiceLister) List(selector labels.Selector) (results []*corev1.Service, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *K8sServiceLister) Services(namespace string) corev1listers.ServiceNamespaceLister {
 	return &nsK8sServiceLister{r: r, ns: namespace}
 }
 
-func (r *K8sServiceLister) GetPodServices(p *corev1.Pod) ([]*corev1.Service, error) {
+func (r *K8sServiceLister) GetPodServices(p *corev1.Pod) (results []*corev1.Service, err error) {
 	return nil, fmt.Errorf("unimplemented GetPodServices(%v)", p)
 }
 
@@ -331,8 +406,13 @@ type nsK8sServiceLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ corev1listers.ServiceNamespaceLister = (*nsK8sServiceLister)(nil)
 
-func (r *nsK8sServiceLister) List(selector labels.Selector) ([]*corev1.Service, error) {
-	return r.r.Items, r.r.Err
+func (r *nsK8sServiceLister) List(selector labels.Selector) (results []*corev1.Service, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsK8sServiceLister) Get(name string) (*corev1.Service, error) {
@@ -353,8 +433,13 @@ type ConfigMapLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ corev1listers.ConfigMapLister = (*ConfigMapLister)(nil)
 
-func (r *ConfigMapLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
-	return r.Items, r.Err
+func (r *ConfigMapLister) List(selector labels.Selector) (results []*corev1.ConfigMap, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *ConfigMapLister) ConfigMaps(namespace string) corev1listers.ConfigMapNamespaceLister {
@@ -369,8 +454,13 @@ type nsConfigMapLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ corev1listers.ConfigMapNamespaceLister = (*nsConfigMapLister)(nil)
 
-func (r *nsConfigMapLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
-	return r.r.Items, r.r.Err
+func (r *nsConfigMapLister) List(selector labels.Selector) (results []*corev1.ConfigMap, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsConfigMapLister) Get(name string) (*corev1.ConfigMap, error) {
@@ -391,15 +481,20 @@ type VirtualServiceLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ istiolisters.VirtualServiceLister = (*VirtualServiceLister)(nil)
 
-func (r *VirtualServiceLister) List(selector labels.Selector) ([]*istiov1alpha3.VirtualService, error) {
-	return r.Items, r.Err
+func (r *VirtualServiceLister) List(selector labels.Selector) (results []*istiov1alpha3.VirtualService, err error) {
+	for _, elt := range r.Items {
+		if selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.Err
 }
 
 func (r *VirtualServiceLister) VirtualServices(namespace string) istiolisters.VirtualServiceNamespaceLister {
 	return &nsVirtualServiceLister{r: r, ns: namespace}
 }
 
-func (r *VirtualServiceLister) GetPodServices(p *corev1.Pod) ([]*istiov1alpha3.VirtualService, error) {
+func (r *VirtualServiceLister) GetPodServices(p *corev1.Pod) (results []*istiov1alpha3.VirtualService, err error) {
 	return nil, fmt.Errorf("unimplemented GetPodServices(%v)", p)
 }
 
@@ -411,8 +506,13 @@ type nsVirtualServiceLister struct {
 // Assert that our fake implements the interface it is faking.
 var _ istiolisters.VirtualServiceNamespaceLister = (*nsVirtualServiceLister)(nil)
 
-func (r *nsVirtualServiceLister) List(selector labels.Selector) ([]*istiov1alpha3.VirtualService, error) {
-	return r.r.Items, r.r.Err
+func (r *nsVirtualServiceLister) List(selector labels.Selector) (results []*istiov1alpha3.VirtualService, err error) {
+	for _, elt := range r.r.Items {
+		if elt.Namespace == r.ns && selector.Matches(labels.Set(elt.Labels)) {
+			results = append(results, elt)
+		}
+	}
+	return results, r.r.Err
 }
 
 func (r *nsVirtualServiceLister) Get(name string) (*istiov1alpha3.VirtualService, error) {


### PR DESCRIPTION
While refactoring, I noticed that the Lists performed while updating labels in the Route controller were seeing Configurations that shouldn't have been returned by the list.  This was because our lister fakes simply returned their item lists.  This adds the same simply blob of logic to each of the fakes (using named return values mostly to ease search/replace).

Fixes: https://github.com/knative/serving/issues/1496