### PR TITLE
Bug fix: configmaps "fluentd-varlog-config" not found

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -51,17 +51,6 @@ var (
 		MountPath: "/var/log",
 	}
 
-	fluentdConfigMapVolume = corev1.Volume{
-		Name: fluentdConfigMapVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "fluentd-varlog-config",
-				},
-			},
-		},
-	}
-
 	userPorts = []corev1.ContainerPort{{
 		Name:          userPortName,
 		ContainerPort: int32(userPort),
@@ -109,6 +98,19 @@ func rewriteUserProbe(p *corev1.Probe) {
 	}
 }
 
+func getFluentdConfigMapVolume(name string) *corev1.Volume {
+	return &corev1.Volume{
+		Name: fluentdConfigMapVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+			},
+		},
+	}
+}
+
 func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observabilityConfig *config.Observability, autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.PodSpec {
 	userContainer := rev.Spec.Container.DeepCopy()
 	// Adding or removing an overwritten corev1.Container field here? Don't forget to
@@ -137,7 +139,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	// Add Fluentd sidecar and its config map volume if var log collection is enabled.
 	if observabilityConfig.EnableVarLogCollection {
 		podSpec.Containers = append(podSpec.Containers, *makeFluentdContainer(rev, observabilityConfig))
-		podSpec.Volumes = append(podSpec.Volumes, fluentdConfigMapVolume)
+		podSpec.Volumes = append(podSpec.Volumes, *getFluentdConfigMapVolume(names.FluentdConfigMap(rev)))
 	}
 
 	return podSpec

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -33,10 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const (
-	fluentdConfigMapVolumeName = "configmap"
-	varLogVolumeName           = "varlog"
-)
+const varLogVolumeName = "varlog"
 
 var (
 	varLogVolume = corev1.Volume{
@@ -98,19 +95,6 @@ func rewriteUserProbe(p *corev1.Probe) {
 	}
 }
 
-func getFluentdConfigMapVolume(name string) *corev1.Volume {
-	return &corev1.Volume{
-		Name: fluentdConfigMapVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: name,
-				},
-			},
-		},
-	}
-}
-
 func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observabilityConfig *config.Observability, autoscalerConfig *autoscaler.Config, controllerConfig *config.Controller) *corev1.PodSpec {
 	userContainer := rev.Spec.Container.DeepCopy()
 	// Adding or removing an overwritten corev1.Container field here? Don't forget to
@@ -139,7 +123,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	// Add Fluentd sidecar and its config map volume if var log collection is enabled.
 	if observabilityConfig.EnableVarLogCollection {
 		podSpec.Containers = append(podSpec.Containers, *makeFluentdContainer(rev, observabilityConfig))
-		podSpec.Volumes = append(podSpec.Volumes, *getFluentdConfigMapVolume(names.FluentdConfigMap(rev)))
+		podSpec.Volumes = append(podSpec.Volumes, *makeFluentdConfigMapVolume(rev))
 	}
 
 	return podSpec

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -682,7 +682,7 @@ func TestMakePodSpec(t *testing.T) {
 				}},
 				VolumeMounts: fluentdVolumeMounts,
 			}},
-			Volumes: []corev1.Volume{varLogVolume, fluentdConfigMapVolume},
+			Volumes: []corev1.Volume{varLogVolume,  *getFluentdConfigMapVolume("bar-fluentd")},
 		},
 	}, {
 		name: "complex pod spec",

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -682,7 +682,16 @@ func TestMakePodSpec(t *testing.T) {
 				}},
 				VolumeMounts: fluentdVolumeMounts,
 			}},
-			Volumes: []corev1.Volume{varLogVolume,  *getFluentdConfigMapVolume("bar-fluentd")},
+			Volumes: []corev1.Volume{varLogVolume, corev1.Volume{
+				Name: fluentdConfigMapVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "bar-fluentd",
+						},
+					},
+				},
+			}},
 		},
 	}, {
 		name: "complex pod spec",

--- a/pkg/reconciler/v1alpha1/revision/resources/fluentd.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/fluentd.go
@@ -65,6 +65,8 @@ const fluentdSidecarPreOutputConfig = `
 
 `
 
+const fluentdConfigMapVolumeName = "configmap"
+
 var (
 	fluentdResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -93,6 +95,19 @@ func MakeFluentdConfigMap(rev *v1alpha1.Revision, observabilityConfig *config.Ob
 		},
 		Data: map[string]string{
 			"varlog.conf": varlogConf,
+		},
+	}
+}
+
+func makeFluentdConfigMapVolume(rev *v1alpha1.Revision) *corev1.Volume {
+	return &corev1.Volume{
+		Name: fluentdConfigMapVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: names.FluentdConfigMap(rev),
+				},
+			},
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/fluentd_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/fluentd_test.go
@@ -110,7 +110,43 @@ func TestMakeFluentdConfigMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := MakeFluentdConfigMap(test.rev, test.oc)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("MakeDeployment (-want, +got) = %v", diff)
+				t.Errorf("MakeFluentdConfigMap (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestMakeFluentdConfigMapVolume(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *v1alpha1.Revision
+		want *corev1.Volume
+	}{{
+		name: "happy path",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+			},
+		},
+		want: &corev1.Volume{
+			Name: fluentdConfigMapVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "bar-fluentd",
+					},
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := makeFluentdConfigMapVolume(test.rev)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("makeFluentdConfigMapVolume (-want, +got) = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2237

## Proposed Changes

  * Instead of using the hard-coded config map name, use the the same name where the config map is created in [`fluentd.go`](https://github.com/knative/serving/blob/master/pkg/reconciler/v1alpha1/revision/resources/fluentd.go#L88)


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
