### PR TITLE
Remove myself as an owner

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
 - adrcunha
-- bobcatfish
 - jessiezcc
 - srinivashegde86
 - steuhs

--- a/test/conformance/OWNERS
+++ b/test/conformance/OWNERS
@@ -1,4 +1,0 @@
-# The OWNERS file is used by prow to automatically merge approved PRs.
-
-approvers:
-- bobcatfish


### PR DESCRIPTION
I'll be transitioning off of this project so I won't need to own the
test dir and the conformance tests can be owned by the owners of the
rest of the tests.

## Proposed Changes
  * Removing myself as an owner

```release-note
n/a
```
