### PR TITLE
Allow abbreviations for cluster local domains.

### DIFF
--- a/pkg/controller/route/resources/virtual_service.go
+++ b/pkg/controller/route/resources/virtual_service.go
@@ -66,11 +66,11 @@ func MakeVirtualService(u *v1alpha1.Route, tc *traffic.TrafficConfig) *v1alpha3.
 }
 
 func dedup(strs []string) []string {
-	existed := make(map[string]bool)
+	existed := make(map[string]struct{})
 	unique := []string{}
 	for _, s := range strs {
-		if ok, _ := existed[s]; !ok {
-			existed[s] = true
+		if _, ok := existed[s]; !ok {
+			existed[s] = struct{}{}
 			unique = append(unique, s)
 		}
 	}
@@ -119,9 +119,7 @@ func getRouteDomains(targetName string, u *v1alpha1.Route, domain string) []stri
 			names.K8sServiceFullname(u),
 			fmt.Sprintf("%s.%s.svc", u.Name, u.Namespace),
 			fmt.Sprintf("%s.%s", u.Name, u.Namespace),
-		}
-		if u.Namespace == "default" {
-			domains = append(domains, u.Name)
+			u.Name,
 		}
 	} else {
 		domains = []string{fmt.Sprintf("%s.%s", targetName, domain)}

--- a/pkg/controller/route/resources/virtual_service.go
+++ b/pkg/controller/route/resources/virtual_service.go
@@ -65,6 +65,18 @@ func MakeVirtualService(u *v1alpha1.Route, tc *traffic.TrafficConfig) *v1alpha3.
 	}
 }
 
+func dedup(strs []string) []string {
+	existed := make(map[string]bool)
+	unique := []string{}
+	for _, s := range strs {
+		if ok, _ := existed[s]; !ok {
+			existed[s] = true
+			unique = append(unique, s)
+		}
+	}
+	return unique
+}
+
 func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.RevisionTarget) v1alpha3.VirtualServiceSpec {
 	domain := u.Status.Domain
 	spec := v1alpha3.VirtualServiceSpec{
@@ -76,13 +88,13 @@ func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.Revi
 			names.K8sGatewayFullname,
 			"mesh",
 		},
-		Hosts: []string{
+		Hosts: dedup([]string{
 			// Traffic originates from outside of the cluster would be of the form "*.domain", or "domain"
 			fmt.Sprintf("*.%s", domain),
 			domain,
 			// Traffic from inside the cluster will use the FQDN of the Route's headless Service.
 			names.K8sServiceFullname(u),
-		},
+		}),
 	}
 	names := []string{}
 	for name := range targets {
@@ -98,13 +110,23 @@ func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.Revi
 }
 
 func getRouteDomains(targetName string, u *v1alpha1.Route, domain string) []string {
+	var domains []string
 	if targetName == "" {
-		// Nameless traffic targets correspond to two domains: the Route.Status.Domain, and also the FQDN
-		// of the Route's headless Service.
-		return []string{domain, names.K8sServiceFullname(u)}
+		// Nameless traffic targets correspond to many domains: the
+		// Route.Status.Domain, and also various names of the Route's
+		// headless Service.
+		domains = []string{domain,
+			names.K8sServiceFullname(u),
+			fmt.Sprintf("%s.%s.svc", u.Name, u.Namespace),
+			fmt.Sprintf("%s.%s", u.Name, u.Namespace),
+		}
+		if u.Namespace == "default" {
+			domains = append(domains, u.Name)
+		}
+	} else {
+		domains = []string{fmt.Sprintf("%s.%s", targetName, domain)}
 	}
-	// Named traffic targets correspond to a subdomain of the Route.Status.Domain.
-	return []string{fmt.Sprintf("%s.%s", targetName, domain)}
+	return dedup(domains)
 }
 
 func makeVirtualServiceRoute(domains []string, ns string, targets []traffic.RevisionTarget) *v1alpha3.HTTPRoute {

--- a/pkg/controller/route/resources/virtual_service_test.go
+++ b/pkg/controller/route/resources/virtual_service_test.go
@@ -114,6 +114,10 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Authority: &v1alpha3.StringMatch{Exact: "domain.com"},
 		}, {
 			Authority: &v1alpha3.StringMatch{Exact: "test-route.test-ns.svc.cluster.local"},
+		}, {
+			Authority: &v1alpha3.StringMatch{Exact: "test-route.test-ns.svc"},
+		}, {
+			Authority: &v1alpha3.StringMatch{Exact: "test-route.test-ns"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -161,7 +165,34 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		},
 	}
 	base := "domain.com"
