### PR TITLE
Emit metrics about the scaled entity from the autoscaler.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -337,9 +337,11 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 			a.panicTime = &now
 			a.maxPanicPods = desiredPanicPodCount
 		}
+		a.reporter.Report(DesiredPodCountM, float64(a.maxPanicPods))
 		return int32(math.Max(1.0, math.Ceil(a.maxPanicPods))), true
 	}
 	logger.Debug("Operating in stable mode.")
+	a.reporter.Report(DesiredPodCountM, float64(desiredStablePodCount))
 	return int32(math.Max(1.0, math.Ceil(desiredStablePodCount))), true
 }
 

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/autoscaler"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions/autoscaling/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
@@ -211,6 +212,20 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, kpa *kpa.PodAuto
 	}
 	want := appliedScale
 	logger.Infof("KPA got=%v, want=%v", got, want)
+
+	var serviceLabel string
+	var configLabel string
+	if kpa.Labels != nil {
+		serviceLabel = kpa.Labels[serving.ServiceLabelKey]
+		configLabel = kpa.Labels[serving.ConfigurationLabelKey]
+	}
+	reporter, err := autoscaler.NewStatsReporter(kpa.Namespace, serviceLabel, configLabel, kpa.Name)
+	if err != nil {
+		return err
+	}
+
+	reporter.Report(autoscaler.ActualPodCountM, float64(got))
+	reporter.Report(autoscaler.RequestedPodCountM, float64(want))
 
 	switch {
 	case want == 0:

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -155,7 +155,6 @@ func (ks *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredS
 		return desiredScale, nil
 	}
 	logger.Infof("Scaling from %d to %d", currentScale, desiredScale)
-	reporter.Report(autoscaler.DesiredPodCountM, float64(desiredScale))
 
 	// Scale the target reference.
 	scl.Spec.Replicas = desiredScale

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/logging"
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
@@ -127,20 +126,6 @@ func (ks *kpaScaler) Scale(ctx context.Context, kpa *kpa.PodAutoscaler, desiredS
 		return desiredScale, err
 	}
 	currentScale := scl.Spec.Replicas
-
-	var serviceLabel string
-	var configLabel string
-	if kpa.Labels != nil {
-		serviceLabel = kpa.Labels[serving.ServiceLabelKey]
-		configLabel = kpa.Labels[serving.ConfigurationLabelKey]
-	}
-	reporter, err := autoscaler.NewStatsReporter(kpa.Namespace, serviceLabel, configLabel, kpa.Name)
-	if err != nil {
-		return err
-	}
-
-	reporter.Report(autoscaler.ActualPodCountM, float64(currentScale))
-	reporter.Report(autoscaler.RequestedPodCountM, float64(currentScale))
 
 	if desiredScale == 0 {
 		// Scale to zero grace period.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1993

To be able to see the difference between the autoscaler's PoV and the actual Kubernetes PoV this emits metrics that reflect both views.

@josephburnett I only saw now that the issue was assigned to you. If you've been working on this already, don't hesitate to bin this PR.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
None
```
