### PR TITLE
Move to use the controller.Impl from knative/pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -259,13 +259,14 @@
   packages = [
     "apis",
     "configmap",
+    "controller",
     "logging",
     "logging/logkey",
     "logging/testing",
     "signals",
     "webhook"
   ]
-  revision = "484160f313516c21c2c619e30a515e4aa600445a"
+  revision = "bf6f9e373f9fae2757acbc3fda183c62db5789a7"
 
 [[projects]]
   branch = "master"
@@ -805,6 +806,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ac2a2dd0ad8c194db279e6dc08fa8fd51a42ceeacaec3e1c6e2c417b66db0465"
+  inputs-digest = "608c773db335eecf9a349432e701dac358a39028a4f75337f973fe6b78c39d5c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -23,7 +23,8 @@ import (
 
 	"github.com/knative/pkg/configmap"
 
-	"github.com/knative/serving/pkg/controller"
+	"github.com/knative/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/logging"
 
 	"github.com/knative/serving/pkg/system"
@@ -107,7 +108,7 @@ func main() {
 
 	configMapWatcher := configmap.NewDefaultWatcher(kubeClient, system.Namespace)
 
-	opt := controller.ReconcileOptions{
+	opt := reconciler.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		BuildClientSet:   buildClient,

--- a/cmd/multitenant-autoscaler/main.go
+++ b/cmd/multitenant-autoscaler/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/knative/serving/pkg/autoscaler/statserver"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
-	"github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/autoscaling"
 	"github.com/knative/serving/pkg/logging"
 	"go.opencensus.io/exporter/prometheus"
@@ -98,7 +98,7 @@ func main() {
 
 	multiScaler := autoscaler.NewMultiScaler(config, revisionScaler, stopCh, uniScalerFactory, logger)
 
-	opt := controller.ReconcileOptions{
+	opt := reconciler.Options{
 		KubeClientSet:    kubeClientSet,
 		ServingClientSet: servingClientSet,
 		Logger:           logger,

--- a/pkg/controller/configuration/configuration_test.go
+++ b/pkg/controller/configuration/configuration_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	"github.com/knative/pkg/controller"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/configuration/resources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -338,9 +339,9 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/revision-recovers",
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+	table.Test(t, func(listers *Listers, opt reconciler.Options) controller.Reconciler {
 		return &Reconciler{
-			Base:                controller.NewBase(opt, controllerAgentName),
+			Base:                reconciler.NewBase(opt, controllerAgentName),
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
 		}

--- a/pkg/controller/configuration/queueing_test.go
+++ b/pkg/controller/configuration/queueing_test.go
@@ -21,11 +21,12 @@ import (
 	"time"
 
 	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
+	ctrl "github.com/knative/pkg/controller"
 	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
-	ctrl "github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	hooks "github.com/knative/serving/pkg/controller/testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -106,7 +107,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	servingInformer = informers.NewSharedInformerFactory(servingClient, 0)
 
 	controller = NewController(
-		ctrl.ReconcileOptions{
+		reconciler.Options{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			BuildClientSet:   fakebuildclientset.NewSimpleClientset(),

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -31,10 +31,10 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-// ReconcileOptions defines the common reconciler options.
+// Options defines the common reconciler options.
 // We define this to reduce the boilerplate argument list when
 // creating our controllers.
-type ReconcileOptions struct {
+type Options struct {
 	KubeClientSet    kubernetes.Interface
 	ServingClientSet clientset.Interface
 	BuildClientSet   buildclientset.Interface
@@ -70,7 +70,7 @@ type Base struct {
 
 // NewBase instantiates a new instance of Base implementing
 // the common & boilerplate code between our reconcilers.
-func NewBase(opt ReconcileOptions, controllerAgentName string) *Base {
+func NewBase(opt Options, controllerAgentName string) *Base {
 	// Enrich the logs with controller name
 	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
 

--- a/pkg/controller/revision/queueing_test.go
+++ b/pkg/controller/revision/queueing_test.go
@@ -23,12 +23,13 @@ import (
 	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
 	buildinformers "github.com/knative/build/pkg/client/informers/externalversions"
 	"github.com/knative/pkg/configmap"
+	ctrl "github.com/knative/pkg/controller"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
-	ctrl "github.com/knative/serving/pkg/controller"
+	rclr "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/system"
@@ -197,7 +198,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	vpaInformer = vpainformers.NewSharedInformerFactory(vpaClient, 0)
 
 	controller = NewController(
-		ctrl.ReconcileOptions{
+		rclr.Options{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,

--- a/pkg/controller/revision/table_test.go
+++ b/pkg/controller/revision/table_test.go
@@ -21,10 +21,11 @@ import (
 	"time"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
-	"github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/revision/config"
 	"github.com/knative/serving/pkg/controller/revision/resources"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1562,9 +1563,9 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/failed-build-stable",
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+	table.Test(t, func(listers *Listers, opt reconciler.Options) controller.Reconciler {
 		return &Reconciler{
-			Base:                controller.NewBase(opt, controllerAgentName),
+			Base:                reconciler.NewBase(opt, controllerAgentName),
 			revisionLister:      listers.GetRevisionLister(),
 			buildLister:         listers.GetBuildLister(),
 			deploymentLister:    listers.GetDeploymentLister(),
@@ -1821,9 +1822,9 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		Key: "foo/update-configmap-failure",
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+	table.Test(t, func(listers *Listers, opt reconciler.Options) controller.Reconciler {
 		return &Reconciler{
-			Base:                controller.NewBase(opt, controllerAgentName),
+			Base:                reconciler.NewBase(opt, controllerAgentName),
 			revisionLister:      listers.GetRevisionLister(),
 			buildLister:         listers.GetBuildLister(),
 			deploymentLister:    listers.GetDeploymentLister(),

--- a/pkg/controller/route/queueing_test.go
+++ b/pkg/controller/route/queueing_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
-	ctrl "github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/route/config"
 	"github.com/knative/serving/pkg/system"
 	corev1 "k8s.io/api/core/v1"
@@ -81,7 +81,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
 
 	controller := NewController(
-		ctrl.ReconcileOptions{
+		reconciler.Options{
 			KubeClientSet:    kubeClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,

--- a/pkg/controller/route/table_test.go
+++ b/pkg/controller/route/table_test.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/knative/pkg/controller"
 	istiov1alpha3 "github.com/knative/serving/pkg/apis/istio/v1alpha3"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/route/config"
 	"github.com/knative/serving/pkg/controller/route/resources"
 	"github.com/knative/serving/pkg/controller/route/traffic"
@@ -1435,9 +1436,9 @@ func TestReconcile(t *testing.T) {
 	// TODO(mattmoor): Revision inactive (indirect reference)
 	// TODO(mattmoor): Multiple inactive Revisions
 
-	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+	table.Test(t, func(listers *Listers, opt reconciler.Options) controller.Reconciler {
 		return &Reconciler{
-			Base:                 controller.NewBase(opt, controllerAgentName),
+			Base:                 reconciler.NewBase(opt, controllerAgentName),
 			routeLister:          listers.GetRouteLister(),
 			configurationLister:  listers.GetConfigurationLister(),
 			revisionLister:       listers.GetRevisionLister(),

--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -25,10 +25,11 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
+	"github.com/knative/pkg/controller"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
-	"github.com/knative/serving/pkg/controller"
+	reconciler "github.com/knative/serving/pkg/controller"
 	"github.com/knative/serving/pkg/controller/service/resources"
 
 	. "github.com/knative/pkg/logging/testing"
@@ -228,9 +229,9 @@ func TestReconcile(t *testing.T) {
 		}},
 	}}
 
-	table.Test(t, func(listers *Listers, opt controller.ReconcileOptions) controller.Reconciler {
+	table.Test(t, func(listers *Listers, opt reconciler.Options) controller.Reconciler {
 		return &Reconciler{
-			Base:                controller.NewBase(opt, controllerAgentName),
+			Base:                reconciler.NewBase(opt, controllerAgentName),
 			serviceLister:       listers.GetServiceLister(),
 			configurationLister: listers.GetConfigurationLister(),
 			routeLister:         listers.GetRouteLister(),
@@ -247,7 +248,7 @@ func TestNew(t *testing.T) {
 	routeInformer := servingInformer.Serving().V1alpha1().Routes()
 	configurationInformer := servingInformer.Serving().V1alpha1().Configurations()
 
-	c := NewController(controller.ReconcileOptions{
+	c := NewController(reconciler.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		Logger:           TestLogger(t),

--- a/vendor/github.com/knative/pkg/logging/config.go
+++ b/vendor/github.com/knative/pkg/logging/config.go
@@ -51,10 +51,7 @@ func NewLogger(configJSON string, levelOverride string) (*zap.SugaredLogger, zap
 	if err2 != nil {
 		panic(err2)
 	}
-
-	logger.Error("Failed to parse the logging config. Falling back to default logger.",
-		zap.Error(err), zap.String(logkey.JSONConfig, configJSON))
-	return logger.Sugar(), loggingCfg.Level
+	return logger.Named("fallback-logger").Sugar(), loggingCfg.Level
 }
 
 // NewLoggerFromConfig creates a logger using the provided Config


### PR DESCRIPTION
This doesn't yet rename `./pkg/controller` to `./pkg/reconciler`, but it aliases it as that wherever it is still imported.  This also drops the stutter that creates for `reconciler.[Reconcile]Options`.