### PR TITLE
Populate Service name as a label to Revision

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -41,6 +41,11 @@ func MakeRevision(config *v1alpha1.Configuration, buildName string) *v1alpha1.Re
 	}
 	rev.Labels[serving.ConfigurationLabelKey] = config.Name
 
+	// Populate the Service label.
+	if serviceName, ok := config.Labels[serving.ServiceLabelKey]; ok {
+		rev.Labels[serving.ServiceLabelKey] = serviceName
+	}
+
 	// Populate the Configuration Generation annotation.
 	if rev.Annotations == nil {
 		rev.Annotations = make(map[string]string)

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -137,6 +137,7 @@ func TestRevisions(t *testing.T) {
 						Labels: map[string]string{
 							"foo": "bar",
 							"baz": "blah",
+							serving.ServiceLabelKey: "labels-service",
 						},
 					},
 					Spec: v1alpha1.RevisionSpec{
@@ -159,6 +160,7 @@ func TestRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
+					serving.ServiceLabelKey:       "labels-service",
 					serving.ConfigurationLabelKey: "labels",
 					"foo": "bar",
 					"baz": "blah",


### PR DESCRIPTION
Fixes #1795 

## Proposed Changes

  * Populate Service name from Configuration(if it exists) to its Revisions as a label. The pods of Revision will inherit the Service name as label from Revision. This information from pods will be used to divide logs/metrics by service. 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
