### PR TITLE
Use dep-collector from prow-tests image

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,8 +9,6 @@ required = [
   "k8s.io/code-generator/cmd/client-gen",
   "k8s.io/code-generator/cmd/lister-gen",
   "k8s.io/code-generator/cmd/informer-gen",
-  "github.com/google/go-containerregistry/cmd/ko",
-  "github.com/mattmoor/dep-collector",
 ]
 
 

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,14 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Load github.com/knative/test-infra/images/prow-tests/scripts/library.sh
+[ -f /workspace/library.sh ] \
+  && source /workspace/library.sh \
+  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat library.sh')"
+[ -v KNATIVE_TEST_INFRA ] || exit 1
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-SERVING_ROOT=$(dirname ${BASH_SOURCE})/..
-
-pushd ${SERVING_ROOT}
-trap popd EXIT
+cd ${REPO_ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure
@@ -29,10 +32,9 @@ dep ensure
 # Patch the Kubernetes client to fix panics in fake watches. This patch is from
 # https://github.com/kubernetes/kubernetes/pull/61195 and can be removed once
 # that PR makes it here.
-git apply --exclude='*_test.go' $SERVING_ROOT/hack/61195.patch
+git apply --exclude='*_test.go' ${REPO_ROOT_DIR}/hack/61195.patch
 
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')
 
-# Run dep-collector to update our VENDOR-LICENSE
-go run ./vendor/github.com/mattmoor/dep-collector/*.go ./cmd/* > third_party/VENDOR-LICENSE
+update_licenses third_party/VENDOR-LICENSE "./cmd/*"

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -41,7 +41,7 @@ function build_tests() {
   # Fetch the google/licenseclassifier for its license db
   go get github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  go run ./vendor/github.com/mattmoor/dep-collector/*.go -check ./cmd/* || result=1
+  dep-collector -check ./cmd/* || result=1
   return ${result}
 }
 


### PR DESCRIPTION
We're consolidating the test infrastructure into a single place, so all repos get the same fixes, updates and new features.

`dep-collector` was added to prow-tests image in knative/test-infra#22 and `update_licenses() in knative/test-infra#24

Bonus: also remove `ko` as a dependency, since it's also already installed in prow-tests image.