### PR TITLE
Turn on the multi-tenant autoscaler.

### DIFF
--- a/config/config-controller.yaml
+++ b/config/config-controller.yaml
@@ -25,7 +25,7 @@ data:
   queueSidecarImage: github.com/knative/serving/cmd/queue
 
   # Comment the following lines to disable the single-tenant autoscaler.
-  autoscalerImage: github.com/knative/serving/cmd/autoscaler
+  # autoscalerImage: github.com/knative/serving/cmd/autoscaler
 
   # List of repositories for which tag to digest resolving should be skipped
   registriesSkippingTagResolving: "ko.local,dev.local"

--- a/config/config-controller.yaml
+++ b/config/config-controller.yaml
@@ -24,7 +24,7 @@ data:
   # and substituted here.
   queueSidecarImage: github.com/knative/serving/cmd/queue
 
-  # Comment the following lines to disable the single-tenant autoscaler.
+  # Uncomment the following lines to enable the single-tenant autoscaler.
   # autoscalerImage: github.com/knative/serving/cmd/autoscaler
 
   # List of repositories for which tag to digest resolving should be skipped


### PR DESCRIPTION
Part of #1750

## Proposed Changes

  * Turn on the multi-tenant autoscaler by default

**Release Note**
```release-note
* Single-tenant autoscalers will no longer be created in the knative-serving namespace
* Requires redeployment of existing kservices.
```
