### PR TITLE
Set a minimal queue-depth of 10 in queue-proxy.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -244,9 +244,14 @@ func main() {
 
 	// If containerConcurrency == 0 then concurrency is unlimited.
 	if *containerConcurrency > 0 {
-		// We set the queue depth to be equal to the container concurrency.
-		breaker = queue.NewBreaker(int32(*containerConcurrency), int32(*containerConcurrency))
-		logger.Infof("Queue container is starting with queueDepth and containerConcurrency: %s", *containerConcurrency)
+		// We set the queue depth to be equal to the container concurrency but at least 10 to
+		// allow the autoscaler to get a strong enough signal.
+		queueDepth := *containerConcurrency
+		if queueDepth < 10 {
+			queueDepth = 10
+		}
+		breaker = queue.NewBreaker(int32(queueDepth), int32(*containerConcurrency))
+		logger.Infof("Queue container is starting with queueDepth: %d, containerConcurrency: %d", queueDepth, *containerConcurrency)
 	}
 
 	config, err := rest.InClusterConfig()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2141 

Set a minimal queue-depth of 10 in queue-proxy to give the autoscaler a strong enough scaling signal, even for low containerConcurrency values.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
