### PR TITLE
Log the route and config objects when created by conformance tests

### DIFF
--- a/test/configuration.go
+++ b/test/configuration.go
@@ -17,11 +17,24 @@ limitations under the License.
 
 package test
 
+import (
+	"encoding/json"
+
+	"go.uber.org/zap"
+)
+
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specifed by imagePath.
-func CreateConfiguration(clients *Clients, names ResourceNames, imagePath string) error {
+func CreateConfiguration(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) error {
 	config := Configuration(Flags.Namespace, names, imagePath)
 	// Log config object
-	_, err := clients.Configs.Create(config)
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		logger.Infof("Failed to create json from route object")
+	} else {
+		logger.Infow("Created resource object",
+			"CONFIGURATION", string(configJSON))
+	}
+	_, err = clients.Configs.Create(config)
 	return err
 }

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -28,13 +28,11 @@ import (
 func CreateConfiguration(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) error {
 	config := Configuration(Flags.Namespace, names, imagePath)
 	// Log config object
-	configJSON, err := json.Marshal(config)
-	if err != nil {
+	if configJSON, err := json.Marshal(config); err != nil {
 		logger.Infof("Failed to create json from route object")
 	} else {
-		logger.Infow("Created resource object",
-			"CONFIGURATION", string(configJSON))
+		logger.Infow("Created resource object", "CONFIGURATION", string(configJSON))
 	}
-	_, err = clients.Configs.Create(config)
+	_, err := clients.Configs.Create(config)
 	return err
 }

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -42,12 +42,12 @@ const (
 	defaultNamespaceName = "pizzaplanet"
 )
 
-func createRouteAndConfig(clients *test.Clients, names test.ResourceNames, imagePaths []string) error {
-	err := test.CreateConfiguration(clients, names, imagePaths[0])
+func createRouteAndConfig(logger *zap.SugaredLogger, clients *test.Clients, names test.ResourceNames, imagePaths []string) error {
+	err := test.CreateConfiguration(logger, clients, names, imagePaths[0])
 	if err != nil {
 		return err
 	}
-	err = test.CreateRoute(clients, names)
+	err = test.CreateRoute(logger, clients, names)
 	return err
 }
 
@@ -164,7 +164,7 @@ func TestRouteCreation(t *testing.T) {
 	defer tearDown(clients, names)
 
 	logger.Infof("Creating a new Route and Configuration")
-	err := createRouteAndConfig(clients, names, imagePaths)
+	err := createRouteAndConfig(logger, clients, names, imagePaths)
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}

--- a/test/route.go
+++ b/test/route.go
@@ -27,14 +27,12 @@ import (
 func CreateRoute(logger *zap.SugaredLogger, clients *Clients, names ResourceNames) error {
 	route := Route(Flags.Namespace, names)
 	// Log the route object
-	routeJSON, err := json.Marshal(route)
-	if err != nil {
+	if routeJSON, err := json.Marshal(route); err != nil {
 		logger.Infof("Failed to create json from route object")
 	} else {
-		logger.Infow("Created resource object",
-			"ROUTE", string(routeJSON))
+		logger.Infow("Created resource object", "ROUTE", string(routeJSON))
 	}
 
-	_, err = clients.Routes.Create(route)
+	_, err := clients.Routes.Create(route)
 	return err
 }

--- a/test/route.go
+++ b/test/route.go
@@ -17,10 +17,24 @@ limitations under the License.
 
 package test
 
+import (
+	"encoding/json"
+
+	"go.uber.org/zap"
+)
+
 // CreateRoute creates a route in the given namespace using the route name in names
-func CreateRoute(clients *Clients, names ResourceNames) error {
+func CreateRoute(logger *zap.SugaredLogger, clients *Clients, names ResourceNames) error {
 	route := Route(Flags.Namespace, names)
 	// Log the route object
-	_, err := clients.Routes.Create(route)
+	routeJSON, err := json.Marshal(route)
+	if err != nil {
+		logger.Infof("Failed to create json from route object")
+	} else {
+		logger.Infow("Created resource object",
+			"ROUTE", string(routeJSON))
+	}
+
+	_, err = clients.Routes.Create(route)
 	return err
 }


### PR DESCRIPTION
Part of #1006 

## Proposed Changes
  * Log the route and configuation objects when they are created.
  * Update the route_test.go file to pass in the logger when calling the methods
 

