### PR TITLE
Report clear error on missing configuration in observed-concurrency test.

### DIFF
--- a/test/performance/observed-concurrency/reporter.lua
+++ b/test/performance/observed-concurrency/reporter.lua
@@ -41,8 +41,8 @@ local threads = {}
 
 function setup(thread)
   table.insert(threads, thread)
-  if os.getenv('concurrency') == nil then
-    print('"concurrency" environment variable must be defined. Set it to the number of connections configured for wrk')
+  if tonumber(os.getenv('concurrency')) == nil then
+    print('"concurrency" environment variable must be defined and be a number. Set it to the number of connections configured for wrk.')
     os.exit()
   end
 end

--- a/test/performance/observed-concurrency/reporter.lua
+++ b/test/performance/observed-concurrency/reporter.lua
@@ -19,12 +19,12 @@ function parse_response(res)
   local end_ts = tonumber(res:sub(split_at+1))
   return start_ts, end_ts
 end
-  
+
 -- converts nanoseconds to milliseconds
 function nanos_to_millis(n)
   return math.floor(n / 1000000)
 end
-  
+
 -- returns the time it took to scale up to a certain scale
 -- returns -1 if that scale was never reached
 function time_to_scale(accumulated, scale)
@@ -35,12 +35,16 @@ function time_to_scale(accumulated, scale)
   end
   return -1
 end
-  
-  
+
+
 local threads = {}
 
 function setup(thread)
   table.insert(threads, thread)
+  if os.getenv('concurrency') == nil then
+    print('"concurrency" environment variable must be defined. Set it to the number of connections configured for wrk')
+    os.exit()
+  end
 end
 
 function init(args)


### PR DESCRIPTION
Fixes #2012.

## Proposed Changes

Due to a limitation of wrk's lua script, it's not possible to obtain the parameters passed to the wrk call itself inside the lua script. To work around that, the script needs an environment variable 'concurrency' set to the amount of connections configured for wrk. If that's not present, the script will panic in the end.


  * Add a validation step to check if the variable is there and exit early

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
