### PR TITLE
Switch TableTest to take []runtime.Object.

### DIFF
--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/knative/serving/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 
 	. "github.com/knative/serving/pkg/controller/testing"
@@ -57,17 +58,15 @@ func TestReconcile(t *testing.T) {
 		Key:  "foo/not-found",
 	}, {
 		Name: "create revision matching generation",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "no-revisions-yet"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 1234,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "no-revisions-yet"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 1234,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-				}},
+				},
 			},
 		},
 		WantCreates: []metav1.Object{
@@ -98,22 +97,20 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/no-revisions-yet",
 	}, {
 		Name: "create revision matching generation with build",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "need-rev-and-build"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 99998,
-						Build:      &buildSpec,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: v1alpha1.RevisionSpec{
-								Container: corev1.Container{
-									Image: "busybox",
-								},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "need-rev-and-build"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 99998,
+					Build:      &buildSpec,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: v1alpha1.RevisionSpec{
+							Container: corev1.Container{
+								Image: "busybox",
 							},
 						},
 					},
-				}},
+				},
 			},
 		},
 		WantCreates: []metav1.Object{
@@ -158,23 +155,19 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/need-rev-and-build",
 	}, {
 		Name: "reconcile revision matching generation (ready: unknown)",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "matching-revision-not-done"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 5432,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "matching-revision-not-done"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 5432,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-				}},
+				},
 			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{{
-					ObjectMeta: com("foo", "matching-revision-not-done", 5432),
-					Spec:       revisionSpec,
-				}},
+			&v1alpha1.Revision{
+				ObjectMeta: com("foo", "matching-revision-not-done", 5432),
+				Spec:       revisionSpec,
 			},
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -199,29 +192,25 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/matching-revision-not-done",
 	}, {
 		Name: "reconcile revision matching generation (ready: true)",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "matching-revision-done"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 5555,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "matching-revision-done"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 5555,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-				}},
