### PR TITLE
Override no metrics with ServingState Active

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -200,17 +200,17 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 		}
 	}
 
+	// Do nothing when we have no data.
+	if stableData.observedPods() == 0 {
+		logger.Debug("No data to scale on.")
+		return 0, false
+	}
+
 	// Scale to zero if the last request is from too long ago
 	if !a.scaleToZeroThresholdExceeded && a.lastRequestTime.Add(config.ScaleToZeroIdlePeriod).Before(now) {
 		logger.Debug("Last request is older than scale to zero threshold. Scaling to 0.")
 		a.scaleToZeroThresholdExceeded = true
 		return 0, true
-	}
-
-	// Do nothing when we have no data.
-	if stableData.observedPods() == 0 {
-		logger.Debug("No data to scale on.")
-		return 0, false
 	}
 
 	// Log system totals

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -32,6 +32,23 @@ func TestAutoscaler_NoData_NoAutoscale(t *testing.T) {
 	a.expectScale(t, time.Now(), 0, false)
 }
 
+func TestAutoscaler_NoDataAtZero_NoAutoscale(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+	now := a.recordLinearSeries(
+		t,
+		time.Now(),
+		linearSeries{
+			startConcurrency: 0,
+			endConcurrency:   0,
+			durationSeconds:  300, // 5 minutes
+			podCount:         1,
+		})
+
+	a.expectScale(t, now, 0, true)
+	now = now.Add(2 * time.Minute)
+	a.expectScale(t, now, 0, false) // do nothing
+}
+
 func TestAutoscaler_StableMode_NoChange(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -166,7 +166,7 @@ func (m *MultiScaler) createScaler(ctx context.Context, kpa *kpa.PodAutoscaler) 
 	}
 
 	stopCh := make(chan struct{})
-	runner := &scalerRunner{scaler: scaler, latestScale: -1, stopCh: stopCh}
+	runner := &scalerRunner{scaler: scaler, latestScale: 1, stopCh: stopCh}
 
 	ticker := time.NewTicker(m.dynConfig.Current().TickInterval)
 

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -166,7 +166,7 @@ func (m *MultiScaler) createScaler(ctx context.Context, kpa *kpa.PodAutoscaler) 
 	}
 
 	stopCh := make(chan struct{})
-	runner := &scalerRunner{scaler: scaler, latestScale: 1, stopCh: stopCh}
+	runner := &scalerRunner{scaler: scaler, latestScale: -1, stopCh: stopCh}
 
 	ticker := time.NewTicker(m.dynConfig.Current().TickInterval)
 

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -146,6 +146,11 @@ func (rs *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredS
 		desiredScale = 0
 	}
 
+	// When ServingState=Active propagates to us and we are scaled to zero, scale up to 1.
+	if kpa.Spec.ServingState == v1alpha1.RevisionServingStateActive && desiredScale == 0 {
+		desiredScale = 1
+	}
+
 	currentScale := scl.Spec.Replicas
 	if desiredScale == currentScale {
 		return nil

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
@@ -121,7 +121,23 @@ func TestKPAScaler(t *testing.T) {
 			}}
 		},
 	}, {
-		label:         "does not scale up from zero",
+		label:         "scales up from zero with no metrics",
+		startState:    v1alpha1.RevisionServingStateActive,
+		startReplicas: 0,
+		scaleTo:       -1, // no metrics
+		wantState:     v1alpha1.RevisionServingStateActive,
+		wantReplicas:  1,
+		wantScaling:   true,
+	}, {
+		label:         "scales up from zero to desired one",
+		startState:    v1alpha1.RevisionServingStateActive,
+		startReplicas: 0,
+		scaleTo:       1,
+		wantState:     v1alpha1.RevisionServingStateActive,
+		wantReplicas:  1,
+		wantScaling:   true,
+	}, {
+		label:         "scales up from zero to desired high scale",
 		startState:    v1alpha1.RevisionServingStateActive,
 		startReplicas: 0,
 		scaleTo:       10,


### PR DESCRIPTION
Fixes #2080

## Proposed Changes

  * Override no-metrics signal from Autoscaler when getting an activation signal from the Activator (ServingState=Active via the Revision).
  * Do not recommend scale-to-zero when we have no metrics.

Root cause explanation: https://github.com/knative/serving/issues/2080#issuecomment-424505413

**Release Note**
```release-note
NONE
```
