### PR TITLE
Add retries to VirtualService Spec

### DIFF
--- a/pkg/reconciler/v1alpha1/route/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/route/resources/virtual_service.go
@@ -35,7 +35,8 @@ const (
 	PortNumber = 80
 	PortName   = "http"
 
-	DefaultRouteTimeout = "60s"
+	DefaultRouteTimeout       = "60s"
+	DefaultRouteRetryAttempts = 3
 )
 
 // MakeVirtualService creates an Istio VirtualService to set up routing rules.  Such VirtualService specifies
@@ -150,6 +151,10 @@ func makeVirtualServiceRoute(domains []string, ns string, targets []traffic.Revi
 		Match:   matches,
 		Route:   weights,
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	// Add traffic rules for activator.
 	return addActivatorRoutes(&route, ns, inactive)

--- a/pkg/reconciler/v1alpha1/route/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/virtual_service_test.go
@@ -129,6 +129,10 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Weight: 100,
 		}},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}, {
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Authority: &v1alpha3.StringMatch{Exact: "v1.domain.com"},
@@ -141,6 +145,10 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Weight: 100,
 		}},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}}
 	routes := MakeVirtualService(r, &traffic.TrafficConfig{Targets: targets}).Spec.Http
 	if diff := cmp.Diff(expected, routes); diff != "" {
@@ -219,6 +227,10 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 			Weight: 100,
 		}},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)
@@ -256,6 +268,10 @@ func TestMakeVirtualServiceRoute_ZeroPercentTarget(t *testing.T) {
 			Weight: 100,
 		}},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)
@@ -300,6 +316,10 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 			Weight: 10,
 		}},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)
@@ -338,6 +358,10 @@ func TestMakeVirtualServiceRoute_VanillaScaledToZero(t *testing.T) {
 			"knative-serving-namespace":     "test-ns",
 		},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)
@@ -381,6 +405,10 @@ func TestMakeVirtualServiceRoute_TwoInactiveTargets(t *testing.T) {
 			"knative-serving-namespace":     "test-ns",
 		},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)
@@ -419,6 +447,10 @@ func TestMakeVirtualServiceRoute_ZeroPercentNamedTargetScaledToZero(t *testing.T
 			Weight: 100,
 		}},
 		Timeout: DefaultRouteTimeout,
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      DefaultRouteRetryAttempts,
+			PerTryTimeout: DefaultRouteTimeout,
+		},
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -357,6 +357,10 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				rclr.GetRevisionHeaderNamespace(): testNamespace,
 			},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, vs.Spec); diff != "" {
@@ -449,6 +453,10 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 				Weight: 10,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, vs.Spec); diff != "" {
@@ -542,6 +550,10 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 				rclr.GetRevisionHeaderNamespace(): testNamespace,
 			},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, vs.Spec); diff != "" {
@@ -649,6 +661,10 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				Weight: 50,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}, {
 			Match: []v1alpha3.HTTPMatchRequest{{Authority: &v1alpha3.StringMatch{Exact: "test-revision-1." + domain}}},
 			Route: []v1alpha3.DestinationWeight{{
@@ -659,6 +675,10 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				Weight: 100,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}, {
 			Match: []v1alpha3.HTTPMatchRequest{{Authority: &v1alpha3.StringMatch{Exact: "test-revision-2." + domain}}},
 			Route: []v1alpha3.DestinationWeight{{
@@ -669,6 +689,10 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				Weight: 100,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, vs.Spec); diff != "" {
@@ -761,6 +785,10 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				Weight: 50,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}, {
 			Match: []v1alpha3.HTTPMatchRequest{{Authority: &v1alpha3.StringMatch{Exact: "bar." + domain}}},
 			Route: []v1alpha3.DestinationWeight{{
@@ -771,6 +799,10 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				Weight: 100,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}, {
 			Match: []v1alpha3.HTTPMatchRequest{{Authority: &v1alpha3.StringMatch{Exact: "foo." + domain}}},
 			Route: []v1alpha3.DestinationWeight{{
@@ -781,6 +813,10 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				Weight: 100,
 			}},
 			Timeout: resources.DefaultRouteTimeout,
+			Retries: &v1alpha3.HTTPRetry{
+				Attempts:      resources.DefaultRouteRetryAttempts,
+				PerTryTimeout: resources.DefaultRouteTimeout,
+			},
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, vs.Spec); diff != "" {


### PR DESCRIPTION
I added some retries to VirtualService Spec and saw that we don't fail TestRouteCreation or the Route prober after 700 runs.