### PR TITLE
Fix the cause of flaky TestGlobalResyncOnUpdateDomainConfigMap

### DIFF
--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -117,6 +117,7 @@ func (c *Reconciler) updateStatus(ctx context.Context, route *v1alpha1.Route) (*
 	if err != nil {
 		return nil, err
 	}
+	existing = existing.DeepCopy()
 	// If there's nothing to update, just return.
 	if reflect.DeepEqual(existing.Status, route.Status) {
 		return existing, nil

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -897,7 +897,6 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 }
 
 func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
-	t.Skip("Disabled until #2281 is fixed")
 	_, _, servingClient, controller, _, kubeInformer, sharedInformer, servingInformer, watcher := newTestSetup(t)
 
 	stopCh := make(chan struct{})


### PR DESCRIPTION
DeepCopy route before modifying the route obtained through
Reconciler.routeLister as it appears to return a shared copy of route.

Fixes #2281