### PR TITLE
[PoC] Phased Reconciliation for Routes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1028,6 +1028,7 @@
     "github.com/google/go-containerregistry/pkg/v1/random",
     "github.com/google/go-containerregistry/pkg/v1/remote",
     "github.com/gorilla/websocket",
+    "github.com/imdario/mergo",
     "github.com/knative/build/pkg/apis/build/v1alpha1",
     "github.com/knative/caching/pkg/apis/caching",
     "github.com/knative/caching/pkg/apis/caching/v1alpha1",

--- a/pkg/reconciler/dependencies.go
+++ b/pkg/reconciler/dependencies.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	pkgapis "github.com/knative/pkg/apis"
+	sharedclientset "github.com/knative/pkg/client/clientset/versioned"
+	sharedinformers "github.com/knative/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicclientset "k8s.io/client-go/dynamic"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+// DependencyFactory manages common reconciler clientsets and informers
+type DependencyFactory struct {
+	Kubernetes struct {
+		Client          kubeclientset.Interface
+		InformerFactory kubeinformers.SharedInformerFactory
+	}
+
+	Dynamic struct {
+		Client dynamicclientset.Interface
+	}
+
+	Shared struct {
+		Client          sharedclientset.Interface
+		InformerFactory sharedinformers.SharedInformerFactory
+	}
+}
+
+// NewDependencyFactory creates a new DepedencyFactory with the given
+// restclient config & resync period
+//
+// It will return an error if any of the clientsets cannot be created
+func NewDependencyFactory(cfg *rest.Config, resyncPeriod time.Duration) (*DependencyFactory, error) {
+	d := &DependencyFactory{}
+
+	var err error
+
+	d.Kubernetes.Client, err = kubeclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error building kubernetes clientset: %v", err)
+	}
+
+	d.Shared.Client, err = sharedclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error building shared clientset: %v", err)
+	}
+
+	d.Dynamic.Client, err = dynamicclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error building dynamic clientset: %v", err)
+	}
+
+	d.Kubernetes.InformerFactory = kubeinformers.NewSharedInformerFactory(
+		d.Kubernetes.Client,
+		resyncPeriod,
+	)
+
+	d.Shared.InformerFactory = sharedinformers.NewSharedInformerFactory(
+		d.Shared.Client,
+		resyncPeriod,
+	)
+
+	return d, nil
+}
+
+// StartInformers starts all the shared informers factories that are
+// managed by this DependencyFactory
+func (o *DependencyFactory) StartInformers(stopCh <-chan struct{}) {
+	o.Kubernetes.InformerFactory.Start(stopCh)
+	o.Shared.InformerFactory.Start(stopCh)
+}
+
+// WaitForInformerCacheSync waits for all the shared informers factories
+// managed by this DependencyFactory to sync their caches
+func (o *DependencyFactory) WaitForInformerCacheSync(stopCh <-chan struct{}) error {
+	waiters := []func(stopCh <-chan struct{}) map[reflect.Type]bool{
+		o.Kubernetes.InformerFactory.WaitForCacheSync,
+		o.Shared.InformerFactory.WaitForCacheSync,
+	}
+
+	for _, wait := range waiters {
+		result := wait(stopCh)
+
+		for informerType, started := range result {
+			if !started {
+				return fmt.Errorf("failed to wait for cache sync for type %q", informerType.Name())
+			}
+		}
+	}
+
+	return nil
+}
+
+// InformerFor will return the correct informer for the given
+// GroupVersionKind.
+//
+// It will return an error if the informer is not found
+func (d *DependencyFactory) InformerFor(gvk schema.GroupVersionKind) (cache.SharedIndexInformer, error) {
+	gvr := pkgapis.KindToResource(gvk)
+
+	if i, err := d.Kubernetes.InformerFactory.ForResource(gvr); i != nil && err == nil {
+		return i.Informer(), nil
+	}
+
+	if i, err := d.Shared.InformerFactory.ForResource(gvr); i != nil && err == nil {
+		return i.Informer(), nil
+	}
+
+	return nil, fmt.Errorf("Unabled to find informer for resource %q", gvr)
+}

--- a/pkg/reconciler/reconciler_new.go
+++ b/pkg/reconciler/reconciler_new.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/tracker"
+	"go.uber.org/zap"
+	"k8s.io/client-go/tools/record"
+)
+
+type (
+	// Phase is a partial step in an object's reconciliation
+	//
+	// As an example a Knative object's reconciliation may require
+	// that N Kubernetes objects are created. A reconciler can be
+	// composed with N phases where each phase is responsible for
+	// reconciling a single Kubernetes resource. This abstraction
+	// is intended to help manage a reconciler's complexity.
+	//
+	// Phases can specify what should trigger reconcilation by
+	// conforming to the 'WithTriggers' interface. eg:
+	//
+	//	func (p *myPhase) Triggers() []reconciler.Trigger {
+	//		return []reconciler.Trigger{{
+	//			ObjectKind:  corev1.SchemeGroupVersion.WithKind("Service"),
+	//			EnqueueType: reconciler.EnqueueObject,
+	//		}}
+	//	}
+	//
+	Phase interface{}
+
+	// Reconciler is the interface that controller implementations are expected
+	// to implement, so that the shared controller.Impl can drive work through it.
+	Reconciler interface {
+		Reconcile(ctx context.Context, key string) error
+	}
+
+	// WithPhases is an interface a reconciler may conform to
+	// in order to surface it's phases
+	//
+	// The motivation to expose a reconciler's phases is to setup
+	// any phase triggers
+	WithPhases interface {
+		Phases() []Phase
+	}
+
+	// ConfigStore is responsbile for storing it's configuration into context
+	// Subsequently it instructs the configmap.Watcher to watch certain configs
+	// a reconciler may be interested in.
+	ConfigStore interface {
+		ToContext(context.Context) context.Context
+		WatchConfigs(configmap.Watcher)
+	}
+
+	// WorkQueue is a consumer interface which exposes the underlying work queue
+	// to the reconciler
+	WorkQueue interface {
+		EnqueueKey(key string)
+		Enqueue(obj interface{})
+		EnqueueControllerOf(obj interface{})
+	}
+
+	// CommonOptions contains the dependencies that are associated with a specific
+	// instance of a reconciler
+	CommonOptions struct {
+		Logger           *zap.SugaredLogger
+		Recorder         record.EventRecorder
+		ObjectTracker    tracker.Interface
+		WorkQueue        WorkQueue
+		ConfigMapWatcher configmap.Watcher
+	}
+)

--- a/pkg/reconciler/testing/dependencies.go
+++ b/pkg/reconciler/testing/dependencies.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"github.com/knative/pkg/apis"
+	sharedclientset "github.com/knative/pkg/client/clientset/versioned"
+	fakesharedclientset "github.com/knative/pkg/client/clientset/versioned/fake"
+	sharedinformers "github.com/knative/pkg/client/informers/externalversions"
+	"github.com/knative/serving/pkg/reconciler"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicclientset "k8s.io/client-go/dynamic"
+	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+type AddToScheme func(*runtime.Scheme)
+
+func NewFakeDependencies(objs []runtime.Object, schemes ...AddToScheme) (*runtime.Scheme, ObjectSorter, *reconciler.DependencyFactory) {
+	scheme := runtime.NewScheme()
+	fakekubeclientset.AddToScheme(scheme)
+	fakesharedclientset.AddToScheme(scheme)
+
+	// The dynamic client requires the correct schemes to handle
+	// objects that are not unstructured
+	for _, addToScheme := range schemes {
+		addToScheme(scheme)
+	}
+
+	sorter := NewObjectSorter(scheme)
+	sorter.AddObjects(objs...)
+
+	k8sObjs := sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
+	sharedObjs := sorter.ObjectsForSchemeFunc(fakesharedclientset.AddToScheme)
+
+	fakeKubeClientset := fakekubeclientset.NewSimpleClientset(k8sObjs...)
+	fakeSharedClientset := fakesharedclientset.NewSimpleClientset(sharedObjs...)
+
+	// Initialize the dynamic client with all the objects
+	fakeClient := fakedynamicclientset.NewSimpleDynamicClient(runtime.NewScheme())
+
+	kubeInformer := kubeinformers.NewSharedInformerFactory(fakeKubeClientset, 0)
+	sharedInformer := sharedinformers.NewSharedInformerFactory(fakeSharedClientset, 0)
+
+	for _, obj := range objs {
+		kinds, _, _ := scheme.ObjectKinds(obj)
+		for _, kind := range kinds {
+			resource := apis.KindToResource(kind)
+			if inf, _ := kubeInformer.ForResource(resource); inf != nil {
+				inf.Informer().GetStore().Add(obj)
+			}
+			if inf, _ := sharedInformer.ForResource(resource); inf != nil {
+				inf.Informer().GetStore().Add(obj)
+			}
+		}
+	}
+
+	return scheme, sorter, &reconciler.DependencyFactory{
+		Kubernetes: struct {
+			Client          kubeclientset.Interface
+			InformerFactory kubeinformers.SharedInformerFactory
+		}{
+			Client:          fakeKubeClientset,
+			InformerFactory: kubeInformer,
+		},
+		Shared: struct {
+			Client          sharedclientset.Interface
+			InformerFactory sharedinformers.SharedInformerFactory
+		}{
+			Client:          fakeSharedClientset,
+			InformerFactory: sharedInformer,
+		},
+		Dynamic: struct {
+			Client dynamicclientset.Interface
+		}{
+			Client: fakeClient,
+		},
+	}
+}

