### PR TITLE
Label Configurations with Routes via a separate Reconciler 

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,6 +45,7 @@ import (
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/labeler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/service"
@@ -164,6 +165,12 @@ func main() {
 			revisionInformer,
 			coreServiceInformer,
 			virtualServiceInformer,
+		),
+		labeler.NewController(
+			opt,
+			routeInformer,
+			configurationInformer,
+			revisionInformer,
 		),
 		service.NewController(
 			opt,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -166,7 +166,7 @@ func main() {
 			coreServiceInformer,
 			virtualServiceInformer,
 		),
-		labeler.NewController(
+		labeler.NewRouteToConfigurationController(
 			opt,
 			routeInformer,
 			configurationInformer,

--- a/pkg/reconciler/v1alpha1/labeler/doc.go
+++ b/pkg/reconciler/v1alpha1/labeler/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package labeler holds the logic that applies Route labels to
+// Configurations to implement knative/serving#226.  We run this
+// as a separate reconciliation because we may choose to relax the
+// 1:N relationship between Route:Configuration in the future.
+package labeler

--- a/pkg/reconciler/v1alpha1/labeler/labeler.go
+++ b/pkg/reconciler/v1alpha1/labeler/labeler.go
@@ -49,8 +49,9 @@ type Reconciler struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*Reconciler)(nil)
 
-// NewController wraps a new instance of this Reconciler in a controller.
-func NewController(
+// NewRouteToConfigurationController wraps a new instance of the labeler that labels
+// Configurations with Routes in a controller.
+func NewRouteToConfigurationController(
 	opt reconciler.Options,
 	routeInformer servinginformers.RouteInformer,
 	configInformer servinginformers.ConfigurationInformer,

--- a/pkg/reconciler/v1alpha1/labeler/labeler.go
+++ b/pkg/reconciler/v1alpha1/labeler/labeler.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labeler
+
+import (
+	"context"
+	"time"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/logging"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/knative/pkg/tracker"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+)
+
+const (
+	controllerAgentName = "labeler-controller"
+)
+
+// Reconciler implements controller.Reconciler for Route resources.
+type Reconciler struct {
+	*reconciler.Base
+
+	// Listers index properties about resources
+	routeLister         listers.RouteLister
+	configurationLister listers.ConfigurationLister
+	revisionLister      listers.RevisionLister
+	tracker             tracker.Interface
+}
+
+// Check that our Reconciler implements controller.Reconciler
+var _ controller.Reconciler = (*Reconciler)(nil)
+
+// NewController wraps a new instance of this Reconciler in a controller.
+func NewController(
+	opt reconciler.Options,
+	routeInformer servinginformers.RouteInformer,
+	configInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
+) *controller.Impl {
+
+	c := &Reconciler{
+		Base:                reconciler.NewBase(opt, controllerAgentName),
+		routeLister:         routeInformer.Lister(),
+		configurationLister: configInformer.Lister(),
+		revisionLister:      revisionInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, "Labels")
+
+	c.Logger.Info("Setting up event handlers")
+	routeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+		DeleteFunc: impl.Enqueue,
+	})
+
+	// TODO(mattmoor): We should have a ResyncPeriod in reconciler.Options
+	c.tracker = tracker.New(impl.EnqueueKey, 30*time.Minute)
+	configInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.tracker.OnChanged,
+		UpdateFunc: controller.PassNew(c.tracker.OnChanged),
+	})
+	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.tracker.OnChanged,
+		UpdateFunc: controller.PassNew(c.tracker.OnChanged),
+	})
+
+	return impl
+}
+
+// Reconcile compares the actual state with the desired, and attempts to
+// converge the two. In this case, it attempts to label all Configurations
+// with the Routes that direct traffic to their Revisions.
+func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
+	// Convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		c.Logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+	logger := logging.FromContext(ctx)
+
+	// Get the Route resource with this namespace/name
+	route, err := c.routeLister.Routes(namespace).Get(name)
+	if apierrs.IsNotFound(err) {
+		logger.Infof("Clearing labels for deleted Route: %q", key)
+		return c.deleteLabelForOutsideOfGivenConfigurations(
+			ctx, namespace, name, map[string]struct{}{},
+		)
+	} else if err != nil {
+		return err
+	}
+
+	logger.Infof("Time to sync the labels: %#v", route)
+	return c.syncLabels(ctx, route)
+}

