### PR TITLE
Allow running e2e tests against existing knative/serving installation

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -61,11 +61,13 @@ function create_monitoring() {
 }
 
 function create_everything() {
-  create_istio
-  create_serving
-  create_test_resources
+  if [[ -z $USING_EXISTING_SERVING ]]; then
+    create_istio
+    create_serving     
+  fi
   # TODO(#2122): Re-enable once we have monitoring e2e.
   # create_monitoring
+  create_test_resources
 }
 
 function delete_istio() {
@@ -98,8 +100,10 @@ function delete_everything() {
   # TODO(#2122): Re-enable once we have monitoring e2e.
   # delete_monitoring
   delete_test_resources
-  delete_serving
-  delete_istio
+  if [[ -z $USING_EXISTING_SERVING ]]; then
+    delete_serving
+    delete_istio
+  fi  
 }
 
 function wait_until_cluster_up() {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
We already have an option to run e2e tests against an existing Kube cluster via USING_EXISTING_CLUSTER variable. This PR adds an option to run against an existing cluster with knative/serving and istio pre-installed. This might be useful when fixing/re-running tests against existing code.
The variable USING_EXISTING_SERVING is undefined by default which means istio and knative/serving will be installed and uninstalled. When setting this env variable the script will skip this step and will only isntall test resources and run the tests.
