### PR TITLE
Add '.status.imageDigest' to Revision

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -304,6 +304,10 @@ status:
   #   revision. Typically, the name will be the same as the name of the
   #   revision.
   serviceName: myservice-a1e34
+
+  # imageDigest: The imageDigest is the spec.container.image field resolved
+  #   to a particular digest at revision creation.
+  imageDigest: gcr.io/my-project/...@sha256:60ab5...
 ```
 
 

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -226,7 +226,7 @@ type RevisionStatus struct {
 	LogURL string `json:"logUrl,omitempty"`
 
 	// ImageDigest holds the resolved digest for the image specified
-	// within .Spec.Container. The digest is resolved during the creation
+	// within .Spec.Container.Image. The digest is resolved during the creation
 	// of Revision. This field holds the digest value regardless of whether
 	// a tag or digest was originally specified in the Container object. It
 	// may be empty if the image comes from a registry listed to skip resolution.

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -224,6 +224,14 @@ type RevisionStatus struct {
 	// based on the revision url template specified in the controller's config.
 	// +optional
 	LogURL string `json:"logUrl,omitempty"`
+
+	// ImageDigest holds the resolved digest for the image specified
+	// within .Spec.Container. The digest is resolved during the creation
+	// of Revision. This field holds the digest value regardless of whether
+	// a tag or digest was originally specified in the Container object. It
+	// may be empty if the image comes from a registry listed to skip resolution.
+	// +optional
+	ImageDigest string `json:"imageDigest,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -18,7 +18,6 @@ package revision
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -28,14 +27,12 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/config"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
-	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revision) (*appsv1.Deployment, error) {
-	logger := logging.FromContext(ctx)
 	cfgs := config.FromContext(ctx)
 
 	deployment := resources.MakeDeployment(
@@ -46,13 +43,6 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revisio
 		cfgs.Autoscaler,
 		cfgs.Controller,
 	)
-
-	// Resolve tag image references to digests.
-	if err := c.resolver.Resolve(deployment, cfgs.Controller.RegistriesSkippingTagResolving); err != nil {
-		logger.Error("Error resolving deployment", zap.Error(err))
-		rev.Status.MarkContainerMissing(err.Error())
-		return nil, fmt.Errorf("Error resolving container to digest: %v", err)
-	}
 
 	return c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Create(deployment)
 }

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	fakecachingclientset "github.com/knative/caching/pkg/client/clientset/versioned/fake"
 	cachinginformers "github.com/knative/caching/pkg/client/informers/externalversions"
 	"github.com/knative/pkg/apis/duck"
