### PR TITLE
Disable autoscaling e2e test until flakiness is sorted out.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -133,6 +133,8 @@ func tearDown(clients *test.Clients, names test.ResourceNames, logger *logging.B
 }
 
 func TestAutoscaleUpDownUp(t *testing.T) {
+	t.Skip("Re-enable this once #2052 is addressed")
+
 	//add test case specific name to its own logger
 	logger := logging.GetContextLogger("TestAutoscaleUpDownUp")
 


### PR DESCRIPTION
Related: https://github.com/knative/serving/issues/2052