### PR TITLE
Refactor the condition logic.

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -206,15 +206,11 @@ func (cs *ConfigurationStatus) setCondition(new *ConfigurationCondition) {
 }
 
 func (cs *ConfigurationStatus) InitializeConditions() {
-	for _, cond := range []ConfigurationConditionType{
-		ConfigurationConditionReady,
-	} {
-		if rc := cs.GetCondition(cond); rc == nil {
-			cs.setCondition(&ConfigurationCondition{
-				Type:   cond,
-				Status: corev1.ConditionUnknown,
-			})
-		}
+	if rc := cs.GetCondition(ConfigurationConditionReady); rc == nil {
+		cs.setCondition(&ConfigurationCondition{
+			Type:   ConfigurationConditionReady,
+			Status: corev1.ConditionUnknown,
+		})
 	}
 }
 
@@ -230,29 +226,19 @@ func (cs *ConfigurationStatus) SetLatestCreatedRevisionName(name string) {
 
 func (cs *ConfigurationStatus) SetLatestReadyRevisionName(name string) {
 	cs.LatestReadyRevisionName = name
-	for _, cond := range []ConfigurationConditionType{
-		ConfigurationConditionReady,
-	} {
-		cs.setCondition(&ConfigurationCondition{
-			Type:   cond,
-			Status: corev1.ConditionTrue,
-		})
-	}
+	cs.setCondition(&ConfigurationCondition{
+		Type:   ConfigurationConditionReady,
+		Status: corev1.ConditionTrue,
+	})
 }
 
 func (cs *ConfigurationStatus) MarkLatestCreatedFailed(name, message string) {
-	cct := []ConfigurationConditionType{ConfigurationConditionReady}
-	if cs.LatestReadyRevisionName == "" {
-		cct = append(cct, ConfigurationConditionReady)
-	}
-	for _, cond := range cct {
-		cs.setCondition(&ConfigurationCondition{
-			Type:    cond,
-			Status:  corev1.ConditionFalse,
-			Reason:  "RevisionFailed",
-			Message: fmt.Sprintf("Revision %q failed with message: %q.", name, message),
-		})
-	}
+	cs.setCondition(&ConfigurationCondition{
+		Type:    ConfigurationConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  "RevisionFailed",
+		Message: fmt.Sprintf("Revision %q failed with message: %q.", name, message),
+	})
 }
 
 func (cs *ConfigurationStatus) MarkRevisionCreationFailed(message string) {
@@ -265,14 +251,11 @@ func (cs *ConfigurationStatus) MarkRevisionCreationFailed(message string) {
 }
 
 func (cs *ConfigurationStatus) MarkLatestReadyDeleted() {
-	cct := []ConfigurationConditionType{ConfigurationConditionReady}
-	for _, cond := range cct {
-		cs.setCondition(&ConfigurationCondition{
-			Type:    cond,
-			Status:  corev1.ConditionFalse,
-			Reason:  "RevisionDeleted",
-			Message: fmt.Sprintf("Revision %q was deleted.", cs.LatestReadyRevisionName),
-		})
-	}
+	cs.setCondition(&ConfigurationCondition{
+		Type:    ConfigurationConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  "RevisionDeleted",
+		Message: fmt.Sprintf("Revision %q was deleted.", cs.LatestReadyRevisionName),
+	})
 	cs.LatestReadyRevisionName = ""
 }

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -239,87 +239,48 @@ func (rs *RouteStatus) InitializeConditions() {
 }
 
 func (rs *RouteStatus) MarkTrafficAssigned() {
-	rs.setCondition(&RouteCondition{
-		Type:   RouteConditionAllTrafficAssigned,
-		Status: corev1.ConditionTrue,
-	})
-	rs.checkAndMarkReady()
-}
-
-func (rs *RouteStatus) markTrafficTargetNotReady(reason, msg string) {
-	rs.setCondition(&RouteCondition{
-		Type:    RouteConditionAllTrafficAssigned,
-		Status:  corev1.ConditionUnknown,
-		Reason:  reason,
-		Message: msg,
-	})
-	// TODO(tcnghia): when we start with new RouteConditionReady every revision,
-	// uncomment the short-circuiting below.
-	//
-	// // Do not downgrade Ready condition.
-	// if c := rs.GetCondition(RouteConditionReady); c != nil && c.Status == corev1.ConditionFalse {
-	// 	return
-	// }
-	//
-	// For now, the following is harmless because RouteConditionAllTrafficAssigned
-	// is the only condition RouteConditionReady depends on.
-	rs.setCondition(&RouteCondition{
-		Type:    RouteConditionReady,
-		Status:  corev1.ConditionUnknown,
-		Reason:  reason,
-		Message: msg,
-	})
-}
-
-func (rs *RouteStatus) markTrafficTargetFailed(reason, msg string) {
-	for _, cond := range []RouteConditionType{
-		RouteConditionAllTrafficAssigned,
-		RouteConditionReady,
-	} {
-		rs.setCondition(&RouteCondition{
-			Type:    cond,
-			Status:  corev1.ConditionFalse,
-			Reason:  reason,
-			Message: msg,
-		})
-	}
+	rs.markTrue(RouteConditionAllTrafficAssigned)
 }
 
 func (rs *RouteStatus) MarkUnknownTrafficError(msg string) {
-	rs.markTrafficTargetNotReady("Unknown", msg)
+	rs.markUnknown(RouteConditionAllTrafficAssigned, "Unknown", msg)
 }
 
 func (rs *RouteStatus) MarkConfigurationNotReady(name string) {
 	reason := "RevisionMissing"
 	msg := fmt.Sprintf("Configuration %q is waiting for a Revision to become ready.", name)
-	rs.markTrafficTargetNotReady(reason, msg)
+	rs.markUnknown(RouteConditionAllTrafficAssigned, reason, msg)
 }
 
 func (rs *RouteStatus) MarkConfigurationFailed(name string) {
 	reason := "RevisionMissing"
 	msg := fmt.Sprintf("Configuration %q does not have any ready Revision.", name)
-	rs.markTrafficTargetFailed(reason, msg)
+	rs.markFalse(RouteConditionAllTrafficAssigned, reason, msg)
 }
 
 func (rs *RouteStatus) MarkRevisionNotReady(name string) {
 	reason := "RevisionMissing"
 	msg := fmt.Sprintf("Revision %q is not yet ready.", name)
-	rs.markTrafficTargetNotReady(reason, msg)
+	rs.markUnknown(RouteConditionAllTrafficAssigned, reason, msg)
 }
 
 func (rs *RouteStatus) MarkRevisionFailed(name string) {
 	reason := "RevisionMissing"
 	msg := fmt.Sprintf("Revision %q failed to become ready.", name)
-	rs.markTrafficTargetFailed(reason, msg)
+	rs.markFalse(RouteConditionAllTrafficAssigned, reason, msg)
 }
 
 func (rs *RouteStatus) MarkMissingTrafficTarget(kind, name string) {
 	reason := kind + "Missing"
 	msg := fmt.Sprintf("%s %q referenced in traffic not found.", kind, name)
-	rs.markTrafficTargetFailed(reason, msg)
+	rs.markFalse(RouteConditionAllTrafficAssigned, reason, msg)
 }
 
-func (rs *RouteStatus) checkAndMarkReady() {
+func (rs *RouteStatus) markTrue(t RouteConditionType) {
+	rs.setCondition(&RouteCondition{
+		Type:   t,
+		Status: corev1.ConditionTrue,
+	})
 	for _, cond := range []RouteConditionType{
 		RouteConditionAllTrafficAssigned,
 	} {
@@ -328,12 +289,46 @@ func (rs *RouteStatus) checkAndMarkReady() {
 			return
 		}
 	}
-	rs.markReady()
-}
-
-func (rs *RouteStatus) markReady() {
 	rs.setCondition(&RouteCondition{
 		Type:   RouteConditionReady,
 		Status: corev1.ConditionTrue,
 	})
+}
+
+func (rs *RouteStatus) markUnknown(t RouteConditionType, reason, message string) {
+	rs.setCondition(&RouteCondition{
+		Type:    t,
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason,
+		Message: message,
+	})
+	for _, cond := range []RouteConditionType{
+		RouteConditionAllTrafficAssigned,
+	} {
+		c := rs.GetCondition(cond)
+		if c == nil || c.Status == corev1.ConditionFalse {
+			// Failed conditions trump unknown conditions
+			return
+		}
+	}
+	rs.setCondition(&RouteCondition{
+		Type:    RouteConditionReady,
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+func (rs *RouteStatus) markFalse(t RouteConditionType, reason, message string) {
+	for _, cond := range []RouteConditionType{
+		t,
+		RouteConditionReady,
+	} {
+		rs.setCondition(&RouteCondition{
+			Type:    cond,
+			Status:  corev1.ConditionFalse,
+			Reason:  reason,
+			Message: message,
+		})
+	}
 }

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -473,8 +473,6 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 		return HookComplete
 	})
 
-	completeMessage := "a long human-readable complete message."
-
 	bld := &buildv1alpha1.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
@@ -504,9 +502,8 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 	// successfully.
 	bld.Status = buildv1alpha1.BuildStatus{
 		Conditions: []buildv1alpha1.BuildCondition{{
-			Type:    buildv1alpha1.BuildSucceeded,
-			Status:  corev1.ConditionTrue,
-			Message: completeMessage,
+			Type:   buildv1alpha1.BuildSucceeded,
+			Status: corev1.ConditionTrue,
 		}},
 	}
 	// Since Reconcile looks in the lister, we need to add it to the informer
@@ -525,7 +522,6 @@ func TestCreateRevWithCompletedBuildNameCompletes(t *testing.T) {
 		want := &v1alpha1.RevisionCondition{
 			Type:               ct,
 			Status:             corev1.ConditionTrue,
-			Message:            completeMessage,
 			LastTransitionTime: got.LastTransitionTime,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
This refactors the condition logic so that each `setCondition` call goes through one of `mark{True,False,Unknown}`, which are largely uniform and implement our common condition semantics.

cc @n3wscott 