### PR TITLE
Request Prow to automatically lint go code in PRs

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,3 +1,9 @@
+<!--
+Request Prow to automatically lint any go code in this PR:
+
+/lint
+-->
+
 Fixes #
 
 ## Proposed Changes


### PR DESCRIPTION
Sneak `/lint` into the PR template, so hopefully this will trigger the lint job automatically for most PRs we get. :)