### PR TITLE
Add Options structure for test parameters.

### DIFF
--- a/test/configuration.go
+++ b/test/configuration.go
@@ -23,19 +23,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// CreateConfiguration create a configuration resource in namespace with the name names.Config
-// that uses the image specified by imagePath.
-func CreateConfiguration(logger *logging.BaseLogger, clients *Clients, names ResourceNames, imagePath string) error {
-	return CreateConfigurationWithEnv(logger, clients, names, imagePath, nil)
+// Options are test setup parameters.
+type Options struct {
+	EnvVars              []corev1.EnvVar
+	ContainerConcurrency int
 }
 
-// CreateConfigurationWithEnv create a configuration resource in namespace with the name names.Config
-// that uses the image specifed by imagePath and give environment variables.
-func CreateConfigurationWithEnv(logger *logging.BaseLogger, clients *Clients, names ResourceNames, imagePath string, envVars []corev1.EnvVar) error {
-	config := Configuration(ServingNamespace, names, imagePath)
-	if envVars != nil && len(envVars) > 0 {
-		config.Spec.RevisionTemplate.Spec.Container.Env = envVars
-	}
+// CreateConfiguration create a configuration resource in namespace with the name names.Config
+// that uses the image specified by imagePath.
+func CreateConfiguration(logger *logging.BaseLogger, clients *Clients, names ResourceNames, imagePath string, options *Options) error {
+	config := Configuration(ServingNamespace, names, imagePath, options)
 
 	LogResourceObject(logger, ResourceObjects{Configuration: config})
 	_, err := clients.ServingClient.Configs.Create(config)

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -180,7 +180,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	defer tearDown(clients, names)
 
 	logger.Infof("Creating a Configuration")
-	if err := test.CreateConfiguration(logger, clients, names, imagePaths[0]); err != nil {
+	if err := test.CreateConfiguration(logger, clients, names, imagePaths[0], &test.Options{}); err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
 

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -41,7 +41,7 @@ const (
 )
 
 func createRouteAndConfig(logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, imagePaths []string) error {
-	err := test.CreateConfiguration(logger, clients, names, imagePaths[0])
+	err := test.CreateConfiguration(logger, clients, names, imagePaths[0], &test.Options{})
 	if err != nil {
 		return err
 	}

--- a/test/crd.go
+++ b/test/crd.go
@@ -90,8 +90,8 @@ func BlueGreenRoute(namespace string, names, blue, green ResourceNames) *v1alpha
 
 // Configuration returns a Configuration object in namespace with the name names.Config
 // that uses the image specified by imagePath.
-func Configuration(namespace string, names ResourceNames, imagePath string) *v1alpha1.Configuration {
-	return &v1alpha1.Configuration{
+func Configuration(namespace string, names ResourceNames, imagePath string, options *Options) *v1alpha1.Configuration {
+	config := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      names.Config,
@@ -102,11 +102,15 @@ func Configuration(namespace string, names ResourceNames, imagePath string) *v1a
 					Container: corev1.Container{
 						Image: imagePath,
 					},
-					ContainerConcurrency: 10,
+					ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
 				},
 			},
 		},
 	}
+	if options.EnvVars != nil && len(options.EnvVars) > 0 {
+		config.Spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
+	}
+	return config
 }
 
 func ConfigurationWithBuild(namespace string, names ResourceNames, build *buildv1alpha1.BuildSpec, imagePath string) *v1alpha1.Configuration {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -141,7 +141,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 
 	logger.Infof("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{
-		ContainerConcurrency: 20,
+		ContainerConcurrency: 10,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -140,7 +140,9 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	imagePath := test.ImagePath("autoscale")
 
 	logger.Infof("Creating a new Route and Configuration")
-	names, err := CreateRouteAndConfig(clients, logger, imagePath)
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{
+		ContainerConcurrency: 20,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
 	// https://github.com/kubernetes/client-go/issues/242
@@ -40,18 +39,12 @@ func TearDown(clients *test.Clients, names test.ResourceNames, logger *logging.B
 
 // CreateRouteAndConfig will create Route and Config objects using clients.
 // The Config object will serve requests to a container started from the image at imagePath.
-func CreateRouteAndConfig(clients *test.Clients, logger *logging.BaseLogger, imagePath string) (test.ResourceNames, error) {
-	return CreateRouteAndConfigWithEnv(clients, logger, imagePath, nil)
-}
-
-// CreateRouteAndConfigWithEnv will create Route and Config objects using clients.
-// The Config object will serve requests to a container started from the image at imagePath and configured with given environment variables.
-func CreateRouteAndConfigWithEnv(clients *test.Clients, logger *logging.BaseLogger, imagePath string, envVars []corev1.EnvVar) (test.ResourceNames, error) {
+func CreateRouteAndConfig(clients *test.Clients, logger *logging.BaseLogger, imagePath string, options *test.Options) (test.ResourceNames, error) {
 	var names test.ResourceNames
 	names.Config = test.AppendRandomString(configName, logger)
 	names.Route = test.AppendRandomString(routeName, logger)
 
-	if err := test.CreateConfigurationWithEnv(logger, clients, names, imagePath, envVars); err != nil {
+	if err := test.CreateConfiguration(logger, clients, names, imagePath, options); err != nil {
 		return test.ResourceNames{}, err
 	}
 	err := test.CreateRoute(logger, clients, names)

--- a/test/e2e/errorcondition_test.go
+++ b/test/e2e/errorcondition_test.go
@@ -54,7 +54,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	imagePath := test.ImagePath("invalidhelloworld")
 
 	logger.Infof("Creating a new Route and Configuration %s", imagePath)
-	names, err := CreateRouteAndConfig(clients, logger, imagePath)
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -41,7 +41,7 @@ func TestHelloWorld(t *testing.T) {
 	var imagePath = test.ImagePath("helloworld")
 
 	logger.Infof("Creating a new Route and Configuration")
-	names, err := CreateRouteAndConfig(clients, logger, imagePath)
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -82,7 +82,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	// Set up helloworld app.
 	helloWorldImagePath := test.ImagePath("helloworld")
 	logger.Infof("Creating a Route and Configuration for helloworld test app.")
-	helloWorldNames, err := CreateRouteAndConfig(clients, logger, helloWorldImagePath)
+	helloWorldNames, err := CreateRouteAndConfig(clients, logger, helloWorldImagePath, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}
@@ -97,7 +97,9 @@ func TestServiceToServiceCall(t *testing.T) {
 
 	logger.Infof("Creating a Route and Configuration for httpproxy test app.")
 	envVars := createTargetHostEnvVars(helloWorldNames.Route, t)
-	httpProxyNames, err := CreateRouteAndConfigWithEnv(clients, logger, httpProxyImagePath, envVars)
+	httpProxyNames, err := CreateRouteAndConfig(clients, logger, httpProxyImagePath, &test.Options{
+		EnvVars: envVars,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}


### PR DESCRIPTION
Fixes #1999

## Proposed Changes

  * Add an Options struct for tests to pass parameters to the underlying test framework.
  * Use Options for EnvVars and ContainerConcurrency.

**Release Note**
```release-note
NONE
```