-	expected := []string{base, "test-route.test-ns.svc.cluster.local"}
+	expected := []string{base,
+		"test-route.test-ns.svc.cluster.local",
+		"test-route.test-ns.svc",
+		"test-route.test-ns",
+	}
+	domains := getRouteDomains("", r, base)
+	if diff := cmp.Diff(expected, domains); diff != "" {
+		t.Errorf("Unexpected domains  (-want +got): %v", diff)
+	}
+}
+
+func TestGetRouteDomains_NamelessTargetDefaultNamespace(t *testing.T) {
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+			Labels: map[string]string{
+				"route": "test-route",
+			},
+		},
+	}
+	base := "domain.com"
+	expected := []string{base,
+		"test-route.default.svc.cluster.local",
+		"test-route.default.svc",
+		"test-route.default",
+		"test-route",
+	}
 	domains := getRouteDomains("", r, base)
 	if diff := cmp.Diff(expected, domains); diff != "" {
 		t.Errorf("Unexpected domains  (-want +got): %v", diff)

--- a/pkg/controller/route/resources/virtual_service_test.go
+++ b/pkg/controller/route/resources/virtual_service_test.go
@@ -118,6 +118,8 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Authority: &v1alpha3.StringMatch{Exact: "test-route.test-ns.svc"},
 		}, {
 			Authority: &v1alpha3.StringMatch{Exact: "test-route.test-ns"},
+		}, {
+			Authority: &v1alpha3.StringMatch{Exact: "test-route"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -169,28 +171,6 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		"test-route.test-ns.svc.cluster.local",
 		"test-route.test-ns.svc",
 		"test-route.test-ns",
-	}
-	domains := getRouteDomains("", r, base)
-	if diff := cmp.Diff(expected, domains); diff != "" {
-		t.Errorf("Unexpected domains  (-want +got): %v", diff)
-	}
-}
-
-func TestGetRouteDomains_NamelessTargetDefaultNamespace(t *testing.T) {
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "default",
-			Labels: map[string]string{
-				"route": "test-route",
-			},
-		},
-	}
-	base := "domain.com"
-	expected := []string{base,
-		"test-route.default.svc.cluster.local",
-		"test-route.default.svc",
-		"test-route.default",
 		"test-route",
 	}
 	domains := getRouteDomains("", r, base)

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -308,6 +308,8 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route"},
 			}},
 			Route: []v1alpha3.DestinationWeight{getActivatorDestinationWeight(100)},
 			AppendHeaders: map[string]string{
@@ -391,6 +393,8 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -486,6 +490,8 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -590,6 +596,8 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -709,6 +717,8 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
 			}, {
 				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -16,13 +16,6 @@ limitations under the License.
 
 package route
 
-/* TODO tests:
-- When a Route is created:
-  - a namespace is created
-
-- When a Revision is updated TODO
-- When a Revision is deleted TODO
-*/
 import (
 	"fmt"
 	"strings"
@@ -292,7 +285,6 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		t.Errorf("Unexpected rule owner refs diff (-want +got): %v", diff)
 	}
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
-	clusterDomain := "test-route.test.svc.cluster.local"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -305,13 +297,17 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		Hosts: []string{
 			"*." + domain,
 			domain,
-			clusterDomain,
+			"test-route.test.svc.cluster.local",
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
-				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc.cluster.local"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
 			}},
 			Route: []v1alpha3.DestinationWeight{getActivatorDestinationWeight(100)},
 			AppendHeaders: map[string]string{
@@ -372,7 +368,6 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 	}
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
-	clusterDomain := "test-route.test.svc.cluster.local"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -385,13 +380,17 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		Hosts: []string{
 			"*." + domain,
 			domain,
-			clusterDomain,
+			"test-route.test.svc.cluster.local",
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
-				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc.cluster.local"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -464,7 +463,6 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 	}
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
-	clusterDomain := "test-route.test.svc.cluster.local"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -477,13 +475,17 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 		Hosts: []string{
 			"*." + domain,
 			domain,
-			clusterDomain,
+			"test-route.test.svc.cluster.local",
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
-				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc.cluster.local"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -565,7 +567,6 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 	}
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
-	clusterDomain := "test-route.test.svc.cluster.local"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -578,13 +579,17 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		Hosts: []string{
 			"*." + domain,
 			domain,
-			clusterDomain,
+			"test-route.test.svc.cluster.local",
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
-				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc.cluster.local"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{
@@ -681,7 +686,6 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		t.Fatalf("error getting virtualservice: %v", err)
 	}
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
-	clusterDomain := "test-route.test.svc.cluster.local"
 	expectedSpec := v1alpha3.VirtualServiceSpec{
 		// We want to connect to two Gateways: the Route's ingress
 		// Gateway, and the 'mesh' Gateway.  The former provides
@@ -694,13 +698,17 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		Hosts: []string{
 			"*." + domain,
 			domain,
-			clusterDomain,
+			"test-route.test.svc.cluster.local",
 		},
 		Http: []v1alpha3.HTTPRoute{{
 			Match: []v1alpha3.HTTPMatchRequest{{
 				Authority: &v1alpha3.StringMatch{Exact: domain},
 			}, {
-				Authority: &v1alpha3.StringMatch{Exact: clusterDomain},
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc.cluster.local"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test.svc"},
+			}, {
+				Authority: &v1alpha3.StringMatch{Exact: "test-route.test"},
 			}},
 			Route: []v1alpha3.DestinationWeight{{
 				Destination: v1alpha3.Destination{


### PR DESCRIPTION
This allows us to access routes without using fully qualified names.  For example, `curl <route>.<ns>` or `curl <route>.<ns>.svc` will work, and `curl <route>` will also work for requests coming from a pod within the same namespace.

Fixes #1429 

/assign @mattmoor 