### PR TITLE
Make the activator metric reporting scalable.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -65,8 +65,6 @@ const (
 )
 
 var (
-	podName string
-
 	logger *zap.SugaredLogger
 
 	statSink *websocket.ManagedConnection
@@ -88,10 +86,6 @@ func statReporter() {
 	}
 }
 
-func initEnv() {
-	podName = util.GetRequiredEnvOrFatal("POD_NAME", logger)
-}
-
 func main() {
 	flag.Parse()
 	cm, err := configmap.Load("/etc/config-logging")
@@ -107,8 +101,6 @@ func main() {
 	defer logger.Sync()
 
 	logger.Info("Starting the knative activator")
-
-	initEnv()
 
 	clusterConfig, err := rest.InClusterConfig()
 	if err != nil {
@@ -156,6 +148,7 @@ func main() {
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter()
 
+	podName := util.GetRequiredEnvOrFatal("POD_NAME", logger)
 	activatorhandler.NewConcurrencyReporter(podName, activatorhandler.Channels{
 		ReqChan:    reqChan,
 		StatChan:   statChan,

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -49,6 +49,11 @@ spec:
           # and seeing k8s logs in addition to ours is not useful.
         - "-logtostderr=false"
         - "-stderrthreshold=FATAL"
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"context"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -67,17 +68,18 @@ type statKey struct {
 // Creates a new totalAggregation
 func newTotalAggregation(window time.Duration) *totalAggregation {
 	return &totalAggregation{
-		window:             window,
-		perPodAggregations: make(map[string]*perPodAggregation),
+		window:              window,
+		perPodAggregations:  make(map[string]*perPodAggregation),
+		activatorsContained: make(map[string]struct{}),
 	}
 }
 
 // Holds an aggregation across all pods
 type totalAggregation struct {
-	window                   time.Duration
-	perPodAggregations       map[string]*perPodAggregation
-	probeCount               int32
-	containsActivatorMetrics bool
+	window              time.Duration
+	perPodAggregations  map[string]*perPodAggregation
+	probeCount          int32
+	activatorsContained map[string]struct{}
 }
 
 // Aggregates a given stat to the correct pod-aggregation
@@ -91,8 +93,8 @@ func (agg *totalAggregation) aggregate(stat Stat) {
 		current.lameduck(stat.Time)
 	} else {
 		current.aggregate(stat.AverageConcurrentRequests)
-		if stat.PodName == ActivatorPodName {
-			agg.containsActivatorMetrics = true
+		if strings.HasPrefix(stat.PodName, ActivatorPodName) {
+			agg.activatorsContained[stat.PodName] = struct{}{}
 		}
 		agg.probeCount += 1
 	}
@@ -106,10 +108,11 @@ func (agg *totalAggregation) observedPods(now time.Time) float64 {
 		podCount += pod.usageRatio(now)
 	}
 
-	// Discount the activator in the pod count.
-	if agg.containsActivatorMetrics {
-		discountedPodCount := podCount - 1.0
-		// Report a minimum of 1 pod if the activator is sending metrics.
+	activatorsCount := float64(len(agg.activatorsContained))
+	// Discount the activators in the pod count.
+	if activatorsCount > 0 {
+		discountedPodCount := podCount - float64(activatorsCount)
+		// Report a minimum of 1 pod if the activators are sending metrics.
 		if discountedPodCount < 1.0 {
 			return 1.0
 		}
@@ -126,7 +129,7 @@ func (agg *totalAggregation) observedConcurrencyPerPod(now time.Time) float64 {
 	activatorConcurrency := float64(0)
 	observedPods := agg.observedPods(now)
 	for podName, perPod := range agg.perPodAggregations {
-		if podName == ActivatorPodName {
+		if strings.HasPrefix(podName, ActivatorPodName) {
 			activatorConcurrency += perPod.calculateAverage(now)
 		} else {
 			accumulatedConcurrency += perPod.calculateAverage(now)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -96,7 +96,7 @@ func (agg *totalAggregation) aggregate(stat Stat) {
 		if strings.HasPrefix(stat.PodName, ActivatorPodName) {
 			agg.activatorsContained[stat.PodName] = struct{}{}
 		}
-		agg.probeCount += 1
+		agg.probeCount++
 	}
 }
 
@@ -108,7 +108,7 @@ func (agg *totalAggregation) observedPods(now time.Time) float64 {
 		podCount += pod.usageRatio(now)
 	}
 
-	activatorsCount := float64(len(agg.activatorsContained))
+	activatorsCount := len(agg.activatorsContained)
 	// Discount the activators in the pod count.
 	if activatorsCount > 0 {
 		discountedPodCount := podCount - float64(activatorsCount)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -93,6 +93,7 @@ func (agg *totalAggregation) aggregate(stat Stat) {
 		current.lameduck(stat.Time)
 	} else {
 		current.aggregate(stat.AverageConcurrentRequests)
+		// TODO(#2282): This can cause naming collisions.
 		if strings.HasPrefix(stat.PodName, ActivatorPodName) {
 			agg.activatorsContained[stat.PodName] = struct{}{}
 		}
@@ -129,6 +130,7 @@ func (agg *totalAggregation) observedConcurrencyPerPod(now time.Time) float64 {
 	activatorConcurrency := float64(0)
 	observedPods := agg.observedPods(now)
 	for podName, perPod := range agg.perPodAggregations {
+		// TODO(#2282): This can cause naming collisions.
 		if strings.HasPrefix(podName, ActivatorPodName) {
 			activatorConcurrency += perPod.calculateAverage(now)
 		} else {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -361,6 +361,26 @@ func TestAutoscaler_Activator_CausesInstantScale(t *testing.T) {
 	a.expectScale(t, now, 10, true)
 }
 
+func TestAutoscaler_Activator_MultipleInstancesAreAggregated(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+
+	now := time.Now()
+	now = a.recordMetric(t, Stat{
+		Time:                      &now,
+		PodName:                   ActivatorPodName + "-0",
+		RequestCount:              0,
+		AverageConcurrentRequests: 50.0,
+	})
+	now = a.recordMetric(t, Stat{
+		Time:                      &now,
+		PodName:                   ActivatorPodName + "-1",
+		RequestCount:              0,
+		AverageConcurrentRequests: 50.0,
+	})
+
+	a.expectScale(t, now, 10, true)
+}
+
 func TestAutoscaler_Activator_IsIgnored(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 
@@ -378,7 +398,13 @@ func TestAutoscaler_Activator_IsIgnored(t *testing.T) {
 
 	now = a.recordMetric(t, Stat{
 		Time:                      &now,
-		PodName:                   ActivatorPodName,
+		PodName:                   ActivatorPodName + "-0",
+		RequestCount:              0,
+		AverageConcurrentRequests: 1000.0,
+	})
+	now = a.recordMetric(t, Stat{
+		Time:                      &now,
+		PodName:                   ActivatorPodName + "-1",
 		RequestCount:              0,
 		AverageConcurrentRequests: 1000.0,
 	})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2229

## Proposed Changes

The activator metrics are sent as a fixed, hard-coded pod name today. That makes the activator unscalable since the autoscaler cannot disambiguate which activator the metrics are from and thus it cannot aggregate the metrics.

This instead sends the metrics under the actual activator pod-name and aggregates accordingly.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Activator metrics reporting is now scalable to multiple instances of the activator.
```
