### PR TITLE
Allow the activator to deal with multiple service ports.

### DIFF
--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -23,6 +23,7 @@ import (
 	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	revisionresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -132,13 +133,19 @@ func (r *revisionActivator) getRevisionEndpoint(revision *v1alpha1.Revision) (en
 		return end, errors.Wrapf(err, "Unable to get service %s for revision", serviceName)
 	}
 
-	// TODO: in the future, the target service could have more than one port.
-	// https://github.com/knative/serving/issues/837
-	if len(svc.Spec.Ports) != 1 {
-		return end, fmt.Errorf("Revision needs one port. Found %v", len(svc.Spec.Ports))
-	}
 	fqdn := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, revision.Namespace)
-	port := svc.Spec.Ports[0].Port
+
+	// Search for the correct port in all the service ports.
+	port := int32(-1)
+	for _, p := range svc.Spec.Ports {
+		if p.Name == revisionresources.ServicePortName {
+			port = p.Port
+			break
+		}
+	}
+	if port == -1 {
+		return internalError("Revision needs external port. Found %v", len(svc.Spec.Ports))
+	}
 
 	return Endpoint{
 		FQDN: fqdn,

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -144,7 +144,7 @@ func (r *revisionActivator) getRevisionEndpoint(revision *v1alpha1.Revision) (en
 		}
 	}
 	if port == -1 {
-		return internalError("Revision needs external port. Found %v", len(svc.Spec.Ports))
+		return end, fmt.Errorf("Revision needs external. Found %v", len(svc.Spec.Ports))
 	}
 
 	return Endpoint{

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	. "github.com/knative/pkg/logging/testing"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -293,8 +294,12 @@ func newServiceBuilder() *serviceBuilder {
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
 					{
-						Name: "http",
+						Name: revisionresources.ServicePortName,
 						Port: 8080,
+					},
+					{
+						Name: "anotherport",
+						Port: 9090,
 					},
 				},
 			},

--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -37,7 +37,11 @@ const (
 
 	// TODO(mattmoor): Make this private once we remove revision_test.go
 	AutoscalerPort       = 8080
-	ServicePort    int32 = 80
+
+	// ServicePortName is the name of the external port of the service
+	ServicePortName      = "http"
+	// ServicePort is the external port of the service
+	ServicePort          = int32(80)
 	AppLabelKey          = "app"
 )
 

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	servicePorts = []corev1.ServicePort{{
-		Name:       "http",
+		Name:       ServicePortName,
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ServicePort,
 		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: queue.RequestQueuePortName},


### PR DESCRIPTION
Fixes #837

## Proposed Changes

The activator today assumes that a service has exactly one port. An unnecessary restriction.

This exposes a well-known port per service and allows the activator to deal with an arbitrary number of ports on the service side as long as the well-known port exists at least.

* Create a constant name for the external port of the service.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Allow the activator to deal with multiple service ports.
```
