### PR TITLE
Fix link to instructions for installing Knative

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We expect this list to grow as more areas are identified.
 
 You can choose to install individual Knative components following the
 instructions in each repo, or install a pre-built suite of components
-by following the instructions at https://github.com/knative/install.
+by following the instructions at https://github.com/knative/docs.
 
 
 # Who is Knative for?
@@ -55,11 +55,10 @@ functions, applications, and containers to an auto-scaling runtime.
 To get started as a developer, [pick a Kubernetes cluster of your
 choice](https://kubernetes.io/docs/setup/pick-right-solution/) and
 follow the [Knative installation
-instructions](https://github.com/knative/install) to get the system up
-and running and [run some sample code](./sample/README.md). The
-install instructions also include a [sample
-application](https://github.com/knative/install#test-app) which
-demonstrates some of the key features of Knative.
+instructions](https://github.com/knative/docs) to get the system up
+and running and run some [sample
+applications](https://github.com/knative/docs/blob/master/serving/samples/README.md) which
+demonstrate some of the key features of Knative.
 
 To join the conversation, head over to
 https://groups.google.com/d/forum/knative-users.


### PR DESCRIPTION
## Proposed Changes

  * Switch links from install to docs project
  * Add link to samples in docs project

**Release Note**
```release-note
NONE
```