--- a/pkg/reconciler/testing/fakes.go
+++ b/pkg/reconciler/testing/fakes.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/serving/pkg/reconciler"
+)
+
+type FakeWorkQueue struct{}
+
+func (q *FakeWorkQueue) EnqueueKey(key string)               {}
+func (q *FakeWorkQueue) Enqueue(obj interface{})             {}
+func (q *FakeWorkQueue) EnqueueControllerOf(obj interface{}) {}
+
+var _ reconciler.WorkQueue = (*FakeWorkQueue)(nil)
+
+type FakeConfigMapWatcher struct{}
+
+func (f *FakeConfigMapWatcher) Watch(string, configmap.Observer) {}
+func (f *FakeConfigMapWatcher) Start(<-chan struct{}) error {
+	return nil
+}
+
+var _ configmap.Watcher = (*FakeConfigMapWatcher)(nil)
+
+type FakeConfigStore struct{}
+
+func (s *FakeConfigStore) ToContext(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (s *FakeConfigStore) WatchConfigs(w configmap.Watcher) {}
+
+var _ reconciler.ConfigStore = (*FakeConfigStore)(nil)

--- a/pkg/reconciler/testing/phase.go
+++ b/pkg/reconciler/testing/phase.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/logging"
+	"github.com/knative/serving/pkg/reconciler"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+
+	. "github.com/knative/pkg/logging/testing"
+)
+
+type (
+	// We add these aliases for better readability
+	Failures   []clientgotesting.ReactionFunc
+	Creates    []runtime.Object
+	Updates    []runtime.Object
+	Patches    []clientgotesting.PatchActionImpl
+	Objects    []runtime.Object
+	PhaseTests []PhaseTest
+
+	// PhaseSetupFunc is responsible for creating a phase and setting up
+	// any various clients and informers with the given runtime objects.
+	//
+	// The function should return the list of fake clientsets
+	// so the test can assert on create, update and patch actions.
+	//
+	// PhaseTests will also prepend validation and failure reactors.
+	// These failure reactors can be set on the PhaseTests's Failures
+	// property
+	PhaseSetupFunc func(reconciler.CommonOptions, []runtime.Object) (interface{}, []FakeClient)
+
+	// Resource defines the Kubernetes resource being reconciled
+	Resource interface {
+		runtime.Object
+		metav1.Object
+	}
+
+	// FakeClient is used to capture creates, updates, deletes as well as
+	// inducing failures
+	FakeClient interface {
+		ActionRecorder
+		PrependReactor(verb, resource string, reaction clientgotesting.ReactionFunc)
+	}
+
+	// PhaseTest is used to test a single invocation of a phase's reconcilation
+	PhaseTest struct {
+		Name string
+
+		// World State
+		Resource Resource
+		Failures Failures
+		Objects  Objects
+		Context  context.Context
+
+		// Expectations
+		ExpectedCreates Creates
+		ExpectedPatches Patches
+		ExpectedUpdates Updates
+		ExpectError     bool
+
+		// ExpectStatus should be a non-pointer struct that should be
+		// compared to the reconciled resource's status
+		ExpectedStatus interface{}
+	}
+)
+
+// Run will iterate over each PhaseTests and invoke them as a subtest
+//
+// The Kubernetes resource in the phase's reconcile method should match
+// the PhaseTest's resource type
+func (tests PhaseTests) Run(t *testing.T, setup PhaseSetupFunc) {
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Run(t, setup)
+		})
+	}
+}
+
+// Run will setup the PhaseTest, trigger a reconcile and perform
+// the necessary test assertions.
+//
+// The Kubernetes resource in the phase's reconcile method should match
+// the PhaseTest's resource type
+func (s *PhaseTest) Run(t *testing.T, setup PhaseSetupFunc) {
+	opts := reconciler.CommonOptions{
+		Logger:           TestLogger(t),
+		Recorder:         &record.FakeRecorder{},
+		ObjectTracker:    &NullTracker{},
+		ConfigMapWatcher: &FakeConfigMapWatcher{},
+		WorkQueue:        &FakeWorkQueue{},
+	}
+
+	phase, fakeClients := setup(opts, s.Objects)
+
+	clients := setupClientValidations(fakeClients, s.Failures)
+	s.ensurePhaseType(t, phase)
+
+	status, err := s.invokeReconcile(t, phase)
+
+	if (err != nil) != s.ExpectError {
+		t.Errorf("Reconcile() error = %v, expected error %v", err, s.ExpectError)
+	}
+
+	if diff := cmp.Diff(s.ExpectedStatus, status, cmpOpts); diff != "" {
+		t.Errorf("resource status (-want, +got) %s", diff)
+	}
+
+	actions, err := clients.ActionsByVerb()
+
+	if err != nil {
+		t.Errorf("error capturing actions by verb: %q", err)
+	}
+
+	expectedNamespace := s.Resource.GetNamespace()
+
+	assertCreates(t, s.ExpectedCreates, actions.Creates, expectedNamespace)
+	assertUpdates(t, s.ExpectedUpdates, actions.Updates, expectedNamespace)
+	assertPatches(t, s.ExpectedPatches, actions.Patches, expectedNamespace)
+}
+
+func (s *PhaseTest) resourceStatus(resource interface{}) interface{} {
+	// TODO(dprotaso) Consider adding `Status()` method to all our resource types
+	return reflect.ValueOf(resource).Elem().FieldByName("Status").Interface()
+}
+
+func (s *PhaseTest) invokeReconcile(t *testing.T, phase interface{}) (interface{}, error) {
+	phaseVal := reflect.ValueOf(phase)
+	ctx := context.TODO()
+
+	if s.Context != nil {
+		ctx = s.Context
+	}
+
+	ctx = logging.WithLogger(ctx, TestLogger(t))
+
+	input := []reflect.Value{
+		reflect.ValueOf(ctx),
+		reflect.ValueOf(s.Resource),
+	}
+
+	output := phaseVal.MethodByName("Reconcile").Call(input)
+
+	var err error = nil
+
+	if !output[1].IsNil() {
+		err = output[1].Interface().(error)
+	}
+
+	return output[0].Interface(), err
+}
+
+func (s *PhaseTest) ensurePhaseType(t *testing.T, phase interface{}) {
+	phaseType := reflect.TypeOf(phase)
+
+	if phaseType.Kind() != reflect.Ptr {
+		t.Fatalf("expected the constructed phase to be a pointer type %q", phaseType)
+	}
+
+	resourceType := reflect.TypeOf(s.Resource)
+	statusField, ok := resourceType.Elem().FieldByName("Status")
+
+	if !ok {
+		t.Fatalf("Resource %q must have a 'Status' field", resourceType)
+	}
+
+	method, ok := phaseType.MethodByName("Reconcile")
+
+	errMsg := fmt.Sprintf(
+		"phase should have the method Reconcile(context.Context, %s) (%s, error)",
+		resourceType,
+		statusField.Type,
+	)
+
+	if !ok {
+		t.Fatal(errMsg)
+	}
+
+	// 0 - index is the receiver
+	if method.Type.NumIn() != 3 {
+		t.Fatal(errMsg)
+	}
+
+	contextType := reflect.TypeOf((*context.Context)(nil)).Elem()
+
+	if method.Type.In(1) != contextType {
+		t.Fatal(errMsg)
+	}
+
+	if method.Type.In(2) != resourceType {
+		t.Fatal(errMsg)
+	}
+
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	if method.Type.NumOut() != 2 {
+		t.Fatal(errMsg)
+	}
+
+	if method.Type.Out(0) != statusField.Type {
+		t.Fatal(errMsg)
+	}
+
+	if method.Type.Out(1) != errorType {
+		t.Fatal(errMsg)
+	}
+}
+
+func assertCreates(
+	t *testing.T,
+	expectedCreates Creates,
+	creates []clientgotesting.CreateAction,
+	expectedNamespace string,
+) {
+
+	for i, want := range expectedCreates {
+		if i >= len(creates) {
+			t.Errorf("missing create: %v", want)
+			continue
+		}
+
+		got := creates[i]
+		obj := got.GetObject()
+
+		if got.GetNamespace() != expectedNamespace {
+			t.Errorf("unexpected action[%d]: %#v", i, got.GetObject())
+		}
+
+		if diff := cmp.Diff(want, obj, cmpOpts); diff != "" {
+			t.Errorf("unexpected create diff (-want +got): %s", diff)
+		}
+	}
+
+	if got, want := len(creates), len(expectedCreates); got > want {
+		for _, extra := range creates[want:] {
+			t.Errorf("extra create actions: %v", extra.GetObject())
+		}
+	}
+}
+
+func assertUpdates(
+	t *testing.T,
+	expectedUpdates Updates,
+	updates []clientgotesting.UpdateAction,
+	expectedNamespace string,
+) {
+
+	for i, want := range expectedUpdates {
+		if i >= len(updates) {
+			t.Errorf("missing update: %v", want)
+			continue
+		}
+
+		got := updates[i]
+		obj := got.GetObject()
+
+		if got.GetNamespace() != expectedNamespace {
+			t.Errorf("unexpected update action[%d]: %#v", i, got.GetObject())
+		}
+
+		if diff := cmp.Diff(want, obj, cmpOpts); diff != "" {
+			t.Errorf("unexpected update diff (-want +got): %s", diff)
+		}
+	}
+
+	if got, want := len(updates), len(expectedUpdates); got > want {
+		for _, extra := range updates[want:] {
+			t.Errorf("extra update actions: %#v", extra.GetObject())
+		}
+	}
+}
+
+func assertPatches(
+	t *testing.T,
+	expected Patches,
+	patches []clientgotesting.PatchAction,
+	expectedNamespace string,
+) {
+
+	for i, want := range expected {
+		if i >= len(patches) {
+			t.Errorf("missing patch: %v", prettyPatch(want))
+			continue
+		}
+
+		got := patches[i]
+
+		if got.GetName() != want.GetName() {
+			t.Errorf("unexpected patch action[%d]: %s", i, prettyPatch(got))
+		}
+
+		if got.GetNamespace() != want.GetNamespace() {
+			t.Errorf("unexpected patch action[%d]: %s", i, prettyPatch(got))
+		}
+
+		if diff := cmp.Diff(want.GetPatch(), got.GetPatch()); diff != "" {
+			t.Errorf("unexpected patch diff (-want +got): %s", diff)
+		}
+	}
+
+	if got, want := len(patches), len(expected); got > want {
+		for _, extra := range patches[want:] {
+			t.Errorf("extra patch actions: %s", prettyPatch(extra))
+		}
+	}
+}
+
+func setupClientValidations(clients []FakeClient, failures Failures) ActionRecorderList {
+	var recorders ActionRecorderList
+
+	for _, client := range clients {
+		recorders = append(recorders, client)
+
+		client.PrependReactor("create", "*", ValidateCreates)
+		client.PrependReactor("update", "*", ValidateUpdates)
+
+		for _, failure := range failures {
+			client.PrependReactor("*", "*", failure)
+		}
+	}
+
+	return recorders
+}
+
+func prettyPatch(patch clientgotesting.PatchAction) string {
+	return fmt.Sprintf("resource: %q - name: %q - namespace: %q - patch: %s",
+		patch.GetResource().Resource,
+		patch.GetName(),
+		patch.GetNamespace(),
+		string(patch.GetPatch()),
+	)
+}
+
+var cmpOpts = cmp.Options{
+	cmpopts.EquateEmpty(),
+	safeDeployDiff,
+	ignoreLastTransitionTime,
+}

--- a/pkg/reconciler/testing/reconciler.go
+++ b/pkg/reconciler/testing/reconciler.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/knative/pkg/logging"
+	"github.com/knative/serving/pkg/reconciler"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+
+	. "github.com/knative/pkg/logging/testing"
+)
+
+type (
+	// ReconcilerSetupFunc is responsible for creating a reconciler and setting up
+	// any various clients and informers with the given runtime objects.
+	//
+	// The function should return the list of fake clientsets
+	// so the test can assert on create, update and patch actions.
+	//
+	// ReconcilerTest will also prepend validation and failure reactors.
+	// These failure reactors can be set on the ReconcilerTest's Failures
+	// property
+	ReconcilerSetupFunc func(reconciler.CommonOptions, []runtime.Object) (reconciler.Reconciler, []FakeClient)
+
+	ReconcilerTests []ReconcilerTest
+
+	// ReconcilerTest is used to test a single reconciler reconciliation.
+	ReconcilerTest struct {
+		Name    string
+		Key     string
+		Context context.Context
+
+		// World State
+		Failures Failures
+		Objects  Objects
+		//
+		// Expectations
+		ExpectedCreates Creates
+		ExpectedPatches Patches
+		ExpectedUpdates Updates
+		ExpectError     bool
+	}
+)
+
+// Run will iterate over each ReconcilerTest and invoke them as a subtest.
+func (tests ReconcilerTests) Run(t *testing.T, setup ReconcilerSetupFunc) {
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Run(t, setup)
+		})
+	}
+}
+
+// Run will setup the ReconcilerTest, trigger a reconcile and perform
+// the necessary test assertions.
+func (s *ReconcilerTest) Run(t *testing.T, setup ReconcilerSetupFunc) {
+	logger := TestLogger(t)
+
+	opts := reconciler.CommonOptions{
+		Logger:           TestLogger(t),
+		Recorder:         &record.FakeRecorder{},
+		ObjectTracker:    &NullTracker{},
+		ConfigMapWatcher: &FakeConfigMapWatcher{},
+		WorkQueue:        &FakeWorkQueue{},
+	}
+
+	reconciler, fakeClients := setup(opts, s.Objects)
+
+	clients := setupClientValidations(fakeClients, s.Failures)
+
+	ctx := context.TODO()
+
+	if s.Context != nil {
+		ctx = s.Context
+	}
+
+	ctx = logging.WithLogger(ctx, logger)
+
+	err := reconciler.Reconcile(ctx, s.Key)
+
+	if (err != nil) != s.ExpectError {
+		t.Errorf("Reconcile() error = %v, expected error %v", err, s.ExpectError)
+	}
+
+	actions, err := clients.ActionsByVerb()
+
+	if err != nil {
+		t.Errorf("error capturing actions by verb: %q", err)
+	}
+
+	expectedNamespace, _, _ := cache.SplitMetaNamespaceKey(s.Key)
+
+	assertCreates(t, s.ExpectedCreates, actions.Creates, expectedNamespace)
+	assertUpdates(t, s.ExpectedUpdates, actions.Updates, expectedNamespace)
+	assertPatches(t, s.ExpectedPatches, actions.Patches, expectedNamespace)
+}