@@ -46,7 +47,7 @@ import (
 
 type nopResolver struct{}
 
-func (r *nopResolver) Resolve(_ string, _ string, _ string, _ map[string]struct{}) (string, error) {
+func (r *nopResolver) Resolve(_ string, _ k8schain.Options, _ map[string]struct{}) (string, error) {
 	return "", nil
 }
 

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -34,7 +34,6 @@ import (
 	rclr "github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/config"
 	"github.com/knative/serving/pkg/system"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,8 +46,8 @@ import (
 
 type nopResolver struct{}
 
-func (r *nopResolver) Resolve(*appsv1.Deployment, map[string]struct{}) error {
-	return nil
+func (r *nopResolver) Resolve(_ string, _ string, _ string, _ map[string]struct{}) (string, error) {
+	return "", nil
 }
 
 const (

--- a/pkg/reconciler/v1alpha1/revision/resolve.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -35,44 +34,43 @@ type digestResolver struct {
 
 // Resolve resolves the image references that use tags to digests.
 func (r *digestResolver) Resolve(
-	deploy *appsv1.Deployment,
+	image string,
+	namespace string,
+	serviceAccountName string,
 	registriesToSkip map[string]struct{},
-) error {
-	pod := deploy.Spec.Template.Spec
+) (string, error) {
 	opt := k8schain.Options{
-		Namespace:          deploy.Namespace,
-		ServiceAccountName: pod.ServiceAccountName,
+		Namespace:          namespace,
+		ServiceAccountName: serviceAccountName,
 		// ImagePullSecrets: Not possible via RevisionSpec, since we
 		// don't expose such a field.
 	}
 	kc, err := k8schain.New(r.client, opt)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	for i := range pod.Containers {
-		if _, err := name.NewDigest(pod.Containers[i].Image, name.WeakValidation); err == nil {
-			// Already a digest
-			continue
-		}
-		tag, err := name.NewTag(pod.Containers[i].Image, name.WeakValidation)
-		if err != nil {
-			return err
-		}
-
-		if _, ok := registriesToSkip[tag.Registry.RegistryStr()]; ok {
-			continue
-		}
-
-		img, err := remote.Image(tag, remote.WithTransport(r.transport), remote.WithAuthFromKeychain(kc))
-		if err != nil {
-			return err
-		}
-		digest, err := img.Digest()
-		if err != nil {
-			return err
-		}
-		pod.Containers[i].Image = fmt.Sprintf("%s@%s", tag.Repository.String(), digest)
+	if _, err := name.NewDigest(image, name.WeakValidation); err == nil {
+		// Already a digest
+		return image, nil
 	}
-	return nil
+
+	tag, err := name.NewTag(image, name.WeakValidation)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := registriesToSkip[tag.Registry.RegistryStr()]; ok {
+		return "", nil
+	}
+
+	img, err := remote.Image(tag, remote.WithTransport(r.transport), remote.WithAuthFromKeychain(kc))
+	if err != nil {
+		return "", err
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s@%s", tag.Repository.String(), digest), nil
 }

--- a/pkg/reconciler/v1alpha1/revision/resolve.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve.go
@@ -35,16 +35,9 @@ type digestResolver struct {
 // Resolve resolves the image references that use tags to digests.
 func (r *digestResolver) Resolve(
 	image string,
-	namespace string,
-	serviceAccountName string,
+	opt k8schain.Options,
 	registriesToSkip map[string]struct{},
 ) (string, error) {
-	opt := k8schain.Options{
-		Namespace:          namespace,
-		ServiceAccountName: serviceAccountName,
-		// ImagePullSecrets: Not possible via RevisionSpec, since we
-		// don't expose such a field.
-	}
 	kc, err := k8schain.New(r.client, opt)
 	if err != nil {
 		return "", err

--- a/pkg/reconciler/v1alpha1/revision/resolve_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
@@ -156,28 +155,13 @@ func TestResolve(t *testing.T) {
 
 	// Resolve our tag on the fake registry to the digest of the random.Image()
 	dr := &digestResolver{client: client, transport: http.DefaultTransport}
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: ns,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: svcacct,
-					Containers: []corev1.Container{{
-						Image: tag.String(),
-					}},
-				},
-			},
-		},
-	}
-	if err := dr.Resolve(deploy, emptyRegistrySet); err != nil {
+	resolvedDigest, err := dr.Resolve(tag.String(), ns, svcacct, emptyRegistrySet)
+	if err != nil {
 		t.Fatalf("Resolve() = %v", err)
 	}
 
 	// Make sure that we get back the appropriate digest.
-	digest, err := name.NewDigest(deploy.Spec.Template.Spec.Containers[0].Image, name.WeakValidation)
+	digest, err := name.NewDigest(resolvedDigest, name.WeakValidation)
 	if err != nil {
 		t.Fatalf("NewDigest() = %v", err)
 	}
@@ -187,66 +171,40 @@ func TestResolve(t *testing.T) {
 }
 
 func TestResolveWithDigest(t *testing.T) {
+	ns, svcacct := "foo", "default"
 	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
-			Namespace: "foo",
+			Namespace: ns,
 		},
 	})
+	originalDigest := "ubuntu@sha256:e7def0d56013d50204d73bb588d99e0baa7d69ea1bc1157549b898eb67287612"
 	dr := &digestResolver{client: client, transport: http.DefaultTransport}
-	original := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: "foo",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: "default",
-					Containers: []corev1.Container{{
-						Image: "ubuntu@sha256:e7def0d56013d50204d73bb588d99e0baa7d69ea1bc1157549b898eb67287612",
-					}},
-				},
-			},
-		},
-	}
-	deploy := original.DeepCopy()
-	if err := dr.Resolve(deploy, emptyRegistrySet); err != nil {
+
+	resolvedDigest, err := dr.Resolve(originalDigest, ns, svcacct, emptyRegistrySet)
+	if err != nil {
 		t.Fatalf("Resolve() = %v", err)
 	}
 
-	if diff := cmp.Diff(original, deploy); diff != "" {
-		t.Errorf("Deployment should not change (-want +got): %s", diff)
+	if diff := cmp.Diff(originalDigest, resolvedDigest); diff != "" {
+		t.Errorf("Digest should not change (-want +got): %s", diff)
 	}
 }
 
 func TestResolveWithBadTag(t *testing.T) {
+	ns, svcacct := "foo", "default"
 	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
-			Namespace: "foo",
+			Namespace: ns,
 		},
 	})
 	dr := &digestResolver{client: client, transport: http.DefaultTransport}
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: "foo",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: "default",
-					Containers: []corev1.Container{{
-						// Invalid character
-						Image: "ubuntu%latest",
-					}},
-				},
-			},
-		},
-	}
-	if err := dr.Resolve(deploy, emptyRegistrySet); err == nil {
-		t.Fatalf("Resolve() = %v, want error", deploy)
+
+	// Invalid character
+	invalidImage := "ubuntu%latest"
+	if resolvedDigest, err := dr.Resolve(invalidImage, ns, svcacct, emptyRegistrySet); err == nil {
+		t.Fatalf("Resolve() = %v, want error", resolvedDigest)
 	}
 }
 
