### PR TITLE
Vendor the test infrastructre scripts

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -14,11 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Load github.com/knative/test-infra/images/prow-tests/scripts/library.sh
-[ -f /workspace/library.sh ] \
-  && source /workspace/library.sh \
-  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat library.sh')"
-[ -v KNATIVE_TEST_INFRA ] || exit 1
+source $(dirname $0)/../test/scripts/library.sh
 
 set -o errexit
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -14,11 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Load github.com/knative/test-infra/images/prow-tests/scripts/release.sh
-[ -f /workspace/release.sh ] \
-  && source /workspace/release.sh \
-  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat release.sh')"
-[ -v KNATIVE_TEST_INFRA ] || exit 1
+source $(dirname $0)/../test/scripts/release.sh
 
 # Set default GCS/GCR
 : ${SERVING_RELEASE_GCS:="knative-releases/serving"}

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,14 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Load github.com/knative/test-infra/images/prow-tests/scripts/library.sh
-[ -f /workspace/library.sh ] \
-  && source /workspace/library.sh \
-  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat library.sh')"
-
-if [ -z "${KNATIVE_TEST_INFRA}" ]; then
-  exit 1
-fi
+source $(dirname $0)/../test/scripts/library.sh
 
 set -o errexit
 set -o nounset

--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -201,7 +201,6 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 func (c *Reconciler) createRevision(config *v1alpha1.Configuration, revName string) (*v1alpha1.Revision, error) {
 	logger := loggerWithConfigInfo(c.Logger, config.Namespace, config.Name)
 
-	buildName := ""
 	if config.Spec.Build != nil {
 		// TODO(mattmoor): Determine whether we reuse the previous build.
 		build := resources.MakeBuild(config)
@@ -211,10 +210,9 @@ func (c *Reconciler) createRevision(config *v1alpha1.Configuration, revName stri
 		}
 		logger.Infof("Created Build:\n%+v", created.Name)
 		c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Build %q", created.Name)
-		buildName = created.Name
 	}
 
-	rev := resources.MakeRevision(config, buildName)
+	rev := resources.MakeRevision(config)
 	created, err := c.ServingClientSet.ServingV1alpha1().Revisions(config.Namespace).Create(rev)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -48,8 +48,6 @@ var (
 	}
 )
 