--- a/pkg/reconciler/testing/sorter.go
+++ b/pkg/reconciler/testing/sorter.go
@@ -75,6 +75,24 @@ func (o *ObjectSorter) ObjectsForSchemeFunc(funcs ...func(scheme *runtime.Scheme
 	return o.ObjectsForScheme(scheme)
 }
 
+func (o *ObjectSorter) ObjectsOfType(obj runtime.Object) []runtime.Object {
+	objType := reflect.TypeOf(obj).Elem()
+
+	indexer, ok := o.cache[objType]
+
+	if !ok {
+		panic(fmt.Sprintf("objects for type %v doesn't exist", objType.Name()))
+	}
+
+	var objs []runtime.Object
+
+	for _, obj := range indexer.List() {
+		objs = append(objs, obj.(runtime.Object))
+	}
+
+	return objs
+}
+
 func (o *ObjectSorter) IndexerForObjectType(obj runtime.Object) cache.Indexer {
 	objType := reflect.TypeOf(obj).Elem()
 

--- a/pkg/reconciler/triggers.go
+++ b/pkg/reconciler/triggers.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// EnqueueObject indicates that the object kind being informed on should
+	// queued objects for reconciliation.
+	EnqueueObject EnqueueType = "controller-object"
+
+	// EnqueueOwner indicates that the object kind being informed on should
+	// queue it's controlling owner for reconciliation.
+	EnqueueOwner EnqueueType = "controller-owner"
+
+	// EnqueueTracker indicates that the object kind being informed on should
+	// queue objects to the tracker.
+	EnqueueTracker EnqueueType = "tracker-object"
+)
+
+type (
+	// EnqueueType is an enum who's value specifies what should be
+	// enqueued and where.
+	EnqueueType string
+
+	// Trigger allows a phase or reconciler to specify which object changes
+	// should trigger reconciliation.
+	Trigger struct {
+		// ObjectKind defines the object that should trigger reconcilation
+		// +required
+		ObjectKind schema.GroupVersionKind
+
+		// OwnerKind defines the kind of controlling owner reference the
+		// ObjectKind should have
+		// +optional
+		OwnerKind schema.GroupVersionKind
+
+		// EnqueueType specifies which object should be enqueued
+		// +required
+		EnqueueType EnqueueType
+	}
+
+	// WithTriggers defines an interface a reconciler or phase may conform to
+	// that indicates the objects changes that should trigger reconciliation.
+	WithTriggers interface {
+		Triggers() []Trigger
+	}
+)

--- a/pkg/reconciler/triggers_test.go
+++ b/pkg/reconciler/triggers_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSetupTriggers_NoTriggers(t *testing.T) {
+	err := SetupTriggers("hello", &invocationRecorder{}, &invocationRecorder{}, &fakeInformerFactory{})
+
+	if err != nil {
+		t.Errorf("SetupTriggers should not have returned an error - got: %v", err)
+	}
+}
+
+func TestSetupTriggers_NoInformer(t *testing.T) {
+	fake := &fakeTriggers{
+		triggers: []Trigger{{
+			ObjectKind: schema.GroupVersionKind{Kind: "hello"},
+		}},
+	}
+
+	errorInformerFactory := &fakeInformerFactory{err: errors.New("no informer")}
+	err := SetupTriggers(fake, &invocationRecorder{}, &invocationRecorder{}, errorInformerFactory)
+
+	if err == nil {
+		t.Errorf("SetupTriggers should have returned an error")
+	}
+}
+
+func TestSetupTriggers_FilteringAllow(t *testing.T) {
+	triggers := &fakeTriggers{
+		triggers: []Trigger{{
+			ObjectKind:  schema.GroupVersionKind{Kind: "hello"},
+			OwnerKind:   schema.GroupVersionKind{Kind: "hello-owner"},
+			EnqueueType: EnqueueTracker,
+		}},
+	}
+
+	recorder := &invocationRecorder{}
+	informer := &fakeInformerFactory{}
+	err := SetupTriggers(triggers, recorder, recorder, informer)
+
+	if err != nil {
+		t.Fatalf("unexpected error setting up triggers: %v", err)
+	}
+
+	owner := &metav1.ObjectMeta{
+		Name: "hello-owner",
+	}
+
+	obj := &metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(owner, schema.GroupVersionKind{Kind: "hello-owner"}),
+		},
+	}
+
+	informer.handler.OnAdd(obj)
+	assertTrackerInvoked(t, recorder, "add")
+
+	recorder.resetInvocations()
+	informer.handler.OnUpdate(obj, obj)
+	assertTrackerInvoked(t, recorder, "update")
+
+	recorder.resetInvocations()
+
+	informer.handler.OnDelete(obj)
+	assertTrackerInvoked(t, recorder, "delete")
+}
+
+func TestSetupTriggers_FilteringBlocks(t *testing.T) {
+	triggers := &fakeTriggers{
+		triggers: []Trigger{{
+			ObjectKind:  schema.GroupVersionKind{Kind: "object-kind"},
+			OwnerKind:   schema.GroupVersionKind{Kind: "owner-kind"},
+			EnqueueType: EnqueueTracker,
+		}},
+	}
+
+	recorder := &invocationRecorder{}
+	informer := &fakeInformerFactory{}
+	err := SetupTriggers(triggers, recorder, recorder, informer)
+
+	if err != nil {
+		t.Fatalf("unexpected error setting up triggers: %v", err)
+	}
+
+	owner := &metav1.ObjectMeta{
+		Name: "owner",
+	}
+
+	obj := &metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(owner, schema.GroupVersionKind{Kind: "different-owner-kind"}),
+		},
+	}
+
+	informer.handler.OnAdd(obj)
+	assertNoInvocations(t, recorder, "add")
+
+	recorder.resetInvocations()
+
+	informer.handler.OnUpdate(obj, obj)
+	assertNoInvocations(t, recorder, "update")
+
+	recorder.resetInvocations()
+
+	informer.handler.OnDelete(obj)
+	assertNoInvocations(t, recorder, "delete")
+}
+
+func TestSetupTriggers(t *testing.T) {
+	gvk := schema.GroupVersionKind{Kind: "fun"}
+
+	tests := []struct {
+		name        string
+		trigger     Trigger
+		expectError bool
+	}{{
+		name: "enqueue object",
+		trigger: Trigger{
+			ObjectKind:  gvk,
+			EnqueueType: EnqueueObject,
+		},
+	}, {
+		name: "enqueue owner",
+		trigger: Trigger{
+			ObjectKind:  gvk,
+			EnqueueType: EnqueueOwner,
+		},
+	}, {
+		name: "enqueue tracker",
+		trigger: Trigger{
+			ObjectKind:  gvk,
+			EnqueueType: EnqueueTracker,
+		},
+	}, {
+		name:        "unknown enqueue type",
+		expectError: true,
+		trigger: Trigger{
+			ObjectKind:  gvk,
+			EnqueueType: "unknown type",
+		},
+	}, {
+		name:        "empty object kind",
+		expectError: true,
+		trigger: Trigger{
+			ObjectKind:  schema.EmptyObjectKind.GroupVersionKind(),
+			EnqueueType: EnqueueObject,
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			triggers := &fakeTriggers{
+				triggers: []Trigger{test.trigger},
+			}
+
+			recorder := &invocationRecorder{}
+			informer := &fakeInformerFactory{}
+			err := SetupTriggers(triggers, recorder, recorder, informer)
+
+			if err == nil && test.expectError {
+				t.Errorf("SetupTriggers should have returned an error")
+			} else if err != nil && test.expectError {
+				return
+			} else if err != nil {
+				t.Errorf("SetupTriggers should not have returned an error - got: %v", err)
+			}
+
+			var assertCorrectInvocations func(*testing.T, *invocationRecorder, string)
+
+			switch test.trigger.EnqueueType {
+			case EnqueueObject:
+				assertCorrectInvocations = assertEnqueueInvoked
+			case EnqueueOwner:
+				assertCorrectInvocations = assertEnqueueControllerOfInvoked
+			case EnqueueTracker:
+				assertCorrectInvocations = assertTrackerInvoked
+			default:
+				t.Fatalf("unexpected enqueue type: %v", test.trigger.EnqueueType)
+			}
+
+			informer.handler.OnAdd("add")
+			assertCorrectInvocations(t, recorder, "add")
+
+			recorder.resetInvocations()
+
+			informer.handler.OnUpdate("update-old", "update-new")
+			assertCorrectInvocations(t, recorder, "update")
+
+			recorder.resetInvocations()
+
+			informer.handler.OnDelete("delete")
+			assertCorrectInvocations(t, recorder, "delete")
+		})
+	}
+}
+
+func assertNoInvocations(t *testing.T, r *invocationRecorder, event string) {
+	t.Helper()
+
+	if r.enqueueInvoked {
+		t.Errorf("the controller's 'Enqueue' was unexpectedly setup correct for %q events", event)
+	}
+
+	if r.enqueueControllerOfInvoked {
+		t.Errorf("the controller's 'EnqueueControllerOf' was unexpectedly setup for %q events", event)
+	}
+
+	if r.trackerInvoked {
+		t.Errorf("the trackers's 'OnChange' was unexpectedly setup for %q events", event)
+	}
+}
+
+func assertTrackerInvoked(t *testing.T, r *invocationRecorder, event string) {
+	t.Helper()
+
+	if r.enqueueInvoked {
+		t.Errorf("the controller's 'Enqueue' was unexpectedly setup correct for %q events", event)
+	}
+
+	if r.enqueueControllerOfInvoked {
+		t.Errorf("the controller's 'EnqueueControllerOf' was unexpectedly setup for %q events", event)
+	}
+
+	if !r.trackerInvoked {
+		t.Errorf("the trackers's 'OnChange' was not setup for %q events", event)
+	}
+}
+
+func assertEnqueueControllerOfInvoked(t *testing.T, r *invocationRecorder, event string) {
+	t.Helper()
+
+	if r.enqueueInvoked {
+		t.Errorf("the controller's 'Enqueue' was unexpectedly setup correct for %q events", event)
+	}
+
+	if !r.enqueueControllerOfInvoked {
+		t.Errorf("the controller's 'EnqueueControllerOf' was not setup for %q events", event)
+	}
+
+	if r.trackerInvoked {
+		t.Errorf("the trackers's 'OnChange' was unexpectedly setup for %q events", event)
+	}
+}
+
+func assertEnqueueInvoked(t *testing.T, r *invocationRecorder, event string) {
+	t.Helper()
+
+	if !r.enqueueInvoked {
+		t.Errorf("the controller's 'Enqueue' was not setup for %q events", event)
+	}
+
+	if r.enqueueControllerOfInvoked {
+		t.Errorf("the controller's 'EnqueueControllerOf' was unexpectedly setup for %q events", event)
+	}
+
+	if r.trackerInvoked {
+		t.Errorf("the trackers's 'OnChange' was unexpectedly setup for %q events", event)
+	}
+}
+
+type fakeTriggers struct {
+	triggers []Trigger
+}
+
+func (f *fakeTriggers) Triggers() []Trigger {
+	return f.triggers
+}
+
+type fakeInformerFactory struct {
+	cache.SharedIndexInformer
+	err     error
+	handler cache.ResourceEventHandler
+}
+
+func (f *fakeInformerFactory) InformerFor(schema.GroupVersionKind) (cache.SharedIndexInformer, error) {
+	return f, f.err
+}
+
+func (f *fakeInformerFactory) AddEventHandler(handler cache.ResourceEventHandler) {
+	f.handler = handler
+}
+
+type invocationRecorder struct {
+	enqueueInvoked             bool
+	enqueueControllerOfInvoked bool
+	trackerInvoked             bool
+}
+
+func (f *invocationRecorder) resetInvocations() {
+	f.enqueueControllerOfInvoked = false
+	f.enqueueInvoked = false
+	f.trackerInvoked = false
+}
+
+func (f *invocationRecorder) Enqueue(obj interface{}) {
+	f.enqueueInvoked = true
+}
+
+func (f *invocationRecorder) EnqueueKey(key string) {
+	panic("EnqueueKey should not be invoked")
+}
+
+func (f *invocationRecorder) EnqueueControllerOf(obj interface{}) {
+	f.enqueueControllerOfInvoked = true
+}
+
+func (f *invocationRecorder) OnChanged(obj interface{}) {
+	f.trackerInvoked = true
+}

