### PR TITLE
Run conformance and E2E tests concurrently

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -108,8 +108,7 @@ test images used by the conformance and e2e tests. It requires:
 To run the script for all end to end test images:
 
 ```bash
-./test/upload-test-images.sh ./test/e2e/test_images
-./test/upload-test-images.sh ./test/conformance/test_images
+./test/upload-test-images.sh ./test/e2e/test_images ./test/conformance/test_images
 ```
 
 ### Adding new test images

--- a/test/README.md
+++ b/test/README.md
@@ -61,10 +61,9 @@ go test -v -tags=e2e -count=1 ./test/e2e -run ^TestAutoscaleUpDownUp$
 These tests require:
 
 1. [A running `Knative Serving` cluster.](/DEVELOPMENT.md#getting-started)
-2. The namespaces `pizzaplanet` and `noodleburg`:
+2. The namespace `serving-tests``:
     ```bash
-    kubectl create namespace pizzaplanet
-    kubectl create namespace noodleburg
+    kubectl create namespace serving-tests
     ```
 3. A docker repo containing [the test images](#test-images)
 
@@ -121,6 +120,8 @@ for building and running the test image.
 The new test images will also need to be uploaded to the e2e tests Docker repo. You will need one
 of the owners found in [`/test/OWNERS`](OWNERS) to do this.
 
+Because the test images are uploaded to the same folder, they **must** have different names.
+
 ## Flags
 
 These flags are useful for running against an existing cluster, making use of your existing
@@ -171,7 +172,7 @@ kubectl config get-clusters
 ### Specifying namespace
 
 The `--namespace` argument lets you specify the namespace to use for the
-tests. By default, `conformance` will use `noodleburg` and `e2e` will use `pizzaplanet`.
+tests. By default, tests will use `serving-tests`.
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/conformance --namespace your-namespace-name

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -39,7 +39,7 @@ import (
 const (
 	image1               = "pizzaplanetv1"
 	image2               = "pizzaplanetv2"
-	defaultNamespaceName = "pizzaplanet"
+	defaultNamespaceName = "serving-tests"
 )
 
 func createRouteAndConfig(clients *test.Clients, names test.ResourceNames, imagePaths []string) error {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -106,22 +106,7 @@ function dump_extra_cluster_state() {
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
   echo ">>> Knative Serving controller log:"
-  local controller=$(kubectl get pods -n knative-serving \
-    --selector=app=controller --output=jsonpath="{.items[0].metadata.name}")
   kubectl logs $(get_app_pod controller knative-serving)
-}
-
-function run_e2e_tests() {
-  header "Running tests in $1"
-  kubectl create namespace $2
-  kubectl label namespace $2 istio-injection=enabled --overwrite
-  local options=""
-  (( EMIT_METRICS )) && options="-emitmetrics"
-  report_go_test -v -tags=e2e -count=1 ./test/$1 -dockerrepo gcr.io/knative-tests/test-images/$1 ${options}
-
-  local result=$?
-  [[ ${result} -ne 0 ]] && dump_cluster_state
-  return ${result}
 }
 
 # Script entry point.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -146,8 +146,14 @@ wait_until_service_has_external_ip istio-system knative-ingressgateway || fail_t
 
 # Run the tests
 
-result=0
-run_e2e_tests conformance pizzaplanet || result=1
-run_e2e_tests e2e noodleburg || result=1
-[[ ${result} -ne 0 ]] && exit 1 # run_e2e_tests already dumps state
+header "Running tests"
+kubectl create namespace serving-tests
+kubectl label namespace serving-tests istio-injection=enabled --overwrite
+options=""
+(( EMIT_METRICS )) && options="-emitmetrics"
+report_go_test -v -tags=e2e -count=1 \
+  ./test/conformance ./test/e2e \
+  ${options} \
+  -dockerrepo gcr.io/knative-tests/test-images/knative-serving || fail_test
+
 success

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,7 +17,7 @@ import (
 const (
 	configName           = "prod"
 	routeName            = "noodleburg"
-	defaultNamespaceName = "noodleburg"
+	defaultNamespaceName = "serving-tests"
 )
 
 // Setup creates the client objects needed in the e2e tests.

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -16,15 +16,15 @@
 
 set -o errexit
 
-: ${1:?"Pass the directory with the test images as argument"}
+: ${1:?"Pass the directories with the test images as arguments"}
 : ${DOCKER_REPO_OVERRIDE:?"You must set 'DOCKER_REPO_OVERRIDE', see DEVELOPMENT.md"}
 
-DOCKER_FILES="$(ls -1 $1/*/Dockerfile)"
-: ${DOCKER_FILES:?"No subdirectories with Dockerfile files found in $1"}
+DOCKER_FILES="$(find $@ -name Dockerfile)"
+: ${DOCKER_FILES:?"No subdirectories with Dockerfile files found in $@"}
 
 for docker_file in ${DOCKER_FILES}; do
   image_dir="$(dirname ${docker_file})"
-  versioned_name="${DOCKER_REPO_OVERRIDE}/$(basename ${image_dir})"
+  versioned_name="${DOCKER_REPO_OVERRIDE}/knative-serving/$(basename ${image_dir})"
   docker build "${image_dir}" -f "${docker_file}" -t "${versioned_name}"
   docker push "${versioned_name}"
 done


### PR DESCRIPTION
This saves about 5 minutes of run time.

This also simplifies the running part of the E2E/conformance tests in the `e2e-tests.sh` script, as actually there's no reason to run these tests sequentially anynore.

However, in order to achieve that, the namespaces and test images location had to be unified for both set of tests (although this doesn't affect their run).

Bonus: `upload-test-images.sh` now accepts multiple dirs as arguments.

Addresses knative/test-infra#20