+				},
 			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{{
-					ObjectMeta: com("foo", "matching-revision-done", 5555),
-					Spec:       revisionSpec,
-					Status: v1alpha1.RevisionStatus{
-						Conditions: []v1alpha1.RevisionCondition{{
-							Type:   v1alpha1.RevisionConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-					},
-				}},
+			&v1alpha1.Revision{
+				ObjectMeta: com("foo", "matching-revision-done", 5555),
+				Spec:       revisionSpec,
+				Status: v1alpha1.RevisionStatus{
+					Conditions: []v1alpha1.RevisionCondition{{
+						Type:   v1alpha1.RevisionConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
 			},
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -247,68 +236,60 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/matching-revision-done",
 	}, {
 		Name: "reconcile revision matching generation (ready: true, idempotent)",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "matching-revision-done-idempotent"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 5566,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "matching-revision-done-idempotent"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 5566,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-					Status: v1alpha1.ConfigurationStatus{
-						LatestCreatedRevisionName: "matching-revision-done-idempotent-05566",
-						LatestReadyRevisionName:   "matching-revision-done-idempotent-05566",
-						ObservedGeneration:        5566,
-						Conditions: []v1alpha1.ConfigurationCondition{{
-							Type:   v1alpha1.ConfigurationConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-					},
-				}},
+				},
+				Status: v1alpha1.ConfigurationStatus{
+					LatestCreatedRevisionName: "matching-revision-done-idempotent-05566",
+					LatestReadyRevisionName:   "matching-revision-done-idempotent-05566",
+					ObservedGeneration:        5566,
+					Conditions: []v1alpha1.ConfigurationCondition{{
+						Type:   v1alpha1.ConfigurationConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
 			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{{
-					ObjectMeta: com("foo", "matching-revision-done-idempotent", 5566),
-					Spec:       revisionSpec,
-					Status: v1alpha1.RevisionStatus{
-						Conditions: []v1alpha1.RevisionCondition{{
-							Type:   v1alpha1.RevisionConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-					},
-				}},
+			&v1alpha1.Revision{
+				ObjectMeta: com("foo", "matching-revision-done-idempotent", 5566),
+				Spec:       revisionSpec,
+				Status: v1alpha1.RevisionStatus{
+					Conditions: []v1alpha1.RevisionCondition{{
+						Type:   v1alpha1.RevisionConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
 			},
 		},
 		Key: "foo/matching-revision-done-idempotent",
 	}, {
 		Name: "reconcile revision matching generation (ready: false)",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "matching-revision-failed"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 5555,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "matching-revision-failed"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 5555,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-				}},
+				},
 			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{{
-					ObjectMeta: com("foo", "matching-revision-failed", 5555),
-					Spec:       revisionSpec,
-					Status: v1alpha1.RevisionStatus{
-						Conditions: []v1alpha1.RevisionCondition{{
-							Type:    v1alpha1.RevisionConditionReady,
-							Status:  corev1.ConditionFalse,
-							Reason:  "Armageddon",
-							Message: "It's the end of the world as we know it.",
-						}},
-					},
-				}},
+			&v1alpha1.Revision{
+				ObjectMeta: com("foo", "matching-revision-failed", 5555),
+				Spec:       revisionSpec,
+				Status: v1alpha1.RevisionStatus{
+					Conditions: []v1alpha1.RevisionCondition{{
+						Type:    v1alpha1.RevisionConditionReady,
+						Status:  corev1.ConditionFalse,
+						Reason:  "Armageddon",
+						Message: "It's the end of the world as we know it.",
+					}},
+				},
 			},
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -335,29 +316,25 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/matching-revision-failed",
 	}, {
 		Name: "reconcile revision matching generation (ready: bad)",
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "bad-condition"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 5555,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "bad-condition"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 5555,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-				}},
+				},
 			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{{
-					ObjectMeta: com("foo", "bad-condition", 5555),
-					Spec:       revisionSpec,
-					Status: v1alpha1.RevisionStatus{
-						Conditions: []v1alpha1.RevisionCondition{{
-							Type:   v1alpha1.RevisionConditionReady,
-							Status: "Bad",
-						}},
-					},
-				}},
+			&v1alpha1.Revision{
+				ObjectMeta: com("foo", "bad-condition", 5555),
+				Spec:       revisionSpec,
+				Status: v1alpha1.RevisionStatus{
+					Conditions: []v1alpha1.RevisionCondition{{
+						Type:   v1alpha1.RevisionConditionReady,
+						Status: "Bad",
+					}},
+				},
 			},
 		},
 		WantErr: true,
@@ -388,22 +365,20 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "builds"),
 		},
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "create-build-failure"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 99998,
-						Build:      &buildSpec,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: v1alpha1.RevisionSpec{
-								Container: corev1.Container{
-									Image: "busybox",
-								},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "create-build-failure"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 99998,
+					Build:      &buildSpec,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: v1alpha1.RevisionSpec{
+							Container: corev1.Container{
+								Image: "busybox",
 							},
 						},
 					},
-				}},
+				},
 			},
 		},
 		WantCreates: []metav1.Object{
@@ -443,22 +418,20 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "revisions"),
 		},
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "create-revision-failure"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 99998,
-						Build:      &buildSpec,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: v1alpha1.RevisionSpec{
-								Container: corev1.Container{
-									Image: "busybox",
-								},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "create-revision-failure"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 99998,
+					Build:      &buildSpec,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: v1alpha1.RevisionSpec{
+							Container: corev1.Container{
+								Image: "busybox",
 							},
 						},
 					},
-				}},
+				},
 			},
 		},
 		WantCreates: []metav1.Object{
@@ -506,17 +479,15 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "configurations"),
 		},
