### PR TITLE
Factor out websocket connection primitives.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -97,7 +97,7 @@ func statReporter() {
 	for {
 		s := <-statChan
 		if statSink == nil {
-			logger.Error("Stat sink not connected.")
+			logger.Warn("Stat sink not (yet) connected.")
 			continue
 		}
 		sm := autoscaler.StatMessage{
@@ -257,11 +257,12 @@ func main() {
 
 	go func() {
 		autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
-		logger.Info("Connecting to autoscaler at %s", autoscalerEndpoint)
+		logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 		conn, err := websocket.NewDurableSendingConnection(autoscalerEndpoint)
 		if err != nil {
 			logger.Fatal("Failed to connect to autoscaler, shutting down", zap.Error(err))
 		}
+		logger.Info("Connection to autoscaler established")
 		statSink = conn
 	}()
 	go statReporter()

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -260,7 +260,7 @@ func main() {
 		logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 		conn, err := websocket.NewDurableSendingConnection(autoscalerEndpoint)
 		if err != nil {
-			logger.Fatal("Failed to connect to autoscaler, shutting down", zap.Error(err))
+			logger.Error("Failed to connect to autoscaler, shutting down", zap.Error(err))
 		}
 		logger.Info("Connection to autoscaler established")
 		statSink = conn

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -17,9 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/gob"
 	"flag"
 	"fmt"
 	"io"
@@ -33,7 +31,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/cmd/util"
 	"github.com/knative/serving/pkg/autoscaler"
@@ -41,7 +38,9 @@ import (
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/system"
+	"github.com/knative/serving/pkg/websocket"
 	"go.uber.org/zap"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ var (
 	statChan              = make(chan *autoscaler.Stat, statReportingQueueLength)
 	reqChan               = make(chan queue.ReqEvent, requestCountingQueueLength)
 	kubeClient            *kubernetes.Clientset
-	statSink              *websocket.Conn
+	statSink              *websocket.Connection
 	logger                *zap.SugaredLogger
 	breaker               *queue.Breaker
 
@@ -94,38 +93,6 @@ func initEnv() {
 	servingRevisionKey = fmt.Sprintf("%s/%s", servingNamespace, servingRevision)
 }
 
-func connectStatSink() {
-	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s",
-		servingAutoscaler, system.Namespace, servingAutoscalerPort)
-	logger.Infof("Connecting to autoscaler at %s.", autoscalerEndpoint)
-	for {
-		// TODO: use exponential backoff here
-		time.Sleep(time.Second)
-
-		dialer := &websocket.Dialer{
-			HandshakeTimeout: 3 * time.Second,
-		}
-		conn, _, err := dialer.Dial(autoscalerEndpoint, nil)
-		if err != nil {
-			logger.Error("Retrying connection to autoscaler.", zap.Error(err))
-		} else {
-			logger.Info("Connected to stat sink.")
-			statSink = conn
-			waitForClose(conn)
-		}
-	}
-}
-
-func waitForClose(c *websocket.Conn) {
-	for {
-		if _, _, err := c.NextReader(); err != nil {
-			logger.Error("Error reading from websocket", zap.Error(err))
-			c.Close()
-			return
-		}
-	}
-}
-
 func statReporter() {
 	for {
 		s := <-statChan
@@ -137,16 +104,9 @@ func statReporter() {
 			Stat: *s,
 			Key:  servingRevisionKey,
 		}
-		var b bytes.Buffer
-		enc := gob.NewEncoder(&b)
-		err := enc.Encode(sm)
+		err := statSink.Send(sm)
 		if err != nil {
-			logger.Error("Failed to encode data from stats channel", zap.Error(err))
-			continue
-		}
-		err = statSink.WriteMessage(websocket.BinaryMessage, b.Bytes())
-		if err != nil {
-			logger.Error("Failed to write to stat sink.", zap.Error(err))
+			logger.Error("Error while sending stat", zap.Error(err))
 		}
 	}
 }
@@ -294,8 +254,18 @@ func main() {
 		logger.Fatal("Error creating new config", zap.Error(err))
 	}
 	kubeClient = kc
-	go connectStatSink()
+
+	go func() {
+		autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
+		logger.Info("Connecting to autoscaler at %s", autoscalerEndpoint)
+		conn, err := websocket.NewDurableSendingConnection(autoscalerEndpoint)
+		if err != nil {
+			logger.Fatal("Failed to connect to autoscaler, shutting down", zap.Error(err))
+		}
+		statSink = conn
+	}()
 	go statReporter()
+
 	bucketTicker := time.NewTicker(*concurrencyQuantumOfTime).C
 	reportTicker := time.NewTicker(time.Second).C
 	queue.NewStats(podName, queue.Channels{

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -255,16 +255,10 @@ func main() {
 	}
 	kubeClient = kc
 
-	go func() {
-		autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
-		logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
-		conn, err := websocket.NewDurableSendingConnection(autoscalerEndpoint)
-		if err != nil {
-			logger.Error("Failed to connect to autoscaler, shutting down", zap.Error(err))
-		}
-		logger.Info("Connection to autoscaler established")
-		statSink = conn
-	}()
+	// Open a websocket connection to the autoscaler
+	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
+	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
+	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter()
 
 	bucketTicker := time.NewTicker(*concurrencyQuantumOfTime).C

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -31,7 +31,6 @@ import (
 	"syscall"
 	"time"
 
-	rawwebsocket "github.com/gorilla/websocket"
 	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/cmd/util"
 	"github.com/knative/serving/pkg/autoscaler"
@@ -259,13 +258,7 @@ func main() {
 	// Open a websocket connection to the autoscaler
 	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
 	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
-	statSink = websocket.NewDurableSendingConnection(func() (websocket.RawConnection, error) {
-		dialer := &rawwebsocket.Dialer{
-			HandshakeTimeout: 3 * time.Second,
-		}
-		conn, _, err := dialer.Dial(autoscalerEndpoint, nil)
-		return conn, err
-	})
+	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter()
 
 	bucketTicker := time.NewTicker(*concurrencyQuantumOfTime).C

--- a/pkg/websocket/connection.go
+++ b/pkg/websocket/connection.go
@@ -33,7 +33,7 @@ import (
 func NewDurableSendingConnection(target string) (conn *Connection, err error) {
 	// The error of the first connection attempt is surfaced to rule out
 	// unrecoverable configuration issues.
-	conn, err = NewConnection(target)
+	conn, err = newConnection(target)
 
 	// Keep the connection alive asynchronously and reconnect on
 	// connection failure.
@@ -41,7 +41,7 @@ func NewDurableSendingConnection(target string) (conn *Connection, err error) {
 		for {
 			if _, _, err := conn.connection.NextReader(); err != nil {
 				conn.connection.Close()
-				conn.Reconnect()
+				conn.reconnect()
 			}
 		}
 	}()
@@ -82,7 +82,7 @@ type Connection struct {
 }
 
 // NewConnection creates a new websocket connection to the given target.
-func NewConnection(target string) (*Connection, error) {
+func newConnection(target string) (*Connection, error) {
 	conn, err := connect(target)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func NewConnection(target string) (*Connection, error) {
 }
 
 // Reconnect reestablishes a websocket connection.
-func (c *Connection) Reconnect() (err error) {
+func (c *Connection) reconnect() (err error) {
 	c.connection, err = connect(c.target)
 	return err
 }

--- a/pkg/websocket/connection.go
+++ b/pkg/websocket/connection.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"bytes"
+	"encoding/gob"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/gorilla/websocket"
+)
+
+// NewDurableSendingConnection creates a new websocket connection
+// that can only send messages to the endpoint it connects to.
+// The connection will continuously be kept alive and reconnected
+// in case of a loss of connectivity.
+func NewDurableSendingConnection(target string) (conn *Connection, err error) {
+	// The error of the first connection attempt is surfaced to rule out
+	// unrecoverable configuration issues.
+	conn, err = NewConnection(target)
+
+	// Keep the connection alive asynchronously and reconnect on
+	// connection failure.
+	go func() {
+		for {
+			if _, _, err := conn.connection.NextReader(); err != nil {
+				conn.connection.Close()
+				conn.Reconnect()
+			}
+		}
+	}()
+
+	return
+}
+
+func connect(target string) (rConnection *websocket.Conn, rError error) {
+	wait.ExponentialBackoff(wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1.3,
+		Steps:    20,
+		Jitter:   0.5,
+	}, func() (bool, error) {
+		dialer := &websocket.Dialer{
+			HandshakeTimeout: 3 * time.Second,
+		}
+		conn, _, err := dialer.Dial(target, nil)
+		if err != nil {
+			rError = err
+			return false, nil
+		}
+
+		rError = nil
+		rConnection = conn
+		return true, nil
+	})
+
+	return rConnection, rError
+}
+
+// Connection represents a websocket connection.
+type Connection struct {
+	target         string
+	connection     *websocket.Conn
+	messageBuffer  *bytes.Buffer
+	messageEncoder *gob.Encoder
+}
+
+// NewConnection creates a new websocket connection to the given target.
+func NewConnection(target string) (*Connection, error) {
+	conn, err := connect(target)
+	if err != nil {
+		return nil, err
+	}
+
+	buffer := &bytes.Buffer{}
+	return &Connection{
+		target:         target,
+		connection:     conn,
+		messageBuffer:  buffer,
+		messageEncoder: gob.NewEncoder(buffer),
+	}, nil
+}
+
+// Reconnect reestablishes a websocket connection.
+func (c *Connection) Reconnect() (err error) {
+	c.connection, err = connect(c.target)
+	return err
+}
+
+// Send sends an encodable message over the websocket connection.
+func (c *Connection) Send(msg interface{}) error {
+	if err := c.messageEncoder.Encode(msg); err != nil {
+		return err
+	}
+
+	return c.connection.WriteMessage(websocket.BinaryMessage, c.messageBuffer.Bytes())
+}
+
+// Close closes the websocket connection.
+func (c *Connection) Close() error {
+	return c.connection.Close()
+}

--- a/pkg/websocket/connection.go
+++ b/pkg/websocket/connection.go
@@ -46,7 +46,7 @@ func NewDurableSendingConnection(target string) (conn *Connection, err error) {
 		}
 	}()
 
-	return
+	return conn, err
 }
 
 func connect(target string) (rConnection *websocket.Conn, rError error) {

--- a/pkg/websocket/connection_test.go
+++ b/pkg/websocket/connection_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+type inspectableConnection struct {
+	nextReaderCalls   chan struct{}
+	writeMessageCalls chan struct{}
+	closeCalls        chan struct{}
+
+	nextReaderFunc func() (int, io.Reader, error)
+}
+
+func (c *inspectableConnection) WriteMessage(messageType int, data []byte) error {
+	c.writeMessageCalls <- struct{}{}
+	return nil
+}
+
+func (c *inspectableConnection) NextReader() (int, io.Reader, error) {
+	c.nextReaderCalls <- struct{}{}
+	return c.nextReaderFunc()
+}
+
+func (c *inspectableConnection) Close() error {
+	c.closeCalls <- struct{}{}
+	return nil
+}
+
+func TestRetriesWhileConnect(t *testing.T) {
+	want := 2
+	got := 0
+
+	spy := &inspectableConnection{
+		closeCalls: make(chan struct{}, 1),
+	}
+	conn := newConnection(func() (RawConnection, error) {
+		got++
+		if got == want {
+			return spy, nil
+		}
+		return nil, errors.New("not yet")
+	})
+
+	conn.connect()
+	conn.Close()
+
+	if got != want {
+		t.Fatalf("Wanted %v retries. Got %v.", want, got)
+	}
+	if len(spy.closeCalls) != 1 {
+		t.Fatalf("Wanted 'Close' to be called once, but got %v", len(spy.closeCalls))
+	}
+}
+
+func TestSendErrorOnNoConnection(t *testing.T) {
+	want := ErrConnectionNotEstablished
+
+	conn := &ManagedConnection{}
+	got := conn.Send("test")
+
+	if got != want {
+		t.Fatalf("Wanted error to be %v, but it was %v.", want, got)
+	}
+}
+
+func TestSendErrorOnEncode(t *testing.T) {
+	spy := &inspectableConnection{
+		writeMessageCalls: make(chan struct{}, 1),
+	}
+	conn := newConnection(func() (RawConnection, error) {
+		return spy, nil
+	})
+	conn.connect()
+	// gob cannot encode nil values
+	got := conn.Send(nil)
+
+	if got == nil {
+		t.Fatal("Expected an error but got none")
+	}
+	if len(spy.writeMessageCalls) != 0 {
+		t.Fatalf("Expected 'WriteMessage' not to be called, but was called %v times", spy.writeMessageCalls)
+	}
+}
+
+func TestSendMessage(t *testing.T) {
+	spy := &inspectableConnection{
+		writeMessageCalls: make(chan struct{}, 1),
+	}
+	conn := newConnection(func() (RawConnection, error) {
+		return spy, nil
+	})
+	conn.connect()
+	got := conn.Send("test")
+
+	if got != nil {
+		t.Fatalf("Expected no error but got: %+v", got)
+	}
+	if len(spy.writeMessageCalls) != 1 {
+		t.Fatalf("Expected 'WriteMessage' to be called once, but was called %v times", spy.writeMessageCalls)
+	}
+}
+
+func TestCloseClosesConnection(t *testing.T) {
+	spy := &inspectableConnection{
+		closeCalls: make(chan struct{}, 1),
+	}
+	conn := &ManagedConnection{
+		connection: spy,
+	}
+	conn.Close()
+
+	if len(spy.closeCalls) != 1 || conn.IsClosed != true {
+		t.Fatal("Wanted 'Close' to be called, but it wasn't")
+	}
+}
+
+func TestCloseIgnoresNoConnection(t *testing.T) {
+	conn := &ManagedConnection{}
+	got := conn.Close()
+
+	if got != nil || conn.IsClosed != true {
+		t.Fatal("Wanted 'Close' to be called, but it wasn't")
+	}
+}
+
+func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
+	testConn := &inspectableConnection{
+		nextReaderCalls:   make(chan struct{}, 1),
+		writeMessageCalls: make(chan struct{}, 1),
+		closeCalls:        make(chan struct{}, 1),
+
+		nextReaderFunc: func() (int, io.Reader, error) {
+			return 1, nil, errors.New("next reader errored")
+		},
+	}
+	connectAttempts := make(chan struct{}, 1)
+	conn := NewDurableSendingConnection(func() (RawConnection, error) {
+		connectAttempts <- struct{}{}
+		return testConn, nil
+	})
+
+	// the connection is constantly created, tried to read from
+	// and closed because NextReader (which holds the connection
+	// open) fails.
+	for i := 0; i < 100; i++ {
+		<-connectAttempts
+		<-testConn.nextReaderCalls
+		<-testConn.closeCalls
+	}
+
+	conn.Close()
+}


### PR DESCRIPTION
## Proposed Changes

As proposed in #1923, this factors the logic for creating durable websocket connections into a pkg. 

Wondering how to test this though. I **could** build a `WsConnection` and a `Dialer` interface I suppose to mock out the innerts of the client. Any ideas appreciated.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
