### PR TITLE
Increase E2E tests timeout to 20 minutes.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -136,7 +136,8 @@ kubectl create namespace serving-tests
 kubectl label namespace serving-tests istio-injection=enabled --overwrite
 options=""
 (( EMIT_METRICS )) && options="-emitmetrics"
-report_go_test -v -tags=e2e -count=1 \
+report_go_test \
+  -v -tags=e2e -count=1 -timeout=20m \
   ./test/conformance ./test/e2e \
   ${options} \
   -dockerrepo gcr.io/knative-tests/test-images/knative-serving || fail_test


### PR DESCRIPTION
Currently 10 minutes may not be enough, for example as in #1701.

With future work like knative/test-infra#20 we hopefully will be able to bring this down.