### PR TITLE
Verify requests succeed while testing autoscaling.

### DIFF
--- a/pkg/activator/util/retryer.go
+++ b/pkg/activator/util/retryer.go
@@ -45,7 +45,7 @@ func (r RetryerFunc) Retry(f ActionFunc) int {
 // between retries by the `intervalFunc`
 func NewRetryer(intervalFunc IntervalFunc, maxRetries int) Retryer {
 	return RetryerFunc(func(action ActionFunc) (retries int) {
-		for retries = 1; !action() && retries < maxRetries; retries++ {
+		for retries = 1; action() && retries < maxRetries; retries++ {
 			time.Sleep(intervalFunc(retries))
 		}
 		return

--- a/pkg/activator/util/retryer_test.go
+++ b/pkg/activator/util/retryer_test.go
@@ -28,25 +28,25 @@ func TestRetryer(t *testing.T) {
 		{
 			label:       "atleast once",
 			maxRetries:  0,
-			responses:   []bool{true},
+			responses:   []bool{false},
 			wantRetries: 1,
 		},
 		{
 			label:       "< maxRetries",
 			maxRetries:  3,
-			responses:   []bool{false, true},
+			responses:   []bool{true, false},
 			wantRetries: 2,
 		},
 		{
 			label:       "= maxRetries",
 			maxRetries:  3,
-			responses:   []bool{false, false, true},
+			responses:   []bool{true, true, false},
 			wantRetries: 3,
 		},
 		{
 			label:       "> maxRetries",
 			maxRetries:  3,
-			responses:   []bool{false, false, false, true},
+			responses:   []bool{true, true, true, false},
 			wantRetries: 3,
 		},
 	}

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -81,7 +81,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, logger *zap.Sugared
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 
-	err = test.WaitForEndpointState(
+	_, err = test.WaitForEndpointState(
 		clients.KubeClient,
 		logger,
 		updatedRoute.Status.Domain,

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -54,7 +54,7 @@ func updateServiceWithImage(clients *test.Clients, names test.ResourceNames, ima
 // Shamelessly cribbed from route_test. We expect the Route and Configuration to be ready if the Service is ready.
 func assertServiceResourcesUpdated(t *testing.T, logger *zap.SugaredLogger, clients *test.Clients, names test.ResourceNames, routeDomain, expectedGeneration, expectedText string) {
 	// TODO(#1178): Remove "Wait" from all checks below this point.
-	err := test.WaitForEndpointState(
+	_, err := test.WaitForEndpointState(
 		clients.KubeClient,
 		logger,
 		routeDomain,

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -72,7 +72,7 @@ func TestBuildAndServe(t *testing.T) {
 	domain := route.Status.Domain
 
 	endState := test.Retrying(test.MatchesBody(helloWorldExpectedOutput), http.StatusNotFound)
-	if err := test.WaitForEndpointState(clients.KubeClient, logger, domain, endState, "HelloWorldServesText"); err != nil {
+	if _, err := test.WaitForEndpointState(clients.KubeClient, logger, domain, endState, "HelloWorldServesText"); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
 

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -59,7 +59,7 @@ func TestHelloWorld(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	err = test.WaitForEndpointState(
+	_, err = test.WaitForEndpointState(
 		clients.KubeClient,
 		logger,
 		domain,

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -109,7 +109,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get Route %s: %v", httpProxyNames.Route, err)
 	}
-	if err = test.WaitForEndpointState(
+	if _, err = test.WaitForEndpointState(
 		clients.KubeClient,
 		logger,
 		httpProxyRoute.Status.Domain, test.Retrying(test.MatchesAny, http.StatusServiceUnavailable, http.StatusNotFound),

--- a/test/request.go
+++ b/test/request.go
@@ -80,21 +80,21 @@ func EventuallyMatchesBody(expected string) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClientset *KubeClient, logger *zap.SugaredLogger, domain string, inState spoof.ResponseChecker, desc string) error {
+func WaitForEndpointState(kubeClientset *KubeClient, logger *zap.SugaredLogger, domain string, inState spoof.ResponseChecker, desc string) (*spoof.Response, error) {
 	metricName := fmt.Sprintf("WaitForEndpointState/%s", desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	client, err := spoof.New(kubeClientset.Kube, logger, domain, ServingFlags.ResolvableDomain)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = client.Poll(req, inState)
-	return err
+	res, err := client.Poll(req, inState)
+	return res, err
 }


### PR DESCRIPTION
Fixes #1878

## Proposed Changes

  * Verify response success when scaling revisions up during e2e testing.

**Release Note**
```release-note
NONE
```
