### PR TITLE
Removed ConfigurationName  from Route.Status.TrafficTarget

### DIFF
--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -260,7 +260,7 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 		return r, err
 	}
 	logger.Info("VirtualService created, marking AllTrafficAssigned with traffic information.")
-	r.Status.Traffic = t.GetTrafficTargets()
+	r.Status.Traffic = t.GetRevisionTrafficTargets()
 	r.Status.MarkTrafficAssigned()
 	return r, nil
 }

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -202,7 +202,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00001",
 					Percent:           100,
 				}},
@@ -342,7 +341,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00001",
 					Percent:           100,
 				}},
@@ -393,7 +391,6 @@ func TestReconcile(t *testing.T) {
 						Status: corev1.ConditionTrue,
 					}},
 					Traffic: []v1alpha1.TrafficTarget{{
-						ConfigurationName: "config",
 						RevisionName:      "config-00001",
 						Percent:           100,
 					}},
@@ -442,7 +439,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00001",
 					Percent:           100,
 				}},
@@ -561,7 +557,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00002",
 					Percent:           100,
 				}},
@@ -657,7 +652,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00001",
 					Percent:           100,
 				}},
@@ -762,7 +756,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00001",
 					Percent:           100,
 				}},
@@ -809,7 +802,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
 					RevisionName:      "config-00001",
 					Percent:           100,
 				}},
@@ -994,7 +986,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "newconfig",
 					RevisionName:      "newconfig-00001",
 					Percent:           100,
 				}},
@@ -1232,11 +1223,9 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "blue",
 					RevisionName:      "blue-00001",
 					Percent:           50,
 				}, {
-					ConfigurationName: "green",
 					RevisionName:      "green-00001",
 					Percent:           50,
 				}},
@@ -1334,7 +1323,6 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "green",
 					RevisionName:      "green-00001",
 					Percent:           100,
 				}},

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -58,11 +58,11 @@ func BuildTrafficConfiguration(configLister listers.ConfigurationLister, revList
 	return builder.build()
 }
 
-// GetTrafficTargets returns a list of TrafficTarget.
-func (t *TrafficConfig) GetTrafficTargets() []v1alpha1.TrafficTarget {
+// GetRevisionTrafficTargets return a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.
+func (t *TrafficConfig) GetRevisionTrafficTargets() []v1alpha1.TrafficTarget {
 	results := []v1alpha1.TrafficTarget{}
 	for _, tt := range t.Targets[""] {
-		results = append(results, tt.TrafficTarget)
+		results = append(results, v1alpha1.TrafficTarget{ RevisionName:tt.RevisionName, Name:tt.Name, Percent:tt.Percent })
 	}
 	return results
 }

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -588,22 +588,19 @@ func TestRoundTripping(t *testing.T) {
 		ConfigurationName: niceConfig.Name,
 	}}
 	expected := []v1alpha1.TrafficTarget{{
-		ConfigurationName: goodConfig.Name,
 		RevisionName:      goodOldRev.Name,
 		Percent:           100,
 	}, {
 		Name:              "beta",
-		ConfigurationName: goodConfig.Name,
 		RevisionName:      goodNewRev.Name,
 	}, {
 		Name:              "alpha",
-		ConfigurationName: niceConfig.Name,
 		RevisionName:      niceNewRev.Name,
 	}}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc.GetTrafficTargets()); diff != "" {
-		fmt.Printf("%+v\n", tc.GetTrafficTargets())
+	} else if diff := cmp.Diff(expected, tc.GetRevisionTrafficTargets()); diff != "" {
+		fmt.Printf("%+v\n", tc.GetRevisionTrafficTargets())
 		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
 	}
 }


### PR DESCRIPTION
- Removed ConfigurationName while building TrafficTarget
- To aligned with Route spec

Fixes #2061

## Proposed Changes
 * Renamed GetTrafficTargets to GetRevisionTrafficTargets
 * GetRevisionTrafficTargets return a list of TrafficTarget flattened to the RevisionName
 * ConfigurationName cleared out.
  *
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
ConfigurationName is removed from Route.Status.TrafficTarget.
```
