### PR TITLE
Add a delay following inactivity before scaling to zero.

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -66,6 +66,11 @@ data:
   
   # Dynamic parameters (take effect when config map is updated):
 
-  # Scale to zero threshold is the time a revision must be idle before
-  # it is scaled to zero.
+  # Scale to zero threshold is the total time between traffic dropping to
+  # zero and when it's resources are deprovisioned.  Must be at least 30s
+  # more than scale-to-zero-grace-period (min: 60s)
   scale-to-zero-threshold: "5m"
+
+  # Scale to zero grace period is the time an inactive revision is left
+  # running before it is scaled to zero (min: 30s).
+  scale-to-zero-grace-period: "2m"

--- a/pkg/apis/autoscaling/v1alpha1/kpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_types.go
@@ -256,3 +256,17 @@ func (rs *PodAutoscalerStatus) markReady() {
 		Status: corev1.ConditionTrue,
 	})
 }
+
+// CanScaleToZero checks whether the pod autoscaler has been in an inactive state
+// for at least the specified grace period.
+func (rs *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
+	if cond := rs.GetCondition(PodAutoscalerConditionActive); cond != nil {
+		switch cond.Status {
+		case corev1.ConditionFalse:
+			// Check that this PodAutoscaler has been inactive for
+			// at least the grace period.
+			return time.Now().After(cond.LastTransitionTime.Inner.Add(gracePeriod))
+		}
+	}
+	return false
+}

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -200,7 +200,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	}
 
 	// Scale to zero if the last request is from too long ago
