### PR TITLE
Validate revision.spec.buildRef

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -250,7 +250,11 @@ func (r *Revision) GetGroupVersionKind() schema.GroupVersionKind {
 
 func (r *Revision) BuildRef() *corev1.ObjectReference {
 	if r.Spec.BuildRef != nil {
-		return r.Spec.BuildRef
+		buildRef := r.Spec.BuildRef.DeepCopy()
+		if buildRef.Namespace == "" {
+			buildRef.Namespace = r.Namespace
+		}
+		return buildRef
 	}
 
 	if r.Spec.BuildName != "" {

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -145,13 +145,13 @@ func validateBuildRef(buildRef *corev1.ObjectReference) *apis.FieldError {
 	if len(validation.IsCIdentifier(buildRef.Kind)) != 0 {
 		return apis.ErrInvalidValue(buildRef.Kind, "kind")
 	}
-	if len(validation.IsDNS1123Label(buildRef.Namespace)) != 0 {
-		return apis.ErrInvalidValue(buildRef.Namespace, "namespace")
-	}
 	if len(validation.IsDNS1123Label(buildRef.Name)) != 0 {
 		return apis.ErrInvalidValue(buildRef.Name, "name")
 	}
 	var disallowedFields []string
+	if buildRef.Namespace != "" {
+		disallowedFields = append(disallowedFields, "namespace")
+	}
 	if buildRef.FieldPath != "" {
 		disallowedFields = append(disallowedFields, "fieldPath")
 	}

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/knative/pkg/apis"
 )
@@ -42,7 +43,8 @@ func (rs *RevisionSpec) Validate() *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	errs := rs.ServingState.Validate().ViaField("servingState").
-		Also(validateContainer(rs.Container).ViaField("container"))
+		Also(validateContainer(rs.Container).ViaField("container")).
+		Also(validateBuildRef(rs.BuildRef).ViaField("buildRef"))
 
 	if err := rs.ConcurrencyModel.Validate().ViaField("concurrencyModel"); err != nil {
 		errs = errs.Also(err)
@@ -131,6 +133,38 @@ func validateContainer(container corev1.Container) *apis.FieldError {
 		errs = errs.Also(err)
 	}
 	return errs
+}
+
+func validateBuildRef(buildRef *corev1.ObjectReference) *apis.FieldError {
+	if buildRef == nil {
+		return nil
+	}
+	if len(validation.IsQualifiedName(buildRef.APIVersion)) != 0 {
+		return apis.ErrInvalidValue(buildRef.APIVersion, "apiVersion")
+	}
+	if len(validation.IsCIdentifier(buildRef.Kind)) != 0 {
+		return apis.ErrInvalidValue(buildRef.Kind, "kind")
+	}
+	if len(validation.IsDNS1123Label(buildRef.Namespace)) != 0 {
+		return apis.ErrInvalidValue(buildRef.Namespace, "namespace")
+	}
+	if len(validation.IsDNS1123Label(buildRef.Name)) != 0 {
+		return apis.ErrInvalidValue(buildRef.Name, "name")
+	}
+	var disallowedFields []string
+	if buildRef.FieldPath != "" {
+		disallowedFields = append(disallowedFields, "fieldPath")
+	}
+	if buildRef.ResourceVersion != "" {
+		disallowedFields = append(disallowedFields, "resourceVersion")
+	}
+	if buildRef.UID != "" {
+		disallowedFields = append(disallowedFields, "uid")
+	}
+	if len(disallowedFields) != 0 {
+		return apis.ErrDisallowedFields(disallowedFields...)
+	}
+	return nil
 }
 
 func validateProbe(p *corev1.Probe) *apis.FieldError {

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -164,6 +164,102 @@ func TestContainerValidation(t *testing.T) {
 	}
 }
 
+func TestBuildRefValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *corev1.ObjectReference
+		want *apis.FieldError
+	}{{
+		name: "nil",
+	}, {
+		name: "no api version",
+		r:    &corev1.ObjectReference{},
+		want: apis.ErrInvalidValue("", "apiVersion"),
+	}, {
+		name: "bad api version",
+		r: &corev1.ObjectReference{
+			APIVersion: "/v1alpha1",
+		},
+		want: apis.ErrInvalidValue("/v1alpha1", "apiVersion"),
+	}, {
+		name: "no kind",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo/v1alpha1",
+		},
+		want: apis.ErrInvalidValue("", "kind"),
+	}, {
+		name: "bad kind",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo/v1alpha1",
+			Kind:       "Bad Kind",
+		},
+		want: apis.ErrInvalidValue("Bad Kind", "kind"),
+	}, {
+		name: "no namespace",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+		},
+		want: apis.ErrInvalidValue("", "namespace"),
+	}, {
+		name: "bad namespace",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Namespace:  "bad namespace",
+		},
+		want: apis.ErrInvalidValue("bad namespace", "namespace"),
+	}, {
+		name: "no name",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Namespace:  "foo",
+		},
+		want: apis.ErrInvalidValue("", "name"),
+	}, {
+		name: "bad name",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Namespace:  "foo",
+			Name:       "bad name",
+		},
+		want: apis.ErrInvalidValue("bad name", "name"),
+	}, {
+		name: "disallowed fields",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Namespace:  "foo",
+			Name:       "bar0001",
+
+			FieldPath:       "some.field.path",
+			ResourceVersion: "234234",
+			UID:             "deadbeefcafebabe",
+		},
+		want: apis.ErrDisallowedFields("fieldPath", "resourceVersion", "uid"),
+	}, {
+		name: "all good",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Namespace:  "foo",
+			Name:       "bar0001",
+		},
+		want: nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := validateBuildRef(test.r)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("validateBuildRef (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
 func TestConcurrencyModelValidation(t *testing.T) {
 	tests := []struct {
 		name string
@@ -321,6 +417,15 @@ func TestRevisionSpecValidation(t *testing.T) {
 			ServingState: "blah",
 		},
 		want: apis.ErrInvalidValue("blah", "servingState"),
+	}, {
+		name: "has bad build ref",
+		rs: &RevisionSpec{
+			Container: corev1.Container{
+				Image: "helloworld",
+			},
+			BuildRef: &corev1.ObjectReference{},
+		},
+		want: apis.ErrInvalidValue("", "buildRef.apiVersion"),
 	}, {
 		name: "bad concurrency model",
 		rs: &RevisionSpec{

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -199,22 +199,14 @@ func TestBuildRefValidation(t *testing.T) {
 		r: &corev1.ObjectReference{
 			APIVersion: "foo.group/v1alpha1",
 			Kind:       "Bar",
+			Name:       "the-bar-0001",
 		},
-		want: apis.ErrInvalidValue("", "namespace"),
-	}, {
-		name: "bad namespace",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo.group/v1alpha1",
-			Kind:       "Bar",
-			Namespace:  "bad namespace",
-		},
-		want: apis.ErrInvalidValue("bad namespace", "namespace"),
+		want: nil,
 	}, {
 		name: "no name",
 		r: &corev1.ObjectReference{
 			APIVersion: "foo.group/v1alpha1",
 			Kind:       "Bar",
-			Namespace:  "foo",
 		},
 		want: apis.ErrInvalidValue("", "name"),
 	}, {
@@ -222,7 +214,6 @@ func TestBuildRefValidation(t *testing.T) {
 		r: &corev1.ObjectReference{
 			APIVersion: "foo.group/v1alpha1",
 			Kind:       "Bar",
-			Namespace:  "foo",
 			Name:       "bad name",
 		},
 		want: apis.ErrInvalidValue("bad name", "name"),
@@ -231,20 +222,19 @@ func TestBuildRefValidation(t *testing.T) {
 		r: &corev1.ObjectReference{
 			APIVersion: "foo.group/v1alpha1",
 			Kind:       "Bar",
-			Namespace:  "foo",
 			Name:       "bar0001",
 
+			Namespace:       "foo",
 			FieldPath:       "some.field.path",
 			ResourceVersion: "234234",
 			UID:             "deadbeefcafebabe",
 		},
-		want: apis.ErrDisallowedFields("fieldPath", "resourceVersion", "uid"),
+		want: apis.ErrDisallowedFields("namespace", "fieldPath", "resourceVersion", "uid"),
 	}, {
 		name: "all good",
 		r: &corev1.ObjectReference{
 			APIVersion: "foo.group/v1alpha1",
 			Kind:       "Bar",
-			Namespace:  "foo",
 			Name:       "bar0001",
 		},
 		want: nil,

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -72,7 +72,6 @@ func buildRef(config *v1alpha1.Configuration) *corev1.ObjectReference {
 	return &corev1.ObjectReference{
 		APIVersion: b.GetAPIVersion(),
 		Kind:       b.GetKind(),
-		Namespace:  b.GetNamespace(),
 		Name:       b.GetName(),
 	}
 }

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -122,7 +122,6 @@ func TestRevisions(t *testing.T) {
 				BuildRef: &corev1.ObjectReference{
 					APIVersion: "build.knative.dev/v1alpha1",
 					Kind:       "Build",
-					Namespace:  "with",
 					Name:       "build-00099",
 				},
 				Container: corev1.Container{

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -1659,7 +1659,6 @@ func addBuild(rev *v1alpha1.Revision, name string) *v1alpha1.Revision {
 		APIVersion: "testing.build.knative.dev/v1alpha1",
 		Kind:       "Build",
 		Name:       name,
-		Namespace:  rev.Namespace,
 	}
 	return rev
 }


### PR DESCRIPTION
We need buildRef to be a valid object reference.

These, and only these, fields need to be present:
- `apiVersion`
- `kind`
- `namespace`
- `name`

Relates to #1961.

/lint
