### PR TITLE
Change per-Revision Service to the default type ClusterIP.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -52,7 +52,6 @@ func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: servicePorts,
-			Type:  "NodePort",
 			Selector: map[string]string{
 				serving.RevisionLabelKey: rev.Name,
 			},

--- a/pkg/reconciler/v1alpha1/revision/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service_test.go
@@ -64,7 +64,6 @@ func TestMakeK8sService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: servicePorts,
-				Type:  "NodePort",
 				Selector: map[string]string{
 					serving.RevisionLabelKey: "bar",
 				},
@@ -101,7 +100,6 @@ func TestMakeK8sService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: servicePorts,
-				Type:  "NodePort",
 				Selector: map[string]string{
 					serving.RevisionLabelKey: "baz",
 				},


### PR DESCRIPTION
NodePort limits scalability, since we will be limited by the available ports on the nodes.
