### PR TITLE
Drop ServingState in the KPA.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/kpa_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_defaults.go
@@ -25,9 +25,6 @@ func (r *PodAutoscaler) SetDefaults() {
 }
 
 func (rs *PodAutoscalerSpec) SetDefaults() {
-	if rs.ServingState == "" {
-		rs.ServingState = servingv1alpha1.RevisionServingStateActive
-	}
 	// When ConcurrencyModel is specified but ContainerConcurrency
 	// is not (0), use the ConcurrencyModel value.
 	if rs.ConcurrencyModel == servingv1alpha1.RevisionRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {

--- a/pkg/apis/autoscaling/v1alpha1/kpa_defaults_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_defaults_test.go
@@ -32,9 +32,7 @@ func TestPodAutoscalerDefaulting(t *testing.T) {
 		in:   &PodAutoscaler{},
 		want: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				// In the context of a PodAutoscaler we initialize ServingState.
 				ContainerConcurrency: 0,
-				ServingState:         "Active",
 			},
 		},
 	}, {
@@ -42,13 +40,11 @@ func TestPodAutoscalerDefaulting(t *testing.T) {
 		in: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: 1,
-				ServingState:         "Reserve",
 			},
 		},
 		want: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: 1,
-				ServingState:         "Reserve",
 			},
 		},
 	}, {
@@ -59,7 +55,6 @@ func TestPodAutoscalerDefaulting(t *testing.T) {
 		want: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: 0,
-				ServingState:         "Active",
 			},
 		},
 	}, {
@@ -68,14 +63,12 @@ func TestPodAutoscalerDefaulting(t *testing.T) {
 			Spec: PodAutoscalerSpec{
 				ConcurrencyModel:     "Single",
 				ContainerConcurrency: 0, // unspecified
-				ServingState:         "Active",
 			},
 		},
 		want: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
 				ConcurrencyModel:     "Single",
 				ContainerConcurrency: 1,
-				ServingState:         "Active",
 			},
 		},
 	}}