-const noBuildName = ""
-
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
@@ -64,7 +62,7 @@ func TestReconcile(t *testing.T) {
 			cfg("no-revisions-yet", "foo", 1234),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeRevision(cfg("no-revisions-yet", "foo", 1234), noBuildName),
+			resources.MakeRevision(cfg("no-revisions-yet", "foo", 1234)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("no-revisions-yet", "foo", 1234,
@@ -86,7 +84,7 @@ func TestReconcile(t *testing.T) {
 			setConcurrencyModel(cfg("validation-failure", "foo", 1234), "Bogus"),
 		},
 		WantCreates: []metav1.Object{
-			setRevConcurrencyModel(resources.MakeRevision(cfg("validation-failure", "foo", 1234), noBuildName), "Bogus"),
+			setRevConcurrencyModel(resources.MakeRevision(cfg("validation-failure", "foo", 1234)), "Bogus"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: setConcurrencyModel(cfgWithStatus("validation-failure", "foo", 1234,
@@ -107,8 +105,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeBuild(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec)),
-			resources.MakeRevision(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec),
-				resources.MakeBuild(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec)).Name),
+			resources.MakeRevision(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithBuildAndStatus("need-rev-and-build", "foo", 99998, &buildSpec,
@@ -127,7 +124,7 @@ func TestReconcile(t *testing.T) {
 		Name: "reconcile revision matching generation (ready: unknown)",
 		Objects: []runtime.Object{
 			cfg("matching-revision-not-done", "foo", 5432),
-			resources.MakeRevision(cfg("matching-revision-not-done", "foo", 5432), noBuildName),
+			resources.MakeRevision(cfg("matching-revision-not-done", "foo", 5432)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("matching-revision-not-done", "foo", 5432,
@@ -146,7 +143,7 @@ func TestReconcile(t *testing.T) {
 		Name: "reconcile revision matching generation (ready: true)",
 		Objects: []runtime.Object{
 			cfg("matching-revision-done", "foo", 5555),
-			makeRevReady(t, resources.MakeRevision(cfg("matching-revision-done", "foo", 5555), noBuildName)),
+			makeRevReady(t, resources.MakeRevision(cfg("matching-revision-done", "foo", 5555))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("matching-revision-done", "foo", 5555,
@@ -176,14 +173,14 @@ func TestReconcile(t *testing.T) {
 					}},
 				},
 			),
-			makeRevReady(t, resources.MakeRevision(cfg("matching-revision-done-idempotent", "foo", 5566), noBuildName)),
+			makeRevReady(t, resources.MakeRevision(cfg("matching-revision-done-idempotent", "foo", 5566))),
 		},
 		Key: "foo/matching-revision-done-idempotent",
 	}, {
 		Name: "reconcile revision matching generation (ready: false)",
 		Objects: []runtime.Object{
 			cfg("matching-revision-failed", "foo", 5555),
-			makeRevFailed(resources.MakeRevision(cfg("matching-revision-failed", "foo", 5555), noBuildName)),
+			makeRevFailed(resources.MakeRevision(cfg("matching-revision-failed", "foo", 5555))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("matching-revision-failed", "foo", 5555,
@@ -204,7 +201,7 @@ func TestReconcile(t *testing.T) {
 		Name: "reconcile revision matching generation (ready: bad)",
 		Objects: []runtime.Object{
 			cfg("bad-condition", "foo", 5555),
-			makeRevStatus(resources.MakeRevision(cfg("bad-condition", "foo", 5555), noBuildName),
+			makeRevStatus(resources.MakeRevision(cfg("bad-condition", "foo", 5555)),
 				v1alpha1.RevisionStatus{
 					Conditions: []v1alpha1.RevisionCondition{{
 						Type:   v1alpha1.RevisionConditionReady,
@@ -265,7 +262,7 @@ func TestReconcile(t *testing.T) {
 			cfg("create-revision-failure", "foo", 99998),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeRevision(cfg("create-revision-failure", "foo", 99998), noBuildName),
+			resources.MakeRevision(cfg("create-revision-failure", "foo", 99998)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("create-revision-failure", "foo", 99998,
@@ -291,7 +288,7 @@ func TestReconcile(t *testing.T) {
 			cfg("update-config-failure", "foo", 1234),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeRevision(cfg("update-config-failure", "foo", 1234), noBuildName),
+			resources.MakeRevision(cfg("update-config-failure", "foo", 1234)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("update-config-failure", "foo", 1234,
@@ -321,7 +318,7 @@ func TestReconcile(t *testing.T) {
 					}},
 				},
 			),
-			makeRevReady(t, resources.MakeRevision(cfg("revision-recovers", "foo", 1337), noBuildName)),
+			makeRevReady(t, resources.MakeRevision(cfg("revision-recovers", "foo", 1337))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfgWithStatus("revision-recovers", "foo", 1337,

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources/names"
 )
 
-func MakeRevision(config *v1alpha1.Configuration, buildName string) *v1alpha1.Revision {
+func MakeRevision(config *v1alpha1.Configuration) *v1alpha1.Revision {
 	// Start from the ObjectMeta/Spec inlined in the Configuration resources.
 	rev := &v1alpha1.Revision{
 		ObjectMeta: config.Spec.RevisionTemplate.ObjectMeta,
@@ -51,7 +51,7 @@ func MakeRevision(config *v1alpha1.Configuration, buildName string) *v1alpha1.Re
 	rev.OwnerReferences = append(rev.OwnerReferences, *reconciler.NewControllerRef(config))
 
 	// Fill in the build name, if specified.
-	rev.Spec.BuildName = buildName
+	rev.Spec.BuildName = names.Build(config)
 
 	return rev
 }

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -25,7 +25,6 @@ import (
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources/names"
 )
 
 func TestRevisions(t *testing.T) {
@@ -227,7 +226,7 @@ func TestRevisions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := MakeRevision(test.configuration, names.Build(test.configuration))
+			got := MakeRevision(test.configuration)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("MakeRevision (-want, +got) = %v", diff)
 			}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,11 +25,7 @@
 # project $PROJECT_ID, start knative in it, run the tests and delete the
 # cluster.
 
-# Load github.com/knative/test-infra/images/prow-tests/scripts/e2e-tests.sh
-[ -f /workspace/e2e-tests.sh ] \
-  && source /workspace/e2e-tests.sh \
-  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat e2e-tests.sh')"
-[ -v KNATIVE_TEST_INFRA ] || exit 1
+source $(dirname $0)/scripts/e2e-tests.sh
 
 # Location of istio for the test cluster
 readonly ISTIO_YAML=./third_party/istio-1.0.0/istio.yaml

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,11 +21,7 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
-# Load github.com/knative/test-infra/images/prow-tests/scripts/presubmit-tests.sh
-[ -f /workspace/presubmit-tests.sh ] \
-  && source /workspace/presubmit-tests.sh \
-  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat presubmit-tests.sh')"
-[ -v KNATIVE_TEST_INFRA ] || exit 1
+source $(dirname $0)/scripts/presubmit-tests.sh
 
 function build_tests() {
   header "Running build tests"


### PR DESCRIPTION
* test-infra repo now contains the branch `exported-scripts`, generated with `git subtree split`;
* `//test/scripts` was added by `git subtree --prefix=test/scripts/ --squash add git@github.com:knative/test-infra.git exported-scripts`;
* all bash scripts were updated to use the shared scripts from test-infra;