### PR TITLE
Use the builder pattern to improve readability of configuration table testing

### DIFF
--- a/pkg/apis/serving/v1alpha1/testing/configuration_builder.go
+++ b/pkg/apis/serving/v1alpha1/testing/configuration_builder.go
@@ -32,11 +32,11 @@ type ConfigBuilder struct {
 	obj *v1alpha1.Configuration
 }
 
-func Config(name, namespace string) ConfigBuilder {
+func Config(name string) ConfigBuilder {
 	return ConfigBuilder{&v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: "default",
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
@@ -74,6 +74,11 @@ func (bldr ConfigBuilder) ToUpdateAction() clientgotesting.UpdateActionImpl {
 	action.Verb = "update"
 	action.Object = bldr.Build()
 	return action
+}
+
+func (bldr ConfigBuilder) WithNamespace(namespace string) ConfigBuilder {
+	bldr.obj.ObjectMeta.Namespace = namespace
+	return bldr
 }
 
 func (bldr ConfigBuilder) WithGeneration(generation int64) ConfigBuilder {

--- a/pkg/apis/serving/v1alpha1/testing/configuration_builder.go
+++ b/pkg/apis/serving/v1alpha1/testing/configuration_builder.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+type ConfigToBuildFunc func(*v1alpha1.Configuration) *buildv1alpha1.Build
+type ConfigToRevisionFunc func(*v1alpha1.Configuration) *v1alpha1.Revision
+
+type ConfigBuilder struct {
+	obj *v1alpha1.Configuration
+}
+
+func Config(name, namespace string) ConfigBuilder {
+	return ConfigBuilder{&v1alpha1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ConfigurationSpec{
+			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				Spec: v1alpha1.RevisionSpec{
+					Container: corev1.Container{
+						Image: "busybox",
+					},
+				},
+			},
+		},
+		Status: v1alpha1.ConfigurationStatus{
+			Conditions: []v1alpha1.ConfigurationCondition{},
+		},
+	}}
+}
+
+func (bldr ConfigBuilder) Build() *v1alpha1.Configuration {
+	return bldr.obj.DeepCopy()
+}
+
+func (bldr ConfigBuilder) Object() runtime.Object {
+	return bldr.Build()
+}
+
+func (bldr ConfigBuilder) ToChildBuild(convert ConfigToBuildFunc) *buildv1alpha1.Build {
+	return convert(bldr.Build())
+}
+
+func (bldr ConfigBuilder) ToChildRevision(convert ConfigToRevisionFunc) RevisionBuilder {
+	return RevisionBuilder{convert(bldr.Build())}
+}
+
+func (bldr ConfigBuilder) ToUpdateAction() clientgotesting.UpdateActionImpl {
+	action := clientgotesting.UpdateActionImpl{}
+	action.Verb = "update"
+	action.Object = bldr.Build()
+	return action
+}
+
+func (bldr ConfigBuilder) WithGeneration(generation int64) ConfigBuilder {
+	bldr.obj.Spec.Generation = generation
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithStatus(s v1alpha1.ConfigurationStatus) ConfigBuilder {
+	bldr.obj.Status = s
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithBuild(b buildv1alpha1.BuildSpec) ConfigBuilder {
+	bldr.obj.Spec.Build = &b
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithObservedGeneration(gen int64) ConfigBuilder {
+	bldr.obj.Status.ObservedGeneration = gen
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithLatestCreatedRevisionName(name string) ConfigBuilder {
+	bldr.obj.Status.LatestCreatedRevisionName = name
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithLatestReadyRevisionName(name string) ConfigBuilder {
+	bldr.obj.Status.LatestReadyRevisionName = name
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithConcurrencyModel(cm v1alpha1.RevisionRequestConcurrencyModelType) ConfigBuilder {
+	bldr.obj.Spec.RevisionTemplate.Spec.ConcurrencyModel = cm
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithReadyConditionUnknown() ConfigBuilder {
+	bldr.obj.Status.Conditions = []v1alpha1.ConfigurationCondition{
+		{
+			Type:   v1alpha1.ConfigurationConditionReady,
+			Status: corev1.ConditionUnknown,
+		},
+	}
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithReadyConditionTrue() ConfigBuilder {
+	bldr.obj.Status.Conditions = []v1alpha1.ConfigurationCondition{
+		{
+			Type:   v1alpha1.ConfigurationConditionReady,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	return bldr
+}
+
+func (bldr ConfigBuilder) WithReadyConditionFalse(reason, message string) ConfigBuilder {
+	bldr.obj.Status.Conditions = []v1alpha1.ConfigurationCondition{
+		{
+			Type:    v1alpha1.ConfigurationConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  reason,
+			Message: message,
+		},
+	}
+	return bldr
+}

--- a/pkg/apis/serving/v1alpha1/testing/revision_builder.go
+++ b/pkg/apis/serving/v1alpha1/testing/revision_builder.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type RevisionBuilder struct {
+	obj *v1alpha1.Revision
+}
+
+func (bldr RevisionBuilder) Build() *v1alpha1.Revision {
+	return bldr.obj.DeepCopy()
+}
+
+func (bldr RevisionBuilder) Object() runtime.Object {
+	return bldr.Build()
+}
+
+func (bldr RevisionBuilder) WithConcurrencyModel(cm v1alpha1.RevisionRequestConcurrencyModelType) RevisionBuilder {
+	bldr.obj.Spec.ConcurrencyModel = cm
+	return bldr
+}
+
+func (bldr RevisionBuilder) WithReadyCondition(status corev1.ConditionStatus) RevisionBuilder {
+	bldr.obj.Status.Conditions = []v1alpha1.RevisionCondition{
+		{
+			Type:   v1alpha1.RevisionConditionReady,
+			Status: status,
+		},
+	}
+	return bldr
+}
+
+func (bldr RevisionBuilder) WithReadyConditionTrue() RevisionBuilder {
+	bldr.obj.Status.Conditions = []v1alpha1.RevisionCondition{
+		{
+			Type:   v1alpha1.RevisionConditionReady,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	return bldr
+}
+
+func (bldr RevisionBuilder) WithReadyConditionFalse(reason, message string) RevisionBuilder {
+	bldr.obj.Status.Conditions = []v1alpha1.RevisionCondition{
+		{
+			Type:    v1alpha1.RevisionConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  reason,
+			Message: message,
+		},
+	}
+	return bldr
+}

--- a/pkg/reconciler/testing/table.go
+++ b/pkg/reconciler/testing/table.go
@@ -151,7 +151,7 @@ func (r *TableRow) Test(t *testing.T, ctor Ctor) {
 			continue
 		}
 		got := deleteActions[i]
-		if got.GetName() != want.Name {
+		if got.GetName() != want.GetName() {
 			t.Errorf("unexpected delete[%d]: %#v", i, got)
 		}
 		if got.GetNamespace() != expectedNamespace && got.GetNamespace() != system.Namespace {
@@ -171,7 +171,7 @@ func (r *TableRow) Test(t *testing.T, ctor Ctor) {
 		}
 
 		got := patchActions[i]
-		if got.GetName() != want.Name {
+		if got.GetName() != want.GetName() {
 			t.Errorf("unexpected patch[%d]: %#v", i, got)
 		}
 		if got.GetNamespace() != expectedNamespace && got.GetNamespace() != system.Namespace {

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -49,48 +49,48 @@ func TestReconcile(t *testing.T) {
 		Key:  "too/many/parts",
 	}, {
 		Name: "key not found",
-		Key:  "foo/not-found",
+		Key:  "default/not-found",
 	}, {
 		Name: "create revision matching generation",
 		Objects: []runtime.Object{
-			Config("no-revisions-yet", "foo").
+			Config("no-revisions-yet").
 				WithGeneration(1234).
 				Build(),
 		},
 		WantCreates: []metav1.Object{
-			Config("no-revisions-yet", "foo").
+			Config("no-revisions-yet").
 				WithGeneration(1234).
 				ToChildRevision(resources.MakeRevision).
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("no-revisions-yet", "foo").
+			Config("no-revisions-yet").
 				WithGeneration(1234).
 				WithLatestCreatedRevisionName("no-revisions-yet-01234").
 				WithObservedGeneration(1234).
 				WithReadyConditionUnknown().
 				ToUpdateAction(),
 		},
-		Key: "foo/no-revisions-yet",
+		Key: "default/no-revisions-yet",
 	}, {
 		Name: "webhook validation failure",
 		// If we attempt to create a Revision with a bad ConcurrencyModel set, we fail.
 		WantErr: true,
 		Objects: []runtime.Object{
-			Config("validation-failure", "foo").
+			Config("validation-failure").
 				WithGeneration(1234).
 				WithConcurrencyModel("Bogus").
 				Build(),
 		},
 		WantCreates: []metav1.Object{
-			Config("validation-failure", "foo").
+			Config("validation-failure").
 				WithGeneration(1234).
 				WithConcurrencyModel("Bogus").
 				ToChildRevision(resources.MakeRevision).
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("validation-failure", "foo").
+			Config("validation-failure").
 				WithGeneration(1234).
 				WithConcurrencyModel("Bogus").
 				WithReadyConditionFalse(
@@ -99,28 +99,28 @@ func TestReconcile(t *testing.T) {
 				).
 				ToUpdateAction(),
 		},
-		Key: "foo/validation-failure",
+		Key: "default/validation-failure",
 	}, {
 		Name: "create revision matching generation with build",
 		Objects: []runtime.Object{
-			Config("need-rev-and-build", "foo").
+			Config("need-rev-and-build").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				Build(),
 		},
 		WantCreates: []metav1.Object{
-			Config("need-rev-and-build", "foo").
+			Config("need-rev-and-build").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				ToChildBuild(resources.MakeBuild),
-			Config("need-rev-and-build", "foo").
+			Config("need-rev-and-build").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				ToChildRevision(resources.MakeRevision).
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("need-rev-and-build", "foo").
+			Config("need-rev-and-build").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				WithLatestCreatedRevisionName("need-rev-and-build-99998").
@@ -128,41 +128,41 @@ func TestReconcile(t *testing.T) {
 				WithReadyConditionUnknown().
 				ToUpdateAction(),
 		},
-		Key: "foo/need-rev-and-build",
+		Key: "default/need-rev-and-build",
 	}, {
 		Name: "reconcile revision matching generation (ready: unknown)",
 		Objects: []runtime.Object{
-			Config("matching-revision-not-done", "foo").
+			Config("matching-revision-not-done").
 				WithGeneration(5432).
 				Build(),
-			Config("matching-revision-not-done", "foo").
+			Config("matching-revision-not-done").
 				WithGeneration(5432).
 				ToChildRevision(resources.MakeRevision).
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("matching-revision-not-done", "foo").
+			Config("matching-revision-not-done").
 				WithGeneration(5432).
 				WithLatestCreatedRevisionName("matching-revision-not-done-05432").
 				WithObservedGeneration(5432).
 				WithReadyConditionUnknown().
 				ToUpdateAction(),
 		},
-		Key: "foo/matching-revision-not-done",
+		Key: "default/matching-revision-not-done",
 	}, {
 		Name: "reconcile revision matching generation (ready: true)",
 		Objects: []runtime.Object{
-			Config("matching-revision-done", "foo").
+			Config("matching-revision-done").
 				WithGeneration(5555).
 				Build(),
-			Config("matching-revision-done", "foo").
+			Config("matching-revision-done").
 				WithGeneration(5555).
 				ToChildRevision(resources.MakeRevision).
 				WithReadyConditionTrue().
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("matching-revision-done", "foo").
+			Config("matching-revision-done").
 				WithGeneration(5555).
 				WithLatestCreatedRevisionName("matching-revision-done-05555").
 				WithLatestReadyRevisionName("matching-revision-done-05555").
@@ -170,31 +170,31 @@ func TestReconcile(t *testing.T) {
 				WithReadyConditionTrue().
 				ToUpdateAction(),
 		},
-		Key: "foo/matching-revision-done",
+		Key: "default/matching-revision-done",
 	}, {
 		Name: "reconcile revision matching generation (ready: true, idempotent)",
 		Objects: []runtime.Object{
-			Config("matching-revision-done-idempotent", "foo").
+			Config("matching-revision-done-idempotent").
 				WithGeneration(5566).
 				WithLatestCreatedRevisionName("matching-revision-done-idempotent-05566").
 				WithLatestReadyRevisionName("matching-revision-done-idempotent-05566").
 				WithObservedGeneration(5566).
 				WithReadyConditionTrue().
 				Build(),
-			Config("matching-revision-done-idempotent", "foo").
+			Config("matching-revision-done-idempotent").
 				WithGeneration(5566).
 				ToChildRevision(resources.MakeRevision).
 				WithReadyConditionTrue().
 				Build(),
 		},
-		Key: "foo/matching-revision-done-idempotent",
+		Key: "default/matching-revision-done-idempotent",
 	}, {
 		Name: "reconcile revision matching generation (ready: false)",
 		Objects: []runtime.Object{
-			Config("matching-revision-failed", "foo").
+			Config("matching-revision-failed").
 				WithGeneration(5555).
 				Build(),
-			Config("matching-revision-failed", "foo").
+			Config("matching-revision-failed").
 				WithGeneration(5555).
 				ToChildRevision(resources.MakeRevision).
 				WithReadyConditionFalse(
@@ -204,7 +204,7 @@ func TestReconcile(t *testing.T) {
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("matching-revision-failed", "foo").
+			Config("matching-revision-failed").
 				WithGeneration(5555).
 				WithLatestCreatedRevisionName("matching-revision-failed-05555").
 				WithObservedGeneration(5555).
@@ -214,14 +214,14 @@ func TestReconcile(t *testing.T) {
 				).
 				ToUpdateAction(),
 		},
-		Key: "foo/matching-revision-failed",
+		Key: "default/matching-revision-failed",
 	}, {
 		Name: "reconcile revision matching generation (ready: bad)",
 		Objects: []runtime.Object{
-			Config("bad-condition", "foo").
+			Config("bad-condition").
 				WithGeneration(5555).
 				Build(),
-			Config("bad-condition", "foo").
+			Config("bad-condition").
 				WithGeneration(5555).
 				ToChildRevision(resources.MakeRevision).
 				WithReadyCondition("Bad").
@@ -229,14 +229,14 @@ func TestReconcile(t *testing.T) {
 		},
 		WantErr: true,
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("bad-condition", "foo").
+			Config("bad-condition").
 				WithGeneration(5555).
 				WithLatestCreatedRevisionName("bad-condition-05555").
 				WithObservedGeneration(5555).
 				WithReadyConditionUnknown().
 				ToUpdateAction(),
 		},
-		Key: "foo/bad-condition",
+		Key: "default/bad-condition",
 	}, {
 		Name: "failure creating build",
 		// We induce a failure creating a build
@@ -245,20 +245,20 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "builds"),
 		},
 		Objects: []runtime.Object{
-			Config("create-build-failure", "foo").
+			Config("create-build-failure").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				Build(),
 		},
 		WantCreates: []metav1.Object{
-			Config("create-build-failure", "foo").
+			Config("create-build-failure").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				ToChildBuild(resources.MakeBuild),
 			// No Revision gets created.
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("create-build-failure", "foo").
+			Config("create-build-failure").
 				WithGeneration(99998).
 				WithBuild(buildSpec).
 				WithReadyConditionFalse(
@@ -267,7 +267,7 @@ func TestReconcile(t *testing.T) {
 				).
 				ToUpdateAction(),
 		},
-		Key: "foo/create-build-failure",
+		Key: "default/create-build-failure",
 	}, {
 		Name: "failure creating revision",
 		// We induce a failure creating a revision
@@ -276,18 +276,18 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "revisions"),
 		},
 		Objects: []runtime.Object{
-			Config("create-revision-failure", "foo").
+			Config("create-revision-failure").
 				WithGeneration(99998).
 				Build(),
 		},
 		WantCreates: []metav1.Object{
-			Config("create-revision-failure", "foo").
+			Config("create-revision-failure").
 				WithGeneration(99998).
 				ToChildRevision(resources.MakeRevision).
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("create-revision-failure", "foo").
+			Config("create-revision-failure").
 				WithGeneration(99998).
 				WithReadyConditionFalse(
 					"RevisionFailed",
@@ -295,7 +295,7 @@ func TestReconcile(t *testing.T) {
 				).
 				ToUpdateAction(),
 		},
-		Key: "foo/create-revision-failure",
+		Key: "default/create-revision-failure",
 	}, {
 		Name: "failure updating configuration status",
 		// Induce a failure updating the status of the configuration.
@@ -304,29 +304,29 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "configurations"),
 		},
 		Objects: []runtime.Object{
-			Config("update-config-failure", "foo").
+			Config("update-config-failure").
 				WithGeneration(1234).
 				Build(),
 		},
 		WantCreates: []metav1.Object{
-			Config("update-config-failure", "foo").
+			Config("update-config-failure").
 				WithGeneration(1234).
 				ToChildRevision(resources.MakeRevision).
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("update-config-failure", "foo").
+			Config("update-config-failure").
 				WithGeneration(1234).
 				WithLatestCreatedRevisionName("update-config-failure-01234").
 				WithObservedGeneration(1234).
 				WithReadyConditionUnknown().
 				ToUpdateAction(),
 		},
-		Key: "foo/update-config-failure",
+		Key: "default/update-config-failure",
 	}, {
 		Name: "failed revision recovers",
 		Objects: []runtime.Object{
-			Config("revision-recovers", "foo").
+			Config("revision-recovers").
 				WithGeneration(1337).
 				WithLatestCreatedRevisionName("revision-recovers-01337").
 				WithLatestReadyRevisionName("revision-recovers-01337").
@@ -335,14 +335,14 @@ func TestReconcile(t *testing.T) {
 					`Revision "revision-recovers-01337" failed with message: "Weebles wobble, but they don't fall down".`,
 				).
 				Build(),
-			Config("revision-recovers", "foo").
+			Config("revision-recovers").
 				WithGeneration(1337).
 				ToChildRevision(resources.MakeRevision).
 				WithReadyConditionTrue().
 				Build(),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			Config("revision-recovers", "foo").
+			Config("revision-recovers").
 				WithGeneration(1337).
 				WithLatestCreatedRevisionName("revision-recovers-01337").
 				WithLatestReadyRevisionName("revision-recovers-01337").
@@ -350,7 +350,7 @@ func TestReconcile(t *testing.T) {
 				WithReadyConditionTrue().
 				ToUpdateAction(),
 		},
-		Key: "foo/revision-recovers",
+		Key: "default/revision-recovers",
 	}}
 
 	table.Test(t, func(listers *Listers, opt reconciler.Options) controller.Reconciler {

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -21,7 +21,6 @@ import (
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/pkg/controller"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources"
 	corev1 "k8s.io/api/core/v1"
@@ -29,16 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 
+	. "github.com/knative/serving/pkg/apis/serving/v1alpha1/testing"
 	. "github.com/knative/serving/pkg/reconciler/testing"
 )
 
 var (
-	boolTrue     = true
-	revisionSpec = v1alpha1.RevisionSpec{
-		Container: corev1.Container{
-			Image: "busybox",
-		},
-	}
 	buildSpec = buildv1alpha1.BuildSpec{
 		Steps: []corev1.Container{{
 			Image: "build-step1",
@@ -59,170 +53,189 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "create revision matching generation",
 		Objects: []runtime.Object{
-			cfg("no-revisions-yet", "foo", 1234),
+			Config("no-revisions-yet", "foo").
+				WithGeneration(1234).
+				Build(),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeRevision(cfg("no-revisions-yet", "foo", 1234)),
+			Config("no-revisions-yet", "foo").
+				WithGeneration(1234).
+				ToChildRevision(resources.MakeRevision).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("no-revisions-yet", "foo", 1234,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "no-revisions-yet-01234",
-					ObservedGeneration:        1234,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionUnknown,
-					}},
-				}),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("no-revisions-yet", "foo").
+				WithGeneration(1234).
+				WithLatestCreatedRevisionName("no-revisions-yet-01234").
+				WithObservedGeneration(1234).
+				WithReadyConditionUnknown().
+				ToUpdateAction(),
+		},
 		Key: "foo/no-revisions-yet",
 	}, {
 		Name: "webhook validation failure",
 		// If we attempt to create a Revision with a bad ConcurrencyModel set, we fail.
 		WantErr: true,
 		Objects: []runtime.Object{
-			setConcurrencyModel(cfg("validation-failure", "foo", 1234), "Bogus"),
+			Config("validation-failure", "foo").
+				WithGeneration(1234).
+				WithConcurrencyModel("Bogus").
+				Build(),
 		},
 		WantCreates: []metav1.Object{
-			setRevConcurrencyModel(resources.MakeRevision(cfg("validation-failure", "foo", 1234)), "Bogus"),
+			Config("validation-failure", "foo").
+				WithGeneration(1234).
+				WithConcurrencyModel("Bogus").
+				ToChildRevision(resources.MakeRevision).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: setConcurrencyModel(cfgWithStatus("validation-failure", "foo", 1234,
-				v1alpha1.ConfigurationStatus{
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:    v1alpha1.ConfigurationConditionReady,
-						Status:  corev1.ConditionFalse,
-						Reason:  "RevisionFailed",
-						Message: `Revision creation failed with message: "invalid value \"Bogus\": spec.concurrencyModel".`,
-					}},
-				}), "Bogus"),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("validation-failure", "foo").
+				WithGeneration(1234).
+				WithConcurrencyModel("Bogus").
+				WithReadyConditionFalse(
+					"RevisionFailed",
+					`Revision creation failed with message: "invalid value \"Bogus\": spec.concurrencyModel".`,
+				).
+				ToUpdateAction(),
+		},
 		Key: "foo/validation-failure",
 	}, {
 		Name: "create revision matching generation with build",
 		Objects: []runtime.Object{
-			cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec),
+			Config("need-rev-and-build", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				Build(),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeBuild(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec)),
-			resources.MakeRevision(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec)),
+			Config("need-rev-and-build", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				ToChildBuild(resources.MakeBuild),
+			Config("need-rev-and-build", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				ToChildRevision(resources.MakeRevision).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithBuildAndStatus("need-rev-and-build", "foo", 99998, &buildSpec,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "need-rev-and-build-99998",
-					ObservedGeneration:        99998,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionUnknown,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("need-rev-and-build", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				WithLatestCreatedRevisionName("need-rev-and-build-99998").
+				WithObservedGeneration(99998).
+				WithReadyConditionUnknown().
+				ToUpdateAction(),
+		},
 		Key: "foo/need-rev-and-build",
 	}, {
 		Name: "reconcile revision matching generation (ready: unknown)",
 		Objects: []runtime.Object{
-			cfg("matching-revision-not-done", "foo", 5432),
-			resources.MakeRevision(cfg("matching-revision-not-done", "foo", 5432)),
+			Config("matching-revision-not-done", "foo").
+				WithGeneration(5432).
+				Build(),
+			Config("matching-revision-not-done", "foo").
+				WithGeneration(5432).
+				ToChildRevision(resources.MakeRevision).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("matching-revision-not-done", "foo", 5432,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "matching-revision-not-done-05432",
-					ObservedGeneration:        5432,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionUnknown,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("matching-revision-not-done", "foo").
+				WithGeneration(5432).
+				WithLatestCreatedRevisionName("matching-revision-not-done-05432").
+				WithObservedGeneration(5432).
+				WithReadyConditionUnknown().
+				ToUpdateAction(),
+		},
 		Key: "foo/matching-revision-not-done",
 	}, {
 		Name: "reconcile revision matching generation (ready: true)",
 		Objects: []runtime.Object{
-			cfg("matching-revision-done", "foo", 5555),
-			makeRevReady(t, resources.MakeRevision(cfg("matching-revision-done", "foo", 5555))),
+			Config("matching-revision-done", "foo").
+				WithGeneration(5555).
+				Build(),
+			Config("matching-revision-done", "foo").
+				WithGeneration(5555).
+				ToChildRevision(resources.MakeRevision).
+				WithReadyConditionTrue().
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("matching-revision-done", "foo", 5555,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "matching-revision-done-05555",
-					LatestReadyRevisionName:   "matching-revision-done-05555",
-					ObservedGeneration:        5555,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("matching-revision-done", "foo").
+				WithGeneration(5555).
+				WithLatestCreatedRevisionName("matching-revision-done-05555").
+				WithLatestReadyRevisionName("matching-revision-done-05555").
+				WithObservedGeneration(5555).
+				WithReadyConditionTrue().
+				ToUpdateAction(),
+		},
 		Key: "foo/matching-revision-done",
 	}, {
 		Name: "reconcile revision matching generation (ready: true, idempotent)",
 		Objects: []runtime.Object{
-			cfgWithStatus("matching-revision-done-idempotent", "foo", 5566,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "matching-revision-done-idempotent-05566",
-					LatestReadyRevisionName:   "matching-revision-done-idempotent-05566",
-					ObservedGeneration:        5566,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-			),
-			makeRevReady(t, resources.MakeRevision(cfg("matching-revision-done-idempotent", "foo", 5566))),
+			Config("matching-revision-done-idempotent", "foo").
+				WithGeneration(5566).
+				WithLatestCreatedRevisionName("matching-revision-done-idempotent-05566").
+				WithLatestReadyRevisionName("matching-revision-done-idempotent-05566").
+				WithObservedGeneration(5566).
+				WithReadyConditionTrue().
+				Build(),
+			Config("matching-revision-done-idempotent", "foo").
+				WithGeneration(5566).
+				ToChildRevision(resources.MakeRevision).
+				WithReadyConditionTrue().
+				Build(),
 		},
 		Key: "foo/matching-revision-done-idempotent",
 	}, {
 		Name: "reconcile revision matching generation (ready: false)",
 		Objects: []runtime.Object{
-			cfg("matching-revision-failed", "foo", 5555),
-			makeRevFailed(resources.MakeRevision(cfg("matching-revision-failed", "foo", 5555))),
+			Config("matching-revision-failed", "foo").
+				WithGeneration(5555).
+				Build(),
+			Config("matching-revision-failed", "foo").
+				WithGeneration(5555).
+				ToChildRevision(resources.MakeRevision).
+				WithReadyConditionFalse(
+					"MissingContainer",
+					"It's the end of the world as we know it",
+				).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("matching-revision-failed", "foo", 5555,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "matching-revision-failed-05555",
-					ObservedGeneration:        5555,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:    v1alpha1.ConfigurationConditionReady,
-						Status:  corev1.ConditionFalse,
-						Reason:  "RevisionFailed",
-						Message: `Revision "matching-revision-failed-05555" failed with message: "It's the end of the world as we know it".`,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("matching-revision-failed", "foo").
+				WithGeneration(5555).
+				WithLatestCreatedRevisionName("matching-revision-failed-05555").
+				WithObservedGeneration(5555).
+				WithReadyConditionFalse(
+					"RevisionFailed",
+					`Revision "matching-revision-failed-05555" failed with message: "It's the end of the world as we know it".`,
+				).
+				ToUpdateAction(),
+		},
 		Key: "foo/matching-revision-failed",
 	}, {
 		Name: "reconcile revision matching generation (ready: bad)",
 		Objects: []runtime.Object{
-			cfg("bad-condition", "foo", 5555),
-			makeRevStatus(resources.MakeRevision(cfg("bad-condition", "foo", 5555)),
-				v1alpha1.RevisionStatus{
-					Conditions: []v1alpha1.RevisionCondition{{
-						Type:   v1alpha1.RevisionConditionReady,
-						Status: "Bad",
-					}},
-				},
-			),
+			Config("bad-condition", "foo").
+				WithGeneration(5555).
+				Build(),
+			Config("bad-condition", "foo").
+				WithGeneration(5555).
+				ToChildRevision(resources.MakeRevision).
+				WithReadyCondition("Bad").
+				Build(),
 		},
 		WantErr: true,
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("bad-condition", "foo", 5555,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "bad-condition-05555",
-					ObservedGeneration:        5555,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionUnknown,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("bad-condition", "foo").
+				WithGeneration(5555).
+				WithLatestCreatedRevisionName("bad-condition-05555").
+				WithObservedGeneration(5555).
+				WithReadyConditionUnknown().
+				ToUpdateAction(),
+		},
 		Key: "foo/bad-condition",
 	}, {
 		Name: "failure creating build",
@@ -232,24 +245,28 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "builds"),
 		},
 		Objects: []runtime.Object{
-			cfgWithBuild("create-build-failure", "foo", 99998, &buildSpec),
+			Config("create-build-failure", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				Build(),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeBuild(cfgWithBuild("create-build-failure", "foo", 99998, &buildSpec)),
+			Config("create-build-failure", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				ToChildBuild(resources.MakeBuild),
 			// No Revision gets created.
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithBuildAndStatus("create-build-failure", "foo", 99998, &buildSpec,
-				v1alpha1.ConfigurationStatus{
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:    v1alpha1.ConfigurationConditionReady,
-						Status:  corev1.ConditionFalse,
-						Reason:  "RevisionFailed",
-						Message: `Revision creation failed with message: "inducing failure for create builds".`,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("create-build-failure", "foo").
+				WithGeneration(99998).
+				WithBuild(buildSpec).
+				WithReadyConditionFalse(
+					"RevisionFailed",
+					`Revision creation failed with message: "inducing failure for create builds".`,
+				).
+				ToUpdateAction(),
+		},
 		Key: "foo/create-build-failure",
 	}, {
 		Name: "failure creating revision",
@@ -259,23 +276,25 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "revisions"),
 		},
 		Objects: []runtime.Object{
-			cfg("create-revision-failure", "foo", 99998),
+			Config("create-revision-failure", "foo").
+				WithGeneration(99998).
+				Build(),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeRevision(cfg("create-revision-failure", "foo", 99998)),
+			Config("create-revision-failure", "foo").
+				WithGeneration(99998).
+				ToChildRevision(resources.MakeRevision).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("create-revision-failure", "foo", 99998,
-				v1alpha1.ConfigurationStatus{
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:    v1alpha1.ConfigurationConditionReady,
-						Status:  corev1.ConditionFalse,
-						Reason:  "RevisionFailed",
-						Message: `Revision creation failed with message: "inducing failure for create revisions".`,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("create-revision-failure", "foo").
+				WithGeneration(99998).
+				WithReadyConditionFalse(
+					"RevisionFailed",
+					`Revision creation failed with message: "inducing failure for create revisions".`,
+				).
+				ToUpdateAction(),
+		},
 		Key: "foo/create-revision-failure",
 	}, {
 		Name: "failure updating configuration status",
@@ -285,54 +304,52 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "configurations"),
 		},
 		Objects: []runtime.Object{
-			cfg("update-config-failure", "foo", 1234),
+			Config("update-config-failure", "foo").
+				WithGeneration(1234).
+				Build(),
 		},
 		WantCreates: []metav1.Object{
-			resources.MakeRevision(cfg("update-config-failure", "foo", 1234)),
+			Config("update-config-failure", "foo").
+				WithGeneration(1234).
+				ToChildRevision(resources.MakeRevision).
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("update-config-failure", "foo", 1234,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "update-config-failure-01234",
-					ObservedGeneration:        1234,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionUnknown,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("update-config-failure", "foo").
+				WithGeneration(1234).
+				WithLatestCreatedRevisionName("update-config-failure-01234").
+				WithObservedGeneration(1234).
+				WithReadyConditionUnknown().
+				ToUpdateAction(),
+		},
 		Key: "foo/update-config-failure",
 	}, {
 		Name: "failed revision recovers",
 		Objects: []runtime.Object{
-			cfgWithStatus("revision-recovers", "foo", 1337,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "revision-recovers-01337",
-					LatestReadyRevisionName:   "revision-recovers-01337",
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:    v1alpha1.ConfigurationConditionReady,
-						Status:  corev1.ConditionFalse,
-						Reason:  "RevisionFailed",
-						Message: `Revision "revision-recovers-01337" failed with message: "Weebles wobble, but they don't fall down".`,
-					}},
-				},
-			),
-			makeRevReady(t, resources.MakeRevision(cfg("revision-recovers", "foo", 1337))),
+			Config("revision-recovers", "foo").
+				WithGeneration(1337).
+				WithLatestCreatedRevisionName("revision-recovers-01337").
+				WithLatestReadyRevisionName("revision-recovers-01337").
+				WithReadyConditionFalse(
+					"RevisionFailed",
+					`Revision "revision-recovers-01337" failed with message: "Weebles wobble, but they don't fall down".`,
+				).
+				Build(),
+			Config("revision-recovers", "foo").
+				WithGeneration(1337).
+				ToChildRevision(resources.MakeRevision).
+				WithReadyConditionTrue().
+				Build(),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfgWithStatus("revision-recovers", "foo", 1337,
-				v1alpha1.ConfigurationStatus{
-					LatestCreatedRevisionName: "revision-recovers-01337",
-					LatestReadyRevisionName:   "revision-recovers-01337",
-					ObservedGeneration:        1337,
-					Conditions: []v1alpha1.ConfigurationCondition{{
-						Type:   v1alpha1.ConfigurationConditionReady,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-			),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			Config("revision-recovers", "foo").
+				WithGeneration(1337).
+				WithLatestCreatedRevisionName("revision-recovers-01337").
+				WithLatestReadyRevisionName("revision-recovers-01337").
+				WithObservedGeneration(1337).
+				WithReadyConditionTrue().
+				ToUpdateAction(),
+		},
 		Key: "foo/revision-recovers",
 	}}
 
@@ -343,64 +360,4 @@ func TestReconcile(t *testing.T) {
 			revisionLister:      listers.GetRevisionLister(),
 		}
 	})
-}
-
-func cfgWithBuildAndStatus(name, namespace string, generation int64, build *buildv1alpha1.BuildSpec, status v1alpha1.ConfigurationStatus) *v1alpha1.Configuration {
-	return &v1alpha1.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: v1alpha1.ConfigurationSpec{
-			Generation: generation,
-			Build:      build,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-				Spec: revisionSpec,
-			},
-		},
-		Status: status,
-	}
-}
-
-func cfgWithStatus(name, namespace string, generation int64, status v1alpha1.ConfigurationStatus) *v1alpha1.Configuration {
-	return cfgWithBuildAndStatus(name, namespace, generation, nil, status)
-}
-
-func cfgWithBuild(name, namespace string, generation int64, build *buildv1alpha1.BuildSpec) *v1alpha1.Configuration {
-	return cfgWithBuildAndStatus(name, namespace, generation, build, v1alpha1.ConfigurationStatus{})
-}
-
-func cfg(name, namespace string, generation int64) *v1alpha1.Configuration {
-	return cfgWithStatus(name, namespace, generation, v1alpha1.ConfigurationStatus{})
-}
-
-func setConcurrencyModel(cfg *v1alpha1.Configuration, ss v1alpha1.RevisionRequestConcurrencyModelType) *v1alpha1.Configuration {
-	cfg.Spec.RevisionTemplate.Spec.ConcurrencyModel = ss
-	return cfg
-}
-
-func setRevConcurrencyModel(rev *v1alpha1.Revision, ss v1alpha1.RevisionRequestConcurrencyModelType) *v1alpha1.Revision {
-	rev.Spec.ConcurrencyModel = ss
-	return rev
-}
-
-func makeRevReady(t *testing.T, rev *v1alpha1.Revision) *v1alpha1.Revision {
-	rev.Status.InitializeConditions()
-	rev.Status.MarkContainerHealthy()
-	rev.Status.MarkResourcesAvailable()
-	if !rev.Status.IsReady() {
-		t.Fatalf("Wanted ready revision: %v", rev)
-	}
-	return rev
-}
-
-func makeRevFailed(rev *v1alpha1.Revision) *v1alpha1.Revision {
-	rev.Status.InitializeConditions()
-	rev.Status.MarkContainerMissing("It's the end of the world as we know it")
-	return rev
-}
-
-func makeRevStatus(rev *v1alpha1.Revision, status v1alpha1.RevisionStatus) *v1alpha1.Revision {
-	rev.Status = status
-	return rev
 }


### PR DESCRIPTION
From the PoC (https://github.com/knative/serving/pull/1762) this is the cleanup for the configuration table test 

Will focus on revision & route next.