### PR TITLE
Bypass istio to prevent activator retry loop.

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -55,5 +55,8 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = a.Transport
 
+	// Clear the host to avoid the request to be routed by istio.
+	r.Host = ""
+
 	proxy.ServeHTTP(w, r)
 }

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -108,10 +108,13 @@ func TestActivationHandler(t *testing.T) {
 
 	for _, e := range examples {
 		t.Run(e.label, func(t *testing.T) {
+			var host string
 			rt := util.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				if e.wantErr != nil {
 					return nil, e.wantErr
 				}
+
+				host = r.Host
 
 				return http.DefaultTransport.RoundTrip(r)
 			})
@@ -137,6 +140,10 @@ func TestActivationHandler(t *testing.T) {
 			gotBody, _ := ioutil.ReadAll(resp.Body)
 			if string(gotBody) != e.wantBody {
 				t.Errorf("Unexpected response body. Want %q, got %q", e.wantBody, gotBody)
+			}
+
+			if host != "" {
+				t.Errorf("Unexpected Host header. Wanted empty, got %s.", host)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1907

## Proposed Changes

When the activator proxies and retries requests to make sure a Revision is actually routable, Istio will pick the requests up and forward them to the activator itself if network programming is not done completely.

Resetting the Host header bypasses istio so the Revision's service can be adressed directly.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Bypass istio to prevent activator retry loop.
```
