### PR TITLE
Use `false` instead of `exit 1` for failing build

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -115,7 +115,7 @@ func TestBuildFailure(t *testing.T) {
 	build := &buildv1alpha1.BuildSpec{
 		Steps: []v1.Container{{
 			Image: "ubuntu",
-			Args:  []string{"exit", "1"}, // build will fail.
+			Args:  []string{"false"}, // build will fail.
 		}},
 	}
 


### PR DESCRIPTION
Fixes #1848

This changes the failure mode from:

```yaml
exitCode: 127
reason: ContainerCannotRun
```

to:

```yaml
exitCode: 1
reason: Error
```