### PR TITLE
Removed hardcoded cluster domain form queue-proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -256,7 +256,7 @@ func main() {
 	kubeClient = kc
 
 	// Open a websocket connection to the autoscaler
-	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
+	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s:%s", servingAutoscaler, system.Namespace, servingAutoscalerPort)
 	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter()


### PR DESCRIPTION
- Currently it was set to default kubernetes cluster domain name

Fixes #1931

## Proposed Changes

  * Remove the cluster domain suffix
  * kubernetes DNS will automatically resolve 
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
