### PR TITLE
Use an int instead of enum for max request concurrency

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -86,7 +86,8 @@ var (
 
 	concurrencyQuantumOfTime = flag.Duration("concurrencyQuantumOfTime", 100*time.Millisecond, "")
 	concurrencyModel         = flag.String("concurrencyModel", string(v1alpha1.RevisionRequestConcurrencyModelMulti), "")
-	singleConcurrencyBreaker = queue.NewBreaker(singleConcurrencyQueueDepth, 1)
+	maxConcurrency           = flag.Int("maxConcurrency", 0, "Max number of requests to pass to the instance at once.")
+	breaker                  *queue.Breaker
 )
 
 func initEnv() {
@@ -183,16 +184,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		reqChan <- queue.ReqOut
 	}()
-	if *concurrencyModel == string(v1alpha1.RevisionRequestConcurrencyModelSingle) {
-		// Enforce single concurrency and breaking
-		ok := singleConcurrencyBreaker.Maybe(func() {
-			proxy.ServeHTTP(w, r)
-		})
-		if !ok {
-			http.Error(w, "overload", http.StatusServiceUnavailable)
-		}
-	} else {
-		proxy.ServeHTTP(w, r)
+	// Enforce maximum requested concurrency
+	if !breaker.Maybe(func() { proxy.ServeHTTP(w, r) }) {
+		http.Error(w, "overload", http.StatusServiceUnavailable)
 	}
 }
 
@@ -274,6 +268,13 @@ func main() {
 		zap.String(logkey.Configuration, servingConfiguration),
 		zap.String(logkey.Revision, servingRevision),
 		zap.String(logkey.Pod, podName))
