### PR TITLE
Make Revision controller insensitive to ServingState.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -35,20 +35,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	vpav1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 )
 
 func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revision) (*appsv1.Deployment, error) {
 	logger := logging.FromContext(ctx)
 
-	// TODO(mattmoor): REMOVE ME
-	var replicaCount int32 = 1
-	if rev.Spec.ServingState == v1alpha1.RevisionServingStateReserve {
-		replicaCount = 0
-	}
 	deployment := resources.MakeDeployment(rev, c.getLoggingConfig(), c.getNetworkConfig(),
-		c.getObservabilityConfig(), c.getAutoscalerConfig(), c.getControllerConfig(), replicaCount)
+		c.getObservabilityConfig(), c.getAutoscalerConfig(), c.getControllerConfig())
 
 	// Resolve tag image references to digests.
 	if err := c.getResolver().Resolve(deployment); err != nil {
@@ -75,19 +69,6 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 	// deployment.Spec = desiredDeployment.Spec
 	// d, err := c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Update(deployment)
 	// return d, WasChanged, err
-}
-
-func (c *Reconciler) deleteDeployment(ctx context.Context, deployment *appsv1.Deployment) error {
-	logger := logging.FromContext(ctx)
-
-	err := c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Delete(deployment.Name, fgDeleteOptions)
-	if apierrs.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		logger.Errorf("deployments.Delete for %q failed: %s", deployment.Name, err)
-		return err
-	}
-	return nil
 }
 
 func (c *Reconciler) createKPA(ctx context.Context, rev *v1alpha1.Revision) (*kpa.PodAutoscaler, error) {
@@ -140,39 +121,10 @@ func (c *Reconciler) checkAndUpdateService(ctx context.Context, rev *v1alpha1.Re
 	return d, WasChanged, err
 }
 
-func (c *Reconciler) deleteService(ctx context.Context, svc *corev1.Service) error {
-	logger := logging.FromContext(ctx)
-
-	err := c.KubeClientSet.CoreV1().Services(svc.Namespace).Delete(svc.Name, fgDeleteOptions)
-	if apierrs.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		logger.Errorf("service.Delete for %q failed: %s", svc.Name, err)
-		return err
-	}
-	return nil
-}
-
 func (c *Reconciler) createVPA(ctx context.Context, rev *v1alpha1.Revision) (*vpav1alpha1.VerticalPodAutoscaler, error) {
 	vpa := resources.MakeVPA(rev)
 
 	return c.vpaClient.PocV1alpha1().VerticalPodAutoscalers(vpa.Namespace).Create(vpa)
-}
-
-func (c *Reconciler) deleteVPA(ctx context.Context, vpa *vpav1alpha1.VerticalPodAutoscaler) error {
-	logger := logging.FromContext(ctx)
-	if !c.getAutoscalerConfig().EnableVPA {
-		return nil
-	}
-
-	err := c.vpaClient.PocV1alpha1().VerticalPodAutoscalers(vpa.Namespace).Delete(vpa.Name, fgDeleteOptions)
-	if apierrs.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		logger.Errorf("vpa.Delete for %q failed: %v", vpa.Name, err)
-		return err
-	}
-	return nil
 }
 
 func (c *Reconciler) getNetworkConfig() *config.Network {

--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	commonlogkey "github.com/knative/pkg/logging/logkey"
+	kpav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/logging/logkey"
@@ -48,65 +49,44 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 	logger := logging.FromContext(ctx).With(zap.String(commonlogkey.Deployment, deploymentName))
 
 	deployment, getDepErr := c.deploymentLister.Deployments(ns).Get(deploymentName)
-	switch rev.Spec.ServingState {
-	case v1alpha1.RevisionServingStateActive, v1alpha1.RevisionServingStateReserve:
-		// When Active or Reserved, deployment should exist and have a particular specification.
-		if apierrs.IsNotFound(getDepErr) {
-			// Deployment does not exist. Create it.
-			rev.Status.MarkDeploying("Deploying")
-			var err error
-			deployment, err = c.createDeployment(ctx, rev)
-			if err != nil {
-				logger.Errorf("Error creating deployment %q: %v", deploymentName, err)
-				return err
-			}
-			logger.Infof("Created deployment %q", deploymentName)
-		} else if getDepErr != nil {
-			logger.Errorf("Error reconciling deployment %q: %v", deploymentName, getDepErr)
-			return getDepErr
-		} else {
-			// Deployment exist. Update the replica count based on the serving state if necessary
-			var changed Changed
-			var err error
-			deployment, changed, err = c.checkAndUpdateDeployment(ctx, rev, deployment)
-			if err != nil {
-				logger.Errorf("Error updating deployment %q: %v", deploymentName, err)
-				return err
-			}
-			if changed == WasChanged {
-				logger.Infof("Updated deployment %q", deploymentName)
-				rev.Status.MarkDeploying("Updating")
-			}
-		}
-
-		// Now that we have a Deployment, determine whether there is any relevant
-		// status to surface in the Revision.
-		if hasDeploymentTimedOut(deployment) {
-			rev.Status.MarkProgressDeadlineExceeded(fmt.Sprintf(
-				"Unable to create pods for more than %d seconds.", resources.ProgressDeadlineSeconds))
-			c.Recorder.Eventf(rev, corev1.EventTypeNormal, "ProgressDeadlineExceeded",
-				"Revision %s not ready due to Deployment timeout", rev.Name)
-		}
-		return nil
-
-	case v1alpha1.RevisionServingStateRetired:
-		// When Retired, we remove the underlying Deployment.
-		if apierrs.IsNotFound(getDepErr) {
-			// If it does not exist, then we have nothing to do.
-			return nil
-		}
-		if err := c.deleteDeployment(ctx, deployment); err != nil {
-			logger.Errorf("Error deleting deployment %q: %v", deploymentName, err)
+	// When Active or Reserved, deployment should exist and have a particular specification.
+	if apierrs.IsNotFound(getDepErr) {
+		// Deployment does not exist. Create it.
+		rev.Status.MarkDeploying("Deploying")
+		var err error
+		deployment, err = c.createDeployment(ctx, rev)
+		if err != nil {
+			logger.Errorf("Error creating deployment %q: %v", deploymentName, err)
 			return err
 		}
-		logger.Infof("Deleted deployment %q", deploymentName)
-		rev.Status.MarkInactive(fmt.Sprintf("Revision %q is Inactive.", rev.Name))
-		return nil
-
-	default:
-		logger.Errorf("Unknown serving state: %v", rev.Spec.ServingState)
-		return nil
+		logger.Infof("Created deployment %q", deploymentName)
+	} else if getDepErr != nil {
+		logger.Errorf("Error reconciling deployment %q: %v", deploymentName, getDepErr)
+		return getDepErr
+	} else {
+		// Deployment exist. Update the replica count based on the serving state if necessary
+		var changed Changed
+		var err error
+		deployment, changed, err = c.checkAndUpdateDeployment(ctx, rev, deployment)
+		if err != nil {
+			logger.Errorf("Error updating deployment %q: %v", deploymentName, err)
+			return err
+		}
+		if changed == WasChanged {
+			logger.Infof("Updated deployment %q", deploymentName)
+			rev.Status.MarkDeploying("Updating")
+		}
 	}
+
+	// Now that we have a Deployment, determine whether there is any relevant
+	// status to surface in the Revision.
+	if hasDeploymentTimedOut(deployment) {
+		rev.Status.MarkProgressDeadlineExceeded(fmt.Sprintf(
+			"Unable to create pods for more than %d seconds.", resources.ProgressDeadlineSeconds))
+		c.Recorder.Eventf(rev, corev1.EventTypeNormal, "ProgressDeadlineExceeded",
+			"Revision %s not ready due to Deployment timeout", rev.Name)
+	}
+	return nil
 }
 
 func (c *Reconciler) reconcileKPA(ctx context.Context, rev *v1alpha1.Revision) error {
@@ -137,7 +117,18 @@ func (c *Reconciler) reconcileKPA(ctx context.Context, rev *v1alpha1.Revision) e
 		}
 	}
 
-	// TODO(mattmoor): Update status based on the KPA status.
+	// Reflect the KPA status in our own.
+	cond := kpa.Status.GetCondition(kpav1alpha1.PodAutoscalerConditionReady)
+	switch {
+	case cond == nil:
+		// TODO(mattmoor): rev.Status.MarkActivating("Deploying", "")
+	case cond.Status == corev1.ConditionUnknown:
+		// TODO(mattmoor): rev.Status.MarkActivating(cond.Reason, cond.Message)
+	case cond.Status == corev1.ConditionFalse:
+		rev.Status.MarkInactive(cond.Message)
+	case cond.Status == corev1.ConditionTrue:
+		// TODO(mattmoor): rev.Status.MarkActive()
+	}
 	return nil
 }
 