-		Listers: Listers{
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{{
-					ObjectMeta: om("foo", "update-config-failure"),
-					Spec: v1alpha1.ConfigurationSpec{
-						Generation: 1234,
-						RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-							Spec: revisionSpec,
-						},
+		Objects: []runtime.Object{
+			&v1alpha1.Configuration{
+				ObjectMeta: om("foo", "update-config-failure"),
+				Spec: v1alpha1.ConfigurationSpec{
+					Generation: 1234,
+					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+						Spec: revisionSpec,
 					},
-				}},
+				},
 			},
 		},
 		WantCreates: []metav1.Object{

--- a/pkg/controller/route/table_test.go
+++ b/pkg/controller/route/table_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knative/serving/pkg/controller/route/traffic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 
 	. "github.com/knative/serving/pkg/controller/testing"
@@ -44,21 +45,13 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/not-found",
 	}, {
 		Name: "configuration not yet ready",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "first-reconcile", "not-ready", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleNotReadyConfig("default", "not-ready")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleNotReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleNotReadyConfig("default", "not-ready").Status.LatestCreatedRevisionName,
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "first-reconcile", "not-ready", nil),
+			simpleNotReadyConfig("default", "not-ready"),
+			simpleNotReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleNotReadyConfig("default", "not-ready").Status.LatestCreatedRevisionName,
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "first-reconcile", "not-ready", nil)),
@@ -94,21 +87,13 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "routes"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "first-reconcile", "not-ready", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleNotReadyConfig("default", "not-ready")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleNotReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleNotReadyConfig("default", "not-ready").Status.LatestCreatedRevisionName,
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "first-reconcile", "not-ready", nil),
+			simpleNotReadyConfig("default", "not-ready"),
+			simpleNotReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleNotReadyConfig("default", "not-ready").Status.LatestCreatedRevisionName,
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "first-reconcile", "not-ready", nil)),
@@ -139,21 +124,13 @@ func TestReconcile(t *testing.T) {
 		Key: "default/first-reconcile",
 	}, {
 		Name: "simple route becomes ready",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "becomes-ready", "config", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "becomes-ready", "config", nil),
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeVirtualService(
@@ -204,21 +181,13 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "configurations"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "label-config-failure", "config", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "label-config-failure", "config", nil),
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "label-config-failure", "config", nil)),
@@ -249,21 +218,13 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "services"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "create-svc-failure", "config", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "create-svc-failure", "config", nil),
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "create-svc-failure", "config", nil)),
@@ -282,21 +243,13 @@ func TestReconcile(t *testing.T) {
 		Key: "default/create-svc-failure",
 	}, {
 		Name: "failure creating virtual service",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "vs-create-failure", "config", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "vs-create-failure", "config", nil),
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
 		},
 		// We induce a failure creating the VirtualService.
 		WantErr: true,
