### PR TITLE
Allow resources in Revision

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -174,6 +174,7 @@ spec:
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
+        resources: ...  # Optional
 
       # +optional concurrency strategy.  Defaults to Multi.
       # Deprecated in favor of ContainerConcurrency.
@@ -249,6 +250,7 @@ spec:
     - ...
     livenessProbe: ...  # Optional
     readinessProbe: ...  # Optional
+    resources: ...  # Optional
 
   # Name of the service account the code should run as.
   serviceAccountName: ...
@@ -368,6 +370,7 @@ spec:  # One of "runLatest" or "pinned"
         - ...
         livenessProbe: ...  # Optional
         readinessProbe: ...  # Optional
+        resources: ...  # Optional
       containerConcurrency: ... # Optional
       timeoutSeconds: ...
       serviceAccountName: ...  # Name of the service account the code should run as

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -62,7 +62,7 @@ func TestContainerValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrDisallowedFields("resources"),
+		want: nil,
 	}, {
 		name: "has ports",
 		c: corev1.Container{
@@ -136,11 +136,6 @@ func TestContainerValidation(t *testing.T) {
 		name: "has numerous problems",
 		c: corev1.Container{
 			Name: "foo",
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceName("cpu"): resource.MustParse("25m"),
-				},
-			},
 			Ports: []corev1.ContainerPort{{
 				Name:          "http",
 				ContainerPort: 8080,
@@ -151,7 +146,7 @@ func TestContainerValidation(t *testing.T) {
 			}},
 			Lifecycle: &corev1.Lifecycle{},
 		},
-		want: apis.ErrDisallowedFields("name", "resources", "ports", "volumeMounts", "lifecycle"),
+		want: apis.ErrDisallowedFields("name", "ports", "volumeMounts", "lifecycle"),
 	}}
 
 	for _, test := range tests {
@@ -576,6 +571,40 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old:  &notARevision{},
 		want: &apis.FieldError{Message: "The provided original was not a Revision"},
+	}, {
+		name: "bad (resources image change)",
+		new: &Revision{
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName("cpu"): resource.MustParse("50m"),
+						},
+					},
+				},
+				ConcurrencyModel: "Multi",
+			},
+		},
+		old: &Revision{
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName("cpu"): resource.MustParse("100m"),
+						},
+					},
+				},
+				ConcurrencyModel: "Multi",
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1alpha1.RevisionSpec}.Container.Resources.Requests["cpu"]:
+	-: resource.Quantity{i: resource.int64Amount{value: 100, scale: resource.Scale(-3)}, s: "100m", Format: resource.Format("DecimalSI")}
+	+: resource.Quantity{i: resource.int64Amount{value: 50, scale: resource.Scale(-3)}, s: "50m", Format: resource.Format("DecimalSI")}
+`,
+		},
 	}, {
 		name: "bad (container image change)",
 		new: &Revision{

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -794,6 +794,16 @@ func TestMakePodSpec(t *testing.T) {
 						Name:  "BAZ",
 						Value: "blah",
 					}},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("666Mi"),
+							corev1.ResourceCPU:    resource.MustParse("666m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("888Mi"),
+							corev1.ResourceCPU:    resource.MustParse("888m"),
+						},
+					},
 				},
 			},
 		},
@@ -826,7 +836,16 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "K_SERVICE",
 					Value: "",
 				}},
-				Resources:    userResources,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("666Mi"),
+						corev1.ResourceCPU:    resource.MustParse("666m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("888Mi"),
+						corev1.ResourceCPU:    resource.MustParse("888m"),
+					},
+				},
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
 				Lifecycle:    userLifecycle,
@@ -872,8 +891,12 @@ func TestMakePodSpec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			quantityComparer := cmp.Comparer(func(x, y resource.Quantity) bool {
+				return x.Cmp(y) == 0
+			})
+
 			got := makePodSpec(test.rev, test.lc, test.oc, test.ac, test.cc)
-			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, quantityComparer); diff != "" {
 				t.Errorf("makePodSpec (-want, +got) = %v", diff)
 			}
 		})
@@ -1174,6 +1197,89 @@ func TestMakeDeployment(t *testing.T) {
 			got := MakeDeployment(test.rev, test.lc, test.nc, test.oc, test.ac, test.cc)
 			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
 				t.Errorf("MakeDeployment (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestApplyDefaultResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		defaults corev1.ResourceRequirements
+		in       *corev1.ResourceRequirements
+		want     *corev1.ResourceRequirements
+	}{
+		{
+			name: "resources are empty",
+			defaults: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"resource": resource.MustParse("100m"),
+				},
+				Limits: corev1.ResourceList{
+					"resource": resource.MustParse("100m"),
+				},
+			},
+			in: &corev1.ResourceRequirements{},
+			want: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"resource": resource.MustParse("100m"),
+				},
+				Limits: corev1.ResourceList{
+					"resource": resource.MustParse("100m"),
+				},
+			},
+		},
+		{
+			name: "requests are not empty",
+			defaults: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"same":  resource.MustParse("100m"),
+					"other": resource.MustParse("200m"),
+				},
+			},
+			in: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"same": resource.MustParse("500m"),
+					"new":  resource.MustParse("300m"),
+				},
+			},
+			want: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"same":  resource.MustParse("500m"),
+					"new":   resource.MustParse("200m"),
+					"other": resource.MustParse("300m"),
+				},
+			},
+		},
+		{
+			name: "limits are not empty",
+			defaults: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"same":  resource.MustParse("100m"),
+					"other": resource.MustParse("200m"),
+				},
+			},
+			in: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"same": resource.MustParse("500m"),
+					"new":  resource.MustParse("300m"),
+				},
+			},
+			want: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"same":  resource.MustParse("500m"),
+					"new":   resource.MustParse("200m"),
+					"other": resource.MustParse("300m"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			applyDefaultResources(test.defaults, test.in)
+			if diff := cmp.Diff(test.want, test.in, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" { // Maybe this compare fails
+				t.Errorf("ApplyDefaultResources (-want, +got) = %v", diff)
 			}
 		})
 	}

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -27,6 +27,7 @@ import (
 type Options struct {
 	EnvVars              []corev1.EnvVar
 	ContainerConcurrency int
+	ContainerResources   corev1.ResourceRequirements
 }
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config

--- a/test/crd.go
+++ b/test/crd.go
@@ -100,7 +100,8 @@ func Configuration(namespace string, names ResourceNames, imagePath string, opti
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					Container: corev1.Container{
-						Image: imagePath,
+						Image:     imagePath,
+						Resources: options.ContainerResources,
 					},
 					ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
 				},

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -1,0 +1,147 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/spoof"
+	"github.com/knative/serving/test"
+	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCustomResourcesLimits(t *testing.T) {
+	clients = Setup(t)
+
+	//add test case specific name to its own logger
+	logger = logging.GetContextLogger("TestCustomResourcesLimits")
+
+	var imagePath = test.ImagePath("bloatingcow")
+
+	logger.Infof("Creating a new Route and Configuration")
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
+		},
+	}
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{ContainerResources: resources})
+	if err != nil {
+		t.Fatalf("Failed to create Route and Configuration: %v", err)
+	}
+	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
+	defer TearDown(clients, names, logger)
+
+	logger.Infof("When the Revision can have traffic routed to it, the Route is marked as Ready.")
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
+	}
+
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+	}
+	domain := route.Status.Domain
+
+	logger.Info("Waiting for pod list to contain desired resource configuration")
+	err = test.WaitForPodListState(
+		clients.KubeClient,
+		func(p *v1.PodList) (bool, error) {
+			for _, pod := range p.Items {
+				if strings.HasPrefix(pod.Name, names.Config) {
+					for _, c := range pod.Spec.Containers {
+						if c.Name == "user-container" {
+							want := corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("350Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("350Mi"),
+									corev1.ResourceCPU:    resource.MustParse("400m"), // Default value
+								},
+							}
+
+							if !equality.Semantic.DeepEqual(c.Resources, want) {
+								return false, fmt.Errorf("Invalid resource configuration for pod %v. Want: %+v, got: %+v.", pod.Name, want, c.Resources)
+							} else {
+								return true, nil
+							}
+						}
+					}
+				}
+			}
+			return false, nil
+		},
+		"WaitForAvailablePods")
+	if err != nil {
+		logger.Fatalf(`Waiting for Pod.List to have pods with custom resources: %v`, err)
+	}
+
+	logger.Info("pods are running with the desired configuration.")
+
+	pokeCowForMB := func(mb int) error {
+		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, domain, fmt.Sprintf("memory_in_mb=%d", mb))
+		if err != nil {
+			return err
+		}
+		want := "Moo!"
+		if want != strings.TrimSpace(string(response.Body)) {
+			return fmt.Errorf("The response '%s' is not equal to expected response '%s'.", string(response.Body), want)
+		}
+		return nil
+	}
+
+	logger.Info("Querying the application to see if the memory limits are enforced.")
+	if err := pokeCowForMB(100); err != nil {
+		t.Fatalf("Didn't get a response from bloating cow with %d MBs of Memory: %v", 100, err)
+	}
+
+	if err := pokeCowForMB(200); err != nil {
+		t.Fatalf("Didn't get a response from bloating cow with %d MBs of Memory: %v", 200, err)
+	}
+
+	if err := pokeCowForMB(500); err == nil {
+		t.Fatalf("We shouldn't have got a response from bloating cow with %d MBs of Memory: %v", 500, err)
+	}
+}
+
+func sendPostRequest(resolvableDomain bool, domain string, query string) (*spoof.Response, error) {
+	logger.Infof("The domain of request is %s and its query is %s", domain, query)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, resolvableDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s?%s", domain, query), nil)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}

--- a/test/test_images/bloatingcow/README.md
+++ b/test/test_images/bloatingcow/README.md
@@ -1,0 +1,13 @@
+# Bloating cow test image
+
+This directory contains the test image used in the resources e2e test.
+
+The image contains a simple Go webserver, `bloatingcow.go`, that will, by default, listen on port `8080` and expose a service at `/`.
+
+When called, the server emits a "Moo!" message, if query parameter `memory_in_mb` is specified, the app will allocated so many Mbs of memory. 
+
+## Building
+
+For details about building and adding new images, see the [section about test
+images](/test/README.md#test-images).
+

--- a/test/test_images/bloatingcow/bloatingcow.go
+++ b/test/test_images/bloatingcow/bloatingcow.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+func bloat(mb int) {
+	if mb == 0 {
+		return
+	}
+	fmt.Printf("Bloat %v Mb of memory.\n", mb)
+
+	b := make([]byte, mb*1024*1024)
+	b[0] = 1
+	b[len(b)-1] = 1
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	memoryInMB := r.URL.Query().Get("memory_in_mb")
+	if memoryInMB != "" {
+		if mb, err := strconv.Atoi(memoryInMB); err != nil {
+			fmt.Fprintf(w, "cannot convert %s to int", memoryInMB)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		} else {
+			bloat(mb)
+		}
+	}
+
+	log.Print("Moo!")
+	fmt.Fprintln(w, "Moo!")
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Bloating cow app started.")
+
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
[fixes knative/serving#2099]

## Proposed Changes

* Allow `resources` defined by the user
* If `resources` is empty, configure the user-container with the recommended values