### PR TITLE
Avoid emitting headers that later reject requests

### DIFF
--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -24,7 +24,7 @@ const (
 	// ResponseCountHTTPHeader is the header key for number of tries.
 	// TODO this header is used to pass state between component of the
 	// activator, it is not used outside the activator and should be removed
-	ResponseCountHTTPHeader string = "knative-activator-attempts"
+	ResponseCountHTTPHeader string = "knative-internal-activator-attempts"
 	// RevisionHeaderName is the header key for revision name
 	RevisionHeaderName string = "knative-serving-revision"
 	// RevisionHeaderNamespace is the header key for revision's namespace

--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -18,11 +18,13 @@ package activator
 
 const (
 	// K8sServiceName is the name of the activator service
-	K8sServiceName          = "activator-service"
+	K8sServiceName = "activator-service"
+	// RequestCountHTTPHeader is the header key for number of tries
+	RequestCountHTTPHeader string = "knative-activator-attempts"
 	// ResponseCountHTTPHeader is the header key for number of tries
-  ResponseCountHTTPHeader = "Knative-Activator-Num-Retries"
+	ResponseCountHTTPHeader string = "knative-activator-num-retries"
 	// RevisionHeaderName is the header key for revision name
-	RevisionHeaderName      string = "knative-serving-revision"
+	RevisionHeaderName string = "knative-serving-revision"
 	// RevisionHeaderNamespace is the header key for revision's namespace
 	RevisionHeaderNamespace string = "knative-serving-namespace"
 )

--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -20,9 +20,11 @@ const (
 	// K8sServiceName is the name of the activator service
 	K8sServiceName = "activator-service"
 	// RequestCountHTTPHeader is the header key for number of tries
-	RequestCountHTTPHeader string = "knative-activator-attempts"
-	// ResponseCountHTTPHeader is the header key for number of tries
-	ResponseCountHTTPHeader string = "knative-activator-num-retries"
+	RequestCountHTTPHeader string = "knative-activator-num-retries"
+	// ResponseCountHTTPHeader is the header key for number of tries.
+	// TODO this header is used to pass state between component of the
+	// activator, it is not used outside the activator and should be removed
+	ResponseCountHTTPHeader string = "knative-activator-attempts"
 	// RevisionHeaderName is the header key for revision name
 	RevisionHeaderName string = "knative-serving-revision"
 	// RevisionHeaderNamespace is the header key for revision's namespace

--- a/pkg/activator/handler/filtering_handler.go
+++ b/pkg/activator/handler/filtering_handler.go
@@ -28,7 +28,7 @@ type FilteringHandler struct {
 func (h *FilteringHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If this header is set the request was sent by the activator itself, thus
 	// we immediatly return a 503 to trigger a retry.
-	if r.Header.Get(activator.ResponseCountHTTPHeader) != "" {
+	if r.Header.Get(activator.RequestCountHTTPHeader) != "" {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}

--- a/pkg/activator/handler/filtering_handler_test.go
+++ b/pkg/activator/handler/filtering_handler_test.go
@@ -34,13 +34,13 @@ func TestFilteringHandler(t *testing.T) {
 	},
 		{
 			label:          "filter a request containing retry header",
-			headers:        http.Header{http.CanonicalHeaderKey(activator.RequestCountHTTPHeader): {"4"}},
+			headers:        mapToHeader(map[string]string{activator.RequestCountHTTPHeader: "4"}),
 			passed:         false,
 			expectedStatus: http.StatusServiceUnavailable,
 		},
 		{
 			label:          "forward a request containing empty retry header",
-			headers:        http.Header{http.CanonicalHeaderKey(activator.RequestCountHTTPHeader): {""}},
+			headers:        mapToHeader(map[string]string{activator.RequestCountHTTPHeader: ""}),
 			passed:         true,
 			expectedStatus: http.StatusOK,
 		},
@@ -74,4 +74,12 @@ func TestFilteringHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mapToHeader(m map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range m {
+		h.Add(k, v)
+	}
+	return h
 }

--- a/pkg/activator/handler/filtering_handler_test.go
+++ b/pkg/activator/handler/filtering_handler_test.go
@@ -34,13 +34,13 @@ func TestFilteringHandler(t *testing.T) {
 	},
 		{
 			label:          "filter a request containing retry header",
-			headers:        http.Header{activator.ResponseCountHTTPHeader: {"4"}},
+			headers:        http.Header{http.CanonicalHeaderKey(activator.RequestCountHTTPHeader): {"4"}},
 			passed:         false,
 			expectedStatus: http.StatusServiceUnavailable,
 		},
 		{
 			label:          "forward a request containing empty retry header",
-			headers:        http.Header{activator.ResponseCountHTTPHeader: {""}},
+			headers:        http.Header{http.CanonicalHeaderKey(activator.RequestCountHTTPHeader): {""}},
 			passed:         true,
 			expectedStatus: http.StatusOK,
 		},

--- a/pkg/activator/util/header.go
+++ b/pkg/activator/util/header.go
@@ -24,6 +24,7 @@ import (
 )
 
 var headersToRemove = []string{
+	activator.RequestCountHTTPHeader,
 	activator.RevisionHeaderName,
 	activator.RevisionHeaderNamespace,
 }

--- a/pkg/activator/util/transports.go
+++ b/pkg/activator/util/transports.go
@@ -86,7 +86,7 @@ func (rrt *retryRoundTripper) RoundTrip(r *http.Request) (resp *http.Response, e
 		rrt.logger.Debugf("Retrying")
 
 		attempts++
-		r.Header.Add(activator.ResponseCountHTTPHeader, strconv.Itoa(attempts))
+		r.Header.Add(activator.RequestCountHTTPHeader, strconv.Itoa(attempts))
 		resp, err = rrt.transport.RoundTrip(r)
 
 		if err != nil {

--- a/pkg/activator/util/transports_test.go
+++ b/pkg/activator/util/transports_test.go
@@ -141,7 +141,7 @@ func TestRetryRoundTripper(t *testing.T) {
 		t.Run(e.label, func(t *testing.T) {
 			allRequestsGotRetryHeader := true
 			transport := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-				if r.Header.Get(activator.ResponseCountHTTPHeader) == "" {
+				if r.Header.Get(activator.RequestCountHTTPHeader) == "" {
 					allRequestsGotRetryHeader = false
 				}
 


### PR DESCRIPTION
The activator set the `Knative-Activator-Num-Retries` header on requests
it forwards to a starting revsion as well as on responses returned from
the activator. When the activator recieves a new request with the
`Knative-Activator-Num-Retries` header it immediatly returns a 503. This
has the effect of causing a request that hits the activator to fail if
the request is triggered from the response that also hit the activator.

This PR makes two distinct changes to prevent this situation from
recurring:
- the request and response headers now use distinct names. The request
  header is `knative-activator-attempts`, while the response header
  is preserved as `knative-activator-num-retries`
- the request header is stripped off the request in the queue-proxy
  along side the other activator headers

Fixes #2234
Fixes knative/eventing#523

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```

<!--
/assign @josephburnett 
/cc @jchesterpivotal 
/cc @dprotaso 
-->