### PR TITLE
reconcile ClusterIngress into VirtualService

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/knative/pkg/signals"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/labeler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision"
@@ -132,6 +133,7 @@ func main() {
 	configurationInformer := servingInformerFactory.Serving().V1alpha1().Configurations()
 	revisionInformer := servingInformerFactory.Serving().V1alpha1().Revisions()
 	kpaInformer := servingInformerFactory.Autoscaling().V1alpha1().PodAutoscalers()
+	clusterIngressInformer := servingInformerFactory.Networking().V1alpha1().ClusterIngresses()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	coreServiceInformer := kubeInformerFactory.Core().V1().Services()
 	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
@@ -178,6 +180,11 @@ func main() {
 			configurationInformer,
 			routeInformer,
 		),
+		clusteringress.NewController(
+			opt,
+			clusterIngressInformer,
+			virtualServiceInformer,
+		),
 	}
 
 	// Watch the logging config map and dynamically update logging levels.
@@ -200,6 +207,7 @@ func main() {
 		configurationInformer.Informer().HasSynced,
 		revisionInformer.Informer().HasSynced,
 		kpaInformer.Informer().HasSynced,
+		clusterIngressInformer.Informer().HasSynced,
 		imageInformer.Informer().HasSynced,
 		deploymentInformer.Informer().HasSynced,
 		coreServiceInformer.Informer().HasSynced,

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -29,6 +29,8 @@ const (
 
 	// RouteLabelKey is the label key attached to a Configuration indicating by
 	// which Route it is configured as traffic target.
+	// The key can also be attached to ClusterIngress resources to indicate
+	// which Route triggered their creation.
 	RouteLabelKey = GroupName + "/route"
 
 	// RevisionLabelKey is the label key attached to k8s resources to indicate

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -33,6 +33,10 @@ const (
 	// which Route triggered their creation.
 	RouteLabelKey = GroupName + "/route"
 
+	// RouteNamespaceLabelKey is the label key attached to a ClusterIngress indicating by
+	// the Route in which namespace it is created.
+	RouteNamespaceLabelKey = GroupName + "/routeNamespace"
+
 	// RevisionLabelKey is the label key attached to k8s resources to indicate
 	// which Revision triggered their creation.
 	RevisionLabelKey = GroupName + "/revision"

--- a/pkg/reconciler/testing/table.go
+++ b/pkg/reconciler/testing/table.go
@@ -61,6 +61,10 @@ type TableRow struct {
 	// WithReactors is a set of functions that are installed as Reactors for the execution
 	// of this row of the table-driven-test.
 	WithReactors []clientgotesting.ReactionFunc
+
+	// For cluster-scoped resources like ClusterIngress, it does not have to be
+	// in the same namespace with its child resources.
+	SkipNamespaceValidation bool
 }
 
 type Factory func(*testing.T, *TableRow) (controller.Reconciler, ActionRecorderList)
@@ -87,7 +91,7 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 			continue
 		}
 		got := actions.Creates[i]
-		if got.GetNamespace() != expectedNamespace {
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
 			t.Errorf("unexpected action[%d]: %#v", i, got)
 		}
 		obj := got.GetObject()
@@ -126,7 +130,7 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 		if got.GetName() != want.GetName() {
 			t.Errorf("unexpected delete[%d]: %#v", i, got)
 		}
-		if got.GetNamespace() != expectedNamespace {
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
 			t.Errorf("unexpected delete[%d]: %#v", i, got)
 		}
 	}
@@ -146,7 +150,7 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 		if got.GetName() != want.GetName() {
 			t.Errorf("unexpected patch[%d]: %#v", i, got)
 		}
-		if got.GetNamespace() != expectedNamespace {
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
 			t.Errorf("unexpected patch[%d]: %#v", i, got)
 		}
 		if diff := cmp.Diff(string(want.GetPatch()), string(got.GetPatch())); diff != "" {

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusteringress
+
+import (
+	"context"
+	"reflect"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+	istioinformers "github.com/knative/pkg/client/informers/externalversions/istio/v1alpha3"
+	istiolisters "github.com/knative/pkg/client/listers/istio/v1alpha3"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/logging"
+	"github.com/knative/serving/pkg/apis/networking"
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	listers "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/resources"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/resources/names"
+)
+
+const controllerAgentName = "clusteringress-controller"
+
+// Reconciler implements controller.Reconciler for ClusterIngress resources.
+type Reconciler struct {
+	*reconciler.Base
+
+	// listers index properties about resources
+	clusterIngressLister listers.ClusterIngressLister
+	virtualServiceLister istiolisters.VirtualServiceLister
+}
+
+// Check that our Reconciler implements controller.Reconciler
+var _ controller.Reconciler = (*Reconciler)(nil)
+
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events.
+func NewController(
+	opt reconciler.Options,
+	clusterIngressInformer informers.ClusterIngressInformer,
+	virtualServiceInformer istioinformers.VirtualServiceInformer,
+) *controller.Impl {
+
+	c := &Reconciler{
+		Base:                 reconciler.NewBase(opt, controllerAgentName),
+		clusterIngressLister: clusterIngressInformer.Lister(),
+		virtualServiceLister: virtualServiceInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, "ClusterIngresses")
+
+	c.Logger.Info("Setting up event handlers")
+	clusterIngressInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+		DeleteFunc: impl.Enqueue,
+	})
+
+	virtualServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.enqueueOwnerIngress(impl),
+		UpdateFunc: controller.PassNew(c.enqueueOwnerIngress(impl)),
+	})
+
+	return impl
+}
+
+// Reconcile compares the actual state with the desired, and attempts to
+// converge the two. It then updates the Status block of the ClusterIngress resource
+// with the current status of the resource.
+func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
+	// Convert the namespace/name string into a distinct namespace and name
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		c.Logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+	logger := logging.FromContext(ctx)
+
+	// Get the ClusterIngress resource with this name.
+	original, err := c.clusterIngressLister.Get(name)
+	if apierrs.IsNotFound(err) {
+		// The resource may no longer exist, in which case we stop processing.
+		logger.Errorf("clusteringress %q in work queue no longer exists", key)
+		return nil
+	} else if err != nil {
+		return err
+	}
+	// Don't modify the informers copy
+	ci := original.DeepCopy()
+
+	// Reconcile this copy of the ClusterIngress and then write back any status
+	// updates regardless of whether the reconciliation errored out.
+	err = c.reconcile(ctx, ci)
+	if equality.Semantic.DeepEqual(original.Status, ci.Status) {
+		// If we didn't change anything then don't call updateStatus.
+		// This is important because the copy we loaded from the informer's
+		// cache may be stale and we don't want to overwrite a prior update
+		// to status with this stale state.
+	} else if _, err := c.updateStatus(ctx, ci); err != nil {
+		logger.Warn("Failed to update clusterIngress status", zap.Error(err))
+		c.Recorder.Eventf(ci, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update status for ClusterIngress %q: %v", ci.Name, err)
+		return err
+	}
+	return err
+}
+
+// Update the Status of the ClusterIngress.  Caller is responsible for checking
+// for semantic differences before calling.
+func (c *Reconciler) updateStatus(ctx context.Context, ci *v1alpha1.ClusterIngress) (*v1alpha1.ClusterIngress, error) {
+	existing, err := c.clusterIngressLister.Get(ci.Name)
+	if err != nil {
+		return nil, err
+	}
+	// If there's nothing to update, just return.
+	if reflect.DeepEqual(existing.Status, ci.Status) {
+		return existing, nil
+	}
+	existing.Status = ci.Status
+	// TODO: for CRD there's no updatestatus, so use normal update.
+	updated, err := c.ServingClientSet.NetworkingV1alpha1().ClusterIngresses().Update(existing)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Recorder.Eventf(ci, corev1.EventTypeNormal, "Updated", "Updated status for clusterIngress %q", ci.Name)
+	return updated, nil
+}
+
+func (c *Reconciler) reconcile(ctx context.Context, ci *v1alpha1.ClusterIngress) error {
+	logger := logging.FromContext(ctx)
+	ci.Status.InitializeConditions()
+	vs := resources.MakeVirtualService(ci)
+
+	logger.Infof("Reconciling clusterIngress :%v", ci)
+	logger.Info("Creating/Updating VirtualService")
+	if err := c.reconcileVirtualService(ctx, ci, vs); err != nil {
+		// TODO(lichuqiang): should we explicitly mark the ingress as unready
+		// when error reconciling VirtualService?
+		return err
+	}
+	// As underlying network programming (VirtualService now) is stateless,
+	// here we simply mark the ingress as ready if the VirtualService
+	// is successfully synced.
+	ci.Status.MarkNetworkConfigured()
+	ci.Status.MarkLoadBalancerReady([]v1alpha1.LoadBalancerIngressStatus{
+		{DomainInternal: names.K8sGatewayServiceFullname},
+	})
+	logger.Info("ClusterIngress successfully synced")
+	return nil
+}
+
+func (c *Reconciler) reconcileVirtualService(ctx context.Context, ci *v1alpha1.ClusterIngress,
+	desired *v1alpha3.VirtualService) error {
+	logger := logging.FromContext(ctx)
+	ns := desired.Namespace
+	name := desired.Name
+
+	vs, err := c.virtualServiceLister.VirtualServices(ns).Get(name)
+	if apierrs.IsNotFound(err) {
+		vs, err = c.SharedClientSet.NetworkingV1alpha3().VirtualServices(ns).Create(desired)
+		if err != nil {
+			logger.Error("Failed to create VirtualService", zap.Error(err))
+			c.Recorder.Eventf(ci, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create VirtualService %q/%q: %v", ns, name, err)
+			return err
+		}
+		c.Recorder.Eventf(ci, corev1.EventTypeNormal, "Created",
+			"Created VirtualService %q", desired.Name)
+	} else if err != nil {
+		return err
+	} else if !equality.Semantic.DeepEqual(vs.Spec, desired.Spec) {
+		vs.Spec = desired.Spec
+		vs, err = c.SharedClientSet.NetworkingV1alpha3().VirtualServices(ns).Update(vs)
+		if err != nil {
+			logger.Error("Failed to update VirtualService", zap.Error(err))
+			return err
+		}
+		c.Recorder.Eventf(desired, corev1.EventTypeNormal, "Updated",
+			"Updated status for VirtualService %q/%q", ns, name)
+	}
+
+	return nil
+}
+
+func (c *Reconciler) enqueueOwnerIngress(impl *controller.Impl) func(obj interface{}) {
+	return func(obj interface{}) {
+		vs, ok := obj.(*v1alpha3.VirtualService)
+		if !ok {
+			c.Logger.Infof("Ignoring non-VirtualService objects %v", obj)
+			return
+		}
+		// Check whether the VirtualService is referred by a ClusterIngress.
+		ingressName, ok := vs.Labels[networking.IngressLabelKey]
+		if !ok {
+			c.Logger.Infof("VirtualService %s/%s does not have a referring ingress", vs.Namespace, vs.Name)
+			return
+		}
+		impl.EnqueueKey(ingressName)
+	}
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusteringress
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgotesting "k8s.io/client-go/testing"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/networking"
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/resources"
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+	"github.com/knative/serving/pkg/system"
+)
+
+var (
+	ingressRules = []v1alpha1.ClusterIngressRule{{
+		Hosts: []string{
+			"domain.com",
+			"test-route.test-ns.svc.cluster.local",
+			"test-route.test-ns.svc",
+			"test-route.test-ns",
+			"test-route",
+		},
+		HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []v1alpha1.HTTPClusterIngressPath{{
+				Splits: []v1alpha1.ClusterIngressBackendSplit{{
+					Backend: &v1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "test-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				Timeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+				Retries: &v1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+					Attempts:      v1alpha1.DefaultRetryCount,
+				}},
+			},
+		},
+	}}
+)
+
+// This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
+func TestReconcile(t *testing.T) {
+	table := TableTest{{
+		Name:                    "bad workqueue key",
+		Key:                     "too/many/parts",
+		SkipNamespaceValidation: true,
+	}, {
+		Name:                    "key not found",
+		Key:                     "foo/not-found",
+		SkipNamespaceValidation: true,
+	}, {
+		Name:                    "create VirtualService matching ClisterIngress",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingress("no-virtualservice-yet", 1234),
+		},
+		WantCreates: []metav1.Object{
+			resources.MakeVirtualService(ingress("no-virtualservice-yet", 1234)),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithStatus("no-virtualservice-yet", 1234,
+				v1alpha1.IngressStatus{
+					LoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: "knative-ingressgateway.istio-system.svc.cluster.local"},
+						},
+					},
+					Conditions: duckv1alpha1.Conditions{{
+						Type:   v1alpha1.ClusterIngressConditionLoadBalancerReady,
+						Status: corev1.ConditionTrue,
+					}, {
+						Type:   v1alpha1.ClusterIngressConditionNetworkConfigured,
+						Status: corev1.ConditionTrue,
+					}, {
+						Type:   v1alpha1.ClusterIngressConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			),
+		}},
+		Key: "no-virtualservice-yet",
+	}, {
+		Name:                    "reconcile VirtualService to match desired one",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingress("reconcile-virtualservice", 1234),
+			&v1alpha3.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "reconcile-virtualservice",
+					Namespace: system.Namespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey: "reconcile-virtualservice",
+						serving.RouteLabelKey:      "test-route",
+					},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
+				},
+				Spec: v1alpha3.VirtualServiceSpec{},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: resources.MakeVirtualService(ingress("reconcile-virtualservice", 1234)),
+		}, {
+			Object: ingressWithStatus("reconcile-virtualservice", 1234,
+				v1alpha1.IngressStatus{
+					LoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: "knative-ingressgateway.istio-system.svc.cluster.local"},
+						},
+					},
+					Conditions: duckv1alpha1.Conditions{{
+						Type:   v1alpha1.ClusterIngressConditionLoadBalancerReady,
+						Status: corev1.ConditionTrue,
+					}, {
+						Type:   v1alpha1.ClusterIngressConditionNetworkConfigured,
+						Status: corev1.ConditionTrue,
+					}, {
+						Type:   v1alpha1.ClusterIngressConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			),
+		}},
+		Key: "reconcile-virtualservice",
+	}}
+
+	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {
+		return &Reconciler{
+			Base:                 reconciler.NewBase(opt, controllerAgentName),
+			virtualServiceLister: listers.GetVirtualServiceLister(),
+			clusterIngressLister: listers.GetClusterIngressLister(),
+		}
+	}))
+}
+
+func ingressWithStatus(name string, generation int64, status v1alpha1.IngressStatus) *v1alpha1.ClusterIngress {
+	return &v1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{serving.RouteLabelKey: "test-route"},
+		},
+		Spec: v1alpha1.IngressSpec{
+			Generation: generation,
+			Rules:      ingressRules,
+		},
+		Status: status,
+	}
+}
+
+func ingress(name string, generation int64) *v1alpha1.ClusterIngress {
+	return ingressWithStatus(name, generation, v1alpha1.IngressStatus{})
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -78,7 +78,7 @@ func TestReconcile(t *testing.T) {
 		Key:                     "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "create VirtualService matching ClisterIngress",
+		Name:                    "create VirtualService matching ClusterIngress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingress("no-virtualservice-yet", 1234),
@@ -118,8 +118,9 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice",
 					Namespace: system.Namespace,
 					Labels: map[string]string{
-						networking.IngressLabelKey: "reconcile-virtualservice",
-						serving.RouteLabelKey:      "test-route",
+						networking.IngressLabelKey:     "reconcile-virtualservice",
+						serving.RouteLabelKey:          "test-route",
+						serving.RouteNamespaceLabelKey: "test-ns",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
 				},
@@ -164,8 +165,11 @@ func TestReconcile(t *testing.T) {
 func ingressWithStatus(name string, generation int64, status v1alpha1.IngressStatus) *v1alpha1.ClusterIngress {
 	return &v1alpha1.ClusterIngress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{serving.RouteLabelKey: "test-route"},
+			Name: name,
+			Labels: map[string]string{
+				serving.RouteLabelKey:          "test-route",
+				serving.RouteNamespaceLabelKey: "test-ns",
+			},
 		},
 		Spec: v1alpha1.IngressSpec{
 			Generation: generation,

--- a/pkg/reconciler/v1alpha1/clusteringress/doc.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+
+Package clusteringress implements a kubernetes controller which tracks ClusterIngress resource
+and reconcile VirtualService as its child resource.
+
+*/
+package clusteringress

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/doc.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resources holds simple functions for synthesizing child resources from
+// a ClusterIngress resource and any relevant ClusterIngress controller configuration.
+package resources

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/names/doc.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/names/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package names holds simple functions for synthesizing resource names.
+package names

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/names/names.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/system"
+)
+
+// K8sGatewayFullname is the fully-qualified name of Knative shared gateway.
+var K8sGatewayFullname = reconciler.GetK8sServiceFullname(
+	"knative-shared-gateway",
+	system.Namespace)
+
+// K8sGatewayServiceFullname is the fully-qualified name of in-cluster Knative gateway.
+var K8sGatewayServiceFullname = reconciler.GetK8sServiceFullname(
+	"knative-ingressgateway",
+	"istio-system")
+
+// VirtualService returns the name of the VirtualService child resource for given ClusterIngress.
+func VirtualService(i *v1alpha1.ClusterIngress) string {
+	return i.Name
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/names/names_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+)
+
+func TestNamer(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress *v1alpha1.ClusterIngress
+		f       func(*v1alpha1.ClusterIngress) string
+		want    string
+	}{{
+		name: "VirtualService",
+		ingress: &v1alpha1.ClusterIngress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		f:    VirtualService,
+		want: "foo",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.f(test.ingress)
+			if got != test.want {
+				t.Errorf("%s() = %v, wanted %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	istiov1alpha1 "github.com/knative/pkg/apis/istio/common/v1alpha1"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/networking"
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/resources/names"
+	"github.com/knative/serving/pkg/system"
+)
+
+// MakeVirtualService creates an Istio VirtualService as network programming.
+// Such VirtualService specifies which Gateways and Hosts that it applies to,
+// as well as the routing rules.
+func MakeVirtualService(ci *v1alpha1.ClusterIngress) *v1alpha3.VirtualService {
+	vs := &v1alpha3.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            names.VirtualService(ci),
+			Namespace:       system.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
+		},
+		Spec: *makeVirtualServiceSpec(ci),
+	}
+
+	// Populate the ClusterIngress labels.
+	if vs.Labels == nil {
+		vs.Labels = make(map[string]string)
+	}
+	vs.Labels[networking.IngressLabelKey] = ci.Name
+
+	ingressLabels := ci.Labels
+	vs.Labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
+
+	return vs
+}
+
+func makeVirtualServiceSpec(ci *v1alpha1.ClusterIngress) *v1alpha3.VirtualServiceSpec {
+	spec := v1alpha3.VirtualServiceSpec{
+		// We want to connect to two Gateways: the Knative shared
+		// Gateway, and the 'mesh' Gateway.  The former provides
+		// access from outside of the cluster, and the latter provides
+		// access for services from inside the cluster.
+		Gateways: []string{
+			names.K8sGatewayFullname,
+			"mesh",
+		},
+		Hosts: getHosts(ci),
+	}
+
+	for _, rule := range ci.Spec.Rules {
+		hosts := rule.Hosts
+		for _, p := range rule.HTTP.Paths {
+			spec.Http = append(spec.Http, *makeVirtualServiceRoute(hosts, &p))
+		}
+	}
+	return &spec
+}
+
+func makePortSelector(ios intstr.IntOrString) v1alpha3.PortSelector {
+	if ios.Type == intstr.Int {
+		return v1alpha3.PortSelector{
+			Number: uint32(ios.IntValue()),
+		}
+	}
+	return v1alpha3.PortSelector{
+		Name: ios.String(),
+	}
+}
+
+func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPath) *v1alpha3.HTTPRoute {
+	matches := []v1alpha3.HTTPMatchRequest{}
+	for _, host := range hosts {
+		matches = append(matches, makeMatch(host, http.Path))
+	}
+	weights := []v1alpha3.DestinationWeight{}
+	for _, split := range http.Splits {
+		weights = append(weights, v1alpha3.DestinationWeight{
+			Destination: v1alpha3.Destination{
+				Host: reconciler.GetK8sServiceFullname(
+					split.Backend.ServiceName, split.Backend.ServiceNamespace),
+				Port: makePortSelector(split.Backend.ServicePort),
+			},
+			Weight: split.Percent,
+		})
+	}
+	return &v1alpha3.HTTPRoute{
+		Match:   matches,
+		Route:   weights,
+		Timeout: http.Timeout.Duration.String(),
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      http.Retries.Attempts,
+			PerTryTimeout: http.Retries.PerTryTimeout.Duration.String(),
+		},
+		AppendHeaders: http.AppendHeaders,
+	}
+}
+
+func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
+	match := v1alpha3.HTTPMatchRequest{
+		Authority: &istiov1alpha1.StringMatch{
+			Exact: host,
+		},
+	}
+	// Empty pathRegExp is considered match all path. We only need to
+	// consider pathRegExp when it's non-empty.
+	if pathRegExp != "" {
+		match.Uri = &istiov1alpha1.StringMatch{
+			Regex: pathRegExp,
+		}
+	}
+	return match
+}
+
+func getHosts(ci *v1alpha1.ClusterIngress) []string {
+	hosts := make(map[string]interface{})
+	unique := []string{}
+	for _, rule := range ci.Spec.Rules {
+		for _, h := range rule.Hosts {
+			if _, existed := hosts[h]; !existed {
+				hosts[h] = true
+				unique = append(unique, h)
+			}
+		}
+	}
+	// Sort the names to give a deterministic ordering.
+	sort.Strings(unique)
+	return unique
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -54,6 +54,7 @@ func MakeVirtualService(ci *v1alpha1.ClusterIngress) *v1alpha3.VirtualService {
 
 	ingressLabels := ci.Labels
 	vs.Labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
+	vs.Labels[serving.RouteNamespaceLabelKey] = ingressLabels[serving.RouteNamespaceLabelKey]
 
 	return vs
 }

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -35,8 +35,11 @@ import (
 func TestMakeVirtualServiceSpec_CorrectMetadata(t *testing.T) {
 	ci := &v1alpha1.ClusterIngress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "test-ingress",
-			Labels: map[string]string{serving.RouteLabelKey: "test-route"},
+			Name: "test-ingress",
+			Labels: map[string]string{
+				serving.RouteLabelKey:          "test-route",
+				serving.RouteNamespaceLabelKey: "test-ns",
+			},
 		},
 		Spec: v1alpha1.IngressSpec{},
 	}
@@ -44,8 +47,9 @@ func TestMakeVirtualServiceSpec_CorrectMetadata(t *testing.T) {
 		Name:      "test-ingress",
 		Namespace: system.Namespace,
 		Labels: map[string]string{
-			networking.IngressLabelKey: "test-ingress",
-			serving.RouteLabelKey:      "test-route",
+			networking.IngressLabelKey:     "test-ingress",
+			serving.RouteLabelKey:          "test-route",
+			serving.RouteNamespaceLabelKey: "test-ns",
 		},
 		OwnerReferences: []metav1.OwnerReference{
 			*kmeta.NewControllerRef(ci),

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	istiov1alpha1 "github.com/knative/pkg/apis/istio/common/v1alpha1"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/networking"
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestMakeVirtualServiceSpec_CorrectMetadata(t *testing.T) {
+	ci := &v1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-ingress",
+			Labels: map[string]string{serving.RouteLabelKey: "test-route"},
+		},
+		Spec: v1alpha1.IngressSpec{},
+	}
+	expected := metav1.ObjectMeta{
+		Name:      "test-ingress",
+		Namespace: system.Namespace,
+		Labels: map[string]string{
+			networking.IngressLabelKey: "test-ingress",
+			serving.RouteLabelKey:      "test-route",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			*kmeta.NewControllerRef(ci),
+		},
+	}
+	meta := MakeVirtualService(ci).ObjectMeta
+	if diff := cmp.Diff(expected, meta); diff != "" {
+		t.Errorf("Unexpected metadata (-want +got): %v", diff)
+	}
+}
+
+func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
+	ci := &v1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ingress",
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.ClusterIngressRule{{
+				Hosts: []string{
+					"domain.com",
+					"test-route.test-ns.svc.cluster.local",
+					"test-route.test-ns.svc",
+					"test-route.test-ns",
+					"test-route",
+				},
+				HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
+					Paths: []v1alpha1.HTTPClusterIngressPath{{
+						Path: "^/pets/(.*?)?",
+						Splits: []v1alpha1.ClusterIngressBackendSplit{{
+							Backend: &v1alpha1.ClusterIngressBackend{
+								ServiceNamespace: "test-ns",
+								ServiceName:      "v2-service",
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+						Timeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+						Retries: &v1alpha1.HTTPRetry{
+							PerTryTimeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+							Attempts:      v1alpha1.DefaultRetryCount,
+						},
+					}},
+				},
+			}, {
+				Hosts: []string{
+					"v1.domain.com",
+				},
+				HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
+					Paths: []v1alpha1.HTTPClusterIngressPath{{
+						Path: "^/pets/(.*?)?",
+						Splits: []v1alpha1.ClusterIngressBackendSplit{{
+							Backend: &v1alpha1.ClusterIngressBackend{
+								ServiceNamespace: "test-ns",
+								ServiceName:      "v1-service",
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+						Timeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+						Retries: &v1alpha1.HTTPRetry{
+							PerTryTimeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+							Attempts:      v1alpha1.DefaultRetryCount,
+						},
+					}},
+				},
+			},
+			},
+		},
+	}
+	expected := []v1alpha3.HTTPRoute{{
+		Match: []v1alpha3.HTTPMatchRequest{{
+			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "domain.com"},
+		}, {
+			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc.cluster.local"},
+		}, {
+			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc"},
+		}, {
+			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns"},
+		}, {
+			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "test-route"},
+		}},
+		Route: []v1alpha3.DestinationWeight{{
+			Destination: v1alpha3.Destination{
+				Host: "v2-service.test-ns.svc.cluster.local",
+				Port: v1alpha3.PortSelector{Number: 80},
+			},
+			Weight: 100,
+		}},
+		Timeout: v1alpha1.DefaultTimeout.String(),
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      v1alpha1.DefaultRetryCount,
+			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
+		},
+	}, {
+		Match: []v1alpha3.HTTPMatchRequest{{
+			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "v1.domain.com"},
+		}},
+		Route: []v1alpha3.DestinationWeight{{
+			Destination: v1alpha3.Destination{
+				Host: "v1-service.test-ns.svc.cluster.local",
+				Port: v1alpha3.PortSelector{Number: 80},
+			},
+			Weight: 100,
+		}},
+		Timeout: v1alpha1.DefaultTimeout.String(),
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      v1alpha1.DefaultRetryCount,
+			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
+		},
+	}}
+	routes := MakeVirtualService(ci).Spec.Http
+	if diff := cmp.Diff(expected, routes); diff != "" {
+		fmt.Printf("%+v\n", routes)
+		fmt.Printf("%+v\n", expected)
+		t.Errorf("Unexpected routes (-want +got): %v", diff)
+	}
+}
+
+// One active target.
+func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
+	ingressPath := &v1alpha1.HTTPClusterIngressPath{
+		Splits: []v1alpha1.ClusterIngressBackendSplit{{
+			Backend: &v1alpha1.ClusterIngressBackend{
+				ServiceNamespace: "test-ns",
+				ServiceName:      "revision-service",
+				ServicePort:      intstr.FromInt(80),
+			},
+			Percent: 100,
+		}},
+		Timeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+		Retries: &v1alpha1.HTTPRetry{
+			PerTryTimeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+			Attempts:      v1alpha1.DefaultRetryCount,
+		},
+	}
+	hosts := []string{"a.com", "b.org"}
+	route := makeVirtualServiceRoute(hosts, ingressPath)
+	expected := v1alpha3.HTTPRoute{
+		Match: []v1alpha3.HTTPMatchRequest{{
+			Authority: &istiov1alpha1.StringMatch{Exact: "a.com"},
+		}, {
+			Authority: &istiov1alpha1.StringMatch{Exact: "b.org"},
+		}},
+		Route: []v1alpha3.DestinationWeight{{
+			Destination: v1alpha3.Destination{
+				Host: "revision-service.test-ns.svc.cluster.local",
+				Port: v1alpha3.PortSelector{Number: 80},
+			},
+			Weight: 100,
+		}},
+		Timeout: v1alpha1.DefaultTimeout.String(),
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      v1alpha1.DefaultRetryCount,
+			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
+		},
+	}
+	if diff := cmp.Diff(&expected, route); diff != "" {
+		t.Errorf("Unexpected route  (-want +got): %v", diff)
+	}
+}
+
+// Two active targets.
+func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
+	ingressPath := &v1alpha1.HTTPClusterIngressPath{
+		Splits: []v1alpha1.ClusterIngressBackendSplit{{
+			Backend: &v1alpha1.ClusterIngressBackend{
+				ServiceNamespace: "test-ns",
+				ServiceName:      "revision-service",
+				ServicePort:      intstr.FromInt(80),
+			},
+			Percent: 90,
+		}, {
+			Backend: &v1alpha1.ClusterIngressBackend{
+				ServiceNamespace: "test-ns",
+				ServiceName:      "new-revision-service",
+				ServicePort:      intstr.FromString("test-port"),
+			},
+			Percent: 10,
+		}},
+		Timeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+		Retries: &v1alpha1.HTTPRetry{
+			PerTryTimeout: &metav1.Duration{Duration: v1alpha1.DefaultTimeout},
+			Attempts:      v1alpha1.DefaultRetryCount,
+		},
+	}
+	hosts := []string{"test.org"}
+	route := makeVirtualServiceRoute(hosts, ingressPath)
+	expected := v1alpha3.HTTPRoute{
+		Match: []v1alpha3.HTTPMatchRequest{{
+			Authority: &istiov1alpha1.StringMatch{Exact: "test.org"},
+		}},
+		Route: []v1alpha3.DestinationWeight{{
+			Destination: v1alpha3.Destination{
+				Host: "revision-service.test-ns.svc.cluster.local",
+				Port: v1alpha3.PortSelector{Number: 80},
+			},
+			Weight: 90,
+		}, {
+			Destination: v1alpha3.Destination{
+				Host: "new-revision-service.test-ns.svc.cluster.local",
+				Port: v1alpha3.PortSelector{Name: "test-port"},
+			},
+			Weight: 10,
+		}},
+		Timeout: v1alpha1.DefaultTimeout.String(),
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      v1alpha1.DefaultRetryCount,
+			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
+		},
+	}
+	if diff := cmp.Diff(&expected, route); diff != "" {
+		t.Errorf("Unexpected route  (-want +got): %v", diff)
+	}
+}
+
+func TestGetHosts_Duplicate(t *testing.T) {
+	ci := &v1alpha1.ClusterIngress{
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.ClusterIngressRule{{
+				Hosts: []string{
+					"test-route1",
+					"test-route2",
+				},
+			}, {
+				Hosts: []string{
+					"test-route1",
+					"test-route3",
+				},
+			}},
+		},
+	}
+	hosts := getHosts(ci)
+	expected := []string{
+		"test-route1",
+		"test-route2",
+		"test-route3",
+	}
+	if diff := cmp.Diff(expected, hosts); diff != "" {
+		t.Errorf("Unexpected hosts  (-want +got): %v", diff)
+	}
+}

