### PR TITLE
Adjust the concurrency measurement strategy to measure concurrent utilization.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -80,8 +80,7 @@ var (
 
 	health *healthServer = &healthServer{alive: true}
 
-	concurrencyQuantumOfTime = flag.Duration("concurrencyQuantumOfTime", 100*time.Millisecond, "")
-	containerConcurrency     = flag.Int("containerConcurrency", 0, "")
+	containerConcurrency = flag.Int("containerConcurrency", 0, "")
 )
 
 func initEnv() {

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -55,13 +55,6 @@ data:
   # observed pods.
   max-scale-up-rate: "10"
 
-  # Concurrency quantum of time is the minimum time is the quantum in
-  # which concurrency will be measured by the queue-proxy.
-  # The maximum concurrency in each of the "buckets" (of the duration
-  # defined here) is taken and the average over all buckets is
-  # reported.
-  concurrency-quantum-of-time: "100ms"
-
   # Scale to zero feature flag
   enable-scale-to-zero: "true"
 

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -43,11 +43,10 @@ type Config struct {
 	ContainerConcurrencyTargetDefault    float64
 
 	// General autoscaler algorithm configuration.
-	MaxScaleUpRate           float64
-	StableWindow             time.Duration
-	PanicWindow              time.Duration
-	TickInterval             time.Duration
-	ConcurrencyQuantumOfTime time.Duration
+	MaxScaleUpRate float64
+	StableWindow   time.Duration
+	PanicWindow    time.Duration
+	TickInterval   time.Duration
 
 	ScaleToZeroThreshold   time.Duration
 	ScaleToZeroGracePeriod time.Duration
@@ -137,9 +136,6 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		field:        &lc.ScaleToZeroGracePeriod,
 		optional:     true,
 		defaultValue: 2 * time.Minute,
-	}, {
-		key:   "concurrency-quantum-of-time",
-		field: &lc.ConcurrencyQuantumOfTime,
 	}, {
 		key:   "tick-interval",
 		field: &lc.TickInterval,

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -78,7 +78,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
@@ -90,7 +89,6 @@ func TestNewConfig(t *testing.T) {
 			ScaleToZeroThreshold:                 10 * time.Minute,
 			ScaleToZeroGracePeriod:               2 * time.Minute,
 			ScaleToZeroIdlePeriod:                8 * time.Minute,
-			ConcurrencyQuantumOfTime:             100 * time.Millisecond,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -104,7 +102,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
@@ -118,7 +115,6 @@ func TestNewConfig(t *testing.T) {
 			ScaleToZeroThreshold:                 10 * time.Minute,
 			ScaleToZeroGracePeriod:               2 * time.Minute,
 			ScaleToZeroIdlePeriod:                8 * time.Minute,
-			ConcurrencyQuantumOfTime:             100 * time.Millisecond,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -132,7 +128,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
@@ -146,7 +141,6 @@ func TestNewConfig(t *testing.T) {
 			ScaleToZeroThreshold:                 10 * time.Minute,
 			ScaleToZeroGracePeriod:               2 * time.Minute,
 			ScaleToZeroIdlePeriod:                8 * time.Minute,
-			ConcurrencyQuantumOfTime:             100 * time.Millisecond,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -160,7 +154,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
@@ -172,7 +165,6 @@ func TestNewConfig(t *testing.T) {
 			ScaleToZeroThreshold:                 10 * time.Minute,
 			ScaleToZeroGracePeriod:               2 * time.Minute,
 			ScaleToZeroIdlePeriod:                8 * time.Minute,
-			ConcurrencyQuantumOfTime:             100 * time.Millisecond,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -187,7 +179,6 @@ func TestNewConfig(t *testing.T) {
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "60s",
 			"scale-to-zero-grace-period":              "30s",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
@@ -199,7 +190,6 @@ func TestNewConfig(t *testing.T) {
 			ScaleToZeroThreshold:                 60 * time.Second,
 			ScaleToZeroGracePeriod:               30 * time.Second,
 			ScaleToZeroIdlePeriod:                30 * time.Second,
-			ConcurrencyQuantumOfTime:             100 * time.Millisecond,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -210,7 +200,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		wantErr: true,
@@ -222,7 +211,6 @@ func TestNewConfig(t *testing.T) {
 			"container-concurrency-target-default":    "10.0",
 			"stable-window":                           "5m",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		wantErr: true,
@@ -235,7 +223,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		wantErr: true,
@@ -248,7 +235,6 @@ func TestNewConfig(t *testing.T) {
 			"stable-window":                           "not a duration",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 		wantErr: true,

--- a/pkg/autoscaler/dynamic_config_test.go
+++ b/pkg/autoscaler/dynamic_config_test.go
@@ -32,7 +32,6 @@ var configMap = map[string]string{"max-scale-up-rate": "1",
 	"panic-window":                            "5s",
 	"scale-to-zero-threshold":                 "60s", // min
 	"scale-to-zero-grace-period":              "30s", // min
-	"concurrency-quantum-of-time":             "7s",
 	"tick-interval":                           "8s"}
 
 func TestNewDynamicConfigFromMap(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
@@ -61,7 +61,6 @@ func newConfigWatcher() configmap.Watcher {
 				"panic-window":                            "10s",
 				"scale-to-zero-threshold":                 "10m",
 				"scale-to-zero-grace-period":              gracePeriod.String(),
-				"concurrency-quantum-of-time":             "100ms",
 				"tick-interval":                           "2s",
 			},
 		})

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -216,7 +216,6 @@ func newTestController(t *testing.T, stopCh <-chan struct{}, servingObjects ...r
 				"stable-window":                           "5m",
 				"panic-window":                            "10s",
 				"scale-to-zero-threshold":                 "10m",
-				"concurrency-quantum-of-time":             "100ms",
 				"tick-interval":                           "2s",
 			}},
 	}

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -95,7 +95,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+				Args: []string{"-containerConcurrency=1"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -179,7 +179,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+				Args: []string{"-containerConcurrency=1"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -272,7 +272,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=0"},
+				Args: []string{"-containerConcurrency=0"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -363,7 +363,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=0"},
+				Args: []string{"-containerConcurrency=0"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -456,7 +456,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=0"},
+				Args: []string{"-containerConcurrency=0"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -545,7 +545,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=0"},
+				Args: []string{"-containerConcurrency=0"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -625,7 +625,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+				Args: []string{"-containerConcurrency=1"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace
@@ -748,7 +748,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+				Args: []string{"-containerConcurrency=1"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -92,7 +92,6 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 		Lifecycle:      queueLifecycle,
 		ReadinessProbe: queueReadinessProbe,
 		Args: []string{
-			fmt.Sprintf("-concurrencyQuantumOfTime=%v", autoscalerConfig.ConcurrencyQuantumOfTime),
 			fmt.Sprintf("-containerConcurrency=%v", rev.Spec.ContainerConcurrency),
 		},
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -65,7 +65,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
-			Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+			Args: []string{"-containerConcurrency=1"},
 			Env: []corev1.EnvVar{{
 				Name:  "SERVING_NAMESPACE",
 				Value: "foo", // matches namespace
@@ -120,7 +120,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
-			Args:  []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+			Args:  []string{"-containerConcurrency=1"},
 			Env: []corev1.EnvVar{{
 				Name:  "SERVING_NAMESPACE",
 				Value: "foo", // matches namespace
@@ -179,7 +179,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
-			Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=0"},
+			Args: []string{"-containerConcurrency=0"},
 			Env: []corev1.EnvVar{{
 				Name:  "SERVING_NAMESPACE",
 				Value: "baz", // matches namespace
@@ -236,7 +236,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
-			Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=0"},
+			Args: []string{"-containerConcurrency=0"},
 			Env: []corev1.EnvVar{{
 				Name:  "SERVING_NAMESPACE",
 				Value: "log", // matches namespace
@@ -288,7 +288,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
-			Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=10"},
+			Args: []string{"-containerConcurrency=10"},
 			Env: []corev1.EnvVar{{
 				Name:  "SERVING_NAMESPACE",
 				Value: "foo", // matches namespace

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -209,7 +209,6 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controll
 			"stable-window":                           "5m",
 			"panic-window":                            "10s",
 			"scale-to-zero-threshold":                 "10m",
-			"concurrency-quantum-of-time":             "100ms",
 			"tick-interval":                           "2s",
 		},
 	},


### PR DESCRIPTION
Fixes #2016

## Proposed Changes

  * Adjust the concurrency measurement strategy to measure concurrent utilization. For a detailed writeup of what that means, see #2016. In a nutshell, the new method takes into account how much the container is actually in use vs. relying on a fixed concurrencyQuantum to check.
  * Remove concurrencyQuantum configuration.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Stabilized autoscaling algorithm for short-lived requests.
```
