### PR TITLE
Automate the creation of versioned releases

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -372,11 +372,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8bf82c3f3612d2c19b22248c148e434e3e5218063a2cdfd37ff20c8a07b86880"
+  digest = "1:f42d23c4286880873a951329d5a6002fcb9ee9f7d6c5fd8263ea53df2391acee"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "10ab5a9cc454dafe8611c3961f758ea409c20e20"
+  revision = "e7ddaaf7b3c285a538c6dfe061d59b73ace965cf"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -372,11 +372,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:00f434f614520a4b48ef3f6d3ed5c7a1a4f89be1bed98c250711413f6da2eb51"
+  digest = "1:8bf82c3f3612d2c19b22248c148e434e3e5218063a2cdfd37ff20c8a07b86880"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "c21d3a832727d5d4334e734c0878eac3a5a07ae7"
+  revision = "10ab5a9cc454dafe8611c3961f758ea409c20e20"
 
 [[projects]]
   branch = "master"

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,11 @@
+# Assorted scripts for development
+
+This directory contains several scripts useful in the development process of Knative Serving.
+
+* `boilerplate/add-boilerplate.sh` Adds license boilerplate to *txt* or *go* files in a directory, recursively.
+* `deploy.sh` Deploys Knative Serving to an [environment](environments.md).
+* `diagnose-me.sh` Performs several diagnostic checks on the running Kubernetes cluster, for debugging.
+* `release.sh` Creates a new [release](release.md) of Knative Serving.
+* `update-codegen.sh` Updates auto-generated client libraries.
+* `update-deps.sh` Updates Go dependencies.
+* `verify-codegen.sh` Verifies that auto-generated client libraries are up-to-date.

--- a/hack/release.md
+++ b/hack/release.md
@@ -32,6 +32,16 @@ Nightly releases are built against the current git tree. The behavior of the
 script is defined by the common flags. You must have write access to the GCR
 and GCS bucket the release will be pushed to, unless `--nopublish` is used.
 
+Examples:
+
+```bash
+# Create and publish a nightly, tagged release.
+./hack/release.sh --publish --tag-release
+
+# Create release, but don't test, publish or tag it.
+./hack/release.sh --skip-tests --nopublish --notag-release
+```
+
 ## Creating versioned releases
 
 *Note: only Knative admins can create versioned releases.*