@@ -149,93 +140,73 @@ func (c *Reconciler) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 	rev.Status.ServiceName = serviceName
 
 	service, err := c.serviceLister.Services(ns).Get(serviceName)
-	switch rev.Spec.ServingState {
-	case v1alpha1.RevisionServingStateActive:
-		// When Active, the Service should exist and have a particular specification.
-		if apierrs.IsNotFound(err) {
-			// If it does not exist, then create it.
-			rev.Status.MarkDeploying("Deploying")
-			service, err = c.createService(ctx, rev, resources.MakeK8sService)
-			if err != nil {
-				logger.Errorf("Error creating Service %q: %v", serviceName, err)
-				return err
-			}
-			logger.Infof("Created Service %q", serviceName)
-		} else if err != nil {
-			logger.Errorf("Error reconciling Active Service %q: %v", serviceName, err)
-			return err
-		} else {
-			// If it exists, then make sure if looks as we expect.
-			// It may change if a user edits things around our controller, which we
-			// should not allow, or if our expectations of how the service should look
-			// changes (e.g. we update our controller with new sidecars).
-			var changed Changed
-			service, changed, err = c.checkAndUpdateService(ctx, rev, resources.MakeK8sService, service)
-			if err != nil {
-				logger.Errorf("Error updating Service %q: %v", serviceName, err)
-				return err
-			}
-			if changed == WasChanged {
-				logger.Infof("Updated Service %q", serviceName)
-				rev.Status.MarkDeploying("Updating")
-			}
-		}
-
-		// We cannot determine readiness from the Service directly.  Instead, we look up
-		// the backing Endpoints resource and check it for healthy pods.  The name of the
-		// Endpoints resource matches the Service it backs.
-		endpoints, err := c.endpointsLister.Endpoints(ns).Get(serviceName)
-		if apierrs.IsNotFound(err) {
-			// If it isn't found, then we need to wait for the Service controller to
-			// create it.
-			logger.Infof("Endpoints not created yet %q", serviceName)
-			rev.Status.MarkDeploying("Deploying")
-			return nil
-		} else if err != nil {
-			logger.Errorf("Error checking Active Endpoints %q: %v", serviceName, err)
+	// When Active, the Service should exist and have a particular specification.
+	if apierrs.IsNotFound(err) {
+		// If it does not exist, then create it.
+		rev.Status.MarkDeploying("Deploying")
+		service, err = c.createService(ctx, rev, resources.MakeK8sService)
+		if err != nil {
+			logger.Errorf("Error creating Service %q: %v", serviceName, err)
 			return err
 		}
-		// If the endpoints resource indicates that the Service it sits in front of is ready,
-		// then surface this in our Revision status as resources available (pods were scheduled)
-		// and container healthy (endpoints should be gated by any provided readiness checks).
-		if getIsServiceReady(endpoints) {
-			rev.Status.MarkResourcesAvailable()
-			rev.Status.MarkContainerHealthy()
-			// TODO(mattmoor): How to ensure this only fires once?
-			c.Recorder.Eventf(rev, corev1.EventTypeNormal, "RevisionReady",
-				"Revision becomes ready upon endpoint %q becoming ready", serviceName)
-		} else {
-			// If the endpoints is NOT ready, then check whether it is taking unreasonably
-			// long to become ready and if so mark our revision as having timed out waiting
-			// for the Service to become ready.
-			revisionAge := time.Now().Sub(getRevisionLastTransitionTime(rev))
-			if revisionAge >= serviceTimeoutDuration {
-				rev.Status.MarkServiceTimeout()
-				// TODO(mattmoor): How to ensure this only fires once?
-				c.Recorder.Eventf(rev, corev1.EventTypeWarning, "RevisionFailed",
-					"Revision did not become ready due to endpoint %q", serviceName)
-			}
-		}
-		return nil
-
-	case v1alpha1.RevisionServingStateReserve, v1alpha1.RevisionServingStateRetired:
-		// When Reserve or Retired, we remove the underlying Service.
-		if apierrs.IsNotFound(err) {
-			// If it does not exist, then we have nothing to do.
-			return nil
-		}
-		if err := c.deleteService(ctx, service); err != nil {
-			logger.Errorf("Error deleting Service %q: %v", serviceName, err)
+		logger.Infof("Created Service %q", serviceName)
+	} else if err != nil {
+		logger.Errorf("Error reconciling Active Service %q: %v", serviceName, err)
+		return err
+	} else {
+		// If it exists, then make sure if looks as we expect.
+		// It may change if a user edits things around our controller, which we
+		// should not allow, or if our expectations of how the service should look
+		// changes (e.g. we update our controller with new sidecars).
+		var changed Changed
+		service, changed, err = c.checkAndUpdateService(ctx, rev, resources.MakeK8sService, service)
+		if err != nil {
+			logger.Errorf("Error updating Service %q: %v", serviceName, err)
 			return err
 		}
-		logger.Infof("Deleted Service %q", serviceName)
-		rev.Status.MarkInactive(fmt.Sprintf("Revision %q is Inactive.", rev.Name))
-		return nil
-
-	default:
-		logger.Errorf("Unknown serving state: %v", rev.Spec.ServingState)
-		return nil
+		if changed == WasChanged {
+			logger.Infof("Updated Service %q", serviceName)
+			rev.Status.MarkDeploying("Updating")
+		}
 	}
+
+	// We cannot determine readiness from the Service directly.  Instead, we look up
+	// the backing Endpoints resource and check it for healthy pods.  The name of the
+	// Endpoints resource matches the Service it backs.
+	endpoints, err := c.endpointsLister.Endpoints(ns).Get(serviceName)
+	if apierrs.IsNotFound(err) {
+		// If it isn't found, then we need to wait for the Service controller to
+		// create it.
+		logger.Infof("Endpoints not created yet %q", serviceName)
+		rev.Status.MarkDeploying("Deploying")
+		return nil
+	} else if err != nil {
+		logger.Errorf("Error checking Active Endpoints %q: %v", serviceName, err)
+		return err
+	}
+
+	// If the endpoints resource indicates that the Service it sits in front of is ready,
+	// then surface this in our Revision status as resources available (pods were scheduled)
+	// and container healthy (endpoints should be gated by any provided readiness checks).
+	if getIsServiceReady(endpoints) {
+		rev.Status.MarkResourcesAvailable()
+		rev.Status.MarkContainerHealthy()
+		// TODO(mattmoor): How to ensure this only fires once?
+		c.Recorder.Eventf(rev, corev1.EventTypeNormal, "RevisionReady",
+			"Revision becomes ready upon endpoint %q becoming ready", serviceName)
+	} else {
+		// If the endpoints is NOT ready, then check whether it is taking unreasonably
+		// long to become ready and if so mark our revision as having timed out waiting
+		// for the Service to become ready.
+		revisionAge := time.Now().Sub(getRevisionLastTransitionTime(rev))
+		if revisionAge >= serviceTimeoutDuration {
+			rev.Status.MarkServiceTimeout()
+			// TODO(mattmoor): How to ensure this only fires once?
+			c.Recorder.Eventf(rev, corev1.EventTypeWarning, "RevisionFailed",
+				"Revision did not become ready due to endpoint %q", serviceName)
+		}
+	}
+	return nil
 }
 
 func (c *Reconciler) reconcileFluentdConfigMap(ctx context.Context, rev *v1alpha1.Revision) error {
@@ -275,6 +246,7 @@ func (c *Reconciler) reconcileFluentdConfigMap(ctx context.Context, rev *v1alpha
 	return nil
 }
 
+// TODO(#1876): Move this into the KPA's scope.
 func (c *Reconciler) reconcileVPA(ctx context.Context, rev *v1alpha1.Revision) error {
 	logger := logging.FromContext(ctx)
 	if !c.getAutoscalerConfig().EnableVPA {
@@ -285,45 +257,23 @@ func (c *Reconciler) reconcileVPA(ctx context.Context, rev *v1alpha1.Revision) e
 	vpaName := resourcenames.VPA(rev)
 
 	// TODO(mattmoor): Switch to informer lister once it can reliably be sunk.
-	vpa, err := c.vpaClient.PocV1alpha1().VerticalPodAutoscalers(ns).Get(vpaName, metav1.GetOptions{})
-	switch rev.Spec.ServingState {
-	case v1alpha1.RevisionServingStateActive:
-		// When Active, the VPA should exist and have a particular specification.
-		if apierrs.IsNotFound(err) {
-			// If it does not exist, then create it.
-			vpa, err = c.createVPA(ctx, rev)
-			if err != nil {
-				logger.Errorf("Error creating VPA %q: %v", vpaName, err)
-				return err
-			}
-			logger.Infof("Created VPA %q", vpaName)
-		} else if err != nil {
-			logger.Errorf("Error reconciling Active VPA %q: %v", vpaName, err)
-			return err
-		} else {
-			// TODO(mattmoor): Should we checkAndUpdate the VPA, or would it
-			// suffer similar problems to Deployment?
-		}
-
-		// TODO(mattmoor): We don't predicate the Revision's readiness on any readiness
-		// properties of the autoscaler, but perhaps we should.
-		return nil
-
-	case v1alpha1.RevisionServingStateReserve, v1alpha1.RevisionServingStateRetired:
-		// When Reserve or Retired, we remove the underlying VPA.
-		if apierrs.IsNotFound(err) {
-			// If it does not exist, then we have nothing to do.
-			return nil
-		}
-		if err := c.deleteVPA(ctx, vpa); err != nil {
-			logger.Errorf("Error deleting VPA %q: %v", vpaName, err)
+	_, err := c.vpaClient.PocV1alpha1().VerticalPodAutoscalers(ns).Get(vpaName, metav1.GetOptions{})
+	// When Active, the VPA should exist and have a particular specification.
+	if apierrs.IsNotFound(err) {
+		// If it does not exist, then create it.
+		_, err = c.createVPA(ctx, rev)
+		if err != nil {
+			logger.Errorf("Error creating VPA %q: %v", vpaName, err)
 			return err
 		}
-		logger.Infof("Deleted VPA %q", vpaName)
-		return nil
-
-	default:
-		logger.Errorf("Unknown serving state: %v", rev.Spec.ServingState)
-		return nil
+		logger.Infof("Created VPA %q", vpaName)
+	} else if err != nil {
+		logger.Errorf("Error reconciling Active VPA %q: %v", vpaName, err)
+		return err
+	} else {
+		// TODO(mattmoor): Should we checkAndUpdate the VPA, or would it
+		// suffer similar problems to Deployment?
 	}
+
+	return nil
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -135,7 +135,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 
 func MakeDeployment(rev *v1alpha1.Revision,
 	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
-	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller, replicaCount int32) *appsv1.Deployment {
+	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *appsv1.Deployment {
 
 	podTemplateAnnotations := makeAnnotations(rev)
 	podTemplateAnnotations[sidecarIstioInjectAnnotation] = "true"
@@ -154,6 +154,7 @@ func MakeDeployment(rev *v1alpha1.Revision,
 		}
 	}
 
+	one := int32(1)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            names.Deployment(rev),
@@ -163,7 +164,7 @@ func MakeDeployment(rev *v1alpha1.Revision,
 			OwnerReferences: []metav1.OwnerReference{*reconciler.NewControllerRef(rev)},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:                &replicaCount,
+			Replicas:                &one,
 			Selector:                makeSelector(rev),
 			ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -688,7 +688,7 @@ func TestMakePodSpec(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := makePodSpec(test.rev, test.lc, test.oc, test.ac, test.cc)
 			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-				t.Errorf("MakeDeployment (-want, +got) = %v", diff)
+				t.Errorf("makePodSpec (-want, +got) = %v", diff)
 			}
 		})
 	}
@@ -696,15 +696,14 @@ func TestMakePodSpec(t *testing.T) {
 
 func TestMakeDeployment(t *testing.T) {
 	tests := []struct {
-		name     string
-		rev      *v1alpha1.Revision
-		lc       *logging.Config
-		nc       *config.Network
-		oc       *config.Observability
-		ac       *autoscaler.Config
-		cc       *config.Controller
-		replicas int32
-		want     *appsv1.Deployment
+		name string
+		rev  *v1alpha1.Revision
+		lc   *logging.Config
+		nc   *config.Network
+		oc   *config.Observability
+		ac   *autoscaler.Config
+		cc   *config.Controller
+		want *appsv1.Deployment
 	}{{
 		name: "simple concurrency=single no owner",
 		rev: &v1alpha1.Revision{
@@ -720,12 +719,11 @@ func TestMakeDeployment(t *testing.T) {
 				},
 			},
 		},
-		lc:       &logging.Config{},
-		nc:       &config.Network{},
-		oc:       &config.Observability{},
-		ac:       &autoscaler.Config{},
-		cc:       &config.Controller{},
-		replicas: 1,
+		lc: &logging.Config{},
+		nc: &config.Network{},
+		oc: &config.Observability{},
+		ac: &autoscaler.Config{},
+		cc: &config.Controller{},
 		want: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -792,12 +790,11 @@ func TestMakeDeployment(t *testing.T) {
 				},
 			},
 		},
-		lc:       &logging.Config{},
-		nc:       &config.Network{},
-		oc:       &config.Observability{},
-		ac:       &autoscaler.Config{},
-		cc:       &config.Controller{},
-		replicas: 1,
+		lc: &logging.Config{},
+		nc: &config.Network{},
+		oc: &config.Observability{},
+		ac: &autoscaler.Config{},
+		cc: &config.Controller{},
 		want: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -861,10 +858,9 @@ func TestMakeDeployment(t *testing.T) {
 		nc: &config.Network{
 			IstioOutboundIPRanges: "*",
 		},
-		oc:       &config.Observability{},
-		ac:       &autoscaler.Config{},
-		cc:       &config.Controller{},
-		replicas: 1,
+		oc: &config.Observability{},
+		ac: &autoscaler.Config{},
+		cc: &config.Controller{},
 		want: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -932,10 +928,9 @@ func TestMakeDeployment(t *testing.T) {
 		nc: &config.Network{
 			IstioOutboundIPRanges: "*",
 		},
-		oc:       &config.Observability{},
-		ac:       &autoscaler.Config{},
-		cc:       &config.Controller{},
-		replicas: 1,
+		oc: &config.Observability{},
+		ac: &autoscaler.Config{},
+		cc: &config.Controller{},
 		want: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -990,7 +985,7 @@ func TestMakeDeployment(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Tested above so that we can rely on it here for brevity.
 			test.want.Spec.Template.Spec = *makePodSpec(test.rev, test.lc, test.oc, test.ac, test.cc)
-			got := MakeDeployment(test.rev, test.lc, test.nc, test.oc, test.ac, test.cc, test.replicas)
+			got := MakeDeployment(test.rev, test.lc, test.nc, test.oc, test.ac, test.cc)
 			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
 				t.Errorf("MakeDeployment (-want, +got) = %v", diff)
 			}

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -351,31 +351,6 @@ func TestReconcile(t *testing.T) {
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: kpa("foo", "deactivate", "Reserve", "busybox"),
-		}, {
-			Object: makeStatus(
-				rev("foo", "deactivate", "Reserve", "busybox"),
-				// After reconciliation, the status will change to reflect that this is being Deactivated.
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "deactivate", "Reserve", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:    "Ready",
-						Status:  "False",
-						Reason:  "Inactive",
-						Message: `Revision "deactivate" is Inactive.`,
-					}, {
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-		}},
-		WantDeletes: []clientgotesting.DeleteActionImpl{{
-			Name: svc("foo", "deactivate", "Reserve", "busybox").Name,
 		}},
 		// We update the Deployments to have zero replicas and delete the K8s Services when we deactivate.
 		Key: "foo/deactivate",
@@ -413,32 +388,6 @@ func TestReconcile(t *testing.T) {
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: kpa("foo", "update-kpa-failure", "Reserve", "busybox"),
-		}, {
-			Object: makeStatus(
-				rev("foo", "update-kpa-failure", "Reserve", "busybox"),
-				// After reconciliation, the status will change to reflect that this is being Deactivated.
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "update-kpa-failure", "Reserve", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:    "Ready",
-						Status:  "False",
-						Reason:  "Inactive",
-						Message: `Revision "update-kpa-failure" is Inactive.`,
-					}, {
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-		}},
-		WantDeletes: []clientgotesting.DeleteActionImpl{{
-			Name: svc("foo", "update-kpa-failure", "Reserve", "busybox").Name,
-			// We don't reach deleting the autoscaler service.
 		}},
 		// We update the Deployments to have zero replicas and delete the K8s Services when we deactivate.
 		Key: "foo/update-kpa-failure",
@@ -455,200 +404,25 @@ func TestReconcile(t *testing.T) {
 					ServiceName: svc("foo", "stable-deactivation", "Reserve", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Updating",
-					}, {
 						Type:   "ContainerHealthy",
 						Status: "Unknown",
-						Reason: "Updating",
+						Reason: "Deploying",
 					}, {
-						Type:    "Ready",
-						Status:  "False",
-						Reason:  "Inactive",
-						Message: `Revision "stable-deactivation" is Inactive.`,
+						Type:   "Ready",
+						Status: "Unknown",
+						Reason: "Deploying",
+					}, {
+						Type:   "ResourcesAvailable",
+						Status: "Unknown",
+						Reason: "Deploying",
 					}},
 				}),
 			kpa("foo", "stable-deactivation", "Reserve", "busybox"),
 			// The Deployments match what we'd expect of an Reserve revision.
 			deploy("foo", "stable-deactivation", "Reserve", "busybox"),
+			svc("foo", "stable-deactivation", "Reserve", "busybox"),
 		},
 		Key: "foo/stable-deactivation",
-	}, {
-		Name: "retire a revision",
-		// Test the transition that's made when Retired is set.
-		// We initialize the world to a stable Active state, but make the
-		// Revision's ServingState Retired.  We then looks for the expected
-		// mutations, which should include the deletion of all Kubernetes
-		// resources.
-		Objects: []runtime.Object{
-			makeStatus(
-				// The revision has been set to Retired, but all of the objects
-				// reflect being Active.
-				rev("foo", "retire", "Retired", "busybox"),
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "retire", "Active", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "Ready",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-			kpa("foo", "retire", "Retired", "busybox"),
-			// The Deployments match what we'd expect of an Active revision.
-			deploy("foo", "retire", "Active", "busybox"),
-			// The Services match what we'd expect of an Active revision.
-			svc("foo", "retire", "Active", "busybox"),
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeStatus(
-				rev("foo", "retire", "Retired", "busybox"),
-				// After reconciliation, the status will change to reflect that this is being Retired.
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "retire", "Retired", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:    "Ready",
-						Status:  "False",
-						Reason:  "Inactive",
-						Message: `Revision "retire" is Inactive.`,
-					}, {
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-		}},
-		WantDeletes: []clientgotesting.DeleteActionImpl{{
-			Name: deploy("foo", "retire", "Retired", "busybox").Name,
-		}, {
-			Name: svc("foo", "retire", "Retired", "busybox").Name,
-		}},
-		// We delete a bunch of stuff when we retire.
-		Key: "foo/retire",
-	}, {
-		Name: "failure deleting user deployment",
-		// Induce a failure deleting the user's deployment
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("delete", "deployments"),
-		},
-		Objects: []runtime.Object{
-			makeStatus(
-				// The revision has been set to Retired, but all of the objects
-				// reflect being Active.
-				rev("foo", "delete-user-deploy-failure", "Retired", "busybox"),
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "delete-user-deploy-failure", "Active", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "Ready",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-			kpa("foo", "delete-user-deploy-failure", "Retired", "busybox"),
-			// The Deployments match what we'd expect of an Active revision.
-			deploy("foo", "delete-user-deploy-failure", "Active", "busybox"),
-			// The Services match what we'd expect of an Active revision.
-			svc("foo", "delete-user-deploy-failure", "Active", "busybox"),
-		},
-		WantDeletes: []clientgotesting.DeleteActionImpl{{
-			Name: deploy("foo", "delete-user-deploy-failure", "Retired", "busybox").Name,
-			// We don't get to deleting anything else.
-		}},
-		// We delete a bunch of stuff when we retire.
-		Key: "foo/delete-user-deploy-failure",
-	}, {
-		Name: "failure deleting user service",
-		// Induce a failure deleting the user's service
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("delete", "services"),
-		},
-		Objects: []runtime.Object{
-			makeStatus(
-				// The revision has been set to Retired, but all of the objects
-				// reflect being Active.
-				rev("foo", "delete-user-svc-failure", "Retired", "busybox"),
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "delete-user-svc-failure", "Active", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "Ready",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-			kpa("foo", "delete-user-svc-failure", "Retired", "busybox"),
-			// The Services match what we'd expect of an Active revision.
-			svc("foo", "delete-user-svc-failure", "Active", "busybox"),
-		},
-		WantDeletes: []clientgotesting.DeleteActionImpl{{
-			Name: svc("foo", "delete-user-svc-failure", "Active", "busybox").Name,
-			// We don't get to deleting anything else.
-		}},
-		// We delete a bunch of stuff when we retire.
-		Key: "foo/delete-user-svc-failure",
-	}, {
-		Name: "retired revision is stable",
-		// Test a simple stable reconciliation of a Retired Revision.
-		// We feed in a Revision and the resources it controls in a steady
-		// state (port-Retired), and verify that no changes are necessary.
-		Objects: []runtime.Object{
-			makeStatus(
-				rev("foo", "stable-retirement", "Retired", "busybox"),
-				// The Status properly reflects that of a Retired revision.
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "stable-retirement", "Retired", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:    "Ready",
-						Status:  "False",
-						Reason:  "Inactive",
-						Message: `Revision "stable-retirement" is Inactive.`,
-					}},
-				}),
-			kpa("foo", "stable-retirement", "Retired", "busybox"),
-		},
-		Key: "foo/stable-retirement",
 	}, {
 		Name: "activate a reserve revision",
 		// Test the transition that's made when Active is set.
@@ -725,6 +499,7 @@ func TestReconcile(t *testing.T) {
 			kpa("foo", "create-in-reserve", "Reserve", "busybox"),
 			// Only Deployments are created and they have no replicas.
 			deploy("foo", "create-in-reserve", "Reserve", "busybox"),
+			svc("foo", "create-in-reserve", "Reserve", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
@@ -1662,14 +1437,10 @@ func getDeploy(namespace, name string, servingState v1alpha1.RevisionServingStat
 	loggingConfig *logging.Config, networkConfig *config.Network, observabilityConfig *config.Observability,
 	autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *appsv1.Deployment {
 
-	var replicaCount int32 = 1
-	if servingState == v1alpha1.RevisionServingStateReserve {
-		replicaCount = 0
-	}
 	rev := getRev(namespace, name, servingState, image, loggingConfig, networkConfig, observabilityConfig,
 		autoscalerConfig, controllerConfig)
 	return resources.MakeDeployment(rev, loggingConfig, networkConfig, observabilityConfig,
-		autoscalerConfig, controllerConfig, replicaCount)
+		autoscalerConfig, controllerConfig)
 }
 
 func getKPA(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string,


### PR DESCRIPTION
This makes the behavior of the Revision controller largely agnostic of the ServingState.  Revision is still the source of truth for ServingState, and it is mutable, but the only real effect is to apply it to the KPA.

WIP until #1882 lands