### PR TITLE
Update build vendor to pick up nop-image

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -315,7 +315,7 @@
     "pkg/client/listers/build/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "2891231d4e47f80c9b72637da071468d7072cb62"
+  revision = "95e3199746a50f0a4e4ba62f1d8760e9a203b30e"
 
 [[projects]]
   digest = "1:826576a2dbea52eb350ed5c0fd3e53f1f24cd6bdcfaf89ff89239b8cd426cd0d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,8 +28,8 @@ required = [
 
 [[constraint]]
   name = "github.com/knative/build"
-  # HEAD as of 2018-09-20
-  revision = "2891231d4e47f80c9b72637da071468d7072cb62"
+  # HEAD as of 2018-09-21
+  revision = "95e3199746a50f0a4e4ba62f1d8760e9a203b30e"
 
 [[override]]
   name = "github.com/knative/pkg"

--- a/third_party/config/build/release.yaml
+++ b/third_party/config/build/release.yaml
@@ -224,7 +224,7 @@ metadata:
   name: creds-init
   namespace: knative-build
 spec:
-  image: gcr.io/knative-releases/github.com/knative/build/cmd/creds-init@sha256:f6594d53dab8c47a30110c054c64839d68b3215bb0591028e1c0ef291430eec7
+  image: gcr.io/knative-releases/github.com/knative/build/cmd/creds-init@sha256:9188a0c6d9fc55b17eea5b94e607ac7aaa28c45b3e696093dc74fa47d71300a8
 ---
 apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
@@ -232,7 +232,7 @@ metadata:
   name: git-init
   namespace: knative-build
 spec:
-  image: gcr.io/knative-releases/github.com/knative/build/cmd/git-init@sha256:940f2268bee5c1856da72aec475f8652e692601095918d87c8f4f4d90e76e987
+  image: gcr.io/knative-releases/github.com/knative/build/cmd/git-init@sha256:d248a2a92496f1bf510e285648fa7a235abf7fee06167976fbc0761298a65c15
 ---
 apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
@@ -241,6 +241,14 @@ metadata:
   namespace: knative-build
 spec:
   image: gcr.io/cloud-builders/gcs-fetcher
+---
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  name: nop
+  namespace: knative-build
+spec:
+  image: gcr.io/knative-releases/github.com/knative/build/cmd/nop@sha256:e9e55ff57f9effb6a012468cc8b50db2afff0ecec92b95ee00951a4a3fdea38e
 ---
 apiVersion: v1
 data:
@@ -296,10 +304,12 @@ spec:
         - -stderrthreshold
         - INFO
         - -creds-image
-        - gcr.io/knative-releases/github.com/knative/build/cmd/creds-init@sha256:f6594d53dab8c47a30110c054c64839d68b3215bb0591028e1c0ef291430eec7
+        - gcr.io/knative-releases/github.com/knative/build/cmd/creds-init@sha256:9188a0c6d9fc55b17eea5b94e607ac7aaa28c45b3e696093dc74fa47d71300a8
         - -git-image
-        - gcr.io/knative-releases/github.com/knative/build/cmd/git-init@sha256:940f2268bee5c1856da72aec475f8652e692601095918d87c8f4f4d90e76e987
-        image: gcr.io/knative-releases/github.com/knative/build/cmd/controller@sha256:1f5553d89d1ccc17d92421e57e7512c48c074adc63b9a0fa3f89bc745af1b196
+        - gcr.io/knative-releases/github.com/knative/build/cmd/git-init@sha256:d248a2a92496f1bf510e285648fa7a235abf7fee06167976fbc0761298a65c15
+        - -nop-image
+        - gcr.io/knative-releases/github.com/knative/build/cmd/nop@sha256:e9e55ff57f9effb6a012468cc8b50db2afff0ecec92b95ee00951a4a3fdea38e
+        image: gcr.io/knative-releases/github.com/knative/build/cmd/controller@sha256:e44facb78d3be5b4e76e7a48e5b071b6b5fddde5e288814ae8334ad7d3a68901
         name: build-controller
         volumeMounts:
         - mountPath: /etc/config-logging
@@ -328,7 +338,7 @@ spec:
         - -logtostderr
         - -stderrthreshold
         - INFO
-        image: gcr.io/knative-releases/github.com/knative/build/cmd/webhook@sha256:da3d38bd402a283328f13c3da2def7bee4b14c4d6bc162b8e16b3b00834c2c45
+        image: gcr.io/knative-releases/github.com/knative/build/cmd/webhook@sha256:ae85e09efead23b505319d139b0dd7d20af1701b704ddd17fc0901c106b801c6
         name: build-webhook
         volumeMounts:
         - mountPath: /etc/config-logging


### PR DESCRIPTION
`nop-image` ensures build components don't depend on outside images like `busybox`.

```
gsutil cp gs://knative-releases/build/latest/release.yaml third_party/config/build/release.yaml
```

**Release Note**
```release-note
NONE
```

/assign mattmoor