### PR TITLE
Make the conditions better reflect the sequence diagram.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
@@ -368,8 +368,8 @@ func TestReserveWithEndpoints(t *testing.T) {
 	if err != nil {
 		t.Errorf("Get() = %v", err)
 	}
-	if cond := newKPA.Status.GetCondition("Ready"); cond == nil || cond.Status != "Unknown" {
-		t.Errorf("GetCondition(Ready) = %v, wanted Unknown", cond)
+	if cond := newKPA.Status.GetCondition("Ready"); cond == nil || cond.Status != "False" {
+		t.Errorf("GetCondition(Ready) = %v, wanted False", cond)
 	}
 }
 


### PR DESCRIPTION
The conditions as they were didn't accurately reflect the [diagram](https://www.websequencediagrams.com/?lz=ICAgIG9wdCBSZWxhdGlvbnNoaXBzCiAgICBSb3V0ZS0tPlJldmlzaW9uOiBXYXRjaGUAFwcADwctPkRlcGxveW1lbnQ6IENyZWF0ZXMgLwAVF0tQQQANGEFjdGl2YXRvci0ARQ4AaQxLUEEADw9Db2xsZWN0cyBtZXRyaWMAGwwASAkADxdlbmQAgWMFAIFoBW9wdCBEZWEAfgZpb24ADA5LUEEgUmVjb25jaWxlAIIYBQCBawotAIFPB09ic2VydmVzIG5vIHRyYWZmaWMAgSsJAIFyBgCBXQVlPUZhbHMAPwYAcREAgmMIAF4PAIFxBgCCfgoAYglpbgCBLQUAgQ0GIyB2aWEgUHJvcGFnYXRlS1BBU3RhdHVzKGtwYSkAgyUPAINKCgByI291dGUAgXAPAIN1CS0-AIQiBQB6GlRPRE86IHMAgQUFIGZyb20gSXN0aW8vSW5ncmVzcz8AgTALABQFIHByb2dyYW1taW5nIChub3Qgc2hvd24AgToHAIUOBQBrCEVuYWJsZQCELwoAZQ1XZSBzaG91bGQgaGF2ZSB0aGlzIGxpbmUgdW50aWwAgioHS1BBIGlzIHNvdXJjZS1vZi10cnV0aACCRwcAZQgAhXYJU2VydmluZ1N0YXRlPVJlAINqBQCENBYAhCMNIChyZXN5bmMAgn4GIyBUaGlzIGlzIG91ciAic2xlZXAiLCBvbmNlIHdlIGRlcHJlY2F0ZSBzAGgGAII2BQCDWQgAgUEFd2lsbCBlbnN1cmUgdW5yb3V0AIICBQCHHwhzIGFyZSB0dXJuZWQgZG93bi4AbAx3AIIOBWJlIHNlcXVlbmNlZCBhZnRlciB0aGUgAIV4B29yIGJpdACETQdhYm92AIIuBwCCJwh0aGUAgiMQAF4Gbm90ZSByaWdodCBvZiAAh2cFV2FpdCBmb3IAh1UKIChhcyBuZWVkZWQAggoIVmlhAE8GY2FsZVRhcmdldFJlZgCGNAoAiFYMU2NhbGUgdG8gemVybwCHOw0Ahz8RAIhLBwCHKyMAgSsOAIguC1JlY2VpdmUAh0QNAIkdDACHbgwAh2kNAIEeN29uAIdoCgCIKA1Vbmtub3cAiREGAId4PwCDXwhpbmcAhQkJAIQ1CiBpcwCJIgcsIGJ1dACEEwVFbmRwb2ludACEVgVuJ3QgbmVjZXNzYXJpbHkgcG9wdWxhdGVkAIRiBgCISRsAgScdAIc4DgCEPA4AjAEOAIRKB3JlYWRpbmVzAI0nBiMgV2hlbgCBHw9iYWNraW5nAIVXBUs4cwCHOwZjZSBpbiBLUEEAii4HZ2V0cyBhbiBlbnRyeSBpAIhrBQCGHQdSZWFkeQCGOQYAi2MNAIxPCwCDdAgAfhBGb3J3YXJkAIZSBXF1ZXVlZACMDQgAhwkGAI1kCgCOMw0ALgkAjDYLAIhAHgCMcB4gKGYAgQMGZWQpAIx4HlRydQCMUEUAiD8GAIt1CQCDdGYAgSIbAI0qEwCEIQtyAI5pCGJlY29tZXMgYACDbwU6IFRydWVgAI1NHgCBXA5Td2FwIG8AhioHAIo_CmEAhFcFaW50ZXJtZWRpYXIAhEkHAI08DkRpcwCNOBMAiU0M&s=default).

In particular, we expect `Active=False` to happen when activity drops to zero, NOT when the resource has actually been scaled down.  This is to enable the stuff at the higher level to key off of `Active=False` to hook in the activator.  We cannot use `Active=Unknown` since we are in this state for both down and up.

This also updates a few TODOs.

Related: https://github.com/knative/serving/issues/1655