### PR TITLE
More output for Blue/Green test when Revision fails to come up.

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -206,13 +206,21 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, image2, err)
 	}
 
-	// TODO(#882): Remove these?
+	// We should only need to wait until the Revision is routable,
+	// i.e. Ready or Inactive.  At that point, activator could start
+	// queuing requests until the Revision wakes up.  However, due to
+	// #882 we are currently lumping the inactive splits and that
+	// would result in 100% requests reaching Blue or Green.
+	//
+	// TODO: After we implement #1583 and honor the split percentage
+	// for inactive cases, change this wait to allow for inactive
+	// revisions as well.
 	logger.Infof("Waiting for revision %q to be ready", blue.Revision)
-	if err := test.WaitForRevisionState(clients.ServingClient, blue.Revision, test.IsRevisionRoutable, "RevisionIsRoutable"); err != nil {
+	if err := test.WaitForRevisionState(clients.ServingClient, blue.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
 		t.Fatalf("The Revision %q still can't serve traffic: %v", blue.Revision, err)
 	}
 	logger.Infof("Waiting for revision %q to be ready", green.Revision)
-	if err := test.WaitForRevisionState(clients.ServingClient, green.Revision, test.IsRevisionRoutable, "RevisionIsRoutable"); err != nil {
+	if err := test.WaitForRevisionState(clients.ServingClient, green.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
 		t.Fatalf("The Revision %q still can't serve traffic: %v", green.Revision, err)
 	}
 

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -88,7 +88,6 @@ func sendRequests(client spoof.Interface, domain string, num int) ([]string, err
 			return nil
 		})
 	}
-
 	return responses, g.Wait()
 }
 
@@ -209,12 +208,12 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// TODO(#882): Remove these?
 	logger.Infof("Waiting for revision %q to be ready", blue.Revision)
-	if err := test.WaitForRevisionState(clients.ServingClient, blue.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q was not marked as Ready: %v", blue.Revision, err)
+	if err := test.WaitForRevisionState(clients.ServingClient, blue.Revision, test.IsRevisionRoutable, "RevisionIsRoutable"); err != nil {
+		t.Fatalf("The Revision %q still can't serve traffic: %v", blue.Revision, err)
 	}
 	logger.Infof("Waiting for revision %q to be ready", green.Revision)
-	if err := test.WaitForRevisionState(clients.ServingClient, green.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q was not marked as Ready: %v", green.Revision, err)
+	if err := test.WaitForRevisionState(clients.ServingClient, green.Revision, test.IsRevisionRoutable, "RevisionIsRoutable"); err != nil {
+		t.Fatalf("The Revision %q still can't serve traffic: %v", green.Revision, err)
 	}
 
 	// Set names for traffic targets to make them directly routable.

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,7 +34,7 @@ import (
 
 const (
 	interval = 1 * time.Second
-	timeout  = 5 * time.Minute
+	timeout  = 6 * time.Minute
 )
 
 // WaitForRouteState polls the status of the Route called name from client every
@@ -113,13 +114,24 @@ func WaitForRevisionState(client *ServingClients, name string, inState func(r *v
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		r, err := client.Revisions.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
 		return inState(r)
 	})
+	// Attempt to add revision Status to error message.
+	if waitErr != nil {
+		r, err := client.Revisions.Get(name, metav1.GetOptions{})
+		if err != nil {
+			// Cant' look for Revision, don't append Status to error message.
+			return waitErr
+		}
+		// Wrap error with information about Status.
+		return errors.Wrapf(waitErr, "Status=%#v", r.Status)
+	}
+	return nil
 }
 
 // CheckRevisionState verifies the status of the Revision called name from client

--- a/test/states.go
+++ b/test/states.go
@@ -79,6 +79,13 @@ func IsRevisionReady(r *v1alpha1.Revision) (bool, error) {
 	return r.Status.IsReady(), nil
 }
 
+// IsRevisionRoutable will check the status conditions of the
+// revision and return true if the revision is ready to serve traffic,
+// or inactive.
+func IsRevisionRoutable(r *v1alpha1.Revision) (bool, error) {
+	return r.Status.IsReady() || r.Status.IsActivationRequired(), nil
+}
+
 // IsServiceReady will check the status conditions of the service and return true if the service is
 // ready. This means that its configurations and routes have all reported ready.
 func IsServiceReady(s *v1alpha1.Service) (bool, error) {

--- a/test/states.go
+++ b/test/states.go
@@ -79,13 +79,6 @@ func IsRevisionReady(r *v1alpha1.Revision) (bool, error) {
 	return r.Status.IsReady(), nil
 }
 
-// IsRevisionRoutable will check the status conditions of the
-// revision and return true if the revision is ready to serve traffic,
-// or inactive.
-func IsRevisionRoutable(r *v1alpha1.Revision) (bool, error) {
-	return r.Status.IsReady() || r.Status.IsActivationRequired(), nil
-}
-
 // IsServiceReady will check the status conditions of the service and return true if the service is
 // ready. This means that its configurations and routes have all reported ready.
 func IsServiceReady(s *v1alpha1.Service) (bool, error) {


### PR DESCRIPTION
We have seen Blue/Green tests failing when waiting for the revisions to come up.  I'm adding here some additional output for such cases to understand & deflake the test.

/assign @adrcunha 