### PR TITLE
[WIP] Make (cluster-local) DNS work out of the box by default.

### DIFF
--- a/config/config-domain.yaml
+++ b/config/config-domain.yaml
@@ -19,12 +19,15 @@ metadata:
   namespace: knative-serving
 data:
   # These are example settings of domain.
-  # example.org will be used for routes having app=prod.
-  # example.org: |
+  # example.com will be used for routes having app=external.
+  # example.com: |
   #   selector:
-  #     app: prod
+  #     app: external
 
-  # Default value for domain, for routes that does not have app=prod labels.
-  # Although it will match all routes, it is the least-specific rule so it
-  # will only be used if no other domain matches.
-  example.com: |
+  # This is the default value for domain, for routes that does not have
+  # app=external labels. This is the least-specific rule and acts as a default.
+  # The 'svc.cluster.local' default provides a DNS name which works inside the
+  # cluster. If you want your cluster to be public, you'll need to follow the
+  # instructions here:
+  # https://github.com/knative/docs/blob/master/serving/using-a-custom-domain.md#publish-your-domain
+  svc.cluster.local: |

--- a/pkg/controller/route/resources/service.go
+++ b/pkg/controller/route/resources/service.go
@@ -39,10 +39,8 @@ func MakeK8sService(route *v1alpha1.Route) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name: PortName,
-				Port: PortNumber,
-			}},
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "knative-ingressgateway.istio-system.svc.cluster.local",
 		},
 	}
 }

--- a/pkg/controller/route/resources/virtual_service.go
+++ b/pkg/controller/route/resources/virtual_service.go
@@ -80,9 +80,11 @@ func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.Revi
 			// Traffic originates from outside of the cluster would be of the form "*.domain", or "domain"
 			fmt.Sprintf("*.%s", domain),
 			domain,
-			// Traffic from inside the cluster will use the FQDN of the Route's headless Service.
-			names.K8sServiceFullname(u),
 		},
+	}
+	if domain != names.K8sServiceFullname(u) {
+		// Add a local alias for the k8s Service in the svc.cluster.local DNS space.
+		spec.Hosts = append(spec.Hosts, names.K8sServiceFullname(u))
 	}
 	names := []string{}
 	for name := range targets {


### PR DESCRIPTION
Related to #1598 

## Proposed Changes

  * Change the default out-of-the-box domain to `svc.cluster.local`, which:
     1. Documents that the name only works locally until the cluster is further configured.
     1. Makes `spec.domain` be a DNS-resolvable name by default, in case we want to implement #1598 
  * Change the k8s `Service` created as the public route endpoint to be an `ExternalName` to the knative gateway in the ingress. This makes pods launched without the istio sidecar still able to call knative. (Tested by hand.)
  * Fix a bug in managing the `VirtualService` where the same domain could be added to the `VirtualService` twice if the cluster's domain suffix were set to `svc.cluster.local`. This causes Istio to fail internal configuration propagation checks and route updates to not be applied.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Change the default out-of-the-box domain to `svc.cluster.local`, to provide local no-DNS-setup installation of knative/serving.
Changes the route.ns.svc.cluster.local DNS name to point to the istio ingress to enable non-instio-injected pods to call knative.
```

<!--
/assign @mattmoor 
/assign @tcnghia 
-->