--- a/pkg/reconciler/v1alpha1/dependencies.go
+++ b/pkg/reconciler/v1alpha1/dependencies.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	cachingclientset "github.com/knative/caching/pkg/client/clientset/versioned"
+	cachinginformers "github.com/knative/caching/pkg/client/informers/externalversions"
+	pkgapis "github.com/knative/pkg/apis"
+	servingclientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	"github.com/knative/serving/pkg/reconciler"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+type DependencyFactory struct {
+	*reconciler.DependencyFactory
+
+	Serving struct {
+		Client          servingclientset.Interface
+		InformerFactory servinginformers.SharedInformerFactory
+	}
+
+	Caching struct {
+		Client          cachingclientset.Interface
+		InformerFactory cachinginformers.SharedInformerFactory
+	}
+}
+
+func NewDependencyFactory(cfg *rest.Config, resync time.Duration) (*DependencyFactory, error) {
+	common, err := reconciler.NewDependencyFactory(cfg, resync)
+
+	if err != nil {
+		return nil, err
+	}
+
+	d := &DependencyFactory{DependencyFactory: common}
+
+	d.Serving.Client, err = servingclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error building serving clientset: %v", err)
+	}
+
+	d.Caching.Client, err = cachingclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error building caching clientset: %v", err)
+	}
+
+	d.Serving.InformerFactory = servinginformers.NewSharedInformerFactory(
+		d.Serving.Client,
+		resync,
+	)
+
+	d.Caching.InformerFactory = cachinginformers.NewSharedInformerFactory(
+		d.Caching.Client,
+		resync,
+	)
+
+	return d, nil
+}
+
+func (d *DependencyFactory) StartInformers(stopCh <-chan struct{}) {
+	d.DependencyFactory.StartInformers(stopCh)
+
+	d.Serving.InformerFactory.Start(stopCh)
+	d.Caching.InformerFactory.Start(stopCh)
+}
+
+func (d *DependencyFactory) WaitForInformerCacheSync(stopCh <-chan struct{}) error {
+	if err := d.DependencyFactory.WaitForInformerCacheSync(stopCh); err != nil {
+		return err
+	}
+
+	waiters := []func(stopCh <-chan struct{}) map[reflect.Type]bool{
+		d.Serving.InformerFactory.WaitForCacheSync,
+		d.Caching.InformerFactory.WaitForCacheSync,
+	}
+
+	for _, wait := range waiters {
+		result := wait(stopCh)
+
+		for informerType, started := range result {
+			if !started {
+				return fmt.Errorf("failed to wait for cache sync for type %q", informerType.Name())
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DependencyFactory) InformerFor(gvk schema.GroupVersionKind) (cache.SharedIndexInformer, error) {
+	if informer, err := d.DependencyFactory.InformerFor(gvk); informer != nil && err == nil {
+		return informer, nil
+	}
+
+	gvr := pkgapis.KindToResource(gvk)
+
+	if i, err := d.Serving.InformerFactory.ForResource(gvr); i != nil && err == nil {
+		return i.Informer(), nil
+	}
+
+	if i, err := d.Caching.InformerFactory.ForResource(gvr); i != nil && err == nil {
+		return i.Informer(), nil
+	}
+
+	return nil, fmt.Errorf("Unabled to find informer for resource %q", gvr)
+}

--- a/pkg/reconciler/v1alpha1/initializer.go
+++ b/pkg/reconciler/v1alpha1/initializer.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"time"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/logging/logkey"
+	"github.com/knative/pkg/tracker"
+	kubescheme "github.com/knative/serving/pkg/client/clientset/versioned/scheme"
+	servingscheme "github.com/knative/serving/pkg/client/clientset/versioned/scheme"
+	"github.com/knative/serving/pkg/reconciler"
+	"go.uber.org/zap"
+	kubeapicorev1 "k8s.io/api/core/v1"
+	kubetypedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func init() {
+	// Add serving types to the default Kubernetes Scheme so Events can be
+	// logged for serving types.
+	servingscheme.AddToScheme(kubescheme.Scheme)
+}
+
+type newReconciler func(reconciler.CommonOptions, *DependencyFactory) reconciler.Reconciler
+
+func NewController(
+	logger *zap.SugaredLogger,
+	newFunc newReconciler,
+	componentName string,
+	queueName string,
+	watcher configmap.Watcher,
+	deps *DependencyFactory,
+	trackerLease time.Duration,
+) (*controller.Impl, error) {
+
+	// There's a circular dependency between
+	// the reconciler and the host controller
+	//
+	// controller -> reconciler -> tracker -> controller
+	//
+	// We'll set the reconciler after it's been constructed
+	c := controller.NewImpl(nil, logger, queueName)
+
+	logger = logger.Named(componentName).
+		With(logkey.ControllerType, componentName)
+
+	recorder := newRecorder(componentName, logger, deps)
+	tracker := tracker.New(c.EnqueueKey, trackerLease)
+
+	rec := newFunc(reconciler.CommonOptions{
+		Logger:           logger,
+		Recorder:         recorder,
+		ObjectTracker:    tracker,
+		WorkQueue:        c,
+		ConfigMapWatcher: watcher,
+	}, deps)
+
+	if err := reconciler.SetupTriggers(rec, c, tracker, deps); err != nil {
+		return nil, err
+	}
+
+	if phasedRec, ok := rec.(reconciler.WithPhases); ok {
+		for _, phase := range phasedRec.Phases() {
+			if err := reconciler.SetupTriggers(phase, c, tracker, deps); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	c.Reconciler = rec
+
+	return c, nil
+}
+
+func newRecorder(
+	name string,
+	logger *zap.SugaredLogger,
+	factory *DependencyFactory,
+) record.EventRecorder {
+
+	// Create event broadcaster
+	logger.Debugf("Creating event broadcaster for %q", name)
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartLogging(logger.Named("event-broadcaster").Infof)
+	broadcaster.StartRecordingToSink(&kubetypedcorev1.EventSinkImpl{
+		Interface: factory.Kubernetes.Client.CoreV1().Events(""),
+	})
+
+	return broadcaster.NewRecorder(
+		kubescheme.Scheme,
+		kubeapicorev1.EventSource{Component: name},
+	)
+}

--- a/pkg/reconciler/v1alpha1/routephase/phase/domain.go
+++ b/pkg/reconciler/v1alpha1/routephase/phase/domain.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phase
+
+import (
+	"context"
+	"fmt"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	reconcilerv1alpha1 "github.com/knative/serving/pkg/reconciler/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
+)
+
+func NewDomain(reconciler.CommonOptions, *reconcilerv1alpha1.DependencyFactory) *Domain {
+	return &Domain{}
+}
+
+type Domain struct{}
+
+func (p *Domain) Reconcile(ctx context.Context, route *v1alpha1.Route) (v1alpha1.RouteStatus, error) {
+	return v1alpha1.RouteStatus{
+		Domain: routeDomain(ctx, route),
+		Targetable: &duckv1alpha1.Targetable{
+			DomainInternal: names.K8sServiceFullname(route),
+		},
+	}, nil
+}
+
+// TODO(dprotaso) should we just consolidate this with virtual service reconciler?
+// My argument is no since we test config changes here
+func routeDomain(ctx context.Context, route *v1alpha1.Route) string {
+	cfg := config.FromContext(ctx)
+	domain := cfg.Domain.LookupDomainForLabels(route.ObjectMeta.Labels)
+	return fmt.Sprintf("%s.%s.%s", route.Name, route.Namespace, domain)
+}

--- a/pkg/reconciler/v1alpha1/routephase/phase/domain_test.go
+++ b/pkg/reconciler/v1alpha1/routephase/phase/domain_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phase
+
+import (
+	"context"
+	"testing"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
+
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+)
+
+func TestDomainReconcile(t *testing.T) {
+	scenarios := PhaseTests{{
+		Name: "first-reconcile",
+		Context: contextWithDomainConfig(&config.Domain{
+			Domains: map[string]*config.LabelSelector{
+				"example.com": {},
+			}},
+		),
+		Resource: simpleRunLatest("default", "first-reconcile", "config"),
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Domain: "first-reconcile.default.example.com",
+			Targetable: &duckv1alpha1.Targetable{
+				"first-reconcile.default.svc.cluster.local",
+			},
+		},
+	}, {
+		Name: "config-change",
+		Context: contextWithDomainConfig(&config.Domain{
+			Domains: map[string]*config.LabelSelector{
+				"new-example.com": {},
+			}},
+		),
+		Resource: simpleRunLatest("default", "config-change", "config"),
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Domain: "config-change.default.new-example.com",
+			Targetable: &duckv1alpha1.Targetable{
+				"config-change.default.svc.cluster.local",
+			},
+		},
+	}, {
+		Name: "explicit-route-label-uses-different-domain",
+		Context: contextWithDomainConfig(&config.Domain{
+			Domains: map[string]*config.LabelSelector{
+				"new-example.com": {},
+				"explicit-example.com": {
+					Selector: map[string]string{"app": "prod"},
+				},
+			}},
+		),
+		Resource: addRouteLabel(
+			simpleRunLatest("default", "explicit-label", "config"),
+			"app", "prod",
+		),
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Domain: "explicit-label.default.explicit-example.com",
+			Targetable: &duckv1alpha1.Targetable{
+				"explicit-label.default.svc.cluster.local",
+			},
+		},
+	}}
+
+	scenarios.Run(t, PhaseSetup(NewDomain))
+}
+
+func contextWithDefaultDomain(domain string) context.Context {
+	return contextWithDomainConfig(&config.Domain{
+		Domains: map[string]*config.LabelSelector{
+			domain: {},
+		}},
+	)
+}
+
+func contextWithDomainConfig(c *config.Domain) context.Context {
+	return config.ToContext(context.TODO(), &config.Config{
+		Domain: c,
+	})
+}
+
+func addRouteLabel(route *v1alpha1.Route, key, value string) *v1alpha1.Route {
+	if route.Labels == nil {
+		route.Labels = make(map[string]string)
+	}
+	route.Labels[key] = value
+	return route
+}

--- a/pkg/reconciler/v1alpha1/routephase/phase/service.go
+++ b/pkg/reconciler/v1alpha1/routephase/phase/service.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phase
+
+import (
+	"context"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	reconcilerv1alpha1 "github.com/knative/serving/pkg/reconciler/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func NewK8sService(o reconciler.CommonOptions, d *reconcilerv1alpha1.DependencyFactory) *K8sService {
+	return &K8sService{
+		ServiceLister: d.Kubernetes.InformerFactory.Core().V1().Services().Lister(),
+		KubeClientSet: d.Kubernetes.Client,
+		Recorder:      o.Recorder,
+	}
+}
+
+type K8sService struct {
+	ServiceLister corev1listers.ServiceLister
+	KubeClientSet kubernetes.Interface
+	Recorder      record.EventRecorder
+}
+
+func (p *K8sService) Triggers() []reconciler.Trigger {
+	return []reconciler.Trigger{{
+		ObjectKind:  corev1.SchemeGroupVersion.WithKind("Service"),
+		OwnerKind:   v1alpha1.SchemeGroupVersion.WithKind("Route"),
+		EnqueueType: reconciler.EnqueueOwner,
+	}}
+}
+
+func (p *K8sService) Reconcile(ctx context.Context, route *v1alpha1.Route) (status v1alpha1.RouteStatus, err error) {
+
+	logger := logging.FromContext(ctx)
+	logger.Infof("Reconciling route - kubernetes service")
+
+	ns := route.Namespace
+	name := names.K8sService(route)
+
+	service, err := p.ServiceLister.Services(ns).Get(name)
+
+	if apierrs.IsNotFound(err) {
+		err = p.create(logger, route)
+	} else if err == nil {
+		err = p.update(logger, route, service)
+	}
+
+	if err != nil {
+		return
+	}
+
+	// Update the information that makes us Targetable.
+	status.DomainInternal = names.K8sServiceFullname(route)
+	status.Targetable = &duckv1alpha1.Targetable{
+		DomainInternal: names.K8sServiceFullname(route),
+	}
+
+	// TODO(mattmoor): This is where we'd look at the state of the Service and
+	// reflect any necessary state into the Route.
+	return
+}
+
+func (p *K8sService) create(logger *zap.SugaredLogger, route *v1alpha1.Route) error {
+	service := resources.MakeK8sService(route)
+	name := names.K8sService(route)
+
+	_, err := p.KubeClientSet.CoreV1().Services(route.Namespace).Create(service)
+	if err != nil {
+		logger.Error("Failed to create service", zap.Error(err))
+		p.Recorder.Eventf(route, corev1.EventTypeWarning, "CreationFailed", "Failed to create service %q: %v", name, err)
+		return err
+	}
+
+	logger.Infof("Created service %s", name)
+	p.Recorder.Eventf(route, corev1.EventTypeNormal, "Created", "Created service %q", name)
+	return nil
+}
+
+func (p *K8sService) update(logger *zap.SugaredLogger, route *v1alpha1.Route, service *corev1.Service) error {
+	// Make sure that the service has the proper specification
+	desiredService := resources.MakeK8sService(route)
+
+	// Preserve the ClusterIP field in the Service's Spec, if it has been set.
+	desiredService.Spec.ClusterIP = service.Spec.ClusterIP
+
+	if equality.Semantic.DeepEqual(service.Spec, desiredService.Spec) {
+		return nil
+	}
+
+	service.Spec = desiredService.Spec
+	_, err := p.KubeClientSet.CoreV1().
+		Services(route.Namespace).
+		Update(service)
+
+	if err != nil {
+		logger.Error("Failed to update service", zap.Error(err))
+	} else {
+		logger.Infof("Updated service %s", desiredService.Name)
+	}
+
+	return err
+}

--- a/pkg/reconciler/v1alpha1/routephase/phase/service_test.go
+++ b/pkg/reconciler/v1alpha1/routephase/phase/service_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phase
+
+import (
+	"testing"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+)
+
+func TestServiceReconcile(t *testing.T) {
+	scenarios := PhaseTests{
+		{
+			Name:     "first-reconcile",
+			Resource: simpleRunLatest("default", "first-reconcile", "not-ready"),
+			ExpectedStatus: v1alpha1.RouteStatus{
+				DomainInternal: "first-reconcile.default.svc.cluster.local",
+				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "first-reconcile.default.svc.cluster.local"},
+			},
+			ExpectedCreates: Creates{
+				resources.MakeK8sService(
+					simpleRunLatest("default", "first-reconcile", "not-ready"),
+				),
+			},
+		}, {
+			Name:     "create-service-fails",
+			Resource: simpleRunLatest("default", "first-reconcile", "not-ready"),
+			Failures: Failures{
+				InduceFailure("create", "services"),
+			},
+			ExpectError:    true,
+			ExpectedStatus: v1alpha1.RouteStatus{},
+			ExpectedCreates: Creates{
+				resources.MakeK8sService(
+					simpleRunLatest("default", "first-reconcile", "not-ready"),
+				),
+			},
+		}, {
+			Name:     "steady-state",
+			Resource: simpleRunLatest("default", "steady-state", "not-ready"),
+			Objects: Objects{
+				resources.MakeK8sService(
+					simpleRunLatest("default", "steady-state", "not-ready"),
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				DomainInternal: "steady-state.default.svc.cluster.local",
+				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "steady-state.default.svc.cluster.local"},
+			},
+		}, {
+			Name:     "service-spec-change",
+			Resource: simpleRunLatest("default", "service-change", "not-ready"),
+			Objects: Objects{
+				mutateService(
+					resources.MakeK8sService(
+						simpleRunLatest("default", "service-change", "not-ready"),
+					),
+				),
+			},
+			ExpectedUpdates: Updates{
+				resources.MakeK8sService(
+					simpleRunLatest("default", "service-change", "not-ready"),
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				DomainInternal: "service-change.default.svc.cluster.local",
+				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "service-change.default.svc.cluster.local"},
+			},
+		}, {
+			Name:     "service-update-failed",
+			Resource: simpleRunLatest("default", "service-change", "not-ready"),
+			Objects: Objects{
+				mutateService(
+					resources.MakeK8sService(
+						simpleRunLatest("default", "service-change", "not-ready"),
+					),
+				),
+			},
+			Failures: Failures{
+				InduceFailure("update", "services"),
+			},
+			ExpectError:    true,
+			ExpectedStatus: v1alpha1.RouteStatus{},
+			ExpectedUpdates: Updates{
+				resources.MakeK8sService(
+					simpleRunLatest("default", "service-change", "not-ready"),
+				),
+			},
+		}, {
+			Name:     "allow cluster ip",
+			Resource: simpleRunLatest("default", "cluster-ip", "config"),
+			Objects: Objects{
+				setClusterIP(
+					resources.MakeK8sService(
+						simpleRunLatest("default", "cluster-ip", "config"),
+					),
+					"127.0.0.1",
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				DomainInternal: "cluster-ip.default.svc.cluster.local",
+				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "cluster-ip.default.svc.cluster.local"},
+			},
+		},
+	}
+
+	scenarios.Run(t, PhaseSetup(NewK8sService))
+}
+
+func mutateService(svc *corev1.Service) *corev1.Service {
+	// Thor's Hammer
+	svc.Spec = corev1.ServiceSpec{}
+	return svc
+}
+
+func simpleRunLatest(namespace, name, config string) *v1alpha1.Route {
+	return routeWithTraffic(namespace, name, v1alpha1.TrafficTarget{
+		ConfigurationName: config,
+		Percent:           100,
+	})
+}
+
+func routeWithTraffic(namespace, name string, traffic ...v1alpha1.TrafficTarget) *v1alpha1.Route {
+	return &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1alpha1.RouteSpec{
+			Traffic: traffic,
+		},
+	}
+}
+
+func setClusterIP(svc *corev1.Service, ip string) *corev1.Service {
+	svc.Spec.ClusterIP = ip
+	return svc
+}

