### PR TITLE
Add configurationGeneration label to revisions #2222

### DIFF
--- a/docs/spec/normative_examples.md
+++ b/docs/spec/normative_examples.md
@@ -167,7 +167,6 @@ metadata:
   name: def
   labels:
     knative.dev/configuration: my-service
-  annotations:
     knative.dev/configurationGeneration: 1235
   ...
 spec:
@@ -398,9 +397,7 @@ metadata:
   labels:
     # name and generation of the configuration that created the revision
     knative.dev/configuration: my-service
-  annotations:
     knative.dev/configurationGeneration: 1234
-  ...  # uid, resourceVersion, creationTimestamp, generation, selfLink, etc
 spec:
   ...  # spec from the configuration
 status:
@@ -919,7 +916,6 @@ metadata:
   name: abc
   labels:
     knative.dev/configuration: my-service
-  annotations:
     knative.dev/configurationGeneration: 1234
   ...
 spec:

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -213,8 +213,7 @@ metadata:
   labels:
     knative.dev/configuration: ...  # name of the Configuration automatically filled in 
     knative.dev/service: ...  # name of the Service automatically filled in
-  annotations:
-    knative.dev/configurationGeneration: ...  # generation of configuration that created this Revision
+    knative.dev/configurationGeneration: ... # generation of configuration that created this Revision
   # system generated meta
   uid: ...
   resourceVersion: ...  # used for optimistic concurrency control

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -56,4 +56,8 @@ const (
 	// ServiceLabelKey is the label key attached to a Route and Configuration indicating by
 	// which Service they are created.
 	ServiceLabelKey = GroupName + "/service"
+
+	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
+	// generation of the Configuration that created this revision
+	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
 )

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -23,10 +23,6 @@ const (
 	// which Configuration it is created.
 	ConfigurationLabelKey = GroupName + "/configuration"
 
-	// ConfigurationGenerationAnnotationKey is the annotation key attached to a Revision indicating the
-	// generation of the Configuration that created this revision
-	ConfigurationGenerationAnnotationKey = GroupName + "/configurationGeneration"
-
 	// RevisionLastPinnedAnnotationKey is the annotation key used for determining when a route has
 	// pinned a revision
 	RevisionLastPinnedAnnotationKey = GroupName + "/lastPinned"

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -374,6 +374,8 @@ func (rs *RevisionStatus) SetConditions(conditions duckv1alpha1.Conditions) {
 const (
 	AnnotationParseErrorTypeMissing = "Missing"
 	AnnotationParseErrorTypeInvalid = "Invalid"
+	LabelParserErrorTypeMissing = "Missing"
+	LabelParserErrorTypeInvalid = "Invalid"
 )
 
 // +k8s:deepcopy-gen=false
@@ -437,23 +439,23 @@ func (r *Revision) GetLastPinned() (time.Time, error) {
 }
 
 func (r *Revision) GetConfigurationGeneration() (int64, error) {
-	if r.Annotations == nil {
+	if r.Labels == nil {
 		return 0, configurationGenerationParseError{
-			Type: AnnotationParseErrorTypeMissing,
+			Type: LabelParserErrorTypeMissing,
 		}
 	}
 
-	str, ok := r.ObjectMeta.Annotations[serving.ConfigurationGenerationAnnotationKey]
+	str, ok := r.ObjectMeta.Labels[serving.ConfigurationGenerationLabelKey]
 	if !ok {
 		return 0, configurationGenerationParseError{
-			Type: AnnotationParseErrorTypeMissing,
+			Type: LabelParserErrorTypeMissing,
 		}
 	}
 
 	gen, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
 		return 0, configurationGenerationParseError{
-			Type:  AnnotationParseErrorTypeInvalid,
+			Type:  LabelParserErrorTypeInvalid,
 			Value: str,
 			Err:   err,
 		}

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -722,6 +722,7 @@ func TestRevisionAnnotations(t *testing.T) {
 	cases := []struct {
 		name               string
 		annotations        map[string]string
+		labels             map[string]string
 		setLastPinned      *time.Time
 		expectLastPinned   time.Time
 		expectConfigGen    *int64
@@ -753,12 +754,12 @@ func TestRevisionAnnotations(t *testing.T) {
 		},
 		expectLastPinned: fakeTime,
 		expectConfigGenErr: configurationGenerationParseError{
-			Type: AnnotationParseErrorTypeMissing,
+			Type: LabelParserErrorTypeMissing,
 		},
 	}, {
-		name: "annotated configGeneration",
-		annotations: map[string]string{
-			serving.ConfigurationGenerationAnnotationKey: "10",
+		name: "labeled configGeneration",
+		labels: map[string]string{
+			serving.ConfigurationGenerationLabelKey: "10",
 		},
 		expectConfigGen: &fakeGen,
 	}}
@@ -768,6 +769,7 @@ func TestRevisionAnnotations(t *testing.T) {
 			rev := Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: tc.annotations,
+					Labels: tc.labels,
 				},
 			}
 

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -584,8 +584,8 @@ func TestIsRevisionStale(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "myrev",
 				CreationTimestamp: metav1.Time{curTime},
-				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "1",
+				Labels: map[string]string{
+					serving.ConfigurationGenerationLabelKey: "1",
 				},
 			},
 		},
@@ -596,8 +596,8 @@ func TestIsRevisionStale(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "myrev",
 				CreationTimestamp: metav1.Time{staleTime},
-				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "1",
+				Labels: map[string]string{
+					serving.ConfigurationGenerationLabelKey: "1",
 				},
 			},
 		},
@@ -608,8 +608,10 @@ func TestIsRevisionStale(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "myrev",
 				CreationTimestamp: metav1.Time{staleTime},
+				Labels: map[string]string{
+					serving.ConfigurationGenerationLabelKey: "1",
+				},
 				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "1",
 					"serving.knative.dev/lastPinned":             fmt.Sprintf("%d", staleTime.Unix()),
 				},
 			},
@@ -621,8 +623,10 @@ func TestIsRevisionStale(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "myrev",
 				CreationTimestamp: metav1.Time{staleTime},
+				Labels: map[string]string{
+					serving.ConfigurationGenerationLabelKey: "1",
+				},
 				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "1",
 					"serving.knative.dev/lastPinned":             fmt.Sprintf("%d", curTime.Unix()),
 				},
 			},
