### PR TITLE
Do not modify config-map in autoscale test.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -124,11 +124,10 @@ func setup(t *testing.T, logger *logging.BaseLogger) *test.Clients {
 	if err != nil {
 		t.Fatalf("Unable to get autoscaler config map: %v", err)
 	}
-	threshold, err := time.ParseDuration(configMap.Data["scale-to-zero-threshold"])
+	scaleToZeroThreshold, err = time.ParseDuration(configMap.Data["scale-to-zero-threshold"])
 	if err != nil {
 		t.Fatalf("Unable to parse scale-to-zero-threshold as duration: %v", err)
 	}
-	scaleToZeroThreshold = threshold
 
 	return clients
 }

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -219,9 +219,6 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	logger.Infof(`The autoscaler successfully scales down when devoid of
 		    traffic.`)
 
-	logger.Infof(`Manually setting ScaleToZeroThreshold to '1m' to facilitate
-		    faster testing.`)
-
 	logger.Infof("Waiting for scale to zero")
 	err = test.WaitForDeploymentState(
 		clients.KubeClient,

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -22,6 +22,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	pkgTest "github.com/knative/pkg/test"
 	"go.opencensus.io/trace"
@@ -35,7 +36,7 @@ import (
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForDeploymentState(client *pkgTest.KubeClient, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string) error {
+func WaitForDeploymentState(client *pkgTest.KubeClient, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string, timeout time.Duration) error {
 	d := client.Kube.ExtensionsV1beta1().Deployments(ServingNamespace)
 	metricName := fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)


### PR DESCRIPTION
This is a step in removing the cluster-level flakiness that the autoscale test seems to introduce.  One theory is that reducing the scale-to-zero-threshold is causing the blue-green test to scale down and flake (either not becoming ready or getting the wrong split from the activator).

## Proposed Changes

  * Remove config map modification from the autoscale test.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
