### PR TITLE
This breaks up our release monolith.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,12 +26,11 @@ readonly SERVING_RELEASE_GCR
 # We publish our own istio.yaml, so users don't need to use helm
 readonly ISTIO_YAML=./third_party/istio-1.0.2/istio.yaml
 readonly ISTIO_LEAN_YAML=./third_party/istio-1.0.2/istio-lean.yaml
-# Local generated yaml file.
-readonly OUTPUT_YAML=release.yaml
-# Local generated lite yaml file.
-readonly LITE_YAML=release-lite.yaml
-# Local generated yaml file without the logging and monitoring components.
-readonly NO_MON_YAML=release-no-mon.yaml
+
+readonly BUILD_YAML=build.yaml
+readonly SERVING_YAML=serving.yaml
+readonly MONITORING_YAML=monitoring.yaml
+readonly MONITORING_LEAN_YAML=monitoring-lean.yaml
 
 # Script entry point
 
@@ -45,7 +44,7 @@ run_validation_tests ./test/presubmit-tests.sh
 banner "Building the release"
 
 # Set the repository
-export KO_DOCKER_REPO=${SERVING_RELEASE_GCR}
+export KO_DOCKER_REPO="${SERVING_RELEASE_GCR}"
 # Build should not try to deploy anything, use a bogus value for cluster.
 export K8S_CLUSTER_OVERRIDE=CLUSTER_NOT_SET
 export K8S_USER_OVERRIDE=USER_NOT_SET
@@ -59,25 +58,20 @@ fi
 # Build the release
 
 echo "Copying Build release"
-cp ${REPO_ROOT_DIR}/third_party/config/build/release.yaml ${OUTPUT_YAML}
-echo "---" >> ${OUTPUT_YAML}
+cp "${REPO_ROOT_DIR}/third_party/config/build/release.yaml" "${BUILD_YAML}"
 
 echo "Building Knative Serving"
-ko resolve ${KO_FLAGS} -f config/ >> ${OUTPUT_YAML}
-echo "---" >> ${OUTPUT_YAML}
+ko resolve ${KO_FLAGS} -f config/ >> "${SERVING_YAML}"
 
 echo "Building Monitoring & Logging"
-# Make a copy for the lite version
-cp ${OUTPUT_YAML} ${LITE_YAML}
-# Make a copy for the no monitoring version
-cp ${OUTPUT_YAML} ${NO_MON_YAML}
 # Use ko to concatenate them all together.
 ko resolve ${KO_FLAGS} -R -f config/monitoring/100-common \
     -f config/monitoring/150-elasticsearch \
     -f third_party/config/monitoring/common \
     -f third_party/config/monitoring/elasticsearch \
     -f config/monitoring/200-common \
-    -f config/monitoring/200-common/100-istio.yaml >> ${OUTPUT_YAML}
+    -f config/monitoring/200-common/100-istio.yaml >> "${MONITORING_YAML}"
+
 # Use ko to do the same for the lite version.
 ko resolve ${KO_FLAGS} -R -f config/monitoring/100-common \
     -f third_party/config/monitoring/common/istio \
@@ -91,9 +85,40 @@ ko resolve ${KO_FLAGS} -R -f config/monitoring/100-common \
     -f config/monitoring/200-common/100-istio.yaml \
     -f config/monitoring/200-common/200-prometheus-exporter \
     -f config/monitoring/200-common/300-prometheus \
-    -f config/monitoring/200-common/100-istio.yaml >> ${LITE_YAML}
+    -f config/monitoring/200-common/100-istio.yaml >> "${MONITORING_LEAN_YAML}"
 
-tag_images_in_yaml ${OUTPUT_YAML} ${SERVING_RELEASE_GCR} ${TAG}
+
+echo "Building Release Bundles."
+
+# These are the "bundled" yaml files that we publish.
+# Local generated yaml file.
+readonly RELEASE_YAML=release.yaml
+# Local generated lite yaml file.
+readonly LITE_YAML=release-lite.yaml
+# Local generated yaml file without the logging and monitoring components.
+readonly NO_MON_YAML=release-no-mon.yaml
+
+# NO_MON is just build and serving
+cat "${BUILD_YAML}" > "${NO_MON_YAML}"
+echo "---" >> "${NO_MON_YAML}"
+cat "${SERVING_YAML}" >> "${NO_MON_YAML}"
+echo "---" >> "${NO_MON_YAML}"
+
+# LITE is NO_MON plus "lean" monitoring
+cat "${NO_MON_YAML}" > "${LITE_YAML}"
+echo "---" >> "${LITE_YAML}"
+cat "${MONITORING_LEAN_YAML}" >> "${LITE_YAML}"
+echo "---" >> "${LITE_YAML}"
+
+# RELEASE is NO_MON plus full monitoring
+cat "${NO_MON_YAML}" > "${RELEASE_YAML}"
+echo "---" >> "${RELEASE_YAML}"
+cat "${MONITORING_YAML}" >> "${RELEASE_YAML}"
+echo "---" >> "${RELEASE_YAML}"
+
+echo "Tagging referenced images with ${TAG}."
+
+tag_images_in_yaml "${RELEASE_YAML}" "${SERVING_RELEASE_GCR}" "${TAG}"
 
 echo "New release built successfully"
 
@@ -103,9 +128,9 @@ fi
 
 # Publish the release
 
-for yaml in ${OUTPUT_YAML} ${LITE_YAML} ${NO_MON_YAML} ${ISTIO_YAML} ${ISTIO_LEAN_YAML}; do
+for yaml in "${RELEASE_YAML}" "${LITE_YAML}" "${NO_MON_YAML}" "${SERVING_YAML}" "${BUILD_YAML}" "${MONITORING_YAML}" "${MONITORING_LEAN_YAML}" "${ISTIO_YAML}" "${ISTIO_LEAN_YAML}"; do
   echo "Publishing ${yaml}"
-  publish_yaml ${yaml} ${SERVING_RELEASE_GCS} ${TAG}
+  publish_yaml "${yaml}" "${SERVING_RELEASE_GCS}" "${TAG}"
 done
 
 echo "New release published successfully"


### PR DESCRIPTION
The release now publishes the following units in addition to the "bundles":
 * `build.yaml` (just build)
 * `serving.yaml` (just serving)
 * `monitoring-lean.yaml` (the "lite" portions of monitoring)
 * `monitoring.yaml` (all monitoring stuff)
 * `istio-lean.yaml` (just istio ingress functionality)
 * `istio.yaml` (the full service mesh)

This preserves the 3 existing "bundles" that we produce, but constructs them in terms of the above.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

cc @ImJasonH @scothis @jessiezcc 