### PR TITLE
Split e2e test flags into common and serving

### DIFF
--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -165,7 +165,7 @@ in the state you want it to be in (or timeout) use `WaitForEndpointState`:
 err = test.WaitForEndpointState(
 		clients.Kube,
 		logger,
-		test.Flags.ResolvableDomain,
+		test.ServingFlags.ResolvableDomain,
 		updatedRoute.Status.Domain,
 		test.EventuallyMatchesBody(expectedText),
 		"SomeDescription")

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -51,7 +51,7 @@ const (
 // Probe until we get a successful response. This ensures the domain is
 // routable before we send it a bunch of traffic.
 func probeDomain(logger *zap.SugaredLogger, clients *test.Clients, domain string) error {
-	client, err := spoof.New(clients.Kube, logger, domain, test.Flags.ResolvableDomain)
+	client, err := spoof.New(clients.Kube, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func checkResponses(logger *zap.SugaredLogger, num int, min int, domain string, 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
 func checkDistribution(logger *zap.SugaredLogger, clients *test.Clients, domain string, num, min int, expectedResponses []string) error {
-	client, err := spoof.New(clients.Kube, logger, domain, test.Flags.ResolvableDomain)
+	client, err := spoof.New(clients.Kube, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -115,7 +115,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	logger.Info("httpproxy is ready.")
 
 	// Send request to httpproxy to trigger the http call from httpproxy Pod to internal service of helloworld app.
-	response, err := sendRequest(test.Flags.ResolvableDomain, httpProxyRoute.Status.Domain)
+	response, err := sendRequest(test.ServingFlags.ResolvableDomain, httpProxyRoute.Status.Domain)
 	if err != nil {
 		t.Fatalf("Failed to send request to httpproxy: %v", err)
 	}

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -26,21 +26,29 @@ import (
 	"path"
 )
 
-// Flags holds the command line flags or defaults for settings in the user's environment.
+// Flags holds the command line flags or defaults for common knative settings in the user's environment.
 // See EnvironmentFlags for a list of supported fields.
-var Flags = initializeFlags()
+var Flags = initializeCommonFlags()
 
-type EnvironmentFlags struct {
-	Cluster          string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
-	DockerRepo       string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
-	Kubeconfig       string // Path to kubeconfig (defaults to ./kube/config)
-	Namespace        string // K8s namespace (blank by default, to be overwritten by test suite)
-	ResolvableDomain bool   // Resolve Route controller's `domainSuffix`
-	LogVerbose       bool   // Enable verbose logging
-	EmitMetrics      bool   // Emit metrics
+// ServingFlags holds the flags or defaults for knative/serving settings in the user's environment.
+var ServingFlags = initializeServingFlags()
+
+// ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
+type ServingEnvironmentFlags struct {
+	ResolvableDomain bool // Resolve Route controller's `domainSuffix`
 }
 
-func initializeFlags() *EnvironmentFlags {
+// EnvironmentFlags holds e2e flags common to knative repos
+type EnvironmentFlags struct {
+	Cluster     string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
+	DockerRepo  string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
+	Kubeconfig  string // Path to kubeconfig (defaults to ./kube/config)
+	Namespace   string // K8s namespace (blank by default, to be overwritten by test suite)
+	LogVerbose  bool   // Enable verbose logging
+	EmitMetrics bool   // Emit metrics
+}
+
+func initializeCommonFlags() *EnvironmentFlags {
 	var f EnvironmentFlags
 	defaultCluster := os.Getenv("K8S_CLUSTER_OVERRIDE")
 	flag.StringVar(&f.Cluster, "cluster", defaultCluster,
@@ -59,9 +67,6 @@ func initializeFlags() *EnvironmentFlags {
 	flag.StringVar(&f.Namespace, "namespace", "",
 		"Provide the namespace you would like to use for these tests.")
 
-	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
-		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
-
 	flag.BoolVar(&f.LogVerbose, "logverbose", false,
 		"Set this flag to true if you would like to see verbose logging.")
 
@@ -75,5 +80,14 @@ func initializeFlags() *EnvironmentFlags {
 	if f.EmitMetrics {
 		initializeMetricExporter()
 	}
+	return &f
+}
+
+func initializeServingFlags() *ServingEnvironmentFlags {
+	var f ServingEnvironmentFlags
+
+	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
+		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
+
 	return &f
 }

--- a/test/request.go
+++ b/test/request.go
@@ -86,7 +86,7 @@ func WaitForEndpointState(kubeClientset *kubernetes.Clientset, logger *zap.Sugar
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	client, err := spoof.New(kubeClientset, logger, domain, Flags.ResolvableDomain)
+	client, err := spoof.New(kubeClientset, logger, domain, ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Part of https://github.com/knative/pkg/issues/26

This splits the e2e flags needed into common and serving related flags. The common ones will be moved to knative/pkg in a later PR and will be referenced from there.