### PR TITLE
Filter requests sent by the activator itself.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -102,14 +102,16 @@ func main() {
 
 	rt := activatorutil.NewRetryRoundTripper(activatorutil.AutoTransport, logger, retryer, shouldRetry)
 
-	ah := &activatorhandler.ReportingHTTPHandler{
-		Reporter: reporter,
-		NextHandler: &activatorhandler.EnforceMaxContentLengthHandler{
-			MaxContentLengthBytes: maxUploadBytes,
-			NextHandler: &activatorhandler.ActivationHandler{
-				Activator: a,
-				Transport: rt,
-				Logger:    logger,
+	ah := &activatorhandler.FilteringHandler{
+		NextHandler: &activatorhandler.ReportingHTTPHandler{
+			Reporter: reporter,
+			NextHandler: &activatorhandler.EnforceMaxContentLengthHandler{
+				MaxContentLengthBytes: maxUploadBytes,
+				NextHandler: &activatorhandler.ActivationHandler{
+					Activator: a,
+					Transport: rt,
+					Logger:    logger,
+				},
 			},
 		},
 	}

--- a/pkg/activator/handler/filtering_handler.go
+++ b/pkg/activator/handler/filtering_handler.go
@@ -26,7 +26,7 @@ type FilteringHandler struct {
 }
 
 func (h *FilteringHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Iff this header is set the request was sent by the activator itself, thus
+	// If this header is set the request was sent by the activator itself, thus
 	// we immediatly return a 503 to trigger a retry.
 	if r.Header.Get(activator.ResponseCountHTTPHeader) != "" {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/activator/handler/filtering_handler.go
+++ b/pkg/activator/handler/filtering_handler.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/http"
+
+	"github.com/knative/serving/pkg/activator"
+)
+
+// FilteringHandler will filter requests sent by the
+// activator itself.
+type FilteringHandler struct {
+	NextHandler http.Handler
+}
+
+func (h *FilteringHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Iff this header is set the request was sent by the activator itself, thus
+	// we immediatly return a 503 to trigger a retry.
+	if r.Header.Get(activator.ResponseCountHTTPHeader) != "" {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	h.NextHandler.ServeHTTP(w, r)
+}

--- a/pkg/activator/handler/filtering_handler_test.go
+++ b/pkg/activator/handler/filtering_handler_test.go
@@ -26,8 +26,7 @@ func TestFilteringHandler(t *testing.T) {
 		headers        http.Header
 		passed         bool
 		expectedStatus int
-	}{
-		{
+	}{{
 			label:          "forward a normal request",
 			headers:        http.Header{},
 			passed:         true,

--- a/pkg/activator/handler/filtering_handler_test.go
+++ b/pkg/activator/handler/filtering_handler_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/knative/serving/pkg/activator"
+)
+
+func TestFilteringHandler(t *testing.T) {
+	examples := []struct {
+		label          string
+		headers        http.Header
+		passed         bool
+		expectedStatus int
+	}{
+		{
+			label:          "forward a normal request",
+			headers:        http.Header{},
+			passed:         true,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			label:          "filter a request containing retry header",
+			headers:        http.Header{activator.ResponseCountHTTPHeader: {"4"}},
+			passed:         false,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			label:          "forward a request containing empty retry header",
+			headers:        http.Header{activator.ResponseCountHTTPHeader: {""}},
+			passed:         true,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, e := range examples {
+		t.Run(e.label, func(t *testing.T) {
+			wasPassed := false
+			baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wasPassed = true
+				w.WriteHeader(http.StatusOK)
+			})
+			handler := FilteringHandler{NextHandler: baseHandler}
+
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "http://example.com", nil)
+			req.Header = e.headers
+
+			handler.ServeHTTP(resp, req)
+
+			if wasPassed != e.passed {
+				if !e.passed {
+					t.Errorf("Request got passed to the next handler unexpectedly")
+				} else {
+					t.Errorf("Request was not passed to the next handler as expected")
+				}
+			}
+
+			if resp.Code != e.expectedStatus {
+				t.Errorf("Unexpected response status. Want %d, got %d", e.expectedStatus, resp.Code)
+			}
+		})
+	}
+}

--- a/pkg/activator/util/transports.go
+++ b/pkg/activator/util/transports.go
@@ -79,8 +79,12 @@ func (rrt *retryRoundTripper) RoundTrip(r *http.Request) (resp *http.Response, e
 		r.Body = NewRewinder(r.Body)
 	}
 
+	attempt := 0
 	attempts := rrt.retryer.Retry(func() bool {
 		rrt.logger.Debugf("Retrying")
+
+		attempt++
+		r.Header.Add(activator.ResponseCountHTTPHeader, strconv.Itoa(attempt))
 		resp, err = rrt.transport.RoundTrip(r)
 
 		if err != nil {


### PR DESCRIPTION
Fixes #1907

## Proposed Changes

Due to the istio mesh, the activator is sent the requests it itself sends out to retry as long as a revision is not properly routable. This filters these requests out early on.

* Sets the retry header for each retried request from the activator
* Filters all requests that carry that header

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Filter requests sent by the activator itself.
```
