### PR TITLE
Reduce E2E scaleup time from 60 to 20 seconds.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -250,7 +250,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 
 	logger.Infof("Scaled down.")
 	logger.Infof("Sending traffic again to verify deployment scales back up")
-	err = generateTraffic(clients, logger, 20, 60*time.Second, domain)
+	err = generateTraffic(clients, logger, 20, 20*time.Second, domain)
 	if err != nil {
 		t.Fatalf("Error during final scale up: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes

  * Reduce load time for the second scaleup in the autoscale UpDownUp E2E test.

The UpDownUp test needed to load the revision for 60 seconds after scale-to-zero because sometimes there was a deadzone after scaledown (#2103).  That's been fixed with #2109 so we should only need the same 20 seconds we need for the first scaleup.

**Release Note**
```release-note
NONE
```
