### PR TITLE
Rename the monitoring namespace to knative-monitoring (#1774)

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -56,7 +56,7 @@ data:
       @log_level info
       include_tag_key true
       # Elasticsearch service is in monitoring namespace.
-      host elasticsearch-logging.monitoring
+      host elasticsearch-logging.knative-monitoring
       port 9200
       logstash_format true
       <buffer>
@@ -78,4 +78,4 @@ data:
   # revision uid. For the url to work you'll need to set up monitoring and have access to
   # the kibana dashboard using `kubectl proxy`.
   logging.revision-url-template: |
-    http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+    http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))

--- a/config/monitoring/100-common/100-namespace.yaml
+++ b/config/monitoring/100-common/100-namespace.yaml
@@ -15,4 +15,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: monitoring
+  name: knative-monitoring

--- a/config/monitoring/150-elasticsearch/100-fluentd-configmap.yaml
+++ b/config/monitoring/150-elasticsearch/100-fluentd-configmap.yaml
@@ -16,7 +16,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: fluentd-ds-config
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:

--- a/config/monitoring/150-elasticsearch/100-scaling-configmap.yaml
+++ b/config/monitoring/150-elasticsearch/100-scaling-configmap.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scaling-config
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   scaling-dashboard.json: |+
       {  

--- a/config/monitoring/150-stackdriver/fluentd-configmap.yaml
+++ b/config/monitoring/150-stackdriver/fluentd-configmap.yaml
@@ -16,7 +16,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: fluentd-ds-config
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:

--- a/config/monitoring/200-common/100-fluentd.yaml
+++ b/config/monitoring/200-common/100-fluentd.yaml
@@ -19,7 +19,7 @@ metadata:
   # Any changes to this name should ensure to fix it in
   # all places where this name is referred.
   name: fluentd-ds
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: fluentd-ds
 spec:

--- a/config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml
+++ b/config/monitoring/200-common/100-grafana-dash-knative-efficiency.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-knative-efficiency
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   knative-control-plane-efficiency-dashboard.json: |+
     {
@@ -121,11 +121,11 @@ data:
               "refId": "E"
             },
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"monitoring\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"knative-monitoring\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
-              "legendFormat": "monitoring",
+              "legendFormat": "knative-monitoring",
               "refId": "B"
             }
           ],
@@ -246,11 +246,11 @@ data:
               "refId": "E"
             },
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"monitoring\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"knative-monitoring\"})",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
-              "legendFormat": "monitoring",
+              "legendFormat": "knative-monitoring",
               "refId": "B"
             }
           ],
@@ -330,7 +330,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace!~\"knative-serving|monitoring|knative-build|istio-system|kube-system|kube-public|^$\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace!~\"knative-serving|knative-monitoring|knative-build|istio-system|kube-system|kube-public|^$\"}[1m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -338,7 +338,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"knative-serving|monitoring|knative-build|istio-system|kube-system|kube-public\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"knative-serving|knative-monitoring|knative-build|istio-system|kube-system|kube-public\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Control plane",
@@ -421,7 +421,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace!~\"knative-serving|monitoring|knative-build|istio-system|kube-system|kube-public|^$\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace!~\"knative-serving|knative-monitoring|knative-build|istio-system|kube-system|kube-public|^$\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -429,7 +429,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=~\"knative-serving|monitoring|knative-build|istio-system|kube-system|kube-public\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace=~\"knative-serving|knative-monitoring|knative-build|istio-system|kube-system|kube-public\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Control plane",

