### PR TITLE
Update 202-gateway.yaml to match Istio 1.0.2's istio.yaml.

### DIFF
--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -97,7 +97,7 @@ spec:
       targetPort: 15031
 ---
 # This is the corresponding Deployment to backed the aforementioned Service.
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: knative-ingressgateway
@@ -110,10 +110,6 @@ metadata:
     knative: ingressgateway
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app: knative-ingressgateway
-      knative: ingressgateway
   template:
     metadata:
       labels:
@@ -126,7 +122,7 @@ spec:
       serviceAccountName: istio-ingressgateway-service-account
       containers:
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.0.1"
+          image: "docker.io/istio/proxyv2:1.0.2"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Update `knative-ingressgateway` pods to match Istio 1.0.2's settings.

After #1963 is done we can proceed to #1969 which should allow us to move to using Istio's gateway pods by default so we don't have to keep doing this.
