### PR TITLE
Backoff retries in the activator.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -98,7 +98,7 @@ func main() {
 	// a small delay for k8s to include the ready IP in service.
 	// https://github.com/knative/serving/issues/660#issuecomment-384062553
 	shouldRetry := activatorutil.RetryStatus(http.StatusServiceUnavailable)
-	retryer := activatorutil.NewExponentialRetryer(minRetryInterval, exponentialBackoffBase, maxRetries)
+	retryer := activatorutil.NewRetryer(activatorutil.NewExponentialIntervalFunc(minRetryInterval, exponentialBackoffBase), maxRetries)
 
 	rt := activatorutil.NewRetryRoundTripper(activatorutil.AutoTransport, logger, retryer, shouldRetry)
 

--- a/pkg/activator/util/retryer.go
+++ b/pkg/activator/util/retryer.go
@@ -18,18 +18,31 @@ import (
 	"time"
 )
 
-type Retryer interface {
-	Retry(func() bool) int
-}
-
-type ActionFunc func() bool
+// RetryerFunc is a function that wraps an action to be
+// retried.
 type RetryerFunc func(ActionFunc) int
+
+// ActionFunc is a function that is retried by a `Retryer`.
+// Returns true iff succeeded, false if not.
+type ActionFunc func() bool
+
+// IntervalFunc is a function that calculates an interval
+// given the number of retries that already happened.
 type IntervalFunc func(int) time.Duration
 
-func (r RetryerFunc) Retry(f func() bool) int {
+// Retryer is an entity that can retry a given `ActionFunc`.
+type Retryer interface {
+	Retry(ActionFunc) int
+}
+
+// Retry invokes 1 retry on `f`
+func (r RetryerFunc) Retry(f ActionFunc) int {
 	return r(f)
 }
 
+// NewRetryer creates a function where `action` will be retried
+// at most `maxRetries` times, with an interval calculated in
+// between retries by the `intervalFunc`
 func NewRetryer(intervalFunc IntervalFunc, maxRetries int) Retryer {
 	return RetryerFunc(func(action ActionFunc) (retries int) {
 		for retries = 1; !action() && retries < maxRetries; retries++ {
@@ -39,28 +52,21 @@ func NewRetryer(intervalFunc IntervalFunc, maxRetries int) Retryer {
 	})
 }
 
+// NewLinearIntervalFunc creates a function always returning
+// a static value `interval`
 func NewLinearIntervalFunc(interval time.Duration) IntervalFunc {
 	return func(_ int) time.Duration {
 		return interval
 	}
 }
 
+// NewExponentialIntervalFunc creates a function returning a
+// `time.Duration`, that represents the time to wait in between
+// two retries, calculated as `minInterval * (base ^ retries)`
 func NewExponentialIntervalFunc(minInterval time.Duration, base float64) IntervalFunc {
 	return func(retries int) time.Duration {
 		retryIntervalMs := float64(minInterval / time.Millisecond)
 		multiplicator := math.Pow(base, float64(retries))
 		return time.Duration(int(retryIntervalMs*multiplicator)) * time.Millisecond
 	}
-}
-
-// NewLinearRetryer will return a retryer that retries `action` up to
-// `maxRetries` times with `interval` delay between retries
-func NewLinearRetryer(interval time.Duration, maxRetries int) Retryer {
-	return NewRetryer(NewLinearIntervalFunc(interval), maxRetries)
-}
-
-// NewExponentialRetryer will return a retryer that retries `action` up to
-// `maxRetries` times with an interval calculated as `minInterval * (base ^ retries)`
-func NewExponentialRetryer(minInterval time.Duration, base float64, maxRetries int) Retryer {
-	return NewRetryer(NewExponentialIntervalFunc(minInterval, base), maxRetries)
 }


### PR DESCRIPTION
Fixes #1229

## Proposed Changes

Added an exponential backoff to the activator's retry logic. In the process, I lowered the timeout to start with (we might need to adjust that a bit to hit a sweet spot) and the total time to retry is now bounded by the elapsed time spent in retrying + requesting.

To determine a good retry interval, the following table can help. Production data on how many retries were needed in reality will help to adjust though.

![image](https://user-images.githubusercontent.com/1289147/43839904-9296d2d2-9b1f-11e8-92d2-6ffe9821b221.png)

Regarding tests: Didn't find any for this specific file. I'd love to add some but will need some guidance on how to do so if necessary.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Added an exponential backoff to the activator's retry logic
```