--- a/config/monitoring/200-common/100-grafana-dash-knative.yaml
+++ b/config/monitoring/200-common/100-grafana-dash-knative.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-knative
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   revision-dashboard.json: |+
     {

--- a/config/monitoring/200-common/100-grafana.yaml
+++ b/config/monitoring/200-common/100-grafana.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-datasources
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   prometheus.yaml: |+
     datasources:
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboards
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   dashboards.yaml: |+
     - name: 'knative'
@@ -130,7 +130,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: grafana
 spec:
@@ -146,7 +146,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   replicas: 1
   template:

--- a/config/monitoring/200-common/100-istio.yaml
+++ b/config/monitoring/200-common/100-istio.yaml
@@ -46,7 +46,7 @@ metadata:
   name: requestloghandler
   namespace: istio-system
 spec:
-  address: "fluentd-ds.monitoring:24224"
+  address: "fluentd-ds.knative-monitoring:24224"
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule

--- a/config/monitoring/200-common/100-zipkin.yaml
+++ b/config/monitoring/200-common/100-zipkin.yaml
@@ -55,9 +55,9 @@ spec:
         - name: STORAGE_TYPE
           value: elasticsearch
         - name: ES_HOSTS
-          value: elasticsearch-logging.monitoring.svc.cluster.local:9200
+          value: elasticsearch-logging.knative-monitoring.svc.cluster.local:9200
         - name: ES_INDEX
           value: zipkin
         - name: ZIPKIN_UI_LOGS_URL
-          value: http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana#/
+          value: http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/
 ---

--- a/config/monitoring/200-common/200-prometheus-exporter/kube-controller-metrics.yaml
+++ b/config/monitoring/200-common/200-prometheus-exporter/kube-controller-metrics.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: monitoring
+  namespace: knative-monitoring
   name: kube-controller-manager
   labels:
     app: kube-controller-manager

--- a/config/monitoring/200-common/200-prometheus-exporter/prometheus.yaml
+++ b/config/monitoring/200-common/200-prometheus-exporter/prometheus.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-system-discovery
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: prometheus
 spec:

--- a/config/monitoring/200-common/300-prometheus/100-scrape-config.yaml
+++ b/config/monitoring/200-common/300-prometheus/100-scrape-config.yaml
@@ -18,7 +18,7 @@ metadata:
   name: prometheus-scrape-config
   labels:
     name: prometheus-scrape-config
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   prometheus.yml: |-
     global:
@@ -91,7 +91,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: monitoring;fluentd-ds;prometheus-metrics
+        regex: knative-monitoring;fluentd-ds;prometheus-metrics
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
@@ -278,7 +278,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: monitoring;kube-controller-manager;http-metrics
+        regex: knative-monitoring;kube-controller-manager;http-metrics
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
@@ -333,7 +333,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: monitoring;kube-state-metrics;https-main
+        regex: knative-monitoring;kube-state-metrics;https-main
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
@@ -362,7 +362,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: monitoring;kube-state-metrics;https-self
+        regex: knative-monitoring;kube-state-metrics;https-self
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
@@ -440,7 +440,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: monitoring;node-exporter;https
+        regex: knative-monitoring;node-exporter;https
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
@@ -465,7 +465,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: monitoring;prometheus;web
+        regex: knative-monitoring;prometheus;web
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/config/monitoring/200-common/300-prometheus/200-prometheus.yaml
+++ b/config/monitoring/200-common/300-prometheus/200-prometheus.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -40,7 +40,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 rules:
 - apiGroups: [""]
   resources:
@@ -90,7 +90,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 rules:
 - apiGroups: [""]
   resources:
@@ -120,13 +120,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -134,7 +134,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -148,7 +148,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -162,7 +162,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -175,13 +175,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-system-np
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   type: NodePort
   selector:
@@ -194,7 +194,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: prometheus-system
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   replicas: 2
   podManagementPolicy: Parallel

--- a/docs/debugging/application-debugging-guide.md
+++ b/docs/debugging/application-debugging-guide.md
@@ -25,7 +25,7 @@ ERROR: Non-zero return code '1' from command: Process exited with status 1
 ## Check application logs
 Knative Serving provides default out-of-the-box logs for your application. After entering
 `kubectl proxy`, you can go to the
-[Kibana UI](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana)
+[Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana)
 to search for logs. _(See [telemetry guide](../telemetry.md) for more information
 on logging and monitoring features of Knative Serving.)_
 
@@ -166,7 +166,7 @@ kubectl get build $(kubectl get revision <revision-name> -o jsonpath="{.spec.bui
 ```
 
 The `conditions` in `status` provide the reason if there is any failure. To
-access build logs, first execute `kubectl proxy` and then open [Kibana UI](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana).
+access build logs, first execute `kubectl proxy` and then open [Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana).
 Use any of the following filters within Kibana UI to
 see build logs. _(See [telemetry guide](../telemetry.md) for more information on
 logging and monitoring features of Knative Serving.)_

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -36,7 +36,7 @@ discovery issues for metrics. To access to the web UI, forward the Prometheus
 server to your machine:
 
 ```shell
-kubectl port-forward -n monitoring $(kubectl get pods -n monitoring --selector=app=prometheus --output=jsonpath="{.items[0].metadata.name}") 9090
+kubectl port-forward -n knative-monitoring $(kubectl get pods -n knative-monitoring --selector=app=prometheus --output=jsonpath="{.items[0].metadata.name}") 9090
 ```
 
 Then browse to http://localhost:9090 to access the UI.

--- a/third_party/config/monitoring/common/istio/istio-dashboard.json
+++ b/third_party/config/monitoring/common/istio/istio-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-istio
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   istio-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/istio/mixer-dashboard.json
+++ b/third_party/config/monitoring/common/istio/mixer-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-mixer
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   mixer-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/istio/pilot-dashboard.json
+++ b/third_party/config/monitoring/common/istio/pilot-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-pilot
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   pilot-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/kubernetes/fluentd/fluentd-ds.yaml
+++ b/third_party/config/monitoring/common/kubernetes/fluentd/fluentd-ds.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fluentd-ds
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
@@ -38,7 +38,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: fluentd-ds
-  namespace: monitoring
+  namespace: knative-monitoring
   apiGroup: ""
 roleRef:
   kind: ClusterRole
@@ -49,7 +49,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-ds
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: fluentd-ds
     version: v2.0.4

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/100-kube-state-metrics-service-account.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/100-kube-state-metrics-service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/200-kube-state-metrics-role.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/200-kube-state-metrics-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: kube-state-metrics-resizer
-  namespace: monitoring
+  namespace: knative-monitoring
 rules:
 - apiGroups: [""]
   resources:

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/201-kube-state-metrics-role-binding.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/201-kube-state-metrics-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/202-kube-state-metrics-cluster-role.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/202-kube-state-metrics-cluster-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring
 rules:
 - apiGroups: [""]
   resources:

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/203-kube-state-metrics-cluster-role-binding.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/203-kube-state-metrics-cluster-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/300-kube-state-metrics-deployment.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/300-kube-state-metrics-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   replicas: 1
   template:

--- a/third_party/config/monitoring/common/kubernetes/kube-state-metrics/300-kube-state-metrics-service.yaml
+++ b/third_party/config/monitoring/common/kubernetes/kube-state-metrics/300-kube-state-metrics-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   clusterIP: None
   ports:

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/deployment-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/deployment-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-deployment
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-deployment-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-capacity-planning-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-capacity-planning-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-capacity-planning
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-capacity-planning-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-cluster-health-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-cluster-health-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-cluster-health
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-cluster-health-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-cluster-status-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-cluster-status-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-cluster-status
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-cluster-status-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-control-plane-status-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-control-plane-status-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-control-plane-status
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-control-plane-status-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-resource-requests-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/kubernetes-resource-requests-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-resource-requests
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-resource-requests-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/nodes-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/nodes-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-nodes
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-nodes-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/pods-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/pods-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-pods
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-pods-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/dashboards/statefulset-dashboard.json
+++ b/third_party/config/monitoring/common/prometheus-operator/dashboards/statefulset-dashboard.json
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-kubernetes-statefulset
-  namespace: monitoring
+  namespace: knative-monitoring
 data:
   kubernetes-statefulset-dashboard.json: |+
     {

--- a/third_party/config/monitoring/common/prometheus-operator/node-exporter/100-node-exporter-service-account.yaml
+++ b/third_party/config/monitoring/common/prometheus-operator/node-exporter/100-node-exporter-service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: node-exporter
-  namespace: monitoring
+  namespace: knative-monitoring

--- a/third_party/config/monitoring/common/prometheus-operator/node-exporter/200-node-exporter-cluster-role.yaml
+++ b/third_party/config/monitoring/common/prometheus-operator/node-exporter/200-node-exporter-cluster-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: node-exporter
-  namespace: monitoring
+  namespace: knative-monitoring
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources:

--- a/third_party/config/monitoring/common/prometheus-operator/node-exporter/201-node-exporter-cluster-role-binding.yaml
+++ b/third_party/config/monitoring/common/prometheus-operator/node-exporter/201-node-exporter-cluster-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: node-exporter
-  namespace: monitoring
+  namespace: knative-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: node-exporter
-  namespace: monitoring
+  namespace: knative-monitoring

--- a/third_party/config/monitoring/common/prometheus-operator/node-exporter/300-node-exporter-daemonset.yaml
+++ b/third_party/config/monitoring/common/prometheus-operator/node-exporter/300-node-exporter-daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: node-exporter
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   updateStrategy:
     rollingUpdate:
@@ -13,7 +13,7 @@ spec:
       labels:
         app: node-exporter
       name: node-exporter
-      namespace: monitoring
+      namespace: knative-monitoring
     spec:
       serviceAccountName: node-exporter
       securityContext:

--- a/third_party/config/monitoring/common/prometheus-operator/node-exporter/301-node-exporter-service.yaml
+++ b/third_party/config/monitoring/common/prometheus-operator/node-exporter/301-node-exporter-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: node-exporter
   name: node-exporter
-  namespace: monitoring
+  namespace: knative-monitoring
 spec:
   type: ClusterIP
   clusterIP: None

--- a/third_party/config/monitoring/elasticsearch/es-service.yaml
+++ b/third_party/config/monitoring/elasticsearch/es-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elasticsearch-logging
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: elasticsearch-logging
     kubernetes.io/cluster-service: "true"

--- a/third_party/config/monitoring/elasticsearch/es-statefulset.yaml
+++ b/third_party/config/monitoring/elasticsearch/es-statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: elasticsearch-logging
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: elasticsearch-logging
     kubernetes.io/cluster-service: "true"
@@ -30,7 +30,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: monitoring
+  namespace: knative-monitoring
   name: elasticsearch-logging
   labels:
     app: elasticsearch-logging
@@ -39,7 +39,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: elasticsearch-logging
-  namespace: monitoring
+  namespace: knative-monitoring
   apiGroup: ""
 roleRef:
   kind: ClusterRole
@@ -51,7 +51,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch-logging
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: elasticsearch-logging
     version: v5.6.4

--- a/third_party/config/monitoring/elasticsearch/kibana-deployment.yaml
+++ b/third_party/config/monitoring/elasticsearch/kibana-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana-logging
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: kibana-logging
     kubernetes.io/cluster-service: "true"
@@ -29,7 +29,7 @@ spec:
           - name: ELASTICSEARCH_URL
             value: http://elasticsearch-logging:9200
           - name: SERVER_BASEPATH
-            value: /api/v1/namespaces/monitoring/services/kibana-logging/proxy
+            value: /api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy
           - name: XPACK_MONITORING_ENABLED
             value: "false"
           - name: XPACK_SECURITY_ENABLED

--- a/third_party/config/monitoring/elasticsearch/kibana-service.yaml
+++ b/third_party/config/monitoring/elasticsearch/kibana-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kibana-logging
-  namespace: monitoring
+  namespace: knative-monitoring
   labels:
     app: kibana-logging
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Fixes #1774

## Proposed Changes

  * Rename the `monitoring` namespace to `knative-monitoring`

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
The 'monitoring' namespace has been renamed to 'knative-monitoring'
```
