### PR TITLE
Point at the updated installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ We expect this list to grow as more areas are identified.
 
 You can choose to install individual Knative components following the
 instructions in each repo, or install a pre-built suite of components
-by following the instructions at https://github.com/knative/install.
+by following the instructions at
+https://github.com/knative/docs/blob/master/install/Knative-with-GKE.md.
 
 
 # Who is Knative for?


### PR DESCRIPTION
Doc fix, switching from the deprecated installation instructions to the current instructions.