@@ -343,276 +296,196 @@ func TestReconcile(t *testing.T) {
 		Key: "default/vs-create-failure",
 	}, {
 		Name: "steady state",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "steady-state", "config", &v1alpha1.RouteStatus{
-						Domain: "steady-state.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "steady-state",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "steady-state", "config", nil), "steady-state.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "steady-state", "config", &v1alpha1.RouteStatus{
+				Domain: "steady-state.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "steady-state",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "steady-state", "config", nil), "steady-state.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "steady-state", "config", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "steady-state", "config", nil)),
 		},
 		Key: "default/steady-state",
 	}, {
 		Name: "different labels, different domain",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					addRouteLabel(
-						simpleRunLatest("default", "different-domain", "config", &v1alpha1.RouteStatus{
-							Domain: "different-domain.default.another-example.com",
-							Conditions: []v1alpha1.RouteCondition{{
-								Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-								Status: corev1.ConditionTrue,
-							}, {
-								Type:   v1alpha1.RouteConditionReady,
-								Status: corev1.ConditionTrue,
-							}},
-							Traffic: []v1alpha1.TrafficTarget{{
-								ConfigurationName: "config",
-								RevisionName:      "config-00001",
-								Percent:           100,
-							}},
-						}),
-						"app", "prod",
-					),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "different-domain",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "different-domain", "config", nil), "different-domain.default.another-example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			addRouteLabel(
+				simpleRunLatest("default", "different-domain", "config", &v1alpha1.RouteStatus{
+					Domain: "different-domain.default.another-example.com",
+					Conditions: []v1alpha1.RouteCondition{{
+						Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+						Status: corev1.ConditionTrue,
+					}, {
+						Type:   v1alpha1.RouteConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+					Traffic: []v1alpha1.TrafficTarget{{
+						ConfigurationName: "config",
+						RevisionName:      "config-00001",
+						Percent:           100,
+					}},
+				}),
+				"app", "prod",
+			),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "different-domain",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "different-domain", "config", nil), "different-domain.default.another-example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "different-domain", "config", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "different-domain", "config", nil)),
 		},
 		Key: "default/different-domain",
 	}, {
 		Name: "new latest created revision",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "new-latest-created", "config", &v1alpha1.RouteStatus{
-						Domain: "new-latest-created.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					setLatestCreatedRevision(
-						addConfigLabel(
-							simpleReadyConfig("default", "config"),
-							// The Route controller attaches our label to this Configuration.
-							"serving.knative.dev/route", "new-latest-created",
-						),
-						"config-00002",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-					// This is the name of the new revision we're referencing above.
-					simpleNotReadyRevision("default", "config-00002"),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "new-latest-created", "config", nil), "new-latest-created.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "new-latest-created", "config", &v1alpha1.RouteStatus{
+				Domain: "new-latest-created.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			setLatestCreatedRevision(
+				addConfigLabel(
+					simpleReadyConfig("default", "config"),
+					// The Route controller attaches our label to this Configuration.
+					"serving.knative.dev/route", "new-latest-created",
+				),
+				"config-00002",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			// This is the name of the new revision we're referencing above.
+			simpleNotReadyRevision("default", "config-00002"),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "new-latest-created", "config", nil), "new-latest-created.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "new-latest-created", "config", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "new-latest-created", "config", nil)),
 		},
 		// A new LatestCreatedRevisionName on the Configuration alone should result in no changes to the Route.
 		Key: "default/new-latest-created",
 	}, {
 		Name: "new latest ready revision",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "new-latest-ready", "config", &v1alpha1.RouteStatus{
-						Domain: "new-latest-ready.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					setLatestReadyRevision(setLatestCreatedRevision(
-						addConfigLabel(
-							simpleReadyConfig("default", "config"),
-							// The Route controller attaches our label to this Configuration.
-							"serving.knative.dev/route", "new-latest-ready",
-						),
-						"config-00002",
-					)),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-					// This is the name of the new revision we're referencing above.
-					simpleReadyRevision("default", "config-00002"),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "new-latest-ready", "config", nil), "new-latest-ready.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "new-latest-ready", "config", &v1alpha1.RouteStatus{
+				Domain: "new-latest-ready.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			setLatestReadyRevision(setLatestCreatedRevision(
+				addConfigLabel(
+					simpleReadyConfig("default", "config"),
+					// The Route controller attaches our label to this Configuration.
+					"serving.knative.dev/route", "new-latest-ready",
+				),
+				"config-00002",
+			)),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			// This is the name of the new revision we're referencing above.
+			simpleReadyRevision("default", "config-00002"),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "new-latest-ready", "config", nil), "new-latest-ready.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "new-latest-ready", "config", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "new-latest-ready", "config", nil)),
 		},
 		// A new LatestReadyRevisionName on the Configuration should result in the new Revision being rolled out.
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -656,72 +529,52 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "virtualservices"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "update-vs-failure", "config", &v1alpha1.RouteStatus{
-						Domain: "update-vs-failure.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					setLatestReadyRevision(setLatestCreatedRevision(
-						addConfigLabel(
-							simpleReadyConfig("default", "config"),
-							// The Route controller attaches our label to this Configuration.
-							"serving.knative.dev/route", "update-vs-failure",
-						),
-						"config-00002",
-					)),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-					// This is the name of the new revision we're referencing above.
-					simpleReadyRevision("default", "config-00002"),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "update-vs-failure", "config", nil), "update-vs-failure.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "update-vs-failure", "config", &v1alpha1.RouteStatus{
+				Domain: "update-vs-failure.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			setLatestReadyRevision(setLatestCreatedRevision(
+				addConfigLabel(
+					simpleReadyConfig("default", "config"),
+					// The Route controller attaches our label to this Configuration.
+					"serving.knative.dev/route", "update-vs-failure",
+				),
+				"config-00002",
+			)),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			// This is the name of the new revision we're referencing above.
+			simpleReadyRevision("default", "config-00002"),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "update-vs-failure", "config", nil), "update-vs-failure.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "update-vs-failure", "config", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "update-vs-failure", "config", nil)),
 		},
 		// A new LatestReadyRevisionName on the Configuration should result in the new Revision being rolled out.
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -744,67 +597,47 @@ func TestReconcile(t *testing.T) {
 		Key: "default/update-vs-failure",
 	}, {
 		Name: "reconcile service mutation",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "svc-mutation", "config", &v1alpha1.RouteStatus{
-						Domain: "svc-mutation.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "svc-mutation",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "svc-mutation", "config", nil), "svc-mutation.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "svc-mutation", "config", &v1alpha1.RouteStatus{
+				Domain: "svc-mutation.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "svc-mutation",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "svc-mutation", "config", nil), "svc-mutation.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					mutateService(resources.MakeK8sService(simpleRunLatest("default", "svc-mutation", "config", nil))),
-				},
-			},
+			),
+			mutateService(resources.MakeK8sService(simpleRunLatest("default", "svc-mutation", "config", nil))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: resources.MakeK8sService(simpleRunLatest("default", "svc-mutation", "config", nil)),
@@ -817,67 +650,47 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "services"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "svc-mutation", "config", &v1alpha1.RouteStatus{
-						Domain: "svc-mutation.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "svc-mutation",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "svc-mutation", "config", nil), "svc-mutation.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "svc-mutation", "config", &v1alpha1.RouteStatus{
+				Domain: "svc-mutation.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "svc-mutation",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "svc-mutation", "config", nil), "svc-mutation.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					mutateService(resources.MakeK8sService(simpleRunLatest("default", "svc-mutation", "config", nil))),
-				},
-			},
+			),
+			mutateService(resources.MakeK8sService(simpleRunLatest("default", "svc-mutation", "config", nil))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: resources.MakeK8sService(simpleRunLatest("default", "svc-mutation", "config", nil)),
@@ -885,132 +698,92 @@ func TestReconcile(t *testing.T) {
 		Key: "default/svc-mutation",
 	}, {
 		Name: "allow cluster ip",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "cluster-ip", "config", &v1alpha1.RouteStatus{
-						Domain: "cluster-ip.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "cluster-ip",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "cluster-ip", "config", nil), "cluster-ip.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "cluster-ip", "config", &v1alpha1.RouteStatus{
+				Domain: "cluster-ip.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "cluster-ip",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "cluster-ip", "config", nil), "cluster-ip.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					setClusterIP(resources.MakeK8sService(simpleRunLatest("default", "cluster-ip", "config", nil)), "127.0.0.1"),
-				},
-			},
+			),
+			setClusterIP(resources.MakeK8sService(simpleRunLatest("default", "cluster-ip", "config", nil)), "127.0.0.1"),
 		},
 		Key: "default/cluster-ip",
 	}, {
 		Name: "reconcile virtual service mutation",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "virt-svc-mutation", "config", &v1alpha1.RouteStatus{
-						Domain: "virt-svc-mutation.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "virt-svc-mutation",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					mutateVirtualService(resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "virt-svc-mutation", "config", nil), "virt-svc-mutation.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "virt-svc-mutation", "config", &v1alpha1.RouteStatus{
+				Domain: "virt-svc-mutation.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "virt-svc-mutation",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			mutateVirtualService(resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "virt-svc-mutation", "config", nil), "virt-svc-mutation.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					)),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "virt-svc-mutation", "config", nil)),
-				},
-			},
+			)),
+			resources.MakeK8sService(simpleRunLatest("default", "virt-svc-mutation", "config", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: resources.MakeVirtualService(
@@ -1032,140 +805,100 @@ func TestReconcile(t *testing.T) {
 		Key: "default/virt-svc-mutation",
 	}, {
 		Name: "config labelled by another route",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "licked-cookie", "config", &v1alpha1.RouteStatus{
-						Domain: "licked-cookie.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "config",
-							RevisionName:      "config-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "config"),
-						// This configuration is being referenced by another Route.
-						"serving.knative.dev/route", "this-cookie-has-been-licked",
-					),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "licked-cookie", "config", nil), "licked-cookie.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "licked-cookie", "config", &v1alpha1.RouteStatus{
+				Domain: "licked-cookie.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "config",
+					RevisionName:      "config-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "config"),
+				// This configuration is being referenced by another Route.
+				"serving.knative.dev/route", "this-cookie-has-been-licked",
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "licked-cookie", "config", nil), "licked-cookie.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "licked-cookie", "config", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "licked-cookie", "config", nil)),
 		},
 		WantErr: true,
 		Key:     "default/licked-cookie",
 	}, {
 		Name: "switch to a different config",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					// The status reflects "oldconfig", but the spec "newconfig".
-					simpleRunLatest("default", "change-configs", "newconfig", &v1alpha1.RouteStatus{
-						Domain: "change-configs.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "oldconfig",
-							RevisionName:      "oldconfig-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					// Both configs exist, but only "oldconfig" is labelled.
-					addConfigLabel(
-						simpleReadyConfig("default", "oldconfig"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "change-configs",
-					),
-					simpleReadyConfig("default", "newconfig"),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "oldconfig").Status.LatestReadyRevisionName,
-					),
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "newconfig").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "change-configs", "oldconfig", nil), "change-configs.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "oldconfig").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			// The status reflects "oldconfig", but the spec "newconfig".
+			simpleRunLatest("default", "change-configs", "newconfig", &v1alpha1.RouteStatus{
+				Domain: "change-configs.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "oldconfig",
+					RevisionName:      "oldconfig-00001",
+					Percent:           100,
+				}},
+			}),
+			// Both configs exist, but only "oldconfig" is labelled.
+			addConfigLabel(
+				simpleReadyConfig("default", "oldconfig"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "change-configs",
+			),
+			simpleReadyConfig("default", "newconfig"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "oldconfig").Status.LatestReadyRevisionName,
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "newconfig").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "change-configs", "oldconfig", nil), "change-configs.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "oldconfig").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "change-configs", "oldconfig", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "change-configs", "oldconfig", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			// The label is removed from "oldconfig"
@@ -1215,10 +948,8 @@ func TestReconcile(t *testing.T) {
 		Key: "default/change-configs",
 	}, {
 		Name: "configuration missing",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "config-missing", "not-found", nil)},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "config-missing", "not-found", nil),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "config-missing", "not-found", nil)),
