### PR TITLE
Remove GetWorkQueue from controller.Interface

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -44,7 +44,6 @@ import (
 type Interface interface {
 	Run(threadiness int, stopCh <-chan struct{}) error
 	Reconcile(key string) error
-	GetWorkQueue() workqueue.RateLimitingInterface
 }
 
 func init() {
@@ -268,9 +267,4 @@ func (c *Base) processNextWorkItem(syncHandler func(string) error) bool {
 	}
 
 	return true
-}
-
-// GetWorkQueue helps implement Interface for derivatives.
-func (b *Base) GetWorkQueue() workqueue.RateLimitingInterface {
-	return b.WorkQueue
 }

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -34,13 +34,12 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	. "github.com/knative/pkg/logging/testing"
 	istiov1alpha3 "github.com/knative/serving/pkg/apis/istio/v1alpha3"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
-	. "github.com/knative/pkg/logging/testing"
 )
 
 // Listers holds the universe of objects that are available at the start
@@ -252,9 +251,6 @@ type TableRow struct {
 	// WantPatches holds the set of Patch calls we expect during reconcilliation
 	WantPatches []clientgotesting.PatchActionImpl
 
-	// WantQueue is the set of keys we expect to be in the workqueue following reconciliation.
-	WantQueue []string
-
 	// WithReactors is a set of functions that are installed as Reactors for the execution
 	// of this row of the table-driven-test.
 	WithReactors []clientgotesting.ReactionFunc
@@ -292,12 +288,6 @@ func (r *TableRow) Test(t *testing.T, ctor Ctor) {
 	}
 	// Now check that the Reconcile had the desired effects.
 	expectedNamespace, _, _ := cache.SplitMetaNamespaceKey(r.Key)
-
-	c.GetWorkQueue().ShutDown()
-	gotQueue := drainWorkQueue(c.GetWorkQueue())
-	if diff := cmp.Diff(r.WantQueue, gotQueue); diff != "" {
-		t.Errorf("unexpected queue (-Want +got): %s", diff)
-	}
 
 	createActions, updateActions, deleteActions, patchActions := extractActions(t, buildClient, client, kubeClient)
 
@@ -410,17 +400,6 @@ func extractActions(t *testing.T, clients ...hasActions) (
 				t.Errorf("Unexpected verb %v: %+v", action.GetVerb(), action)
 			}
 		}
-	}
-	return
-}
-
-func drainWorkQueue(wq workqueue.RateLimitingInterface) (hasQueue []string) {
-	for {
-		key, shutdown := wq.Get()
-		if shutdown {
-			break
-		}
-		hasQueue = append(hasQueue, key.(string))
 	}
 	return
 }


### PR DESCRIPTION
Nothing is using the WantQueue stuff in the table testing, and as I chase #1505 it will become less practical to do so.
