### PR TITLE
add last check for revision ready in activator

### DIFF
--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -92,6 +92,10 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 		for {
 			select {
 			case <-time.After(r.readyTimout):
+				// last chance to check
+				if revision.Status.IsReady() {
+					break RevisionReady
+				}
 				return nil, errors.New("Timeout waiting for revision to become ready")
 			case event := <-ch:
 				if revision, ok := event.Object.(*v1alpha1.Revision); ok {


### PR DESCRIPTION
Fixes #
https://github.com/knative/serving/blob/d841ed1bf12c73f2578f5937ed905ae232b5a285/pkg/activator/revision.go#L82-L83

After it first check the status of revision, it still need to spend some time to start the revision watch. It still have the chance that missing the event.

## Proposed Changes
  Add a last check before timeout.
