### PR TITLE
move go init func to the top of the code

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -57,8 +57,8 @@ const (
 )
 
 var (
-	masterURL  string
-	kubeconfig string
+	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 )
 
 func main() {
@@ -80,7 +80,7 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
 		logger.Fatal("Error building kubeconfig.", zap.Error(err))
 	}
@@ -236,9 +236,4 @@ func configurationName(kpa *kpa.PodAutoscaler) string {
 		}
 	}
 	return ""
-}
-
-func init() {
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -60,8 +60,8 @@ const (
 )
 
 var (
-	masterURL  string
-	kubeconfig string
+	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 )
 
 func main() {
@@ -80,7 +80,7 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
 		logger.Fatalf("Error building kubeconfig: %v", err)
 	}
@@ -237,9 +237,4 @@ func main() {
 	}
 
 	<-stopCh
-}
-
-func init() {
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }


### PR DESCRIPTION
Fixes #2094 

## Proposed Changes

  * get serving params directly instead of addFlag in init func

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