--- a/pkg/reconciler/v1alpha1/labeler/labeler_test.go
+++ b/pkg/reconciler/v1alpha1/labeler/labeler_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labeler
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions"
+	"github.com/knative/serving/pkg/reconciler"
+	rtesting "github.com/knative/serving/pkg/reconciler/testing"
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+)
+
+// This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
+func TestReconcile(t *testing.T) {
+	table := TableTest{{
+		Name: "bad workqueue key",
+		// Make sure Reconcile handles bad keys.
+		Key: "too/many/parts",
+	}, {
+		Name: "key not found",
+		// Make sure Reconcile handles good keys that don't exist.
+		Key: "foo/not-found",
+	}, {
+		Name: "label runLatest configuration",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "first-reconcile", "the-config"),
+			simpleConfig("default", "the-config"),
+			simpleRevision("default", "the-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("default", "the-config", "serving.knative.dev/route", "first-reconcile", "v1"),
+		},
+		Key: "default/first-reconcile",
+	}, {
+		Name: "steady state",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "steady-state", "the-config"),
+			routeLabel(simpleConfig("default", "the-config"), "steady-state"),
+			simpleRevision("default", "the-config"),
+		},
+		Key: "default/steady-state",
+	}, {
+		Name: "failure adding label",
+		// Induce a failure during patching
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("patch", "configurations"),
+		},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "add-label-failure", "the-config"),
+			simpleConfig("default", "the-config"),
+			simpleRevision("default", "the-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("default", "the-config", "serving.knative.dev/route", "add-label-failure", "v1"),
+		},
+		Key: "default/add-label-failure",
+	}, {
+		Name:    "label config with incorrect label",
+		WantErr: true,
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "the-route", "the-config"),
+			routeLabel(simpleConfig("default", "the-config"), "another-route"),
+			simpleRevision("default", "the-config"),
+		},
+		Key: "default/the-route",
+	}, {
+		Name: "change configurations",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "config-change", "new-config"),
+			routeLabel(simpleConfig("default", "old-config"), "config-change"),
+			simpleConfig("default", "new-config"),
+			simpleRevision("default", "new-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchRemoveLabel("default", "old-config", "serving.knative.dev/route", "v1"),
+			patchAddLabel("default", "new-config", "serving.knative.dev/route", "config-change", "v1"),
+		},
+		Key: "default/config-change",
+	}, {
+		Name: "delete route",
+		Objects: []runtime.Object{
+			routeLabel(simpleConfig("default", "the-config"), "delete-route"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchRemoveLabel("default", "the-config", "serving.knative.dev/route", "v1"),
+		},
+		Key: "default/delete-route",
+	}, {
+		Name: "failure while removing an annotation should return an error",
+		// Induce a failure during patching
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("patch", "configurations"),
+		},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "delete-label-failure", "new-config"),
+			routeLabel(simpleConfig("default", "old-config"), "delete-label-failure"),
+			routeLabel(simpleConfig("default", "new-config"), "delete-label-failure"),
+			simpleRevision("default", "new-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchRemoveLabel("default", "old-config", "serving.knative.dev/route", "v1"),
+		},
+		Key: "default/delete-label-failure",
+	}}
+
+	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {
+		return &Reconciler{
+			Base:                reconciler.NewBase(opt, controllerAgentName),
+			routeLister:         listers.GetRouteLister(),
+			configurationLister: listers.GetConfigurationLister(),
+			revisionLister:      listers.GetRevisionLister(),
+			tracker:             &rtesting.NullTracker{},
+		}
+	}))
+}
+
+func routeWithTraffic(namespace, name string, traffic ...v1alpha1.TrafficTarget) *v1alpha1.Route {
+	return &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: v1alpha1.RouteStatus{
+			Traffic: traffic,
+		},
+	}
+}
+
+func simpleRunLatest(namespace, name, config string) *v1alpha1.Route {
+	return routeWithTraffic(namespace, name, v1alpha1.TrafficTarget{
+		RevisionName: config + "-00001",
+		Percent:      100,
+	})
+}
+
+func routeLabel(cfg *v1alpha1.Configuration, route string) *v1alpha1.Configuration {
+	if cfg.Labels == nil {
+		cfg.Labels = make(map[string]string)
+	}
+	cfg.Labels["serving.knative.dev/route"] = route
+	return cfg
+}
+
+func simpleConfig(namespace, name string) *v1alpha1.Configuration {
+	cfg := &v1alpha1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			ResourceVersion: "v1",
+		},
+	}
+	cfg.Status.InitializeConditions()
+	cfg.Status.SetLatestCreatedRevisionName(name + "-00001")
+	cfg.Status.SetLatestReadyRevisionName(name + "-00001")
+	return cfg
+}
+
+func simpleRevision(namespace, name string) *v1alpha1.Revision {
+	cfg := simpleConfig(namespace, name)
+	return &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            cfg.Status.LatestCreatedRevisionName,
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(cfg)},
+		},
+	}
+}
+
+func patchRemoveLabel(namespace, name, key, version string) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = name
+	action.Namespace = namespace
+
+	patch := fmt.Sprintf(`{"metadata":{"labels":{"%s":null},"resourceVersion":"%s"}}`, key, version)
+
+	action.Patch = []byte(patch)
+	return action
+}
+
+func patchAddLabel(namespace, name, key, value, version string) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = name
+	action.Namespace = namespace
+
+	patch := fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"},"resourceVersion":"%s"}}`, key, value, version)
+
+	action.Patch = []byte(patch)
+	return action
+}
+
+func TestNew(t *testing.T) {
+	kubeClient := fakekubeclientset.NewSimpleClientset()
+	servingClient := fakeclientset.NewSimpleClientset()
+	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
+
+	routeInformer := servingInformer.Serving().V1alpha1().Routes()
+	configurationInformer := servingInformer.Serving().V1alpha1().Configurations()
+	revisionInformer := servingInformer.Serving().V1alpha1().Revisions()
+
+	c := NewController(reconciler.Options{
+		KubeClientSet:    kubeClient,
+		ServingClientSet: servingClient,
+		Logger:           TestLogger(t),
+	}, routeInformer, configurationInformer, revisionInformer)
+
+	if c == nil {
+		t.Fatal("Expected NewController to return a non-nil value")
+	}
+}

