### PR TITLE
Move activation to the autoscaler.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -41,26 +41,32 @@ func NewConcurrencyReporter(podName string, channels Channels) {
 
 	go func() {
 		outstandingRequestsPerKey := make(map[string]int32)
+
+		// Contains the number of incoming requests in the current
+		// reporting period, per key.
+		incomingRequestsPerKey := make(map[string]int32)
 		for {
 			select {
 			case event := <-channels.ReqChan:
 				switch event.EventType {
 				case ReqIn:
+					incomingRequestsPerKey[event.Key]++
 					outstandingRequestsPerKey[event.Key]++
 				case ReqOut:
 					outstandingRequestsPerKey[event.Key]--
-
 				}
 			case now := <-channels.ReportChan:
 				for key, concurrency := range outstandingRequestsPerKey {
 					if concurrency == 0 {
 						delete(outstandingRequestsPerKey, key)
 					} else {
+						requestCount := incomingRequestsPerKey[key]
+
 						stat := autoscaler.Stat{
 							Time:                      &now,
 							PodName:                   podName,
 							AverageConcurrentRequests: float64(concurrency),
-							RequestCount:              0,
+							RequestCount:              requestCount,
 						}
 
 						// Send the stat to another goroutine to transmit
@@ -71,6 +77,8 @@ func NewConcurrencyReporter(podName string, channels Channels) {
 						}
 					}
 				}
+
+				incomingRequestsPerKey = make(map[string]int32)
 			}
 		}
 	}()

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -45,7 +45,7 @@ func TestMultipleDifferentKeys(t *testing.T) {
 				Time:                      &now,
 				PodName:                   autoscaler.ActivatorPodName,
 				AverageConcurrentRequests: 2.0,
-				RequestCount:              0,
+				RequestCount:              2,
 			},
 		},
 		&autoscaler.StatMessage{
@@ -54,7 +54,7 @@ func TestMultipleDifferentKeys(t *testing.T) {
 				Time:                      &now,
 				PodName:                   autoscaler.ActivatorPodName,
 				AverageConcurrentRequests: 1.0,
-				RequestCount:              0,
+				RequestCount:              1,
 			},
 		},
 	})
@@ -70,7 +70,7 @@ func TestMultipleDifferentKeys(t *testing.T) {
 				Time:                      &now,
 				PodName:                   autoscaler.ActivatorPodName,
 				AverageConcurrentRequests: 1.0,
-				RequestCount:              0,
+				RequestCount:              0, // no new request arrived after reporting
 			},
 		},
 	})

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -77,21 +77,6 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 
 	serviceName, configurationName := getServiceAndConfigurationLabels(revision)
 	r.reporter.ReportRequest(namespace, serviceName, configurationName, name, string(revision.Spec.ServingState), 1.0)
