### PR TITLE
Disable Istio sidecar injection in namespace `istio-system`.

### DIFF
--- a/third_party/istio-1.0-prerelease/istio.yaml
+++ b/third_party/istio-1.0-prerelease/istio.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-system
+  labels:
+    istio-injection: disabled
 # PATCH #1 ends.
 ---
 # Source: istio/charts/galley/templates/configmap.yaml

--- a/third_party/istio-1.0-prerelease/namespace.yaml.patch
+++ b/third_party/istio-1.0-prerelease/namespace.yaml.patch
@@ -1,8 +1,10 @@
-1a2,8
+1a2,10
 > # PATCH #1: Creating the istio-system namespace.
 > apiVersion: v1
 > kind: Namespace
 > metadata:
 >   name: istio-system
+>   labels:
+>     istio-injection: disabled
 > # PATCH #1 ends.
 > ---


### PR DESCRIPTION
In order to use the flag `sidecarInjectorWebhook.enableNamespacesByDefault=true` we need to
explicitly disable sidecar injection on the `istio-system` namespace.  This flag allows us to enable sidecar injection solely by annotation, and avoid having to ask users to enable sidecar injection for the whole namespace just so that our Revisions' Pods get sidecar injection.

This PR update our `istio-system` namespace patch to add `istio-injection: disabled` label.

Fixes #1744 