### PR TITLE
Reduce blue/green number of concurrent request.

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	concurrentRequests = 100
+	concurrentRequests = 50
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.
 	// This might be a bad assumption.
 	minDirectPercentage = 1


### PR DESCRIPTION
We reduced the concurrencyTarget of the test objects in #1989, which
results in Blue/Green concurrent requests being rejected with
`503 overload`.