### PR TITLE
Add a conformance test for single-threaded concurrency

### DIFF
--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -1,0 +1,128 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	singleThreadedImage = "singlethreaded"
+)
+
+func TestSingleConcurrency(t *testing.T) {
+	clients := setup(t)
+
+	// add test case specific name to its own logger
+	logger := logging.GetContextLogger("TestSingleConcurrency")
+
+	imagePath := test.ImagePath(singleThreadedImage)
+
+	names := test.ResourceNames{
+		Config: test.AppendRandomString("prod", logger),
+		Route:  test.AppendRandomString("pizzaplanet", logger),
+	}
+
+	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer tearDown(clients, names)
+
+	configOptions := test.Options{
+		ContainerConcurrency: 1,
+	}
+	logger.Infof("Creating a new Configuration")
+	err := test.CreateConfiguration(logger, clients, names, imagePath, &configOptions)
+	if err != nil {
+		t.Fatalf("Failed to create Configuration: %v", err)
+	}
+
+	logger.Infof("Creating a new Route")
+	err = test.CreateRoute(logger, clients, names)
+	if err != nil {
+		t.Fatalf("Failed to create Route: %v", err)
+	}
+
+	logger.Infof("The Configuration will be updated with the name of the Revision once it is created")
+	revisionName, err := getNextRevisionName(clients, names)
+	if err != nil {
+		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
+	}
+	names.Revision = revisionName
+
+	logger.Infof("Waiting for revision %q to be ready", names.Revision)
+	if err := test.WaitForRevisionState(clients.ServingClient, names.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
+		t.Fatalf("The Revision %q still can't serve traffic: %v", names.Revision, err)
+	}
+
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+	}
+	domain := route.Status.Domain
+
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		t.Fatalf("Error creating spoofing client: %v", err)
+	}
+
+	concurrency := 5
+	duration := 20 * time.Second
+	logger.Infof("Maintaining %d concurrent requests for %v.", concurrency, duration)
+	group, _ := errgroup.WithContext(context.Background())
+	for i := 0; i < concurrency; i++ {
+		group.Go(func() error {
+			done := time.After(duration)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+			if err != nil {
+				return fmt.Errorf("Error creating http request: %v", err)
+			}
+
+			for {
+				select {
+				case <-done:
+					return nil
+				default:
+					res, err := client.Do(req)
+					if err != nil {
+						return fmt.Errorf("Error making request %v", err)
+					}
+					if res.StatusCode == http.StatusInternalServerError {
+						return fmt.Errorf("Detected concurrent requests")
+					} else if res.StatusCode != http.StatusOK {
+						return fmt.Errorf("Non 200 response %v", res.StatusCode)
+					}
+				}
+			}
+		})
+	}
+	logger.Infof("Waiting for all requests to complete.")
+	if err := group.Wait(); err != nil {
+		t.Fatalf("Error making requests for single threaded test: %v.", err)
+	}
+}

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -100,7 +100,7 @@ func TestSingleConcurrency(t *testing.T) {
 			done := time.After(duration)
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
 			if err != nil {
-				return fmt.Errorf("Error creating http request: %v", err)
+				return fmt.Errorf("error creating http request: %v", err)
 			}
 
 			for {
@@ -110,12 +110,12 @@ func TestSingleConcurrency(t *testing.T) {
 				default:
 					res, err := client.Do(req)
 					if err != nil {
-						return fmt.Errorf("Error making request %v", err)
+						return fmt.Errorf("error making request %v", err)
 					}
 					if res.StatusCode == http.StatusInternalServerError {
-						return fmt.Errorf("Detected concurrent requests")
+						return fmt.Errorf("detected concurrent requests")
 					} else if res.StatusCode != http.StatusOK {
-						return fmt.Errorf("Non 200 response %v", res.StatusCode)
+						return fmt.Errorf("non 200 response %v", res.StatusCode)
 					}
 				}
 			}

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -20,6 +20,7 @@ package conformance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -56,19 +57,19 @@ func TestSingleConcurrency(t *testing.T) {
 	configOptions := test.Options{
 		ContainerConcurrency: 1,
 	}
-	logger.Infof("Creating a new Configuration")
+	logger.Info("Creating a new Configuration")
 	err := test.CreateConfiguration(logger, clients, names, imagePath, &configOptions)
 	if err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
 
-	logger.Infof("Creating a new Route")
+	logger.Info("Creating a new Route")
 	err = test.CreateRoute(logger, clients, names)
 	if err != nil {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
-	logger.Infof("The Configuration will be updated with the name of the Revision once it is created")
+	logger.Info("The Configuration will be updated with the name of the Revision once it is created")
 	revisionName, err := getNextRevisionName(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
@@ -113,7 +114,7 @@ func TestSingleConcurrency(t *testing.T) {
 						return fmt.Errorf("error making request %v", err)
 					}
 					if res.StatusCode == http.StatusInternalServerError {
-						return fmt.Errorf("detected concurrent requests")
+						return errors.New("detected concurrent requests")
 					} else if res.StatusCode != http.StatusOK {
 						return fmt.Errorf("non 200 response %v", res.StatusCode)
 					}
@@ -121,7 +122,7 @@ func TestSingleConcurrency(t *testing.T) {
 			}
 		})
 	}
-	logger.Infof("Waiting for all requests to complete.")
+	logger.Info("Waiting for all requests to complete.")
 	if err := group.Wait(); err != nil {
 		t.Fatalf("Error making requests for single threaded test: %v.", err)
 	}

--- a/test/test_images/singlethreaded/README.md
+++ b/test/test_images/singlethreaded/README.md
@@ -1,0 +1,16 @@
+# Conformance test image (single threaded)
+
+This directory contains a test image used in the conformance tests.
+
+The images contain a webserver that will by default listens on port
+`8080` and expose a service at `/`.
+
+When called, the server sleeps a short period and returns a 200 status
+if no other request is running in the container concurrently. If it
+does detect concurrent requests, it instead returns a 500 status.
+
+## Building
+
+For details about building and adding new images, see the [section about test
+images](/test/README.md#test-images).
+

--- a/test/test_images/singlethreaded/main.go
+++ b/test/test_images/singlethreaded/main.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	lockedFlag uint32
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Use an atomic int as a simple boolean flag we can check safely
+	if !atomic.CompareAndSwapUint32(&lockedFlag, 0, 1) {
+		// Return HTTP 500 if more than 1 request at a time gets in
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer atomic.StoreUint32(&lockedFlag, 0)
+
+	time.Sleep(500 * time.Millisecond)
+	fmt.Fprintf(w, "One at a time")
+}
+
+func main() {
+	flag.Parse()
+
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/test/test_images/singlethreaded/main.go
+++ b/test/test_images/singlethreaded/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// The singlethreaded program
 package main
 
 import (


### PR DESCRIPTION
This adds a conformance test to ensure concurrent requests don't ever
happen in a container with a `ContainerConcurrency` of 1.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2211 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
NONE
```
