### PR TITLE
Adding serving specific name validation to serving.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -318,7 +318,7 @@
   revision = "e7a708f4562329a7d2bd51eb9f2a3889145a80a7"
 
 [[projects]]
-  digest = "1:7eff6e4a02854116799050b5dc6ac1f857b7d6c220e302a379c7362c81eda2a5"
+  digest = "1:358640ffd7336aa49b208b14a572c184f96009478ff007f70116d92f9794df13"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -343,7 +343,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "bc264c290f777cc51f53644a1996f5e8887dcba6"
+  revision = "a3bc2db77a14d9ca6195172e81b4bf33e6190f85"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@ required = [
 
 [[constraint]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-08-09
-  revision = "bc264c290f777cc51f53644a1996f5e8887dcba6"
+  # HEAD as of 2018-08-14
+  revision = "a3bc2db77a14d9ca6195172e81b4bf33e6190f85"
 
 [[constraint]]
   name = "github.com/google/go-containerregistry"

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -23,6 +23,9 @@ import (
 )
 
 func (c *Configuration) Validate() *apis.FieldError {
+	if err := validateMetadata(c); err != nil {
+		return err.ViaField("metadata")
+	}
 	return c.Spec.Validate().ViaField("spec")
 }
 
@@ -35,5 +38,6 @@ func (cs *ConfigurationSpec) Validate() *apis.FieldError {
 	if cs.RevisionTemplate.Spec.ServingState != "" {
 		return apis.ErrDisallowedFields("revisionTemplate.spec.servingState")
 	}
+
 	return cs.RevisionTemplate.Validate().ViaField("revisionTemplate")
 }

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -23,7 +23,7 @@ import (
 )
 
 func (c *Configuration) Validate() *apis.FieldError {
-	if err := validateMetadata(c); err != nil {
+	if err := validateObjectMetadata(c.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return c.Spec.Validate().ViaField("spec")

--- a/pkg/apis/serving/v1alpha1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/apis"
 )
@@ -119,6 +121,22 @@ func TestConfigurationValidation(t *testing.T) {
 		name: "empty spec",
 		c:    &Configuration{},
 		want: apis.ErrMissingField("spec"),
+	}, {
+		name: "invalid name - dots",
+		c: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "do.not.use.dots",
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: special character . must not be present", Paths: []string{"metadata.name"}},
+	}, {
+		name: "invalid name - too long",
+		c: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("a", 65),
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: length must be no more than 63 characters", Paths: []string{"metadata.name"}},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1alpha1/metadata_validation.go
+++ b/pkg/apis/serving/v1alpha1/metadata_validation.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/webhook"
+	"strings"
+)
+
+func validateMetadata(new webhook.GenericCRD) *apis.FieldError {
+	name := new.GetObjectMeta().GetName()
+
+	if strings.Contains(name, ".") {
+		return &apis.FieldError{
+			Message: "Invalid resource name: special character . must not be present",
+			Paths:   []string{"name"},
+		}
+	}
+
+	if len(name) > 63 {
+		return &apis.FieldError{
+			Message: "Invalid resource name: length must be no more than 63 characters",
+			Paths:   []string{"name"},
+		}
+	}
+	return nil
+}

--- a/pkg/apis/serving/v1alpha1/metadata_validation.go
+++ b/pkg/apis/serving/v1alpha1/metadata_validation.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/webhook"
 	"strings"
+
+	"github.com/knative/pkg/apis"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func validateMetadata(new webhook.GenericCRD) *apis.FieldError {
-	name := new.GetObjectMeta().GetName()
+func validateObjectMetadata(meta metav1.Object) *apis.FieldError {
+	name := meta.GetName()
 
 	if strings.Contains(name, ".") {
 		return &apis.FieldError{

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (rt *Revision) Validate() *apis.FieldError {
-	if err := validateMetadata(rt); err != nil {
+	if err := validateObjectMetadata(rt.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return rt.Spec.Validate().ViaField("spec")

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -27,6 +27,9 @@ import (
 )
 
 func (rt *Revision) Validate() *apis.FieldError {
+	if err := validateMetadata(rt); err != nil {
+		return err.ViaField("metadata")
+	}
 	return rt.Spec.Validate().ViaField("spec")
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/knative/pkg/apis"
@@ -363,6 +365,22 @@ func TestRevisionValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.container.name"),
+	}, {
+		name: "invalid name - dots",
+		r: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "do.not.use.dots",
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: special character . must not be present", Paths: []string{"metadata.name"}},
+	}, {
+		name: "invalid name - too long",
+		r: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("a", 65),
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: length must be no more than 63 characters", Paths: []string{"metadata.name"}},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -25,8 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-func (rt *Route) Validate() *apis.FieldError {
-	return rt.Spec.Validate().ViaField("spec")
+func (r *Route) Validate() *apis.FieldError {
+	if err := validateMetadata(r); err != nil {
+		return err.ViaField("metadata")
+	}
+	return r.Spec.Validate().ViaField("spec")
 }
 
 func (rs *RouteSpec) Validate() *apis.FieldError {

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (r *Route) Validate() *apis.FieldError {
-	if err := validateMetadata(r); err != nil {
+	if err := validateObjectMetadata(r.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return r.Spec.Validate().ViaField("spec")

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/apis"
 )
@@ -73,6 +75,22 @@ func TestRouteValidation(t *testing.T) {
 				"spec.traffic[0].configurationName",
 			},
 		},
+	}, {
+		name: "invalid name - dots",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "do.not.use.dots",
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: special character . must not be present", Paths: []string{"metadata.name"}},
+	}, {
+		name: "invalid name - too long",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("a", 65),
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: length must be no more than 63 characters", Paths: []string{"metadata.name"}},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -21,6 +21,9 @@ import (
 )
 
 func (s *Service) Validate() *apis.FieldError {
+	if err := validateMetadata(s); err != nil {
+		return err.ViaField("metadata")
+	}
 	return s.Spec.Validate().ViaField("spec")
 }
 

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *Service) Validate() *apis.FieldError {
-	if err := validateMetadata(s); err != nil {
+	if err := validateObjectMetadata(s.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return s.Spec.Validate().ViaField("spec")

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/apis"
 )
@@ -146,6 +148,22 @@ func TestServiceValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.pinned.configuration.revisionTemplate.spec.container.name"),
+	}, {
+		name: "invalid name - dots",
+		s: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "do.not.use.dots",
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: special character . must not be present", Paths: []string{"metadata.name"}},
+	}, {
+		name: "invalid name - too long",
+		s: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("a", 65),
+			},
+		},
+		want: &apis.FieldError{Message: "Invalid resource name: length must be no more than 63 characters", Paths: []string{"metadata.name"}},
 	}}
 
 	for _, test := range tests {

--- a/vendor/github.com/knative/pkg/webhook/webhook.go
+++ b/vendor/github.com/knative/pkg/webhook/webhook.go
@@ -558,24 +558,7 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVers
 		}
 	}
 
-	if err := validateMetadata(newObj); err != nil {
-		logger.Error("Failed to validate", zap.Error(err))
-		return nil, fmt.Errorf("Failed to validate: %s", err)
-	}
 	return json.Marshal(patches)
-}
-
-func validateMetadata(new GenericCRD) error {
-	name := new.GetObjectMeta().GetName()
-
-	if strings.Contains(name, ".") {
-		return errors.New("Invalid resource name: special character . must not be present")
-	}
-
-	if len(name) > 63 {
-		return errors.New("Invalid resource name: length must be no more than 63 characters")
-	}
-	return nil
 }
 
 // updateGeneration sets the generation by following this logic:


### PR DESCRIPTION
Eventing wants to share the webhook code in pkg, but there was serving limitations on name that did not apply to eventing. Moved that limitation to serving.

relates to https://github.com/knative/pkg/pull/44