### PR TITLE
Add back Spec.Selector of knative-ingressgateway Deployment removed by #2265.

### DIFF
--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -110,6 +110,10 @@ metadata:
     knative: ingressgateway
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: knative-ingressgateway
+      knative: ingressgateway
   template:
     metadata:
       labels:


### PR DESCRIPTION
The change in #2265  seems to break upgrade from previous version, since
Spec.Selector is an immutable field.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

