### PR TITLE
Refactor pkg/webhook a tiny bit.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -74,11 +74,12 @@ func main() {
 	}
 
 	options := webhook.ControllerOptions{
-		ServiceName:      "webhook",
-		ServiceNamespace: system.Namespace,
-		Port:             443,
-		SecretName:       "webhook-certs",
-		WebhookName:      "webhook.knative.dev",
+		ServiceName:    "webhook",
+		DeploymentName: "webhook",
+		Namespace:      system.Namespace,
+		Port:           443,
+		SecretName:     "webhook-certs",
+		WebhookName:    "webhook.serving.knative.dev",
 	}
 	controller, err := webhook.NewAdmissionController(kubeClient, options, logger)
 	if err != nil {

--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -27,8 +27,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/knative/serving/pkg/system"
-
 	"go.uber.org/zap"
 
 	"github.com/knative/serving/pkg/logging"
@@ -41,14 +39,14 @@ const (
 
 // Create the common parts of the cert. These don't change between
 // the root/CA cert and the server cert.
-func createCertTemplate() (*x509.Certificate, error) {
+func createCertTemplate(name, namespace string) (*x509.Certificate, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, errors.New("failed to generate serial number: " + err.Error())
 	}
 
-	serviceName := servingWebhookDeployment + "." + system.Namespace
+	serviceName := name + "." + namespace
 	serviceNames := []string{serviceName, serviceName + ".svc", serviceName + ".svc.cluster.local"}
 
 	tmpl := x509.Certificate{
@@ -64,8 +62,8 @@ func createCertTemplate() (*x509.Certificate, error) {
 }
 
 // Create cert template suitable for CA and hence signing
-func createCACertTemplate() (*x509.Certificate, error) {
-	rootCert, err := createCertTemplate()
+func createCACertTemplate(name, namespace string) (*x509.Certificate, error) {
+	rootCert, err := createCertTemplate(name, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +75,8 @@ func createCACertTemplate() (*x509.Certificate, error) {
 }
 
 // Create cert template that we can use on the server for TLS
-func createServerCertTemplate() (*x509.Certificate, error) {
-	serverCert, err := createCertTemplate()
+func createServerCertTemplate(name, namespace string) (*x509.Certificate, error) {
+	serverCert, err := createCertTemplate(name, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +102,7 @@ func createCert(template, parent *x509.Certificate, pub interface{}, parentPriv 
 	return
 }
 
-func createCA(ctx context.Context) (*rsa.PrivateKey, *x509.Certificate, []byte, error) {
+func createCA(ctx context.Context, name, namespace string) (*rsa.PrivateKey, *x509.Certificate, []byte, error) {
 	logger := logging.FromContext(ctx)
 	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -112,7 +110,7 @@ func createCA(ctx context.Context) (*rsa.PrivateKey, *x509.Certificate, []byte, 
 		return nil, nil, nil, err
 	}
 
-	rootCertTmpl, err := createCACertTemplate()
+	rootCertTmpl, err := createCACertTemplate(name, namespace)
 	if err != nil {
 		logger.Error("error generating CA cert", zap.Error(err))
 		return nil, nil, nil, err
@@ -130,10 +128,10 @@ func createCA(ctx context.Context) (*rsa.PrivateKey, *x509.Certificate, []byte, 
 // key for the server. serverKey and serverCert are used by the server
 // to establish trust for clients, CA certificate is used by the
 // client to verify the server authentication chain.
-func CreateCerts(ctx context.Context) (serverKey, serverCert, caCert []byte, err error) {
+func CreateCerts(ctx context.Context, name, namespace string) (serverKey, serverCert, caCert []byte, err error) {
 	logger := logging.FromContext(ctx)
 	// First create a CA certificate and private key
-	caKey, caCertificate, caCertificatePEM, err := createCA(ctx)
+	caKey, caCertificate, caCertificatePEM, err := createCA(ctx, name, namespace)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -144,7 +142,7 @@ func CreateCerts(ctx context.Context) (serverKey, serverCert, caCert []byte, err
 		logger.Error("error generating random key", zap.Error(err))
 		return nil, nil, nil, err
 	}
-	servCertTemplate, err := createServerCertTemplate()
+	servCertTemplate, err := createServerCertTemplate(name, namespace)
 	if err != nil {
 		logger.Error("failed to create the server certificate template", zap.Error(err))
 		return nil, nil, nil, err

--- a/pkg/webhook/certs_test.go
+++ b/pkg/webhook/certs_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestCreateCerts(t *testing.T) {
-	sKey, serverCertPEM, caCertBytes, err := CreateCerts(context.TODO())
+	sKey, serverCertPEM, caCertBytes, err := CreateCerts(context.TODO(), "got-the-hook", "knative-webhook")
 	if err != nil {
 		t.Fatalf("Failed to create certs %v", err)
 	}
@@ -59,9 +59,9 @@ func TestCreateCerts(t *testing.T) {
 
 	// Verify domain names
 	expectedDNSNames := []string{
-		"webhook.knative-serving",
-		"webhook.knative-serving.svc",
-		"webhook.knative-serving.svc.cluster.local",
+		"got-the-hook.knative-webhook",
+		"got-the-hook.knative-webhook.svc",
+		"got-the-hook.knative-webhook.svc.cluster.local",
 	}
 	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
 		t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)

--- a/pkg/webhook/keep.go
+++ b/pkg/webhook/keep.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+// NewAdmissionController creates a new instance of the admission webhook controller.
+func NewAdmissionController(client kubernetes.Interface, options ControllerOptions, logger *zap.SugaredLogger) (*AdmissionController, error) {
+	return &AdmissionController{
+		client:  client,
+		options: options,
+		// TODO(mattmoor): Will we need to rework these to support versioning?
+		groupVersion: v1alpha1.SchemeGroupVersion,
+		handlers: map[string]runtime.Object{
+			"Revision":      &v1alpha1.Revision{},
+			"Configuration": &v1alpha1.Configuration{},
+			"Route":         &v1alpha1.Route{},
+			"Service":       &v1alpha1.Service{},
+		},
+		logger: logger,
+	}, nil
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -26,19 +26,17 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
-
-	"github.com/knative/serving/pkg/system"
-
-	"github.com/knative/serving/pkg/logging/logkey"
 
 	"go.uber.org/zap"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/serving/pkg/apis/serving"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+
+	// TODO(mattmoor): Awaiting https://github.com/knative/pkg/issues/7
 	"github.com/knative/serving/pkg/logging"
+	"github.com/knative/serving/pkg/logging/logkey"
 
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -48,17 +46,15 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	clientadmissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 )
 
 const (
-	knativeAPIVersion = "v1alpha1"
-	secretServerKey   = "server-key.pem"
-	secretServerCert  = "server-cert.pem"
-	secretCACert      = "ca-cert.pem"
-	// TODO: Could these come from somewhere else.
-	servingWebhookDeployment = "webhook"
+	secretServerKey  = "server-key.pem"
+	secretServerCert = "server-cert.pem"
+	secretCACert     = "ca-cert.pem"
 )
 
 var (
@@ -75,8 +71,8 @@ type ControllerOptions struct {
 	// ServiceName is the service name of the webhook.
 	ServiceName string
 
-	// ServiceNamespace is the namespace of the webhook service.
-	ServiceNamespace string
+	// DeploymentName is the service name of the webhook.
+	DeploymentName string
 
 	// SecretName is the name of k8s secret that contains the webhook
 	// server key/cert and corresponding CA cert that signed them. The
@@ -84,6 +80,9 @@ type ControllerOptions struct {
 	// is provided to k8s apiserver during admission controller
 	// registration.
 	SecretName string
+
+	// Namespace is the namespace in which everything above lives
+	Namespace string
 
 	// Port where the webhook is served. Per k8s admission
 	// registration requirements this should be 443 unless there is
@@ -107,20 +106,14 @@ type ResourceCallback func(patches *[]jsonpatch.JsonPatchOperation, old GenericC
 // is denied. Mutations should be appended to the patches operations.
 type ResourceDefaulter func(patches *[]jsonpatch.JsonPatchOperation, crd GenericCRD) error
 
-// GenericCRDHandler defines the factory object to use for unmarshaling incoming objects
-type GenericCRDHandler struct {
-	Factory   runtime.Object
-	Defaulter ResourceDefaulter
-	Validator ResourceCallback
-}
-
 // AdmissionController implements the external admission webhook for validation of
 // pilot configuration.
 type AdmissionController struct {
-	client   kubernetes.Interface
-	options  ControllerOptions
-	handlers map[string]GenericCRDHandler
-	logger   *zap.SugaredLogger
+	client       kubernetes.Interface
+	options      ControllerOptions
+	groupVersion schema.GroupVersion
+	handlers     map[string]runtime.Object
+	logger       *zap.SugaredLogger
 }
 
 // GenericCRD is the interface definition that allows us to perform the generic
@@ -176,25 +169,25 @@ func makeTLSConfig(serverCert, serverKey, caCert []byte) (*tls.Config, error) {
 	}, nil
 }
 
-func getOrGenerateKeyCertsFromSecret(ctx context.Context, client kubernetes.Interface, name,
-	namespace string) (serverKey, serverCert, caCert []byte, err error) {
+func getOrGenerateKeyCertsFromSecret(ctx context.Context, client kubernetes.Interface,
+	options *ControllerOptions) (serverKey, serverCert, caCert []byte, err error) {
 	logger := logging.FromContext(ctx)
-	secret, err := client.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	secret, err := client.CoreV1().Secrets(options.Namespace).Get(options.SecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, nil, nil, err
 		}
 		logger.Info("Did not find existing secret, creating one")
-		newSecret, err := generateSecret(ctx, name, namespace)
+		newSecret, err := generateSecret(ctx, options)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		secret, err = client.CoreV1().Secrets(namespace).Create(newSecret)
+		secret, err = client.CoreV1().Secrets(newSecret.Namespace).Create(newSecret)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return nil, nil, nil, err
 		}
 		// Ok, so something else might have created, try fetching it one more time
-		secret, err = client.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+		secret, err = client.CoreV1().Secrets(options.Namespace).Get(options.SecretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -211,38 +204,6 @@ func getOrGenerateKeyCertsFromSecret(ctx context.Context, client kubernetes.Inte
 		return nil, nil, nil, errors.New("ca cert missing")
 	}
 	return serverKey, serverCert, caCert, nil
-}
-
-// NewAdmissionController creates a new instance of the admission webhook controller.
-func NewAdmissionController(client kubernetes.Interface, options ControllerOptions, logger *zap.SugaredLogger) (*AdmissionController, error) {
-	ctx := logging.WithLogger(context.TODO(), logger)
-	return &AdmissionController{
-		client:  client,
-		options: options,
-		handlers: map[string]GenericCRDHandler{
-			"Revision": {
-				Factory:   &v1alpha1.Revision{},
-				Defaulter: SetDefaults(ctx),
-				Validator: Validate(ctx),
-			},
-			"Configuration": {
-				Factory:   &v1alpha1.Configuration{},
-				Defaulter: SetDefaults(ctx),
-				Validator: Validate(ctx),
-			},
-			"Route": {
-				Factory:   &v1alpha1.Route{},
-				Defaulter: SetDefaults(ctx),
-				Validator: Validate(ctx),
-			},
-			"Service": {
-				Factory:   &v1alpha1.Service{},
-				Defaulter: SetDefaults(ctx),
-				Validator: Validate(ctx),
-			},
-		},
-		logger: logger,
-	}, nil
 }
 
 // Validate checks whether "new" and "old" implement HasImmutableFields and checks them,
@@ -296,7 +257,7 @@ func configureCerts(ctx context.Context, client kubernetes.Interface, options *C
 		return nil, nil, err
 	}
 	serverKey, serverCert, caCert, err := getOrGenerateKeyCertsFromSecret(
-		ctx, client, options.SecretName, options.ServiceNamespace)
+		ctx, client, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -365,12 +326,17 @@ func (ac *AdmissionController) unregister(
 
 // Register registers the external admission webhook for pilot
 // configuration types.
-
 func (ac *AdmissionController) register(
 	ctx context.Context, client clientadmissionregistrationv1beta1.MutatingWebhookConfigurationInterface, caCert []byte) error { // nolint: lll
 	logger := logging.FromContext(ctx)
-	resources := []string{"configurations", "routes", "revisions", "services"}
 	failurePolicy := admissionregistrationv1beta1.Fail
+
+	resources := sort.StringSlice{}
+	for k := range ac.handlers {
+		// Lousy pluralizer
+		resources = append(resources, strings.ToLower(k)+"s")
+	}
+	resources.Sort()
 
 	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -384,14 +350,14 @@ func (ac *AdmissionController) register(
 					admissionregistrationv1beta1.Update,
 				},
 				Rule: admissionregistrationv1beta1.Rule{
-					APIGroups:   []string{serving.GroupName},
-					APIVersions: []string{knativeAPIVersion},
+					APIGroups:   []string{ac.groupVersion.Group},
+					APIVersions: []string{ac.groupVersion.Version},
 					Resources:   resources,
 				},
 			}},
 			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
 				Service: &admissionregistrationv1beta1.ServiceReference{
-					Namespace: ac.options.ServiceNamespace,
+					Namespace: ac.options.Namespace,
 					Name:      ac.options.ServiceName,
 				},
 				CABundle: caCert,
@@ -401,7 +367,7 @@ func (ac *AdmissionController) register(
 	}
 
 	// Set the owner to our deployment
-	deployment, err := ac.client.ExtensionsV1beta1().Deployments(system.Namespace).Get(servingWebhookDeployment, metav1.GetOptions{})
+	deployment, err := ac.client.ExtensionsV1beta1().Deployments(ac.options.Namespace).Get(ac.options.DeploymentName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to fetch our deployment: %s", err)
 	}
@@ -520,8 +486,8 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind string, oldBytes
 		return nil, fmt.Errorf("unhandled kind: %q", kind)
 	}
 
-	oldObj := handler.Factory.DeepCopyObject().(GenericCRD)
-	newObj := handler.Factory.DeepCopyObject().(GenericCRD)
+	oldObj := handler.DeepCopyObject().(GenericCRD)
+	newObj := handler.DeepCopyObject().(GenericCRD)
 
 	if len(newBytes) != 0 {
 		newDecoder := json.NewDecoder(bytes.NewBuffer(newBytes))
@@ -553,7 +519,7 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind string, oldBytes
 		return nil, fmt.Errorf("Failed to update generation: %s", err)
 	}
 
-	if defaulter := handler.Defaulter; defaulter != nil {
+	if defaulter := SetDefaults(ctx); defaulter != nil {
 		if err := defaulter(&patches, newObj); err != nil {
 			logger.Error("Failed the resource specific defaulter", zap.Error(err))
 			// Return the error message as-is to give the defaulter callback
@@ -566,11 +532,13 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind string, oldBytes
 	if newObj == nil {
 		return nil, errMissingNewObject
 	}
-	if err := handler.Validator(&patches, oldObj, newObj); err != nil {
-		logger.Error("Failed the resource specific validation", zap.Error(err))
-		// Return the error message as-is to give the validation callback
-		// discretion over (our portion of) the message that the user sees.
-		return nil, err
+	if validator := Validate(ctx); validator != nil {
+		if err := validator(&patches, oldObj, newObj); err != nil {
+			logger.Error("Failed the resource specific validation", zap.Error(err))
+			// Return the error message as-is to give the validation callback
+			// discretion over (our portion of) the message that the user sees.
+			return nil, err
+		}
 	}
 
 	if err := validateMetadata(newObj); err != nil {
@@ -661,15 +629,15 @@ func updateGeneration(ctx context.Context, patches *[]jsonpatch.JsonPatchOperati
 	return nil
 }
 
-func generateSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
-	serverKey, serverCert, caCert, err := CreateCerts(ctx)
+func generateSecret(ctx context.Context, options *ControllerOptions) (*corev1.Secret, error) {
+	serverKey, serverCert, caCert, err := CreateCerts(ctx, options.ServiceName, options.Namespace)
 	if err != nil {
 		return nil, err
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      options.SecretName,
+			Namespace: options.Namespace,
 		},
 		Data: map[string][]byte{
 			secretServerKey:  serverKey,

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -45,11 +45,11 @@ import (
 
 func newDefaultOptions() ControllerOptions {
 	return ControllerOptions{
-		ServiceName:      "webhook",
-		ServiceNamespace: system.Namespace,
-		Port:             443,
-		SecretName:       "webhook-certs",
-		WebhookName:      "webhook.knative.dev",
+		Namespace:   system.Namespace,
+		ServiceName: "webhook",
+		Port:        443,
+		SecretName:  "webhook-certs",
+		WebhookName: "webhook.knative.dev",
 	}
 }
 
@@ -506,11 +506,11 @@ func TestCertConfigurationForAlreadyGeneratedSecret(t *testing.T) {
 	ns := "test-namespace"
 	opts := newDefaultOptions()
 	opts.SecretName = secretName
-	opts.ServiceNamespace = ns
+	opts.Namespace = ns
 	kubeClient, ac := newNonRunningTestAdmissionController(t, opts)
 
 	ctx := context.TODO()
-	newSecret, err := generateSecret(ctx, secretName, ns)
+	newSecret, err := generateSecret(ctx, &opts)
 	if err != nil {
 		t.Fatalf("Failed to generate secret: %v", err)
 	}
@@ -551,7 +551,7 @@ func TestCertConfigurationForGeneratedSecret(t *testing.T) {
 	ns := "test-namespace"
 	opts := newDefaultOptions()
 	opts.SecretName = secretName
-	opts.ServiceNamespace = ns
+	opts.Namespace = ns
 	kubeClient, ac := newNonRunningTestAdmissionController(t, opts)
 
 	ctx := context.TODO()
@@ -658,7 +658,7 @@ func createUpdateRoute(old, new *v1alpha1.Route) *admissionv1beta1.AdmissionRequ
 func createDeployment(ac *AdmissionController) {
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      servingWebhookDeployment,
+			Name:      "whatever",
 			Namespace: system.Namespace,
 		},
 	}


### PR DESCRIPTION
This change tries to tease apart the parts of `pkg/webhook` that are generic and can move to `knative/pkg` (`certs.go`, `webhook.go`) from the parts that should continue to live in `knative/serving` (`keep.go`).

Related to: https://github.com/knative/pkg/issues/9
