### PR TITLE
Point to knative/docs instead of knative/install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ We expect this list to grow as more areas are identified.
 
 You can choose to install individual Knative components following the
 instructions in each repo, or install a pre-built suite of components
-by following the instructions at https://github.com/knative/install.
+by following the instructions at
+[docs/install](https://github.com/knative/docs/tree/master/install).
 
 
 # Who is Knative for?
@@ -54,12 +55,12 @@ functions, applications, and containers to an auto-scaling runtime.
 
 To get started as a developer, [pick a Kubernetes cluster of your
 choice](https://kubernetes.io/docs/setup/pick-right-solution/) and
-follow the [Knative installation
-instructions](https://github.com/knative/install) to get the system up
-and running and [run some sample code](./sample/README.md). The
-install instructions also include a [sample
-application](https://github.com/knative/install#test-app) which
-demonstrates some of the key features of Knative.
+follow the [Knative installation 
+instructions](https://github.com/knative/docs/tree/master/install) 
+to get the system up and running and [run some sample 
+code](./sample/README.md). The install instructions also include a 
+[sample application](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#test-app) 
+which demonstrates some of the key features of Knative.
 
 To join the conversation, head over to
 https://groups.google.com/d/forum/knative-users.


### PR DESCRIPTION
## Proposed Changes

  * Adapt references to knative/docs after knative/install was archived
  * **Note:** I am not sure the link to the sample app is equally valid for all Knative installs on all infrastructures, so maybe instructions for deploying a sample app working for all types of installs are needed here

Fixes #1532 