### PR TITLE
Adopt OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,9 @@
+aliases:
+  serving-api-approvers:
+  - mattmoor
+  - nghia
+  - grantr
+  serving-api-reviewers:
+  - mattmoor
+  - nghia
+  - grantr

--- a/cmd/controller/OWNERS
+++ b/cmd/controller/OWNERS
@@ -1,6 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- mattmoor
-- grantr
-- tcnghia
+- serving-api-approvers
+
+reviewers:
+- serving-api-reviewers

--- a/pkg/reconciler/OWNERS
+++ b/pkg/reconciler/OWNERS
@@ -1,6 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- mattmoor
-- grantr
-- tcnghia
+- serving-api-approvers
+
+reviewers:
+- serving-api-reviewers


### PR DESCRIPTION
To reduce the repetition of team lists across the codebase, define top-level aliases for the teams and reference those.  This is based on [this](https://github.com/kubernetes/kubernetes/blob/master/OWNERS_ALIASES) which I happened to come across.