### PR TITLE
Few linting enhancements

### DIFF
--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -81,7 +81,7 @@ func TestMultiScalerScaling(t *testing.T) {
 		}
 	})
 
-	m, err = ms.Create(ctx, kpa)
+	_, err = ms.Create(ctx, kpa)
 	if err != nil {
 		t.Errorf("Create() = %v", err)
 	}
@@ -157,7 +157,7 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 		}
 	})
 
-	m, err = ms.Create(ctx, kpa)
+	_, err = ms.Create(ctx, kpa)
 	if err != nil {
 		t.Errorf("Create() = %v", err)
 	}
@@ -212,7 +212,7 @@ func TestMultiScalerWithoutScaleToZero(t *testing.T) {
 		done <- struct{}{}
 	})
 
-	m, err = ms.Create(ctx, kpa)
+	_, err = ms.Create(ctx, kpa)
 	if err != nil {
 		t.Errorf("Create() = %v", err)
 	}

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -35,6 +35,7 @@ import (
 	rclr "github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/config"
 	"github.com/knative/serving/pkg/system"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -229,7 +230,6 @@ func newTestController(t *testing.T, stopCh <-chan struct{}, servingObjects ...r
 
 func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	stopCh := make(chan struct{})
-	defer close(stopCh)
 
 	rev := getTestRevision()
 	// TODO(grantr): inserting the route at client creation is necessary
@@ -250,15 +250,21 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 		return HookComplete
 	})
 
+	eg := errgroup.Group{}
+	defer func() {
+		close(stopCh)
+		if err := eg.Wait(); err != nil {
+			t.Fatalf("Error running controller: %v", err)
+		}
+	}()
+
 	kubeInformer.Start(stopCh)
 	servingInformer.Start(stopCh)
 	servingSystemInformer.Start(stopCh)
 
