### PR TITLE
Switch to default namespace when deploying Knative Serving

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -62,6 +62,7 @@ gcloud --project=${PROJECT_ID} container clusters create \
 header "Setting cluster admin"
 acquire_cluster_admin_role ${PROJECT_USER} ${K8S_CLUSTER_NAME} ${K8S_CLUSTER_ZONE}
 
+kubectl config set-context $(kubectl config current-context) --namespace=default
 start_latest_knative_serving
 
 header "Knative Serving deployed successfully to ${K8S_CLUSTER_NAME}"


### PR DESCRIPTION
For security, Prow jobs default to `test-pods` namespace.