### PR TITLE
Don't ignore failures in the admission webhook

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -369,6 +369,7 @@ func (ac *AdmissionController) register(
 	ctx context.Context, client clientadmissionregistrationv1beta1.MutatingWebhookConfigurationInterface, caCert []byte) error { // nolint: lll
 	logger := logging.FromContext(ctx)
 	resources := []string{"configurations", "routes", "revisions", "services"}
+	failurePolicy := admissionregistrationv1beta1.Fail
 
 	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -394,6 +395,7 @@ func (ac *AdmissionController) register(
 				},
 				CABundle: caCert,
 			},
+			FailurePolicy: &failurePolicy,
 		}},
 	}
 


### PR DESCRIPTION
By default, admission webhook failures are ignored. So if the webhook
service is down or can't be communicated with, the admission process
will happily ignore that and continue with the resoure changes.

By setting the FailurePolicy to Fail, we ensure that problems
communicating with the webhook service don't get silently ignored,
leading to problems later on.
