### PR TITLE
Invert the relationship between controller.Base and derivatives.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	configMapWatcher := configmap.NewDefaultWatcher(kubeClient, system.Namespace)
 
-	opt := controller.Options{
+	opt := controller.ReconcileOptions{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		BuildClientSet:   buildClient,
@@ -129,7 +129,7 @@ func main() {
 
 	// Build all of our controllers, with the clients constructed above.
 	// Add new controllers to this array.
-	controllers := []controller.Interface{
+	controllers := []*controller.Impl{
 		configuration.NewController(
 			opt,
 			configurationInformer,
@@ -196,7 +196,7 @@ func main() {
 
 	// Start all of the controllers.
 	for _, ctrlr := range controllers {
-		go func(ctrlr controller.Interface) {
+		go func(ctrlr *controller.Impl) {
 			// We don't expect this to return until stop is called,
 			// but if it does, propagate it back.
 			if runErr := ctrlr.Run(threadsPerController, stopCh); runErr != nil {

--- a/cmd/multitenant-autoscaler/main.go
+++ b/cmd/multitenant-autoscaler/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/autoscaler/statserver"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/autoscaling"
 	"github.com/knative/serving/pkg/logging"
@@ -36,6 +37,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -96,16 +98,31 @@ func main() {
 
 	multiScaler := autoscaler.NewMultiScaler(config, revisionScaler, stopCh, uniScalerFactory, logger)
 
-	opt := controller.Options{
+	opt := controller.ReconcileOptions{
 		KubeClientSet:    kubeClientSet,
 		ServingClientSet: servingClientSet,
 		Logger:           logger,
 	}
 
-	ctl := autoscaling.NewController(&opt, multiScaler, time.Second*30)
+	servingInformerFactory := informers.NewSharedInformerFactory(servingClientSet, time.Second*30)
+	revisionInformer := servingInformerFactory.Serving().V1alpha1().Revisions()
+
+	ctl := autoscaling.NewController(&opt, revisionInformer, multiScaler, time.Second*30)
+
+	// Start the serving informer factory.
+	servingInformerFactory.Start(stopCh)
+
+	// Wait for the caches to be synced before starting controllers.
+	logger.Info("Waiting for informer caches to sync")
+	for i, synced := range []cache.InformerSynced{
+		revisionInformer.Informer().HasSynced,
+	} {
+		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
+			logger.Fatalf("failed to wait for cache at index %v to sync", i)
+		}
+	}
 
 	var eg errgroup.Group
-
 	eg.Go(func() error {
 		return ctl.Run(controllerThreads, stopCh)
 	})

--- a/pkg/controller/autoscaling/autoscaling.go
+++ b/pkg/controller/autoscaling/autoscaling.go
@@ -22,7 +22,6 @@ import (
 
 	commonlogkey "github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller"
@@ -30,12 +29,10 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
 
 const (
-	controllerName      = "Autoscaling"
 	controllerAgentName = "autoscaling-controller"
 )
 
@@ -48,80 +45,54 @@ type RevisionSynchronizer interface {
 	OnAbsent(namespace string, name string, logger *zap.SugaredLogger)
 }
 
-// Controller tracks revisions and notifies a RevisionSynchronizer of their presence and absence.
-type Controller struct {
+// Reconciler tracks revisions and notifies a RevisionSynchronizer of their presence and absence.
+type Reconciler struct {
 	*controller.Base
-	revSynch               RevisionSynchronizer
-	kubeInformerFactory    kubeinformers.SharedInformerFactory
-	servingInformerFactory informers.SharedInformerFactory
-	sharedRevisionInformer servinginformers.RevisionInformer
-	lister                 listers.RevisionLister
-	logger                 *zap.SugaredLogger
+
+	revisionLister listers.RevisionLister
+	revSynch       RevisionSynchronizer
 }
+
+// Check that our Reconciler implements controller.Reconciler
+var _ controller.Reconciler = (*Reconciler)(nil)
 
 // NewController creates an autoscaling Controller.
 func NewController(
-	opts *controller.Options,
+	opts *controller.ReconcileOptions,
+	revisionInformer servinginformers.RevisionInformer,
 	revSynch RevisionSynchronizer,
-	informerResyncInterval time.Duration) *Controller {
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(opts.KubeClientSet, informerResyncInterval)
-	servingInformerFactory := informers.NewSharedInformerFactory(opts.ServingClientSet, informerResyncInterval)
+	informerResyncInterval time.Duration,
+) *controller.Impl {
 
-	sharedRevisionInformer := servingInformerFactory.Serving().V1alpha1().Revisions()
-
-	c := Controller{
-		Base: controller.NewBase(*opts,
-			controllerAgentName,
-			controllerName,
-		),
-		revSynch:               revSynch,
-		kubeInformerFactory:    kubeInformerFactory,
-		servingInformerFactory: servingInformerFactory,
-		sharedRevisionInformer: sharedRevisionInformer,
-		lister:                 sharedRevisionInformer.Lister(),
-		logger:                 opts.Logger,
+	c := &Reconciler{
+		Base:           controller.NewBase(*opts, controllerAgentName),
+		revisionLister: revisionInformer.Lister(),
+		revSynch:       revSynch,
 	}
+	impl := controller.NewImpl(c, c.Logger, "Autoscaling")
 
-	opts.Logger.Debugf("NewController returning controller %#v", c)
-	return &c
-}
-
-// Run starts the Controller monitoring revisions. The Controller uses numThreads goroutines for
-// monitoring and blocks until stopCh is closed, at which point it terminates gracefully
-// and returns.
-func (c *Controller) Run(numThreads int, stopCh <-chan struct{}) error {
-	c.logger.Info("Starting revision informer")
-	go c.servingInformerFactory.Start(stopCh)
-
-	c.logger.Info("Waiting for revision informer cache to sync")
-	informer := c.sharedRevisionInformer.Informer()
-	if ok := cache.WaitForCacheSync(stopCh, informer.HasSynced); !ok {
-		c.logger.Fatalf("failed to wait for revision informer cache to sync")
-	}
-
-	c.logger.Info("Setting up event handlers")
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.Enqueue,
-		UpdateFunc: controller.PassNew(c.Enqueue),
-		DeleteFunc: c.Enqueue,
+	c.Logger.Info("Setting up event handlers")
+	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+		DeleteFunc: impl.Enqueue,
 	})
 
-	c.logger.Info("Launching controller worker threads")
-	return c.RunController(numThreads, stopCh, c.Reconcile, controllerName)
+	return impl
 }
 
 // Reconcile notifies the RevisionSynchronizer of the presence or absence.
-func (c *Controller) Reconcile(revKey string) error {
+func (c *Reconciler) Reconcile(revKey string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(revKey)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("invalid resource key %s: %v", revKey, err))
 		return nil
 	}
 
-	logger := loggerWithRevisionInfo(c.logger, namespace, name)
+	logger := loggerWithRevisionInfo(c.Logger, namespace, name)
 	logger.Debug("Reconcile Revision")
 
-	rev, err := c.lister.Revisions(namespace).Get(name)
+	rev, err := c.revisionLister.Revisions(namespace).Get(name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.Debug("Revision no longer exists")

--- a/pkg/controller/autoscaling/autoscaling_test.go
+++ b/pkg/controller/autoscaling/autoscaling_test.go
@@ -18,13 +18,12 @@ package autoscaling_test
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
-	fakeBld "github.com/knative/build/pkg/client/clientset/versioned/fake"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/autoscaling"
 	"go.uber.org/atomic"
@@ -42,41 +41,36 @@ const (
 func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	kubeClient := fakeK8s.NewSimpleClientset()
 	servingClient := fakeKna.NewSimpleClientset()
-	buildClient := fakeBld.NewSimpleClientset()
 
 	stopCh := make(chan struct{})
 	createdCh := make(chan struct{})
 
-	opts := controller.Options{
+	opts := controller.ReconcileOptions{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
-		BuildClientSet:   buildClient,
 		Logger:           zap.NewNop().Sugar(),
 	}
 
+	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
+
 	fakeSynchronizer := newTestRevisionSynchronizer(createdCh, stopCh)
 	ctl := autoscaling.NewController(&opts,
+		servingInformer.Serving().V1alpha1().Revisions(),
 		fakeSynchronizer,
 		time.Duration(0), // disable resynch
 	)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	servingInformer.Start(stopCh)
 
-	// Run the controller.
-	go func() {
-		if err := ctl.Run(1, stopCh); err != nil {
-			t.Fatalf("Error running controller: %v", err)
-		}
-		wg.Done()
-	}()
-
-	servingClient.ServingV1alpha1().Revisions(testNamespace).Create(newTestRevision(testNamespace, testRevision))
+	rev := newTestRevision(testNamespace, testRevision)
+	servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
+	ctl.Reconciler.Reconcile(testNamespace + "/" + testRevision)
 
 	// Ensure revision creation has been seen before deleting it.
 	select {
 	case <-createdCh:
-	case <-time.After(time.Minute):
+	case <-time.After(3 * time.Second):
 		t.Fatal("Revision creation notification timed out")
 	}
 
@@ -85,9 +79,8 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	}
 
 	servingClient.ServingV1alpha1().Revisions(testNamespace).Delete(testRevision, nil)
-
-	// Check the controller terminates normally.
-	wg.Wait()
+	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Delete(rev)
+	ctl.Reconciler.Reconcile(testNamespace + "/" + testRevision)
 
 	if fakeSynchronizer.onAbsentCallCount.Load() == 0 {
 		t.Fatal("OnAbsent was not called")

--- a/pkg/controller/configuration/configuration.go
+++ b/pkg/controller/configuration/configuration.go
@@ -39,8 +39,8 @@ import (
 
 const controllerAgentName = "configuration-controller"
 
-// Controller implements the controller for Configuration resources
-type Controller struct {
+// Reconciler implements controller.Reconciler for Configuration resources.
+type Reconciler struct {
 	*controller.Base
 
 	// listers index properties about resources
@@ -48,41 +48,38 @@ type Controller struct {
 	revisionLister      listers.RevisionLister
 }
 
+// Check that our Reconciler implements controller.Reconciler
+var _ controller.Reconciler = (*Reconciler)(nil)
+
 // NewController creates a new Configuration controller
 func NewController(
-	opt controller.Options,
+	opt controller.ReconcileOptions,
 	configurationInformer servinginformers.ConfigurationInformer,
 	revisionInformer servinginformers.RevisionInformer,
-) *Controller {
+) *controller.Impl {
 
-	c := &Controller{
-		Base:                controller.NewBase(opt, controllerAgentName, "Configurations"),
+	c := &Reconciler{
+		Base:                controller.NewBase(opt, controllerAgentName),
 		configurationLister: configurationInformer.Lister(),
 		revisionLister:      revisionInformer.Lister(),
 	}
+	impl := controller.NewImpl(c, c.Logger, "Configurations")
 
 	c.Logger.Info("Setting up event handlers")
 	configurationInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.Enqueue,
-		UpdateFunc: controller.PassNew(c.Enqueue),
-		DeleteFunc: c.Enqueue,
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+		DeleteFunc: impl.Enqueue,
 	})
 
 	revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Configuration")),
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    c.EnqueueControllerOf,
-			UpdateFunc: controller.PassNew(c.EnqueueControllerOf),
+			AddFunc:    impl.EnqueueControllerOf,
+			UpdateFunc: controller.PassNew(impl.EnqueueControllerOf),
 		},
 	})
-	return c
-}
-
-// Run starts the controller's worker threads, the number of which is threadiness. It then blocks until stopCh
-// is closed, at which point it shuts down its internal work queue and waits for workers to finish processing their
-// current work items.
-func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
-	return c.RunController(threadiness, stopCh, c.Reconcile, "Configuration")
+	return impl
 }
 
 // loggerWithConfigInfo enriches the logs with configuration name and namespace.
@@ -93,7 +90,7 @@ func loggerWithConfigInfo(logger *zap.SugaredLogger, ns string, name string) *za
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Configuration
 // resource with the current status of the resource.
-func (c *Controller) Reconcile(key string) error {
+func (c *Reconciler) Reconcile(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -132,7 +129,7 @@ func (c *Controller) Reconcile(key string) error {
 	return err
 }
 
-func (c *Controller) reconcile(ctx context.Context, config *v1alpha1.Configuration) error {
+func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configuration) error {
 	logger := logging.FromContext(ctx)
 	config.Status.InitializeConditions()
 
@@ -200,7 +197,7 @@ func (c *Controller) reconcile(ctx context.Context, config *v1alpha1.Configurati
 	return nil
 }
 
-func (c *Controller) createRevision(config *v1alpha1.Configuration, revName string) (*v1alpha1.Revision, error) {
+func (c *Reconciler) createRevision(config *v1alpha1.Configuration, revName string) (*v1alpha1.Revision, error) {
 	logger := loggerWithConfigInfo(c.Logger, config.Namespace, config.Name)
 
 	buildName := ""
@@ -227,7 +224,7 @@ func (c *Controller) createRevision(config *v1alpha1.Configuration, revName stri
 	return created, nil
 }
 
-func (c *Controller) updateStatus(u *v1alpha1.Configuration) (*v1alpha1.Configuration, error) {
+func (c *Reconciler) updateStatus(u *v1alpha1.Configuration) (*v1alpha1.Configuration, error) {
 	newu, err := c.configurationLister.Configurations(u.Namespace).Get(u.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -338,9 +338,9 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/revision-recovers",
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.Options) controller.Interface {
-		return &Controller{
-			Base:                controller.NewBase(opt, controllerAgentName, "Configurations"),
+	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+		return &Reconciler{
+			Base:                controller.NewBase(opt, controllerAgentName),
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
 		}

--- a/pkg/controller/configuration/queueing_test.go
+++ b/pkg/controller/configuration/queueing_test.go
@@ -21,12 +21,12 @@ import (
 	"time"
 
 	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
+	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	ctrl "github.com/knative/serving/pkg/controller"
 	hooks "github.com/knative/serving/pkg/controller/testing"
-	. "github.com/knative/pkg/logging/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +89,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	kubeClient *fakekubeclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
-	controller *Controller,
+	controller *ctrl.Impl,
 	kubeInformer kubeinformers.SharedInformerFactory,
 	servingInformer informers.SharedInformerFactory) {
 
@@ -106,7 +106,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	servingInformer = informers.NewSharedInformerFactory(servingClient, 0)
 
 	controller = NewController(
-		ctrl.Options{
+		ctrl.ReconcileOptions{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			BuildClientSet:   fakebuildclientset.NewSimpleClientset(),

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,36 +20,20 @@ import (
 	"fmt"
 	"time"
 
-	buildclientset "github.com/knative/build/pkg/client/clientset/versioned"
-	"github.com/knative/pkg/configmap"
-	"github.com/knative/pkg/logging/logkey"
-	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
-	servingScheme "github.com/knative/serving/pkg/client/clientset/versioned/scheme"
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 )
 
-// Interface defines the controller interface
-type Interface interface {
-	Run(threadiness int, stopCh <-chan struct{}) error
+// Reconciler is the interface that controller implementations are expected
+// to implement, so that the shared controller.Impl can drive work through it.
+type Reconciler interface {
 	Reconcile(key string) error
-}
-
-func init() {
-	// Add serving types to the default Kubernetes Scheme so Events can be
-	// logged for serving types.
-	servingScheme.AddToScheme(scheme.Scheme)
 }
 
 // PassNew makes it simple to create an UpdateFunc for use with
@@ -77,24 +61,11 @@ func Filter(gvk schema.GroupVersionKind) func(obj interface{}) bool {
 	}
 }
 
-// Base implements most of the boilerplate and common code
-// we have in our controllers.
-type Base struct {
-	// KubeClientSet allows us to talk to the k8s for core APIs
-	KubeClientSet kubernetes.Interface
-
-	// ServingClientSet allows us to configure Serving objects
-	ServingClientSet clientset.Interface
-
-	// BuildClientSet allows us to configure Build objects
-	BuildClientSet buildclientset.Interface
-
-	// ConfigMapWatcher allows us to watch for ConfigMap changes.
-	ConfigMapWatcher configmap.Watcher
-
-	// Recorder is an event recorder for recording Event resources to the
-	// Kubernetes API.
-	Recorder record.EventRecorder
+// Impl implements the core controller logic, given a Reconciler.
+type Impl struct {
+	// Reconciler is the workhorse of this controller, it is fed the keys
+	// from the workqueue to process.  Public for testing.
+	Reconciler Reconciler
 
 	// WorkQueue is a rate limited work queue. This is used to queue work to be
 	// processed instead of performing it as soon as a change happens. This
@@ -108,54 +79,29 @@ type Base struct {
 	// and use the returned raw logger instead. In addition to the
 	// performance benefits, raw logger also preserves type-safety at
 	// the expense of slightly greater verbosity.
-	Logger *zap.SugaredLogger
+	logger *zap.SugaredLogger
 }
 
-// Options defines the common controller options passed to NewBase.
-// We define this to reduce the boilerplate argument list when
-// creating derivative controllers.
-type Options struct {
-	KubeClientSet    kubernetes.Interface
-	ServingClientSet clientset.Interface
-	BuildClientSet   buildclientset.Interface
-	ConfigMapWatcher configmap.Watcher
-	Logger           *zap.SugaredLogger
-}
-
-// NewBase instantiates a new instance of Base implementing
+// NewImpl instantiates a new instance of Base implementing
 // the common & boilerplate code between our controllers.
-func NewBase(opt Options, controllerAgentName, workQueueName string) *Base {
-	// Enrich the logs with controller name
-	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
-
-	// Create event broadcaster
-	logger.Debug("Creating event broadcaster")
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof)
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: opt.KubeClientSet.CoreV1().Events("")})
-	recorder := eventBroadcaster.NewRecorder(
-		scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
-
-	base := &Base{
-		KubeClientSet:    opt.KubeClientSet,
-		ServingClientSet: opt.ServingClientSet,
-		BuildClientSet:   opt.BuildClientSet,
-		ConfigMapWatcher: opt.ConfigMapWatcher,
-		Recorder:         recorder,
-		WorkQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), workQueueName),
-		Logger:           logger,
+func NewImpl(r Reconciler, logger *zap.SugaredLogger, workQueueName string) *Impl {
+	return &Impl{
+		Reconciler: r,
+		WorkQueue: workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			workQueueName,
+		),
+		logger: logger,
 	}
-
-	return base
 }
 
 // Enqueue takes a resource and converts it into a
 // namespace/name string which is then put onto the work queue.
-func (c *Base) Enqueue(obj interface{}) {
+func (c *Impl) Enqueue(obj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
-		c.Logger.Error(zap.Error(err))
+		c.logger.Error(zap.Error(err))
 		return
 	}
 	c.EnqueueKey(key)
@@ -163,13 +109,13 @@ func (c *Base) Enqueue(obj interface{}) {
 
 // EnqueueControllerOf takes a resource, identifies its controller resource, and
 // converts it into a namespace/name string which is then put onto the work queue.
-func (c *Base) EnqueueControllerOf(obj interface{}) {
+func (c *Impl) EnqueueControllerOf(obj interface{}) {
 	// TODO(mattmoor): This will not properly handle Delete, which we do
 	// not currently use.  Consider using "cache.DeletedFinalStateUnknown"
 	// to enqueue the last known owner.
 	object, err := meta.Accessor(obj)
 	if err != nil {
-		c.Logger.Error(zap.Error(err))
+		c.logger.Error(zap.Error(err))
 		return
 	}
 
@@ -181,30 +127,23 @@ func (c *Base) EnqueueControllerOf(obj interface{}) {
 }
 
 // EnqueueKey takes a namespace/name string and puts it onto the work queue.
-func (c *Base) EnqueueKey(key string) {
+func (c *Impl) EnqueueKey(key string) {
 	c.WorkQueue.AddRateLimited(key)
 }
 
 // RunController starts the controller's worker threads, the number of which is threadiness. It then blocks until stopCh
 // is closed, at which point it shuts down its internal work queue and waits for workers to finish processing their
 // current work items.
-func (c *Base) RunController(
-	threadiness int,
-	stopCh <-chan struct{},
-	syncHandler func(string) error,
-	controllerName string) error {
-
+func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer runtime.HandleCrash()
 	defer c.WorkQueue.ShutDown()
 
-	logger := c.Logger
-	logger.Infof("Starting %s controller", controllerName)
-
 	// Launch workers to process Revision resources
-	logger.Info("Starting workers")
+	logger := c.logger
+	logger.Info("Starting controller and workers")
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(func() {
-			for c.processNextWorkItem(syncHandler) {
+			for c.processNextWorkItem(c.Reconciler.Reconcile) {
 			}
 		}, time.Second, stopCh)
 	}
@@ -218,7 +157,7 @@ func (c *Base) RunController(
 
 // processNextWorkItem will read a single work item off the workqueue and
 // attempt to process it, by calling the syncHandler.
-func (c *Base) processNextWorkItem(syncHandler func(string) error) bool {
+func (c *Impl) processNextWorkItem(syncHandler func(string) error) bool {
 	obj, shutdown := c.WorkQueue.Get()
 
 	if shutdown {
@@ -246,7 +185,7 @@ func (c *Base) processNextWorkItem(syncHandler func(string) error) bool {
 			// Forget here else we'd go into a loop of attempting to
 			// process a work item that is invalid.
 			c.WorkQueue.Forget(obj)
-			c.Logger.Errorf("expected string in workqueue but got %#v", obj)
+			c.logger.Errorf("expected string in workqueue but got %#v", obj)
 			return nil
 		}
 		// Run the syncHandler, passing it the namespace/name string of the
@@ -257,12 +196,12 @@ func (c *Base) processNextWorkItem(syncHandler func(string) error) bool {
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.WorkQueue.Forget(obj)
-		c.Logger.Infof("Successfully synced %q", key)
+		c.logger.Infof("Successfully synced %q", key)
 		return nil
 	}(obj)
 
 	if err != nil {
-		c.Logger.Error(zap.Error(err))
+		c.logger.Error(zap.Error(err))
 		return true
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,14 +131,14 @@ func (c *Impl) EnqueueKey(key string) {
 	c.WorkQueue.AddRateLimited(key)
 }
 
-// RunController starts the controller's worker threads, the number of which is threadiness. It then blocks until stopCh
-// is closed, at which point it shuts down its internal work queue and waits for workers to finish processing their
-// current work items.
+// Run starts the controller's worker threads, the number of which is threadiness.
+// It then blocks until stopCh is closed, at which point it shuts down its internal
+// work queue and waits for workers to finish processing their current work items.
 func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer runtime.HandleCrash()
 	defer c.WorkQueue.ShutDown()
 
-	// Launch workers to process Revision resources
+	// Launch workers to process resources that get enqueued to our workqueue.
 	logger := c.logger
 	logger.Info("Starting controller and workers")
 	for i := 0; i < threadiness; i++ {

--- a/pkg/controller/keep.go
+++ b/pkg/controller/keep.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"k8s.io/client-go/kubernetes/scheme"
+
+	buildclientset "github.com/knative/build/pkg/client/clientset/versioned"
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/logging/logkey"
+	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	servingScheme "github.com/knative/serving/pkg/client/clientset/versioned/scheme"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+// ReconcileOptions defines the common reconciler options.
+// We define this to reduce the boilerplate argument list when
+// creating our controllers.
+type ReconcileOptions struct {
+	KubeClientSet    kubernetes.Interface
+	ServingClientSet clientset.Interface
+	BuildClientSet   buildclientset.Interface
+	ConfigMapWatcher configmap.Watcher
+	Logger           *zap.SugaredLogger
+}
+
+// Base implements the core controller logic, given a Reconciler.
+type Base struct {
+	// KubeClientSet allows us to talk to the k8s for core APIs
+	KubeClientSet kubernetes.Interface
+
+	// ServingClientSet allows us to configure Serving objects
+	ServingClientSet clientset.Interface
+
+	// BuildClientSet allows us to configure Build objects
+	BuildClientSet buildclientset.Interface
+
+	// ConfigMapWatcher allows us to watch for ConfigMap changes.
+	ConfigMapWatcher configmap.Watcher
+
+	// Recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	Recorder record.EventRecorder
+
+	// Sugared logger is easier to use but is not as performant as the
+	// raw logger. In performance critical paths, call logger.Desugar()
+	// and use the returned raw logger instead. In addition to the
+	// performance benefits, raw logger also preserves type-safety at
+	// the expense of slightly greater verbosity.
+	Logger *zap.SugaredLogger
+}
+
+// NewBase instantiates a new instance of Base implementing
+// the common & boilerplate code between our reconcilers.
+func NewBase(opt ReconcileOptions, controllerAgentName string) *Base {
+	// Enrich the logs with controller name
+	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
+
+	// Create event broadcaster
+	logger.Debug("Creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: opt.KubeClientSet.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(
+		scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+
+	base := &Base{
+		KubeClientSet:    opt.KubeClientSet,
+		ServingClientSet: opt.ServingClientSet,
+		BuildClientSet:   opt.BuildClientSet,
+		ConfigMapWatcher: opt.ConfigMapWatcher,
+		Recorder:         recorder,
+		Logger:           logger,
+	}
+
+	return base
+}
+
+func init() {
+	// Add serving types to the default Kubernetes Scheme so Events can be
+	// logged for serving types.
+	servingScheme.AddToScheme(scheme.Scheme)
+}

--- a/pkg/controller/revision/queueing_test.go
+++ b/pkg/controller/revision/queueing_test.go
@@ -41,8 +41,8 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
-	. "github.com/knative/serving/pkg/controller/testing"
 	. "github.com/knative/pkg/logging/testing"
+	. "github.com/knative/serving/pkg/controller/testing"
 )
 
 type nopResolver struct{}
@@ -135,7 +135,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	buildClient *fakebuildclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
 	vpaClient *fakevpaclientset.Clientset,
-	controller *Controller,
+	controller *ctrl.Impl,
 	kubeInformer kubeinformers.SharedInformerFactory,
 	buildInformer buildinformers.SharedInformerFactory,
 	servingInformer informers.SharedInformerFactory,
@@ -187,8 +187,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 			"concurrency-quantum-of-time": "100ms",
 			"tick-interval":               "2s",
 		},
-	}, getTestControllerConfigMap(),
-	)
+	}, getTestControllerConfigMap())
 
 	// Create informer factories with fake clients. The second parameter sets the
 	// resync period to zero, disabling it.
@@ -198,7 +197,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	vpaInformer = vpainformers.NewSharedInformerFactory(vpaClient, 0)
 
 	controller = NewController(
-		ctrl.Options{
+		ctrl.ReconcileOptions{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,
@@ -214,7 +213,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 		vpaInformer.Poc().V1alpha1().VerticalPodAutoscalers(),
 	)
 
-	controller.resolver = &nopResolver{}
+	controller.Reconciler.(*Reconciler).resolver = &nopResolver{}
 
 	return
 }

--- a/pkg/controller/revision/revision_test.go
+++ b/pkg/controller/revision/revision_test.go
@@ -31,9 +31,9 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/knative/pkg/configmap"
+	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/logging"
-	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/system"
 
 	"github.com/google/go-cmp/cmp"
@@ -121,7 +121,7 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controll
 	buildClient *fakebuildclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
 	vpaClient *fakevpaclientset.Clientset,
-	controller *Controller,
+	controller *ctrl.Impl,
 	kubeInformer kubeinformers.SharedInformerFactory,
 	buildInformer buildinformers.SharedInformerFactory,
 	servingInformer informers.SharedInformerFactory,
@@ -191,7 +191,7 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controll
 	vpaInformer = vpainformers.NewSharedInformerFactory(vpaClient, 0)
 
 	controller = NewController(
-		ctrl.Options{
+		ctrl.ReconcileOptions{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,
@@ -207,7 +207,7 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controll
 		vpaInformer.Poc().V1alpha1().VerticalPodAutoscalers(),
 	)
 
-	controller.resolver = &nopResolver{}
+	controller.Reconciler.(*Reconciler).resolver = &nopResolver{}
 
 	return
 }
@@ -215,13 +215,13 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controll
 func createRevision(t *testing.T,
 	kubeClient *fakekubeclientset.Clientset, kubeInformer kubeinformers.SharedInformerFactory,
 	servingClient *fakeclientset.Clientset, servingInformer informers.SharedInformerFactory,
-	controller *Controller, rev *v1alpha1.Revision) *v1alpha1.Revision {
+	controller *ctrl.Impl, rev *v1alpha1.Revision) *v1alpha1.Revision {
 	t.Helper()
 	servingClient.ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
 
-	if err := controller.Reconcile(KeyOrDie(rev)); err == nil {
+	if err := controller.Reconciler.Reconcile(KeyOrDie(rev)); err == nil {
 		rev, _, _ = addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
 	}
 	return rev
@@ -230,12 +230,12 @@ func createRevision(t *testing.T,
 func updateRevision(t *testing.T,
 	kubeClient *fakekubeclientset.Clientset, kubeInformer kubeinformers.SharedInformerFactory,
 	servingClient *fakeclientset.Clientset, servingInformer informers.SharedInformerFactory,
-	controller *Controller, rev *v1alpha1.Revision) {
+	controller *ctrl.Impl, rev *v1alpha1.Revision) {
 	t.Helper()
 	servingClient.ServingV1alpha1().Revisions(rev.Namespace).Update(rev)
 	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Update(rev)
 
-	if err := controller.Reconcile(KeyOrDie(rev)); err == nil {
+	if err := controller.Reconciler.Reconcile(KeyOrDie(rev)); err == nil {
 		addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
 	}
 }
@@ -333,7 +333,7 @@ func TestResolutionFailed(t *testing.T) {
 
 	// Unconditionally return this error during resolution.
 	errorMessage := "I am the expected error message, hear me ROAR!"
-	controller.resolver = &errorResolver{errorMessage}
+	controller.Reconciler.(*Reconciler).resolver = &errorResolver{errorMessage}
 
 	rev := getTestRevision()
 	config := getTestConfiguration()
@@ -386,7 +386,7 @@ func TestCreateRevWithVPA(t *testing.T) {
 	revClient := servingClient.ServingV1alpha1().Revisions(testNamespace)
 	rev := getTestRevision()
 
-	if !controller.getAutoscalerConfig().EnableVPA {
+	if !controller.Reconciler.(*Reconciler).getAutoscalerConfig().EnableVPA {
 		t.Fatal("EnableVPA = false, want true")
 	}
 
@@ -429,7 +429,7 @@ func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 	createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, controller, rev)
 
 	// Update controllers logging URL
-	controller.receiveObservabilityConfig(&corev1.ConfigMap{
+	controller.Reconciler.(*Reconciler).receiveObservabilityConfig(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace,
 			Name:      config.ObservabilityConfigName,
@@ -511,8 +511,9 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	buildInformer.Build().V1alpha1().Builds().Informer().GetIndexer().Add(bld)
 
-	controller.EnqueueBuildTrackers(bld)
-	controller.Reconcile(KeyOrDie(rev))
+	f := controller.Reconciler.(*Reconciler).EnqueueBuildTrackers(controller)
+	f(bld)
+	controller.Reconciler.Reconcile(KeyOrDie(rev))
 
 	// Make sure that the changes from the Reconcile are reflected in our Informers.
 	completedRev, _, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
@@ -566,8 +567,9 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 
 	endpoints := getTestReadyEndpoints(rev.Name)
 	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Add(endpoints)
-	controller.EnqueueEndpointsRevision(endpoints)
-	controller.Reconcile(KeyOrDie(rev))
+	f := controller.Reconciler.(*Reconciler).EnqueueEndpointsRevision(controller)
+	f(endpoints)
+	controller.Reconciler.Reconcile(KeyOrDie(rev))
 
 	// Make sure that the changes from the Reconcile are reflected in our Informers.
 	readyRev, _, _ := addResourcesToInformers(t, kubeClient, kubeInformer, servingClient, servingInformer, rev)
@@ -601,7 +603,7 @@ func TestNoAutoscalerImageCreatesNoAutoscalers(t *testing.T) {
 		*ctrl.NewControllerRef(config),
 	)
 	// Update controller config with no autoscaler image
-	controller.receiveControllerConfig(
+	controller.Reconciler.(*Reconciler).receiveControllerConfig(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "config-controller",
@@ -637,7 +639,7 @@ func TestNoQueueSidecarImageUpdateFail(t *testing.T) {
 		*ctrl.NewControllerRef(config),
 	)
 	// Update controller config with no side car image
-	controller.receiveControllerConfig(
+	controller.Reconciler.(*Reconciler).receiveControllerConfig(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "config-controller",
@@ -786,30 +788,31 @@ func TestReceiveLoggingConfig(t *testing.T) {
 		},
 	}
 
-	controller.receiveLoggingConfig(&cm)
-	if controller.getLoggingConfig().LoggingConfig != cm.Data["zap-logger-config"] {
-		t.Errorf("Invalid logging config. want: %v, got: %v", cm.Data["zap-logger-config"], controller.getLoggingConfig().LoggingConfig)
+	r := controller.Reconciler.(*Reconciler)
+	r.receiveLoggingConfig(&cm)
+	if r.getLoggingConfig().LoggingConfig != cm.Data["zap-logger-config"] {
+		t.Errorf("Invalid logging config. want: %v, got: %v", cm.Data["zap-logger-config"], r.getLoggingConfig().LoggingConfig)
 	}
-	if controller.getLoggingConfig().LoggingLevel["controller"] != zapcore.InfoLevel {
-		t.Errorf("Invalid logging level. want: %v, got: %v", zapcore.InfoLevel, controller.getLoggingConfig().LoggingLevel["controller"])
+	if r.getLoggingConfig().LoggingLevel["controller"] != zapcore.InfoLevel {
+		t.Errorf("Invalid logging level. want: %v, got: %v", zapcore.InfoLevel, r.getLoggingConfig().LoggingLevel["controller"])
 	}
 
 	cm.Data["loglevel.controller"] = "debug"
-	controller.receiveLoggingConfig(&cm)
-	if controller.getLoggingConfig().LoggingConfig != cm.Data["zap-logger-config"] {
-		t.Errorf("Invalid logging config. want: %v, got: %v", cm.Data["zap-logger-config"], controller.getLoggingConfig().LoggingConfig)
+	controller.Reconciler.(*Reconciler).receiveLoggingConfig(&cm)
+	if r.getLoggingConfig().LoggingConfig != cm.Data["zap-logger-config"] {
+		t.Errorf("Invalid logging config. want: %v, got: %v", cm.Data["zap-logger-config"], r.getLoggingConfig().LoggingConfig)
 	}
-	if controller.getLoggingConfig().LoggingLevel["controller"] != zapcore.DebugLevel {
-		t.Errorf("Invalid logging level. want: %v, got: %v", zapcore.DebugLevel, controller.getLoggingConfig().LoggingLevel["controller"])
+	if r.getLoggingConfig().LoggingLevel["controller"] != zapcore.DebugLevel {
+		t.Errorf("Invalid logging level. want: %v, got: %v", zapcore.DebugLevel, r.getLoggingConfig().LoggingLevel["controller"])
 	}
 
 	cm.Data["loglevel.controller"] = "invalid"
-	controller.receiveLoggingConfig(&cm)
-	if controller.getLoggingConfig().LoggingConfig != cm.Data["zap-logger-config"] {
-		t.Errorf("Invalid logging config. want: %v, got: %v", cm.Data["zap-logger-config"], controller.getLoggingConfig().LoggingConfig)
+	controller.Reconciler.(*Reconciler).receiveLoggingConfig(&cm)
+	if r.getLoggingConfig().LoggingConfig != cm.Data["zap-logger-config"] {
+		t.Errorf("Invalid logging config. want: %v, got: %v", cm.Data["zap-logger-config"], r.getLoggingConfig().LoggingConfig)
 	}
-	if controller.getLoggingConfig().LoggingLevel["controller"] != zapcore.DebugLevel {
-		t.Errorf("Invalid logging level. want: %v, got: %v", zapcore.DebugLevel, controller.getLoggingConfig().LoggingLevel["controller"])
+	if r.getLoggingConfig().LoggingLevel["controller"] != zapcore.DebugLevel {
+		t.Errorf("Invalid logging level. want: %v, got: %v", zapcore.DebugLevel, r.getLoggingConfig().LoggingLevel["controller"])
 	}
 }
 
@@ -819,8 +822,8 @@ func getPodAnnotationsForConfig(t *testing.T, configMapValue string, configAnnot
 
 	// Resolve image references to this "digest"
 	digest := "foo@sha256:deadbeef"
-	controller.resolver = &fixedResolver{digest}
-	controller.receiveNetworkConfig(&corev1.ConfigMap{
+	controller.Reconciler.(*Reconciler).resolver = &fixedResolver{digest}
+	controller.Reconciler.(*Reconciler).receiveNetworkConfig(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.NetworkConfigName,
 			Namespace: system.Namespace,

--- a/pkg/controller/revision/table_test.go
+++ b/pkg/controller/revision/table_test.go
@@ -1562,9 +1562,9 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/failed-build-stable",
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.Options) controller.Interface {
-		return &Controller{
-			Base:                controller.NewBase(opt, controllerAgentName, "Revisions"),
+	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+		return &Reconciler{
+			Base:                controller.NewBase(opt, controllerAgentName),
 			revisionLister:      listers.GetRevisionLister(),
 			buildLister:         listers.GetBuildLister(),
 			deploymentLister:    listers.GetDeploymentLister(),
@@ -1821,9 +1821,9 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		Key: "foo/update-configmap-failure",
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.Options) controller.Interface {
-		return &Controller{
-			Base:                controller.NewBase(opt, controllerAgentName, "Revisions"),
+	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+		return &Reconciler{
+			Base:                controller.NewBase(opt, controllerAgentName),
 			revisionLister:      listers.GetRevisionLister(),
 			buildLister:         listers.GetBuildLister(),
 			deploymentLister:    listers.GetDeploymentLister(),

--- a/pkg/controller/route/cruds.go
+++ b/pkg/controller/route/cruds.go
@@ -31,7 +31,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func (c *Controller) reconcileVirtualService(ctx context.Context, route *v1alpha1.Route,
+func (c *Reconciler) reconcileVirtualService(ctx context.Context, route *v1alpha1.Route,
 	desiredVirtualService *v1alpha3.VirtualService) error {
 	logger := logging.FromContext(ctx)
 	ns := desiredVirtualService.Namespace
@@ -64,7 +64,7 @@ func (c *Controller) reconcileVirtualService(ctx context.Context, route *v1alpha
 	return err
 }
 
-func (c *Controller) reconcilePlaceholderService(ctx context.Context, route *v1alpha1.Route) error {
+func (c *Reconciler) reconcilePlaceholderService(ctx context.Context, route *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
 	name := resourcenames.K8sService(route)
@@ -107,7 +107,7 @@ func (c *Controller) reconcilePlaceholderService(ctx context.Context, route *v1a
 
 // Update the Status of the route.  Caller is responsible for checking
 // for semantic differences before calling.
-func (c *Controller) updateStatus(ctx context.Context, route *v1alpha1.Route) (*v1alpha1.Route, error) {
+func (c *Reconciler) updateStatus(ctx context.Context, route *v1alpha1.Route) (*v1alpha1.Route, error) {
 	existing, err := c.routeLister.Routes(route.Namespace).Get(route.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/route/cruds_test.go
+++ b/pkg/controller/route/cruds_test.go
@@ -20,16 +20,16 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/apis/istio/v1alpha3"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/controller/route/traffic"
-	. "github.com/knative/pkg/logging/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestReconcileVirtualService_Insert(t *testing.T) {
-	_, servingClient, c, _, _, _ := newTestController(t)
+	_, servingClient, c, _, _, _ := newTestReconciler(t)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -52,7 +52,7 @@ func TestReconcileVirtualService_Insert(t *testing.T) {
 }
 
 func TestReconcileVirtualService_Update(t *testing.T) {
-	_, servingClient, c, _, servingInformer, _ := newTestController(t)
+	_, servingClient, c, _, servingInformer, _ := newTestReconciler(t)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",

--- a/pkg/controller/route/labels.go
+++ b/pkg/controller/route/labels.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (c *Controller) syncLabels(ctx context.Context, r *v1alpha1.Route, tc *traffic.TrafficConfig) error {
+func (c *Reconciler) syncLabels(ctx context.Context, r *v1alpha1.Route, tc *traffic.TrafficConfig) error {
 	if err := c.deleteLabelForOutsideOfGivenConfigurations(ctx, r, tc.Configurations); err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (c *Controller) syncLabels(ctx context.Context, r *v1alpha1.Route, tc *traf
 	return nil
 }
 
-func (c *Controller) setLabelForGivenConfigurations(
+func (c *Reconciler) setLabelForGivenConfigurations(
 	ctx context.Context,
 	route *v1alpha1.Route,
 	configMap map[string]*v1alpha1.Configuration,
@@ -91,7 +91,7 @@ func (c *Controller) setLabelForGivenConfigurations(
 	return nil
 }
 
-func (c *Controller) deleteLabelForOutsideOfGivenConfigurations(
+func (c *Reconciler) deleteLabelForOutsideOfGivenConfigurations(
 	ctx context.Context,
 	route *v1alpha1.Route,
 	configMap map[string]*v1alpha1.Configuration,

--- a/pkg/controller/route/queueing_test.go
+++ b/pkg/controller/route/queueing_test.go
@@ -21,12 +21,12 @@ import (
 	"time"
 
 	"github.com/knative/pkg/configmap"
+	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	ctrl "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/route/config"
-	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/system"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +81,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
 
 	controller := NewController(
-		ctrl.Options{
+		ctrl.ReconcileOptions{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -48,8 +48,8 @@ const (
 	controllerAgentName = "route-controller"
 )
 
-// Controller implements the controller for Route resources.
-type Controller struct {
+// Reconciler implements controller.Reconciler for Route resources.
+type Reconciler struct {
 	*controller.Base
 
 	// Listers index properties about resources
@@ -65,63 +65,60 @@ type Controller struct {
 	domainConfigMutex sync.Mutex
 }
 
+// Check that our Reconciler implements controller.Reconciler
+var _ controller.Reconciler = (*Reconciler)(nil)
+
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 // config - client configuration for talking to the apiserver
 // si - informer factory shared across all controllers for listening to events and indexing resource properties
 // reconcileKey - function for mapping queue keys to resource names
 func NewController(
-	opt controller.Options,
+	opt controller.ReconcileOptions,
 	routeInformer servinginformers.RouteInformer,
 	configInformer servinginformers.ConfigurationInformer,
 	revisionInformer servinginformers.RevisionInformer,
 	serviceInformer corev1informers.ServiceInformer,
 	virtualServiceInformer istioinformers.VirtualServiceInformer,
-) *Controller {
+) *controller.Impl {
 
 	// No need to lock domainConfigMutex yet since the informers that can modify
 	// domainConfig haven't started yet.
-	c := &Controller{
-		Base:                 controller.NewBase(opt, controllerAgentName, "Routes"),
+	c := &Reconciler{
+		Base:                 controller.NewBase(opt, controllerAgentName),
 		routeLister:          routeInformer.Lister(),
 		configurationLister:  configInformer.Lister(),
 		revisionLister:       revisionInformer.Lister(),
 		serviceLister:        serviceInformer.Lister(),
 		virtualServiceLister: virtualServiceInformer.Lister(),
 	}
+	impl := controller.NewImpl(c, c.Logger, "Routes")
 
 	c.Logger.Info("Setting up event handlers")
 	routeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.Enqueue,
-		UpdateFunc: controller.PassNew(c.Enqueue),
-		DeleteFunc: c.Enqueue,
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+		DeleteFunc: impl.Enqueue,
 	})
 
 	configInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.EnqueueReferringRoute,
-		UpdateFunc: controller.PassNew(c.EnqueueReferringRoute),
+		AddFunc:    c.EnqueueReferringRoute(impl),
+		UpdateFunc: controller.PassNew(c.EnqueueReferringRoute(impl)),
 	})
 
 	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.EnqueueControllerOf,
-		UpdateFunc: controller.PassNew(c.EnqueueControllerOf),
+		AddFunc:    impl.EnqueueControllerOf,
+		UpdateFunc: controller.PassNew(impl.EnqueueControllerOf),
 	})
 
 	virtualServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.EnqueueControllerOf,
-		UpdateFunc: controller.PassNew(c.EnqueueControllerOf),
+		AddFunc:    impl.EnqueueControllerOf,
+		UpdateFunc: controller.PassNew(impl.EnqueueControllerOf),
 	})
 
 	c.Logger.Info("Setting up ConfigMap receivers")
 	opt.ConfigMapWatcher.Watch(config.DomainConfigName, c.receiveDomainConfig)
-	return c
-}
-
-// Run starts the controller's worker threads, the number of which is threadiness. It then blocks until stopCh
-// is closed, at which point it shuts down its internal work queue and waits for workers to finish processing their
-// current work items.
-func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
-	return c.RunController(threadiness, stopCh, c.Reconcile, "Route")
+	return impl
 }
 
 /////////////////////////////////////////
@@ -131,7 +128,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Route resource
 // with the current status of the resource.
-func (c *Controller) Reconcile(key string) error {
+func (c *Reconciler) Reconcile(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -171,7 +168,7 @@ func (c *Controller) Reconcile(key string) error {
 	return err
 }
 
-func (c *Controller) reconcile(ctx context.Context, route *v1alpha1.Route) error {
+func (c *Reconciler) reconcile(ctx context.Context, route *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 	route.Status.InitializeConditions()
 
@@ -199,7 +196,7 @@ func (c *Controller) reconcile(ctx context.Context, route *v1alpha1.Route) error
 //
 // In all cases we will add annotations to the referred targets.  This is so that when they become
 // routable we can know (through a listener) and attempt traffic configuration again.
-func (c *Controller) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*v1alpha1.Route, error) {
+func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*v1alpha1.Route, error) {
 	r.Status.Domain = c.routeDomain(r)
 	logger := logging.FromContext(ctx)
 	t, err := traffic.BuildTrafficConfiguration(c.configurationLister, c.revisionLister, r)
@@ -230,30 +227,32 @@ func (c *Controller) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 	return r, nil
 }
 
-func (c *Controller) EnqueueReferringRoute(obj interface{}) {
-	config, ok := obj.(*v1alpha1.Configuration)
-	if !ok {
-		c.Logger.Infof("Ignoring non-Configuration objects %v", obj)
-		return
+func (c *Reconciler) EnqueueReferringRoute(impl *controller.Impl) func(obj interface{}) {
+	return func(obj interface{}) {
+		config, ok := obj.(*v1alpha1.Configuration)
+		if !ok {
+			c.Logger.Infof("Ignoring non-Configuration objects %v", obj)
+			return
+		}
+		if config.Status.LatestReadyRevisionName == "" {
+			c.Logger.Infof("Configuration %s is not ready", config.Name)
+			return
+		}
+		// Check whether is configuration is referred by a route.
+		routeName, ok := config.Labels[serving.RouteLabelKey]
+		if !ok {
+			c.Logger.Infof("Configuration %s does not have a referring route", config.Name)
+			return
+		}
+		// Configuration is referred by a Route.  Update such Route.
+		route, err := c.routeLister.Routes(config.Namespace).Get(routeName)
+		if err != nil {
+			loggerWithRouteInfo(c.Logger, config.Namespace, routeName).Error(
+				"Error fetching route upon configuration becoming ready", zap.Error(err))
+			return
+		}
+		impl.Enqueue(route)
 	}
-	if config.Status.LatestReadyRevisionName == "" {
-		c.Logger.Infof("Configuration %s is not ready", config.Name)
-		return
-	}
-	// Check whether is configuration is referred by a route.
-	routeName, ok := config.Labels[serving.RouteLabelKey]
-	if !ok {
-		c.Logger.Infof("Configuration %s does not have a referring route", config.Name)
-		return
-	}
-	// Configuration is referred by a Route.  Update such Route.
-	route, err := c.routeLister.Routes(config.Namespace).Get(routeName)
-	if err != nil {
-		loggerWithRouteInfo(c.Logger, config.Namespace, routeName).Error(
-			"Error fetching route upon configuration becoming ready", zap.Error(err))
-		return
-	}
-	c.Enqueue(route)
 }
 
 /////////////////////////////////////////
@@ -264,18 +263,18 @@ func loggerWithRouteInfo(logger *zap.SugaredLogger, ns string, name string) *zap
 	return logger.With(zap.String(commonlogkey.Namespace, ns), zap.String(logkey.Route, name))
 }
 
-func (c *Controller) getDomainConfig() *config.Domain {
+func (c *Reconciler) getDomainConfig() *config.Domain {
 	c.domainConfigMutex.Lock()
 	defer c.domainConfigMutex.Unlock()
 	return c.domainConfig
 }
 
-func (c *Controller) routeDomain(route *v1alpha1.Route) string {
+func (c *Reconciler) routeDomain(route *v1alpha1.Route) string {
 	domain := c.getDomainConfig().LookupDomainForLabels(route.ObjectMeta.Labels)
 	return fmt.Sprintf("%s.%s.%s", route.Name, route.Namespace, domain)
 }
 
-func (c *Controller) receiveDomainConfig(configMap *corev1.ConfigMap) {
+func (c *Reconciler) receiveDomainConfig(configMap *corev1.ConfigMap) {
 	newDomainConfig, err := config.NewDomainFromConfigMap(configMap)
 	if err != nil {
 		c.Logger.Error("Failed to parse the new config map. Previous config map will be used.",

--- a/pkg/controller/route/table_test.go
+++ b/pkg/controller/route/table_test.go
@@ -1435,9 +1435,9 @@ func TestReconcile(t *testing.T) {
 	// TODO(mattmoor): Revision inactive (indirect reference)
 	// TODO(mattmoor): Multiple inactive Revisions
 
-	table.Test(t, func(listers *Listers, opt controller.Options) controller.Interface {
-		return &Controller{
-			Base:                 controller.NewBase(opt, controllerAgentName, "Routes"),
+	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+		return &Reconciler{
+			Base:                 controller.NewBase(opt, controllerAgentName),
 			routeLister:          listers.GetRouteLister(),
 			configurationLister:  listers.GetConfigurationLister(),
 			revisionLister:       listers.GetRevisionLister(),

--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/service/resources"
 
-	. "github.com/knative/serving/pkg/controller/testing"
 	. "github.com/knative/pkg/logging/testing"
+	. "github.com/knative/serving/pkg/controller/testing"
 )
 
 var (
@@ -228,9 +228,9 @@ func TestReconcile(t *testing.T) {
 		}},
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.Options) controller.Interface {
-		return &Controller{
-			Base:                controller.NewBase(opt, controllerAgentName, "Services"),
+	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+		return &Reconciler{
+			Base:                controller.NewBase(opt, controllerAgentName),
 			serviceLister:       listers.GetServiceLister(),
 			configurationLister: listers.GetConfigurationLister(),
 			routeLister:         listers.GetRouteLister(),
@@ -247,7 +247,7 @@ func TestNew(t *testing.T) {
 	routeInformer := servingInformer.Serving().V1alpha1().Routes()
 	configurationInformer := servingInformer.Serving().V1alpha1().Configurations()
 
-	c := NewController(controller.Options{
+	c := NewController(controller.ReconcileOptions{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		Logger:           TestLogger(t),

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -256,7 +256,7 @@ type TableRow struct {
 	WithReactors []clientgotesting.ReactionFunc
 }
 
-type Ctor func(*Listers, controller.Options) controller.Interface
+type Ctor func(*Listers, controller.ReconcileOptions) controller.Reconciler
 
 func (r *TableRow) Test(t *testing.T, ctor Ctor) {
 	ls := NewListers(r.Objects)
@@ -265,7 +265,7 @@ func (r *TableRow) Test(t *testing.T, ctor Ctor) {
 	client := fakeclientset.NewSimpleClientset(ls.GetServingObjects()...)
 	buildClient := fakebuildclientset.NewSimpleClientset(ls.GetBuildObjects()...)
 	// Set up our Controller from the fakes.
-	c := ctor(&ls, controller.Options{
+	c := ctor(&ls, controller.ReconcileOptions{
 		KubeClientSet:    kubeClient,
 		BuildClientSet:   buildClient,
 		ServingClientSet: client,


### PR DESCRIPTION
The way we use `controller.Base` today is very reminiscent of OOP; it is effectively trying to be a base class, and many things are painful trying to write this way in Go (e.g. we cannot simply make `Reconcile` an abstract method to be implemented by derivatives).

With this change, we will instead move to a model where `Base` becomes `Impl` and takes an instance of the following interface:
```go
package controller

type Reconciler interface {
  Reconcile(key string) error
}
```

In this model, `controller.Impl` is the single shared controller implementation, and the `NewController` methods become responsible for instantiating it with the appropriate implementation of `Reconciler` and wiring the appropriate events up via the informers.

This cleans up the separation between `./pkg/controller` and `./pkg/controller/foo`, and will hopefully start to make the latter quite small.  The plan is to share the former via `knative/pkg` in a subsequent change.  I'm debating followup changes such as moving to a `./pkg/reconciler/foo` structure, once only `Reconciler`s live in this repo.

Fixes: https://github.com/knative/serving/issues/1505

cc @evankanderson @vaikas-google @n3wscott @grantr @ImJasonH 