--- a/pkg/reconciler/v1alpha1/labeler/labeler_test.go
+++ b/pkg/reconciler/v1alpha1/labeler/labeler_test.go
@@ -224,7 +224,7 @@ func TestNew(t *testing.T) {
 	configurationInformer := servingInformer.Serving().V1alpha1().Configurations()
 	revisionInformer := servingInformer.Serving().V1alpha1().Revisions()
 
-	c := NewController(reconciler.Options{
+	c := NewRouteToConfigurationController(reconciler.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		Logger:           TestLogger(t),

--- a/pkg/reconciler/v1alpha1/labeler/labels.go
+++ b/pkg/reconciler/v1alpha1/labeler/labels.go
@@ -62,12 +62,12 @@ func (c *Reconciler) setLabelForGivenConfigurations(
 
 	// The ordered collection of Configurations to which we
 	// should patch our Route label.
-	order := []string{}
+	configurationOrder := []string{}
 	configMap := make(map[string]*v1alpha1.Configuration)
 
 	// Lookup Configurations that are missing our Route label.
 	for name, _ := range configs {
-		order = append(order, name)
+		configurationOrder = append(configurationOrder, name)
 
 		config, err := c.configurationLister.Configurations(route.Namespace).Get(name)
 		if err != nil {
@@ -84,11 +84,11 @@ func (c *Reconciler) setLabelForGivenConfigurations(
 		}
 	}
 	// Sort the names to give things a deterministic ordering.
-	sort.Strings(order)
+	sort.Strings(configurationOrder)
 
 	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(route.Namespace)
 	// Set label for newly added configurations as traffic target.
-	for _, configName := range order {
+	for _, configName := range configurationOrder {
 		config := configMap[configName]
 		if config.Labels == nil {
 			config.Labels = make(map[string]string)

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -241,13 +241,6 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 		r.Status.MarkUnknownTrafficError(err.Error())
 		return r, err
 	}
-
-	// // If the only errors are missing traffic target, we need to
-	// // update the labels first, so that when these targets recover we
-	// // receive an update.
-	// if err := c.syncLabels(ctx, r, t); err != nil {
-	// 	return r, err
-	// }
 	if badTarget != nil && isTargetError {
 		badTarget.MarkBadTrafficTarget(&r.Status)
 

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -242,12 +242,12 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 		return r, err
 	}
 
-	// If the only errors are missing traffic target, we need to
-	// update the labels first, so that when these targets recover we
-	// receive an update.
-	if err := c.syncLabels(ctx, r, t); err != nil {
-		return r, err
-	}
+	// // If the only errors are missing traffic target, we need to
+	// // update the labels first, so that when these targets recover we
+	// // receive an update.
+	// if err := c.syncLabels(ctx, r, t); err != nil {
+	// 	return r, err
+	// }
 	if badTarget != nil && isTargetError {
 		badTarget.MarkBadTrafficTarget(&r.Status)
 

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -62,9 +62,6 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "first-reconcile", "not-ready", nil)),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "not-ready", "serving.knative.dev/route", "first-reconcile", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleRunLatest("default", "first-reconcile", "not-ready", &v1alpha1.RouteStatus{
 				Domain:         "first-reconcile.default.example.com",
@@ -96,9 +93,6 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "first-reconcile", "permanently-failed", nil)),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "permanently-failed", "serving.knative.dev/route", "first-reconcile", "v1"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleRunLatest("default", "first-reconcile", "permanently-failed", &v1alpha1.RouteStatus{
@@ -135,9 +129,6 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "first-reconcile", "not-ready", nil)),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "not-ready", "serving.knative.dev/route", "first-reconcile", "v1"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleRunLatest("default", "first-reconcile", "not-ready", &v1alpha1.RouteStatus{
@@ -186,9 +177,6 @@ func TestReconcile(t *testing.T) {
 			),
 			resources.MakeK8sService(simpleRunLatest("default", "becomes-ready", "config", nil)),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "config", "serving.knative.dev/route", "becomes-ready", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleRunLatest("default", "becomes-ready", "config", &v1alpha1.RouteStatus{
 				Domain:         "becomes-ready.default.example.com",
@@ -202,48 +190,12 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00001",
-					Percent:           100,
+					RevisionName: "config-00001",
+					Percent:      100,
 				}},
 			}),
 		}},
 		Key: "default/becomes-ready",
-	}, {
-		Name: "failure labeling configuration",
-		// Start from the test case where the route becomes ready and introduce a failure updating the configuration.
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("patch", "configurations"),
-		},
-		Objects: []runtime.Object{
-			simpleRunLatest("default", "label-config-failure", "config", nil),
-			simpleReadyConfig("default", "config"),
-			simpleReadyRevision("default",
-				// Use the Revision name from the config.
-				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-			),
-		},
-		WantCreates: []metav1.Object{
-			resources.MakeK8sService(simpleRunLatest("default", "label-config-failure", "config", nil)),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "config", "serving.knative.dev/route", "label-config-failure", "v1"),
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleRunLatest("default", "label-config-failure", "config", &v1alpha1.RouteStatus{
-				Domain:         "label-config-failure.default.example.com",
-				DomainInternal: "label-config-failure.default.svc.cluster.local",
-				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "label-config-failure.default.svc.cluster.local"},
-				Conditions: duckv1alpha1.Conditions{{
-					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   v1alpha1.RouteConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			}),
-		}},
-		Key: "default/label-config-failure",
 	}, {
 		Name: "failure creating k8s placeholder service",
 		// We induce a failure creating the placeholder service
@@ -308,9 +260,6 @@ func TestReconcile(t *testing.T) {
 			),
 			resources.MakeK8sService(simpleRunLatest("default", "vs-create-failure", "config", nil)),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "config", "serving.knative.dev/route", "vs-create-failure", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleRunLatest("default", "vs-create-failure", "config", &v1alpha1.RouteStatus{
 				Domain:         "vs-create-failure.default.example.com",
@@ -341,8 +290,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00001",
-					Percent:           100,
+					RevisionName: "config-00001",
+					Percent:      100,
 				}},
 			}),
 			addConfigLabel(
@@ -391,8 +340,8 @@ func TestReconcile(t *testing.T) {
 						Status: corev1.ConditionTrue,
 					}},
 					Traffic: []v1alpha1.TrafficTarget{{
-						RevisionName:      "config-00001",
-						Percent:           100,
+						RevisionName: "config-00001",
+						Percent:      100,
 					}},
 				}),
 				"app", "prod",