@@ -1243,13 +974,9 @@ func TestReconcile(t *testing.T) {
 		Key:     "default/config-missing",
 	}, {
 		Name: "revision missing (direct)",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simplePinned("default", "missing-revision-direct", "not-found", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
+		Objects: []runtime.Object{
+			simplePinned("default", "missing-revision-direct", "not-found", nil),
+			simpleReadyConfig("default", "config"),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "missing-revision-direct", "config", nil)),
@@ -1278,13 +1005,9 @@ func TestReconcile(t *testing.T) {
 		Key:     "default/missing-revision-direct",
 	}, {
 		Name: "revision missing (indirect)",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simpleRunLatest("default", "missing-revision-indirect", "config", nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "missing-revision-indirect", "config", nil),
+			simpleReadyConfig("default", "config"),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "missing-revision-indirect", "config", nil)),
@@ -1316,26 +1039,18 @@ func TestReconcile(t *testing.T) {
 		Key:     "default/missing-revision-indirect",
 	}, {
 		Name: "pinned route becomes ready",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{simplePinned("default", "pinned-becomes-ready",
-					// Use the Revision name from the config
-					simpleReadyConfig("default", "config").Status.LatestReadyRevisionName, nil)},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{simpleReadyConfig("default", "config")},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					addOwnerRef(
-						simpleReadyRevision("default",
-							// Use the Revision name from the config.
-							simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-						),
-						or("Configuration", "config"),
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			simplePinned("default", "pinned-becomes-ready",
+				// Use the Revision name from the config
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName, nil),
+			simpleReadyConfig("default", "config"),
+			addOwnerRef(
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+				),
+				or("Configuration", "config"),
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeVirtualService(
@@ -1389,43 +1104,31 @@ func TestReconcile(t *testing.T) {
 		Key: "default/pinned-becomes-ready",
 	}, {
 		Name: "traffic split becomes ready",
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					routeWithTraffic("default", "named-traffic-split", nil,
-						v1alpha1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           50,
-						}, v1alpha1.TrafficTarget{
-							ConfigurationName: "green",
-							Percent:           50,
-						}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					simpleReadyConfig("default", "blue"),
-					simpleReadyConfig("default", "green"),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					addOwnerRef(
-						simpleReadyRevision("default",
-							// Use the Revision name from the config.
-							simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-						),
-						or("Configuration", "blue"),
-					),
-					addOwnerRef(
-						simpleReadyRevision("default",
-							// Use the Revision name from the config.
-							simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
-						),
-						or("Configuration", "green"),
-					),
-				},
-			},
+		Objects: []runtime.Object{
+			routeWithTraffic("default", "named-traffic-split", nil,
+				v1alpha1.TrafficTarget{
+					ConfigurationName: "blue",
+					Percent:           50,
+				}, v1alpha1.TrafficTarget{
+					ConfigurationName: "green",
+					Percent:           50,
+				}),
+			simpleReadyConfig("default", "blue"),
+			simpleReadyConfig("default", "green"),
+			addOwnerRef(
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+				),
+				or("Configuration", "blue"),
+			),
+			addOwnerRef(
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+				),
+				or("Configuration", "green"),
+			),
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeVirtualService(
@@ -1509,72 +1212,52 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "change route configuration",
 		// Start from a steady state referencing "blue", and modify the route spec to point to "green" instead.
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "switch-configs", "green", &v1alpha1.RouteStatus{
-						Domain: "switch-configs.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "blue",
-							RevisionName:      "blue-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "blue"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "switch-configs",
-					),
-					simpleReadyConfig("default", "green"),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-					),
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "switch-configs", "blue", nil), "switch-configs.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "switch-configs", "green", &v1alpha1.RouteStatus{
+				Domain: "switch-configs.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "blue",
+					RevisionName:      "blue-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "blue"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "switch-configs",
+			),
+			simpleReadyConfig("default", "green"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "switch-configs", "blue", nil), "switch-configs.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "switch-configs", "blue", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "switch-configs", "blue", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyConfig("default", "blue"),
@@ -1626,72 +1309,52 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "configurations"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "rmlabel-config-failure", "green", &v1alpha1.RouteStatus{
-						Domain: "rmlabel-config-failure.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "blue",
-							RevisionName:      "blue-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					addConfigLabel(
-						simpleReadyConfig("default", "blue"),
-						// The Route controller attaches our label to this Configuration.
-						"serving.knative.dev/route", "rmlabel-config-failure",
-					),
-					simpleReadyConfig("default", "green"),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-					),
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "rmlabel-config-failure", "blue", nil), "rmlabel-config-failure.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "rmlabel-config-failure", "green", &v1alpha1.RouteStatus{
+				Domain: "rmlabel-config-failure.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "blue",
+					RevisionName:      "blue-00001",
+					Percent:           100,
+				}},
+			}),
+			addConfigLabel(
+				simpleReadyConfig("default", "blue"),
+				// The Route controller attaches our label to this Configuration.
+				"serving.knative.dev/route", "rmlabel-config-failure",
+			),
+			simpleReadyConfig("default", "green"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "rmlabel-config-failure", "blue", nil), "rmlabel-config-failure.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "rmlabel-config-failure", "blue", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "rmlabel-config-failure", "blue", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyConfig("default", "blue"),
@@ -1705,68 +1368,48 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "configurations"),
 		},