--- a/hack/release.md
+++ b/hack/release.md
@@ -1,0 +1,61 @@
+# Creating a new Knative Serving release
+
+The `release.sh` script automates the creation of Knative Serving releases,
+either nightly or versioned ones.
+
+By default, the script creates a nightly release but does not publish anywhere.
+
+## Common flags for cutting releases
+
+The following flags affect the behavior of the script, no matter the type of
+the release.
+
+* `--skip-tests` Do not run tests before building the release. Otherwise,
+build, unit and end-to-end tests are run and they all must pass for the
+release to be built.
+* `--tag-release`, `--notag-release` Tag the generated images with either
+`vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
+versioned releases. *For versioned releases, a tag is always added.*
+* `--publish`, `--nopublish` Whether the generated images should be published
+to a GCR, and the generated manifests written to a GCS bucket or not. If yes,
+the destination GCR is defined by the environment variable
+`$SERVING_RELEASE_GCR` (defaults to `gcr.io/knative-releases`) and the
+destination GCS bucket is defined by the environment variable
+`$SERVING_RELEASE_GCS` (defaults to `knative-releases/serving`). If no, the
+images will be pushed to the `ko.local` registry, and the manifests written
+to the local disk only (in the repository root directory).
+
+## Creating nightly releases
+
+Nightly releases are built against the current git tree. The behavior of the
+script is defined by the common flags. You must have write access to the GCR
+and GCS bucket the release will be pushed to, unless `--nopublish` is used.
+
+## Creating versioned releases
+
+*Note: only Knative admins can create versioned releases.*
+
+To specify a versioned release to be cut, you must use the `--version` flag.
+Versioned releases are usually built against a branch in the Knative Serving
+repository, specified by the `--branch` flag. 
+
+* `--version` Defines the version of the release, and must be in the form
+`X.Y.Z`, where X, Y and Z are numbers.
+* `--branch` Defines the branch in Knative Serving repository from which the
+release will be built. If not passed, the `master` branch at HEAD will be
+used. This branch must be created before the script is executed, and must be
+in the form `release-X.Y`, where X and Y must match the numbers used in the
+version passed in the `--version` flag. This flag has no effect unless
+`--version` is also passed.
+* `--release-notes` Points to a markdown file containing a description of the
+release. This is optional but highly recommended. It has no effect unless
+`--version` is also passed.
+
+If this is the first time you're cutting a versioned release, you'll be prompted
+for your GitHub username, password, and possibly 2-factor authentication
+challenge before the release is published.
+
+The release will be published in the *Releases* page of the Knative Serving
+repository, with the title *Knative Serving release vX.Y.Z* and the given
+release notes. It will also be tagged *vX.Y.Z* (both on GitHub and as a git
+annotated tag).

--- a/hack/release.md
+++ b/hack/release.md
@@ -13,9 +13,10 @@ the release.
 * `--skip-tests` Do not run tests before building the release. Otherwise,
 build, unit and end-to-end tests are run and they all must pass for the
 release to be built.
-* `--tag-release`, `--notag-release` Tag the generated images with either
-`vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
-versioned releases. *For versioned releases, a tag is always added.*
+* `--tag-release`, `--notag-release` Tag (or not) the generated images
+with either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or
+`vX.Y.Z` for versioned releases. *For versioned releases, a tag is always
+added.*
 * `--publish`, `--nopublish` Whether the generated images should be published
 to a GCR, and the generated manifests written to a GCS bucket or not. If yes,
 the destination GCR is defined by the environment variable

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -128,11 +128,12 @@ fi
 
 # Publish the release
 
-for yaml in "${RELEASE_YAML}" "${LITE_YAML}" "${NO_MON_YAML}" "${SERVING_YAML}" "${BUILD_YAML}" "${MONITORING_YAML}" "${MONITORING_LEAN_YAML}" "${ISTIO_YAML}" "${ISTIO_LEAN_YAML}"; do
+realonly YAMLS_TO_PUBLISH="${RELEASE_YAML}" "${LITE_YAML}" "${NO_MON_YAML}" "${SERVING_YAML}" "${BUILD_YAML}" "${MONITORING_YAML}" "${MONITORING_LEAN_YAML}" "${ISTIO_YAML}" "${ISTIO_LEAN_YAML}"
+for yaml in ${YAMLS_TO_PUBLISH}; do
   echo "Publishing ${yaml}"
   publish_yaml "${yaml}" "${SERVING_RELEASE_GCS}" "${TAG}"
 done
 
-branch_release "Knative Serving" "${RELEASE_YAML} ${LITE_YAML} ${NO_MON_YAML}"
+branch_release "Knative Serving" ${YAMLS_TO_PUBLISH}
 
 echo "New release published successfully"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -128,7 +128,7 @@ fi
 
 # Publish the release
 
-realonly YAMLS_TO_PUBLISH="${RELEASE_YAML}" "${LITE_YAML}" "${NO_MON_YAML}" "${SERVING_YAML}" "${BUILD_YAML}" "${MONITORING_YAML}" "${MONITORING_LEAN_YAML}" "${ISTIO_YAML}" "${ISTIO_LEAN_YAML}"
+readonly YAMLS_TO_PUBLISH="${RELEASE_YAML}" "${LITE_YAML}" "${NO_MON_YAML}" "${SERVING_YAML}" "${BUILD_YAML}" "${MONITORING_YAML}" "${MONITORING_LEAN_YAML}" "${ISTIO_YAML}" "${ISTIO_LEAN_YAML}"
 for yaml in ${YAMLS_TO_PUBLISH}; do
   echo "Publishing ${yaml}"
   publish_yaml "${yaml}" "${SERVING_RELEASE_GCS}" "${TAG}"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -34,7 +34,7 @@ readonly MONITORING_LEAN_YAML=monitoring-lean.yaml
 
 # Script entry point
 