--- a/pkg/reconciler/v1alpha1/routephase/phase/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/routephase/phase/virtual_service.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phase
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+	sharedclientset "github.com/knative/pkg/client/clientset/versioned"
+	istiolisters "github.com/knative/pkg/client/listers/istio/v1alpha3"
+	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/tracker"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servingclientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	reconcilerv1alpha1 "github.com/knative/serving/pkg/reconciler/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+)
+
+func NewVirtualService(o reconciler.CommonOptions, d *reconcilerv1alpha1.DependencyFactory) *VirtualService {
+	return &VirtualService{
+		ConfigurationLister:  d.Serving.InformerFactory.Serving().V1alpha1().Configurations().Lister(),
+		RevisionLister:       d.Serving.InformerFactory.Serving().V1alpha1().Revisions().Lister(),
+		VirtualServiceLister: d.Shared.InformerFactory.Networking().V1alpha3().VirtualServices().Lister(),
+
+		ServingClient: d.Serving.Client,
+		SharedClient:  d.Shared.Client,
+		Recorder:      o.Recorder,
+		Tracker:       o.ObjectTracker,
+	}
+}
+
+type VirtualService struct {
+	ConfigurationLister  servinglisters.ConfigurationLister
+	RevisionLister       servinglisters.RevisionLister
+	VirtualServiceLister istiolisters.VirtualServiceLister
+
+	ServingClient servingclientset.Interface
+	SharedClient  sharedclientset.Interface
+
+	Recorder record.EventRecorder
+	Tracker  tracker.Interface
+}
+
+func (p *VirtualService) Triggers() []reconciler.Trigger {
+	return []reconciler.Trigger{
+		{
+			ObjectKind:  v1alpha3.SchemeGroupVersion.WithKind("VirtualService"),
+			OwnerKind:   v1alpha1.SchemeGroupVersion.WithKind("Route"),
+			EnqueueType: reconciler.EnqueueOwner,
+		}, {
+			ObjectKind:  v1alpha1.SchemeGroupVersion.WithKind("Configuration"),
+			EnqueueType: reconciler.EnqueueTracker,
+		}, {
+			ObjectKind:  v1alpha1.SchemeGroupVersion.WithKind("Revision"),
+			EnqueueType: reconciler.EnqueueTracker,
+		},
+	}
+}
+
+func (p *VirtualService) Reconcile(ctx context.Context, route *v1alpha1.Route) (v1alpha1.RouteStatus, error) {
+	var status v1alpha1.RouteStatus
+
+	logger := logging.FromContext(ctx)
+	logger.Infof("Reconciling route - virtual service")
+
+	t, err := traffic.BuildTrafficConfiguration(p.ConfigurationLister, p.RevisionLister, route)
+
+	if t != nil {
+		// Tell our trackers to reconcile Route whenever the things referred to by our
+		// Traffic stanza change.
+		for _, configuration := range t.Configurations {
+			if err := p.Tracker.Track(objectRef(configuration), route); err != nil {
+				return status, err
+			}
+		}
+		for _, revision := range t.Revisions {
+			if revision.Status.IsActivationRequired() {
+				logger.Infof("Revision %s/%s is inactive", revision.Namespace, revision.Name)
+			}
+			if err := p.Tracker.Track(objectRef(revision), route); err != nil {
+				return status, err
+			}
+		}
+	}
+
+	badTarget, isTargetError := err.(traffic.TargetError)
+	if err != nil && !isTargetError {
+		// An error that's not due to missing traffic target should
+		// make us fail fast.
+		status.MarkUnknownTrafficError(err.Error())
+		return status, err
+	}
+
+	if badTarget != nil && isTargetError {
+		badTarget.MarkBadTrafficTarget(&status)
+
+		// Traffic targets aren't ready, no need to configure Route.
+		return status, nil
+	}
+	logger.Info("All referred targets are routable.  Creating Istio VirtualService.")
+
+	domain := routeDomain(ctx, route)
+	desired := resources.MakeVirtualService2(domain, route, t)
+	if err := p.reconcileService(logger, route, desired); err != nil {
+		return status, err
+	}
+	logger.Info("VirtualService created, marking AllTrafficAssigned with traffic information.")
+	status.Traffic = t.GetRevisionTrafficTargets()
+	status.MarkTrafficAssigned()
+	return status, nil
+}
+
+func (p *VirtualService) reconcileService(
+	logger *zap.SugaredLogger,
+	route *v1alpha1.Route,
+	desiredVirtualService *v1alpha3.VirtualService,
+) error {
+
+	ns := desiredVirtualService.Namespace
+	name := desiredVirtualService.Name
+
+	virtualService, err := p.VirtualServiceLister.VirtualServices(ns).Get(name)
+	if apierrs.IsNotFound(err) {
+		virtualService, err = p.SharedClient.NetworkingV1alpha3().VirtualServices(ns).Create(desiredVirtualService)
+		if err != nil {
+			logger.Error("Failed to create VirtualService", zap.Error(err))
+			p.Recorder.Eventf(route, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create VirtualService %q: %v", name, err)
+			return err
+		}
+		p.Recorder.Eventf(route, corev1.EventTypeNormal, "Created",
+			"Created VirtualService %q", desiredVirtualService.Name)
+	} else if err != nil {
+		return err
+	} else if !equality.Semantic.DeepEqual(virtualService.Spec, desiredVirtualService.Spec) {
+		virtualService.Spec = desiredVirtualService.Spec
+		virtualService, err = p.SharedClient.NetworkingV1alpha3().VirtualServices(ns).Update(virtualService)
+		if err != nil {
+			logger.Error("Failed to update VirtualService", zap.Error(err))
+			return err
+		}
+	}
+
+	// TODO(mattmoor): This is where we'd look at the state of the VirtualService and
+	// reflect any necessary state into the Route.
+	return err
+}
+
+type accessor interface {
+	GroupVersionKind() schema.GroupVersionKind
+	GetNamespace() string
+	GetName() string
+}
+
+func objectRef(a accessor) corev1.ObjectReference {
+	gvk := a.GroupVersionKind()
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	return corev1.ObjectReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Namespace:  a.GetNamespace(),
+		Name:       a.GetName(),
+	}
+}