@@ -439,8 +388,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00001",
-					Percent:           100,
+					RevisionName: "config-00001",
+					Percent:      100,
 				}},
 			}),
 			setLatestCreatedRevision(
@@ -557,8 +506,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00002",
-					Percent:           100,
+					RevisionName: "config-00002",
+					Percent:      100,
 				}},
 			}),
 		}},
@@ -652,8 +601,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00001",
-					Percent:           100,
+					RevisionName: "config-00001",
+					Percent:      100,
 				}},
 			}),
 			addConfigLabel(
@@ -756,8 +705,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00001",
-					Percent:           100,
+					RevisionName: "config-00001",
+					Percent:      100,
 				}},
 			}),
 			addConfigLabel(
@@ -802,8 +751,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "config-00001",
-					Percent:           100,
+					RevisionName: "config-00001",
+					Percent:      100,
 				}},
 			}),
 			addConfigLabel(
@@ -850,54 +799,6 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		Key: "default/virt-svc-mutation",
-	}, {
-		Name: "config labelled by another route",
-		Objects: []runtime.Object{
-			simpleRunLatest("default", "licked-cookie", "config", &v1alpha1.RouteStatus{
-				Domain:         "licked-cookie.default.example.com",
-				DomainInternal: "licked-cookie.default.svc.cluster.local",
-				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "licked-cookie.default.svc.cluster.local"},
-				Conditions: duckv1alpha1.Conditions{{
-					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-					Status: corev1.ConditionTrue,
-				}, {
-					Type:   v1alpha1.RouteConditionReady,
-					Status: corev1.ConditionTrue,
-				}},
-				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "config",
-					RevisionName:      "config-00001",
-					Percent:           100,
-				}},
-			}),
-			addConfigLabel(
-				simpleReadyConfig("default", "config"),
-				// This configuration is being referenced by another Route.
-				"serving.knative.dev/route", "this-cookie-has-been-licked",
-			),
-			simpleReadyRevision("default",
-				// Use the Revision name from the config.
-				simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-			),
-			resources.MakeVirtualService(
-				setDomain(simpleRunLatest("default", "licked-cookie", "config", nil), "licked-cookie.default.example.com"),
-				&traffic.TrafficConfig{
-					Targets: map[string][]traffic.RevisionTarget{
-						"": {{
-							TrafficTarget: v1alpha1.TrafficTarget{
-								// Use the Revision name from the config.
-								RevisionName: simpleReadyConfig("default", "config").Status.LatestReadyRevisionName,
-								Percent:      100,
-							},
-							Active: true,
-						}},
-					},
-				},
-			),
-			resources.MakeK8sService(simpleRunLatest("default", "licked-cookie", "config", nil)),
-		},
-		WantErr: true,
-		Key:     "default/licked-cookie",
 	}, {
 		Name: "switch to a different config",
 		Objects: []runtime.Object{
@@ -951,10 +852,6 @@ func TestReconcile(t *testing.T) {
 			),
 			resources.MakeK8sService(simpleRunLatest("default", "change-configs", "oldconfig", nil)),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchRemoveLabel("default", "oldconfig", "serving.knative.dev/route", "v1"),
-			patchAddLabel("default", "newconfig", "serving.knative.dev/route", "change-configs", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			// Updated to point to "newconfig" things.
 			Object: resources.MakeVirtualService(
@@ -986,8 +883,8 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "newconfig-00001",
-					Percent:           100,
+					RevisionName: "newconfig-00001",
+					Percent:      100,
 				}},
 			}),
 		}},
