### PR TITLE
Add custom columns to revision CRD

### DIFF
--- a/config/300-revision.yaml
+++ b/config/300-revision.yaml
@@ -28,3 +28,13 @@ spec:
     - knative
     - serving
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: Service Name
+    type: string
+    JSONPath: .status.serviceName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"


### PR DESCRIPTION
In order to improve kubectl UX add custom columns to get output for
revisions

Related-to: #1138

## Proposed Changes

  * Add serving state column to revision CRD

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Add serving state column to revision CRD
```
