### PR TITLE
Fix flakiness in the autoscaler stat server tests

### DIFF
--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -36,7 +36,7 @@ const testAddress = "127.0.0.1:0"
 
 func TestServerLifecycle(t *testing.T) {
 	statsCh := make(chan *autoscaler.StatMessage)
-	server := stats.New(testAddress, statsCh, zap.NewNop().Sugar())
+	server := stats.NewTestServer(statsCh)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -48,6 +48,7 @@ func TestServerLifecycle(t *testing.T) {
 		}
 	}()
 
+	server.ListenAddr()
 	server.Shutdown(time.Second)
 
 	wg.Wait()

--- a/pkg/autoscaler/statserver/server_testing_test.go
+++ b/pkg/autoscaler/statserver/server_testing_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package statserver
 
 import (
+	"net"
+
 	"github.com/knative/serving/pkg/autoscaler"
 	"go.uber.org/zap"
 )
@@ -45,6 +47,15 @@ func (s *TestServer) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-	s.listenAddr <- "http://" + listener.Addr().String()
-	return s.serve(listener)
+	return s.serve(&testListener{listener, s.listenAddr})
+}
+
+type testListener struct {
+	net.Listener
+	listenAddr chan string
+}
+
+func (t *testListener) Accept() (net.Conn, error) {
+	t.listenAddr <- "http://" + t.Listener.Addr().String()
+	return t.Listener.Accept()
 }


### PR DESCRIPTION
I changed the point when the test server address is notified.

Prior this was done before calling http.Server::Serve.

Because of this if http.Server::Shutdown finished before
http.Server::Serve started - Serve would block indefinitely

Now we notify the server address when net.Listener::Accept is
invoked by the http.Server. This required tweaking how TCP
keep alives are set on the connection

Fixes #1738

Ran `go test -v -count=100000 -run TestServerLifecycle`