-	go func() {
-		if err := controller.Run(2, stopCh); err != nil {
-			t.Fatalf("Error running controller: %v", err)
-		}
-	}()
+	eg.Go(func() error {
+		return controller.Run(2, stopCh)
+	})
 
 	if err := h.WaitForHooks(time.Second * 3); err != nil {
 		t.Error(err)

--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -137,7 +137,7 @@ func (c *Reconciler) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 	if apierrs.IsNotFound(err) {
 		// If it does not exist, then create it.
 		rev.Status.MarkDeploying("Deploying")
-		service, err = c.createService(ctx, rev, resources.MakeK8sService)
+		_, err = c.createService(ctx, rev, resources.MakeK8sService)
 		if err != nil {
 			logger.Errorf("Error creating Service %q: %v", serviceName, err)
 			return err
@@ -152,7 +152,7 @@ func (c *Reconciler) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 		// should not allow, or if our expectations of how the service should look
 		// changes (e.g. we update our controller with new sidecars).
 		var changed Changed
-		service, changed, err = c.checkAndUpdateService(ctx, rev, resources.MakeK8sService, service)
+		_, changed, err = c.checkAndUpdateService(ctx, rev, resources.MakeK8sService, service)
 		if err != nil {
 			logger.Errorf("Error updating Service %q: %v", serviceName, err)
 			return err

--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	// TODO(mattmoor): Make this private once we remove revision_test.go
-	UserContainerName    = "user-container"
+	userContainerName    = "user-container"
 	fluentdContainerName = "fluentd-proxy"
 	envoyContainerName   = "istio-proxy"
 	queueContainerName   = "queue-proxy"
@@ -35,8 +34,7 @@ const (
 	userPort        = 8080
 	userPortEnvName = "PORT"
 
-	// TODO(mattmoor): Make this private once we remove revision_test.go
-	AutoscalerPort = 8080
+	autoscalerPort = 8080
 
 	// ServicePortName is the name of the external port of the service
 	ServicePortName = "http"

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -113,7 +113,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	userContainer := rev.Spec.Container.DeepCopy()
 	// Adding or removing an overwritten corev1.Container field here? Don't forget to
 	// update the validations in pkg/webhook.validateContainer.
-	userContainer.Name = UserContainerName
+	userContainer.Name = userContainerName
 	userContainer.Resources = userResources
 	userContainer.Ports = userPorts
 	userContainer.VolumeMounts = append(userContainer.VolumeMounts, varLogVolumeMount)

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -71,7 +71,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:         UserContainerName,
+				Name:         userContainerName,
 				Image:        "busybox",
 				Resources:    userResources,
 				Ports:        userPorts,
@@ -151,7 +151,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:         UserContainerName,
+				Name:         userContainerName,
 				Image:        "busybox@sha256:deadbeef",
 				Resources:    userResources,
 				Ports:        userPorts,
@@ -235,7 +235,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:         UserContainerName,
+				Name:         userContainerName,
 				Image:        "busybox",
 				Resources:    userResources,
 				Ports:        userPorts,
@@ -320,7 +320,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:  UserContainerName,
+				Name:  userContainerName,
 				Image: "busybox",
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -412,7 +412,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:  UserContainerName,
+				Name:  userContainerName,
 				Image: "busybox",
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -503,7 +503,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:  UserContainerName,
+				Name:  userContainerName,
 				Image: "busybox",
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -594,7 +594,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:  UserContainerName,
+				Name:  userContainerName,
 				Image: "busybox",
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -681,7 +681,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:         UserContainerName,
+				Name:         userContainerName,
 				Image:        "busybox",
 				Resources:    userResources,
 				Ports:        userPorts,
@@ -742,7 +742,7 @@ func TestMakePodSpec(t *testing.T) {
 					Value: "--no-supervisor -q",
 				}, {
 					Name:  "SERVING_CONTAINER_NAME",
-					Value: UserContainerName,
+					Value: userContainerName,
 				}, {
 					Name: "SERVING_CONFIGURATION",
 					// No owner reference
@@ -794,7 +794,7 @@ func TestMakePodSpec(t *testing.T) {
 		cc: &config.Controller{},
 		want: &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:    UserContainerName,
+				Name:    userContainerName,
 				Image:   "busybox",
 				Command: []string{"/bin/bash"},
 				Args:    []string{"-c", "echo Hello world"},

--- a/pkg/reconciler/v1alpha1/revision/resources/fluentd.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/fluentd.go
@@ -112,7 +112,7 @@ func makeFluentdContainer(rev *v1alpha1.Revision, observabilityConfig *config.Ob
 			Value: "--no-supervisor -q",
 		}, {
 			Name:  "SERVING_CONTAINER_NAME",
-			Value: UserContainerName,
+			Value: userContainerName,
 		}, {
 			Name:  "SERVING_CONFIGURATION",
 			Value: configName,

--- a/pkg/reconciler/v1alpha1/revision/resources/fluentd_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/fluentd_test.go
@@ -143,7 +143,7 @@ func TestMakeFluentdContainer(t *testing.T) {
 				Value: "--no-supervisor -q",
 			}, {
 				Name:  "SERVING_CONTAINER_NAME",
-				Value: UserContainerName, // matches name
+				Value: userContainerName, // matches name
 			}, {
 				Name:  "SERVING_CONFIGURATION",
 				Value: "", // No OwnerReference
@@ -187,7 +187,7 @@ func TestMakeFluentdContainer(t *testing.T) {
 				Value: "--no-supervisor -q",
 			}, {
 				Name:  "SERVING_CONTAINER_NAME",
-				Value: UserContainerName, // matches name
+				Value: userContainerName, // matches name
 			}, {
 				Name:  "SERVING_CONFIGURATION",
 				Value: "the-parent-config-name", // With OwnerReference
@@ -226,7 +226,7 @@ func TestMakeFluentdContainer(t *testing.T) {
 				Value: "--no-supervisor -q",
 			}, {
 				Name:  "SERVING_CONTAINER_NAME",
-				Value: UserContainerName, // matches name
+				Value: userContainerName, // matches name
 			}, {
 				Name:  "SERVING_CONFIGURATION",
 				Value: "", // no OwnerReference

--- a/pkg/reconciler/v1alpha1/revision/resources/imagecache.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/imagecache.go
@@ -30,7 +30,7 @@ import (
 
 func MakeImageCache(rev *v1alpha1.Revision, deploy *appsv1.Deployment) (*caching.Image, error) {
 	for _, container := range deploy.Spec.Template.Spec.Containers {
-		if container.Name != UserContainerName {
+		if container.Name != userContainerName {
 			// The sidecars are cached once separately.
 			continue
 		}
@@ -53,5 +53,5 @@ func MakeImageCache(rev *v1alpha1.Revision, deploy *appsv1.Deployment) (*caching
 
 		return img, nil
 	}
-	return nil, fmt.Errorf("user container %q not found: %v", UserContainerName, deploy)
+	return nil, fmt.Errorf("user container %q not found: %v", userContainerName, deploy)
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/imagecache_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/imagecache_test.go
@@ -56,7 +56,7 @@ func TestMakeImageCache(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
-							Name:  UserContainerName,
+							Name:  userContainerName,
 							Image: "busybox",
 						}},
 					},
@@ -108,7 +108,7 @@ func TestMakeImageCache(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "privilegeless",
 						Containers: []corev1.Container{{
-							Name:  UserContainerName,
+							Name:  userContainerName,
 							Image: "busybox",
 						}},
 					},

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -108,7 +108,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 			Value: autoscalerAddress,
 		}, {
 			Name:  "SERVING_AUTOSCALER_PORT",
-			Value: strconv.Itoa(AutoscalerPort),
+			Value: strconv.Itoa(autoscalerPort),
 		}, {
 			Name: "SERVING_POD",
 			ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
- resources: unexported some constants  …
  `UserContainerName` and `AutoscalerPort` are only used in the package,
  fixing the TODO wink
- Fix some ineffassign  …
- testing: don't call t.Fatal inside a goroutine  …
  > FailNow must be called from the goroutine running the test or
  > benchmark function, not from other goroutines created during the
  > test. Calling FailNow does not stop those other goroutines.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>