### PR TITLE
Fix istio-statsd-prom-bridge pod crash due to unknown short flag

### DIFF
--- a/third_party/istio-1.0.1/istio.yaml
+++ b/third_party/istio-1.0.1/istio.yaml
@@ -2217,7 +2217,7 @@ spec:
         - containerPort: 9125
           protocol: UDP
         args:
-        - '-statsd.mapping-config=/etc/statsd/mapping.conf'
+        - '--statsd.mapping-config=/etc/statsd/mapping.conf'
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Fixes #1954

## Proposed Changes

  * istio.yaml

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
add one more - to container args about istio-statsd-prom-bridge
```
