### PR TITLE
Use separate port for serving activator metrics (#2043)

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -135,8 +135,11 @@ func main() {
 	}
 
 	// Start the endpoint for Prometheus scraping
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", ah.ServeHTTP)
-	mux.Handle("/metrics", promExporter)
-	h2c.ListenAndServe(":8080", mux)
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promExporter)
+		http.ListenAndServe(":9090", mux)
+	}()
+
+	h2c.ListenAndServe(":8080", ah)
 }

--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -27,4 +27,8 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 8080
+  - name: metrics
+    protocol: TCP
+    port: 9090
+    targetPort: 9090
   type: NodePort

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -38,6 +38,8 @@ spec:
         ports:
         - name: activator-port
           containerPort: 8080
+        - name: metrics-port
+          containerPort: 9090
         args:
           # Disable glog writing into stderr. Our code doesn't use glog
           # and seeing k8s logs in addition to ours is not useful.

--- a/config/monitoring/200-common/300-prometheus/100-scrape-config.yaml
+++ b/config/monitoring/200-common/300-prometheus/100-scrape-config.yaml
@@ -63,7 +63,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_port_name]
         action: keep
-        regex: knative-serving;activator;activator-port
+        regex: knative-serving;activator;metrics-port
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         action: replace


### PR DESCRIPTION
Activator will continue serving data on port 8080, but will now serve
metrics on port 9090.

Fixes #2043