@@ -1056,9 +953,6 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []metav1.Object{
 			resources.MakeK8sService(simpleRunLatest("default", "missing-revision-indirect", "config", nil)),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "config", "serving.knative.dev/route", "missing-revision-indirect", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleRunLatest("default", "missing-revision-indirect", "config", &v1alpha1.RouteStatus{
 				Domain:         "missing-revision-indirect.default.example.com",
@@ -1110,11 +1004,6 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 			resources.MakeK8sService(simpleRunLatest("default", "pinned-becomes-ready", "config", nil)),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			// TODO(#1495): The parent configuration isn't labeled because it's established through
-			// labels instead of owner references.
-			//patchAddLabel("default", "config", "serving.knative.dev/route", "pinned-becomes-ready"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simplePinned("default", "pinned-becomes-ready",
@@ -1206,10 +1095,6 @@ func TestReconcile(t *testing.T) {
 					Percent:           50,
 				})),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "blue", "serving.knative.dev/route", "named-traffic-split", "v1"),
-			patchAddLabel("default", "green", "serving.knative.dev/route", "named-traffic-split", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: routeWithTraffic("default", "named-traffic-split", &v1alpha1.RouteStatus{
 				Domain:         "named-traffic-split.default.example.com",
@@ -1223,11 +1108,11 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "blue-00001",
-					Percent:           50,
+					RevisionName: "blue-00001",
+					Percent:      50,
 				}, {
-					RevisionName:      "green-00001",
-					Percent:           50,
+					RevisionName: "green-00001",
+					Percent:      50,
 				}},
 			}, v1alpha1.TrafficTarget{
 				ConfigurationName: "blue",
@@ -1290,10 +1175,6 @@ func TestReconcile(t *testing.T) {
 			),
 			resources.MakeK8sService(simpleRunLatest("default", "switch-configs", "blue", nil)),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchRemoveLabel("default", "blue", "serving.knative.dev/route", "v1"),
-			patchAddLabel("default", "green", "serving.knative.dev/route", "switch-configs", "v1"),
-		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: resources.MakeVirtualService(
 				setDomain(simpleRunLatest("default", "switch-configs", "green", nil), "switch-configs.default.example.com"),
@@ -1323,130 +1204,12 @@ func TestReconcile(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}},
 				Traffic: []v1alpha1.TrafficTarget{{
-					RevisionName:      "green-00001",
-					Percent:           100,
+					RevisionName: "green-00001",
+					Percent:      100,
 				}},
 			}),
 		}},
 		Key: "default/switch-configs",
