### PR TITLE
[RELEASE 0.1] Change our configurations to work with Istio 1.0 validation.

### DIFF
--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -34,6 +34,8 @@ spec:
       protocol: HTTPS
     hosts:
     - "*"
+    tls:
+      mode: PASSTHROUGH
 ---
 # This is the Service definition for the ingress pods serving
 # Knative's shared Gateway.

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -29,9 +29,9 @@ func GetServingK8SServiceNameForObj(name string) string {
 }
 
 func GetRevisionHeaderName() string {
-	return "Knative-Serving-Revision"
+	return "knative-serving-revision"
 }
 
 func GetRevisionHeaderNamespace() string {
-	return "Knative-Serving-Namespace"
+	return "knative-serving-namespace"
 }

--- a/pkg/controller/route/resources/virtual_service_test.go
+++ b/pkg/controller/route/resources/virtual_service_test.go
@@ -317,8 +317,8 @@ func TestMakeVirtualServiceRoute_VanillaScaledToZero(t *testing.T) {
 			Weight: 100,
 		}},
 		AppendHeaders: map[string]string{
-			"Knative-Serving-Revision":  "revision",
-			"Knative-Serving-Namespace": "test-ns",
+			"knative-serving-revision":  "revision",
+			"knative-serving-namespace": "test-ns",
 			IstioTimeoutHackHeaderKey:   IstioTimeoutHackHeaderValue,
 		},
 		Timeout: DefaultActivatorTimeout,
@@ -360,8 +360,8 @@ func TestMakeVirtualServiceRoute_TwoInactiveTargets(t *testing.T) {
 			Weight: 100,
 		}},
 		AppendHeaders: map[string]string{
-			"Knative-Serving-Revision":  "revision",
-			"Knative-Serving-Namespace": "test-ns",
+			"knative-serving-revision":  "revision",
+			"knative-serving-namespace": "test-ns",
 			IstioTimeoutHackHeaderKey:   IstioTimeoutHackHeaderValue,
 		},
 		Timeout: DefaultActivatorTimeout,


### PR DESCRIPTION
Istio has tightened several aspects of its validation in 1.0:
- They now require `tls.mode` to be set when we use `HTTPS`, and
- They now require header names to lowercase.
