### PR TITLE
Create a new DynamicConfig constructor that takes a map.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -101,7 +101,7 @@ func runAutoscaler() {
 	if err != nil {
 		logger.Fatalf("Error reading config-autoscaler: %v", err)
 	}
-	config, err := autoscaler.NewDynamicConfig(rawConfig, logger)
+	config, err := autoscaler.NewDynamicConfigFromMap(rawConfig, logger)
 	if err != nil {
 		logger.Fatalf("Error loading config-autoscaler: %v", err)
 	}

--- a/cmd/multitenant-autoscaler/main.go
+++ b/cmd/multitenant-autoscaler/main.go
@@ -115,7 +115,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error reading autoscaler configuration: %v", err)
 	}
-	dynConfig, err := autoscaler.NewDynamicConfig(rawConfig, logger)
+	dynConfig, err := autoscaler.NewDynamicConfigFromMap(rawConfig, logger)
 	if err != nil {
 		logger.Fatalf("Error parsing autoscaler configuration: %v", err)
 	}

--- a/pkg/autoscaler/dynamic_config.go
+++ b/pkg/autoscaler/dynamic_config.go
@@ -30,15 +30,19 @@ type DynamicConfig struct {
 	logger *zap.SugaredLogger
 }
 
-func NewDynamicConfig(rawConfig map[string]string, logger *zap.SugaredLogger) (*DynamicConfig, error) {
+func NewDynamicConfig(config *Config, logger *zap.SugaredLogger) *DynamicConfig {
+	return &DynamicConfig{
+		logger: logger,
+		config: config.DeepCopy(),
+	}
+}
+
+func NewDynamicConfigFromMap(rawConfig map[string]string, logger *zap.SugaredLogger) (*DynamicConfig, error) {
 	config, err := NewConfigFromMap(rawConfig)
 	if err != nil {
 		return nil, err
 	}
-	return &DynamicConfig{
-		logger: logger,
-		config: config,
-	}, nil
+	return NewDynamicConfig(config, logger), nil
 }
 
 func (dc *DynamicConfig) Current() *Config {

--- a/pkg/autoscaler/dynamic_config_test.go
+++ b/pkg/autoscaler/dynamic_config_test.go
@@ -34,8 +34,8 @@ var configMap = map[string]string{"max-scale-up-rate": "1",
 	"concurrency-quantum-of-time": "7s",
 	"tick-interval":               "8s"}
 
-func TestNewDynamicConfig(t *testing.T) {
-	dc, err := autoscaler.NewDynamicConfig(configMap, zap.NewNop().Sugar())
+func TestNewDynamicConfigFromMap(t *testing.T) {
+	dc, err := autoscaler.NewDynamicConfigFromMap(configMap, zap.NewNop().Sugar())
 	if err != nil {
 		t.Fatalf("Failed to create dynamic configuration: %v", err)
 	}
@@ -45,17 +45,17 @@ func TestNewDynamicConfig(t *testing.T) {
 	}
 }
 
-func TestNewDynamicConfigError(t *testing.T) {
+func TestNewDynamicConfigFromMapError(t *testing.T) {
 	invalidConfigMap := copyConfigMap()
 	invalidConfigMap["stable-window"] = "4"
-	_, err := autoscaler.NewDynamicConfig(invalidConfigMap, zap.NewNop().Sugar())
+	_, err := autoscaler.NewDynamicConfigFromMap(invalidConfigMap, zap.NewNop().Sugar())
 	if err == nil {
 		t.Fatal("Failed to detect configuration error")
 	}
 }
 
 func TestUpdateDynamicConfig(t *testing.T) {
-	dc, err := autoscaler.NewDynamicConfig(configMap, zap.NewNop().Sugar())
+	dc, err := autoscaler.NewDynamicConfigFromMap(configMap, zap.NewNop().Sugar())
 	if err != nil {
 		t.Fatalf("Failed to create dynamic configuration: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestUpdateDynamicConfig(t *testing.T) {
 }
 
 func TestCurrentDynamicConfigIsSnapshot(t *testing.T) {
-	dc, err := autoscaler.NewDynamicConfig(configMap, zap.NewNop().Sugar())
+	dc, err := autoscaler.NewDynamicConfigFromMap(configMap, zap.NewNop().Sugar())
 	if err != nil {
 		t.Fatalf("Failed to create dynamic configuration: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestCurrentDynamicConfigIsSnapshot(t *testing.T) {
 }
 
 func TestCurrentDynamicConfigIsImmutable(t *testing.T) {
-	dc, err := autoscaler.NewDynamicConfig(configMap, zap.NewNop().Sugar())
+	dc, err := autoscaler.NewDynamicConfigFromMap(configMap, zap.NewNop().Sugar())
 	if err != nil {
 		t.Fatalf("Failed to create dynamic configuration: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestCurrentDynamicConfigIsImmutable(t *testing.T) {
 }
 
 func TestUpdateDynamicConfigError(t *testing.T) {
-	dc, err := autoscaler.NewDynamicConfig(configMap, zap.NewNop().Sugar())
+	dc, err := autoscaler.NewDynamicConfigFromMap(configMap, zap.NewNop().Sugar())
 	if err != nil {
 		t.Fatalf("Failed to create dynamic configuration: %v", err)
 	}


### PR DESCRIPTION
Use this constructor instead of synthesizing DynamicConfigs directly.

Consolidate the package tests use to reduce testing boilerplate.