### PR TITLE
Expose a better error for Inactive Revisions

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -400,11 +400,12 @@ func (rs *RevisionStatus) MarkResourcesAvailable() {
 	rs.checkAndMarkReady()
 }
 
-func (rs *RevisionStatus) MarkInactive() {
+func (rs *RevisionStatus) MarkInactive(message string) {
 	rs.setCondition(&RevisionCondition{
-		Type:   RevisionConditionReady,
-		Status: corev1.ConditionFalse,
-		Reason: "Inactive",
+		Type:    RevisionConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  "Inactive",
+		Message: message,
 	})
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -541,7 +541,7 @@ func TestTypicalFlowWithSuspendResume(t *testing.T) {
 	checkConditionSucceededRevision(r.Status, RevisionConditionReady, t)
 
 	// From a Ready state, make the revision inactive to simulate scale to zero.
-	r.Status.MarkInactive()
+	r.Status.MarkInactive("Reserve")
 	checkConditionSucceededRevision(r.Status, RevisionConditionResourcesAvailable, t)
 	checkConditionSucceededRevision(r.Status, RevisionConditionContainerHealthy, t)
 	if got := checkConditionFailedRevision(r.Status, RevisionConditionReady, t); got == nil || got.Reason != "Inactive" {

--- a/pkg/controller/revision/revision.go
+++ b/pkg/controller/revision/revision.go
@@ -424,7 +424,7 @@ func (c *Controller) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 			return err
 		}
 		logger.Infof("Deleted deployment %q", deploymentName)
-		rev.Status.MarkInactive()
+		rev.Status.MarkInactive(fmt.Sprintf("Revision %q is Inactive.", rev.Name))
 		return nil
 
 	default:
@@ -582,7 +582,7 @@ func (c *Controller) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 			return err
 		}
 		logger.Infof("Deleted Service %q", serviceName)
-		rev.Status.MarkInactive()
+		rev.Status.MarkInactive(fmt.Sprintf("Revision %q is Inactive.", rev.Name))
 		return nil
 
 	default:

--- a/pkg/controller/revision/table_test.go
+++ b/pkg/controller/revision/table_test.go
@@ -414,9 +414,10 @@ func TestReconcile(t *testing.T) {
 						Status: "Unknown",
 						Reason: "Updating",
 					}, {
-						Type:   "Ready",
-						Status: "False",
-						Reason: "Inactive",
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "Inactive",
+						Message: `Revision "deactivate" is Inactive.`,
 					}},
 				}),
 		}, {
@@ -525,9 +526,10 @@ func TestReconcile(t *testing.T) {
 						Status: "Unknown",
 						Reason: "Deploying",
 					}, {
-						Type:   "Ready",
-						Status: "False",
-						Reason: "Inactive",
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "Inactive",
+						Message: `Revision "update-user-deploy-failure" is Inactive.`,
 					}},
 				}),
 		}, {
@@ -560,9 +562,10 @@ func TestReconcile(t *testing.T) {
 						Status: "Unknown",
 						Reason: "Updating",
 					}, {
-						Type:   "Ready",
-						Status: "False",
-						Reason: "Inactive",
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "Inactive",
+						Message: `Revision "stable-deactivation" is Inactive.`,
 					}},
 				}),
 			// The Deployments match what we'd expect of an Reserve revision.
@@ -622,9 +625,10 @@ func TestReconcile(t *testing.T) {
 						Status: "Unknown",
 						Reason: "Deploying",
 					}, {
-						Type:   "Ready",
-						Status: "False",
-						Reason: "Inactive",
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "Inactive",
+						Message: `Revision "retire" is Inactive.`,
 					}},
 				}),
 		}},
@@ -821,9 +825,10 @@ func TestReconcile(t *testing.T) {
 						Status: "Unknown",
 						Reason: "Deploying",
 					}, {
-						Type:   "Ready",
-						Status: "False",
-						Reason: "Inactive",
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "Inactive",
+						Message: `Revision "stable-retirement" is Inactive.`,
 					}},
 				}),
 		},
@@ -852,9 +857,10 @@ func TestReconcile(t *testing.T) {
 						Status: "Unknown",
 						Reason: "Updating",
 					}, {
-						Type:   "Ready",
-						Status: "False",
-						Reason: "Inactive",
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "Inactive",
+						Message: `Revision "activate-revision" is Inactive.`,
 					}},
 				}),
 			// The Deployments match what we'd expect of an Reserve revision.

--- a/pkg/controller/route/traffic/traffic_test.go
+++ b/pkg/controller/route/traffic/traffic_test.go
@@ -691,7 +691,7 @@ func getTestInactiveConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revi
 	rev := getTestRevForConfig(config, name+"-revision")
 	config.Status.SetLatestReadyRevisionName(rev.Name)
 	config.Status.SetLatestCreatedRevisionName(rev.Name)
-	rev.Status.MarkInactive()
+	rev.Status.MarkInactive("Reserve")
 	return config, rev
 }
 


### PR DESCRIPTION
Failed Revision conditions propagate up through Configuration and
Service statuses. Inactive Revisions currently lack a Message, so the
propagated error is poor. This adds a simple Message.

Fixes #1668

## Proposed Changes

  * Add `Message` to Revision's Inactive condition.

Note that currently this message is a bit repetitive because Configuration wraps it:
```yaml
message: 'Revision "kythe-00003" failed with message: "Revision \"kythe-00003\" is Inactive.".'
```
I think that should be a separate change.