### PR TITLE
Add GetGroupVersionKind to our CRD objects

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -27,6 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
 )
@@ -154,6 +155,10 @@ func (r *Configuration) SetGeneration(generation int64) {
 
 func (r *Configuration) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(r.Spec)
+}
+
+func (r *Configuration) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("Configuration")
 }
 
 // IsReady looks at the conditions on the ConfigurationStatus.

--- a/pkg/apis/serving/v1alpha1/configuration_types_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestConfigurationGeneration(t *testing.T) {
@@ -327,4 +328,16 @@ func checkConditionConfiguration(rs ConfigurationStatus, rct ConfigurationCondit
 		t.Fatalf("Get(%v) = %v, wanted %v", rct, r.Status, cs)
 	}
 	return r
+}
+
+func TestConfigurationGetGroupVersionKind(t *testing.T) {
+	c := &Configuration{}
+	want := schema.GroupVersionKind{
+		Group:   "serving.knative.dev",
+		Version: "v1alpha1",
+		Kind:    "Configuration",
+	}
+	if got := c.GetGroupVersionKind(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
 }

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/pkg/apis"
@@ -252,6 +253,10 @@ func (r *Revision) SetGeneration(generation int64) {
 
 func (r *Revision) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(r.Spec)
+}
+
+func (r *Revision) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("Revision")
 }
 
 // IsReady looks at the conditions and if the Status has a condition

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 )
@@ -594,4 +595,16 @@ func checkConditionRevision(rs RevisionStatus, rct RevisionConditionType, cs cor
 		t.Fatalf("Get(%v) = %v, wanted %v", rct, r.Status, cs)
 	}
 	return r
+}
+
+func TestRevisionGetGroupVersionKind(t *testing.T) {
+	r := &Revision{}
+	want := schema.GroupVersionKind{
+		Group:   "serving.knative.dev",
+		Version: "v1alpha1",
+		Kind:    "Revision",
+	}
+	if got := r.GetGroupVersionKind(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
 }

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
 )
@@ -182,6 +183,10 @@ func (r *Route) SetGeneration(generation int64) {
 
 func (r *Route) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(r.Spec)
+}
+
+func (r *Route) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("Route")
 }
 
 func (rs *RouteStatus) IsReady() bool {

--- a/pkg/apis/serving/v1alpha1/route_types_test.go
+++ b/pkg/apis/serving/v1alpha1/route_types_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestRouteGeneration(t *testing.T) {
@@ -266,5 +267,17 @@ func checkConditionRoute(rs RouteStatus, rct RouteConditionType, cs corev1.Condi
 	}
 	if r.Status != cs {
 		t.Fatalf("Get(%v) = %v, wanted %v", rct, r.Status, cs)
+	}
+}
+
+func TestRouteGetGroupVersionKind(t *testing.T) {
+	r := &Route{}
+	want := schema.GroupVersionKind{
+		Group:   "serving.knative.dev",
+		Version: "v1alpha1",
+		Kind:    "Route",
+	}
+	if got := r.GetGroupVersionKind(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
 	}
 }

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
 )
@@ -192,6 +193,10 @@ func (s *Service) SetGeneration(generation int64) {
 
 func (s *Service) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(s.Spec)
+}
+
+func (s *Service) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("Service")
 }
 
 func (ss *ServiceStatus) IsReady() bool {

--- a/pkg/apis/serving/v1alpha1/service_types_test.go
+++ b/pkg/apis/serving/v1alpha1/service_types_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestServiceGeneration(t *testing.T) {
@@ -521,4 +522,16 @@ func checkConditionService(rs ServiceStatus, rct ServiceConditionType, cs corev1
 		t.Fatalf("Get(%v) = %v, wanted %v", rct, r.Status, cs)
 	}
 	return r
+}
+
+func TestServiceGetGroupVersionKind(t *testing.T) {
+	s := &Service{}
+	want := schema.GroupVersionKind{
+		Group:   "serving.knative.dev",
+		Version: "v1alpha1",
+		Kind:    "Service",
+	}
+	if got := s.GetGroupVersionKind(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
 }

--- a/pkg/reconciler/owner_references.go
+++ b/pkg/reconciler/owner_references.go
@@ -17,30 +17,16 @@ limitations under the License.
 package reconciler
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
-func kind(obj metav1.Object) schema.GroupVersionKind {
-	switch obj.(type) {
-	case *v1alpha1.Service:
-		return v1alpha1.SchemeGroupVersion.WithKind("Service")
-	case *v1alpha1.Route:
-		return v1alpha1.SchemeGroupVersion.WithKind("Route")
-	case *v1alpha1.Configuration:
-		return v1alpha1.SchemeGroupVersion.WithKind("Configuration")
-	case *v1alpha1.Revision:
-		return v1alpha1.SchemeGroupVersion.WithKind("Revision")
-	default:
-		panic(fmt.Sprintf("Unsupported object type %T", obj))
-	}
+type NewControllerRefable interface {
+	metav1.ObjectMetaAccessor
+	GetGroupVersionKind() schema.GroupVersionKind
 }
 
 // NewControllerRef creates an OwnerReference pointing to the given Resource.
-func NewControllerRef(obj metav1.Object) *metav1.OwnerReference {
-	return metav1.NewControllerRef(obj, kind(obj))
+func NewControllerRef(obj NewControllerRefable) *metav1.OwnerReference {
+	return metav1.NewControllerRef(obj.GetObjectMeta(), obj.GetGroupVersionKind())
 }


### PR DESCRIPTION
Ref #1962 

We'll need to do something similar in eventing, so this probably belongs in knative/pkg, but this PR demonstrates the changes needed. We can hoist it into knative/pkg later or just wait until https://github.com/kubernetes/apiextensions-apiserver/issues/29 is fixed ¯\\\_(ツ)\_/¯

We currently do type checking to determine an object's Kind. This is
problematic because it requires us to add each CRD version to
owner_references.go manually, which makes adding a new CRD version
tedious.

This method name is odd (non-idiomatic GetFoo()) because:
1. The embedded TypeMeta already implements GroupVersionKind(), but it
is currently empty (https://issues.k8s.io/3030), and we'd like to ensure
that our types implement this interface.
2. It mirrors the other required method, GetObjectMeta.

<!--
/assign @mattmoor 
-->