### PR TITLE
Emit pod scoped metrics from the autoscaler

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -70,7 +70,10 @@ data:
 
   # Tick interval is the time between autoscaling calculations.
   tick-interval: "2s"
-  
+
+  # Report pod scoped metrics
+  enable-pod-scope-metrics: "false"
+
   # Dynamic parameters (take effect when config map is updated):
 
   # Scale to zero threshold is the total time between traffic dropping to

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"go.opencensus.io/tag"
 
 	. "github.com/knative/pkg/logging/testing"
 	"go.uber.org/zap"
@@ -287,7 +288,7 @@ type linearSeries struct {
 
 type mockReporter struct{}
 
-func (r *mockReporter) Report(m Measurement, v float64) error {
+func (r *mockReporter) Report(m Measurement, v float64, mutators ...tag.Mutator) error {
 	return nil
 }
 

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -312,7 +312,7 @@ func newTestAutoscaler(containerConcurrency int) *Autoscaler {
 		config: config,
 		logger: zap.NewNop().Sugar(),
 	}
-	return New(dynConfig, v1alpha1.RevisionContainerConcurrencyType(containerConcurrency), &mockReporter{})
+	return New(config, dynConfig, v1alpha1.RevisionContainerConcurrencyType(containerConcurrency), &mockReporter{})
 }
 
 // Record a data point every second, for every pod, for duration of the

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -34,8 +34,9 @@ const (
 // +k8s:deepcopy-gen=true
 type Config struct {
 	// Feature flags.
-	EnableScaleToZero bool
-	EnableVPA         bool
+	EnableScaleToZero     bool
+	EnableVPA             bool
+	EnablePodScopeMetrics bool
 
 	// Target concurrency knobs for different container concurrency configurations.
 	ContainerConcurrencyTargetPercentage float64
@@ -75,6 +76,9 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}, {
 		key:   "enable-vertical-pod-autoscaling",
 		field: &lc.EnableVPA,
+	}, {
+		key:   "enable-pod-scope-metrics",
+		field: &lc.EnablePodScopeMetrics,
 	}} {
 		if raw, ok := data[b.key]; !ok {
 			*b.field = false

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -98,6 +98,7 @@ func TestNewConfig(t *testing.T) {
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
 			"enable-vertical-pod-autoscaling":         "true",
+			"enable-pod-scope-metrics":                "true",
 			"max-scale-up-rate":                       "1.0",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
@@ -108,8 +109,9 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
-			EnableScaleToZero: true,
-			EnableVPA:         true,
+			EnableScaleToZero:                    true,
+			EnableVPA:                            true,
+			EnablePodScopeMetrics:                true,
 			ContainerConcurrencyTargetPercentage: 0.5,
 			ContainerConcurrencyTargetDefault:    10.0,
 			MaxScaleUpRate:                       1.0,

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -345,7 +345,7 @@ func createMultiScaler(t *testing.T, config *autoscaler.Config) (*autoscaler.Mul
 	uniscaler := &fakeUniScaler{}
 
 	stopChan := make(chan struct{})
-	ms := autoscaler.NewMultiScaler(autoscaler.NewDynamicConfig(config, logger),
+	ms := autoscaler.NewMultiScaler(config, autoscaler.NewDynamicConfig(config, logger),
 		stopChan, uniscaler.fakeUniScalerFactory, logger)
 
 	return ms, stopChan, uniscaler
@@ -358,7 +358,7 @@ type fakeUniScaler struct {
 	lastStat autoscaler.Stat
 }
 
-func (u *fakeUniScaler) fakeUniScalerFactory(*kpa.PodAutoscaler, *autoscaler.DynamicConfig) (autoscaler.UniScaler, error) {
+func (u *fakeUniScaler) fakeUniScalerFactory(*kpa.PodAutoscaler, *autoscaler.Config, *autoscaler.DynamicConfig) (autoscaler.UniScaler, error) {
 	return u, nil
 }
 


### PR DESCRIPTION
## Proposed Changes

  * Emit individual pod concurrency and qps from the autoscaler every 2 seconds.
  * Add the feature flag "enable-pod-scope-metrics" which defaults to "false".
  * Plumb static config through to autoscaler along with existing dynamic config.

The Scaling Working Group has been considering some different mechanisms for buffering requests during scale-from-zero and other overload scenarios (#1846).  It helps to have a clear picture of what's going on and how the load is being distributed across the pods at any given time.

This change adds pod-scoped metrics (qps and concurrency) from the autoscaler which can be stacked to see where the load was going over time.

**Release Note**
```release-note
 * To enable pod qps and concurrency reporting, set `config/config-autoscaler.yaml` `enable-pod-scope-metrics` to `true`.
```

### Examples

Scaling from 0 to 10 pods in single-threaded mode:

```
go run ../docs/serving/samples/autoscale-go/test/test.go -qps 1000 -concurrency 10 -sleep 100 -duration '5m'
```

Pod concurrency stacked:
![image](https://user-images.githubusercontent.com/1103629/44755500-465f2380-aadb-11e8-9e9b-578ba2124c14.png)

Pod qps stacked:
![image](https://user-images.githubusercontent.com/1103629/44755526-642c8880-aadb-11e8-96de-f224287928ed.png)

Errors due to overload:
![image](https://user-images.githubusercontent.com/1103629/44755599-bc638a80-aadb-11e8-97aa-b3992bed190f.png)
