### PR TITLE
Add adrcunha to OWNERS in //hack

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -2,6 +2,3 @@
 
 approvers:
 - adrcunha
-- evankanderson
-- mattmoor
-- vaikas-google


### PR DESCRIPTION
OWNERS are transitive, remaining owners are those in the repo root directory.