### PR TITLE
Fix e2e/conformance tests on minikube

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -115,6 +115,13 @@ To run the script for all end to end test images:
 ```bash
 ./test/upload-test-images.sh
 ```
+A docker tag may be passed as an optional parameter. This can be
+useful on [Minikube] in tandem with the `--tag` [flag](#using-a-docker-tag):
+
+```bash
+eval $(minikube docker-env)
+./test/upload-test-images.sh any-old-tag
+```
 
 ### Adding new test images
 
@@ -131,6 +138,7 @@ Tests importing [`github.com/knative/serving/test`](adding_tests.md#test-library
 * [`--cluster`](#specifying-cluster)
 * [`--namespace`](#specifying-namespace)
 * [`--dockerrepo`](#overriding-docker-repo)
+* [`--tag`](#using-a-docker-tag)
 * [`--resolvabledomain`](#using-a-resolvable-domain)
 * [`--logverbose`](#output-verbose-logs)
 * [`--emitmetrics`](#emit-metrics)
@@ -189,6 +197,22 @@ go test -v -tags=e2e -count=1 ./test/conformance --dockerrepo gcr.myhappyproject
 go test -v -tags=e2e -count=1 ./test/e2e --dockerrepo gcr.myhappyproject
 ```
 
+### Using a docker tag
+
+The default docker tag used for the test images is `latest`, which can
+be problematic on [Minikube]. To avoid having to configure a remote
+container registry to support the `Always` pull policy for `latest`
+tags, you can have the tests use a specific tag:
+
+```bash
+go test -v -tags=e2e -count=1 ./test/conformance --tag any-old-tag
+go test -v -tags=e2e -count=1 ./test/e2e --tag any-old-tag
+```
+
+Of course, this implies that you tagged the images when you [uploaded
+them](#building-the-test-images).
+
+
 ### Using a resolvable domain
 
 If you set up your cluster using [the getting started
@@ -219,3 +243,5 @@ the tests.
 
 * To add additional metrics to a test, see [emitting metrics](adding_tests.md#emit-metrics).
 * For more info on the format of the metrics, see [metric format](adding_tests.md#metric-format).
+
+[Minikube]: https://kubernetes.io/docs/setup/minikube/

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -169,8 +169,8 @@ func TestBlueGreenRoute(t *testing.T) {
 	logger := logging.GetContextLogger("TestBlueGreenRoute")
 
 	var imagePaths []string
-	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))
-	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image2}, "/"))
+	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image1, test.Flags.Tag))
+	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image2, test.Flags.Tag))
 
 	var names, blue, green test.ResourceNames
 	names.Config = test.AppendRandomString("prod", logger)

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -169,8 +169,8 @@ func TestBlueGreenRoute(t *testing.T) {
 	logger := logging.GetContextLogger("TestBlueGreenRoute")
 
 	var imagePaths []string
-	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image1, test.Flags.Tag))
-	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image2, test.Flags.Tag))
+	imagePaths = append(imagePaths, test.ImagePath(image1))
+	imagePaths = append(imagePaths, test.ImagePath(image2))
 
 	var names, blue, green test.ResourceNames
 	names.Config = test.AppendRandomString("prod", logger)

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package conformance
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -163,8 +162,8 @@ func TestRouteCreation(t *testing.T) {
 	logger := logging.GetContextLogger("TestRouteCreation")
 
 	var imagePaths []string
-	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image1, test.Flags.Tag))
-	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image2, test.Flags.Tag))
+	imagePaths = append(imagePaths, test.ImagePath(image1))
+	imagePaths = append(imagePaths, test.ImagePath(image2))
 
 	var names test.ResourceNames
 	names.Config = test.AppendRandomString("prod", logger)

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -19,8 +19,8 @@ limitations under the License.
 package conformance
 
 import (
+	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"encoding/json"
@@ -36,9 +36,8 @@ import (
 )
 
 const (
-	image1               = "pizzaplanetv1"
-	image2               = "pizzaplanetv2"
-	defaultNamespaceName = "serving-tests"
+	image1 = "pizzaplanetv1"
+	image2 = "pizzaplanetv2"
 )
 
 func createRouteAndConfig(logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, imagePaths []string) error {
@@ -144,10 +143,6 @@ func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, er
 }
 
 func setup(t *testing.T) *test.Clients {
-	if test.Flags.Namespace == "" {
-		test.Flags.Namespace = defaultNamespaceName
-	}
-
 	clients, err := test.NewClients(test.Flags.Kubeconfig, test.Flags.Cluster, test.Flags.Namespace)
 	if err != nil {
 		t.Fatalf("Couldn't initialize clients: %v", err)
@@ -168,8 +163,8 @@ func TestRouteCreation(t *testing.T) {
 	logger := logging.GetContextLogger("TestRouteCreation")
 
 	var imagePaths []string
-	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))
-	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image2}, "/"))
+	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image1, test.Flags.Tag))
+	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image2, test.Flags.Tag))
 
 	var names test.ResourceNames
 	names.Config = test.AppendRandomString("prod", logger)

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -20,7 +20,6 @@ package conformance
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -127,8 +126,8 @@ func TestRunLatestService(t *testing.T) {
 	logger := logging.GetContextLogger("TestRunLatestService")
 
 	var imagePaths []string
-	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image1, test.Flags.Tag))
-	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image2, test.Flags.Tag))
+	imagePaths = append(imagePaths, test.ImagePath(image1))
+	imagePaths = append(imagePaths, test.ImagePath(image2))
 
 	var names test.ResourceNames
 	names.Service = test.AppendRandomString("pizzaplanet-service", logger)

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -20,8 +20,8 @@ package conformance
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/knative/pkg/test/logging"
@@ -127,8 +127,8 @@ func TestRunLatestService(t *testing.T) {
 	logger := logging.GetContextLogger("TestRunLatestService")
 
 	var imagePaths []string
-	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image1}, "/"))
-	imagePaths = append(imagePaths, strings.Join([]string{test.Flags.DockerRepo, image2}, "/"))
+	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image1, test.Flags.Tag))
+	imagePaths = append(imagePaths, fmt.Sprintf("%s/%s:%s", test.Flags.DockerRepo, image2, test.Flags.Tag))
 
 	var names test.ResourceNames
 	names.Service = test.AppendRandomString("pizzaplanet-service", logger)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -134,7 +134,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	logger := logging.GetContextLogger("TestAutoscaleUpDownUp")
 
 	clients := setup(t, logger)
-	imagePath := fmt.Sprintf("%s/autoscale:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	imagePath := test.ImagePath("autoscale")
 
 	logger.Infof("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, imagePath)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -21,7 +21,6 @@ package e2e
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/knative/pkg/test/logging"
@@ -135,11 +134,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	logger := logging.GetContextLogger("TestAutoscaleUpDownUp")
 
 	clients := setup(t, logger)
-	imagePath := strings.Join(
-		[]string{
-			test.Flags.DockerRepo,
-			"autoscale"},
-		"/")
+	imagePath := fmt.Sprintf("%s/autoscale:%s", test.Flags.DockerRepo, test.Flags.Tag)
 
 	logger.Infof("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, imagePath)

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -18,8 +18,8 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -36,7 +36,7 @@ func TestBuildAndServe(t *testing.T) {
 	// Add test case specific name to its own logger.
 	logger := logging.GetContextLogger("TestBuildAndServe")
 
-	imagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
+	imagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
 
 	logger.Infof("Creating a new Route and Configuration with build")
 	names := test.ResourceNames{
@@ -120,7 +120,7 @@ func TestBuildFailure(t *testing.T) {
 		}},
 	}
 
-	imagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
+	imagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
 	config, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.Flags.Namespace, names, build, imagePath))
 	if err != nil {
 		t.Fatalf("Failed to create Configuration with failing build: %v", err)

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestBuildAndServe(t *testing.T) {
 	// Add test case specific name to its own logger.
 	logger := logging.GetContextLogger("TestBuildAndServe")
 
-	imagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	imagePath := test.ImagePath("helloworld")
 
 	logger.Infof("Creating a new Route and Configuration with build")
 	names := test.ResourceNames{
@@ -120,7 +119,7 @@ func TestBuildFailure(t *testing.T) {
 		}},
 	}
 
-	imagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	imagePath := test.ImagePath("helloworld")
 	config, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.Flags.Namespace, names, build, imagePath))
 	if err != nil {
 		t.Fatalf("Failed to create Configuration with failing build: %v", err)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -14,17 +14,12 @@ import (
 )
 
 const (
-	configName           = "prod"
-	routeName            = "noodleburg"
-	defaultNamespaceName = "serving-tests"
+	configName = "prod"
+	routeName  = "noodleburg"
 )
 
 // Setup creates the client objects needed in the e2e tests.
 func Setup(t *testing.T) *test.Clients {
-	if test.Flags.Namespace == "" {
-		test.Flags.Namespace = defaultNamespaceName
-	}
-
 	clients, err := test.NewClients(
 		test.Flags.Kubeconfig,
 		test.Flags.Cluster,

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -51,7 +51,7 @@ func TestContainerErrorMsg(t *testing.T) {
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
-	imagePath := strings.Join([]string{test.Flags.DockerRepo, "invalidhelloworld"}, "/")
+	imagePath := test.ImagePath("invalidhelloworld")
 
 	logger.Infof("Creating a new Route and Configuration %s", imagePath)
 	names, err := CreateRouteAndConfig(clients, logger, imagePath)

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -41,7 +41,9 @@ const (
 // for the container image missing scenario.
 
 func TestContainerErrorMsg(t *testing.T) {
-	//t.Skip("Skipping until https://github.com/knative/serving/issues/1240 is closed")
+	if strings.HasSuffix(strings.Split(test.Flags.DockerRepo, "/")[0], ".local") {
+		t.Skip("Skipping for local docker repo")
+	}
 	clients := Setup(t)
 
 	//add test case specific name to its own logger

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -56,7 +57,7 @@ func TestHelloWorldFromShell(t *testing.T) {
 	//add test case specific name to its own logger
 	logger := logging.GetContextLogger("TestHelloWorldFromShell")
 
-	imagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
+	imagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
 
 	logger.Infof("Creating manifest")
 

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -20,7 +20,6 @@ package e2e
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -57,7 +56,7 @@ func TestHelloWorldFromShell(t *testing.T) {
 	//add test case specific name to its own logger
 	logger := logging.GetContextLogger("TestHelloWorldFromShell")
 
-	imagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	imagePath := test.ImagePath("helloworld")
 
 	logger.Infof("Creating manifest")
 

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -19,8 +19,8 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/knative/pkg/test/logging"
@@ -39,7 +39,7 @@ func TestHelloWorld(t *testing.T) {
 	logger := logging.GetContextLogger("TestHelloWorld")
 
 	var imagePath string
-	imagePath = strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
+	imagePath = fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
 
 	logger.Infof("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, imagePath)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -39,7 +38,7 @@ func TestHelloWorld(t *testing.T) {
 	logger := logging.GetContextLogger("TestHelloWorld")
 
 	var imagePath string
-	imagePath = fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	imagePath = test.ImagePath("helloworld")
 
 	logger.Infof("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, imagePath)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -79,7 +79,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	clients = Setup(t)
 
 	// Set up helloworld app.
-	helloWorldImagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	helloWorldImagePath := test.ImagePath("helloworld")
 	logger.Infof("Creating a Route and Configuration for helloworld test app.")
 	helloWorldNames, err := CreateRouteAndConfig(clients, logger, helloWorldImagePath)
 	if err != nil {
@@ -92,7 +92,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	}
 
 	// Set up httpproxy app.
-	httpProxyImagePath := fmt.Sprintf("%s/httpproxy:%s", test.Flags.DockerRepo, test.Flags.Tag)
+	httpProxyImagePath := test.ImagePath("httpproxy")
 
 	logger.Infof("Creating a Route and Configuration for httpproxy test app.")
 	envVars := createTargetHostEnvVars(helloWorldNames.Route, t)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -79,7 +79,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	clients = Setup(t)
 
 	// Set up helloworld app.
-	helloWorldImagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
+	helloWorldImagePath := fmt.Sprintf("%s/helloworld:%s", test.Flags.DockerRepo, test.Flags.Tag)
 	logger.Infof("Creating a Route and Configuration for helloworld test app.")
 	helloWorldNames, err := CreateRouteAndConfig(clients, logger, helloWorldImagePath)
 	if err != nil {
@@ -92,7 +92,8 @@ func TestServiceToServiceCall(t *testing.T) {
 	}
 
 	// Set up httpproxy app.
-	httpProxyImagePath := strings.Join([]string{test.Flags.DockerRepo, "httpproxy"}, "/")
+	httpProxyImagePath := fmt.Sprintf("%s/httpproxy:%s", test.Flags.DockerRepo, test.Flags.Tag)
+
 	logger.Infof("Creating a Route and Configuration for httpproxy test app.")
 	envVars := createTargetHostEnvVars(helloWorldNames.Route, t)
 	httpProxyNames, err := CreateRouteAndConfigWithEnv(clients, logger, httpProxyImagePath, envVars)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -45,6 +45,7 @@ type ServingEnvironmentFlags struct {
 type EnvironmentFlags struct {
 	Cluster     string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
 	DockerRepo  string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
+	Tag         string // Test images version tag
 	Kubeconfig  string // Path to kubeconfig (defaults to ./kube/config)
 	Namespace   string // K8s namespace (blank by default, to be overwritten by test suite)
 	LogVerbose  bool   // Enable verbose logging
@@ -71,8 +72,11 @@ func initializeCommonFlags() *EnvironmentFlags {
 	flag.StringVar(&f.Kubeconfig, "kubeconfig", defaultKubeconfig,
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")
 
-	flag.StringVar(&f.Namespace, "namespace", "",
+	flag.StringVar(&f.Namespace, "namespace", "serving-tests",
 		"Provide the namespace you would like to use for these tests.")
+
+	flag.StringVar(&f.Tag, "tag", "latest",
+		"Provide the version tag for the test images.")
 
 	flag.BoolVar(&f.LogVerbose, "logverbose", false,
 		"Set this flag to true if you would like to see verbose logging.")

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -20,7 +20,15 @@ set -o errexit
 
 export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 IMAGE_DIRS="$(find $(dirname $0)/test_images -mindepth 1 -maxdepth 1 -type d)"
+DOCKER_TAG=$1
 
 for image_dir in ${IMAGE_DIRS}; do
-  ko publish -P "github.com/knative/serving/test/test_images/$(basename ${image_dir})"
+  IMAGE="github.com/knative/serving/test/test_images/$(basename ${image_dir})"
+  ko publish -P $IMAGE
+  if [ -n "$DOCKER_TAG" ]; then
+    IMAGE=$KO_DOCKER_REPO/$IMAGE
+    DIGEST=$(docker images | grep $IMAGE | head -1 | awk '{print $2}')
+    echo "Tagging $IMAGE:$DIGEST with $DOCKER_TAG"
+    docker tag $IMAGE:$DIGEST $IMAGE:$DOCKER_TAG
+  fi
 done

--- a/test/util.go
+++ b/test/util.go
@@ -10,11 +10,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- // util.go provides shared utilities methods across knative serving test
- package test
- import (
+// util.go provides shared utilities methods across knative serving test
+package test
+
+import (
 	"encoding/json"
- 	"github.com/knative/pkg/test/logging"
+	"fmt"
+
+	"github.com/knative/pkg/test/logging"
 )
 
 // LogResourceObject logs the resource object with the resource name and value
@@ -25,4 +28,9 @@ func LogResourceObject(logger *logging.BaseLogger, value ResourceObjects) {
 	} else {
 		logger.Infof("resource %s", string(resourceJSON))
 	}
+}
+
+// Helper function to prefix image name with repo and suffix with tag
+func ImagePath(name string) string {
+	return fmt.Sprintf("%s/%s:%s", Flags.DockerRepo, name, Flags.Tag)
 }


### PR DESCRIPTION
Fixes #609 

## Proposed Changes

  * Provide the ability to specify a docker tag for the test images
  * Document how to configure support for `LoadBalancer` type Services in Minikube
 
That support amounts to two commands:
```
sudo ip route add $(cat ~/.minikube/profiles/minikube/config.json | jq -r ".KubernetesConfig.ServiceCIDR") via $(minikube ip)
kubectl run minikube-lb-patch --replicas=1 --image=elsonrodriguez/minikube-lb-patch:0.1 --namespace=kube-system

```
As odious as those might be, I would argue that they simplify the knative-on-minikube user experience considerably:

- no special `s/LoadBalancer/NodePort/` install instructions
- no special minikube-only way of obtaining the `$SERVICE_IP` in the samples, including those from 3rd parties porting their platform to knative
- no need to configure a docker registry in minikube
- and most importantly... all the tests pass.

And since minikube considers its lack of `LoadBalancer` support to be a [bug](https://github.com/kubernetes/minikube/issues/2834) anyway, it's hopefully only a temporary hack.
