### PR TITLE
Mention how to authenticate to gcr.io KO_DOCKER_REPO

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,9 +65,13 @@ export K8S_CLUSTER_OVERRIDE='my-k8s-cluster-name'
 export K8S_USER_OVERRIDE='my-k8s-user'
 ```
 
-(Make sure to configure [authentication](
+Make sure to configure [authentication](
 https://cloud.google.com/container-registry/docs/advanced-authentication#standalone_docker_credential_helper)
-for your `KO_DOCKER_REPO` if required.)
+for your `KO_DOCKER_REPO` if required. To be able to push images to `gcr.io/<project>`, you need to run this once:
+
+```shell
+gcloud auth configure-docker
+```
 
 For `K8S_CLUSTER_OVERRIDE`, we expect that this name matches a cluster with authentication configured
 with `kubectl`.  You can list the clusters you currently have configured via:


### PR DESCRIPTION
There's a shell command for setting up authentication to gcr.io based KO_DOCKER_REPO:
```sh
gcloud auth configure-docker
```
I've found it in google/go-containerregistry#233

Without it, `ko apply -f config/` failed with the following (not very helpful) error:
```
2018/08/07 12:28:08 error processing import paths in "config/webhook.yaml": Get https://gcr.io/v2/token?scope=repository%3Adistroless%2Fbase%3Apull&service=gcr.io: exit status 1
```

Fixes the above ^^

## Proposed Changes

  * Edit DEVELOPMENT.md 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