-	switch revision.Spec.ServingState {
-	default:
-		return nil, fmt.Errorf("Disregarding activation request for revision in unknown state %v", revision.Spec.ServingState)
-	case v1alpha1.RevisionServingStateRetired:
-		return nil, errors.New("Disregarding activation request for retired revision")
-	case v1alpha1.RevisionServingStateActive:
-		// Revision is already active. Nothing to do
-	case v1alpha1.RevisionServingStateReserve:
-		// Activate the revision
-		revision.Spec.ServingState = v1alpha1.RevisionServingStateActive
-		if _, err := revisionClient.Update(revision); err != nil {
-			return nil, errors.Wrap(err, "Failed to activate revision")
-		}
-		logger.Info("Activated revision")
-	}
 
 	// Wait for the revision to be ready
 	if !revision.Status.IsReady() {

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 package activator
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -64,117 +62,6 @@ func (r *mockReporter) ReportResponseCount(ns, service, config, rev string, resp
 
 func (r *mockReporter) ReportResponseTime(ns, service, config, rev string, responseCode int, d time.Duration) error {
 	return nil
-}
-
-func TestActivator(t *testing.T) {
-	cases := []struct {
-		name             string
-		servingState     v1alpha1.RevisionServingStateType
-		revisionLabels   map[string]string
-		want             ActivationResult
-		wantServingState v1alpha1.RevisionServingStateType
-	}{
-		{
-			name:           "active stays active",
-			servingState:   v1alpha1.RevisionServingStateActive,
-			revisionLabels: defaultRevisionLabels,
-			want: ActivationResult{
-				Endpoint:          Endpoint{testServiceFQDN, 8080},
-				Status:            http.StatusOK,
-				ServiceName:       "test-service",
-				ConfigurationName: "test-config",
-				Error:             nil,
-			},
-			wantServingState: v1alpha1.RevisionServingStateActive,
-		},
-		{
-			name:           "nil revision labels",
-			servingState:   v1alpha1.RevisionServingStateActive,
-			revisionLabels: nil,
-			want: ActivationResult{
-				Endpoint:          Endpoint{testServiceFQDN, 8080},
-				Status:            http.StatusOK,
-				ServiceName:       "",
-				ConfigurationName: "",
-				Error:             nil,
-			},
-			wantServingState: v1alpha1.RevisionServingStateActive,
-		},
-		{
-			name:           "one missing revision label",
-			servingState:   v1alpha1.RevisionServingStateActive,
-			revisionLabels: map[string]string{serving.ConfigurationLabelKey: "test-config"},
-			want: ActivationResult{
-				Endpoint:          Endpoint{testServiceFQDN, 8080},
-				Status:            http.StatusOK,
-				ServiceName:       "",
-				ConfigurationName: "test-config",
-				Error:             nil,
-			},
-			wantServingState: v1alpha1.RevisionServingStateActive,
-		},
-		{
-			name:           "reserve becomes active",
-			servingState:   v1alpha1.RevisionServingStateReserve,
-			revisionLabels: defaultRevisionLabels,
-			want: ActivationResult{
-				Endpoint:          Endpoint{testServiceFQDN, 8080},
-				Status:            http.StatusOK,
-				ServiceName:       "test-service",
-				ConfigurationName: "test-config",
-				Error:             nil,
-			},
-			wantServingState: v1alpha1.RevisionServingStateActive,
-		},
-		{
-			name:           "retired stays retired with error",
-			servingState:   v1alpha1.RevisionServingStateRetired,
-			revisionLabels: defaultRevisionLabels,
-			want: ActivationResult{
-				Endpoint:          Endpoint{},
-				Status:            http.StatusInternalServerError,
-				ServiceName:       "",
-				ConfigurationName: "",
-				Error:             errors.New("error"),
-			},
-			wantServingState: v1alpha1.RevisionServingStateRetired,
-		}}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			k8s, kna := fakeClients()
-			kna.ServingV1alpha1().Revisions(testNamespace).Create(newRevisionBuilder(c.revisionLabels).
-				withServingState(c.servingState).build())
-			k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
-			a := NewRevisionActivator(k8s, kna, TestLogger(t), &mockReporter{})
-			ar := a.ActiveEndpoint(testNamespace, testRevision)
-
-			if ar.Endpoint != c.want.Endpoint {
-				t.Errorf("Wrong endpoint. Want %+v. Got %+v.", c.want.Endpoint, ar.Endpoint)
-			}
-			if ar.Status != c.want.Status {
-				t.Errorf("Unexpected status. Want %v. Got %v.", c.want.Status, ar.Status)
-			}
-			if ar.ServiceName != c.want.ServiceName {
-				t.Errorf("Unexpected service name. Want %v. Got %v.", c.want.ServiceName, ar.ServiceName)
-			}
-			if ar.ConfigurationName != c.want.ConfigurationName {
-				t.Errorf("Unexpected configuration name. Want %v. Got %v.", c.want.ConfigurationName, ar.ConfigurationName)
-			}
-			if ar.Error != nil && c.want.Error == nil {
-				t.Errorf("Unexpected error. Want no error. Got %v.", ar.Error)
-			}
-			if ar.Error == nil && c.want.Error != nil {
-				t.Errorf("Unexpected error. Want error. Got nil.")
-			}
-
-			fmt.Printf("%v, %v", testNamespace, testRevision)
-			rev, _ := kna.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
-			if rev.Spec.ServingState != c.wantServingState {
-				t.Errorf("Unexpected serving state. Want %v. Got %v.", c.wantServingState, rev.Spec.ServingState)
-			}
-		})
-	}
 }
 
 func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -256,7 +256,6 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 			// actually contains requests
 			if a.lastRequestTime.Before(*stat.Time) && stat.RequestCount > 0 {
 				a.lastRequestTime = *stat.Time
-				a.scaleToZeroThresholdExceeded = false
 			}
 		} else {
 			// Drop metrics after 60 seconds
@@ -271,9 +270,8 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	}
 
 	// Scale to zero if the last request is from too long ago
