### PR TITLE
Only activate/deactivate revision if needed.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -190,10 +190,15 @@ func (ks *kpaScaler) updateServingState(logger *zap.SugaredLogger, namespace, na
 		logger.Error("Unable to fetch Revision.", zap.Error(err))
 		return err
 	}
-	rev.Spec.ServingState = state
-	if _, err := revisionClient.Update(rev); err != nil {
-		logger.Error("Error updating revision serving state.", zap.Error(err))
-		return err
+
+	if rev.Spec.ServingState != state {
+		rev.Spec.ServingState = state
+		if _, err := revisionClient.Update(rev); err != nil {
+			logger.Error("Error updating revision serving state.", zap.Error(err))
+			return err
+		}
+	} else {
+		logger.Debugf("Revision's ServingState was already %v", state)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is a slight behavioral change vs. the state before moving activation into the autoscaler. The state flip was guarded by the KPA's ServingState before. This should roughly restore that behavior.

Running this through a couple of integration tests to see if this is related to #2160.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