+
+	requestedConcurrency := *maxConcurrency
+	if *concurrencyModel == string(v1alpha1.RevisionRequestConcurrencyModelSingle) {
+		logger.Info("Using legacy -concurrencyModel=single flag! Overriding -maxConcurrency to 1")
+		requestedConcurrency = 1
+	}
+	breaker = queue.NewBreaker(singleConcurrencyQueueDepth, requestedConcurrency)
 
 	target, err := url.Parse("http://localhost:8080")
 	if err != nil {

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -181,8 +181,8 @@ spec:
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
 
-      # +optional concurrency strategy.  Defaults to Multi.
-      concurrencyModel: ...
+      # +optional max request concurrency per instance.  Defaults to `0` (system decides).
+      instanceConcurrency: ...  # Optional
       # +optional. max time the instance is allowed for responding to a request
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as.
@@ -256,10 +256,15 @@ spec:
   # scaling to/from 0.
   servingState: Active | Reserve | Retired
 
-  # Some function or server frameworks or application code may be written to
-  # expect that each request will be granted a single-tenant process to run
-  # (i.e. that the request code is run single-threaded).
-  concurrencyModel: Single | Multi
+  # Some function or server frameworks or application code may be
+  # written to expect that each request will be granted a single-tenant
+  # process to run (i.e. that the request code is run
+  # single-threaded). An instanceConcurrency value of `1` will
+  # guarantee that only one request is handled at a time by a given
+  # instance of the Revision container. A value of `2` or more will
+  # limit request concurrency to that value.  A value of `0` means the
+  # system should decide.
+  instanceConcurrency: 0 | 1 | 2-N
 
   # NYI: https://github.com/knative/serving/issues/457
   # Many higher-level systems impose a per-request response deadline.
@@ -331,7 +336,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
-      concurrencyModel: ...
+      instanceConcurrency: ...
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as
   # Example, only one of runLatest or pinned can be set in practice.
@@ -353,7 +358,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
-      concurrencyModel: ...
+      instanceConcurrency: ...  #Optional
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as
 status:

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -86,6 +86,7 @@ const (
 
 // RevisionRequestConcurrencyModelType is an enumeration of the
 // concurrency models supported by a Revision.
+// Deprecated in favor of InstanceMaxRequestConcurrency.
 type RevisionRequestConcurrencyModelType string
 
 const (
@@ -98,6 +99,8 @@ const (
 	// Container.
 	RevisionRequestConcurrencyModelMulti RevisionRequestConcurrencyModelType = "Multi"
 )
+
+type RevisionInstanceConcurrencyType int64
 
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
@@ -118,8 +121,17 @@ type RevisionSpec struct {
 	// ConcurrencyModel specifies the desired concurrency model
 	// (Single or Multi) for the
 	// Revision. Defaults to Multi.
+	// Deprecated in favor of InstanceMaxRequestConcurrency.
 	// +optional
 	ConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
+
+	// InstanceConcurrency specifies the maximum allowed
+	// in-flight (concurrent) requests per instance of the Revision
+	// container. Defaults to `0` which means the system should
+	// decide. This field replaces ConcurrencyModel. A value of `1`
+	// is equivalent to `Single` and `0` is equivalent to `Multi`.
+	// +optional
+	InstanceConcurrency RevisionInstanceConcurrencyType `json:"instanceConcurrency,omitempty"`
 
 	// ServiceAccountName holds the name of the Kubernetes service account
 	// as which the underlying K8s resources should be run. If unspecified

--- a/pkg/controller/revision/resources/queue.go
+++ b/pkg/controller/revision/resources/queue.go
@@ -102,6 +102,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 		Args: []string{
 			fmt.Sprintf("-concurrencyQuantumOfTime=%v", autoscalerConfig.ConcurrencyQuantumOfTime),
 			fmt.Sprintf("-concurrencyModel=%v", rev.Spec.ConcurrencyModel),
+			fmt.Sprintf("-maxConcurrency=%v", autoscalerConfig.MaxConcurrency),
 		},
 		Env: []corev1.EnvVar{{
 			Name:  "SERVING_NAMESPACE",

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -29,18 +29,29 @@ type Breaker struct {
 }
 
 // NewBreaker creates a Breaker with the desired queue depth and
-// concurrency limit.
-func NewBreaker(queueDepth, maxConcurrency int32) *Breaker {
+// concurrency limit. If maxConcurrency is 0, this breaker will not
+// enforce any maximum concurrency, and will simply forward all
+// requests.
+func NewBreaker(queueDepth, maxConcurrency int) *Breaker {
 	if queueDepth <= 0 {
 		panic(fmt.Sprintf("Queue depth must be greater than 0. Got %v.", queueDepth))
 	}
-	if maxConcurrency <= 0 {
-		panic(fmt.Sprintf("Max concurrency must be greater than 0. Got %v.", maxConcurrency))
+	if maxConcurrency < 0 {
+		panic(fmt.Sprintf("Max concurrency must be 0 or greater. Got %v.", maxConcurrency))
 	}
-	return &Breaker{
-		pendingRequests: make(chan token, queueDepth),
-		activeRequests:  make(chan token, maxConcurrency),
+	retval := &Breaker{
+		// Active requests keep their pending capacity until
+		// after the request has completed, to prevent hiccups
+		// where there is active capacity which has not yet
+		// been utilized by one of the pending requests. (This
+		// manifests as flakiness in tests.)
+		pendingRequests: make(chan token, queueDepth+maxConcurrency),
 	}
+	if maxConcurrency > 0 {
+		retval.activeRequests = make(chan token, maxConcurrency)
+	}
+	return retval
+
 }
 
 // Maybe conditionally executes thunk based on the Breaker concurrency
@@ -48,6 +59,11 @@ func NewBreaker(queueDepth, maxConcurrency int32) *Breaker {
 // already consumed, Maybe returns immediately without calling thunk. If
 // the thunk was executed, Maybe returns true, else false.
 func (b *Breaker) Maybe(thunk func()) bool {
+	if b.activeRequests == nil {
+		// unlimited concurrency
+		thunk()
+		return true
+	}
 	var t token
 	select {
 	default:
@@ -55,12 +71,10 @@ func (b *Breaker) Maybe(thunk func()) bool {
 		return false
 	case b.pendingRequests <- t:
 		// Pending request has capacity.
-		// Wait for capacity in the active queue.
+		// Acquire capacity in the active queue, too.
 		b.activeRequests <- t
-		// Release capacity in the pending request queue.
-		<-b.pendingRequests
-		// Defer releasing capacity in the active request queue.
-		defer func() { <-b.activeRequests }()
+		// Defer releasing any capacity.
+		defer func() { <-b.activeRequests; <-b.pendingRequests }()
 		// Do the thing.
 		thunk()
 		// Report success

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -18,21 +18,23 @@ package queue
 import (
 	"reflect"
 	"runtime"
+	"sync"
 	"testing"
 )
+
+type request struct {
+	lock     *sync.Mutex
+	accepted chan bool
+}
 
 func TestBreakerOverload(t *testing.T) {
 	t.Skip("Skipping until #1308 is addressed")
 	b := NewBreaker(1, 1)             // Breaker capacity = 2
 	want := []bool{true, true, false} // Only first two requests will be processed
 
-	r1, g1 := b.concurrentRequest()
-	r2, g2 := b.concurrentRequest()
-	r3, g3 := b.concurrentRequest() // Will be shed
-	done(r1)
-	done(r2)
-	done(r3)
-	got := []bool{<-g1, <-g2, <-g3}
+	locks := b.concurrentRequests(3)
+
+	got := accepted(locks)
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("Wanted %v. Got %v.", want, got)
@@ -43,15 +45,14 @@ func TestBreakerNoOverload(t *testing.T) {
 	b := NewBreaker(1, 1)                  // Breaker capacity = 2
 	want := []bool{true, true, true, true} // Only two requests will be in flight at a time
 
-	r1, g1 := b.concurrentRequest()
-	r2, g2 := b.concurrentRequest()
-	done(r1)
-	r3, g3 := b.concurrentRequest()
-	done(r2)
-	r4, g4 := b.concurrentRequest()
-	done(r3)
-	done(r4)
-	got := []bool{<-g1, <-g2, <-g3, <-g4}
+	locks := make([]request, 4)
+	locks[0] = b.concurrentRequest()
+	locks[1] = b.concurrentRequest()
+	locks[0].Ok()
+	locks[2] = b.concurrentRequest()
+	locks[1].Ok()
+	locks[3] = b.concurrentRequest()
+	got := accepted(locks)
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("Wanted %v. Got %v.", want, got)
@@ -62,18 +63,13 @@ func TestBreakerRecover(t *testing.T) {
 	b := NewBreaker(1, 1)                                // Breaker capacity = 2
 	want := []bool{true, true, false, false, true, true} // Shedding will stop when capacity opens up
 
-	r1, g1 := b.concurrentRequest()
-	r2, g2 := b.concurrentRequest()
-	_, g3 := b.concurrentRequest() // Will be shed
-	_, g4 := b.concurrentRequest() // Will be shed
-	done(r1)
-	done(r2)
+	locks := b.concurrentRequests(4)
+	accepted(locks)
+
 	// Breaker recovers
-	r5, g5 := b.concurrentRequest()
-	r6, g6 := b.concurrentRequest()
-	done(r5)
-	done(r6)
-	got := []bool{<-g1, <-g2, <-g3, <-g4, <-g5, <-g6}
+	moreLocks := b.concurrentRequests(2)
+
+	got := accepted(append(locks, moreLocks...))
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("Wanted %v. Got %v.", want, got)
@@ -94,33 +90,18 @@ func TestBreakerLargeCapacityRecover(t *testing.T) {
 		want[i] = true // The next 50 will be processed as capacity opens up
 	}
 
-	releases := make([]chan struct{}, 0)
-	gots := make([]chan bool, 0)
 	// Send 100 requests
-	for i := 0; i < 100; i++ {
-		r, g := b.concurrentRequest()
-		releases = append(releases, r)
-		gots = append(gots, g)
-	}
+	locks := b.concurrentRequests(100)
+
 	// Process one request and send one request, 50 times
 	for i := 100; i < 150; i++ {
 		// Open capacity
-		done(releases[0])
-		releases = releases[1:]
+		locks[i-100].Ok()
 		// Add another request
-		r, g := b.concurrentRequest()
-		releases = append(releases, r)
-		gots = append(gots, g)
+		locks = append(locks, b.concurrentRequest())
+
 	}
-	// Process remaining requests
-	for _, r := range releases {
-		done(r)
-	}
-	// Collect the results
-	got := make([]bool, len(gots))
-	for i, g := range gots {
-		got[i] = <-g
-	}
+	got := accepted(locks)
 
 	// Check the first few suceeded
 	if !reflect.DeepEqual(want[:10], got[:10]) {
@@ -136,17 +117,49 @@ func TestBreakerLargeCapacityRecover(t *testing.T) {
 	}
 }
 
-func (b *Breaker) concurrentRequest() (chan struct{}, chan bool) {
-	release := make(chan struct{})
-	thunk := func() {
-		_, _ = <-release
+func TestUnlimitedBreaker(t *testing.T) {
+	b := NewBreaker(1, 0)
+	requests := b.concurrentRequests(1000)
+	for i, ok := range accepted(requests) {
+		if !ok {
+			t.Fatalf("Expected request %d to be successful, but it failed.", i)
+		}
 	}
-	result := make(chan bool)
+}
+
+// Perform n requests against the breaker, returning mutexes for each
+// request which succeeded, and a slice of bools for all requests.
+func (b *Breaker) concurrentRequests(n int) []request {
+	requests := make([]request, n)
+	for i := 0; i < n; i++ {
+		requests[i] = b.concurrentRequest()
+	}
+	return requests
+}
+
+// Attempts to perform a concurrent request against the specified breaker.
+func (b *Breaker) concurrentRequest() request {
+	r := request{lock: &sync.Mutex{}, accepted: make(chan bool, 2)}
+	r.lock.Lock()
+	started := make(chan bool)
 	go func() {
-		result <- b.Maybe(thunk)
+		started <- true
+		ok := b.Maybe(func() {
+			r.lock.Lock() // Will block on locked mutex.
+			r.lock.Unlock()
+		})
+		r.accepted <- ok
 	}()
-	runtime.Gosched()
-	return release, result
+	<-started // Ensure that the go func has had a chance to execute.
+	return r
+}
+
+func accepted(requests []request) []bool {
+	got := make([]bool, len(requests))
+	for i, r := range requests {
+		got[i] = r.Ok()
+	}
+	return got
 }
 
 func done(release chan struct{}) {
@@ -156,4 +169,18 @@ func done(release chan struct{}) {
 	// queue.
 	runtime.Gosched()
 	runtime.Gosched()
+}
+
+// Allows request to finish and returns whether it was accepted by the
+// breaker or not. May be called multiple times.
+func (r *request) Ok() bool {
+	var ok bool
+	select {
+	case ok = <-r.accepted:
+	default:
+		r.lock.Unlock()
+		ok = <-r.accepted
+	}
+	r.accepted <- ok // Requeue for next usage
+	return ok
 }

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2017 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"reflect"
+	"strings"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/logging"
+	"github.com/mattbaird/jsonpatch"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func errMissingField(fieldPath string) error {
+	return fmt.Errorf("Configuration is missing %q", fieldPath)
+}
+
+func errDisallowedFields(fieldPaths string) error {
+	return fmt.Errorf("The configuration spec must not set the field(s): %s", fieldPaths)
+}
+
+var (
+	errEmptySpecInConfiguration         = errMissingField("spec")
+	errEmptyRevisionTemplateInSpec      = errMissingField("spec.revisionTemplate")
+	errEmptyContainerInRevisionTemplate = errMissingField("spec.revisionTemplate.spec.container")
+	errInvalidConfigurationInput        = errors.New("failed to convert input into Configuration")
+)
+
+// ValidateConfiguration is Configuration resource specific validation and mutation handler
+func ValidateConfiguration(ctx context.Context) ResourceCallback {
+	return func(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
+		_, newConfiguration, err := unmarshalConfigurations(ctx, old, new, "ValidateConfiguration")
+		if err != nil {
+			return err
+		}
+		if err := validateConfiguration(newConfiguration); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func validateConfiguration(configuration *v1alpha1.Configuration) error {
+	if reflect.DeepEqual(configuration.Spec, v1alpha1.ConfigurationSpec{}) {
+		return errEmptySpecInConfiguration
+	}
+	if err := validateConfigurationSpec(&configuration.Spec); err != nil {
+		return err
+	}
+	return validateConcurrencyModel(configuration.Spec.RevisionTemplate.Spec.ConcurrencyModel,
+		configuration.Spec.RevisionTemplate.Spec.InstanceConcurrency)
+}
+
+func validateConfigurationSpec(configurationSpec *v1alpha1.ConfigurationSpec) error {
+	if err := validateTemplate(&configurationSpec.RevisionTemplate); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTemplate(template *v1alpha1.RevisionTemplateSpec) error {
+	if reflect.DeepEqual(*template, v1alpha1.RevisionTemplateSpec{}) {
+		return errEmptyRevisionTemplateInSpec
+	}
+	if template.Spec.ServingState != "" {
+		return errDisallowedFields("revisionTemplate.spec.servingState")
+	}
+	if err := validateContainer(template.Spec.Container); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateConcurrencyModel(value v1alpha1.RevisionRequestConcurrencyModelType,
+  instanceMaxRequestConcurrency v1alpha1.RevisionInstanceConcurrencyType) error {
+	switch value {
+	case v1alpha1.RevisionRequestConcurrencyModelType(""), v1alpha1.RevisionRequestConcurrencyModelMulti:
+		return nil
+	case v1alpha1.RevisionRequestConcurrencyModelSingle:
+		if instanceMaxRequestConcurrency > 1 {
+			return fmt.Errorf("%q does not support concurrency greater than 1, requested: %d", value, instanceMaxRequestConcurrency)
+		}
+		return nil
+	default:
+		return fmt.Errorf("Unrecognized value for concurrencyModel: %q", value)
+	}
+}
+
+func validateContainer(container corev1.Container) error {
+	if reflect.DeepEqual(container, corev1.Container{}) {
+		return errEmptyContainerInRevisionTemplate
+	}
+	// Some corev1.Container fields are set by Knative Serving controller.  We disallow them
+	// here to avoid silently overwriting these fields and causing confusions for
+	// the users.  See pkg/controller/revision.MakeElaPodSpec for the list of fields
+	// overridden.
+	var ignoredFields []string
+	if container.Name != "" {
+		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.name")
+	}
+	if !reflect.DeepEqual(container.Resources, corev1.ResourceRequirements{}) {
+		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.resources")
+	}
+	if len(container.Ports) > 0 {
+		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.ports")
+	}
+	if len(container.VolumeMounts) > 0 {
+		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.volumeMounts")
+	}
+	if container.Lifecycle != nil {
+		ignoredFields = append(ignoredFields, "revisionTemplate.spec.container.lifecycle")
+	}
+	if len(ignoredFields) > 0 {
+		// Complain about all ignored fields so that user can remove them all at once.
+		return errDisallowedFields(strings.Join(ignoredFields, ", "))
+	}
+	return nil
+}
+
+// SetConfigurationDefaults set defaults on an configurations.
+func SetConfigurationDefaults(ctx context.Context) ResourceDefaulter {
+	return func(patches *[]jsonpatch.JsonPatchOperation, crd GenericCRD) error {
+		_, config, err := unmarshalConfigurations(ctx, nil, crd, "SetConfigurationDefaults")
+		if err != nil {
+			return err
+		}
+
+		return setConfigurationSpecDefaults(patches, "/spec", config.Spec)
+	}
+}
+
+func setConfigurationSpecDefaults(patches *[]jsonpatch.JsonPatchOperation, patchBase string, spec v1alpha1.ConfigurationSpec) error {
+	if spec.RevisionTemplate.Spec.ConcurrencyModel == "" {
+		*patches = append(*patches, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      path.Join(patchBase, "revisionTemplate/spec/concurrencyModel"),
+			Value:     v1alpha1.RevisionRequestConcurrencyModelMulti,
+		})
+	}
+	return nil
+}
+
+func unmarshalConfigurations(
+	ctx context.Context, old GenericCRD, new GenericCRD, fnName string) (*v1alpha1.Configuration, *v1alpha1.Configuration, error) {
+	logger := logging.FromContext(ctx)
+	var oldConfiguration *v1alpha1.Configuration
+	if old != nil {
+		var ok bool
+		oldConfiguration, ok = old.(*v1alpha1.Configuration)
+		if !ok {
+			return nil, nil, errInvalidConfigurationInput
+		}
+	}
+	logger.Infof("%s: OLD Configuration is\n%+v", fnName, oldConfiguration)
+
+	newConfiguration, ok := new.(*v1alpha1.Configuration)
+	if !ok {
+		return nil, nil, errInvalidConfigurationInput
+	}
+	logger.Infof("%s: NEW Configuration is\n%+v", fnName, newConfiguration)
+
+	return oldConfiguration, newConfiguration, nil
+}


### PR DESCRIPTION
Instead of a enumeration, we should provide a positive integer parameter
to set the maximum request concurrency.

Fixes #1105

## Proposed Changes

  * Deprecates RevisionRequestConcurrencyModelType in favor of InstanceMaxRequestConcurrency

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
