### PR TITLE
Add coverage for autoscaler rate-limiting and stat validation.

### DIFF
--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -278,6 +278,51 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 	}
 }
 
+func TestAutoscaler_Stats_DenyNoTime(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+	stat := Stat{
+		Time:                      nil,
+		PodName:                   "pod-1",
+		AverageConcurrentRequests: 1.0,
+		RequestCount:              5,
+	}
+	a.Record(TestContextWithLogger(t), stat)
+
+	if len(a.stats) != 0 {
+		t.Errorf("Unexpected stat count. Expected 0. Got %v.", len(a.stats))
+	}
+	a.expectScale(t, time.Now(), 0, false)
+}
+
+func TestAutoscaler_RateLimit_ScaleUp(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+	now := a.recordLinearSeries(
+		t,
+		time.Now(),
+		linearSeries{
+			startConcurrency: 1000,
+			endConcurrency:   1000,
+			durationSeconds:  1,
+			podCount:         1,
+		})
+
+	// Need 100 pods but only scale x10
+	a.expectScale(t, now, 10, true)
+
+	now = a.recordLinearSeries(
+		t,
+		now,
+		linearSeries{
+			startConcurrency: 1000,
+			endConcurrency:   1000,
+			durationSeconds:  1,
+			podCount:         10,
+		})
+
+	// Scale x10 again
+	a.expectScale(t, now, 100, true)
+}
+
 type linearSeries struct {
 	startConcurrency int
 	endConcurrency   int


### PR DESCRIPTION
## Proposed Changes

  * Added tests for rate limiting in the autoscaler
  * Added test for stat validation in the autoscaler

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
