### PR TITLE
BuildRef was missing a JSON annotation.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -172,7 +172,7 @@ type RevisionSpec struct {
 	// BuildRef holds the reference to the build (if there is one) responsible
 	// for producing the container image for this Revision. Otherwise, nil
 	// +optional
-	BuildRef *corev1.ObjectReference
+	BuildRef *corev1.ObjectReference `json:"buildRef,omitempty"`
 
 	// Container defines the unit of execution for this Revision.
 	// In the context of a Revision, we disallow a number of the fields of


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
