### PR TITLE
Update Minikube instructions

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -101,23 +101,23 @@ To use a k8s cluster running in GKE:
 
     ```shell
     minikube start --memory=8192 --cpus=4 \
-    --kubernetes-version=v1.10.4 \
+    --kubernetes-version=v1.10.5 \
     --vm-driver=kvm2 \
     --bootstrapper=kubeadm \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
-    --extra-config=apiserver.admission-control="DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+    --extra-config=apiserver.admission-control="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
     For macOS use:
 
     ```shell
     minikube start --memory=8192 --cpus=4 \
-    --kubernetes-version=v1.10.4 \
+    --kubernetes-version=v1.10.5 \
     --vm-driver=hyperkit \
     --bootstrapper=kubeadm \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
-    --extra-config=apiserver.admission-control="DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+    --extra-config=apiserver.admission-control="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
 1.  [Configure your shell environment](../DEVELOPMENT.md#environment-setup)
     to use your minikube cluster:


### PR DESCRIPTION

## Proposed Changes

  * remove `DenyEscalatingExec` - it's not included in the [Istio installation docs](https://istio.io/docs/setup/kubernetes/quick-start/#minikube); it prevents us from execing into running containers when sidecar injection is enabled; it was also removed from the Minikube instructions in the [docs repo](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#creating-a-kubernetes-cluster)
  * update Kubernetes version to 1.10.5
  *

**Release Note**
```release-note
NONE
```