-		Listers: Listers{
-			Route: &RouteLister{
-				Items: []*v1alpha1.Route{
-					simpleRunLatest("default", "addlabel-config-failure", "green", &v1alpha1.RouteStatus{
-						Domain: "addlabel-config-failure.default.example.com",
-						Conditions: []v1alpha1.RouteCondition{{
-							Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-							Status: corev1.ConditionTrue,
-						}, {
-							Type:   v1alpha1.RouteConditionReady,
-							Status: corev1.ConditionTrue,
-						}},
-						Traffic: []v1alpha1.TrafficTarget{{
-							ConfigurationName: "blue",
-							RevisionName:      "blue-00001",
-							Percent:           100,
-						}},
-					}),
-				},
-			},
-			Configuration: &ConfigurationLister{
-				Items: []*v1alpha1.Configuration{
-					simpleReadyConfig("default", "blue"),
-					simpleReadyConfig("default", "green"),
-				},
-			},
-			Revision: &RevisionLister{
-				Items: []*v1alpha1.Revision{
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-					),
-					simpleReadyRevision("default",
-						// Use the Revision name from the config.
-						simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
-					),
-				},
-			},
-			VirtualService: &VirtualServiceLister{
-				Items: []*istiov1alpha3.VirtualService{
-					resources.MakeVirtualService(
-						setDomain(simpleRunLatest("default", "addlabel-config-failure", "blue", nil), "addlabel-config-failure.default.example.com"),
-						&traffic.TrafficConfig{
-							Targets: map[string][]traffic.RevisionTarget{
-								"": []traffic.RevisionTarget{{
-									TrafficTarget: v1alpha1.TrafficTarget{
-										// Use the Revision name from the config.
-										RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-										Percent:      100,
-									},
-									Active: true,
-								}},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "addlabel-config-failure", "green", &v1alpha1.RouteStatus{
+				Domain: "addlabel-config-failure.default.example.com",
+				Conditions: []v1alpha1.RouteCondition{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					ConfigurationName: "blue",
+					RevisionName:      "blue-00001",
+					Percent:           100,
+				}},
+			}),
+			simpleReadyConfig("default", "blue"),
+			simpleReadyConfig("default", "green"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+			),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService(
+				setDomain(simpleRunLatest("default", "addlabel-config-failure", "blue", nil), "addlabel-config-failure.default.example.com"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": []traffic.RevisionTarget{{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+								Percent:      100,
 							},
-						},
-					),
+							Active: true,
+						}},
+					},
 				},
