### PR TITLE
Update Minikube arguments

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -104,8 +104,6 @@ To use a k8s cluster running in GKE:
     --kubernetes-version=v1.11.3 \
     --vm-driver=kvm2 \
     --bootstrapper=kubeadm \
-    --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
-    --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
 
@@ -116,8 +114,6 @@ To use a k8s cluster running in GKE:
     --kubernetes-version=v1.11.3 \
     --vm-driver=hyperkit \
     --bootstrapper=kubeadm \
-    --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
-    --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
 

--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -78,7 +78,7 @@ To use a k8s cluster running in GKE:
 ## Minikube
 
 1. [Install and configure
-    minikube](https://github.com/kubernetes/minikube#minikube) with a [VM
+    minikube](https://github.com/kubernetes/minikube#minikube) version v0.28.1 or later with a [VM
     driver](https://github.com/kubernetes/minikube#requirements), e.g. `kvm2` on
     Linux or `hyperkit` on macOS.
 
@@ -101,24 +101,24 @@ To use a k8s cluster running in GKE:
 
     ```shell
     minikube start --memory=8192 --cpus=4 \
-    --kubernetes-version=v1.10.5 \
+    --kubernetes-version=v1.11.3 \
     --vm-driver=kvm2 \
     --bootstrapper=kubeadm \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
-    --extra-config=apiserver.admission-control="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+    --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
 
     For macOS use:
 
     ```shell
     minikube start --memory=8192 --cpus=4 \
-    --kubernetes-version=v1.10.5 \
+    --kubernetes-version=v1.11.3 \
     --vm-driver=hyperkit \
     --bootstrapper=kubeadm \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
-    --extra-config=apiserver.admission-control="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+    --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
 
 1. [Configure your shell environment](../DEVELOPMENT.md#environment-setup)


### PR DESCRIPTION

Fixes #

## Proposed Changes

  * update minikube arguments to use new apiserver flag names

  * the admission-control flag is now enable-admission-plugins

  * seems the new name is required when using kubernetes-version v1.11.0 or later

**Release Note**
```release-note
NONE
```