-	}, {
-		Name: "failure unlabeling old configuration",
-		// Start from our test that switches configs and induce a failure when we go to unlabel
-		// the "blue" configuration.
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("patch", "configurations"),
-		},
-		Objects: []runtime.Object{
-			simpleRunLatest("default", "rmlabel-config-failure", "green", &v1alpha1.RouteStatus{
-				Domain:         "rmlabel-config-failure.default.example.com",
-				DomainInternal: "rmlabel-config-failure.default.svc.cluster.local",
-				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "rmlabel-config-failure.default.svc.cluster.local"},
-				Conditions: duckv1alpha1.Conditions{{
-					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-					Status: corev1.ConditionTrue,
-				}, {
-					Type:   v1alpha1.RouteConditionReady,
-					Status: corev1.ConditionTrue,
-				}},
-				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "blue",
-					RevisionName:      "blue-00001",
-					Percent:           100,
-				}},
-			}),
-			addConfigLabel(
-				simpleReadyConfig("default", "blue"),
-				// The Route controller attaches our label to this Configuration.
-				"serving.knative.dev/route", "rmlabel-config-failure",
-			),
-			simpleReadyConfig("default", "green"),
-			simpleReadyRevision("default",
-				// Use the Revision name from the config.
-				simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-			),
-			simpleReadyRevision("default",
-				// Use the Revision name from the config.
-				simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
-			),
-			resources.MakeVirtualService(
-				setDomain(simpleRunLatest("default", "rmlabel-config-failure", "blue", nil), "rmlabel-config-failure.default.example.com"),
-				&traffic.TrafficConfig{
-					Targets: map[string][]traffic.RevisionTarget{
-						"": {{
-							TrafficTarget: v1alpha1.TrafficTarget{
-								// Use the Revision name from the config.
-								RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-								Percent:      100,
-							},
-							Active: true,
-						}},
-					},
-				},
-			),
-			resources.MakeK8sService(simpleRunLatest("default", "rmlabel-config-failure", "blue", nil)),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchRemoveLabel("default", "blue", "serving.knative.dev/route", "v1"),
-		},
-		Key: "default/rmlabel-config-failure",
-	}, {
-		Name: "failure labeling configuration",
-		// Start from our test that switches configs, unlabel "blue" (avoids induced failure),
-		// and induce a failure when we go to label the "green" configuration.
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("patch", "configurations"),
-		},
-		Objects: []runtime.Object{
-			simpleRunLatest("default", "addlabel-config-failure", "green", &v1alpha1.RouteStatus{
-				Domain:         "addlabel-config-failure.default.example.com",
-				DomainInternal: "addlabel-config-failure.default.svc.cluster.local",
-				Targetable:     &duckv1alpha1.Targetable{DomainInternal: "addlabel-config-failure.default.svc.cluster.local"},
-				Conditions: duckv1alpha1.Conditions{{
-					Type:   v1alpha1.RouteConditionAllTrafficAssigned,
-					Status: corev1.ConditionTrue,
-				}, {
-					Type:   v1alpha1.RouteConditionReady,
-					Status: corev1.ConditionTrue,
-				}},
-				Traffic: []v1alpha1.TrafficTarget{{
-					ConfigurationName: "blue",
-					RevisionName:      "blue-00001",
-					Percent:           100,
-				}},
-			}),
-			simpleReadyConfig("default", "blue"),
-			simpleReadyConfig("default", "green"),
-			simpleReadyRevision("default",
-				// Use the Revision name from the config.
-				simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-			),
-			simpleReadyRevision("default",
-				// Use the Revision name from the config.
-				simpleReadyConfig("default", "green").Status.LatestReadyRevisionName,
-			),
-			resources.MakeVirtualService(
-				setDomain(simpleRunLatest("default", "addlabel-config-failure", "blue", nil), "addlabel-config-failure.default.example.com"),
-				&traffic.TrafficConfig{
-					Targets: map[string][]traffic.RevisionTarget{
-						"": {{
-							TrafficTarget: v1alpha1.TrafficTarget{
-								// Use the Revision name from the config.
-								RevisionName: simpleReadyConfig("default", "blue").Status.LatestReadyRevisionName,
-								Percent:      100,
-							},
-							Active: true,
-						}},
-					},
-				},
-			),
-			resources.MakeK8sService(simpleRunLatest("default", "addlabel-config-failure", "blue", nil)),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", "green", "serving.knative.dev/route", "addlabel-config-failure", "v1"),
-		},
-		Key: "default/addlabel-config-failure",
 	}}
 
 	// TODO(mattmoor): Revision inactive (direct reference)


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->