@@ -278,24 +236,8 @@ func TestResolveWithPingFailure(t *testing.T) {
 
 	// Resolve our tag on the fake registry to the digest of the random.Image()
 	dr := &digestResolver{client: client, transport: http.DefaultTransport}
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: ns,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: svcacct,
-					Containers: []corev1.Container{{
-						Image: tag.String(),
-					}},
-				},
-			},
-		},
-	}
-	if err := dr.Resolve(deploy, emptyRegistrySet); err == nil {
-		t.Fatalf("Resolve() = %v, want error", deploy)
+	if resolvedDigest, err := dr.Resolve(tag.String(), ns, svcacct, emptyRegistrySet); err == nil {
+		t.Fatalf("Resolve() = %v, want error", resolvedDigest)
 	}
 }
 
@@ -327,49 +269,18 @@ func TestResolveWithManifestFailure(t *testing.T) {
 
 	// Resolve our tag on the fake registry to the digest of the random.Image()
 	dr := &digestResolver{client: client, transport: http.DefaultTransport}
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: ns,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: svcacct,
-					Containers: []corev1.Container{{
-						Image: tag.String(),
-					}},
-				},
-			},
-		},
-	}
-	if err := dr.Resolve(deploy, emptyRegistrySet); err == nil {
-		t.Fatalf("Resolve() = %v, want error", deploy)
+	if resolvedDigest, err := dr.Resolve(tag.String(), ns, svcacct, emptyRegistrySet); err == nil {
+		t.Fatalf("Resolve() = %v, want error", resolvedDigest)
 	}
 }
 
 func TestResolveNoAccess(t *testing.T) {
+	ns, svcacct := "foo", "default"
 	client := fakeclient.NewSimpleClientset()
 	dr := &digestResolver{client: client, transport: http.DefaultTransport}
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: "foo",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: "default",
-					Containers: []corev1.Container{{
-						Image: "ubuntu:latest",
-					}},
-				},
-			},
-		},
-	}
 	// If there is a failure accessing the ServiceAccount for this Pod, then we should see an error.
