### PR TITLE
Log stats received at debug

### DIFF
--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -148,6 +148,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		s.logger.Debugf("Received stat message: %+v", sm)
 		s.statsCh <- &sm
 	}
 }


### PR DESCRIPTION
## Proposed Changes

  * Log stat messages when received at debug level.  This really helps when debugging the autoscaling metrics pipeline.
