### PR TITLE
Remove RemoveCondition

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -224,16 +224,6 @@ func (cs *ConfigurationStatus) setCondition(new *ConfigurationCondition) {
 	cs.Conditions = conditions
 }
 
-func (cs *ConfigurationStatus) RemoveCondition(t ConfigurationConditionType) {
-	var conditions []ConfigurationCondition
-	for _, cond := range cs.Conditions {
-		if cond.Type != t {
-			conditions = append(conditions, cond)
-		}
-	}
-	cs.Conditions = conditions
-}
-
 func (cs *ConfigurationStatus) InitializeConditions() {
 	for _, cond := range []ConfigurationConditionType{
 		ConfigurationConditionReady,

--- a/pkg/apis/serving/v1alpha1/configuration_types_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types_test.go
@@ -39,104 +39,79 @@ func TestConfigurationIsReady(t *testing.T) {
 		name    string
 		status  ConfigurationStatus
 		isReady bool
-	}{
-		{
-			name:    "empty status should not be ready",
-			status:  ConfigurationStatus{},
-			isReady: false,
+	}{{
+		name:    "empty status should not be ready",
+		status:  ConfigurationStatus{},
+		isReady: false,
+	}, {
+		name: "Different condition type should not be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   "Foo",
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "Different condition type should not be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   "Foo",
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "False condition status should not be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "False condition status should not be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "Unknown condition status should not be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
 		},
-		{
-			name: "Unknown condition status should not be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionUnknown,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "Missing condition status should not be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type: ConfigurationConditionReady,
+			}},
 		},
-		{
-			name: "Missing condition status should not be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type: ConfigurationConditionReady,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "True condition status should be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "True condition status should be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: true,
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status should be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   "Foo",
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "Multiple conditions with ready status should be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   "Foo",
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: true,
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status false should not be ready",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   "Foo",
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "Multiple conditions with ready status false should not be ready",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   "Foo",
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isReady: false,
-		},
-	}
+		isReady: false,
+	}}
 
 	for _, tc := range cases {
 		if e, a := tc.isReady, tc.status.IsReady(); e != a {
@@ -163,13 +138,6 @@ func TestConfigurationConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove a non-existent condition.
-	config.Status.RemoveCondition(bar.Type)
-
-	if got, want := len(config.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add a second condition.
 	config.Status.setCondition(bar)
 
@@ -177,17 +145,10 @@ func TestConfigurationConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove an existing condition.
-	config.Status.RemoveCondition(bar.Type)
-
-	if got, want := len(config.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add nil condition.
 	config.Status.setCondition(nil)
 
-	if got, want := len(config.Status.Conditions), 1; got != want {
+	if got, want := len(config.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 }
@@ -197,61 +158,48 @@ func TestLatestReadyRevisionNameUpToDate(t *testing.T) {
 		name           string
 		status         ConfigurationStatus
 		isUpdateToDate bool
-	}{
-		{
-			name: "Not ready status should not be up-to-date",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isUpdateToDate: false,
+	}{{
+		name: "Not ready status should not be up-to-date",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "Missing LatestReadyRevisionName should not be up-to-date",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-				LatestCreatedRevisionName: "rev-1",
-			},
-			isUpdateToDate: false,
+		isUpdateToDate: false,
+	}, {
+		name: "Missing LatestReadyRevisionName should not be up-to-date",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+			LatestCreatedRevisionName: "rev-1",
 		},
-		{
-			name: "Different revision names should not be up-to-date",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-				LatestCreatedRevisionName: "rev-2",
-				LatestReadyRevisionName:   "rev-1",
-			},
-			isUpdateToDate: false,
+		isUpdateToDate: false,
+	}, {
+		name: "Different revision names should not be up-to-date",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+			LatestCreatedRevisionName: "rev-2",
+			LatestReadyRevisionName:   "rev-1",
 		},
-		{
-			name: "Same revision names and ready status should be up-to-date",
-			status: ConfigurationStatus{
-				Conditions: []ConfigurationCondition{
-					{
-						Type:   ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-				LatestCreatedRevisionName: "rev-1",
-				LatestReadyRevisionName:   "rev-1",
-			},
-			isUpdateToDate: true,
+		isUpdateToDate: false,
+	}, {
+		name: "Same revision names and ready status should be up-to-date",
+		status: ConfigurationStatus{
+			Conditions: []ConfigurationCondition{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+			LatestCreatedRevisionName: "rev-1",
+			LatestReadyRevisionName:   "rev-1",
 		},
-	}
+		isUpdateToDate: true,
+	}}
 
 	for _, tc := range cases {
 		if e, a := tc.isUpdateToDate, tc.status.IsLatestReadyRevisionNameUpToDate(); e != a {

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -306,16 +306,6 @@ func (rs *RevisionStatus) setCondition(new *RevisionCondition) {
 	rs.Conditions = conditions
 }
 
-func (rs *RevisionStatus) RemoveCondition(t RevisionConditionType) {
-	var conditions []RevisionCondition
-	for _, cond := range rs.Conditions {
-		if cond.Type != t {
-			conditions = append(conditions, cond)
-		}
-	}
-	rs.Conditions = conditions
-}
-
 func (rs *RevisionStatus) InitializeConditions() {
 	// We don't include BuildSucceeded here because it could confuse users if
 	// no `buildName` was specified.

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -273,11 +273,6 @@ func TestGetSetCondition(t *testing.T) {
 	if a := rs.GetCondition(RevisionConditionReady); a != nil {
 		t.Errorf("GetCondition expected nil got: %v", a)
 	}
-	// Remove and make sure it's no longer there
-	rs.RemoveCondition(RevisionConditionBuildSucceeded)
-	if a := rs.GetCondition(RevisionConditionBuildSucceeded); a != nil {
-		t.Errorf("empty RevisionStatus returned %v when expected nil", a)
-	}
 }
 
 func TestRevisionConditions(t *testing.T) {
@@ -305,13 +300,6 @@ func TestRevisionConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove a non-existent condition.
-	rev.Status.RemoveCondition(bar.Type)
-
-	if got, want := len(rev.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add a second condition.
 	rev.Status.setCondition(bar)
 
@@ -319,17 +307,10 @@ func TestRevisionConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove an existing condition.
-	rev.Status.RemoveCondition(bar.Type)
-
-	if got, want := len(rev.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add nil condition.
 	rev.Status.setCondition(nil)
 
-	if got, want := len(rev.Status.Conditions), 1; got != want {
+	if got, want := len(rev.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 }

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -243,16 +243,6 @@ func (rs *RouteStatus) setCondition(new *RouteCondition) {
 	rs.Conditions = conditions
 }
 
-func (rs *RouteStatus) RemoveCondition(t RouteConditionType) {
-	var conditions []RouteCondition
-	for _, cond := range rs.Conditions {
-		if cond.Type != t {
-			conditions = append(conditions, cond)
-		}
-	}
-	rs.Conditions = conditions
-}
-
 func (rs *RouteStatus) InitializeConditions() {
 	for _, cond := range []RouteConditionType{
 		RouteConditionAllTrafficAssigned,

--- a/pkg/apis/serving/v1alpha1/route_types_test.go
+++ b/pkg/apis/serving/v1alpha1/route_types_test.go
@@ -146,13 +146,6 @@ func TestRouteConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove a non-existent condition.
-	svc.Status.RemoveCondition(bar.Type)
-
-	if got, want := len(svc.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add a second condition.
 	svc.Status.setCondition(bar)
 
@@ -160,17 +153,10 @@ func TestRouteConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove an existing condition.
-	svc.Status.RemoveCondition(bar.Type)
-
-	if got, want := len(svc.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add nil condition.
 	svc.Status.setCondition(nil)
 
-	if got, want := len(svc.Status.Conditions), 1; got != want {
+	if got, want := len(svc.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 }

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -253,16 +253,6 @@ func (ss *ServiceStatus) setCondition(new *ServiceCondition) {
 	ss.Conditions = conditions
 }
 
-func (ss *ServiceStatus) RemoveCondition(t ServiceConditionType) {
-	var conditions []ServiceCondition
-	for _, cond := range ss.Conditions {
-		if cond.Type != t {
-			conditions = append(conditions, cond)
-		}
-	}
-	ss.Conditions = conditions
-}
-
 func (ss *ServiceStatus) InitializeConditions() {
 	for _, cond := range []ServiceConditionType{
 		ServiceConditionReady,

--- a/pkg/apis/serving/v1alpha1/service_types_test.go
+++ b/pkg/apis/serving/v1alpha1/service_types_test.go
@@ -40,104 +40,79 @@ func TestServiceIsReady(t *testing.T) {
 		name    string
 		status  ServiceStatus
 		isReady bool
-	}{
-		{
-			name:    "empty status should not be ready",
-			status:  ServiceStatus{},
-			isReady: false,
+	}{{
+		name:    "empty status should not be ready",
+		status:  ServiceStatus{},
+		isReady: false,
+	}, {
+		name: "Different condition type should not be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type:   "Foo",
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "Different condition type should not be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type:   "Foo",
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "False condition status should not be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type:   ServiceConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "False condition status should not be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type:   ServiceConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "Unknown condition status should not be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type:   ServiceConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
 		},
-		{
-			name: "Unknown condition status should not be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type:   ServiceConditionReady,
-						Status: corev1.ConditionUnknown,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "Missing condition status should not be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type: ServiceConditionReady,
+			}},
 		},
-		{
-			name: "Missing condition status should not be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type: ServiceConditionReady,
-					},
-				},
-			},
-			isReady: false,
+		isReady: false,
+	}, {
+		name: "True condition status should be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type:   ServiceConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "True condition status should be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type:   ServiceConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: true,
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status should be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type:   "Foo",
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   ServiceConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
 		},
-		{
-			name: "Multiple conditions with ready status should be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type:   "Foo",
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   ServiceConditionReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			isReady: true,
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status false should not be ready",
+		status: ServiceStatus{
+			Conditions: []ServiceCondition{{
+				Type:   "Foo",
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   ServiceConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
 		},
-		{
-			name: "Multiple conditions with ready status false should not be ready",
-			status: ServiceStatus{
-				Conditions: []ServiceCondition{
-					{
-						Type:   "Foo",
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   ServiceConditionReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			isReady: false,
-		},
-	}
+		isReady: false,
+	}}
 
 	for _, tc := range cases {
 		if e, a := tc.isReady, tc.status.IsReady(); e != a {
@@ -163,27 +138,15 @@ func TestServiceConditions(t *testing.T) {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove non-existent condition.
-	svc.Status.RemoveCondition(bar.Type)
-	if got, want := len(svc.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
-	}
-
 	// Add a second Condition.
 	svc.Status.setCondition(bar)
 	if got, want := len(svc.Status.Conditions), 2; got != want {
 		t.Fatalf("Unexpected Condition length; got %d, want %d", got, want)
 	}
 
-	// Remove the first Condition.
-	svc.Status.RemoveCondition(foo.Type)
-	if got, want := len(svc.Status.Conditions), 1; got != want {
-		t.Fatalf("Unexpected condition length; got %d, want %d", got, want)
-	}
-
 	// Test Add nil condition.
 	svc.Status.setCondition(nil)
-	if got, want := len(svc.Status.Conditions), 1; got != want {
+	if got, want := len(svc.Status.Conditions), 2; got != want {
 		t.Fatal("Error, nil condition was allowed to be added.")
 	}
 }


### PR DESCRIPTION
This cleans up the interface of our Status types to drop this function, which besides testing is not called.

This also does a bunch of array literal collapsing to the more compact `{{` notation.
