### PR TITLE
Fix typo in third-party/istio-1.0-prerelease/download-istio.sh

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -127,12 +127,6 @@ kubectl create clusterrolebinding cluster-admin-binding \
 kubectl apply -f ./third_party/istio-1.0-prerelease/istio.yaml
 ```
 
-Optionally label namespaces with `istio-injection=enabled`:
-
-```shell
-kubectl label namespace default istio-injection=enabled
-```
-
 Follow the [instructions](./docs/setting-up-ingress-static-ip.md) if you need
 to set up static IP for Ingresses in the cluster.
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -133,7 +133,6 @@ wait_until_service_has_external_ip istio-system knative-ingressgateway || fail_t
 
 header "Running tests"
 kubectl create namespace serving-tests
-kubectl label namespace serving-tests istio-injection=enabled --overwrite
 options=""
 (( EMIT_METRICS )) && options="-emitmetrics"
 report_go_test \

--- a/third_party/istio-1.0-prerelease/download-istio.sh
+++ b/third_party/istio-1.0-prerelease/download-istio.sh
@@ -10,7 +10,7 @@ helm template --namespace=istio-system \
   --set sidecarInjectorWebhook.enabled=true \
   --set sidecarInjectorWebhook.enableNamespacesByDefault=true \
   --set global.proxy.image=proxyv2 \
-  --set global.autoInject=disabled \
+  --set global.proxy.autoInject=disabled \
   --set prometheus.enabled=false \
   install/kubernetes/helm/istio > ../istio.yaml
 

--- a/third_party/istio-1.0-prerelease/istio.yaml
+++ b/third_party/istio-1.0-prerelease/istio.yaml
@@ -1067,7 +1067,7 @@ metadata:
     istio: sidecar-injector
 data:
   config: |-
-    policy: enabled
+    policy: disabled
     template: |-
       initContainers:
       - name: istio-init


### PR DESCRIPTION
We disable auto inject in our `istio.yaml`, so that we rely on annotation alone for sidecar injection.  This is so that users can use our `istio.yaml` without having to turn on sidecar injection manually for their namespaces, and won't see their Pods suddenly get a sidecar injection.

Also removed places where we have to manually enable injection by namespace in e2e tests.

Fixes #1744 