### PR TITLE
Deflake E2E test: ServiceToServiceTest

### DIFF
--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -76,7 +76,6 @@ func sendRequest(resolvableDomain bool, domain string) (*spoof.Response, error) 
 // The expected result is that the request sent to httpproxy app is successfully redirected
 // to helloworld app.
 func TestServiceToServiceCall(t *testing.T) {
-	t.Skip("Re-enable once https://github.com/knative/serving/issues/1783 is fixed.")
 	logger = test.GetContextLogger("TestServiceToServiceCall")
 	clients = Setup(t)
 
@@ -110,7 +109,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get Route %s: %v", httpProxyNames.Route, err)
 	}
-	if err = test.WaitForEndpointState(clients.Kube, logger, httpProxyRoute.Status.Domain, test.MatchesAny, "HttpProxy"); err != nil {
+	if err = test.WaitForEndpointState(clients.Kube, logger, httpProxyRoute.Status.Domain, test.Retrying(test.MatchesAny, http.StatusServiceUnavailable, http.StatusNotFound), "HttpProxy"); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)
 	}
 	logger.Info("httpproxy is ready.")


### PR DESCRIPTION
Fixes #
https://github.com/knative/serving/issues/1783

## Proposed Changes
In the current ServiceToServiceTest, we intend to send a request to httpproxy service after its endpoint was considered as ready https://github.com/knative/serving/blob/3a8044b65e7d9b20e1c36bfc59e841fdd01618b2/test/e2e/service_to_service_test.go#L113

But actually above code does not exactly check the state of endpoint is ready since we use `MatchesAny` in above code, which means no matter the response of the state check is success or error, we stop polling httpproxy service and consider its endpoint as ready.

The fix is to retry the endpoint check when the response code is `http.StatusServiceUnavailable` or `http.StatusNotFound`.

I have ran the test 30 times, and did not see any failure.
