### PR TITLE
Handle user.Current() when initializing test flags

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -139,7 +139,7 @@ Tests importing [`github.com/knative/serving/test`](adding_tests.md#test-library
 
 By default the tests will use the [kubeconfig
 file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
-at `~/.kube/config`.
+at `~/.kube/config`. If there is an error getting the current user, it will use `kubeconfig` instead as the default value.
 You can specify a different config file with the argument `--kubeconfig`.
 
 To run the tests with a non-default kubeconfig file:

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"os/user"
 	"path"
+
+	"github.com/golang/glog"
 )
 
 // Flags holds the command line flags or defaults for common knative settings in the user's environment.
@@ -58,8 +60,12 @@ func initializeCommonFlags() *EnvironmentFlags {
 	flag.StringVar(&f.DockerRepo, "dockerrepo", defaultRepo,
 		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $DOCKER_REPO_OVERRIDE")
 
-	usr, _ := user.Current()
-	defaultKubeconfig := path.Join(usr.HomeDir, ".kube/config")
+	defaultKubeconfig := "kubeconfig"
+	if usr, err := user.Current(); err != nil {
+		glog.Infof("Error getting current user, using %s as fallback: %v", defaultKubeconfig, err)
+	} else {
+		defaultKubeconfig = path.Join(usr.HomeDir, ".kube/config")
+	}
 
 	flag.StringVar(&f.Kubeconfig, "kubeconfig", defaultKubeconfig,
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")


### PR DESCRIPTION
We call usr.Current() when setting up our e2e flags. But, in cases where usr is null or if Current() throws an error, we throw a null pointer exception. Use default kubeconfig in such cases.