### PR TITLE
[WIP] Consolidate our condition manipulation logic

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_types_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types_test.go
@@ -132,21 +132,14 @@ func TestConfigurationConditions(t *testing.T) {
 	}
 
 	// Add a new condition.
-	config.Status.setCondition(foo)
+	config.Status.setCondition(string(foo.Type), foo.Status, foo.Reason, foo.Message)
 
 	if got, want := len(config.Status.Conditions), 1; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
 	// Add a second condition.
-	config.Status.setCondition(bar)
-
-	if got, want := len(config.Status.Conditions), 2; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
-	// Add nil condition.
-	config.Status.setCondition(nil)
+	config.Status.setCondition(string(bar.Type), bar.Status, bar.Reason, bar.Message)
 
 	if got, want := len(config.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)

--- a/pkg/apis/serving/v1alpha1/errors.go
+++ b/pkg/apis/serving/v1alpha1/errors.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type conditionAccessor interface {
+	setCondition(typ string, status corev1.ConditionStatus, reason string, message string)
+	getConditionStatus(typ string) *corev1.ConditionStatus
+}
+
+type conditionManager struct {
+	ready         string
+	subconditions []string
+}
+
+func (c *conditionManager) initializeConditions(sc conditionAccessor) {
+	for _, cond := range c.subconditions {
+		if rc := sc.getConditionStatus(cond); rc == nil {
+			c.setUnknownCondition(sc, cond, "", "")
+		}
+	}
+}
+
+func (c *conditionManager) setUnknownCondition(sc conditionAccessor, t string, reason, message string) {
+	// Marking a subcondition as Unknown immediately flags Ready as Unknown.
+	for _, cond := range []string{t, c.ready} {
+		sc.setCondition(cond, corev1.ConditionUnknown, reason, message)
+	}
+}
+
+func (c *conditionManager) setFalseCondition(sc conditionAccessor, t string, reason, message string) {
+	// Marking a subcondition as False immediately flags Ready as False.
+	for _, cond := range []string{t, c.ready} {
+		sc.setCondition(cond, corev1.ConditionFalse, reason, message)
+	}
+}
+
+func (c *conditionManager) setTrueCondition(sc conditionAccessor, t string, reason, message string) {
+	sc.setCondition(t, corev1.ConditionTrue, reason, message)
+	// Now, if ALL subconditions are True, mark Ready as True.
+	for _, cond := range c.subconditions {
+		cs := sc.getConditionStatus(cond)
+		if cs == nil || *cs != corev1.ConditionTrue {
+			return
+		}
+	}
+	// Elide Reason/Message from Ready: True.
+	sc.setCondition(c.ready, corev1.ConditionTrue, "", "")
+}

