### PR TITLE
Use common method to log resource objects

### DIFF
--- a/test/configuration.go
+++ b/test/configuration.go
@@ -18,8 +18,6 @@ limitations under the License.
 package test
 
 import (
-	"encoding/json"
-
 	"go.uber.org/zap"
 )
 
@@ -27,12 +25,7 @@ import (
 // that uses the image specifed by imagePath.
 func CreateConfiguration(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) error {
 	config := Configuration(Flags.Namespace, names, imagePath)
-	// Log config object
-	if configJSON, err := json.Marshal(config); err != nil {
-		logger.Infof("Failed to create json from route object")
-	} else {
-		logger.Infow("Created resource object", "CONFIGURATION", string(configJSON))
-	}
+	LogResourceObject(logger, ResourceObjects{Configuration: config})
 	_, err := clients.Configs.Create(config)
 	return err
 }

--- a/test/service.go
+++ b/test/service.go
@@ -18,8 +18,6 @@ limitations under the License.
 package test
 
 import (
-	"encoding/json"
-
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"go.uber.org/zap"
 )
@@ -28,13 +26,7 @@ import (
 // that uses the image specifed by imagePath
 func CreateLatestService(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) (*v1alpha1.Service, error) {
 	service := LatestService(Flags.Namespace, names, imagePath)
-	// Log the service object
-	if serviceJSON, err := json.Marshal(service); err != nil {
-		logger.Infof("Failed to create json from service object: %v", err)
-	} else {
-		logger.Infow("Created resource object", "SERVICE", string(serviceJSON))
-	}
-
+	LogResourceObject(logger, ResourceObjects{Service: service})
 	svc, err := clients.Services.Create(service)
 	return svc, err
 }


### PR DESCRIPTION
Part of #1006 

## Proposed Changes
Use the LogResourceObject method to log config and service objects