### PR TITLE
Add logic to ignore negative scales.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -49,6 +49,11 @@ func NewKPAScaler(servingClientSet clientset.Interface, scaleClientSet scale.Sca
 func (rs *kpaScaler) Scale(kpa *kpa.PodAutoscaler, desiredScale int32) error {
 	logger := loggerWithKPAInfo(rs.logger, kpa.Namespace, kpa.Name)
 
+	if desiredScale < 0 {
+		logger.Debug("Metrics are not yet being collected.")
+		return nil
+	}
+
 	// TODO(mattmoor): Drop this once the KPA is the source of truth for ServingState.
 	revGVK := v1alpha1.SchemeGroupVersion.WithKind("Revision")
 	owner := metav1.GetControllerOf(kpa)

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
@@ -82,6 +82,14 @@ func TestKPAScaler(t *testing.T) {
 		wantState:     v1alpha1.RevisionServingStateActive,
 		wantReplicas:  0,
 		wantScaling:   false,
+	}, {
+		label:         "ignore negative scale",
+		startState:    v1alpha1.RevisionServingStateActive,
+		startReplicas: 12,
+		scaleTo:       -1,
+		wantState:     v1alpha1.RevisionServingStateActive,
+		wantReplicas:  12,
+		wantScaling:   false,
 	}}
 
 	for _, e := range examples {


### PR DESCRIPTION
The metric is initialized to -1, which is fixed the first time the uniscaler "ticks", but the initial reconciliation will see this and try to `/scale` the deployment.