### PR TITLE
Break test clients into different clients so that we can move common parts

### DIFF
--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -139,7 +139,7 @@ The `Clients` struct contains initialized clients for accessing:
 For example, to create a `Route`:
 
 ```bash
-_, err = clients.Routes.Create(test.Route(namespaceName, routeName, configName))
+_, err = clients.ServingClient.Routes.Create(test.Route(namespaceName, routeName, configName))
 ```
 
 And you can use the client to clean up `Route` and `Configuration` resources created
@@ -163,7 +163,7 @@ in the state you want it to be in (or timeout) use `WaitForEndpointState`:
 
 ```go
 err = test.WaitForEndpointState(
-		clients.Kube,
+		clients.KubeClient,
 		logger,
 		test.ServingFlags.ResolvableDomain,
 		updatedRoute.Status.Domain,
@@ -185,7 +185,7 @@ service, you can directly use the `SpoofingClient` that `WaitForEndpointState` w
 
 ```go
 // Error handling elided for brevity, but you know better.
-client, err := spoof.New(clients.Kube, logger, route.Status.Domain, test.Flags.ResolvableDomain)
+client, err := spoof.New(clients.KubeClient.Kube, logger, route.Status.Domain, test.Flags.ResolvableDomain)
 req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", route.Status.Domain), nil)
 
 // Single request.
@@ -215,7 +215,7 @@ for it:
 
 ```go
 var revisionName string
-err := test.WaitForConfigurationState(clients.Configs, configName, func(c *v1alpha1.Configuration) (bool, error) {
+err := test.WaitForConfigurationState(clients.ServingClient, configName, func(c *v1alpha1.Configuration) (bool, error) {
     if c.Status.LatestCreatedRevisionName != "" {
         revisionName = c.Status.LatestCreatedRevisionName
         return true, nil
@@ -230,7 +230,7 @@ We also have `Check*` variants of many of these methods with identical signature
 
 ```go
 var revisionName string