--- a/pkg/reconciler/v1alpha1/routephase/phase/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/routephase/phase/virtual_service_test.go
@@ -1,0 +1,1021 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phase
+
+import (
+	"fmt"
+	"testing"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+)
+
+func TestVirtualServiceReconcile(t *testing.T) {
+	scenarios := PhaseTests{{
+		// When the configuration is not ready there should be
+		Name:     "configuration not yet ready",
+		Context:  contextWithDefaultDomain("example.com"),
+		Resource: simpleRunLatest("default", "first-reconcile", "not-ready"),
+		Objects: Objects{
+			simpleNotReadyConfig("default", "not-ready"),
+			simpleNotReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleNotReadyConfig("default", "not-ready").Status.LatestCreatedRevisionName,
+			),
+		},
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:    v1alpha1.RouteConditionAllTrafficAssigned,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "RevisionMissing",
+				Message: `Configuration "not-ready" is waiting for a Revision to become ready.`,
+			}, {
+				Type:    v1alpha1.RouteConditionReady,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "RevisionMissing",
+				Message: `Configuration "not-ready" is waiting for a Revision to become ready.`,
+			}},
+		},
+	}, {
+		Name:     "configuration permanently failed",
+		Context:  contextWithDefaultDomain("example.com"),
+		Resource: simpleRunLatest("default", "first-reconcile", "permanently-failed"),
+		Objects: []runtime.Object{
+			simpleFailedConfig("default", "permanently-failed"),
+			simpleFailedRevision("default",
+				// Use the Revision name from the config.
+				simpleFailedConfig("default", "permanently-failed").Status.LatestCreatedRevisionName,
+			),
+		},
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:    v1alpha1.RouteConditionAllTrafficAssigned,
+				Status:  corev1.ConditionFalse,
+				Reason:  "RevisionMissing",
+				Message: `Configuration "permanently-failed" does not have any ready Revision.`,
+			}, {
+				Type:    v1alpha1.RouteConditionReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  "RevisionMissing",
+				Message: `Configuration "permanently-failed" does not have any ready Revision.`,
+			}},
+		},
+	}, {
+		Name:     "simple route becomes ready",
+		Context:  contextWithDefaultDomain("example.com"),
+		Resource: simpleRunLatest("default", "becomes-ready", "config"),
+		Objects: Objects{
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+		},
+		ExpectedCreates: Creates{
+			resources.MakeVirtualService2(
+				"becomes-ready.default.example.com",
+				simpleRunLatest("default", "becomes-ready", "config"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": {{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
+		},
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   v1alpha1.RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+			Traffic: []v1alpha1.TrafficTarget{{
+				RevisionName: "config-00001",
+				Percent:      100,
+			}},
+		},
+	}, {
+		Name:     "failure creating virtual service",
+		Context:  contextWithDefaultDomain("example.com"),
+		Resource: simpleRunLatest("default", "vs-create-failure", "config"),
+		Objects: Objects{
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+		},
+		// We induce a failure creating the VirtualService.
+		Failures: Failures{
+			InduceFailure("create", "virtualservices"),
+		},
+		ExpectError:    true,
+		ExpectedStatus: v1alpha1.RouteStatus{},
+		ExpectedCreates: Creates{
+			// This is the Create we see for the virtual service, but we induce a failure.
+			resources.MakeVirtualService2(
+				"vs-create-failure.default.example.com",
+				simpleRunLatest("default", "vs-create-failure", "config"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": {{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
+		},
+	}, {
+		Name:     "steady state",
+		Context:  contextWithDefaultDomain("example.com"),
+		Resource: simpleRunLatest("default", "steady-state", "config"),
+		Objects: Objects{
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService2(
+				"steady-state.default.example.com",
+				simpleRunLatest("default", "steady-state", "config"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": {{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
+		},
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   v1alpha1.RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+			Traffic: []v1alpha1.TrafficTarget{{
+				RevisionName: "config-00001",
+				Percent:      100,
+			}},
+		},
+	}, {
+		Name:     "different domain",
+		Context:  contextWithDefaultDomain("another-example.com"),
+		Resource: simpleRunLatest("default", "different-domain", "config"),
+		Objects: Objects{
+			simpleReadyConfig("default", "config"),
+			simpleReadyRevision("default",
+				// Use the Revision name from the config.
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			resources.MakeVirtualService2(
+				"different-domain.default.example.com",
+				simpleRunLatest("default", "different-domain", "config"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": {{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
+		},
+		ExpectedUpdates: Updates{
+			resources.MakeVirtualService2(
+				"different-domain.default.another-example.com",
+				simpleRunLatest("default", "different-domain", "config"),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": {{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+								Percent:      100,
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
+		},
+		ExpectedStatus: v1alpha1.RouteStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   v1alpha1.RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+			Traffic: []v1alpha1.TrafficTarget{{
+				RevisionName: "config-00001",
+				Percent:      100,
+			}},
+		},
+	},
+		{
+			// A new LatestCreatedRevisionName on the Configuration alone should result in no changes to the Route.
+			Name:     "new latest created revision",
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "new-latest-created", "config"),
+			Objects: Objects{
+				setLatestCreatedRevision(
+					simpleReadyConfig("default", "config"),
+					"config-00002",
+				),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+				),
+				// This is the name of the new revision we're referencing above.
+				simpleNotReadyRevision("default", "config-00002"),
+				resources.MakeVirtualService2(
+					"new-latest-created.default.example.com",
+					simpleRunLatest("default", "new-latest-created", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					RevisionName: "config-00001",
+					Percent:      100,
+				}},
+			},
+		}, {
+			Name:     "new latest ready revision",
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "new-latest-ready", "config"),
+			Objects: Objects{
+				setLatestReadyRevision(setLatestCreatedRevision(
+					simpleReadyConfig("default", "config"),
+					"config-00002",
+				)),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+				),
+				// This is the name of the new revision we're referencing above.
+				simpleReadyRevision("default", "config-00002"),
+				resources.MakeVirtualService2(
+					"new-latest-ready.default.example.com",
+					simpleRunLatest("default", "new-latest-ready", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			// A new LatestReadyRevisionName on the Configuration should result in the new Revision being rolled out.
+			ExpectedUpdates: Updates{
+				resources.MakeVirtualService2(
+					"new-latest-ready.default.example.com",
+					simpleRunLatest("default", "new-latest-ready", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// This is the new config we're making become ready.
+									RevisionName: "config-00002",
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					RevisionName: "config-00002",
+					Percent:      100,
+				}},
+			},
+		}, {
+			Name: "failure updating virtual service",
+			// Starting from the new latest ready, induce a failure updating the virtual service.
+			ExpectError: true,
+			Failures: Failures{
+				InduceFailure("update", "virtualservices"),
+			},
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "update-vs-failure", "config"),
+			Objects: Objects{
+				setLatestReadyRevision(setLatestCreatedRevision(
+					simpleReadyConfig("default", "config"),
+					"config-00002",
+				)),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+				),
+				// This is the name of the new revision we're referencing above.
+				simpleReadyRevision("default", "config-00002"),
+				resources.MakeVirtualService2(
+					"update-vs-failure.default.example.com",
+					simpleRunLatest("default", "update-vs-failure", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+				resources.MakeK8sService(simpleRunLatest("default", "update-vs-failure", "config")),
+			},
+			ExpectedUpdates: Updates{
+				resources.MakeVirtualService2(
+					"update-vs-failure.default.example.com",
+					simpleRunLatest("default", "update-vs-failure", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// This is the new config we're making become ready.
+									RevisionName: "config-00002",
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{},
+		}, {
+			Name:     "reconcile virtual service mutation",
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "virt-svc-mutation", "config"),
+			Objects: Objects{
+				simpleReadyConfig("default", "config"),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+				),
+				mutateVirtualService(resources.MakeVirtualService2(
+					"virt-svc-mutation.default.example.com",
+					simpleRunLatest("default", "virt-svc-mutation", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				)),
+			},
+			ExpectedUpdates: Updates{
+				resources.MakeVirtualService2(
+					"virt-svc-mutation.default.example.com",
+					simpleRunLatest("default", "virt-svc-mutation", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					RevisionName: "config-00001",
+					Percent:      100,
+				}},
+			},
+		}, {
+			Name: "switch to a different config",
+			// The status reflects "oldconfig", but the spec "newconfig".
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "change-configs", "newconfig"),
+			Objects: Objects{
+				// Both configs exist, but only "oldconfig" is labelled.
+				simpleReadyConfig("default", "oldconfig"),
+				simpleReadyConfig("default", "newconfig"),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "oldconfig").Status.LatestReadyRevisionName,
+				),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "newconfig").Status.LatestReadyRevisionName,
+				),
+				resources.MakeVirtualService2(
+					"change-configs.default.example.com",
+					simpleRunLatest("default", "change-configs", "oldconfig"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "oldconfig").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+				resources.MakeK8sService(simpleRunLatest("default", "change-configs", "oldconfig")),
+			},
+			ExpectedUpdates: Updates{
+				// Updated to point to "newconfig" things.
+				resources.MakeVirtualService2(
+					"change-configs.default.example.com",
+					simpleRunLatest("default", "change-configs", "newconfig"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "newconfig").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			// Status updated to "newconfig"
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					RevisionName: "newconfig-00001",
+					Percent:      100,
+				}},
+			},
+		}, {
+			Name:     "configuration missing",
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "config-missing", "not-found"),
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:    v1alpha1.RouteConditionAllTrafficAssigned,
+					Status:  corev1.ConditionFalse,
+					Reason:  "ConfigurationMissing",
+					Message: `Configuration "not-found" referenced in traffic not found.`,
+				}, {
+					Type:    v1alpha1.RouteConditionReady,
+					Status:  corev1.ConditionFalse,
+					Reason:  "ConfigurationMissing",
+					Message: `Configuration "not-found" referenced in traffic not found.`,
+				}},
+			},
+		}, {
+			Name:     "revision missing (direct)",
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simplePinned("default", "missing-revision-direct", "not-found"),
+			Objects: Objects{
+				simpleReadyConfig("default", "config"),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:    v1alpha1.RouteConditionAllTrafficAssigned,
+					Status:  corev1.ConditionFalse,
+					Reason:  "RevisionMissing",
+					Message: `Revision "not-found" referenced in traffic not found.`,
+				}, {
+					Type:    v1alpha1.RouteConditionReady,
+					Status:  corev1.ConditionFalse,
+					Reason:  "RevisionMissing",
+					Message: `Revision "not-found" referenced in traffic not found.`,
+				}},
+			},
+		}, {
+			Name:     "revision missing (indirect)",
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "missing-revision-indirect", "config"),
+			Objects: Objects{
+				simpleReadyConfig("default", "config"),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:    v1alpha1.RouteConditionAllTrafficAssigned,
+					Status:  corev1.ConditionFalse,
+					Reason:  "RevisionMissing",
+					Message: `Revision "config-00001" referenced in traffic not found.`,
+				}, {
+					Type:    v1alpha1.RouteConditionReady,
+					Status:  corev1.ConditionFalse,
+					Reason:  "RevisionMissing",
+					Message: `Revision "config-00001" referenced in traffic not found.`,
+				}},
+			},
+		}, {
+			Name:    "pinned route becomes ready",
+			Context: contextWithDefaultDomain("example.com"),
+			Resource: simplePinned(
+				"default",
+				"pinned-becomes-ready",
+				// Use the Revision name from the config
+				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+			),
+			Objects: Objects{
+				simpleReadyConfig("default", "config"),
+				addOwnerRef(
+					simpleReadyRevision("default",
+						// Use the Revision name from the config.
+						simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+					),
+					or("Configuration", "config"),
+				),
+			},
+			ExpectedCreates: Creates{
+				resources.MakeVirtualService2(
+					"pinned-becomes-ready.default.example.com",
+					simpleRunLatest("default", "pinned-becomes-ready", "config"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			// Use the config's revision name.
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					// TODO(#1495): This is established thru labels instead of OwnerReferences.
+					// ConfigurationName: "config",
+					RevisionName: "config-00001",
+					Percent:      100,
+				}},
+			},
+		}, {
+			Name:    "traffic split becomes ready",
+			Context: contextWithDefaultDomain("example.com"),
+			Resource: routeWithTraffic("default", "named-traffic-split",
+				v1alpha1.TrafficTarget{
+					ConfigurationName: "blue",
+					Percent:           50,
+				}, v1alpha1.TrafficTarget{
+					ConfigurationName: "green",
+					Percent:           50,
+				}),
+			Objects: Objects{
+				simpleReadyConfig("default", "blue"),
+				simpleReadyConfig("default", "green"),
+				addOwnerRef(
+					simpleReadyRevision("default",
+						// Use the Revision name from the config.
+						simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+					),
+					or("Configuration", "blue"),
+				),
+				addOwnerRef(
+					simpleReadyRevision("default",
+						// Use the Revision name from the config.
+						simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+					),
+					or("Configuration", "green"),
+				),
+			},
+			ExpectedCreates: Creates{
+				resources.MakeVirtualService2(
+					"named-traffic-split.default.example.com",
+					routeWithTraffic("default", "named-traffic-split",
+						v1alpha1.TrafficTarget{
+							ConfigurationName: "blue",
+							Percent:           50,
+						}, v1alpha1.TrafficTarget{
+							ConfigurationName: "green",
+							Percent:           50,
+						}),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+									Percent:      50,
+								},
+								Active: true,
+							}, {
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+									Percent:      50,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					RevisionName: "blue-00001",
+					Percent:      50,
+				}, {
+					RevisionName: "green-00001",
+					Percent:      50,
+				}},
+			},
+		}, {
+			Name: "change route configuration",
+			// Start from a steady state referencing "blue", and modify the route spec to point to "green" instead.
+			Context:  contextWithDefaultDomain("example.com"),
+			Resource: simpleRunLatest("default", "switch-configs", "green"),
+			Objects: Objects{
+				simpleReadyConfig("default", "blue"),
+				simpleReadyConfig("default", "green"),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+				),
+				simpleReadyRevision("default",
+					// Use the Revision name from the config.
+					simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+				),
+				resources.MakeVirtualService2(
+					"switch-configs.default.example.com",
+					simpleRunLatest("default", "switch-configs", "blue"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+				resources.MakeK8sService(simpleRunLatest("default", "switch-configs", "blue")),
+			},
+			ExpectedUpdates: Updates{
+				resources.MakeVirtualService2(
+					"switch-configs.default.example.com",
+					simpleRunLatest("default", "switch-configs", "green"),
+					&traffic.TrafficConfig{
+						Targets: map[string][]traffic.RevisionTarget{
+							"": {{
+								TrafficTarget: v1alpha1.TrafficTarget{
+									// Use the Revision name from the config.
+									RevisionName: simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
+									Percent:      100,
+								},
+								Active: true,
+							}},
+						},
+					},
+				),
+			},
+			ExpectedStatus: v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+				Traffic: []v1alpha1.TrafficTarget{{
+					RevisionName: "green-00001",
+					Percent:      100,
+				}},
+			},
+		}}
+
+	scenarios.Run(t, PhaseSetup(NewVirtualService))
+}
+
+// TODO(dprotaso)Review this alternate phase scenario invocation
+//func TestVirtualServiceReconcile_FailureLabellingConfiguration(t *testing.T) {
+//	oldRoute := simpleRunLatest("default", "addlabel-config-failure", "blue")
+//
+//	blueConfig := simpleReadyConfig("default", "blue")
+//	greenConfig := simpleReadyConfig("default", "green")
+//
+//	blueRevision := simpleReadyRevision("default", blueConfig.Status.LatestCreatedRevisionName)
+//	greenRevision := simpleReadyRevision("default", greenConfig.Status.LatestCreatedRevisionName)
+//
+//	virtualService := resources.MakeVirtualService2(
+//		"addlabel-config-failure.default.example.com",
+//		oldRoute,
+//		&traffic.TrafficConfig{
+//			Targets: map[string][]traffic.RevisionTarget{
+//				"": {{
+//					TrafficTarget: v1alpha1.TrafficTarget{
+//						// Use the Revision name from the config.
+//						RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
+//						Percent:      100,
+//					},
+//					Active: true,
+//				}},
+//			},
+//		},
+//	)
+//
+//	scenario := PhaseTest{
+//		Name: "failure labeling configuration",
+//		// Start from our test that switches configs, unlabel "blue" (avoids induced failure),
+//		// and induce a failure when we go to label the "green" configuration.
+//		ExpectError: true,
+//		Failures: Failures{
+//			InduceFailure("patch", "configurations"),
+//		},
+//		Context:  contextWithDefaultDomain("example.com"),
+//		Resource: simpleRunLatest("default", "addlabel-config-failure", "green"),
+//		Objects: Objects{
+//			blueConfig,
+//			blueRevision,
+//			greenConfig,
+//			greenRevision,
+//			virtualService,
+//		},
+//		ExpectedPatches: Patches{
+//			patchAddLabel("default", "green", "serving.knative.dev/route", "addlabel-config-failure", "v1"),
+//		},
+//		ExpectedStatus: v1alpha1.RouteStatus{},
+//	}
+//
+//	scenario.Run(t, VSPhaseSetup, VirtualService{})
+//}
+
+func patchRemoveLabel(namespace, name, key, version string) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = name
+	action.Namespace = namespace
+
+	patch := fmt.Sprintf(`{"metadata":{"labels":{"%s":null},"resourceVersion":"%s"}}`, key, version)
+
+	action.Patch = []byte(patch)
+	return action
+}
+
+func patchAddLabel(namespace, name, key, value, version string) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = name
+	action.Namespace = namespace
+
+	patch := fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"},"resourceVersion":"%s"}}`, key, value, version)
+
+	action.Patch = []byte(patch)
+	return action
+}
+
+func simpleNotReadyConfig(namespace, name string) *v1alpha1.Configuration {
+	cfg := &v1alpha1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			ResourceVersion: "v1",
+		},
+		Spec: v1alpha1.ConfigurationSpec{
+			Generation: 1,
+			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				Spec: v1alpha1.RevisionSpec{
+					Container: corev1.Container{
+						Image: "busybox",
+					},
+				},
+			},
+		},
+	}
+	cfg.Status.InitializeConditions()
+	cfg.Status.SetLatestCreatedRevisionName(name + "-00001")
+	return cfg
+}
+
+func simpleNotReadyRevision(namespace, name string) *v1alpha1.Revision {
+	return &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: v1alpha1.RevisionStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   v1alpha1.RevisionConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}
+}
+
+func simpleFailedConfig(namespace, name string) *v1alpha1.Configuration {
+	cfg := &v1alpha1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			ResourceVersion: "v1",
+		},
+		Spec: v1alpha1.ConfigurationSpec{
+			Generation: 1,
+			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				Spec: v1alpha1.RevisionSpec{
+					Container: corev1.Container{
+						Image: "busybox",
+					},
+				},
+			},
+		},
+	}
+	cfg.Status.InitializeConditions()
+	cfg.Status.MarkLatestCreatedFailed(name+"-00001", "should have used ko")
+	return cfg
+}
+
+func simpleFailedRevision(namespace, name string) *v1alpha1.Revision {
+	return &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: v1alpha1.RevisionStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   v1alpha1.RevisionConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+}
+
+func simpleReadyConfig(namespace, name string) *v1alpha1.Configuration {
+	return setLatestReadyRevision(simpleNotReadyConfig(namespace, name))
+}
+
+func setLatestCreatedRevision(cfg *v1alpha1.Configuration, name string) *v1alpha1.Configuration {
+	cfg.Status.SetLatestCreatedRevisionName(name)
+	return cfg
+}
+
+func setLatestReadyRevision(cfg *v1alpha1.Configuration) *v1alpha1.Configuration {
+	cfg.Status.SetLatestReadyRevisionName(cfg.Status.LatestCreatedRevisionName)
+	return cfg
+}
+
+func simpleReadyRevision(namespace, name string) *v1alpha1.Revision {
+	return &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: v1alpha1.RevisionStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   v1alpha1.RevisionConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+func mutateVirtualService(vs *istiov1alpha3.VirtualService) *istiov1alpha3.VirtualService {
+	// Thor's Hammer
+	vs.Spec = istiov1alpha3.VirtualServiceSpec{}
+	return vs
+}
+
+func simplePinned(namespace, name, revision string) *v1alpha1.Route {
+	return routeWithTraffic(namespace, name, v1alpha1.TrafficTarget{
+		RevisionName: revision,
+		Percent:      100,
+	})
+}
+
+func addOwnerRef(rev *v1alpha1.Revision, o []metav1.OwnerReference) *v1alpha1.Revision {
+	rev.OwnerReferences = o
+	return rev
+}
+
+// or builds OwnerReferences for a child of a Service
+func or(kind, name string) []metav1.OwnerReference {
+	boolTrue := true
+	return []metav1.OwnerReference{{
+		APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+		Kind:               kind,
+		Name:               name,
+		Controller:         &boolTrue,
+		BlockOwnerDeletion: &boolTrue,
+	}}
+}

--- a/pkg/reconciler/v1alpha1/routephase/reconcile_test.go
+++ b/pkg/reconciler/v1alpha1/routephase/reconcile_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routephase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	reconcilerv1alpha1 "github.com/knative/serving/pkg/reconciler/v1alpha1"
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+)
+
+func TestRouteReconcile_Triggers(t *testing.T) {
+	triggers := (&Reconciler{}).Triggers()
+
+	expected := []reconciler.Trigger{{
+		ObjectKind:  v1alpha1.SchemeGroupVersion.WithKind("Route"),
+		EnqueueType: reconciler.EnqueueObject,
+	}}
+
+	if diff := cmp.Diff(expected, triggers); diff != "" {
+		t.Errorf("unexpected diff for the route triggers (-want,+got) %s", diff)
+
+	}
+}
+
+func TestRouteReconcile(t *testing.T) {
+	scenarios := ReconcilerTests{{
+		Name: "missing route",
+		Key:  "default/missing-route",
+	}, {
+		Name: "bad key",
+		Key:  "bad/key/with/many/parts",
+	}, {
+		Name: "new route",
+		Key:  "default/new-route",
+		Objects: Objects{
+			simpleRunLatest("default", "new-route", "config", nil),
+		},
+		ExpectedUpdates: Updates{
+			simpleRunLatest("default", "new-route", "config", &v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionUnknown,
+				}},
+			}),
+		},
+	}, {
+		Name: "update route status failed",
+		Key:  "default/update-route-failed",
+		Failures: Failures{
+			InduceFailure("update", "routes"),
+		},
+		Objects: Objects{
+			simpleRunLatest("default", "update-route-failed", "config", nil),
+		},
+		ExpectError: true,
+		ExpectedUpdates: Updates{
+			simpleRunLatest("default", "update-route-failed", "config", &v1alpha1.RouteStatus{
+				Conditions: duckv1alpha1.Conditions{{
+					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   v1alpha1.RouteConditionReady,
+					Status: corev1.ConditionUnknown,
+				}},
+			}),
+		},
+	}}
+
+	scenarios.Run(t, ReconcilerSetup(reconcilerWithNoPhases))
+}
+
+func TestRouteReconcile_DelegatesToPhases(t *testing.T) {
+	firstPhase := &mockPhase{}
+	secondPhase := &mockPhase{}
+
+	r := testReconciler(t, simpleRunLatest("default", "some-route", "config", nil))
+	r.RoutePhases = []RoutePhase{
+		firstPhase,
+		secondPhase,
+	}
+
+	if got, want := len(r.Phases()), 2; got != want {
+		t.Errorf("unexpected phases size got %d != want %d", got, want)
+	}
+
+	ctx := TestContextWithLogger(t)
+	err := r.Reconcile(ctx, "default/some-route")
+
+	if err != nil {
+		t.Errorf("Expected Reconcile() to not return an error - %s", err)
+	}
+
+	if got := firstPhase.reconcileInvocations; got != 1 {
+		t.Errorf("Expected the first phase to be reconciled only once - got %d", got)
+	}
+
+	if got := secondPhase.reconcileInvocations; got != 1 {
+		t.Errorf("Expected the first phase to be reconciled only once - got %d", got)
+	}
+}
+
+func reconcilerWithNoPhases(
+	opts reconciler.CommonOptions,
+	deps *reconcilerv1alpha1.DependencyFactory,
+) reconciler.Reconciler {
+
+	reconciler := New(opts, deps).(*Reconciler)
+	reconciler.Configs = &FakeConfigStore{}
+	reconciler.RoutePhases = nil
+	return reconciler
+}
+
+func testReconciler(t *testing.T, objs ...runtime.Object) *Reconciler {
+	opts := reconciler.CommonOptions{
+		Logger:           TestLogger(t),
+		Recorder:         &record.FakeRecorder{},
+		ObjectTracker:    &NullTracker{},
+		ConfigMapWatcher: &FakeConfigMapWatcher{},
+		WorkQueue:        &FakeWorkQueue{},
+	}
+
+	deps := NewFakeDependencies(objs)
+	reconciler := New(opts, deps).(*Reconciler)
+	reconciler.Configs = &FakeConfigStore{}
+	reconciler.RoutePhases = nil
+	return reconciler
+}
+
+type mockPhase struct {
+	triggers             []reconciler.Trigger
+	route                *v1alpha1.Route
+	reconcileInvocations int
+	reconcile            func(context.Context, *v1alpha1.Route) (v1alpha1.RouteStatus, error)
+}
+
+func (p *mockPhase) Reconcile(ctx context.Context, route *v1alpha1.Route) (v1alpha1.RouteStatus, error) {
+	p.reconcileInvocations++
+	p.route = route.DeepCopy()
+
+	if p.reconcile != nil {
+		return p.reconcile(ctx, route)
+	}
+	return v1alpha1.RouteStatus{}, nil
+}
+
+func (p *mockPhase) Triggers() []reconciler.Trigger {
+	return p.triggers
+}
+
+func simpleRunLatest(namespace, name, config string, status *v1alpha1.RouteStatus) *v1alpha1.Route {
+	return routeWithTraffic(namespace, name, status, v1alpha1.TrafficTarget{
+		ConfigurationName: config,
+		Percent:           100,
+	})
+}
+
+func routeWithTraffic(namespace, name string, status *v1alpha1.RouteStatus, traffic ...v1alpha1.TrafficTarget) *v1alpha1.Route {
+	route := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1alpha1.RouteSpec{
+			Traffic: traffic,
+		},
+	}
+	if status != nil {
+		route.Status = *status
+	}
+	return route
+}

