### PR TITLE
Add domain, ready to routes CRD

### DIFF
--- a/config/300-route.yaml
+++ b/config/300-route.yaml
@@ -30,3 +30,13 @@ spec:
     shortNames:
     - rt
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: Domain
+    type: string
+    JSONPath: .status.domain
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"


### PR DESCRIPTION
In order to improve kubectl UX add custom columns to get output

Related-to: #1138

## Proposed Changes

  * Add domain and age as custom columns to routes

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Add custom columns to routes CRD
```
