### PR TITLE
Allow unknown JSON fields

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -521,7 +521,6 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind string, oldBytes
 
 	if len(newBytes) != 0 {
 		newDecoder := json.NewDecoder(bytes.NewBuffer(newBytes))
-		newDecoder.DisallowUnknownFields()
 		if err := newDecoder.Decode(&newObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming new object: %v", err)
 		}
@@ -532,7 +531,6 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind string, oldBytes
 
 	if len(oldBytes) != 0 {
 		oldDecoder := json.NewDecoder(bytes.NewBuffer(oldBytes))
-		oldDecoder.DisallowUnknownFields()
 		if err := oldDecoder.Decode(&oldObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming old object: %v", err)
 		}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -236,6 +236,31 @@ func TestValidRouteNoChanges(t *testing.T) {
 	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
 }
 
+func TestInvalidOldRoute(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	new := createRoute(1, testRouteName)
+	new.Spec = v1alpha1.RouteSpec{}
+	newBytes, err := json.Marshal(new)
+	if err != nil {
+		t.Errorf("Marshal(%v) = %v", new, err)
+	}
+	oldBytes := []byte(`{"bad": "field"}`)
+	resp := ac.admit(TestContextWithLogger(t), createUpdateRouteRaw(oldBytes, newBytes))
+	expectFailsWith(t, resp, `missing field(s): spec`)
+}
+
+func TestInvalidNewRoute(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	old := createRoute(1, testRouteName)
+	oldBytes, err := json.Marshal(old)
+	if err != nil {
+		t.Errorf("Marshal(%v) = %v", old, err)
+	}
+	newBytes := []byte(`{"sepc": {}}`)
+	resp := ac.admit(TestContextWithLogger(t), createUpdateRouteRaw(oldBytes, newBytes))
+	expectFailsWith(t, resp, `missing field(s): spec`)
+}
+
 func TestValidRouteChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createRoute(1, testRouteName)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -236,30 +236,6 @@ func TestValidRouteNoChanges(t *testing.T) {
 	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
 }
 
-func TestInvalidOldRoute(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	new := createRoute(1, testRouteName)
-	newBytes, err := json.Marshal(new)
-	if err != nil {
-		t.Errorf("Marshal(%v) = %v", new, err)
-	}
-	oldBytes := []byte(`{"bad": "field"}`)
-	resp := ac.admit(TestContextWithLogger(t), createUpdateRouteRaw(oldBytes, newBytes))
-	expectFailsWith(t, resp, `unknown field "bad"`)
-}
-
-func TestInvalidNewRoute(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	old := createRoute(1, testRouteName)
-	oldBytes, err := json.Marshal(old)
-	if err != nil {
-		t.Errorf("Marshal(%v) = %v", old, err)
-	}
-	newBytes := []byte(`{"sepc": {}}`)
-	resp := ac.admit(TestContextWithLogger(t), createUpdateRouteRaw(oldBytes, newBytes))
-	expectFailsWith(t, resp, `unknown field "sepc"`)
-}
-
 func TestValidRouteChanges(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	old := createRoute(1, testRouteName)


### PR DESCRIPTION
This will allow us to test downgrading to 0.1.X releases of
knative/serving. Currently, if we make additive changes, it's impossible
to downgrade to this release because the new fields would be rejected.

Ref: https://github.com/knative/pkg/issues/128 and https://github.com/knative/serving/issues/2224

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Allow unknown fields in knative resource specs to make future downgrades possible.
```
