### PR TITLE
POC A pattern for using variables in TableRow definitions.

### DIFF
--- a/pkg/reconciler/testing/keep.go
+++ b/pkg/reconciler/testing/keep.go
@@ -101,3 +101,7 @@ func extractActions(t *testing.T, clients ...hasActions) (
 	}
 	return
 }
+
+func BuildRow(f func() TableRow) TableRow {
+	return f()
+}


### PR DESCRIPTION
I believe a significant source of boilerplate in the table tests is the fact that in their current form, they're glorified expressions.  This limits the ability to hoist variables and share things, so redundant expressions end up copied around.

This change demonstrates switching each row in the Revision controller's `table_test.go` to use the following pattern:
```golang
...
// This just calls the function immediately and returns the result, but looks a bit nicer.
BuildRow(func() TableRow {
	input := // construct revision

	// Construct the expected update based on the input.
	output := input.DeepCopy()
	output.Status.MutateSomething()

	return TableRow{
		Name: "...",
		Key: KeyOrDie(input),
		Objects:     []runtime.Object{input},
		WantCreates: []metav1.Object{kpa(input), deploy(input), svc(input)},
		WantUpdates: []clientgotesting.UpdateActionImpl{{Object: output}},
	}
}),
...
```

While a bit ugly the function gives us space to add statements and cut down on verbose expressions.  I also like how tight each of the actual `return TableRow{ ... }` statements have become.


I suspect that things like the builder pattern would still have significant potential to both improve the readability and reduce the code that this leaves (and effect non-`TableTest` code), but this also takes a sizeable bite out of the `TableTest`.

/hold
cc @dprotaso for thoughts