### PR TITLE
Fix several minor problems with the e2e tests.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -101,7 +101,11 @@ function dump_extra_cluster_state() {
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
   echo ">>> Knative Serving controller log:"
-  kubectl logs $(get_app_pod controller knative-serving)
+  kubectl -n knative-serving logs $(get_app_pod controller knative-serving)
+  echo ">>> Knative Serving autoscaler log:"
+  kubectl -n knative-serving logs $(get_app_pod autoscaler knative-serving)
+  echo ">>> Knative Serving activator log:"
+  kubectl -n knative-serving logs $(get_app_pod activator knative-serving)
 }
 
 function publish_test_images() {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -230,6 +230,9 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 			return len(p.Items) == 0, nil
 		},
 		"WaitForAvailablePods")
+	if err != nil {
+		logger.Fatalf(`Waiting for Pod.List to have no items: %v`, err)
+	}
 
 	logger.Infof("Scaled down.")
 	logger.Infof(`The autoscaler spins up additional replicas once again when


### PR DESCRIPTION
Add namespace to the `kubectl logs` command.

Add `kubectl logs` for more components in `knative-serving`.

Add a missing `err` check.