### PR TITLE
fix log format in activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -76,20 +76,20 @@ func main() {
 	}
 	servingClient, err := clientset.NewForConfig(clusterConfig)
 	if err != nil {
-		logger.Fatal("Error building serving clientset: %v", zap.Error(err))
+		logger.Fatal("Error building serving clientset", zap.Error(err))
 	}
 
 	logger.Info("Initializing OpenCensus Prometheus exporter.")
 	promExporter, err := prometheus.NewExporter(prometheus.Options{Namespace: "activator"})
 	if err != nil {
-		logger.Fatal("Failed to create the Prometheus exporter: %v", zap.Error(err))
+		logger.Fatal("Failed to create the Prometheus exporter", zap.Error(err))
 	}
 	view.RegisterExporter(promExporter)
 	view.SetReportingPeriod(10 * time.Second)
 
 	reporter, err := activator.NewStatsReporter()
 	if err != nil {
-		logger.Fatal("Failed to create stats reporter: %v", zap.Error(err))
+		logger.Fatal("Failed to create stats reporter", zap.Error(err))
 	}
 
 	a := activator.NewRevisionActivator(kubeClient, servingClient, logger, reporter)


### PR DESCRIPTION

## Proposed Changes

nit: When walking through the  code, I noticed some of the log in activator are not correctly formatted.

/assign @mattmoor 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