--- a/pkg/apis/serving/v1alpha1/errors_test.go
+++ b/pkg/apis/serving/v1alpha1/errors_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2017 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type cond struct {
+	S corev1.ConditionStatus
+	R string
+	M string
+}
+
+type condr map[string]cond
+
+func (c condr) setCondition(typ string, status corev1.ConditionStatus, reason string, message string) {
+	c[typ] = cond{
+		S: status,
+		R: reason,
+		M: message,
+	}
+}
+
+func (c condr) getConditionStatus(typ string) *corev1.ConditionStatus {
+	if cd, ok := c[typ]; ok {
+		return &cd.S
+	}
+	return nil
+}
+
+func TestConditionManager(t *testing.T) {
+	cr := conditionManager{
+		ready: "ready",
+		subconditions: []string{
+			"foo",
+			"bar",
+		},
+	}
+
+	tests := []struct {
+		name string
+		in   condr
+		want condr
+		m    func(conditionAccessor, string, string, string)
+		typ  string
+		r    string
+		msg  string
+	}{{
+		name: "true for one",
+		in: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionTrue},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		m:   cr.setTrueCondition,
+		typ: "foo",
+	}, {
+		name: "true cascade",
+		in: condr{
+			"foo":   {S: corev1.ConditionTrue},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionTrue},
+			"bar":   {S: corev1.ConditionTrue},
+			"ready": {S: corev1.ConditionTrue},
+		},
+		m:   cr.setTrueCondition,
+		typ: "bar",
+	}, {
+		name: "failure cascade immediately",
+		in: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionFalse},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionFalse},
+		},
+		m:   cr.setFalseCondition,
+		typ: "foo",
+	}, {
+		name: "true does not cascade",
+		in: condr{
+			"foo":   {S: corev1.ConditionFalse},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionFalse},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionFalse},
+			"bar":   {S: corev1.ConditionTrue},
+			"ready": {S: corev1.ConditionFalse},
+		},
+		m:   cr.setTrueCondition,
+		typ: "bar",
+	}, {
+		name: "unknown resets failure",
+		in: condr{
+			"foo":   {S: corev1.ConditionFalse},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionFalse},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		m:   cr.setUnknownCondition,
+		typ: "foo",
+	}, {
+		name: "unknown resets success",
+		in: condr{
+			"foo":   {S: corev1.ConditionTrue},
+			"bar":   {S: corev1.ConditionTrue},
+			"ready": {S: corev1.ConditionTrue},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionTrue},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		m:   cr.setUnknownCondition,
+		typ: "foo",
+	}, {
+		name: "failure propagates reason/message",
+		in: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionFalse, R: "asdf", M: "blah"},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionFalse, R: "asdf", M: "blah"},
+		},
+		m:   cr.setFalseCondition,
+		typ: "foo",
+		r:   "asdf",
+		msg: "blah",
+	}, {
+		name: "unknown propagates reason/message",
+		in: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionUnknown, R: "asdf", M: "blah"},
+			"bar":   {S: corev1.ConditionUnknown},
+			"ready": {S: corev1.ConditionUnknown, R: "asdf", M: "blah"},
+		},
+		m:   cr.setUnknownCondition,
+		typ: "foo",
+		r:   "asdf",
+		msg: "blah",
+	}, {
+		name: "success elides reason/message",
+		in: condr{
+			"foo":   {S: corev1.ConditionUnknown},
+			"bar":   {S: corev1.ConditionTrue},
+			"ready": {S: corev1.ConditionUnknown},
+		},
+		want: condr{
+			"foo":   {S: corev1.ConditionTrue, R: "asdf", M: "blah"},
+			"bar":   {S: corev1.ConditionTrue},
+			"ready": {S: corev1.ConditionTrue},
+		},
+		m:   cr.setTrueCondition,
+		typ: "foo",
+		r:   "asdf",
+		msg: "blah",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.in
+			test.m(test.in, test.typ, test.r, test.msg)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("%s (-got, +want) = %v", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -16,10 +16,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 )
@@ -266,8 +266,8 @@ func TestGetSetCondition(t *testing.T) {
 		Status: corev1.ConditionTrue,
 	}
 	// Set Condition and make sure it's the only thing returned
-	rs.setCondition(rc)
-	if e, a := rc, rs.GetCondition(RevisionConditionBuildSucceeded); !reflect.DeepEqual(e, a) {
+	rs.setCondition(string(rc.Type), rc.Status, rc.Reason, rc.Message)
+	if e, a := rc, rs.GetCondition(RevisionConditionBuildSucceeded); !equality.Semantic.DeepEqual(e, a) {
 		t.Errorf("GetCondition expected %v got: %v", e, a)
 	}
 	if a := rs.GetCondition(RevisionConditionReady); a != nil {
@@ -287,28 +287,14 @@ func TestRevisionConditions(t *testing.T) {
 	}
 
 	// Add a new condition.
-	rev.Status.setCondition(foo)
-
-	if got, want := len(rev.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
-	// Add nothing
-	rev.Status.setCondition(nil)
+	rev.Status.setCondition(string(foo.Type), foo.Status, foo.Reason, foo.Message)
 
 	if got, want := len(rev.Status.Conditions), 1; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
 	// Add a second condition.
-	rev.Status.setCondition(bar)
-
-	if got, want := len(rev.Status.Conditions), 2; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
-	// Add nil condition.
-	rev.Status.setCondition(nil)
+	rev.Status.setCondition(string(bar.Type), bar.Status, bar.Reason, bar.Message)
 
 	if got, want := len(rev.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)

--- a/pkg/apis/serving/v1alpha1/route_types_test.go
+++ b/pkg/apis/serving/v1alpha1/route_types_test.go
@@ -133,28 +133,13 @@ func TestRouteConditions(t *testing.T) {
 	}
 
 	// Add a new condition.
-	svc.Status.setCondition(foo)
-
-	if got, want := len(svc.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
-	// Add nothing
-	svc.Status.setCondition(nil)
-
+	svc.Status.setCondition(string(foo.Type), foo.Status, foo.Reason, foo.Message)
 	if got, want := len(svc.Status.Conditions), 1; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
 	// Add a second condition.
-	svc.Status.setCondition(bar)
-
-	if got, want := len(svc.Status.Conditions), 2; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
-	// Add nil condition.
-	svc.Status.setCondition(nil)
+	svc.Status.setCondition(string(bar.Type), bar.Status, bar.Reason, bar.Message)
 
 	if got, want := len(svc.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)

--- a/pkg/apis/serving/v1alpha1/service_types_test.go
+++ b/pkg/apis/serving/v1alpha1/service_types_test.go
@@ -133,21 +133,15 @@ func TestServiceConditions(t *testing.T) {
 	}
 
 	// Add a single condition.
-	svc.Status.setCondition(foo)
+	svc.Status.setCondition(string(foo.Type), foo.Status, foo.Reason, foo.Message)
 	if got, want := len(svc.Status.Conditions), 1; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
 	// Add a second Condition.
-	svc.Status.setCondition(bar)
+	svc.Status.setCondition(string(bar.Type), bar.Status, bar.Reason, bar.Message)
 	if got, want := len(svc.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
-	// Test Add nil condition.
-	svc.Status.setCondition(nil)
-	if got, want := len(svc.Status.Conditions), 2; got != want {
-		t.Fatal("Error, nil condition was allowed to be added.")
 	}
 }
 


### PR DESCRIPTION
This consolidates the logic for manipulating our conditions into a single private `conditionManager` type.  This operates on strings with the expectation that since it isn't public API we can break the encapsulation of our enums and share this code across our 4 status types.

The hope is that this will make it easier to adhere to our conventions and harder to break them.

WIP based on: https://github.com/knative/serving/pull/1663