### PR TITLE
Create a common location for creating objects in tests

### DIFF
--- a/test/configuration.go
+++ b/test/configuration.go
@@ -13,14 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// logging.go contains the logic to configure and interact with the
-// logging and metrics libraries.
+// configuration.go provides methods to perform actions on the configuration object.
 
 package test
 
-// CreateConfiguration creates a config object
-func CreateConfiguration(clients *Clients, names ResourceNames, imagePaths []string) error {
-	config := Configuration(Flags.Namespace, names, imagePaths[0])
+// CreateConfiguration create a configuration resource in namespace with the name names.Config
+// that uses the image specifed by imagePath.
+func CreateConfiguration(clients *Clients, names ResourceNames, imagePath string) error {
+	config := Configuration(Flags.Namespace, names, imagePath)
 	// Log config object
 	_, err := clients.Configs.Create(config)
 	return err

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -44,7 +44,7 @@ const (
 )
 
 func createRouteAndConfig(clients *test.Clients, names test.ResourceNames, imagePaths []string) error {
-	err := test.CreateConfiguration(clients, names, imagePaths)
+	err := test.CreateConfiguration(clients, names, imagePaths[0])
 	if err != nil {
 		return err
 	}

--- a/test/route.go
+++ b/test/route.go
@@ -13,12 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// logging.go contains the logic to configure and interact with the
-// logging and metrics libraries.
+// route.go provides methods to perform actions on the route resource.
 
 package test
 
-// CreateRoute creates a route object
+// CreateRoute creates a route in the given namespace using the route name in names
 func CreateRoute(clients *Clients, names ResourceNames) error {
 	route := Route(Flags.Namespace, names)
 	// Log the route object


### PR DESCRIPTION
Part of #1006 

## Proposed Changes

  * Use a common location for creating route and configurations.
  * Update the route_test.go file to call these methods.
  
This will help us in performing actions like logging in a central location on object creation.