--- a/pkg/apis/autoscaling/v1alpha1/kpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_types.go
@@ -68,12 +68,6 @@ type PodAutoscalerSpec struct {
 	// +optional
 	Generation int64 `json:"generation,omitempty"`
 
-	// ServingState holds a value describing the desired state the Kubernetes
-	// resources should be in for this PodAutoscaler.
-	// TODO(josephburnett): Remove this when the metrics pipeline is sufficient.
-	// +optional
-	ServingState servingv1alpha1.RevisionServingStateType `json:"servingState,omitempty"`
-
 	// ConcurrencyModel specifies the desired concurrency model
 	// (Single or Multi) for the scale target. Defaults to Multi.
 	// Deprecated in favor of ContainerConcurrency.

--- a/pkg/apis/autoscaling/v1alpha1/kpa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_validation.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -38,7 +37,6 @@ func (rs *PodAutoscalerSpec) Validate() *apis.FieldError {
 	if rs.ServiceName == "" {
 		errs = errs.Also(apis.ErrMissingField("serviceName"))
 	}
-	errs = errs.Also(rs.ServingState.Validate().ViaField("servingState"))
 	if err := rs.ConcurrencyModel.Validate(); err != nil {
 		errs = errs.Also(err.ViaField("concurrencyModel"))
 	} else if err := servingv1alpha1.ValidateContainerConcurrency(rs.ContainerConcurrency, rs.ConcurrencyModel); err != nil {
@@ -70,9 +68,7 @@ func (current *PodAutoscaler) CheckImmutableFields(og apis.Immutable) *apis.Fiel
 		return &apis.FieldError{Message: "The provided original was not a PodAutoscaler"}
 	}
 
-	// The autoscaler is allowed to change ServingState, but consider the rest.
-	ignoreServingState := cmpopts.IgnoreFields(PodAutoscalerSpec{}, "ServingState")
-	if diff := cmp.Diff(original.Spec, current.Spec, ignoreServingState); diff != "" {
+	if diff := cmp.Diff(original.Spec, current.Spec); diff != "" {
 		return &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},

--- a/pkg/apis/autoscaling/v1alpha1/kpa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_validation_test.go
@@ -97,18 +97,6 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		},
 		want: apis.ErrMissingField("serviceName"),
 	}, {
-		name: "has bad serving state",
-		rs: &PodAutoscalerSpec{
-			ServingState: "blah",
-			ServiceName:  "foo",
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-				Name:       "bar",
-			},
-		},
-		want: apis.ErrInvalidValue("blah", "servingState"),
-	}, {
 		name: "bad concurrency model",
 		rs: &PodAutoscalerSpec{
 			ConcurrencyModel: "bogus",
@@ -262,7 +250,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "good (no change)",
 		new: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
 				ConcurrencyModel: "Multi",
 				ServiceName:      "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -274,34 +261,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-			},
-		},
-		want: nil,
-	}, {
-		name: "good (serving state change)",
-		new: &PodAutoscaler{
-			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-			},
-		},
-		old: &PodAutoscaler{
-			Spec: PodAutoscalerSpec{
-				ServingState:     "Reserve",
 				ConcurrencyModel: "Multi",
 				ServiceName:      "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -316,7 +275,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (type mismatch)",
 		new: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
 				ConcurrencyModel: "Multi",
 				ServiceName:      "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -332,7 +290,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (concurrency model change)",
 		new: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
 				ConcurrencyModel: "Multi",
 				ServiceName:      "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -344,7 +301,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
 				ConcurrencyModel: "Single",
 				ServiceName:      "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -366,7 +322,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (container concurrency change)",
 		new: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:         "Active",
 				ContainerConcurrency: 0,
 				ServiceName:          "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -378,7 +333,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:         "Active",
 				ContainerConcurrency: 1,
 				ServiceName:          "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -400,7 +354,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (multiple changes)",
 		new: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Active",
 				ConcurrencyModel: "Multi",
 				ServiceName:      "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -412,7 +365,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &PodAutoscaler{
 			Spec: PodAutoscalerSpec{
-				ServingState:     "Reserve",
 				ConcurrencyModel: "Single",
 				ServiceName:      "food",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
@@ -209,19 +209,17 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, kpa *kpa.PodAuto
 		}
 	}
 	want := metric.DesiredScale
-	logger.Infof("KPA got=%v, want=%v (%v)", got, want, kpa.Spec.ServingState)
+	logger.Infof("KPA got=%v, want=%v", got, want)
 
-	// TODO(josephburnett): Remove ServingState once scale to
-	// zero decisions don't bounce off of zero.
 	switch {
-	case want == 0 || kpa.Spec.ServingState != "Active":
+	case got == 0 || want == 0:
 		kpa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")
 
 	case got == 0 && want > 0:
 		kpa.Status.MarkActivating(
 			"Queued", "Requests to the target are being buffered as resources are provisioned.")
 
-	case got > 0 && (kpa.Spec.ServingState == "Active"):
+	case got > 0:
 		kpa.Status.MarkActive()
 	}
 

--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -76,8 +76,6 @@ func (c *Reconciler) checkAndUpdateKPA(ctx context.Context, rev *v1alpha1.Revisi
 	logger := logging.FromContext(ctx)
 
 	desiredKPA := resources.MakeKPA(rev)
-	// TODO(mattmoor): Preserve the serving state on the KPA (once it is the source of truth)
-	// desiredKPA.Spec.ServingState = kpa.Spec.ServingState
 	desiredKPA.Spec.Generation = kpa.Spec.Generation
 	if equality.Semantic.DeepEqual(desiredKPA.Spec, kpa.Spec) && equality.Semantic.DeepEqual(desiredKPA.Annotations, kpa.Annotations) {
 		return kpa, Unchanged, nil

--- a/pkg/reconciler/v1alpha1/revision/resources/kpa.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/kpa.go
@@ -36,7 +36,6 @@ func MakeKPA(rev *v1alpha1.Revision) *kpa.PodAutoscaler {
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(rev)},
 		},
 		Spec: kpa.PodAutoscalerSpec{
-			ServingState:         rev.Spec.ServingState,
 			ContainerConcurrency: rev.Spec.ContainerConcurrency,
 			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 				APIVersion: "apps/v1",

--- a/pkg/reconciler/v1alpha1/revision/resources/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/kpa_test.go
@@ -68,7 +68,6 @@ func TestMakeKPA(t *testing.T) {
 				}},
 			},
 			Spec: kpa.PodAutoscalerSpec{
-				ServingState:         "Active",
 				ContainerConcurrency: 1,
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
@@ -111,7 +110,6 @@ func TestMakeKPA(t *testing.T) {
 				}},
 			},
 			Spec: kpa.PodAutoscalerSpec{
-				ServingState:         "Reserve",
 				ContainerConcurrency: 0,
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -376,53 +376,9 @@ func TestReconcile(t *testing.T) {
 			svc("foo", "deactivate", "Active", "busybox"),
 			image("foo", "deactivate", "Active", "busybox"),
 		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa("foo", "deactivate", "Reserve", "busybox"),
-		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{},
 		// We update the Deployments to have zero replicas and delete the K8s Services when we deactivate.
 		Key: "foo/deactivate",
-	}, {
-		Name: "failure updating kpa",
-		// Induce a failure updating the kpa
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("update", "podautoscalers"),
-		},
-		Objects: []runtime.Object{
-			makeStatus(
-				rev("foo", "update-kpa-failure", "Reserve", "busybox"),
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "update-kpa-failure", "Active", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: duckv1alpha1.Conditions{{
-						Type:   "Active",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "Ready",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-			kpa("foo", "update-kpa-failure", "Active", "busybox"),
-			// The Deployments match what we'd expect of an Active revision.
-			deploy("foo", "update-kpa-failure", "Reserve", "busybox"),
-			svc("foo", "update-kpa-failure", "Reserve", "busybox"),
-			image("foo", "update-kpa-failure", "Reserve", "busybox"),
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa("foo", "update-kpa-failure", "Reserve", "busybox"),
-		}},
-		// We update the Deployments to have zero replicas and delete the K8s Services when we deactivate.
-		Key: "foo/update-kpa-failure",
 	}, {
 		Name: "deactivated revision is stable",
 		// Test a simple stable reconciliation of a Reserve Revision.
@@ -501,8 +457,6 @@ func TestReconcile(t *testing.T) {
 			image("foo", "activate-revision", "Reserve", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa("foo", "activate-revision", "Active", "busybox"),
-		}, {
 			Object: makeStatus(
 				rev("foo", "activate-revision", "Active", "busybox"),
 				// After activating the Revision status looks like this.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1926 

#2159 needs to be merged first, I'll rebase accordingly.

## Proposed Changes

  * Drop all occurrences of `ServingState` of the KPA.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Dropped ServingState from the KPA.
```