--- a/pkg/reconciler/v1alpha1/testing/listers.go
+++ b/pkg/reconciler/v1alpha1/testing/listers.go
@@ -24,9 +24,11 @@ import (
 	fakesharedclientset "github.com/knative/pkg/client/clientset/versioned/fake"
 	istiolisters "github.com/knative/pkg/client/listers/istio/v1alpha3"
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	networking "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeservingclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	kpalisters "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
+	networkinglisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/testing"
 	appsv1 "k8s.io/api/apps/v1"
@@ -114,6 +116,11 @@ func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
 
 func (l *Listers) GetKPALister() kpalisters.PodAutoscalerLister {
 	return kpalisters.NewPodAutoscalerLister(l.indexerFor(&kpa.PodAutoscaler{}))
+}
+
+// GetClusterIngressLister get lister for ClusterIngress resource.
+func (l *Listers) GetClusterIngressLister() networkinglisters.ClusterIngressLister {
+	return networkinglisters.NewClusterIngressLister(l.indexerFor(&networking.ClusterIngress{}))
 }
 
 func (l *Listers) GetVirtualServiceLister() istiolisters.VirtualServiceLister {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


Part of  #1963
Follow-up #2151

## Proposed Changes

  * update ingress defaulting and validation
  * update test dependency
  * add ingress reconciler to reconcile ClusterIngress into VirtualService

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
``` 
reconcile ClusterIngress into VirtualService
```

/area networking