### PR TITLE
Make blue/green test stricter in non-probe requests.

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	concurrentRequests = 100
+	concurrentRequests = 200
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.
 	// This might be a bad assumption.
 	minDirectPercentage = 1
@@ -106,6 +106,8 @@ func sendRequests(client spoof.Interface, domain string, num int) ([]string, err
 func checkResponses(logger *zap.SugaredLogger, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
 	// counts maps the expected response body to the number of matching requests we saw.
 	counts := make(map[string]int)
+	// counts maps the unexpected response body to the number of matching requests we saw.
+	badCounts := make(map[string]int)
 
 	// counts := eval(
 	//   SELECT body, count(*) AS total
@@ -114,10 +116,15 @@ func checkResponses(logger *zap.SugaredLogger, num int, min int, domain string, 
 	//   GROUP BY body
 	// )
 	for _, ar := range actualResponses {
+		expected := false
 		for _, er := range expectedResponses {
 			if strings.Contains(string(ar), er) {
 				counts[er]++
+				expected = true
 			}
+		}
+		if !expected {
+			badCounts[ar]++
 		}
 	}
 
@@ -134,8 +141,11 @@ func checkResponses(logger *zap.SugaredLogger, num int, min int, domain string, 
 		totalMatches += count
 	}
 	// Verify that the total expected responses match the number of requests made.
+	for badResponse, count := range badCounts {
+		logger.Infof("saw unexpected response %q %d times", badResponse, count)
+	}
 	if totalMatches < num {
-		return fmt.Errorf("Total expected responses %d, wanted %d", totalMatches, num)
+		return fmt.Errorf("saw expected responses %d times, wanted %d", totalMatches, num)
 	}
 	// If we made it here, the implementation conforms. Congratulations!
 	return nil
@@ -243,17 +253,17 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// Istio network programming takes some time to be effective.  Currently Istio
 	// does not expose a Status, so we rely on probes to know when they are effective.
+	// It doesn't matter which domain we probe, we just need to choose one.
 	if err := probeDomain(logger, clients, tealDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", tealDomain, err)
 	}
 
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
 	g, _ := errgroup.WithContext(context.Background())
-	// First, send concurrent requests to tealDomain only, to allow autoscaling
-	// sometime to add more replicas into both Revisions.
-	min := int(concurrentRequests * minSplitPercentage)
-	checkDistribution(logger, clients, tealDomain, concurrentRequests, min, []string{expectedBlue, expectedGreen})
-	// Now send all remaining requests in parallel.
+	g.Go(func() error {
+		min := int(concurrentRequests * minSplitPercentage)
+		return checkDistribution(logger, clients, tealDomain, concurrentRequests, min, []string{expectedBlue, expectedGreen})
+	})
 	g.Go(func() error {
 		min := int(concurrentRequests * minDirectPercentage)
 		return checkDistribution(logger, clients, blueDomain, concurrentRequests, min, []string{expectedBlue})

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	concurrentRequests = 200
+	concurrentRequests = 100
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.
 	// This might be a bad assumption.
 	minDirectPercentage = 1

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -106,7 +106,7 @@ func sendRequests(client spoof.Interface, domain string, num int) ([]string, err
 func checkResponses(logger *zap.SugaredLogger, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
 	// counts maps the expected response body to the number of matching requests we saw.
 	counts := make(map[string]int)
-	// counts maps the unexpected response body to the number of matching requests we saw.
+	// badCounts maps the unexpected response body to the number of matching requests we saw.
 	badCounts := make(map[string]int)
 
 	// counts := eval(

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -65,7 +65,7 @@ function create_everything() {
   #
   # However, since network configurations may reach different ingress pods at slightly
   # different time, even ignoring failures for initial requests won't ensure subsequent
-  # requests will succeeed all the time.  We are disabling ingress pod autoscaling here
+  # requests will succeed all the time.  We are disabling ingress pod autoscaling here
   # to avoid having too much flakes in the tests.  That would allow us to be stricter
   # when checking non-probe requests to discover other routing issues.
   #

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,16 +45,6 @@ readonly SCRIPT_CANONICAL_PATH="$(readlink -f ${BASH_SOURCE})"
 
 function create_istio() {
   kubectl apply -f ${ISTIO_DIR}/istio.yaml
-
-  # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
-  #
-  # However, since network configurations may reach different ingress pods at slightly
-  # different time, even ignoring failures for initial requests won't ensure subsequent
-  # requests will succeeed all the time.  We are disabling that here to avoid having
-  # too much flakes in the tests.
-  #
-  # We should revisit this when Istio API exposes a Status that we can rely on.
-  kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}'
 }
 
 
@@ -71,6 +61,16 @@ function create_everything() {
   create_istio
   kubectl apply -f third_party/config/build/release.yaml
   ko apply -f config/
+  # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
+  #
+  # However, since network configurations may reach different ingress pods at slightly
+  # different time, even ignoring failures for initial requests won't ensure subsequent
+  # requests will succeeed all the time.  We are disabling ingress pod autoscaling here
+  # to avoid having too much flakes in the tests.  That would allow us to be stricter
+  # when checking non-probe requests to discover other routing issues.
+  #
+  # We should revisit this when Istio API exposes a Status that we can rely on.
+  kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}'
   create_monitoring
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,6 +45,16 @@ readonly SCRIPT_CANONICAL_PATH="$(readlink -f ${BASH_SOURCE})"
 
 function create_istio() {
   kubectl apply -f ${ISTIO_DIR}/istio.yaml
+
+  # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
+  #
+  # However, since network configurations may reach different ingress pods at slightly
+  # different time, even ignoring failures for initial requests won't ensure subsequent
+  # requests will succeeed all the time.  We are disabling that here to avoid having
+  # too much flakes in the tests.
+  #
+  # We should revisit this when Istio API exposes a Status that we can rely on.
+  kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}'
 }
 
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -70,6 +70,7 @@ function create_everything() {
   # when checking non-probe requests to discover other routing issues.
   #
   # We should revisit this when Istio API exposes a Status that we can rely on.
+  # TODO(tcnghia): remove this when https://github.com/istio/istio/issues/822 is fixed.
   kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}'
   create_monitoring
 }


### PR DESCRIPTION
Due to the lack of Status in Istio, we can't know when VirtualService
are effective.  Instead we rely on probes in tests.  After probes are 
succesful we should expect no routing error.

This change separates out the probes and the real requests.  During
probing we allow 404s, while during testing we only allow 200s.
During testing we also check that the total successful request matches
the number of requests we sent.

Fixes #1534