-			},
-			K8sService: &K8sServiceLister{
-				Items: []*corev1.Service{
-					resources.MakeK8sService(simpleRunLatest("default", "addlabel-config-failure", "blue", nil)),
-				},
-			},
+			),
+			resources.MakeK8sService(simpleRunLatest("default", "addlabel-config-failure", "blue", nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyConfig("default", "blue"),

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -25,6 +26,8 @@ import (
 	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
 	"github.com/knative/serving/pkg"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +36,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	istiov1alpha3 "github.com/knative/serving/pkg/apis/istio/v1alpha3"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
 	. "github.com/knative/serving/pkg/logging/testing"
 )
@@ -170,13 +176,62 @@ func (f *Listers) GetServingObjects() []runtime.Object {
 	return objs
 }
 
+func NewListers(objs []runtime.Object) Listers {
+	ls := Listers{
+		Service:       &ServiceLister{},
+		Route:         &RouteLister{},
+		Configuration: &ConfigurationLister{},
+		Revision:      &RevisionLister{},
+
+		VirtualService: &VirtualServiceLister{},
+
+		Build: &BuildLister{},
+
+		Deployment: &DeploymentLister{},
+		K8sService: &K8sServiceLister{},
+		Endpoints:  &EndpointsLister{},
+		ConfigMap:  &ConfigMapLister{},
+	}
+	for _, obj := range objs {
+		switch o := obj.(type) {
+		case *v1alpha1.Service:
+			ls.Service.Items = append(ls.Service.Items, o)
+		case *v1alpha1.Route:
+			ls.Route.Items = append(ls.Route.Items, o)
+		case *v1alpha1.Configuration:
+			ls.Configuration.Items = append(ls.Configuration.Items, o)
+		case *v1alpha1.Revision:
+			ls.Revision.Items = append(ls.Revision.Items, o)
+
+		case *istiov1alpha3.VirtualService:
+			ls.VirtualService.Items = append(ls.VirtualService.Items, o)
+
+		case *buildv1alpha1.Build:
+			ls.Build.Items = append(ls.Build.Items, o)
+
+		case *appsv1.Deployment:
+			ls.Deployment.Items = append(ls.Deployment.Items, o)
+		case *corev1.Service:
+			ls.K8sService.Items = append(ls.K8sService.Items, o)
+		case *corev1.Endpoints:
+			ls.Endpoints.Items = append(ls.Endpoints.Items, o)
+		case *corev1.ConfigMap:
+			ls.ConfigMap.Items = append(ls.ConfigMap.Items, o)
+
+		default:
+			panic(fmt.Sprintf("Unsupported type in TableTest %T", obj))
+		}
+	}
+	return ls
+}
+
 // TableRow holds a single row of our table test.
 type TableRow struct {
 	// Name is a descriptive name for this test suitable as a first argument to t.Run()
 	Name string
 
-	// Listers holds the state of the world at the onset of reconciliation.
-	Listers Listers
+	// Objects holds the state of the world at the onset of reconciliation.
+	Objects []runtime.Object
 
 	// Key is the parameter to reconciliation.
 	// This has the form "namespace/name".
@@ -205,11 +260,13 @@ type TableRow struct {
 type Ctor func(*Listers, controller.Options) controller.Interface
 
 func (r *TableRow) Test(t *testing.T, ctor Ctor) {
-	kubeClient := fakekubeclientset.NewSimpleClientset(r.Listers.GetKubeObjects()...)
-	client := fakeclientset.NewSimpleClientset(r.Listers.GetServingObjects()...)
-	buildClient := fakebuildclientset.NewSimpleClientset(r.Listers.GetBuildObjects()...)
+	ls := NewListers(r.Objects)
+
+	kubeClient := fakekubeclientset.NewSimpleClientset(ls.GetKubeObjects()...)
+	client := fakeclientset.NewSimpleClientset(ls.GetServingObjects()...)
+	buildClient := fakebuildclientset.NewSimpleClientset(ls.GetBuildObjects()...)
 	// Set up our Controller from the fakes.
-	c := ctor(&r.Listers, controller.Options{
+	c := ctor(&ls, controller.Options{
 		KubeClientSet:    kubeClient,
 		BuildClientSet:   buildClient,
 		ServingClientSet: client,


### PR DESCRIPTION
This switches our `TableTest` to taking a single `[]runtime.Object` and greatly reduce the boilerplate to set up the state of the world prior to `Reconcile()`.

We still use the Listers, but we set them up by switching over the type of the objects and putting them into the appropriate ones.

Fixes: https://github.com/knative/serving/issues/1519