@@ -634,8 +638,10 @@ func TestIsRevisionStale(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "myrev",
 				CreationTimestamp: metav1.Time{staleTime},
+				Labels: map[string]string{
+					serving.ConfigurationGenerationLabelKey: "2",
+				},
 				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "2",
 					"serving.knative.dev/lastPinned":             fmt.Sprintf("%d", staleTime.Unix()),
 				},
 			},
@@ -647,8 +653,10 @@ func TestIsRevisionStale(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "myrev",
 				CreationTimestamp: metav1.Time{staleTime},
+				Labels: map[string]string{
+					serving.ConfigurationGenerationLabelKey: "1",
+				},
 				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "1",
 					"serving.knative.dev/lastPinned":             fmt.Sprintf("%d", staleTime.Unix()),
 				},
 			},

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -50,7 +50,6 @@ func MakeRevision(config *v1alpha1.Configuration) *v1alpha1.Revision {
 	if rev.Annotations == nil {
 		rev.Annotations = make(map[string]string)
 	}
-	rev.Annotations[serving.ConfigurationGenerationAnnotationKey] = fmt.Sprintf("%v", config.Spec.Generation)
 
 	// Populate OwnerReferences so that deletes cascade.
 	rev.OwnerReferences = append(rev.OwnerReferences, *kmeta.NewControllerRef(config))

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -44,6 +44,7 @@ func MakeRevision(config *v1alpha1.Configuration) *v1alpha1.Revision {
 
 	configLabels := config.Labels
 	rev.Labels[serving.ServiceLabelKey] = configLabels[serving.ServiceLabelKey]
+	rev.Labels[serving.ConfigurationGenerationLabelKey] = fmt.Sprintf("%v", config.Spec.Generation)
 
 	// Populate the Configuration Generation annotation.
 	if rev.Annotations == nil {

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -63,10 +63,8 @@ func TestMakeRevisions(t *testing.T) {
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey: "build",
+					serving.ConfigurationGenerationLabelKey: "12",
 					serving.ServiceLabelKey:       "",
-				},
-				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "12",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -111,10 +109,8 @@ func TestMakeRevisions(t *testing.T) {
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey: "build",
+					serving.ConfigurationGenerationLabelKey: "99",
 					serving.ServiceLabelKey:       "",
-				},
-				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "99",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -166,13 +162,11 @@ func TestMakeRevisions(t *testing.T) {
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey: "labels",
+					serving.ConfigurationGenerationLabelKey: "99",
 					serving.ServiceLabelKey:       "",
 
 					"foo": "bar",
 					"baz": "blah",
-				},
-				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "99",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -218,10 +212,10 @@ func TestMakeRevisions(t *testing.T) {
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey: "annotations",
+					serving.ConfigurationGenerationLabelKey: "99",
 					serving.ServiceLabelKey:       "",
 				},
 				Annotations: map[string]string{
-					serving.ConfigurationGenerationAnnotationKey: "99",
 					"foo": "bar",
 					"baz": "blah",
 				},

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -54,6 +54,7 @@ func TestMakeRevisions(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "no",
 				Name:      "build-00012",
+				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -100,6 +101,7 @@ func TestMakeRevisions(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "with",
 				Name:      "build-00099",
+				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -153,6 +155,7 @@ func TestMakeRevisions(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "with",
 				Name:      "labels-00099",
+				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",

--- a/test/states.go
+++ b/test/states.go
@@ -126,12 +126,12 @@ func IsConfigRevisionCreationFailed(c *v1alpha1.Configuration) (bool, error) {
 // set to the expected value.
 func IsRevisionAtExpectedGeneration(expectedGeneration string) func(r *v1alpha1.Revision) (bool, error) {
 	return func(r *v1alpha1.Revision) (bool, error) {
-		if a, ok := r.Annotations[serving.ConfigurationGenerationAnnotationKey]; ok {
+		if a, ok := r.Labels[serving.ConfigurationGenerationLabelKey]; ok {
 			if a != expectedGeneration {
-				return true, fmt.Errorf("Expected Revision %s to be annotated with generation %s but was %s instead", r.Name, expectedGeneration, a)
+				return true, fmt.Errorf("Expected Revision %s to be labeled with generation %s but was %s instead", r.Name, expectedGeneration, a)
 			}
 			return true, nil
 		}
-		return true, fmt.Errorf("Expected Revision %s to be annotated with generation %s but there was no annotation", r.Name, expectedGeneration)
+		return true, fmt.Errorf("Expected Revision %s to be labeled with generation %s but there was no label", r.Name, expectedGeneration)
 	}
 }


### PR DESCRIPTION
This commit removes the configurationGeneration annotation on revisions and replaces it with the configurationGeneration label.

Fixes #2222 

**Release Note**
> The configurationGeneration annotation on revisions has been removed and the configurationGeneration label has been added in its place. #2222 