### PR TITLE
E2E test for service-to-service call within cluster

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -64,6 +64,8 @@ These tests require:
 2. The namespace `serving-tests``:
     ```bash
     kubectl create namespace serving-tests
+
+    kubectl label namespace serving-tests istio-injection=enabled    
     ```
 3. A docker repo containing [the test images](#test-images)
 

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -18,14 +18,25 @@ limitations under the License.
 package test
 
 import (
-	"go.uber.org/zap"
+        corev1 "k8s.io/api/core/v1"
+        "go.uber.org/zap"
 )
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by imagePath.
 func CreateConfiguration(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) error {
-	config := Configuration(Flags.Namespace, names, imagePath)
-	LogResourceObject(logger, ResourceObjects{Configuration: config})
-	_, err := clients.Configs.Create(config)
-	return err
+        return CreateConfigurationWithEnv(logger, clients, names, imagePath, nil)
+}
+
+// CreateConfiguration create a configuration resource in namespace with the name names.Config
+// that uses the image specifed by imagePath and give environment variables.
+func CreateConfigurationWithEnv(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string, envVars []corev1.EnvVar) error {
+        config := Configuration(Flags.Namespace, names, imagePath)
+        if envVars != nil && len(envVars) > 0 {
+                config.Spec.RevisionTemplate.Spec.Container.Env = envVars
+        }
+
+        LogResourceObject(logger, ResourceObjects{Configuration: config})
+        _, err := clients.Configs.Create(config)
+        return err
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
+	corev1 "k8s.io/api/core/v1"
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
 	// https://github.com/kubernetes/client-go/issues/242
@@ -45,16 +46,19 @@ func TearDown(clients *test.Clients, names test.ResourceNames, logger *zap.Sugar
 // CreateRouteAndConfig will create Route and Config objects using clients.
 // The Config object will serve requests to a container started from the image at imagePath.
 func CreateRouteAndConfig(clients *test.Clients, logger *zap.SugaredLogger, imagePath string) (test.ResourceNames, error) {
-	var names test.ResourceNames
-	names.Config = test.AppendRandomString(configName, logger)
-	names.Route = test.AppendRandomString(routeName, logger)
+	return CreateRouteAndConfigWithEnv(clients, logger, imagePath, nil)
+}
 
-	_, err := clients.Configs.Create(
-		test.Configuration(test.Flags.Namespace, names, imagePath))
-	if err != nil {
-		return test.ResourceNames{}, err
-	}
-	_, err = clients.Routes.Create(
-		test.Route(test.Flags.Namespace, names))
-	return names, err
+// CreateRouteAndConfigWithEnv will create Route and Config objects using clients.
+// The Config object will serve requests to a container started from the image at imagePath and configured with given environment variables.
+func CreateRouteAndConfigWithEnv(clients *test.Clients, logger *zap.SugaredLogger, imagePath string, envVars []corev1.EnvVar) (test.ResourceNames, error) {
+        var names test.ResourceNames
+        names.Config = test.AppendRandomString(configName, logger)
+        names.Route = test.AppendRandomString(routeName, logger)
+
+        if err := test.CreateConfigurationWithEnv(logger, clients, names, imagePath, envVars); err != nil {
+                return test.ResourceNames{}, err
+        }
+        err := test.CreateRoute(logger, clients, names)
+        return names, err
 }

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -1,0 +1,126 @@
+// +build e2e
+ 
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+ 
+package e2e
+ 
+import (
+        "fmt"
+        "net/http"
+        "strings"
+        "testing"
+
+        "github.com/knative/serving/test"
+        "github.com/knative/serving/test/spoof"
+
+        "go.uber.org/zap"
+
+        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+        corev1 "k8s.io/api/core/v1"
+)
+
+var (
+        clients *test.Clients
+        logger *zap.SugaredLogger
+)
+const (
+        targetHostEnv = "TARGET_HOST"
+        helloworldResponse = "Hello World! How about some tasty noodles?"
+)
+
+func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
+        helloWorldRoute, err := clients.Routes.Get(routeName, metav1.GetOptions{})
+        if err != nil {
+                t.Fatalf("Failed to get Route of helloworld app: %v", err)
+        }
+        internalDomain := helloWorldRoute.Status.DomainInternal
+        logger.Infof("helloworld internal domain is %v.", internalDomain)
+        return []corev1.EnvVar{{
+                Name: targetHostEnv,
+                Value: internalDomain,
+        }}
+}
+
+func sendRequest(resolvableDomain bool, domain string) (*spoof.Response, error) {
+        logger.Infof("The domain of request is %s.", domain)
+        client, err := spoof.New(clients.Kube, logger, domain, resolvableDomain)
+        if err != nil {
+                return nil, err
+        }
+        
+        req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+        if err != nil {
+                return nil, err
+        }
+        return client.Do(req)
+}
+
+// In this test, we set up two apps: helloworld and httpproxy.
+// helloworld is a simple app that displays a plaintext string.
+// httpproxy is a proxy that redirects request to internal service of helloworld app
+// with FQDN {route}.{namespace}.svc.cluster.local.
+// The expected result is that the request sent to httpproxy app is successfully redirected
+// to helloworld app.
+func TestServiceToServiceCall(t *testing.T) {        
+        logger = test.GetContextLogger("TestServiceToServiceCall")
+        clients = Setup(t)
+
+        // Set up helloworld app.
+        helloWorldImagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
+        logger.Infof("Creating a Route and Configuration for helloworld test app.")
+        helloWorldNames, err := CreateRouteAndConfig(clients, logger, helloWorldImagePath)
+        if err != nil {
+                t.Fatalf("Failed to create Route and Configuration: %v", err)
+        }
+        test.CleanupOnInterrupt(func() { TearDown(clients, helloWorldNames, logger) }, logger)
+        defer TearDown(clients, helloWorldNames, logger)
+        if err := test.WaitForRouteState(clients.Routes, helloWorldNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+                t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", helloWorldNames.Route, err)
+        }
+ 
+        // Set up httpproxy app.
+        httpProxyImagePath := strings.Join([]string{test.Flags.DockerRepo, "httpproxy"}, "/")
+        logger.Infof("Creating a Route and Configuration for httpproxy test app.")
+        envVars := createTargetHostEnvVars(helloWorldNames.Route, t)
+        httpProxyNames, err := CreateRouteAndConfigWithEnv(clients, logger, httpProxyImagePath, envVars)
+        if err != nil {
+                t.Fatalf("Failed to create Route and Configuration: %v", err)
+        }
+        test.CleanupOnInterrupt(func() { TearDown(clients, httpProxyNames, logger) }, logger)
+        defer TearDown(clients, httpProxyNames, logger)
+        if err := test.WaitForRouteState(clients.Routes, httpProxyNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+                t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", httpProxyNames.Route, err)
+        }
+        httpProxyRoute, err := clients.Routes.Get(httpProxyNames.Route, metav1.GetOptions{})
+        if err != nil {
+                t.Fatalf("Failed to get Route %s: %v", httpProxyNames.Route, err)
+        }
+        if err = test.WaitForEndpointState(clients.Kube, logger, httpProxyRoute.Status.Domain, test.MatchesAny, "HttpProxy"); err != nil {
+                t.Fatalf("Failed to start endpoint of httpproxy: %v", err)
+        }
+        logger.Info("httpproxy is ready.")
+
+
+        // Send request to httpproxy to trigger the http call from httpproxy Pod to internal service of helloworld app.
+        response, err := sendRequest(test.Flags.ResolvableDomain, httpProxyRoute.Status.Domain)
+        if err != nil {
+                t.Fatalf("Failed to send request to httpproxy: %v", err)
+        }
+        // We expect the response from httpproxy is equal to the response from htlloworld
+        if helloworldResponse != strings.TrimSpace(string(response.Body)) {
+                t.Fatalf("The httpproxy response '%s' is not equal to helloworld response '%s'.", string(response.Body), helloworldResponse)
+        }
+}

--- a/test/e2e/test_images/httpproxy/Dockerfile
+++ b/test/e2e/test_images/httpproxy/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:latest
+RUN mkdir /app
+ADD . /app/
+WORKDIR /app
+RUN go build -o httpproxy .
+CMD ["/app/httpproxy"]

--- a/test/e2e/test_images/httpproxy/README.md
+++ b/test/e2e/test_images/httpproxy/README.md
@@ -1,0 +1,14 @@
+# Httpproxy test image
+
+This directory contains the test image used in the e2e test to verify service-to-service call within cluster.
+
+The image contains a simple Go webserver, `httproxy.go`, that will, by default, listen on port `8080` and expose a service at `/`.
+
+When called, the proxy server redirects request to the target server.
+
+To use this image, users need to first set the host of the target server that the proxy redirects request to by setting environment variable `TARGET_HOST`. 
+
+## Building
+
+For details about building and adding new images, see the [section about test
+images](/test/README.md#test-images).

--- a/test/e2e/test_images/httpproxy/httpproxy.go
+++ b/test/e2e/test_images/httpproxy/httpproxy.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+        "fmt"
+        "flag"
+        "log"
+        "os"
+        
+        "net/http"
+        "net/http/httputil"
+        "net/url"
+)
+
+const (
+        targetHostEnv = "TARGET_HOST"
+)
+
+var (
+        httpProxy *httputil.ReverseProxy
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+        log.Print("Http proxy received a request.")
+        // Reverse proxy does not automatically reset the Host header.
+        // We need to manually reset it.
+        r.Host = getTargetHostEnv()
+        httpProxy.ServeHTTP(w, r)
+        return
+}
+
+func getTargetHostEnv() string {
+        value := os.Getenv(targetHostEnv)
+        if value == "" {
+                log.Fatalf("No env %v provided.", targetHostEnv)
+        }
+        return value
+}
+
+func initialHttpProxy(proxyUrl string) *httputil.ReverseProxy {
+        target, err := url.Parse(proxyUrl)
+        if err != nil {
+                log.Fatalf("Failed to parse url %v", proxyUrl)
+        }
+        return httputil.NewSingleHostReverseProxy(target)
+}
+
+func main() {
+        flag.Parse()
+        log.Print("Http Proxy app started.")
+
+        targetHost := getTargetHostEnv()
+        targetUrl := fmt.Sprintf("http://%s", targetHost)
+        httpProxy = initialHttpProxy(targetUrl)
+
+        http.HandleFunc("/", handler)
+        http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Fixes #
https://github.com/knative/serving/issues/1415

## Proposed Changes
  * Add a test image for service-to-service test which is a http proxy app
  * Add an E2E test that verifies a call originated from a Pod (with sidecar injected) to an internal service of the cluster.

The steps of the test are:
1. Set up a helloworld app that returns a plain text.
2. Set up a httpproxy app that redirects external request to internal helloworld service by using the internal FQDN name `{route}.{namespace}.svc.cluster.local` of helloworld.
3. Send external request to httpproxy and verify the response is the same as the response of helloworld.

