### PR TITLE
Bump the activator to 3 replicas to test horizontal scalability.

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -18,9 +18,7 @@ metadata:
   name: activator
   namespace: knative-serving
 spec:
-  # TODO: Increase the replicas
-  # https://github.com/knative/serving/issues/695
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: activator


### PR DESCRIPTION
This doesn't address https://github.com/knative/serving/issues/1625, for which we need HPA, but it is intended to probe the horizontal scalability.

Fixes: https://github.com/knative/serving/issues/695

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->