-	if !a.scaleToZeroThresholdExceeded && a.lastRequestTime.Add(config.ScaleToZeroThreshold).Before(now) {
+	if !a.scaleToZeroThresholdExceeded && a.lastRequestTime.Add(config.ScaleToZeroIdlePeriod).Before(now) {
 		logger.Debug("Last request is older than scale to zero threshold. Scaling to 0.")
 		a.scaleToZeroThresholdExceeded = true
 		return 0, true

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -294,12 +294,15 @@ func (r *mockReporter) Report(m Measurement, v float64) error {
 func newTestAutoscaler(model v1alpha1.RevisionRequestConcurrencyModelType, targetConcurrency float64) *Autoscaler {
 	stableWindow := 60 * time.Second
 	panicWindow := 6 * time.Second
-	scaleToZeroThreshold := 5 * time.Minute
+	scaleToZeroIdlePeriod := 4*time.Minute + 30*time.Second
+	scaleToZeroGracePeriod := 30 * time.Second
 	config := &Config{
-		MaxScaleUpRate:       10.0,
-		StableWindow:         stableWindow,
-		PanicWindow:          panicWindow,
-		ScaleToZeroThreshold: scaleToZeroThreshold,
+		MaxScaleUpRate:         10.0,
+		StableWindow:           stableWindow,
+		PanicWindow:            panicWindow,
+		ScaleToZeroThreshold:   scaleToZeroIdlePeriod + scaleToZeroGracePeriod,
+		ScaleToZeroIdlePeriod:  scaleToZeroIdlePeriod,
+		ScaleToZeroGracePeriod: scaleToZeroGracePeriod,
 	}
 
 	switch model {

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -108,6 +108,8 @@ func TestNewConfig(t *testing.T) {
 			StableWindow:              5 * time.Minute,
 			PanicWindow:               10 * time.Second,
 			ScaleToZeroThreshold:      10 * time.Minute,
+			ScaleToZeroGracePeriod:    2 * time.Minute,
+			ScaleToZeroIdlePeriod:     8 * time.Minute,
 			ConcurrencyQuantumOfTime:  100 * time.Millisecond,
 			TickInterval:              2 * time.Second,
 		},
@@ -132,6 +134,8 @@ func TestNewConfig(t *testing.T) {
 			StableWindow:              5 * time.Minute,
 			PanicWindow:               10 * time.Second,
 			ScaleToZeroThreshold:      10 * time.Minute,
+			ScaleToZeroGracePeriod:    2 * time.Minute,
+			ScaleToZeroIdlePeriod:     8 * time.Minute,
 			ConcurrencyQuantumOfTime:  100 * time.Millisecond,
 			TickInterval:              2 * time.Second,
 		},
@@ -159,6 +163,8 @@ func TestNewConfig(t *testing.T) {
 			StableWindow:              5 * time.Minute,
 			PanicWindow:               10 * time.Second,
 			ScaleToZeroThreshold:      10 * time.Minute,
+			ScaleToZeroGracePeriod:    2 * time.Minute,
+			ScaleToZeroIdlePeriod:     8 * time.Minute,
 			ConcurrencyQuantumOfTime:  100 * time.Millisecond,
 			TickInterval:              2 * time.Second,
 		},
@@ -186,6 +192,8 @@ func TestNewConfig(t *testing.T) {
 			StableWindow:              5 * time.Minute,
 			PanicWindow:               10 * time.Second,
 			ScaleToZeroThreshold:      10 * time.Minute,
+			ScaleToZeroGracePeriod:    2 * time.Minute,
+			ScaleToZeroIdlePeriod:     8 * time.Minute,
 			ConcurrencyQuantumOfTime:  100 * time.Millisecond,
 			TickInterval:              2 * time.Second,
 		},
@@ -211,6 +219,36 @@ func TestNewConfig(t *testing.T) {
 			StableWindow:              5 * time.Minute,
 			PanicWindow:               10 * time.Second,
 			ScaleToZeroThreshold:      10 * time.Minute,
+			ScaleToZeroGracePeriod:    2 * time.Minute,
+			ScaleToZeroIdlePeriod:     8 * time.Minute,
+			ConcurrencyQuantumOfTime:  100 * time.Millisecond,
+			TickInterval:              2 * time.Second,
+		},
+	}, {
+		name: "with explicit grace period",
+		input: map[string]string{
+			"enable-scale-to-zero":            "false",
+			"enable-vertical-pod-autoscaling": "False",
+			"max-scale-up-rate":               "1.0",
+			"single-concurrency-target":       "1.0",
+			"multi-concurrency-target":        "1.0",
+			"stable-window":                   "5m",
+			"panic-window":                    "10s",
+			"scale-to-zero-threshold":         "60s",
+			"scale-to-zero-grace-period":      "30s",
+			"concurrency-quantum-of-time":     "100ms",
+			"tick-interval":                   "2s",
+		},
+		want: &Config{
+			SingleTargetConcurrency:   1.0,
+			MultiTargetConcurrency:    1.0,
+			VPAMultiTargetConcurrency: 10.0,
+			MaxScaleUpRate:            1.0,
+			StableWindow:              5 * time.Minute,
+			PanicWindow:               10 * time.Second,
+			ScaleToZeroThreshold:      60 * time.Second,
+			ScaleToZeroGracePeriod:    30 * time.Second,
+			ScaleToZeroIdlePeriod:     30 * time.Second,
 			ConcurrencyQuantumOfTime:  100 * time.Millisecond,
 			TickInterval:              2 * time.Second,
 		},
@@ -279,7 +317,6 @@ func TestNewConfig(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestOurConfig(t *testing.T) {

--- a/pkg/autoscaler/dynamic_config_test.go
+++ b/pkg/autoscaler/dynamic_config_test.go
@@ -30,7 +30,8 @@ var configMap = map[string]string{"max-scale-up-rate": "1",
 	"multi-concurrency-target":    "3",
 	"stable-window":               "4s",
 	"panic-window":                "5s",
-	"scale-to-zero-threshold":     "6s",
+	"scale-to-zero-threshold":     "60s", // min
+	"scale-to-zero-grace-period":  "30s", // min
 	"concurrency-quantum-of-time": "7s",
 	"tick-interval":               "8s"}
 

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package autoscaling_test
+package autoscaling
 
 import (
 	"context"
@@ -28,7 +28,6 @@ import (
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/reconciler"
-	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
@@ -59,10 +58,10 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
 	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		fakeMetrics,
@@ -146,10 +145,10 @@ func TestNoEndpointsActive(t *testing.T) {
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
 	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		fakeMetrics,
@@ -207,10 +206,10 @@ func TestEmptyEndpointsActive(t *testing.T) {
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
 	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		fakeMetrics,
@@ -268,10 +267,10 @@ func TestNoEndpointsReserve(t *testing.T) {
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
 	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		fakeMetrics,
@@ -330,10 +329,10 @@ func TestReserveWithEndpoints(t *testing.T) {
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
 	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		fakeMetrics,
@@ -389,9 +388,9 @@ func TestControllerCreateError(t *testing.T) {
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		&failingKPAMetrics{
@@ -427,9 +426,9 @@ func TestControllerUpdateError(t *testing.T) {
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		&failingKPAMetrics{
@@ -465,9 +464,9 @@ func TestControllerGetError(t *testing.T) {
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		&failingKPAMetrics{
@@ -504,10 +503,10 @@ func TestScaleFailure(t *testing.T) {
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
 	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		fakeMetrics,
@@ -546,9 +545,9 @@ func TestBadKey(t *testing.T) {
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	scaleClient := &scalefake.FakeScaleClient{}
-	kpaScaler := autoscaling.NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
 
-	ctl := autoscaling.NewController(&opts,
+	ctl := NewController(&opts,
 		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
 		kubeInformer.Core().V1().Endpoints(),
 		&failingKPAMetrics{},

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -18,21 +18,19 @@ package autoscaling
 
 import (
 	"strings"
-	"time"
+	"sync"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/scale"
 
+	"github.com/knative/pkg/configmap"
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/autoscaler"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
-)
-
-const (
-	// The period we wait after Active=False before actually scaling to zero.
-	gracePeriod = 60 * time.Second
 )
 
 // kpaScaler scales the target of a KPA up or down including scaling to zero.
@@ -40,15 +38,48 @@ type kpaScaler struct {
 	servingClientSet clientset.Interface
 	scaleClientSet   scale.ScalesGetter
 	logger           *zap.SugaredLogger
+
+	// autoscalerConfig could change over time and access to it
+	// must go through autoscalerConfigMutex
+	autoscalerConfig      *autoscaler.Config
+	autoscalerConfigMutex sync.Mutex
 }
 
 // NewKPAScaler creates a kpaScaler.
-func NewKPAScaler(servingClientSet clientset.Interface, scaleClientSet scale.ScalesGetter, logger *zap.SugaredLogger) KPAScaler {
-	return &kpaScaler{
+func NewKPAScaler(servingClientSet clientset.Interface, scaleClientSet scale.ScalesGetter,
+	logger *zap.SugaredLogger, configMapWatcher configmap.Watcher) KPAScaler {
+	ks := &kpaScaler{
 		servingClientSet: servingClientSet,
 		scaleClientSet:   scaleClientSet,
 		logger:           logger,
 	}
+
+	// Watch for config changes.
+	configMapWatcher.Watch(autoscaler.ConfigName, ks.receiveAutoscalerConfig)
+
+	return ks
+}
+
+func (ks *kpaScaler) receiveAutoscalerConfig(configMap *corev1.ConfigMap) {
+	newAutoscalerConfig, err := autoscaler.NewConfigFromConfigMap(configMap)
+	ks.autoscalerConfigMutex.Lock()
+	defer ks.autoscalerConfigMutex.Unlock()
+	if err != nil {
+		if ks.autoscalerConfig != nil {
+			ks.logger.Errorf("Error updating Autoscaler ConfigMap: %v", err)
+		} else {
+			ks.logger.Fatalf("Error initializing Autoscaler ConfigMap: %v", err)
+		}
+		return
+	}
+	ks.logger.Infof("Autoscaler config map is added or updated: %v", configMap)
+	ks.autoscalerConfig = newAutoscalerConfig
+}
+
+func (ks *kpaScaler) getAutoscalerConfig() *autoscaler.Config {
+	ks.autoscalerConfigMutex.Lock()
+	defer ks.autoscalerConfigMutex.Unlock()
+	return ks.autoscalerConfig.DeepCopy()
 }
 
 // Scale attempts to scale the given KPA's target reference to the desired scale.
@@ -112,7 +143,7 @@ func (rs *kpaScaler) Scale(kpa *kpa.PodAutoscaler, desiredScale int32) error {
 	// things to zero.
 	if kpa.Spec.ServingState != v1alpha1.RevisionServingStateActive {
 		// Delay the scale to zero until the LTT of "Active=False" is some time in the past.
-		if !kpa.Status.CanScaleToZero(gracePeriod) {
+		if !kpa.Status.CanScaleToZero(rs.getAutoscalerConfig().ScaleToZeroGracePeriod) {
 			logger.Debug("Waiting for Active=False grace period.")
 			return nil
 		}

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -18,6 +18,7 @@ package autoscaling
 
 import (
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,11 @@ import (
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
+)
+
+var (
+	// The period we wait after Active=False before actually scaling to zero.
+	gracePeriod = 60 * time.Second
 )
 
 // kpaScaler scales the target of a KPA up or down including scaling to zero.
@@ -93,8 +99,6 @@ func (rs *kpaScaler) Scale(kpa *kpa.PodAutoscaler, desiredScale int32) error {
 
 	// When scaling to zero, flip the revision's ServingState to Reserve (if Active).
 	if kpa.Spec.ServingState == v1alpha1.RevisionServingStateActive && desiredScale == 0 {
-		// TODO(mattmoor): Delay the scale to zero until the LTT of "Active=False"
-		// is some time in the past.
 		logger.Debug("Setting revision ServingState to Reserve.")
 		rev.Spec.ServingState = v1alpha1.RevisionServingStateReserve
 		if _, err := revisionClient.Update(rev); err != nil {
@@ -107,6 +111,11 @@ func (rs *kpaScaler) Scale(kpa *kpa.PodAutoscaler, desiredScale int32) error {
 	// When ServingState=Reserve (see above) propagates to us, then actually scale
 	// things to zero.
 	if kpa.Spec.ServingState != v1alpha1.RevisionServingStateActive {
+		// Delay the scale to zero until the LTT of "Active=False" is some time in the past.
+		if !kpa.Status.CanScaleToZero(gracePeriod) {
+			logger.Debug("Waiting for Active=False grace period.")
+			return nil
+		}
 		desiredScale = 0
 	}
 

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -30,7 +30,7 @@ import (
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 )
 
-var (
+const (
 	// The period we wait after Active=False before actually scaling to zero.
 	gracePeriod = 60 * time.Second
 )

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
@@ -145,7 +145,7 @@ func TestKPAScaler(t *testing.T) {
 
 			revision := newRevision(t, servingClient, e.startState)
 			deployment := newDeployment(t, scaleClient, revision, e.startReplicas)
-			revisionScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t))
+			revisionScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t), newConfigWatcher())
 
 			kpa := newKPA(t, servingClient, revision)
 			if e.kpaMutation != nil {


### PR DESCRIPTION
This adds a check that the `LastTransitionTime` of the KPA's `Active` condition was at least 60 seconds prior before performing the actual scale to zero.

Progress towards: https://github.com/knative/serving/issues/1655
Fixes: https://github.com/knative/serving/issues/1395