### PR TITLE
Move the use of `VerifyType` in tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -371,7 +371,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "f00975a13e4c7284aac5b8d01181590869472291"
+  revision = "8e471c3d74eda15fbb9405d076008e2cf2008548"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-10-01
-  revision = "f00975a13e4c7284aac5b8d01181590869472291"
+  # HEAD as of 2018-10-02
+  revision = "8e471c3d74eda15fbb9405d076008e2cf2008548"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/apis/autoscaling/v1alpha1/kpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_types.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -59,13 +58,6 @@ var _ apis.Immutable = (*PodAutoscaler)(nil)
 
 // Check that ConfigurationStatus may have its conditions managed.
 var _ duckv1alpha1.ConditionsAccessor = (*PodAutoscalerStatus)(nil)
-
-// Check that PodAutoscaler implements the Conditions duck type.
-var _ = duck.VerifyType(&PodAutoscaler{}, &duckv1alpha1.Conditions{})
-
-// Check that PodAutoscaler implements the Generation duck type.
-var emptyGen duckv1alpha1.Generation
-var _ = duck.VerifyType(&PodAutoscaler{}, &emptyGen)
 
 // PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).
 type PodAutoscalerSpec struct {

--- a/pkg/apis/autoscaling/v1alpha1/kpa_types_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_types_test.go
@@ -20,10 +20,24 @@ import (
 	"time"
 
 	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestPodAutoscalerImplements(t *testing.T) {
+	// Check that PodAutoscaler implements the Conditions duck type.
+	if err := duck.VerifyType(&PodAutoscaler{}, &duckv1alpha1.Conditions{}); err != nil {
+		t.Error(err)
+	}
+
+	// Check that PodAutoscaler implements the Generation duck type.
+	var emptyGen duckv1alpha1.Generation
+	if err := duck.VerifyType(&PodAutoscaler{}, &emptyGen); err != nil {
+		t.Error(err)
+	}
+}
 
 func TestGeneration(t *testing.T) {
 	r := PodAutoscaler{}

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
 )
@@ -58,13 +57,6 @@ var _ kmeta.OwnerRefable = (*Configuration)(nil)
 
 // Check that ConfigurationStatus may have its conditions managed.
 var _ duckv1alpha1.ConditionsAccessor = (*ConfigurationStatus)(nil)
-
-// Check that Configuration implements the Conditions duck type.
-var _ = duck.VerifyType(&Configuration{}, &duckv1alpha1.Conditions{})
-
-// Check that Configuration implements the Generation duck type.
-var emptyGenConfig duckv1alpha1.Generation
-var _ = duck.VerifyType(&Configuration{}, &emptyGenConfig)
 
 // ConfigurationSpec holds the desired state of the Configuration (from the client).
 type ConfigurationSpec struct {

--- a/pkg/apis/serving/v1alpha1/implements_test.go
+++ b/pkg/apis/serving/v1alpha1/implements_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Knative Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+)
+
+func TestTypesImplements(t *testing.T) {
+	var emptyGen duckv1alpha1.Generation
+	testCases := []struct {
+		instance interface{}
+		iface    duck.Implementable
+	}{
+		// Revision
+		{instance: &Revision{}, iface: &duckv1alpha1.Conditions{}},
+		{instance: &Revision{}, iface: &emptyGen},
+		// Configuration
+		{instance: &Configuration{}, iface: &duckv1alpha1.Conditions{}},
+		{instance: &Configuration{}, iface: &emptyGen},
+		// Service
+		{instance: &Service{}, iface: &duckv1alpha1.Conditions{}},
+		{instance: &Service{}, iface: &duckv1alpha1.LegacyTargetable{}},
+		{instance: &Service{}, iface: &duckv1alpha1.Targetable{}},
+		{instance: &Service{}, iface: &emptyGen},
+		// Route
+		{instance: &Route{}, iface: &duckv1alpha1.Conditions{}},
+		{instance: &Route{}, iface: &duckv1alpha1.LegacyTargetable{}},
+		{instance: &Route{}, iface: &duckv1alpha1.Targetable{}},
+		{instance: &Route{}, iface: &emptyGen},
+	}
+	for _, tc := range testCases {
+		if err := duck.VerifyType(tc.instance, tc.iface); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
 )
@@ -57,13 +56,6 @@ var _ apis.Immutable = (*Revision)(nil)
 
 // Check that RevisionStatus may have its conditions managed.
 var _ duckv1alpha1.ConditionsAccessor = (*RevisionStatus)(nil)
-
-// Check that Revision implements the Conditions duck type.
-var _ = duck.VerifyType(&Revision{}, &duckv1alpha1.Conditions{})
-
-// Check that Revision implements the Generation duck type.
-var emptyGenRev duckv1alpha1.Generation
-var _ = duck.VerifyType(&Revision{}, &emptyGenRev)
 
 // Check that we can create OwnerReferences to a Revision.
 var _ kmeta.OwnerRefable = (*Revision)(nil)

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
 )
@@ -55,17 +54,6 @@ var _ apis.Defaultable = (*Route)(nil)
 
 // Check that we can create OwnerReferences to a Route.
 var _ kmeta.OwnerRefable = (*Route)(nil)
-
-// Check that Route implements the Conditions duck type.
-var _ = duck.VerifyType(&Route{}, &duckv1alpha1.Conditions{})
-
-// Check that Route implements the [Legacy]Targetable duck type.
-var _ = duck.VerifyType(&Route{}, &duckv1alpha1.LegacyTargetable{})
-var _ = duck.VerifyType(&Route{}, &duckv1alpha1.Targetable{})
-
-// Check that Route implements the Generation duck type.
-var emptyGenRoute duckv1alpha1.Generation
-var _ = duck.VerifyType(&Route{}, &emptyGenRoute)
 
 // Check that RouteStatus may have its conditions managed.
 var _ duckv1alpha1.ConditionsAccessor = (*RouteStatus)(nil)

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
 )
@@ -61,17 +60,6 @@ var _ kmeta.OwnerRefable = (*Service)(nil)
 
 // Check that ServiceStatus may have its conditions managed.
 var _ duckv1alpha1.ConditionsAccessor = (*ServiceStatus)(nil)
-
-// Check that Service implements the Conditions duck type.
-var _ = duck.VerifyType(&Service{}, &duckv1alpha1.Conditions{})
-
-// Check that Route implements the [Legacy]Targetable duck type.
-var _ = duck.VerifyType(&Service{}, &duckv1alpha1.LegacyTargetable{})
-var _ = duck.VerifyType(&Service{}, &duckv1alpha1.Targetable{})
-
-// Check that Service implements the Generation duck type.
-var emptyGenService duckv1alpha1.Generation
-var _ = duck.VerifyType(&Service{}, &emptyGenService)
 
 // ServiceSpec represents the configuration for the Service object. Exactly one
 // of its members (other than Generation) must be specified. Services can either


### PR DESCRIPTION
This is part of knative/pkg#97 (not closing it as there will be PRs on `serving`, `eventing` and `build` to follow :wink:)

## Proposed Changes

Those calls to `duck.VerifyType` are done at runtime and thus could be
costly at program startup. Putting them under tests ensure we still
assert those types but during unit testing.

This bumps `knative/pkg` to today's master 

cc @dprotaso @mattmoor 
