### PR TITLE
Change autoscaler e2e tests to use a lower burst of traffic

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -190,7 +190,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 
 	logger.Infof(`The autoscaler spins up additional replicas when traffic
 		    increases.`)
-	err = generateTrafficBurst(clients, logger, 500, domain)
+	err = generateTrafficBurst(clients, logger, 50, domain)
 	if err != nil {
 		logger.Fatalf("Error during initial scale up: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	logger.Infof("Scaled down.")
 	logger.Infof(`The autoscaler spins up additional replicas once again when
               traffic increases.`)
-	err = generateTrafficBurst(clients, logger, 500, domain)
+	err = generateTrafficBurst(clients, logger, 50, domain)
 	if err != nil {
 		t.Fatalf("Error during final scale up: %v", err)
 	}


### PR DESCRIPTION
The test cluster is underpowered 