### PR TITLE
Always set Configuration's LatestReadyRevision

### DIFF
--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -175,9 +175,9 @@ func (c *Controller) reconcile(ctx context.Context, config *v1alpha1.Configurati
 			c.Recorder.Eventf(config, corev1.EventTypeNormal, "ConfigurationReady",
 				"Configuration becomes ready")
 		}
+		// Update the LatestReadyRevisionName and surface an event for the transition.
+		config.Status.SetLatestReadyRevisionName(latestCreatedRevision.Name)
 		if created != ready {
-			// Update the LatestReadyRevisionName and surface an event for the transition.
-			config.Status.SetLatestReadyRevisionName(latestCreatedRevision.Name)
 			c.Recorder.Eventf(config, corev1.EventTypeNormal, "LatestReadyUpdate",
 				"LatestReadyRevisionName updated to %q", latestCreatedRevision.Name)
 		}


### PR DESCRIPTION
Fixes #1669

Previously, we would only set this in an edge-triggered way so that
emitting an event made sense. However, calling
SetLatestReadyRevisionName has a side effect of updating the Ready
status. This caused us to fail to recover when the Revision recovered.

1. Revision Ready, call SetLatestReadyRevisionName. Now created == ready.
2. Revision Fails, set Configuration Ready to False.
3. Revision Ready, (recovers) but created == ready, so
SetLatestReadyRevisionName  on Configuration is skipped.

(3) is the bug. This change always calls SetLatestReadyRevisionName so
that its status is appropriately updated.