### PR TITLE
Route.Reconcile() to return no error in case of missing target.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -216,7 +216,9 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 	}
 	if badTarget != nil && isTargetError {
 		badTarget.MarkBadTrafficTarget(&r.Status)
-		return r, badTarget
+
+		// Traffic targets aren't ready, no need to configure Route.
+		return r, nil
 	}
 	logger.Info("All referred targets are routable.  Creating Istio VirtualService.")
 	if err := c.reconcileVirtualService(ctx, r, resources.MakeVirtualService(r, t)); err != nil {

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -78,8 +78,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: false,
-		Key:     "default/first-reconcile",
+		Key: "default/first-reconcile",
 	}, {
 		Name: "configuration permanently failed",
 		Objects: []runtime.Object{
@@ -113,8 +112,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: false,
-		Key:     "default/first-reconcile",
+		Key: "default/first-reconcile",
 	}, {
 		Name:    "failure updating route status",
 		WantErr: true,
@@ -1003,8 +1001,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: false,
-		Key:     "default/config-missing",
+		Key: "default/config-missing",
 	}, {
 		Name: "revision missing (direct)",
 		Objects: []runtime.Object{
@@ -1031,8 +1028,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: false,
-		Key:     "default/missing-revision-direct",
+		Key: "default/missing-revision-direct",
 	}, {
 		Name: "revision missing (indirect)",
 		Objects: []runtime.Object{
@@ -1062,8 +1058,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: false,
-		Key:     "default/missing-revision-indirect",
+		Key: "default/missing-revision-indirect",
 	}, {
 		Name: "pinned route becomes ready",
 		Objects: []runtime.Object{

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -78,7 +78,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: true,
+		WantErr: false,
 		Key:     "default/first-reconcile",
 	}, {
 		Name: "configuration permanently failed",
@@ -113,7 +113,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: true,
+		WantErr: false,
 		Key:     "default/first-reconcile",
 	}, {
 		Name:    "failure updating route status",
@@ -1003,7 +1003,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: true,
+		WantErr: false,
 		Key:     "default/config-missing",
 	}, {
 		Name: "revision missing (direct)",
@@ -1031,7 +1031,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: true,
+		WantErr: false,
 		Key:     "default/missing-revision-direct",
 	}, {
 		Name: "revision missing (indirect)",
@@ -1062,7 +1062,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		WantErr: true,
+		WantErr: false,
 		Key:     "default/missing-revision-indirect",
 	}, {
 		Name: "pinned route becomes ready",


### PR DESCRIPTION
/assign @mattmoor 