--- a/pkg/reconciler/v1alpha1/routephase/reconciler.go
+++ b/pkg/reconciler/v1alpha1/routephase/reconciler.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routephase
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/knative/pkg/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servingclientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	reconcilerv1alpha1 "github.com/knative/serving/pkg/reconciler/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/routephase/phase"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+)
+
+type RoutePhase interface {
+	reconciler.Phase
+	Reconcile(ctx context.Context, route *v1alpha1.Route) (v1alpha1.RouteStatus, error)
+}
+
+type Reconciler struct {
+	reconciler.CommonOptions
+
+	RouteLister      servinglisters.RouteLister
+	ServingClientset servingclientset.Interface
+
+	Configs     reconciler.ConfigStore
+	RoutePhases []RoutePhase
+}
+
+func New(opts reconciler.CommonOptions, deps *reconcilerv1alpha1.DependencyFactory) reconciler.Reconciler {
+	store := config.NewStore(opts.Logger.Named("config-store"))
+	store.WatchConfigs(opts.ConfigMapWatcher)
+
+	return &Reconciler{
+		CommonOptions: opts,
+
+		RouteLister:      deps.Serving.InformerFactory.Serving().V1alpha1().Routes().Lister(),
+		ServingClientset: deps.Serving.Client,
+
+		Configs: store,
+		RoutePhases: []RoutePhase{
+			phase.NewDomain(opts, deps),
+			phase.NewK8sService(opts, deps),
+			phase.NewVirtualService(opts, deps),
+		},
+	}
+
+}
+
+func (r *Reconciler) ConfigStore() reconciler.ConfigStore {
+	return r.Configs
+}
+
+func (r *Reconciler) Phases() []reconciler.Phase {
+	var phases []reconciler.Phase
+
+	for _, routePhase := range r.RoutePhases {
+		phases = append(phases, routePhase)
+	}
+
+	return phases
+}
+
+func (r *Reconciler) Triggers() []reconciler.Trigger {
+	return []reconciler.Trigger{{
+		ObjectKind:  v1alpha1.SchemeGroupVersion.WithKind("Route"),
+		EnqueueType: reconciler.EnqueueObject,
+	}}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
+	ctx = r.Configs.ToContext(ctx)
+	logger := logging.FromContext(ctx)
+
+	// Convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		r.Logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+
+	// Get the Route resource with this namespace/name
+	original, err := r.RouteLister.Routes(namespace).Get(name)
+	if apierrs.IsNotFound(err) {
+		// The resource may no longer exist, in which case we stop processing.
+		logger.Errorf("route %q in work queue no longer exists", key)
+		return nil
+	} else if err != nil {
+		return err
+	}
+	// Don't modify the informers copy
+	route := original.DeepCopy()
+
+	// Reconcile this copy of the route and then write back any status
+	// updates regardless of whether the reconciliation errored out.
+	err = r.reconcilePhases(ctx, logger, route)
+	if equality.Semantic.DeepEqual(original.Status, route.Status) {
+		// If we didn't change anything then don't call updateStatus.
+		// This is important because the copy we loaded from the informer's
+		// cache may be stale and we don't want to overwrite a prior update
+		// to status with this stale state.
+	} else if _, err := r.updateStatus(ctx, route); err != nil {
+		logger.Warn("Failed to update route status", zap.Error(err))
+		r.Recorder.Eventf(route, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update status for route %q: %v", route.Name, err)
+		return err
+	}
+	return err
+}
+
+func (r *Reconciler) reconcilePhases(ctx context.Context, logger *zap.SugaredLogger, route *v1alpha1.Route) error {
+	route.Status.InitializeConditions()
+
+	for _, phase := range r.RoutePhases {
+		status, rerr := phase.Reconcile(ctx, route)
+
+		if err := route.Status.MergePartial(&status); err != nil {
+			// TODO(dprtoaso) Consider failing and returning an error
+			//
+			// Merge fails when argument types are different - this shouldn't happen (for route status)
+			// or
+			// when a provided transformer returns an error - this shouldn't happen (for route status)
+			logger.Warnf("merging route status failed: ", err)
+		}
+
+		if rerr != nil {
+			return rerr
+		}
+	}
+	return nil
+}
+
+// Update the Status of the route.  Caller is responsible for checking
+// for semantic differences before calling.
+func (r *Reconciler) updateStatus(ctx context.Context, route *v1alpha1.Route) (*v1alpha1.Route, error) {
+	existing, err := r.RouteLister.Routes(route.Namespace).Get(route.Name)
+	if err != nil {
+		return nil, err
+	}
+	// If there's nothing to update, just return.
+	if reflect.DeepEqual(existing.Status, route.Status) {
+		return existing, nil
+	}
+	existing.Status = route.Status
+	// TODO: for CRD there's no updatestatus, so use normal update.
+	updated, err := r.ServingClientset.ServingV1alpha1().Routes(route.Namespace).Update(existing)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Recorder.Eventf(route, corev1.EventTypeNormal, "Updated", "Updated status for route %q", route.Name)
+	return updated, nil
+}

--- a/pkg/reconciler/v1alpha1/testing/aliases.go
+++ b/pkg/reconciler/v1alpha1/testing/aliases.go
@@ -28,6 +28,21 @@ type (
 	ActionRecorder     = testing.ActionRecorder
 	Factory            = testing.Factory
 	HookResult         = testing.HookResult
+	PhaseTest          = testing.PhaseTest
+	PhaseTests         = testing.PhaseTests
+	ReconcilerTest     = testing.ReconcilerTest
+	ReconcilerTests    = testing.ReconcilerTests
+	Creates            = testing.Creates
+	Patches            = testing.Patches
+	Failures           = testing.Failures
+	Objects            = testing.Objects
+	Updates            = testing.Updates
+	FakeClient         = testing.FakeClient
+	NullTracker        = testing.NullTracker
+
+	FakeConfigMapWatcher = testing.FakeConfigMapWatcher
+	FakeConfigStore      = testing.FakeConfigStore
+	FakeWorkQueue        = testing.FakeWorkQueue
 )
 
 var (
@@ -39,7 +54,8 @@ var (
 	ValidateUpdates           = testing.ValidateUpdates
 	ConfigMapFromTestFile     = testing.ConfigMapFromTestFile
 
-	TestLogger = logtesting.TestLogger
+	TestLogger            = logtesting.TestLogger
+	TestContextWithLogger = logtesting.TestContextWithLogger
 )
 
 const (

--- a/pkg/reconciler/v1alpha1/testing/initializer.go
+++ b/pkg/reconciler/v1alpha1/testing/initializer.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"reflect"
+
+	cachingclientset "github.com/knative/caching/pkg/client/clientset/versioned"
+	fakecachingclientset "github.com/knative/caching/pkg/client/clientset/versioned/fake"
+	cachinginformers "github.com/knative/caching/pkg/client/informers/externalversions"
+	"github.com/knative/pkg/apis"
+	fakesharedclientset "github.com/knative/pkg/client/clientset/versioned/fake"
+	servingclientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	fakeservingclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/testing"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+type newReconcilerFunc func(reconciler.CommonOptions, *v1alpha1.DependencyFactory) reconciler.Reconciler
+
+func ReconcilerSetup(newReconciler newReconcilerFunc) testing.ReconcilerSetupFunc {
+	return func(opts reconciler.CommonOptions, objs []runtime.Object) (reconciler.Reconciler, []FakeClient) {
+		deps := NewFakeDependencies(objs)
+		reconciler := newReconciler(opts, deps)
+		return reconciler, fakeClients(deps)
+	}
+}
+
+func PhaseSetup(newPhase interface{}) testing.PhaseSetupFunc {
+	return func(opts reconciler.CommonOptions, objs []runtime.Object) (interface{}, []FakeClient) {
+		deps := NewFakeDependencies(objs)
+
+		// TODO(dprotaso) add validation to produce better error messages
+		constructor := reflect.ValueOf(newPhase)
+
+		in := []reflect.Value{
+			reflect.ValueOf(opts),
+			reflect.ValueOf(deps),
+		}
+
+		out := constructor.Call(in)
+
+		return out[0].Interface(), fakeClients(deps)
+	}
+}
+
+func fakeClients(deps *v1alpha1.DependencyFactory) []testing.FakeClient {
+	return []testing.FakeClient{
+		deps.Kubernetes.Client.(*fakekubeclientset.Clientset),
+		deps.Shared.Client.(*fakesharedclientset.Clientset),
+		deps.Serving.Client.(*fakeservingclientset.Clientset),
+		deps.Caching.Client.(*fakecachingclientset.Clientset),
+		deps.Dynamic.Client.(*fakedynamicclientset.FakeDynamicClient),
+	}
+}
+
+func NewFakeDependencies(objs []runtime.Object) *v1alpha1.DependencyFactory {
+	scheme, sorter, commonDeps := testing.NewFakeDependencies(objs,
+		fakecachingclientset.AddToScheme,
+		fakeservingclientset.AddToScheme,
+	)
+
+	servingObjs := sorter.ObjectsForSchemeFunc(fakeservingclientset.AddToScheme)
+	cachingObjs := sorter.ObjectsForSchemeFunc(fakecachingclientset.AddToScheme)
+
+	fakeServingClientset := fakeservingclientset.NewSimpleClientset(servingObjs...)
+	fakeCachingClientset := fakecachingclientset.NewSimpleClientset(cachingObjs...)
+
+	servingInformer := servinginformers.NewSharedInformerFactory(fakeServingClientset, 0)
+	cachingInformer := cachinginformers.NewSharedInformerFactory(fakeCachingClientset, 0)
+
+	for _, obj := range objs {
+		kinds, _, _ := scheme.ObjectKinds(obj)
+		for _, kind := range kinds {
+			resource := apis.KindToResource(kind)
+			if inf, _ := servingInformer.ForResource(resource); inf != nil {
+				inf.Informer().GetStore().Add(obj)
+			}
+			if inf, _ := cachingInformer.ForResource(resource); inf != nil {
+				inf.Informer().GetStore().Add(obj)
+			}
+		}
+	}
+
+	df := &v1alpha1.DependencyFactory{
+		DependencyFactory: commonDeps,
+		Serving: struct {
+			Client          servingclientset.Interface
+			InformerFactory servinginformers.SharedInformerFactory
+		}{
+			Client:          fakeServingClientset,
+			InformerFactory: servingInformer,
+		},
+
+		Caching: struct {
+			Client          cachingclientset.Interface
+			InformerFactory cachinginformers.SharedInformerFactory
+		}{
+			Client:          fakeCachingClientset,
+			InformerFactory: cachingInformer,
+		},
+	}
+
+	return df
+}


### PR DESCRIPTION
Initial PoC for completing #1942

FYI - a real PR will delete the old route reconciler

Looking for feedback on
  * [PhasedTests (TableTest v2)](https://github.com/dprotaso/serving/blob/route-reconciler/pkg/reconciler/testing/phase.go)
  * [The structure of phases and their tests](https://github.com/dprotaso/serving/tree/route-reconciler/pkg/reconciler/v1alpha1/routephase/phase)
  * [Alternative way to invoke a phase/scenario table row](https://github.com/dprotaso/serving/blob/route-reconciler/pkg/reconciler/v1alpha1/routephase/phase/virtual_service_test.go#L814). 
    * This helps with @mattmoor's goals in the PR #1941
  * [Use of injection inspired by controller-runtime](https://github.com/dprotaso/serving/blob/route-reconciler/pkg/reconciler/v1alpha1/inject/inject.go) and it's use [when initializing the phases for tests](https://github.com/dprotaso/serving/blob/route-reconciler/pkg/reconciler/v1alpha1/testing/initializer.go#L16)
* Thoughts about using a similar injection style for the purposes 'production' setup
   * This could end up being a `github.com/knative/pkg/controller` v2
   * Implementation [here](https://github.com/dprotaso/serving/blob/route-reconciler/pkg/reconciler/v1alpha1/initializer.go#L190)

Active Questions:
* What contract should we impose on phases
  * ie. should phases be allowed to 'read' from the resource's status (virtual service does this for the domain, I don't like that it does)
* This approach won't give you a full view of how all the phases combined affect the resource status.
  * For example reconciling a route's k8s service set's the `DomainInternal` other phases don't care or do anything about this property. 
* Should we be setting unrelated properties (ie. DomainInternal) in the fixtures that describe the route's steady state etc.. for phases that don't care about it. Does it matter?

/hold