### PR TITLE
Make (cluster-local) DNS work out of the box by default. 

### DIFF
--- a/pkg/reconciler/v1alpha1/route/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names.go
@@ -26,6 +26,10 @@ var K8sGatewayFullname = reconciler.GetK8sServiceFullname(
 	"knative-shared-gateway",
 	system.Namespace)
 
+var K8sGatewayServiceFullname = reconciler.GetK8sServiceFullname(
+	"knative-ingressgateway",
+	"istio-system")
+
 func K8sService(route *v1alpha1.Route) string {
 	return route.Name
 }

--- a/pkg/reconciler/v1alpha1/route/resources/service.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service.go
@@ -39,10 +39,8 @@ func MakeK8sService(route *v1alpha1.Route) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name: PortName,
-				Port: PortNumber,
-			}},
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: names.K8sGatewayServiceFullname,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/route/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,10 +38,8 @@ func TestMakeK8SService_ValidSpec(t *testing.T) {
 		},
 	}
 	expectedSpec := corev1.ServiceSpec{
-		Ports: []corev1.ServicePort{{
-			Name: "http",
-			Port: 80,
-		}},
+		Type:         corev1.ServiceTypeExternalName,
+		ExternalName: names.K8sGatewayServiceFullname,
 	}
 	spec := MakeK8sService(r).Spec
 	if diff := cmp.Diff(expectedSpec, spec); diff != "" {


### PR DESCRIPTION
Originally proposed by @evankanderson in #1609.  Related to #1598 

## Proposed Changes

  * Change the default out-of-the-box domain to `svc.cluster.local`, which:
     1. Documents that the name only works locally until the cluster is further configured.
     1. Makes `spec.domain` be a DNS-resolvable name by default, in case we want to implement #1598 
  * Change the k8s `Service` created as the public route endpoint to be an `ExternalName` to the knative gateway in the ingress. This makes pods launched without the istio sidecar still able to call knative. (Tested by hand.)
  * Fix a bug in managing the `VirtualService` where the same domain could be added to the `VirtualService` twice if the cluster's domain suffix were set to `svc.cluster.local`. This causes Istio to fail internal configuration propagation checks and route updates to not be applied.
  * Fix a bug in  the `VirtualService` where match headers are added twice when suffix is `svc.cluster.local`. 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Change the default out-of-the-box domain to `svc.cluster.local`, to provide local no-DNS-setup installation of knative/serving.
Changes the route.ns.svc.cluster.local DNS name to point to the istio ingress to enable non-instio-injected pods to call knative.
```

<!--
/assign @mattmoor 
/assign @ZhiminXiang   
-->