-	if !a.scaleToZeroThresholdExceeded && a.lastRequestTime.Add(config.ScaleToZeroIdlePeriod).Before(now) {
+	if a.lastRequestTime.Add(config.ScaleToZeroIdlePeriod).Before(now) {
 		logger.Debug("Last request is older than scale to zero threshold. Scaling to 0.")
-		a.scaleToZeroThresholdExceeded = true
 		return 0, true
 	}
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -105,11 +105,15 @@ func (agg *totalAggregation) observedPods(now time.Time) float64 {
 	for _, pod := range agg.perPodAggregations {
 		podCount += pod.usageRatio(now)
 	}
+
+	// Discount the activator in the pod count.
 	if agg.containsActivatorMetrics {
-		// Discount the activator in the pod count
-		if podCount > 1.0 {
-			return podCount - 1.0
+		discountedPodCount := podCount - 1.0
+		// Report a minimum of 1 pod if the activator is sending metrics.
+		if discountedPodCount < 1.0 {
+			return 1.0
 		}
+		return discountedPodCount
 	}
 	return podCount
 }

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -145,7 +145,7 @@ func TestAutoscaler_StableModeNoTraffic_ScaleToZero(t *testing.T) {
 
 	// Should not scale to zero again if there is no more traffic.
 	// Note: scale of 1 will be ignored since the autoscaler is not responsible for scaling from 0.
-	a.expectScale(t, now, 1, true)
+	a.expectScale(t, now, 0, true)
 }
 
 func TestAutoscaler_PanicMode_DoublePodCount(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -98,7 +98,7 @@ func applyBounds(min, max int32) func(int32) int32 {
 }
 
 // Scale attempts to scale the given KPA's target reference to the desired scale.
-func (rs *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredScale int32) error {
+func (ks *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredScale int32) error {
 	logger := logging.FromContext(ctx)
 
 	// TODO(mattmoor): Drop this once the KPA is the source of truth and we
@@ -120,50 +120,39 @@ func (rs *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredS
 	resourceName := kpa.Spec.ScaleTargetRef.Name
 
 	// Identify the current scale.
-	scl, err := rs.scaleClientSet.Scales(kpa.Namespace).Get(resource, resourceName)
+	scl, err := ks.scaleClientSet.Scales(kpa.Namespace).Get(resource, resourceName)
 	if err != nil {
 		logger.Errorf("Resource %q not found.", resourceName, zap.Error(err))
 		return err
 	}
 	currentScale := scl.Spec.Replicas
 
-	// Scale to zero.  When scaling to zero, flip the revision's
+	// Scale to zero. When scaling to zero, flip the revision's
 	// ServingState to Reserve (if Active).
-	if kpa.Spec.ServingState == v1alpha1.RevisionServingStateActive && desiredScale == 0 {
-		logger.Debug("Setting revision ServingState to Reserve.")
-		revisionClient := rs.servingClientSet.ServingV1alpha1().Revisions(kpa.Namespace)
-		rev, err := revisionClient.Get(owner.Name, metav1.GetOptions{})
-		if err != nil {
-			logger.Error("Unable to fetch Revision.", zap.Error(err))
+	if desiredScale == 0 {
+		if err := ks.updateServingState(logger, kpa.Namespace, owner.Name, v1alpha1.RevisionServingStateReserve); err != nil {
 			return err
 		}
-		rev.Spec.ServingState = v1alpha1.RevisionServingStateReserve
-		if _, err := revisionClient.Update(rev); err != nil {
-			logger.Error("Error updating revision serving state.", zap.Error(err))
-			return err
-		}
-		return nil
-	}
 
-	switch kpa.Spec.ServingState {
-	case v1alpha1.RevisionServingStateActive:
-		// Scale from zero.  When there are no metrics and
-		// desired state is Active, scale to 1.
-		if currentScale == 0 && desiredScale == -1 {
-			logger.Debugf("Scaling up from 0 to 1")
-			desiredScale = 1
-		}
-	default:
-		// Scale to zero grace period.  When revision
-		// ServingState=Reserve (see above) propagates to us,
-		// then actually scale things to zero.
-		// Delay the scale to zero until the LTT of
-		// "Active=False" is some time in the past.
-		if !kpa.Status.CanScaleToZero(rs.getAutoscalerConfig().ScaleToZeroGracePeriod) {
+		// Scale to zero grace period.
+		if !kpa.Status.CanScaleToZero(ks.getAutoscalerConfig().ScaleToZeroGracePeriod) {
 			logger.Debug("Waiting for Active=False grace period.")
 			return nil
 		}
-		desiredScale = 0
+	}
+
+	// Scale from zero. When scaling from zero, flip the revision's
+	// ServingState to Active
+	if currentScale == 0 && desiredScale > 0 {
+		if err := ks.updateServingState(logger, kpa.Namespace, owner.Name, v1alpha1.RevisionServingStateActive); err != nil {
+			return err
+		}
+	}
+
+	// Scale from zero. When there are no metrics scale to 1.
+	if currentScale == 0 && desiredScale == -1 {
+		logger.Debugf("Scaling up from 0 to 1")
+		desiredScale = 1
 	}
 
 	if desiredScale < 0 {
@@ -183,12 +172,28 @@ func (rs *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredS
 
 	// Scale the target reference.
 	scl.Spec.Replicas = desiredScale
-	_, err = rs.scaleClientSet.Scales(kpa.Namespace).Update(resource, scl)
+	_, err = ks.scaleClientSet.Scales(kpa.Namespace).Update(resource, scl)
 	if err != nil {
 		logger.Errorf("Error scaling target reference %v.", resourceName, zap.Error(err))
 		return err
 	}
 
 	logger.Debug("Successfully scaled.")
+	return nil
+}
+
+func (ks *kpaScaler) updateServingState(logger *zap.SugaredLogger, namespace, name string, state v1alpha1.RevisionServingStateType) error {
+	logger.Debugf("Setting revision ServingState to %v.", state)
+	revisionClient := ks.servingClientSet.ServingV1alpha1().Revisions(namespace)
+	rev, err := revisionClient.Get(name, metav1.GetOptions{})
+	if err != nil {
+		logger.Error("Unable to fetch Revision.", zap.Error(err))
+		return err
+	}
+	rev.Spec.ServingState = state
+	if _, err := revisionClient.Update(rev); err != nil {
+		logger.Error("Error updating revision serving state.", zap.Error(err))
+		return err
+	}
 	return nil
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
@@ -138,18 +138,11 @@ func TestKPAScaler(t *testing.T) {
 	}, {
 		label:         "scale up inactive revision",
 		startState:    v1alpha1.RevisionServingStateReserve,
-		startReplicas: 1,
+		startReplicas: 0,
 		scaleTo:       10,
-		wantState:     v1alpha1.RevisionServingStateReserve,
-		wantReplicas:  0,
+		wantState:     v1alpha1.RevisionServingStateActive,
+		wantReplicas:  10,
 		wantScaling:   true,
-		kpaMutation: func(k *kpa.PodAutoscaler) {
-			k.Status.Conditions = duckv1alpha1.Conditions{{
-				Type:   "Active",
-				Status: "False",
-				// No LTT == a long long time ago
-			}}
-		},
 	}, {
 		label:         "scales up from zero with no metrics",
 		startState:    v1alpha1.RevisionServingStateActive,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
/hold
-->

**Note:** After having flakes in the last version, this will run through several integration tests before we should merge it.

This moves the task of activating a revision after it has been scaled to 0 from the activator to the autoscaler, so all scaling operations are part of the autoscaler.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
