### PR TITLE
Disable the flaky GlobalResync test.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -897,6 +897,7 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 }
 
 func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
+	t.Skip("Disabled until #2281 is fixed")
 	_, _, servingClient, controller, _, kubeInformer, sharedInformer, servingInformer, watcher := newTestSetup(t)
 
 	stopCh := make(chan struct{})


### PR DESCRIPTION
Related to: https://github.com/knative/serving/issues/2281

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->