-err := test.CheckConfigurationState(clients.Configs, configName, func(c *v1alpha1.Configuration) (bool, error) {
+err := test.CheckConfigurationState(clients.ServingClient, configName, func(c *v1alpha1.Configuration) (bool, error) {
     if c.Status.LatestCreatedRevisionName != "" {
         revisionName = c.Status.LatestCreatedRevisionName
         return true, nil
@@ -252,7 +252,7 @@ actually serve it, and then the `Revision` object will be updated to indicate it
 can be polled with `test.IsRevisionReady`:
 
 ```go
-err := test.WaitForRevisionState(clients.Revisions, revisionName, test.IsRevisionReady(revisionName))
+err := test.WaitForRevisionState(clients.ServingClient, revisionName, test.IsRevisionReady(revisionName))
 if err != nil {
     t.Fatalf("Revision %s did not become ready to serve traffic: %v", revisionName, err)
 }
@@ -262,7 +262,7 @@ Once the `Revision` is created, all traffic for a `Route` should be routed to it
 `test.AllRouteTrafficAtRevision`:
 
 ```go
-err = test.WaitForRouteState(clients.Routes, routeName, test.AllRouteTrafficAtRevision(routeName, revisionName))
+err = test.WaitForRouteState(clients.ServingClient, routeName, test.AllRouteTrafficAtRevision(routeName, revisionName))
 if err != nil {
     t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", routeName, revisionName, err)
 }
@@ -284,7 +284,7 @@ randomized name:
 ```go
 var names test.ResourceNames
 names.Config := test.RandomizedName('hotdog')
-_, err := clients.Configs.Create(test.Configuration(namespaceName, names, imagePath))
+_, err := clients.ServingClient.Create(test.Configuration(namespaceName, names, imagePath))
 if err != nil {
     return err
 }

--- a/test/clients.go
+++ b/test/clients.go
@@ -30,12 +30,27 @@ import (
 
 // Clients holds instances of interfaces for making requests to Knative Serving.
 type Clients struct {
-	Kube      *kubernetes.Clientset
+	KubeClient    *KubeClient
+	ServingClient *ServingClients
+	BuildClient   *BuildClient
+}
+
+// KubeClient holds instances of interfaces for making requests to kubernetes client.
+type KubeClient struct {
+	Kube *kubernetes.Clientset
+}
+
+// BuildClient holds instances of interfaces for making requests to build client.
+type BuildClient struct {
+	Builds buildtyped.BuildInterface
+}
+
+// ServingClients holds instances of interfaces for making requests to knative serving clients
+type ServingClients struct {
 	Routes    servingtyped.RouteInterface
 	Configs   servingtyped.ConfigurationInterface
 	Revisions servingtyped.RevisionInterface
 	Services  servingtyped.ServiceInterface
-	Builds    buildtyped.BuildInterface
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
@@ -47,37 +62,70 @@ func NewClients(configPath string, clusterName string, namespace string) (*Clien
 	if err != nil {
 		return nil, err
 	}
-	clients.Kube, err = kubernetes.NewForConfig(cfg)
+
+	clients.KubeClient, err = newKubeClient(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	cs, err := versioned.NewForConfig(cfg)
+	clients.BuildClient, err = newBuildClient(cfg, namespace)
 	if err != nil {
 		return nil, err
 	}
 
+	clients.ServingClient, err = newServingClients(cfg, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return clients, nil
+}
+
+// NewKubeClient instantiates and returns several clientsets required for making request to the
+// kube client specified by the combination of clusterName and configPath. Clients can make requests within namespace.
+func newKubeClient(cfg *rest.Config) (*KubeClient, error) {
+	k, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &KubeClient{Kube: k}, nil
+}
+
+// NewBuildclient instantiates and returns several clientsets required for making request to the
+// build client specified by the combination of clusterName and configPath. Clients can make requests within namespace.
+func newBuildClient(cfg *rest.Config, namespace string) (*BuildClient, error) {
 	bcs, err := buildversioned.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
+	return &BuildClient{Builds: bcs.BuildV1alpha1().Builds(namespace)}, nil
+}
+
+// NewServingClients instantiates and returns the serving clientset required to make requests to the
+// knative serving cluster.
+func newServingClients(cfg *rest.Config, namespace string) (*ServingClients, error) {
+	cs, err := versioned.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var clients = &ServingClients{}
 	clients.Routes = cs.ServingV1alpha1().Routes(namespace)
 	clients.Configs = cs.ServingV1alpha1().Configurations(namespace)
 	clients.Revisions = cs.ServingV1alpha1().Revisions(namespace)
 	clients.Services = cs.ServingV1alpha1().Services(namespace)
-	clients.Builds = bcs.BuildV1alpha1().Builds(namespace)
 
 	return clients, nil
 }
 
 // Delete will delete all Routes and Configs with the names routes and configs, if clients
 // has been successfully initialized.
-func (clients *Clients) Delete(routes []string, configs []string) error {
+func (clients *ServingClients) Delete(routes []string, configs []string, services []string) error {
+
 	if clients.Routes != nil {
 		for _, route := range routes {
-			err := clients.Routes.Delete(route, nil)
-			if err != nil {
+			if err := clients.Routes.Delete(route, nil); err != nil {
 				return err
 			}
 		}
@@ -85,8 +133,15 @@ func (clients *Clients) Delete(routes []string, configs []string) error {
 
 	if clients.Configs != nil {
 		for _, config := range configs {
-			err := clients.Configs.Delete(config, nil)
-			if err != nil {
+			if err := clients.Configs.Delete(config, nil); err != nil {
+				return err
+			}
+		}
+	}
+
+	if clients.Services != nil {
+		for _, s := range services {
+			if err := clients.Services.Delete(s, nil); err != nil {
 				return err
 			}
 		}

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -19,25 +19,25 @@ limitations under the License.
 package test
 
 import (
-        corev1 "k8s.io/api/core/v1"
-        "go.uber.org/zap"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by imagePath.
 func CreateConfiguration(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) error {
-        return CreateConfigurationWithEnv(logger, clients, names, imagePath, nil)
+	return CreateConfigurationWithEnv(logger, clients, names, imagePath, nil)
 }
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specifed by imagePath and give environment variables.
 func CreateConfigurationWithEnv(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string, envVars []corev1.EnvVar) error {
-        config := Configuration(Flags.Namespace, names, imagePath)
-        if envVars != nil && len(envVars) > 0 {
-                config.Spec.RevisionTemplate.Spec.Container.Env = envVars
-        }
+	config := Configuration(Flags.Namespace, names, imagePath)
+	if envVars != nil && len(envVars) > 0 {
+		config.Spec.RevisionTemplate.Spec.Container.Env = envVars
+	}
 
-        LogResourceObject(logger, ResourceObjects{Configuration: config})
-        _, err := clients.Configs.Create(config)
-        return err
+	LogResourceObject(logger, ResourceObjects{Configuration: config})
+	_, err := clients.ServingClient.Configs.Create(config)
+	return err
 }

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -51,7 +51,7 @@ const (
 // Probe until we get a successful response. This ensures the domain is
 // routable before we send it a bunch of traffic.
 func probeDomain(logger *zap.SugaredLogger, clients *test.Clients, domain string) error {
-	client, err := spoof.New(clients.Kube, logger, domain, test.ServingFlags.ResolvableDomain)
+	client, err := spoof.New(clients.KubeClient.Kube, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func checkResponses(logger *zap.SugaredLogger, num int, min int, domain string, 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
 func checkDistribution(logger *zap.SugaredLogger, clients *test.Clients, domain string, num, min int, expectedResponses []string) error {
-	client, err := spoof.New(clients.Kube, logger, domain, test.ServingFlags.ResolvableDomain)
+	client, err := spoof.New(clients.KubeClient.Kube, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
@@ -209,11 +209,11 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// TODO(#882): Remove these?
 	logger.Infof("Waiting for revision %q to be ready", blue.Revision)
-	if err := test.WaitForRevisionState(clients.Revisions, blue.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
+	if err := test.WaitForRevisionState(clients.ServingClient, blue.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
 		t.Fatalf("The Revision %q was not marked as Ready: %v", blue.Revision, err)
 	}
 	logger.Infof("Waiting for revision %q to be ready", green.Revision)
-	if err := test.WaitForRevisionState(clients.Revisions, green.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
+	if err := test.WaitForRevisionState(clients.ServingClient, green.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
 		t.Fatalf("The Revision %q was not marked as Ready: %v", green.Revision, err)
 	}
 
@@ -227,11 +227,11 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	logger.Infof("When the Route reports as Ready, everything should be ready.")
-	if err := test.WaitForRouteState(clients.Routes, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
 	}
 
-	route, err := clients.Routes.Get(names.Route, metav1.GetOptions{})
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -61,7 +61,7 @@ func updateConfigWithImage(clients *test.Clients, names test.ResourceNames, imag
 		},
 	}
 	patchBytes, err := json.Marshal(patches)
-	_, err = clients.Configs.Patch(names.Config, types.JSONPatchType, patchBytes, "")
+	_, err = clients.ServingClient.Configs.Patch(names.Config, types.JSONPatchType, patchBytes, "")
 	if err != nil {
 		return err
 	}
@@ -70,19 +70,19 @@ func updateConfigWithImage(clients *test.Clients, names test.ResourceNames, imag
 
 func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.SugaredLogger, clients *test.Clients, names test.ResourceNames, expectedGeneration, expectedText string) {
 	logger.Infof("When the Route reports as Ready, everything should be ready.")
-	if err := test.WaitForRouteState(clients.Routes, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic to Revision %s: %v", names.Route, names.Revision, err)
 	}
 
 	// TODO(#1178): Remove "Wait" from all checks below this point.
 	logger.Infof("Serves the expected data at the endpoint")
-	updatedRoute, err := clients.Routes.Get(names.Route, metav1.GetOptions{})
+	updatedRoute, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 
 	err = test.WaitForEndpointState(
-		clients.Kube,
+		clients.KubeClient,
 		logger,
 		updatedRoute.Status.Domain,
 		test.Retrying(test.EventuallyMatchesBody(expectedText), http.StatusServiceUnavailable, http.StatusNotFound),
@@ -93,29 +93,29 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 
 	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
 	logger.Infof("The Revision will be marked as Ready when it can serve traffic")
-	err = test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady)
+	err = test.CheckRevisionState(clients.ServingClient, names.Revision, test.IsRevisionReady)
 	if err != nil {
 		t.Fatalf("Revision %s did not become ready to serve traffic: %v", names.Revision, err)
 	}
 	logger.Infof("The Revision will be annotated with the generation")
-	err = test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionAtExpectedGeneration(expectedGeneration))
+	err = test.CheckRevisionState(clients.ServingClient, names.Revision, test.IsRevisionAtExpectedGeneration(expectedGeneration))
 	if err != nil {
 		t.Fatalf("Revision %s did not have an expected annotation with generation %s: %v", names.Revision, expectedGeneration, err)
 	}
 	logger.Infof("Updates the Configuration that the Revision is ready")
-	err = test.CheckConfigurationState(clients.Configs, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+	err = test.CheckConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		return c.Status.LatestReadyRevisionName == names.Revision, nil
 	})
 	if err != nil {
 		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
 	}
 	logger.Infof("Updates the Route to route traffic to the Revision")
-	err = test.CheckRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names))
+	err = test.CheckRouteState(clients.ServingClient, names.Route, test.AllRouteTrafficAtRevision(names))
 	if err != nil {
 		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
 	logger.Infof("TODO: The Route is accessible from inside the cluster without external DNS")
-	err = test.CheckRouteState(clients.Routes, names.Route, test.TODO_RouteTrafficToRevisionWithInClusterDNS)
+	err = test.CheckRouteState(clients.ServingClient, names.Route, test.TODO_RouteTrafficToRevisionWithInClusterDNS)
 	if err != nil {
 		t.Fatalf("The Route %s was not able to route traffic to the Revision %s with in cluster DNS: %v", names.Route, names.Revision, err)
 	}
@@ -123,7 +123,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 
 func getNextRevisionName(clients *test.Clients, names test.ResourceNames) (string, error) {
 	var newRevisionName string
-	err := test.WaitForConfigurationState(clients.Configs, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+	err := test.WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
 			newRevisionName = c.Status.LatestCreatedRevisionName
 			return true, nil
@@ -146,8 +146,8 @@ func setup(t *testing.T) *test.Clients {
 }
 
 func tearDown(clients *test.Clients, names test.ResourceNames) {
-	if clients != nil {
-		clients.Delete([]string{names.Route}, []string{names.Config})
+	if clients != nil && clients.ServingClient != nil {
+		clients.ServingClient.Delete([]string{names.Route}, []string{names.Config}, []string{names.Service})
 	}
 }
 

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -32,14 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func tearDownService(clients *test.Clients, names test.ResourceNames) {
-	if clients != nil {
-		if clients.Services != nil {
-			clients.Services.Delete(names.Service, nil)
-		}
-	}
-}
-
 func updateServiceWithImage(clients *test.Clients, names test.ResourceNames, imagePath string) error {
 	patches := []jsonpatch.JsonPatchOperation{
 		{
@@ -52,7 +44,7 @@ func updateServiceWithImage(clients *test.Clients, names test.ResourceNames, ima
 	if err != nil {
 		return err
 	}
-	_, err = clients.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
+	_, err = clients.ServingClient.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
 	if err != nil {
 		return err
 	}
@@ -63,7 +55,7 @@ func updateServiceWithImage(clients *test.Clients, names test.ResourceNames, ima
 func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clients *test.Clients, names test.ResourceNames, routeDomain, expectedGeneration, expectedText string) {
 	// TODO(#1178): Remove "Wait" from all checks below this point.
 	err := test.WaitForEndpointState(
-		clients.Kube,
+		clients.KubeClient,
 		logger,
 		routeDomain,
 		test.Retrying(test.EventuallyMatchesBody(expectedText), http.StatusNotFound),
@@ -74,16 +66,16 @@ func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clie
 
 	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
 	logger.Info("The Revision will be marked as Ready when it can serve traffic")
-	if err := test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionReady); err != nil {
+	if err := test.CheckRevisionState(clients.ServingClient, names.Revision, test.IsRevisionReady); err != nil {
 		t.Fatalf("Revision %s did not become ready to serve traffic: %v", names.Revision, err)
 	}
 	logger.Infof("The Revision will be annotated with the generation")
-	err = test.CheckRevisionState(clients.Revisions, names.Revision, test.IsRevisionAtExpectedGeneration(expectedGeneration))
+	err = test.CheckRevisionState(clients.ServingClient, names.Revision, test.IsRevisionAtExpectedGeneration(expectedGeneration))
 	if err != nil {
 		t.Fatalf("Revision %s did not have an expected annotation with generation %s: %v", names.Revision, expectedGeneration, err)
 	}
 	logger.Info("The Service's latestReadyRevisionName should match the Configuration's")
-	err = test.CheckConfigurationState(clients.Configs, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+	err = test.CheckConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		return c.Status.LatestReadyRevisionName == names.Revision, nil
 	})
 	if err != nil {
@@ -91,12 +83,12 @@ func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clie
 	}
 
 	logger.Info("Updates the Route to route traffic to the Revision")
-	if err := test.CheckRouteState(clients.Routes, names.Route, test.AllRouteTrafficAtRevision(names)); err != nil {
+	if err := test.CheckRouteState(clients.ServingClient, names.Route, test.AllRouteTrafficAtRevision(names)); err != nil {
 		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
 
 	logger.Infof("TODO: The Service's Route is accessible from inside the cluster without external DNS")
-	err = test.CheckServiceState(clients.Services, names.Service, test.TODO_ServiceTrafficToRevisionWithInClusterDNS)
+	err = test.CheckServiceState(clients.ServingClient, names.Service, test.TODO_ServiceTrafficToRevisionWithInClusterDNS)
 	if err != nil {
 		t.Fatalf("The Service %s was not able to route traffic to the Revision %s with in cluster DNS: %v", names.Service, names.Revision, err)
 	}
@@ -106,7 +98,7 @@ func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clie
 
 func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
 	var revisionName string
-	err := test.WaitForServiceState(clients.Services, names.Service, func(s *v1alpha1.Service) (bool, error) {
+	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
 			return true, nil
@@ -118,7 +110,7 @@ func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.Resou
 
 func waitForServiceDomain(clients *test.Clients, names test.ResourceNames) (string, error) {
 	var routeDomain string
-	err := test.WaitForServiceState(clients.Services, names.Service, func(s *v1alpha1.Service) (bool, error) {
+	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		if s.Status.Domain != "" {
 			routeDomain = s.Status.Domain
 			return true, nil
@@ -141,8 +133,8 @@ func TestRunLatestService(t *testing.T) {
 	var names test.ResourceNames
 	names.Service = test.AppendRandomString("pizzaplanet-service", logger)
 
-	defer tearDownService(clients, names)
-	test.CleanupOnInterrupt(func() { tearDownService(clients, names) }, logger)
+	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
 
 	logger.Info("Creating a new Service")
 	svc, err := test.CreateLatestService(logger, clients, names, imagePaths[0])
@@ -166,7 +158,7 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	logger.Info("When the Service reports as Ready, everything should be ready.")
-	if err := test.WaitForServiceState(clients.Services, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
 	}
 	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "1", "What a spaceport!")
@@ -184,7 +176,7 @@ func TestRunLatestService(t *testing.T) {
 	names.Revision = revisionName
 
 	logger.Info("When the Service reports as Ready, everything should be ready.")
-	if err := test.WaitForServiceState(clients.Services, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
 	}
 	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "2", "Re-energize yourself with a slice of pepperoni!")

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -25,12 +25,10 @@ import (
 	"time"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	servingtyped "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	"go.opencensus.io/trace"
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
@@ -42,13 +40,13 @@ const (
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForRouteState(client servingtyped.RouteInterface, name string, inState func(r *v1alpha1.Route) (bool, error), desc string) error {
+func WaitForRouteState(client *ServingClients, name string, inState func(r *v1alpha1.Route) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForRouteState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		r, err := client.Get(name, metav1.GetOptions{})
+		r, err := client.Routes.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -59,8 +57,8 @@ func WaitForRouteState(client servingtyped.RouteInterface, name string, inState 
 // CheckRouteState verifies the status of the Route called name from client
 // is in a particular state by calling `inState` and expecting `true`.
 // This is the non-polling variety of WaitForRouteState
-func CheckRouteState(client servingtyped.RouteInterface, name string, inState func(r *v1alpha1.Route) (bool, error)) error {
-	r, err := client.Get(name, metav1.GetOptions{})
+func CheckRouteState(client *ServingClients, name string, inState func(r *v1alpha1.Route) (bool, error)) error {
+	r, err := client.Routes.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -76,13 +74,13 @@ func CheckRouteState(client servingtyped.RouteInterface, name string, inState fu
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForConfigurationState(client servingtyped.ConfigurationInterface, name string, inState func(c *v1alpha1.Configuration) (bool, error), desc string) error {
+func WaitForConfigurationState(client *ServingClients, name string, inState func(c *v1alpha1.Configuration) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForConfigurationState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		c, err := client.Get(name, metav1.GetOptions{})
+		c, err := client.Configs.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -93,8 +91,8 @@ func WaitForConfigurationState(client servingtyped.ConfigurationInterface, name 
 // CheckConfigurationState verifies the status of the Configuration called name from client
 // is in a particular state by calling `inState` and expecting `true`.
 // This is the non-polling variety of WaitForConfigurationState
-func CheckConfigurationState(client servingtyped.ConfigurationInterface, name string, inState func(r *v1alpha1.Configuration) (bool, error)) error {
-	c, err := client.Get(name, metav1.GetOptions{})
+func CheckConfigurationState(client *ServingClients, name string, inState func(r *v1alpha1.Configuration) (bool, error)) error {
+	c, err := client.Configs.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -110,13 +108,13 @@ func CheckConfigurationState(client servingtyped.ConfigurationInterface, name st
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForRevisionState(client servingtyped.RevisionInterface, name string, inState func(r *v1alpha1.Revision) (bool, error), desc string) error {
+func WaitForRevisionState(client *ServingClients, name string, inState func(r *v1alpha1.Revision) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForRevision/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		r, err := client.Get(name, metav1.GetOptions{})
+		r, err := client.Revisions.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -127,8 +125,8 @@ func WaitForRevisionState(client servingtyped.RevisionInterface, name string, in
 // CheckRevisionState verifies the status of the Revision called name from client
 // is in a particular state by calling `inState` and expecting `true`.
 // This is the non-polling variety of WaitForRevisionState
-func CheckRevisionState(client servingtyped.RevisionInterface, name string, inState func(r *v1alpha1.Revision) (bool, error)) error {
-	r, err := client.Get(name, metav1.GetOptions{})
+func CheckRevisionState(client *ServingClients, name string, inState func(r *v1alpha1.Revision) (bool, error)) error {
+	r, err := client.Revisions.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -144,13 +142,13 @@ func CheckRevisionState(client servingtyped.RevisionInterface, name string, inSt
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForServiceState(client servingtyped.ServiceInterface, name string, inState func(s *v1alpha1.Service) (bool, error), desc string) error {
+func WaitForServiceState(client *ServingClients, name string, inState func(s *v1alpha1.Service) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForServiceState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		s, err := client.Get(name, metav1.GetOptions{})
+		s, err := client.Services.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -161,8 +159,8 @@ func WaitForServiceState(client servingtyped.ServiceInterface, name string, inSt
 // CheckServiceState verifies the status of the Service called name from client
 // is in a particular state by calling `inState` and expecting `true`.
 // This is the non-polling variety of WaitForServiceState
-func CheckServiceState(client servingtyped.ServiceInterface, name string, inState func(s *v1alpha1.Service) (bool, error)) error {
-	s, err := client.Get(name, metav1.GetOptions{})
+func CheckServiceState(client *ServingClients, name string, inState func(s *v1alpha1.Service) (bool, error)) error {
+	s, err := client.Services.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -174,20 +172,7 @@ func CheckServiceState(client servingtyped.ServiceInterface, name string, inStat
 	return nil
 }
 
-// WaitForIngressState polls the status of the Ingress called name
-// from client every interval until inState returns `true` indicating it
-// is done, returns an error or timeout. desc will be used to name the metric
-// that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForIngressState(client v1beta1.IngressInterface, name string, inState func(r *apiv1beta1.Ingress) (bool, error), desc string) error {
-	metricName := fmt.Sprintf("WaitForIngressState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
-	defer span.End()
-
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		i, err := client.Get(name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-		return inState(i)
-	})
+// GetConfigMap gets the knative serving config map.
+func GetConfigMap(client *KubeClient) k8styped.ConfigMapInterface {
+	return client.Kube.CoreV1().ConfigMaps("knative-serving")
 }

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -56,7 +56,7 @@ func generateTrafficBurst(clients *test.Clients, logger *zap.SugaredLogger, num 
 	logger.Infof("Performing %d concurrent requests.", num)
 	for i := 0; i < num; i++ {
 		go func() {
-			test.WaitForEndpointState(clients.Kube,
+			test.WaitForEndpointState(clients.KubeClient,
 				logger,
 				domain,
 				test.Retrying(test.EventuallyMatchesBody(autoscaleExpectedOutput), http.StatusNotFound),
@@ -72,7 +72,7 @@ func generateTrafficBurst(clients *test.Clients, logger *zap.SugaredLogger, num 
 }
 
 func getAutoscalerConfigMap(clients *test.Clients) (*v1.ConfigMap, error) {
-	return clients.Kube.CoreV1().ConfigMaps("knative-serving").Get("config-autoscaler", metav1.GetOptions{})
+	return test.GetConfigMap(clients.KubeClient).Get("config-autoscaler", metav1.GetOptions{})
 }
 
 func setScaleToZeroThreshold(clients *test.Clients, threshold string) error {
@@ -81,7 +81,7 @@ func setScaleToZeroThreshold(clients *test.Clients, threshold string) error {
 		return err
 	}
 	configMap.Data["scale-to-zero-threshold"] = threshold
-	_, err = clients.Kube.CoreV1().ConfigMaps("knative-serving").Update(configMap)
+	_, err = test.GetConfigMap(clients.KubeClient).Update(configMap)
 	return err
 }
 
@@ -132,7 +132,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	logger.Infof(`When the Revision can have traffic routed to it,
 	            the Route is marked as Ready.`)
 	err = test.WaitForRouteState(
-		clients.Routes,
+		clients.ServingClient,
 		names.Route,
 		test.IsRouteReady,
 		"RouteIsReady")
@@ -142,21 +142,21 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	}
 
 	logger.Infof("Serves the expected data at the endpoint")
-	config, err := clients.Configs.Get(names.Config, metav1.GetOptions{})
+	config, err := clients.ServingClient.Configs.Get(names.Config, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf(`Configuration %s was not updated with the new
 		         revision: %v`, names.Config, err)
 	}
 	deploymentName :=
 		config.Status.LatestCreatedRevisionName + "-deployment"
-	route, err := clients.Routes.Get(names.Route, metav1.GetOptions{})
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 	domain := route.Status.Domain
 
 	err = test.WaitForEndpointState(
-		clients.Kube,
+		clients.KubeClient,
 		logger,
 		domain,
 		// Istio doesn't expose a status for us here: https://github.com/istio/istio/issues/6082
@@ -173,7 +173,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		    increases.`)
 	generateTrafficBurst(clients, logger, 5, domain)
 	err = test.WaitForDeploymentState(
-		clients.Kube.ExtensionsV1beta1().Deployments(test.Flags.Namespace),
+		clients.KubeClient,
 		deploymentName,
 		isDeploymentScaledUp(),
 		"DeploymentIsScaledUp")
@@ -189,7 +189,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		    faster testing.`)
 
 	err = test.WaitForDeploymentState(
-		clients.Kube.ExtensionsV1beta1().Deployments(test.Flags.Namespace),
+		clients.KubeClient,
 		deploymentName,
 		isDeploymentScaledToZero(),
 		"DeploymentScaledToZero")
@@ -199,11 +199,10 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	}
 
 	// Account for the case where scaling up uses all available pods.
-	logger.Infof("Wait until there are pods available to scale into.")
-	pc := clients.Kube.CoreV1().Pods(test.Flags.Namespace)
+	logger.Infof("Wait until there are pods available to scale into.")	
 
 	err = test.WaitForPodListState(
-		pc,
+		clients.KubeClient,
 		func(p *v1.PodList) (bool, error) {
 			return len(p.Items) == 0, nil
 		},
@@ -214,7 +213,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
               traffic increases.`)
 	generateTrafficBurst(clients, logger, 8, domain)
 	err = test.WaitForDeploymentState(
-		clients.Kube.ExtensionsV1beta1().Deployments(test.Flags.Namespace),
+		clients.KubeClient,
 		deploymentName,
 		isDeploymentScaledUp(),
 		"DeploymentScaledUp")

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -50,10 +50,10 @@ func TestBuildAndServe(t *testing.T) {
 		}},
 	}
 
-	if _, err := clients.Configs.Create(test.ConfigurationWithBuild(test.Flags.Namespace, names, build, imagePath)); err != nil {
+	if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.Flags.Namespace, names, build, imagePath)); err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
-	if _, err := clients.Routes.Create(test.Route(test.Flags.Namespace, names)); err != nil {
+	if _, err := clients.ServingClient.Routes.Create(test.Route(test.Flags.Namespace, names)); err != nil {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
@@ -61,35 +61,35 @@ func TestBuildAndServe(t *testing.T) {
 	defer TearDown(clients, names, logger)
 
 	logger.Infof("When the Revision can have traffic routed to it, the Route is marked as Ready.")
-	if err := test.WaitForRouteState(clients.Routes, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
 	}
 
-	route, err := clients.Routes.Get(names.Route, metav1.GetOptions{})
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 	domain := route.Status.Domain
 
 	endState := test.Retrying(test.MatchesBody(helloWorldExpectedOutput), http.StatusNotFound)
-	if err := test.WaitForEndpointState(clients.Kube, logger, domain, endState, "HelloWorldServesText"); err != nil {
+	if err := test.WaitForEndpointState(clients.KubeClient, logger, domain, endState, "HelloWorldServesText"); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
 
 	// Get Configuration's latest ready Revision's Build, and check that the Build was successful.
 	logger.Infof("Revision is ready and serving, checking Build status.")
-	config, err := clients.Configs.Get(names.Config, metav1.GetOptions{})
+	config, err := clients.ServingClient.Configs.Get(names.Config, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Configuration after it was seen to be live: %v", err)
 	}
-	rev, err := clients.Revisions.Get(config.Status.LatestReadyRevisionName, metav1.GetOptions{})
+	rev, err := clients.ServingClient.Revisions.Get(config.Status.LatestReadyRevisionName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get latest Revision: %v", err)
 	}
 	buildName := rev.Spec.BuildName
 	logger.Infof("Latest ready Revision is %q", rev.Name)
 	logger.Infof("Revision's Build is %q", buildName)
-	b, err := clients.Builds.Get(buildName, metav1.GetOptions{})
+	b, err := clients.BuildClient.Builds.Get(buildName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get build for latest revision: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestBuildFailure(t *testing.T) {
 	}
 
 	imagePath := strings.Join([]string{test.Flags.DockerRepo, "helloworld"}, "/")
-	config, err := clients.Configs.Create(test.ConfigurationWithBuild(test.Flags.Namespace, names, build, imagePath))
+	config, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.Flags.Namespace, names, build, imagePath))
 	if err != nil {
 		t.Fatalf("Failed to create Configuration with failing build: %v", err)
 	}
@@ -129,27 +129,27 @@ func TestBuildFailure(t *testing.T) {
 	defer TearDown(clients, names, logger)
 
 	// Wait for the Config have a LatestCreatedRevisionName
-	if err := test.WaitForConfigurationState(clients.Configs, names.Config, test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision"); err != nil {
+	if err := test.WaitForConfigurationState(clients.ServingClient, names.Config, test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision"); err != nil {
 		t.Fatalf("The Configuration %q does not have a LatestCreatedRevisionName: %v", names.Config, err)
 	}
 	// Get Configuration's latest Revision's Build, and check that the Build failed.
-	config, err = clients.Configs.Get(config.Name, metav1.GetOptions{})
+	config, err = clients.ServingClient.Configs.Get(config.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Configuration after it was seen to be live: %v", err)
 	}
 	// Wait for the Revision to notice its Build failed.
-	if err := test.WaitForRevisionState(clients.Revisions, config.Status.LatestCreatedRevisionName, test.IsRevisionBuildFailed, "RevisionIsBuildFailed"); err != nil {
+	if err := test.WaitForRevisionState(clients.ServingClient, config.Status.LatestCreatedRevisionName, test.IsRevisionBuildFailed, "RevisionIsBuildFailed"); err != nil {
 		t.Fatalf("The Revision %q was not marked as having a failed build: %v", names.Revision, err)
 	}
 	logger.Infof("Revision %q is not ready because its build failed.", config.Status.LatestCreatedRevisionName)
-	rev, err := clients.Revisions.Get(config.Status.LatestCreatedRevisionName, metav1.GetOptions{})
+	rev, err := clients.ServingClient.Revisions.Get(config.Status.LatestCreatedRevisionName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get latest Revision: %v", err)
 	}
 	buildName := rev.Spec.BuildName
 	logger.Infof("Latest created Revision is %q", rev.Name)
 	logger.Infof("Revision's Build is %q", buildName)
-	b, err := clients.Builds.Get(buildName, metav1.GetOptions{})
+	b, err := clients.BuildClient.Builds.Get(buildName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get build for latest revision: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -38,8 +38,8 @@ func Setup(t *testing.T) *test.Clients {
 
 // TearDown will delete created names using clients.
 func TearDown(clients *test.Clients, names test.ResourceNames, logger *zap.SugaredLogger) {
-	if clients != nil {
-		clients.Delete([]string{names.Route}, []string{names.Config})
+	if clients != nil && clients.ServingClient != nil {
+		clients.ServingClient.Delete([]string{names.Route}, []string{names.Config}, []string{names.Service})
 	}
 }
 
@@ -52,13 +52,13 @@ func CreateRouteAndConfig(clients *test.Clients, logger *zap.SugaredLogger, imag
 // CreateRouteAndConfigWithEnv will create Route and Config objects using clients.
 // The Config object will serve requests to a container started from the image at imagePath and configured with given environment variables.
 func CreateRouteAndConfigWithEnv(clients *test.Clients, logger *zap.SugaredLogger, imagePath string, envVars []corev1.EnvVar) (test.ResourceNames, error) {
-        var names test.ResourceNames
-        names.Config = test.AppendRandomString(configName, logger)
-        names.Route = test.AppendRandomString(routeName, logger)
+	var names test.ResourceNames
+	names.Config = test.AppendRandomString(configName, logger)
+	names.Route = test.AppendRandomString(routeName, logger)
 
-        if err := test.CreateConfigurationWithEnv(logger, clients, names, imagePath, envVars); err != nil {
-                return test.ResourceNames{}, err
-        }
-        err := test.CreateRoute(logger, clients, names)
-        return names, err
+	if err := test.CreateConfigurationWithEnv(logger, clients, names, imagePath, envVars); err != nil {
+		return test.ResourceNames{}, err
+	}
+	err := test.CreateRoute(logger, clients, names)
+	return names, err
 }

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -62,7 +62,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	logger.Infof("When the imagepath is invalid, the Configuration should have error status.")
 
 	// Checking for "Container image not present in repository" scenario defined in error condition spec
-	err = test.WaitForConfigurationState(clients.Configs, names.Config, func(r *v1alpha1.Configuration) (bool, error) {
+	err = test.WaitForConfigurationState(clients.ServingClient, names.Config, func(r *v1alpha1.Configuration) (bool, error) {
 		cond := r.Status.GetCondition(v1alpha1.ConfigurationConditionReady)
 		if cond != nil && cond.Status != corev1.ConditionUnknown {
 			if strings.Contains(cond.Message, manifestUnknown) && cond.Status == corev1.ConditionFalse {
@@ -85,7 +85,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}
 
 	logger.Infof("When the imagepath is invalid, the revision should have error status.")
-	err = test.WaitForRevisionState(clients.Revisions, revisionName, func(r *v1alpha1.Revision) (bool, error) {
+	err = test.WaitForRevisionState(clients.ServingClient, revisionName, func(r *v1alpha1.Revision) (bool, error) {
 		cond := r.Status.GetCondition(v1alpha1.RevisionConditionReady)
 		if cond != nil {
 			if cond.Reason == containerMissing && strings.HasPrefix(cond.Message, manifestUnknown) {
@@ -115,7 +115,7 @@ func TestContainerErrorMsg(t *testing.T) {
 
 // Get revision name from configuration.
 func getRevisionFromConfiguration(clients *test.Clients, configName string) (string, error) {
-	config, err := clients.Configs.Get(configName, metav1.GetOptions{})
+	config, err := clients.ServingClient.Configs.Get(configName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +128,7 @@ func getRevisionFromConfiguration(clients *test.Clients, configName string) (str
 
 // Get LogURL from revision.
 func getLogURLFromRevision(clients *test.Clients, revisionName string) (string, error) {
-	revision, err := clients.Revisions.Get(revisionName, metav1.GetOptions{})
+	revision, err := clients.ServingClient.Revisions.Get(revisionName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -49,18 +49,18 @@ func TestHelloWorld(t *testing.T) {
 	defer TearDown(clients, names, logger)
 
 	logger.Infof("When the Revision can have traffic routed to it, the Route is marked as Ready.")
-	if err := test.WaitForRouteState(clients.Routes, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
 	}
 
-	route, err := clients.Routes.Get(names.Route, metav1.GetOptions{})
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 	domain := route.Status.Domain
 
 	err = test.WaitForEndpointState(
-		clients.Kube,
+		clients.KubeClient,
 		logger,
 		domain,
 		test.Retrying(test.MatchesBody(helloWorldExpectedOutput), http.StatusNotFound),

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -43,7 +43,7 @@ const (
 )
 
 func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
-	helloWorldRoute, err := clients.Routes.Get(routeName, metav1.GetOptions{})
+	helloWorldRoute, err := clients.ServingClient.Routes.Get(routeName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Route of helloworld app: %v", err)
 	}
@@ -57,7 +57,7 @@ func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
 
 func sendRequest(resolvableDomain bool, domain string) (*spoof.Response, error) {
 	logger.Infof("The domain of request is %s.", domain)
-	client, err := spoof.New(clients.Kube, logger, domain, resolvableDomain)
+	client, err := spoof.New(clients.KubeClient.Kube, logger, domain, resolvableDomain)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { TearDown(clients, helloWorldNames, logger) }, logger)
 	defer TearDown(clients, helloWorldNames, logger)
-	if err := test.WaitForRouteState(clients.Routes, helloWorldNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+	if err := test.WaitForRouteState(clients.ServingClient, helloWorldNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", helloWorldNames.Route, err)
 	}
 
@@ -102,14 +102,18 @@ func TestServiceToServiceCall(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { TearDown(clients, httpProxyNames, logger) }, logger)
 	defer TearDown(clients, httpProxyNames, logger)
-	if err := test.WaitForRouteState(clients.Routes, httpProxyNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+	if err := test.WaitForRouteState(clients.ServingClient, httpProxyNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", httpProxyNames.Route, err)
 	}
-	httpProxyRoute, err := clients.Routes.Get(httpProxyNames.Route, metav1.GetOptions{})
+	httpProxyRoute, err := clients.ServingClient.Routes.Get(httpProxyNames.Route, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Route %s: %v", httpProxyNames.Route, err)
 	}
-	if err = test.WaitForEndpointState(clients.Kube, logger, httpProxyRoute.Status.Domain, test.Retrying(test.MatchesAny, http.StatusServiceUnavailable, http.StatusNotFound), "HttpProxy"); err != nil {
+	if err = test.WaitForEndpointState(
+		clients.KubeClient,
+		logger,
+		httpProxyRoute.Status.Domain, test.Retrying(test.MatchesAny, http.StatusServiceUnavailable, http.StatusNotFound),
+		"HttpProxy"); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)
 	}
 	logger.Info("httpproxy is ready.")

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -28,21 +28,20 @@ import (
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 )
 
 // WaitForDeploymentState polls the status of the Deployment called name
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForDeploymentState(client v1beta1.DeploymentInterface, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string) error {
+func WaitForDeploymentState(client *KubeClient, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string) error {
+	d := client.Kube.ExtensionsV1beta1().Deployments(Flags.Namespace)
 	metricName := fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		d, err := client.Get(name, metav1.GetOptions{})
+		d, err := d.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -54,13 +53,14 @@ func WaitForDeploymentState(client v1beta1.DeploymentInterface, name string, inS
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took to get into the state checked by inState.
-func WaitForPodListState(client v1.PodInterface, inState func(p *corev1.PodList) (bool, error), desc string) error {
+func WaitForPodListState(client *KubeClient, inState func(p *corev1.PodList) (bool, error), desc string) error {
+	p := client.Kube.CoreV1().Pods(Flags.Namespace)
 	metricName := fmt.Sprintf("WaitForPodListState/%s", desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		p, err := client.List(metav1.ListOptions{})
+		p, err := p.List(metav1.ListOptions{})
 		if err != nil {
 			return true, err
 		}

--- a/test/request.go
+++ b/test/request.go
@@ -27,7 +27,6 @@ import (
 	"github.com/knative/serving/test/spoof"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
 )
 
 // MatchesAny is a NOP matcher. This is useful for polling until a 200 is returned.
@@ -81,12 +80,12 @@ func EventuallyMatchesBody(expected string) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClientset *kubernetes.Clientset, logger *zap.SugaredLogger, domain string, inState spoof.ResponseChecker, desc string) error {
+func WaitForEndpointState(kubeClientset *KubeClient, logger *zap.SugaredLogger, domain string, inState spoof.ResponseChecker, desc string) error {
 	metricName := fmt.Sprintf("WaitForEndpointState/%s", desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	client, err := spoof.New(kubeClientset, logger, domain, ServingFlags.ResolvableDomain)
+	client, err := spoof.New(kubeClientset.Kube, logger, domain, ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}

--- a/test/route.go
+++ b/test/route.go
@@ -26,7 +26,7 @@ import (
 func CreateRoute(logger *zap.SugaredLogger, clients *Clients, names ResourceNames) error {
 	route := Route(Flags.Namespace, names)
 	LogResourceObject(logger, ResourceObjects{Route: route})
-	_, err := clients.Routes.Create(route)
+	_, err := clients.ServingClient.Routes.Create(route)
 	return err
 }
 
@@ -35,6 +35,6 @@ func CreateRoute(logger *zap.SugaredLogger, clients *Clients, names ResourceName
 func CreateBlueGreenRoute(logger *zap.SugaredLogger, clients *Clients, names, blue, green ResourceNames) error {
 	route := BlueGreenRoute(Flags.Namespace, names, blue, green)
 	LogResourceObject(logger, ResourceObjects{Route: route})
-	_, err := clients.Routes.Create(route)
+	_, err := clients.ServingClient.Routes.Create(route)
 	return err
 }

--- a/test/service.go
+++ b/test/service.go
@@ -28,6 +28,6 @@ import (
 func CreateLatestService(logger *zap.SugaredLogger, clients *Clients, names ResourceNames, imagePath string) (*v1alpha1.Service, error) {
 	service := LatestService(Flags.Namespace, names, imagePath)
 	LogResourceObject(logger, ResourceObjects{Service: service})
-	svc, err := clients.Services.Create(service)
+	svc, err := clients.ServingClient.Services.Create(service)
 	return svc, err
 }


### PR DESCRIPTION
This PR breaks clients.go into serving, kube and build clients. All serving related methods now expect a ServingClient. All the methods have been updated to reflect this and also the doc has been updated.

Part of https://github.com/knative/pkg/issues/26
