### PR TITLE
Add status propagation tests for Service

### DIFF
--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -409,13 +409,13 @@ func mutateRoute(rt *v1alpha1.Route) *v1alpha1.Route {
 	return rt
 }
 
-// TODO(1762): Replace with builders.
+// TODO(#1762): Replace with builders.
 func cfgWithStatus(cfg *v1alpha1.Configuration, s v1alpha1.ConfigurationStatus) *v1alpha1.Configuration {
 	cfg.Status = s
 	return cfg
 }
 
-// TODO(1762): Replace with builders.
+// TODO(#1762): Replace with builders.
 func routeWithStatus(rt *v1alpha1.Route, s v1alpha1.RouteStatus) *v1alpha1.Route {
 	rt.Status = s
 	return rt


### PR DESCRIPTION
Fixes #1542

This tests:
1. Route + Config Ready -> Service Ready
2. Config Fails + Route Ready -> Service Fails
3. Config Ready + Route Fails -> Service Fails

These are similar to the propagation tests in
apis/serving/v1alpha1/service_types_test.go but from the reconciler's
perspective.
