### PR TITLE
Limit burst to 20 requests to reduce e2e flakiness.

### DIFF
--- a/test/crd.go
+++ b/test/crd.go
@@ -102,6 +102,7 @@ func Configuration(namespace string, names ResourceNames, imagePath string) *v1a
 					Container: corev1.Container{
 						Image: imagePath,
 					},
+					ContainerConcurrency: 10,
 				},
 			},
 		},

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -190,7 +190,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 
 	logger.Infof(`The autoscaler spins up additional replicas when traffic
 		    increases.`)
-	err = generateTrafficBurst(clients, logger, 500, domain)
+	err = generateTrafficBurst(clients, logger, 20, domain)
 	if err != nil {
 		logger.Fatalf("Error during initial scale up: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	logger.Infof("Scaled down.")
 	logger.Infof(`The autoscaler spins up additional replicas once again when
               traffic increases.`)
-	err = generateTrafficBurst(clients, logger, 500, domain)
+	err = generateTrafficBurst(clients, logger, 20, domain)
 	if err != nil {
 		t.Fatalf("Error during final scale up: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes

  * Reduces the autoscale test traffic burst to 20 requests from 500 to reduce flakiness

**Release Note**
```release-note
NONE
```