-parse_flags $@
+initialize $@
 
 set -o errexit
 set -o pipefail
@@ -132,5 +132,7 @@ for yaml in "${RELEASE_YAML}" "${LITE_YAML}" "${NO_MON_YAML}" "${SERVING_YAML}" 
   echo "Publishing ${yaml}"
   publish_yaml "${yaml}" "${SERVING_RELEASE_GCS}" "${TAG}"
 done
+
+branch_release "Knative Serving" "${RELEASE_YAML} ${LITE_YAML} ${NO_MON_YAML}"
 
 echo "New release published successfully"

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -68,7 +68,7 @@ This is a helper script for Knative release scripts. To use it:
 
 1. Source the script.
 
-1. Call the `parse_flags()` function passing `$@` (without quotes).
+1. Call the `initialize()` function passing `$@` (without quotes).
 
 1. Call the `run_validation_tests()` function passing the script or executable that
 runs the release validation tests. It will call the script to run the tests unless
@@ -102,7 +102,7 @@ variable `KO_FLAGS` will be updated with the `-L` option.
 ```bash
 source vendor/github.com/knative/test-infra/scripts/release.sh
 
-parse_flags $@
+initialize $@
 
 run_validation_tests ./test/presubmit-tests.sh
 

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -1,3 +1,121 @@
 # Helper scripts
 
-This directory contains helper scripts used by Prow test jobs, as well and local development scripts.
+This directory contains helper scripts used by Prow test jobs, as well and
+local development scripts.
+
+## Using the `e2e-tests.sh` helper script
+
+This is a helper script for Knative E2E test scripts. To use it:
+
+1. Source the script.
+
+1. [optional] Write the `teardown()` function, which will tear down your test
+resources.
+
+1. [optional] Write the `dump_extra_cluster_state()` function. It will be
+called when a test fails, and can dump extra information about the current state
+of the cluster (tipically using `kubectl`).
+
+1. Call the `initialize()` function passing `$@` (without quotes).
+
+1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
+(or `report_go_test()` if you need a more fine-grained control) and call
+`fail_test()` or `success()` if any of them failed. The environment variables
+`DOCKER_REPO_OVERRIDE`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be set
+according to the test cluster. You can also use the following boolean (0 is false,
+1 is true) environment variables for the logic:
+    * `EMIT_METRICS`: true if `--emit-metrics` was passed.
+    * `USING_EXISTING_CLUSTER`: true if the test cluster is an already existing one,
+and not a temporary cluster created by `kubetest`.
+
+    All environment variables above are marked read-only.
+
+**Notes:**
+
+1. Calling your script without arguments will create a new cluster in the GCP
+project `$PROJECT_ID` and run the tests against it.
+
+1. Calling your script with `--run-tests` and the variables `K8S_CLUSTER_OVERRIDE`,
+`K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
+tests against the cluster.
+
+### Sample end-to-end test script
+
+This script will test that the latest Knative Serving nightly release works.
+
+```bash
+source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+function teardown() {
+  echo "TODO: tear down test resources"
+}
+
+initialize $@
+
+start_latest_knative_serving
+
+wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+
+# TODO: use go_test_e2e to run the tests.
+kubectl get pods || fail_test
+
+success
+```
+
+## Using the `release.sh` helper script
+
+This is a helper script for Knative release scripts. To use it:
+
+1. Source the script.
+
+1. Call the `parse_flags()` function passing `$@` (without quotes).
+
+1. Call the `run_validation_tests()` function passing the script or executable that
+runs the release validation tests. It will call the script to run the tests unless
+`--skip_tests` was passed.
+
+1. Write logic for the release process. Call `publish_yaml()` to publish the manifest(s),
+`tag_releases_in_yaml()` to tag the generated images, `branch_release()` to branch
+named releases. Use the following boolean (0 is false, 1 is true) and string environment
+variables for the logic:
+    * `RELEASE_VERSION`: contains the release version if `--version` was passed. This
+also overrides the value of the `TAG` variable as `v<version>`.
+    * `RELEASE_BRANCH`: contains the release branch if `--branch` was passed. Otherwise
+it's empty and `master` HEAD will be considered the release branch.
+    * `RELEASE_NOTES`: contains the filename with the release notes if `--release-notes`
+was passed. The release notes is a simple markdown file.
+    * `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically
+by the run_validation_tests() function.
+    * `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
+variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
+    * `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
+variable `KO_FLAGS` will be updated with the `-L` option.
+    * `BRANCH_RELEASE`: true if both `--version` and `--publish-release` were passed.
+
+    All boolean environment variables default to false for safety.
+
+    All environment variables above, except `KO_FLAGS`, are marked read-only once
+`initialize()` is called.
+
+### Sample release script
+
+```bash
+source vendor/github.com/knative/test-infra/scripts/release.sh
+
+parse_flags $@
+
+run_validation_tests ./test/presubmit-tests.sh
+
+# config/ contains the manifests
+KO_DOCKER_REPO=gcr.io/knative-foo
+ko resolve ${KO_FLAGS} -f config/ > release.yaml
+
+tag_images_in_yaml release.yaml $KO_DOCKER_REPO $TAG
+
+if (( PUBLISH_RELEASE )); then
+  # gs://knative-foo hosts the manifest
+  publish_yaml release.yaml knative-foo $TAG
+fi
+
+branch_release "Knative Foo" release.yaml
+```

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -14,29 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script for Knative E2E test scripts. To use it:
-# 1. Source this script.
-# 2. [optional] Write the teardown() function, which will tear down your test
-#    resources.
-# 3. [optional] Write the dump_extra_cluster_state() function. It will be called
-#    when a test fails, and can dump extra information about the current state of
-#    the cluster (tipically using kubectl).
-# 4. Call the initialize() function passing $@ (without quotes).
-# 5. Write logic for the end-to-end tests. Run all go tests using report_go_test()
-#    and call fail_test() or success() if any of them failed. The envitronment
-#    variables DOCKER_REPO_OVERRIDE, K8S_CLUSTER_OVERRIDE and K8S_USER_OVERRIDE
-#    will be set accordingly to the test cluster. You can also use the following
-#    boolean (0 is false, 1 is true) environment variables for the logic:
-#    EMIT_METRICS: true if --emit-metrics is passed.
-#    USING_EXISTING_CLUSTER: true if the test cluster is an already existing one,
-#                            and not a temporary cluster created by kubetest.
-#    All environment variables above are marked read-only.
-# Notes:
-# 1. Calling your script without arguments will create a new cluster in the GCP
-#    project $PROJECT_ID and run the tests against it.
-# 2. Calling your script with --run-tests and the variables K8S_CLUSTER_OVERRIDE,
-#    K8S_USER_OVERRIDE and DOCKER_REPO_OVERRIDE set will immediately start the
-#    tests against the cluster.
+# This is a helper script for Knative E2E test scripts.
+# See README.md for instructions on how to use it.
 
 source $(dirname ${BASH_SOURCE})/library.sh
 
@@ -51,7 +30,9 @@ function build_resource_name() {
   if [[ -n "${suffix}" ]]; then
     suffix=${suffix:${#suffix}<20?0:-20}
   fi
-  echo "${prefix:0:20}${suffix}"
+  local name="${prefix:0:20}${suffix}"
+  # Ensure name doesn't end with "-"
+  echo "${name%-}"
 }
 
 # Test cluster parameters
@@ -89,6 +70,14 @@ function fail_test() {
   [[ -n $1 ]] && echo "ERROR: $1"
   dump_cluster_state
   exit 1
+}
+
+# Run the given E2E tests (must be tagged as such).
+# Parameters: $1..$n - any go test flags, then directories containing the tests to run.
+function go_test_e2e() {
+  local options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test -v -tags=e2e -count=1 $@ ${options}
 }
 
 # Download the k8s binaries required by kubetest.

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -235,13 +235,8 @@ function report_go_test() {
   echo "Finished run, return code is ${failed}"
   # Tests didn't run.
   [[ ! -s ${report} ]] && return 1
-  # Create WORKSPACE file, required to use bazel, if necessary
-  local has_workspace=0
-  if [[ -e WORKSPACE ]]; then
-    has_workspace=1
-  else
-    touch WORKSPACE
-  fi
+  # Create WORKSPACE file, required to use bazel, if necessary.
+  touch WORKSPACE
   local targets=""
   local last_run=""
   local test_files=""
@@ -328,9 +323,6 @@ function report_go_test() {
   fi
   # Always generate the junit summary.
   bazel test ${targets} > /dev/null 2>&1 || true
-  # Cleanup bazel stuff we created.
-  rm -fr knative
-  (( ! has_workspace )) && rm -fr WORKSPACE bazel-*
   return ${failed}
 }
 

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -94,7 +94,7 @@ function wait_until_object_does_not_exist() {
   fi
   echo -n "Waiting until ${DESCRIPTION} does not exist"
   for i in {1..150}; do  # timeout after 5 minutes
-    kubectl ${KUBECTL_ARGS} 2>&1 > /dev/null || return 0
+    kubectl ${KUBECTL_ARGS} > /dev/null 2>&1 || return 0
     echo -n "."
     sleep 2
   done
@@ -235,9 +235,16 @@ function report_go_test() {
   echo "Finished run, return code is ${failed}"
   # Tests didn't run.
   [[ ! -s ${report} ]] && return 1
-  # Create WORKSPACE file, required to use bazel
-  touch WORKSPACE
+  # Create WORKSPACE file, required to use bazel, if necessary
+  local has_workspace=0
+  if [[ -e WORKSPACE ]]; then
+    has_workspace=1
+  else
+    touch WORKSPACE
+  fi
   local targets=""
+  local last_run=""
+  local test_files=""
   # Parse the report and generate fake tests for each passing/failing test.
   echo "Start parsing results, summary:"
   while read line ; do
@@ -245,15 +252,34 @@ function report_go_test() {
     local field0="${fields[0]}"
     local field1="${fields[1]}"
     local name="${fields[2]}"
+    # Deal with a SIGQUIT log entry (usually a test timeout).
+    # This is a fallback in case there's no kill signal log entry.
+    # SIGQUIT: quit
+    if [[ "${field0}" == "SIGQUIT:" ]]; then
+      name="${last_run}"
+      field1="FAIL:"
+      error="${fields[@]}"
+    fi
     # Ignore subtests (those containing slashes)
     if [[ -n "${name##*/*}" ]]; then
       local error=""
+      # Deal with a kill signal log entry (usually a test timeout).
+      # *** Test killed with quit: ran too long (10m0s).
+      if [[ "${field0}" == "***" ]]; then
+        name="${last_run}"
+        field1="FAIL:"
+        error="${fields[@]:1}"
+      fi
       # Deal with a fatal log entry, which has a different format:
       # fatal   TestFoo   foo_test.go:275 Expected "foo" but got "bar"
       if [[ "${field0}" == "fatal" ]]; then
-        name="${fields[1]}"
+        name="${field1}"
         field1="FAIL:"
         error="${fields[@]:3}"
+      fi
+      # Keep track of the test currently running.
+      if [[ "${field1}" == "RUN" ]]; then
+        last_run="${name}"
       fi
       # Handle regular go test pass/fail entry for a test.
       if [[ "${field1}" == "PASS:" || "${field1}" == "FAIL:" ]]; then
@@ -269,13 +295,14 @@ function report_go_test() {
           echo "exit 1" >> ${src}
         fi
         chmod +x ${src}
+        test_files="${test_files} ${src}"
         # Populate BUILD.bazel
         echo "sh_test(name=\"${name}\", srcs=[\"${src}\"])" >> BUILD.bazel
       elif [[ "${field0}" == "FAIL" || "${field0}" == "ok" ]] && [[ -n "${field1}" ]]; then
         echo "- ${field0} ${field1}"
         # Create the package structure, move tests and BUILD file
         local package=${field1/github.com\//}
-        local bazel_files="$(ls -1 *.sh BUILD.bazel 2> /dev/null)"
+        local bazel_files="$(ls -1 ${test_files} BUILD.bazel 2> /dev/null)"
         if [[ -n "${bazel_files}" ]]; then
           mkdir -p ${package}
           targets="${targets} //${package}/..."
@@ -283,6 +310,7 @@ function report_go_test() {
         else
           echo "*** INTERNAL ERROR: missing tests for ${package}, got [${bazel_files/$'\n'/, }]"
         fi
+        test_files=""
       fi
     fi
   done < ${report}
@@ -291,11 +319,18 @@ function report_go_test() {
   # Otherwise, we already shown the summary.
   # Exception: when emitting metrics, dump the full report.
   if (( failed )) || [[ "$@" == *" -emitmetrics"* ]]; then
-    echo "At least one test failed, full log:"
+    if (( failed )); then
+      echo "At least one test failed, full log:"
+    else
+      echo "Dumping full log as metrics were requested:"
+    fi
     cat ${report}
   fi
   # Always generate the junit summary.
-  bazel test ${targets} > /dev/null 2>&1
+  bazel test ${targets} > /dev/null 2>&1 || true
+  # Cleanup bazel stuff we created.
+  rm -fr knative
+  (( ! has_workspace )) && rm -fr WORKSPACE bazel-*
   return ${failed}
 }
 
@@ -323,14 +358,17 @@ function start_latest_knative_build() {
   wait_until_pods_running knative-build || return 1
 }
 
-# Run dep-collector, installing it first if necessary.
-# Parameters: $1..$n - parameters passed to dep-collector.
-function run_dep_collector() {
-  local local_dep_collector="$(which dep-collector)"
-  if [[ -z ${local_dep_collector} ]]; then
-    go get -u github.com/mattmoor/dep-collector
+# Run a go tool, installing it first if necessary.
+# Parameters: $1 - tool to run.
+#             $2 - tool package for go get.
+#             $3..$n - parameters passed to the tool.
+function run_go_tool() {
+  local tool=$1
+  if [[ -z "$(which ${tool})" ]]; then
+    go get -u $2
   fi
-  dep-collector $@
+  shift 2
+  ${tool} $@
 }
 
 # Run dep-collector to update licenses.
@@ -340,7 +378,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_dep_collector $@ > ./${dst}
+  run_go_tool dep-collector github.com/mattmoor/dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.
@@ -349,7 +387,7 @@ function check_licenses() {
   # Fetch the google/licenseclassifier for its license db
   go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  run_dep_collector -check $@
+  run_go_tool dep-collector github.com/mattmoor/dep-collector -check $@
 }
 
 # Run the given linter on the given files, checking it exists first.

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -65,6 +65,19 @@ function exit_if_presubmit_not_required() {
 function main() {
   exit_if_presubmit_not_required
 
+  # Show the version of the tools we're using
+  if (( IS_PROW )); then
+    # Disable gcloud update notifications
+    gcloud config set component_manager/disable_update_check true
+    header "Current test setup"
+    echo ">> gcloud SDK version"
+    gcloud version
+    echo ">> kubectl version"
+    kubectl version
+    echo ">> go version"
+    go version
+  fi
+
   local all_parameters=$@
   [[ -z $1 ]] && all_parameters="--all-tests"
 


### PR DESCRIPTION
`test-infra` is updated to the latest version to include the required infrastructure.

Bonuses:
* documented the contents of the `hack` directory;
* documented how to use the `release.sh` script;

Fixes #1869.