### PR TITLE
Add debug information to the autoscale test.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -94,7 +94,7 @@ func generateTraffic(clients *test.Clients, logger *logging.BaseLogger, concurre
 						logger.Errorf("request %d failed", requestID)
 						logger.Errorf("non 200 response %v", res.StatusCode)
 						logger.Errorf("response headers: %v", res.Header)
-						logger.Errorf("response body: %v", string(res.Body[:]))
+						logger.Errorf("response body: %v", string(res.Body))
 						continue
 					}
 					mux.Lock()

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -81,7 +81,8 @@ func generateTraffic(clients *test.Clients, logger *logging.BaseLogger, concurre
 					return nil
 				default:
 					mux.Lock()
-					totalRequests++
+					requestId := totalRequests + 1
+					totalRequests = requestId
 					mux.Unlock()
 					res, err := client.Do(req)
 					if err != nil {
@@ -90,6 +91,7 @@ func generateTraffic(clients *test.Clients, logger *logging.BaseLogger, concurre
 					}
 
 					if res.StatusCode != http.StatusOK {
+						logger.Errorf("request %d failed", requestId)
 						logger.Errorf("non 200 response %v", res.StatusCode)
 						logger.Errorf("response headers: %v", res.Header)
 						logger.Errorf("response body: %v", string(res.Body[:]))

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -81,8 +81,8 @@ func generateTraffic(clients *test.Clients, logger *logging.BaseLogger, concurre
 					return nil
 				default:
 					mux.Lock()
-					requestId := totalRequests + 1
-					totalRequests = requestId
+					requestID := totalRequests + 1
+					totalRequests = requestID
 					mux.Unlock()
 					res, err := client.Do(req)
 					if err != nil {
@@ -91,7 +91,7 @@ func generateTraffic(clients *test.Clients, logger *logging.BaseLogger, concurre
 					}
 
 					if res.StatusCode != http.StatusOK {
-						logger.Errorf("request %d failed", requestId)
+						logger.Errorf("request %d failed", requestID)
 						logger.Errorf("non 200 response %v", res.StatusCode)
 						logger.Errorf("response headers: %v", res.Header)
 						logger.Errorf("response body: %v", string(res.Body[:]))

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -92,7 +92,7 @@ func generateTraffic(clients *test.Clients, logger *logging.BaseLogger, concurre
 					if res.StatusCode != http.StatusOK {
 						logger.Errorf("non 200 response %v", res.StatusCode)
 						logger.Errorf("response headers: %v", res.Header)
-						logger.Errorf("response body: %v", res.Body)
+						logger.Errorf("response body: %v", string(res.Body[:]))
 						continue
 					}
 					mux.Lock()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

In an attempt to chase #2160 I added a bit of debug information to the autoscale test to help hunt the bug down.

## Proposed Changes

  * Actually print the body of the response interpreted as a string.
  * Add the id of the request that failed to the log to be able to interpret "where" the dropped requests are happening.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
