### PR TITLE
This adds a Reactor that Validates mutations our controllers make.

### DIFF
--- a/pkg/controller/route/table_test.go
+++ b/pkg/controller/route/table_test.go
@@ -1496,6 +1496,16 @@ func simpleNotReadyConfig(namespace, name string) *v1alpha1.Configuration {
 			Namespace: namespace,
 			Name:      name,
 		},
+		Spec: v1alpha1.ConfigurationSpec{
+			Generation: 1,
+			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				Spec: v1alpha1.RevisionSpec{
+					Container: corev1.Container{
+						Image: "busybox",
+					},
+				},
+			},
+		},
 	}
 	cfg.Status.InitializeConditions()
 	cfg.Status.SetLatestCreatedRevisionName(name + "-00001")

--- a/pkg/controller/testing/reactions.go
+++ b/pkg/controller/testing/reactions.go
@@ -21,6 +21,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
 // InduceFailure is used in conjunction with TableTest's WithReactors field.
@@ -36,4 +38,28 @@ func InduceFailure(verb, resource string) clientgotesting.ReactionFunc {
 		}
 		return true, nil, fmt.Errorf("inducing failure for %s %s", action.GetVerb(), action.GetResource().Resource)
 	}
+}
+
+func ValidateCreates(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+	got := action.(clientgotesting.CreateAction).GetObject()
+	obj, ok := got.(v1alpha1.Validatable)
+	if !ok {
+		return false, nil, nil
+	}
+	if err := obj.Validate(); err != nil {
+		return true, nil, err
+	}
+	return false, nil, nil
+}
+
+func ValidateUpdates(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+	got := action.(clientgotesting.UpdateAction).GetObject()
+	obj, ok := got.(v1alpha1.Validatable)
+	if !ok {
+		return false, nil, nil
+	}
+	if err := obj.Validate(); err != nil {
+		return true, nil, err
+	}
+	return false, nil, nil
 }

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -279,6 +279,10 @@ func (r *TableRow) Test(t *testing.T, ctor Ctor) {
 		buildClient.PrependReactor("*", "*", reactor)
 	}
 
+	// Validate all Create operations through the serving client.
+	client.PrependReactor("create", "*", ValidateCreates)
+	client.PrependReactor("update", "*", ValidateUpdates)
+
 	// Run the Reconcile we're testing.
 	if err := c.Reconcile(r.Key); (err != nil) != r.WantErr {
 		t.Errorf("Reconcile() error = %v, WantErr %v", err, r.WantErr)


### PR DESCRIPTION
This adds a test that verifies the validation is hooked in by making the Configuration controller attempt to create a revision with a bad `ConcurrencyModel`.

This adds a `Spec` to the Configuration used in the Route controller's table testing because we call `Update` to set labels.

Fixes: https://github.com/knative/serving/issues/1506