### PR TITLE
Make `cluster.local` domain works without sidecar.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names.go
@@ -26,6 +26,10 @@ var K8sGatewayFullname = reconciler.GetK8sServiceFullname(
 	"knative-shared-gateway",
 	system.Namespace)
 
+var K8sGatewayServiceFullname = reconciler.GetK8sServiceFullname(
+	"knative-ingressgateway",
+	"istio-system")
+
 func K8sService(route *v1alpha1.Route) string {
 	return route.Name
 }

--- a/pkg/reconciler/v1alpha1/route/resources/service.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service.go
@@ -39,10 +39,8 @@ func MakeK8sService(route *v1alpha1.Route) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name: PortName,
-				Port: PortNumber,
-			}},
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: names.K8sGatewayServiceFullname,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/route/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,10 +38,8 @@ func TestMakeK8SService_ValidSpec(t *testing.T) {
 		},
 	}
 	expectedSpec := corev1.ServiceSpec{
-		Ports: []corev1.ServicePort{{
-			Name: "http",
-			Port: 80,
-		}},
+		Type:         corev1.ServiceTypeExternalName,
+		ExternalName: names.K8sGatewayServiceFullname,
 	}
 	spec := MakeK8sService(r).Spec
 	if diff := cmp.Diff(expectedSpec, spec); diff != "" {


### PR DESCRIPTION
This keeps existing behavior with `cluster.local` domain, but allow Pods without sidecar to access the same.

/assign @mattmoor 