-	if err := dr.Resolve(deploy, emptyRegistrySet); err == nil {
-		t.Fatalf("Resolve() = %v, want error", deploy)
+	if resolvedDigest, err := dr.Resolve("ubuntu:latest", ns, svcacct, emptyRegistrySet); err == nil {
+		t.Fatalf("Resolve() = %v, want error", resolvedDigest)
 	}
 }
 
@@ -403,32 +314,17 @@ func TestResolveSkippingRegistry(t *testing.T) {
 		client:    client,
 		transport: http.DefaultTransport,
 	}
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blah",
-			Namespace: ns,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: svcacct,
-					Containers: []corev1.Container{{
-						Image: "localhost:5000/ubuntu:latest",
-					}},
-				},
-			},
-		},
-	}
 
 	registriesToSkip := map[string]struct{}{
 		"localhost:5000": {},
 	}
 
-	if err := dr.Resolve(deploy, registriesToSkip); err != nil {
+	resolvedDigest, err := dr.Resolve("localhost:5000/ubuntu:latest", ns, svcacct, registriesToSkip)
+	if err != nil {
 		t.Fatalf("Resolve() = %v", err)
 	}
 
-	if got, want := deploy.Spec.Template.Spec.Containers[0].Image, "localhost:5000/ubuntu:latest"; got != want {
+	if got, want := resolvedDigest, ""; got != want {
 		t.Fatalf("Resolve() got %q want of %q", got, want)
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -120,6 +120,10 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	userContainer.Lifecycle = userLifecycle
 	userContainer.Env = append(userContainer.Env, userEnv)
 	userContainer.Env = append(userContainer.Env, getKnativeEnvVar(rev)...)
+	// Prefer imageDigest from revision if available
+	if rev.Status.ImageDigest != "" {
+		userContainer.Image = rev.Status.ImageDigest
+	}
 
 	// If the client provides probes, we should fill in the port for them.
 	rewriteUserProbe(userContainer.ReadinessProbe)

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -175,7 +175,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:      queueLifecycle,
 				ReadinessProbe: queueReadinessProbe,
 				// These changed based on the Revision and configs passed in.
-				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+				Args: []string{"-containerConcurrency=1"},
 				Env: []corev1.EnvVar{{
 					Name:  "SERVING_NAMESPACE",
 					Value: "foo", // matches namespace

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -127,6 +127,86 @@ func TestMakePodSpec(t *testing.T) {
 			Volumes: []corev1.Volume{varLogVolume},
 		},
 	}, {
+		name: "simple concurrency=single no owner digest resolved",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+				Labels:    labels,
+			},
+			Spec: v1alpha1.RevisionSpec{
+				ContainerConcurrency: 1,
+				Container: corev1.Container{
+					Image: "busybox",
+				},
+			},
+			Status: v1alpha1.RevisionStatus{
+				ImageDigest: "busybox@sha256:deadbeef",
+			},
+		},
+		lc: &logging.Config{},
+		oc: &config.Observability{},
+		ac: &autoscaler.Config{},
+		cc: &config.Controller{},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:         UserContainerName,
+				Image:        "busybox@sha256:deadbeef",
+				Resources:    userResources,
+				Ports:        userPorts,
+				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
+				Env: []corev1.EnvVar{userEnv,
+					{
+						Name:  "K_REVISION",
+						Value: "bar",
+					}, {
+						Name:  "K_CONFIGURATION",
+						Value: "cfg",
+					}, {
+						Name:  "K_SERVICE",
+						Value: "svc",
+					}},
+			}, {
+				Name:           queueContainerName,
+				Resources:      queueResources,
+				Ports:          queuePorts,
+				Lifecycle:      queueLifecycle,
+				ReadinessProbe: queueReadinessProbe,
+				// These changed based on the Revision and configs passed in.
+				Args: []string{"-concurrencyQuantumOfTime=0s", "-containerConcurrency=1"},
+				Env: []corev1.EnvVar{{
+					Name:  "SERVING_NAMESPACE",
+					Value: "foo", // matches namespace
+				}, {
+					Name: "SERVING_CONFIGURATION",
+					// No OwnerReference
+				}, {
+					Name:  "SERVING_REVISION",
+					Value: "bar", // matches name
+				}, {
+					Name:  "SERVING_AUTOSCALER",
+					Value: "autoscaler", // no autoscaler configured.
+				}, {
+					Name:  "SERVING_AUTOSCALER_PORT",
+					Value: "8080",
+				}, {
+					Name: "SERVING_POD",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+					},
+				}, {
+					Name: "SERVING_LOGGING_CONFIG",
+					// No logging configuration
+				}, {
+					Name: "SERVING_LOGGING_LEVEL",
+					// No logging level
+				}},
+			}},
+			Volumes: []corev1.Volume{varLogVolume},
+		},
+	}, {
 		name: "simple concurrency=single with owner",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -299,15 +299,20 @@ func (c *Reconciler) reconcileBuild(ctx context.Context, rev *v1alpha1.Revision)
 }
 
 func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision) error {
-	if rev.Spec.Container.Image != "" && rev.Status.ImageDigest == "" {
-		cfgs := config.FromContext(ctx)
-		digest, err := c.resolver.Resolve(rev.Spec.Container.Image, rev.Namespace, rev.Spec.ServiceAccountName, cfgs.Controller.RegistriesSkippingTagResolving)
-		if err != nil {
-			rev.Status.MarkContainerMissing(err.Error())
-			return err
-		}
-		rev.Status.ImageDigest = digest
+	// The image digest has already been resolved.
+	if rev.Status.ImageDigest != "" {
+		return nil
 	}
+
+	cfgs := config.FromContext(ctx)
+	digest, err := c.resolver.Resolve(rev.Spec.Container.Image, rev.Namespace, rev.Spec.ServiceAccountName, cfgs.Controller.RegistriesSkippingTagResolving)
+	if err != nil {
+		rev.Status.MarkContainerMissing(err.Error())
+		return err
+	}
+
+	rev.Status.ImageDigest = digest
+
 	return nil
 }
 

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	fakecachingclientset "github.com/knative/caching/pkg/client/clientset/versioned/fake"
 	cachinginformers "github.com/knative/caching/pkg/client/informers/externalversions"
 	"github.com/knative/pkg/apis/duck"
@@ -348,7 +349,7 @@ type fixedResolver struct {
 	digest string
 }
 
-func (r *fixedResolver) Resolve(_ string, _ string, _ string, _ map[string]struct{}) (string, error) {
+func (r *fixedResolver) Resolve(_ string, _ k8schain.Options, _ map[string]struct{}) (string, error) {
 	return r.digest, nil
 }
 
@@ -356,7 +357,7 @@ type errorResolver struct {
 	error string
 }
 
-func (r *errorResolver) Resolve(_ string, _ string, _ string, _ map[string]struct{}) (string, error) {
+func (r *errorResolver) Resolve(_ string, _ k8schain.Options, _ map[string]struct{}) (string, error) {
 	return "", errors.New(r.error)
 }
 

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -348,20 +348,16 @@ type fixedResolver struct {
 	digest string
 }
 
-func (r *fixedResolver) Resolve(deploy *appsv1.Deployment, _ map[string]struct{}) error {
-	pod := deploy.Spec.Template.Spec
-	for i := range pod.Containers {
-		pod.Containers[i].Image = r.digest
-	}
-	return nil
+func (r *fixedResolver) Resolve(_ string, _ string, _ string, _ map[string]struct{}) (string, error) {
+	return r.digest, nil
 }
 
 type errorResolver struct {
 	error string
 }
 
-func (r *errorResolver) Resolve(*appsv1.Deployment, map[string]struct{}) error {
-	return errors.New(r.error)
+func (r *errorResolver) Resolve(_ string, _ string, _ string, _ map[string]struct{}) (string, error) {
+	return "", errors.New(r.error)
 }
 
 func TestResolutionFailed(t *testing.T) {

--- a/test/conformance/revision_test.go
+++ b/test/conformance/revision_test.go
@@ -1,0 +1,98 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+)
+
+func getImageDigest(clients *test.Clients, names test.ResourceNames) (string, error) {
+	var imageDigest string
+	err := test.WaitForRevisionState(clients.ServingClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
+		if r.Status.ImageDigest != "" {
+			imageDigest = r.Status.ImageDigest
+			return true, nil
+		}
+		return false, nil
+	}, "RevisionUpdatedWithImageDigest")
+	return imageDigest, err
+}
+
+func assertIsDigestForImage(t *testing.T, imageName string, imageDigest string) {
+	imageDigestRegex := fmt.Sprintf("%s/%s@sha256:[0-9a-f]{64}", test.ServingFlags.DockerRepo, imageName)
+	match, err := regexp.MatchString(imageDigestRegex, imageDigest)
+	if err != nil {
+		t.Fatalf("Unable to compare regex %s to digest %s", imageDigestRegex, imageDigest)
+	}
+	if !match {
+		t.Fatalf("Image Digest %s does not match regex %s", imageDigest, imageDigestRegex)
+	}
+}
+
+func TestRevisionCreation(t *testing.T) {
+	clients := setup(t)
+
+	logger := logging.GetContextLogger("TestRevisionCreation")
+
+	imageName := "pizzaplanetv1"
+	imagePath := test.ImagePath(imageName)
+
+	names := test.ResourceNames{
+		Config:        test.AppendRandomString("prod", logger),
+		Route:         test.AppendRandomString("pizzaplanet", logger),
+		TrafficTarget: test.AppendRandomString("pizzaplanet", logger),
+	}
+
+	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer tearDown(clients, names)
+
+	logger.Infof("Creating a new Configuration")
+	err := test.CreateConfiguration(logger, clients, names, imagePath, &test.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create Configuration: %v", err)
+	}
+
+	logger.Infof("Creating a new Route")
+	err = test.CreateRoute(logger, clients, names)
+	if err != nil {
+		t.Fatalf("Failed to create Route: %v", err)
+	}
+
+	logger.Infof("The Configuration will be updated with the name of the Revision once it is created")
+	revisionName, err := getNextRevisionName(clients, names)
+	if err != nil {
+		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
+	}
+	names.Revision = revisionName
+
+	logger.Infof("The Revision will be updated with the digest of the image once it is created")
+	imageDigest, err := getImageDigest(clients, names)
+	if err != nil {
+		t.Fatalf("Revision %s was not updated with the image digest: %v, names.Config", names.Revision, err)
+	}
+
+	logger.Infof("The image digest should be for the given image")
+	assertIsDigestForImage(t, imageName, imageDigest)
+}

--- a/test/conformance/revision_test.go
+++ b/test/conformance/revision_test.go
@@ -90,7 +90,7 @@ func TestRevisionCreation(t *testing.T) {
 	logger.Infof("The Revision will be updated with the digest of the image once it is created")
 	imageDigest, err := getImageDigest(clients, names)
 	if err != nil {
-		t.Fatalf("Revision %s was not updated with the image digest: %v, names.Config", names.Revision, err)
+		t.Fatalf("Revision %s was not updated with the image digest: %v", names.Revision, err)
 	}
 
 	logger.Infof("The image digest should be for the given image")


### PR DESCRIPTION
This change moves image digest resolution from Deployment creation
to Revision reconciliation, and introduces a new field on Revision
status. This change preseves the option to list registries to skip
in which case the imageDigest field will not be populated. When the
imageDigest field is populated, it is used for Deployment creation.

Fixes #2064
