### PR TITLE
Surface metrics from the activator to the autoscaler.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -153,7 +153,7 @@ func main() {
 	})
 
 	ah := &activatorhandler.FilteringHandler{
-		NextHandler: activatorhandler.NewConcurrencyReportingHandler(statChan, time.NewTicker(time.Second).C,
+		NextHandler: activatorhandler.NewRequestEventHandler(reqChan,
 			&activatorhandler.EnforceMaxContentLengthHandler{
 				MaxContentLengthBytes: maxUploadBytes,
 				NextHandler: &activatorhandler.ActivationHandler{

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -91,7 +91,7 @@ func initEnv() {
 	servingAutoscalerPort = util.GetRequiredEnvOrFatal("SERVING_AUTOSCALER_PORT", logger)
 
 	// TODO(mattmoor): Move this key to be in terms of the KPA.
-	servingRevisionKey = fmt.Sprintf("%s/%s", servingNamespace, servingRevision)
+	servingRevisionKey = autoscaler.NewKpaKey(servingNamespace, servingRevision)
 }
 
 func statReporter() {

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -22,22 +22,6 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 )
 
-// ReqEvent represents an incoming/finished request with a given key
-type ReqEvent struct {
-	Key       string
-	EventType ReqEventType
-}
-
-// ReqEventType specifies the type of event (In/Out)
-type ReqEventType int
-
-const (
-	// ReqIn represents an incoming request
-	ReqIn ReqEventType = iota
-	// ReqOut represents a finished request
-	ReqOut
-)
-
 // Channels is a structure for holding the channels for driving Stats.
 // It's just to make the NewStats signature easier to read.
 type Channels struct {
@@ -49,7 +33,10 @@ type Channels struct {
 	StatChan chan *autoscaler.StatMessage
 }
 
-// NewConcurrencyReporter instantiates a new instance of Stats.
+// NewConcurrencyReporter instantiates a new goroutine that consumes and
+// produces from the given channels.
+// On each tick on the ReportChan, StatMessages will be sent to the
+// StatChan.
 func NewConcurrencyReporter(podName string, channels Channels) {
 
 	go func() {

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"time"
+
+	"github.com/knative/serving/pkg/autoscaler"
+)
+
+type ReqEvent struct {
+	Key       string
+	EventType ReqEventType
+}
+
+// Tokens to record ReqIn (request in) and ReqOut (request out) events respectively
+type ReqEventType int
+
+const (
+	ReqIn ReqEventType = iota
+	ReqOut
+)
+
+// Channels is a structure for holding the channels for driving Stats.
+// It's just to make the NewStats signature easier to read.
+type Channels struct {
+	// Ticks with every request arrived/completed respectively
+	ReqChan chan ReqEvent
+	// Ticks with every stat report request
+	ReportChan <-chan time.Time
+	// Stat reporting channel
+	StatChan chan *autoscaler.StatMessage
+}
+
+// NewStats instantiates a new instance of Stats.
+func NewConcurrencyReporter(podName string, channels Channels) {
+
+	go func() {
+		concurrencyPerKey := make(map[string]int32)
+		for {
+			select {
+			case event := <-channels.ReqChan:
+				switch event.EventType {
+				case ReqIn:
+					concurrencyPerKey[event.Key]++
+				case ReqOut:
+					concurrencyPerKey[event.Key]--
+
+				}
+			case now := <-channels.ReportChan:
+				for key, concurrency := range concurrencyPerKey {
+					if concurrency == 0 {
+						delete(concurrencyPerKey, key)
+					} else {
+						stat := autoscaler.Stat{
+							Time:                      &now,
+							PodName:                   podName,
+							AverageConcurrentRequests: float64(concurrency),
+							RequestCount:              0,
+						}
+
+						// Send the stat to another goroutine to transmit
+						// so we can continue bucketing stats.
+						channels.StatChan <- &autoscaler.StatMessage{
+							Key:  key,
+							Stat: stat,
+						}
+					}
+				}
+			}
+		}
+	}()
+}

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -44,7 +44,7 @@ type Channels struct {
 	// Ticks with every request arrived/completed respectively
 	ReqChan chan ReqEvent
 	// Ticks with every stat report request
-	ReportChan chan time.Time
+	ReportChan <-chan time.Time
 	// Stat reporting channel
 	StatChan chan *autoscaler.StatMessage
 }

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/serving/pkg/autoscaler"
+)
+
+func TestNoData(t *testing.T) {
+
+	pod1 := "pod1"
+	pod2 := "pod2"
+
+	s := Channels{}
+	NewConcurrencyReporter(autoscaler.ActivatorPodName, s)
+
+	fmt.Println("got here1")
+
+	s.requestStart(pod1)
+	fmt.Println("got here2")
+	s.requestStart(pod1)
+	s.requestStart(pod2)
+
+	fmt.Println("got here")
+
+	now := time.Now()
+	got := s.report(now)
+
+	want := &autoscaler.StatMessage{
+		Key: "pod1",
+		Stat: autoscaler.Stat{
+			Time:                      &now,
+			PodName:                   autoscaler.ActivatorPodName,
+			AverageConcurrentRequests: 2.0,
+			RequestCount:              0,
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unexpected stat (-want +got): %v", diff)
+	}
+}
+
+func (s *Channels) requestStart(key string) {
+	s.ReqChan <- ReqEvent{Key: key, EventType: ReqIn}
+}
+
+func (s *Channels) requestEnd(key string) {
+	s.ReqChan <- ReqEvent{Key: key, EventType: ReqOut}
+}
+
+func (s *Channels) report(t time.Time) *autoscaler.StatMessage {
+	s.ReportChan <- t
+	return <-s.StatChan
+}

--- a/pkg/activator/handler/concurrency_reporting_handler.go
+++ b/pkg/activator/handler/concurrency_reporting_handler.go
@@ -27,7 +27,7 @@ const (
 	requestCountingQueueLength = 100
 )
 
-func NewConcurrencyReportingHandler(statChan chan *autoscaler.StatMessage, reportChan <-chan time.Time, next http.Handler) *concurrencyReportingHandler {
+func NewConcurrencyReportingHandler(statChan chan *autoscaler.StatMessage, reportChan chan time.Time, next http.Handler) *concurrencyReportingHandler {
 
 	channels := Channels{
 		ReqChan:    make(chan ReqEvent, requestCountingQueueLength),

--- a/pkg/activator/handler/concurrency_reporting_handler.go
+++ b/pkg/activator/handler/concurrency_reporting_handler.go
@@ -27,7 +27,7 @@ const (
 	requestCountingQueueLength = 100
 )
 
-func NewConcurrencyReportingHandler(statChan chan *autoscaler.StatMessage, reportChan chan time.Time, next http.Handler) *concurrencyReportingHandler {
+func NewConcurrencyReportingHandler(statChan chan *autoscaler.StatMessage, reportChan <-chan time.Time, next http.Handler) *concurrencyReportingHandler {
 
 	channels := Channels{
 		ReqChan:    make(chan ReqEvent, requestCountingQueueLength),

--- a/pkg/activator/handler/concurrency_reporting_handler.go
+++ b/pkg/activator/handler/concurrency_reporting_handler.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/knative/serving/pkg/activator"
+
+	"github.com/knative/serving/pkg/autoscaler"
+)
+
+const (
+	// Add enough buffer to not block request serving on stats collection
+	requestCountingQueueLength = 100
+)
+
+func NewConcurrencyReportingHandler(statChan chan *autoscaler.StatMessage, reportChan <-chan time.Time, next http.Handler) *concurrencyReportingHandler {
+
+	channels := Channels{
+		ReqChan:    make(chan ReqEvent, requestCountingQueueLength),
+		StatChan:   statChan,
+		ReportChan: reportChan,
+	}
+
+	NewConcurrencyReporter(autoscaler.ActivatorPodName, channels)
+
+	handler := &concurrencyReportingHandler{
+		NextHandler: next,
+		ReqChan:     channels.ReqChan,
+	}
+
+	return handler
+}
+
+type concurrencyReportingHandler struct {
+	NextHandler http.Handler
+	ReqChan     chan ReqEvent
+}
+
+func (h *concurrencyReportingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
+	name := r.Header.Get(activator.RevisionHeaderName)
+
+	revisionKey := autoscaler.NewKpaKey(namespace, name)
+
+	h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqIn}
+	defer func() { h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqOut} }()
+	h.NextHandler.ServeHTTP(w, r)
+}

--- a/pkg/activator/handler/requestevent_handler_test.go
+++ b/pkg/activator/handler/requestevent_handler_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package handler
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/serving/pkg/activator"
+)
+
+func TestRequestEventHandler(t *testing.T) {
+	namespace := "testspace"
+	revision := "testrevision"
+
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	reqChan := make(chan ReqEvent, 2)
+	handler := NewRequestEventHandler(reqChan, baseHandler)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "http://example.com", bytes.NewBufferString(""))
+	req.Header.Add(activator.RevisionHeaderNamespace, namespace)
+	req.Header.Add(activator.RevisionHeaderName, revision)
+
+	handler.ServeHTTP(resp, req)
+
+	in := <-handler.ReqChan
+	wantIn := ReqEvent{
+		Key:       fmt.Sprintf("%s/%s", namespace, revision),
+		EventType: ReqIn,
+	}
+
+	if diff := cmp.Diff(wantIn, in); diff != "" {
+		t.Errorf("Unexpected event (-want +got): %v", diff)
+	}
+
+	out := <-handler.ReqChan
+	wantOut := ReqEvent{
+		Key:       wantIn.Key,
+		EventType: ReqOut,
+	}
+
+	if diff := cmp.Diff(wantOut, out); diff != "" {
+		t.Errorf("Unexpected event (-want +got): %v", diff)
+	}
+}

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -272,6 +272,47 @@ func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
 	a.expectScale(t, now, 10, true) // back to stable mode
 }
 
+func TestAutoscaler_Activator_CausesInstantScale(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+
+	now := time.Now()
+	now = a.recordMetric(t, Stat{
+		Time:                      &now,
+		PodName:                   ActivatorPodName,
+		RequestCount:              0,
+		AverageConcurrentRequests: 100.0,
+	})
+
+	a.expectScale(t, now, 10, true)
+}
+
+func TestAutoscaler_Activator_IsIgnored(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+
+	now := a.recordLinearSeries(
+		t,
+		time.Now(),
+		linearSeries{
+			startConcurrency: 10,
+			endConcurrency:   10,
+			durationSeconds:  30,
+			podCount:         10,
+		})
+
+	a.expectScale(t, now, 10, true)
+
+	now = a.recordMetric(t, Stat{
+		Time:                      &now,
+		PodName:                   ActivatorPodName,
+		RequestCount:              0,
+		AverageConcurrentRequests: 1000.0,
+	})
+
+	// Scale should not change as the activator metric should
+	// be ignored
+	a.expectScale(t, now, 10, true)
+}
+
 // Autoscaler should drop data after 60 seconds.
 func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 	a := newTestAutoscaler(10.0)
@@ -403,6 +444,12 @@ func (a *Autoscaler) recordLinearSeries(test *testing.T, now time.Time, s linear
 		}
 	}
 	return now
+}
+
+// Record a single datapoint
+func (a *Autoscaler) recordMetric(test *testing.T, stat Stat) time.Time {
+	a.Record(TestContextWithLogger(test), stat)
+	return *stat.Time
 }
 
 func (a *Autoscaler) expectScale(t *testing.T, now time.Time, expectScale int32, expectOk bool) {

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -80,7 +80,9 @@ func (sr *scalerRunner) updateLatestScale(new int32) bool {
 	return false
 }
 
-func newKPAKey(namespace string, name string) string {
+// NewKpaKey identifies a KPA in the multiscaler. Stats send in
+// are identified and routed via this key.
+func NewKpaKey(namespace string, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
@@ -127,7 +129,7 @@ func (m *MultiScaler) Get(ctx context.Context, key string) (*Metric, error) {
 func (m *MultiScaler) Create(ctx context.Context, kpa *kpa.PodAutoscaler) (*Metric, error) {
 	m.scalersMutex.Lock()
 	defer m.scalersMutex.Unlock()
-	key := newKPAKey(kpa.Namespace, kpa.Name)
+	key := NewKpaKey(kpa.Namespace, kpa.Name)
 	scaler, exists := m.scalers[key]
 	if !exists {
 		var err error
@@ -187,7 +189,7 @@ func (m *MultiScaler) createScaler(ctx context.Context, kpa *kpa.PodAutoscaler) 
 		}
 	}()
 
-	kpaKey := newKPAKey(kpa.Namespace, kpa.Name)
+	kpaKey := NewKpaKey(kpa.Namespace, kpa.Name)
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
Fixes #1623

This is an implementation for surfacing metrics from the activator to the autoscaler.

The activator reports the pending requests for each revision on the activator to the autoscaler as if they were concurrency metrics sent directly by a queue-proxy.

/cc @mattmoor 
/cc @josephburnett 

## Caveats:

The autoscaler overshoots because it thinks the activator is a "usual" pod. How much it overshoots depends on the scale we're trying to reach in the first place.

## Todo:

- [x] Break out websocket refactoring in separate PR
- [x] Implement alternative handling of activator metrics
- [x] Remove TODOs in code (mainly hardcoded values)
- [x] Tests

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Surface metrics from the activator to the autoscaler to scale from 0 to N quickly.
```
