### PR TITLE
Add a Configmap including release information to Knative serving when doing versioned release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Knative Serving Changelog
+
 All notable changes to Knative Serving will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -9,7 +10,9 @@ When adding a changelog entry, link to the most relevant issue or PR for more
 details.
 
 ## [Unreleased]
+
 ### Added
+
 * Basic API resources Revision, Configuration, and Route.
 * Integration with the Build API for on-demand container builds. [#36](https://github.com/knative/serving/pull/36)
 * Autoscaling of Revision deployments. [#229](https://github.com/knative/serving/pull/229)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -191,8 +191,9 @@ kubectl apply -R -f config/monitoring/100-namespace.yaml \
 As you make changes to the code-base, there are two special cases to be aware of:
 
 * **If you change an input to generated code**, then you must run [`./hack/update-codegen.sh`](./hack/update-codegen.sh). Inputs include:
-    * API type definitions in [pkg/apis/serving/v1alpha1/](./pkg/apis/serving/v1alpha1/.),
-    * Types definitions annotated with `// +k8s:deepcopy-gen=true`.
+
+  * API type definitions in [pkg/apis/serving/v1alpha1/](./pkg/apis/serving/v1alpha1/.),
+  * Types definitions annotated with `// +k8s:deepcopy-gen=true`.
 
 * **If you change a package's deps** (including adding external dep), then you must run
   [`./hack/update-deps.sh`](./hack/update-deps.sh).

--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -2,17 +2,17 @@
 
 Two options:
 
-*   Setup a [GKE cluster](#gke)
-*   Run [minikube](#minikube) locally
+* Setup a [GKE cluster](#gke)
+* Run [minikube](#minikube) locally
 
 ## GKE
 
 To use a k8s cluster running in GKE:
 
-1.  Install `gcloud` using [the instructions for your
+1. Install `gcloud` using [the instructions for your
     platform](https://cloud.google.com/sdk/downloads).
 
-1.  Create a GCP project (or use an existing project if you've already created
+1. Create a GCP project (or use an existing project if you've already created
     one) at http://console.cloud.google.com/home/dashboard. Set the ID of the
     project in an environment variable (e.g. `PROJECT_ID`).
 
@@ -20,13 +20,13 @@ To use a k8s cluster running in GKE:
     your GKE cluster and other resources free for a short time. Otherwise, any
     GCP resources you create will cost money._
 
-1.  Enable the k8s API:
+1. Enable the k8s API:
 
     ```shell
     gcloud --project=$PROJECT_ID services enable container.googleapis.com
     ```
 
-1.  Create a k8s cluster (version 1.10 or greater):
+1. Create a k8s cluster (version 1.10 or greater):
 
     ```shell
     gcloud --project=$PROJECT_ID container clusters create \
@@ -38,13 +38,13 @@ To use a k8s cluster running in GKE:
       knative-demo
     ```
 
-    *   Version 1.10+ is required
-    *   Change this to whichever zone you choose
-    *   cloud-platform scope is required to access GCB
-    *   Knative Serving currently requires 4-cpu nodes to run conformance tests.
+    * Version 1.10+ is required
+    * Change this to whichever zone you choose
+    * cloud-platform scope is required to access GCB
+    * Knative Serving currently requires 4-cpu nodes to run conformance tests.
         Changing the machine type from the default may cause failures.
-    *   Autoscale from 1 to 3 nodes. Adjust this for your use case
-    *   Change this to your preferred cluster name
+    * Autoscale from 1 to 3 nodes. Adjust this for your use case
+    * Change this to your preferred cluster name
 
     You can see the list of supported cluster versions in a particular zone by
     running:
@@ -54,7 +54,7 @@ To use a k8s cluster running in GKE:
     gcloud container get-server-config --zone us-east1-d
     ```
 
-1.  **Alternately**, if you wish to re-use an already-created cluster,
+1. **Alternately**, if you wish to re-use an already-created cluster,
     you can fetch the credentials to your local machine with:
 
     ```shell
@@ -62,14 +62,14 @@ To use a k8s cluster running in GKE:
     gcloud container clusters get-credentials --zone us-east1-d knative-demo
     ```
 
-1.  If you haven't installed `kubectl` yet, you can install it now with
-    `gcloud`:
+1. If you haven't installed `kubectl` yet, you can install it now with `gcloud`:
 
     ```shell
     gcloud components install kubectl
     ```
 
-1.  Add to your .bashrc:
+1. Add to your .bashrc:
+
     ```shell
     # When using GKE, the K8s user is your GCP user.
     export K8S_USER_OVERRIDE=$(gcloud config get-value core/account)
@@ -77,12 +77,12 @@ To use a k8s cluster running in GKE:
 
 ## Minikube
 
-1.  [Install and configure
+1. [Install and configure
     minikube](https://github.com/kubernetes/minikube#minikube) with a [VM
     driver](https://github.com/kubernetes/minikube#requirements), e.g. `kvm2` on
     Linux or `hyperkit` on macOS.
 
-1.  [Create a cluster](https://github.com/kubernetes/minikube#quickstart) with
+1. [Create a cluster](https://github.com/kubernetes/minikube#quickstart) with
     version 1.10 or greater and your chosen VM driver.
 
     The following commands will setup a cluster with `8192 MB` of memory and `4`
@@ -108,6 +108,7 @@ To use a k8s cluster running in GKE:
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.admission-control="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
+
     For macOS use:
 
     ```shell
@@ -119,7 +120,8 @@ To use a k8s cluster running in GKE:
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.admission-control="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
     ```
-1.  [Configure your shell environment](../DEVELOPMENT.md#environment-setup)
+
+1. [Configure your shell environment](../DEVELOPMENT.md#environment-setup)
     to use your minikube cluster:
 
     ```shell
@@ -128,7 +130,7 @@ To use a k8s cluster running in GKE:
     export K8S_USER_OVERRIDE=$USER
     ```
 
-1.  Install Knative Serving
+1. Install Knative Serving
 
     Before installing knative on minikube, we need to do two things:
 
@@ -138,7 +140,6 @@ To use a k8s cluster running in GKE:
     After doing those, you can [deploy the Knative Serving
     components](../DEVELOPMENT.md#starting-knative-serving) to
     Minikube the same way you would any other Kubernetes cluster.
-
 
 ### `LoadBalancer` Support in Minikube
 
@@ -194,7 +195,7 @@ docker tag gcr.io/knative-samples/primer:latest dev.local/knative-samples/primer
 
 You can use Google Container Registry as the registry for a Minikube cluster.
 
-1.  [Set up a GCR repo](setting-up-a-docker-registry.md). Export the environment
+1. [Set up a GCR repo](setting-up-a-docker-registry.md). Export the environment
     variable `PROJECT_ID` as the name of your project. Also export `GCR_DOMAIN`
     as the domain name of your GCR repo. This will be either `gcr.io` or a
     region-specific variant like `us.gcr.io`.
@@ -212,7 +213,7 @@ You can use Google Container Registry as the registry for a Minikube cluster.
     export DOCKER_REPO_OVERRIDE="${KO_DOCKER_REPO}"
     ```
 
-1.  Create a GCP service account:
+1. Create a GCP service account:
 
     ```shell
     gcloud iam service-accounts create minikube-gcr \
@@ -220,7 +221,7 @@ You can use Google Container Registry as the registry for a Minikube cluster.
       --project $PROJECT_ID
     ```
 
-1.  Give your service account the `storage.objectViewer` role:
+1. Give your service account the `storage.objectViewer` role:
 
     ```shell
     gcloud projects add-iam-policy-binding $PROJECT_ID \
@@ -228,7 +229,7 @@ You can use Google Container Registry as the registry for a Minikube cluster.
       --role roles/storage.objectViewer
     ```
 
-1.  Create a key credential file for the service account:
+1. Create a key credential file for the service account:
 
     ```shell
     gcloud iam service-accounts keys create \
@@ -244,7 +245,7 @@ For example, use these steps to allow Minikube to pull Knative Serving and Build
 from GCR as published in our development flow (`ko apply -f config/`).
 _This is only necessary if you are not using public Knative Serving and Build images._
 
-1.  Create a Kubernetes secret in the `knative-serving` and `knative-build` namespace:
+1. Create a Kubernetes secret in the `knative-serving` and `knative-build` namespace:
 
     ```shell
     export DOCKER_EMAIL=your.email@here.com
@@ -265,7 +266,7 @@ _This is only necessary if you are not using public Knative Serving and Build im
     _The secret must be created in the same namespace as the pod or service
     account._
 
-1.  Add the secret as an imagePullSecret to the `controller` and
+1. Add the secret as an imagePullSecret to the `controller` and
     `build-controller` service accounts:
 
     ```shell
@@ -276,6 +277,7 @@ _This is only necessary if you are not using public Knative Serving and Build im
       -p '{"imagePullSecrets": [{"name": "knative-serving-gcr"}]}' \
       -n "knative-serving"
     ```
+
 Use the same procedure to add imagePullSecrets to service accounts in any
 namespace. Use the `default` service account for pods that do not specify a
 service account.

--- a/docs/debugging/application-debugging-guide.md
+++ b/docs/debugging/application-debugging-guide.md
@@ -13,7 +13,7 @@ This kind of failure is most likely due to either a misconfigured manifest or
 wrong command. For example, the following output says that you must configure
 route traffic percent to sum to 100:
 
-```
+```console
 Error from server (InternalError): error when applying patch:
 {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"serving.knative.dev/v1alpha1\",\"kind\":\"Route\",\"metadata\":{\"annotations\":{},\"name\":\"route-example\",\"namespace\":\"default\"},\"spec\":{\"traffic\":[{\"configurationName\":\"configuration-example\",\"percent\":50}]}}\n"}},"spec":{"traffic":[{"configurationName":"configuration-example","percent":50}]}}
 to:
@@ -23,6 +23,7 @@ ERROR: Non-zero return code '1' from command: Process exited with status 1
 ```
 
 ## Check application logs
+
 Knative Serving provides default out-of-the-box logs for your application. After entering
 `kubectl proxy`, you can go to the
 [Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana)
@@ -73,12 +74,13 @@ kubectl get routerule <routerule-name> -o yaml
 ```
 
 If you don't know the name of your route rule, use the
-```kubectl get routerule``` command to find it.
+`kubectl get routerule` command to find it.
 
 The command returns the configuration of your route rule. Compare the domains
 between your route and route rule; they should match.
 
 ### Check ingress status
+
 Enter:
 
 ```shell
@@ -87,7 +89,6 @@ kubectl get ingress
 
 The command returns the status of the ingress. You can see the name, age,
 domains, and IP address.
-
 
 ## Check Revision status
 
@@ -119,18 +120,18 @@ conditions:
 
 If you see this condition, check the following to continue debugging:
 
-  * [Check Pod status](#check-pod-status)
-  * [Check application logs](#check-application-logs)
-  * [Check Istio routing](#check-istio-routing)
+* [Check Pod status](#check-pod-status)
+* [Check application logs](#check-application-logs)
+* [Check Istio routing](#check-istio-routing)
 
 If you see other conditions, to debug further:
 
-  * Look up the meaning of the conditions in Knative
-     [Error Conditions and Reporting](../spec/errors.md). Note: some of them
-     are not implemented yet. An alternative is to
-     [check Pod status](#check-pod-status).
-  * If you are using `BUILD` to deploy and the `BuidComplete` condition is not
-     `True`, [check BUILD status](#check-build-status).
+* Look up the meaning of the conditions in Knative
+    [Error Conditions and Reporting](../spec/errors.md). Note: some of them
+    are not implemented yet. An alternative is to
+    [check Pod status](#check-pod-status).
+* If you are using `BUILD` to deploy and the `BuidComplete` condition is not
+    `True`, [check BUILD status](#check-build-status).
 
 ## Check Pod status
 
@@ -142,7 +143,7 @@ kubectl get pods
 
 This should list all `Pod`s with brief status. For example:
 
-```
+```console
 NAME                                                      READY     STATUS             RESTARTS   AGE
 configuration-example-00001-deployment-659747ff99-9bvr4   2/2       Running            0          3h
 configuration-example-00002-deployment-5f475b7849-gxcht   1/2       CrashLoopBackOff   2          36s
@@ -153,7 +154,6 @@ Choose one and use the following command to see detailed information for its
 
 ```shell
 kubectl get pod <pod-name> -o yaml
-
 ```
 
 ## Check Build status

--- a/docs/debugging/performance-investigation-guide.md
+++ b/docs/debugging/performance-investigation-guide.md
@@ -1,31 +1,33 @@
 # Investigating Performance Issues
 
-You deployed your application or function to Knative Serving but its performance 
-is not up to the expectations. Knative Serving provides various dashboards and tools to 
+You deployed your application or function to Knative Serving but its performance
+is not up to the expectations. Knative Serving provides various dashboards and tools to
 help investigate such issues. This document goes through these dashboards
 and tools.
 
 ## Request metrics
 
 Start your investigation with "Revision - HTTP Requests" dashboard. To open this dashboard,
-open Grafana UI as described in [telemetry.md](../telemetry.md) and navigate to 
+open Grafana UI as described in [telemetry.md](../telemetry.md) and navigate to
 "Knative Serving - Revision HTTP Requests". Select your configuration and revision
 from the menu on top left of the page. You will see a page like below:
 
 ![Knative Serving - Revision HTTP Requests](images/request_dash1.png)
 
 This dashboard gives visibility into the following for each revision:
+
 * Request volume
 * Request volume per HTTP response code
 * Response time
 * Response time per HTTP response code
 * Request and response sizes
 
-This dashboard can show traffic volume or latency discrepancies between different revisions. 
-If, for example, a revision's latency is higher than others revisions, then 
+This dashboard can show traffic volume or latency discrepancies between different revisions.
+If, for example, a revision's latency is higher than others revisions, then
 focus your investigation on the offending revision through the rest of this guide.
 
 ## Request traces
+
 Next, look into request traces to find out where the time is spent for a single request.
 To access request traces, open Zipkin UI as described in [telemetry.md](../telemetry.md).
 Select your revision from the "Service Name" drop down and click on "Find Traces" button.
@@ -33,9 +35,9 @@ This will bring up a view that looks like below:
 
 ![Zipkin - Trace Overview](images/zipkin1.png)
 
-In the example above, we can see that the request spent most of its time in the 
+In the example above, we can see that the request spent most of its time in the
 [span](https://github.com/opentracing/specification/blob/master/specification.md#the-opentracing-data-model) right before the last.
-Investigation should now be focused on that specific span. 
+Investigation should now be focused on that specific span.
 Clicking on that will bring up a view that looks like below:
 
 ![Zipkin - Span Details](images/zipkin2.png)
@@ -48,18 +50,20 @@ that URL is taking that long.
 ## Autoscaler metrics
 If request metrics or traces do not show any obvious hot spots, or if they show
 that most of the time is spent in your own code, autoscaler metrics should be
-looked next. To open autoscaler dashboard, open Grafana UI and select 
+looked next. To open autoscaler dashboard, open Grafana UI and select
 "Knative Serving - Autoscaler" dashboard. This will bring up a view that looks like below:
 
 ![Knative Serving - Autoscaler](images/autoscaler_dash1.png)
 
 This view shows four key metrics from Knative Serving autoscaler:
+
 * Actual pod count: # of pods that are running a given revision
 * Desired pod count: # of pods that autoscaler thinks that should serve the
   revision
 * Requested pod count: # of pods that autoscaler requested from Kubernetes
-* Panic mode: If 0, autoscaler is operating in [stable mode](../../pkg/autoscaler/README.md#stable-mode).
-If 1, autoscaler is operating in [panic mode](../../pkg/autoscaler/README.md#panic-mode).
+* Panic mode:
+    If 0, autoscaler is operating in [stable mode](../../pkg/autoscaler/README.md#stable-mode).
+    If 1, autoscaler is operating in [panic mode](../../pkg/autoscaler/README.md#panic-mode).
 
 If there is a large gap between actual pod count and requested pod count, that
 means that the Kubernetes cluster is unable to keep up allocating new
@@ -74,8 +78,9 @@ In the example above, autoscaler requested 18 pods to optimally serve the traffi
 but was only granted 8 pods because the cluster is out of resources.
 
 ## CPU and memory usage
-You can access total CPU and memory usage of your revision from 
-"Knative Serving - Revision CPU and Memory Usage" dashboard. Opening this will bring up a 
+
+You can access total CPU and memory usage of your revision from
+"Knative Serving - Revision CPU and Memory Usage" dashboard. Opening this will bring up a
 view that looks like below:
 
 ![Knative Serving - Revision CPU and Memory Usage](images/cpu_dash1.png)
@@ -83,12 +88,14 @@ view that looks like below:
 The first chart shows rate of the CPU usage across all pods serving the revision.
 The second chart shows total memory consumed across all pods serving the revision.
 Both of these metrics are further divided into per container usage.
+
 * user-container: This container runs the user code (application, function or container).
-* [istio-proxy](https://github.com/istio/proxy): Sidecar container to form an 
+* [istio-proxy](https://github.com/istio/proxy): Sidecar container to form an
 [Istio](https://istio.io/docs/concepts/what-is-istio/overview.html) mesh.
 * queue-proxy: Knative Serving owned sidecar container to enforce request concurrency limits.
 * autoscaler: Knative Serving owned sidecar container to provide auto scaling for the revision.
 * fluentd-proxy: Sidecar container to collect logs from /var/log.
 
 ## Profiling
+
 ...To be filled...

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -4,7 +4,6 @@ When discussing user actions, it is often helpful to [define specific
 user roles](https://en.wikipedia.org/wiki/Persona_(user_experience)) who
 might want to do the action.
 
-
 ## Knative Serving Compute
 
 ### Developer Personas
@@ -20,6 +19,7 @@ their native language tooling or business processes.
 * SRE
 
 User stories:
+
 * Deploy some code
 * Update environment
 * Roll back the last change
@@ -38,6 +38,7 @@ organization policy and security patches.
 * Capacity Planner
 
 User stories:
+
 * Create an Knative Serving cluster
 * Apply policy / RBAC
 * Control or charge back for resource usage
@@ -57,9 +58,9 @@ contributors to the project, as well as the impact on end-users.
 * Consultant
 
 User stories:
+
 * Check out the code
 * Build and run the code
 * Run tests
 * View test status
 * Run performance tests
-

--- a/docs/resources-overview.md
+++ b/docs/resources-overview.md
@@ -1,6 +1,6 @@
-For a truly high-level overview, [see these slides](https://docs.google.com/presentation/d/1CbwVC7W2JaSxRyltU8CS1bIsrIXu1RrZqvnlMlDaaJE/edit#slide=id.p)
+# Resources Overview
 
-# Resources
+For a truly high-level overview, [see these slides](https://docs.google.com/presentation/d/1CbwVC7W2JaSxRyltU8CS1bIsrIXu1RrZqvnlMlDaaJE/edit#slide=id.p)
 
 This document provides a high-level description of the resources deployed to a Kubernetes cluster in order to run Knative Serving. The exact list of resources is going to change frequently during the current phase of active development. In order to keep this document from becoming out-of-date frequently it doesn't describe the exact individual resources but instead the higher level objects which they form.
 
@@ -27,7 +27,7 @@ The Knative Serving controller creates Kubernetes, Istio, and Build CRD resource
 
 The various Kubernetes resource configurations are organized as follows:
 
-```
+```plain
 # Knative Serving resources
 config/*.yaml
 
@@ -53,7 +53,7 @@ View the Knative Serving specific deployments by running `kubectl -n knative-ser
 
 For example, given:
 
-```
+```console
 $ kubectl -n knative-serving get deployments
 NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 controller   1         1         1            1           6m
@@ -62,7 +62,7 @@ webhook      1         1         1            1           6m
 
 Based on the desired state shown above, we expect there to be a single pod running for each of the deployments shown above. We can verify this by running and seeing similar output as shown below:
 
-```
+```console
 $ kubectl -n knative-serving get pods
 NAME                              READY     STATUS    RESTARTS   AGE
 controller-5bfb798f96-2zjnf   1/1       Running   0          9m

--- a/docs/roadmap/monitoring.md
+++ b/docs/roadmap/monitoring.md
@@ -1,12 +1,14 @@
 # 2018 Roadmap for Monitoring and Logging
 
-This document captures what we hope to accomplish in 2018 in Monitoring and Logging areas for Knative Serving. 
+This document captures what we hope to accomplish in 2018 in Monitoring and Logging areas for Knative Serving.
 
 ## Overview
-We will provide distinct experiences for [operator personas](../product/personas.md#operator-personas), 
+
+We will provide distinct experiences for [operator personas](../product/personas.md#operator-personas),
 [developer personas](../product/personas.md#developer-personas) and [contributors](../product/personas.md#contributors).
 
 ### Operator Capabilities
+
 * Provide default collection of cluster logs and metrics from infrastructure components such as Kubernetes.
 * Provide default dashboards and interfaces for viewing cluster logs and metrics.
 * Auto-scale, upgrade and maintain the default logging, metrics, alerting and tracing backends.
@@ -17,6 +19,7 @@ We will provide distinct experiences for [operator personas](../product/personas
 * Operators can install extensions that forward logs and metrics to different backends (e.g. Stack Driver).
 
 ### Developer Capabilities
+
 * Provide default collection of logs, metrics, and request traces.
 * Provide default dashboards and interfaces for viewing logs, metrics and traces, and for setting alerts on the same.
 * Developers can set custom application and function alerts.
@@ -25,16 +28,20 @@ We will provide distinct experiences for [operator personas](../product/personas
 * Developers can "tail" logs and metrics using a CLI for any component they have access to.
 
 ### Contributor Capabilities
-* Contributors can write extensions and translate logs and metrics into the format 
+
+* Contributors can write extensions and translate logs and metrics into the format
 for different loggings and metrics stores (e.g. StackDriver).
 
 ## Basics
+
 ### Milestones: M3 and M4
-In this phase, we will enable a shared infrastructure where everyone has access to all data. 
+
+In this phase, we will enable a shared infrastructure where everyone has access to all data.
 No personas specific experience or access will be provided.
 
 The following items will be installed and secured in a cluster by default, 
 but we will provide the ability to replace or remove these in a later milestone.
+
 * Prometheus
 * Alert Manager
 * Prometheus Operator
@@ -45,10 +52,12 @@ but we will provide the ability to replace or remove these in a later milestone.
 * Fluentd
 
 Logs from the following locations will be collected:
+
 * stderr & stdout for all application and function containers
 * Build logs
 
 Following metrics will be collected:
+
 * Envoy, Istio Mixer (per request metrics), Istio Pilot
 * Node and pod level metrics (CPU, memory, disk and network)
 * Knative Serving controller metrics
@@ -56,30 +65,40 @@ Following metrics will be collected:
 Request logs from Istio proxy, user applications and user functions will be collected by Zipkin.
 
 ## Developer Contracts
+
 ### Milestones: M4 and M5
+
 In this phase, we will define and implement features for the developer persona.
+
 * [M4 & M5] Define and implement developer contracts for logging, metrics, alerting and tracing.
 * [M4] Write step-by-step guidelines for developers to debug issues throughout the lifecycle of their applications and functions.
 * [M4] Provide developer samples written in Golang. Support for other languages will come in a later phase.
 * [M5] Implement the developer CLI to list components and tail logs, metrics and traces.
 
 ## Operator Contracts
+
 ### Milestones: M6 and M7
+
 In this phase, we will define and implement features for the operator persona.
+
 * [M6 & M7] Define and implement operator contracts.
 * [M6] Write step-by-step guidelines for operators to debug issues in the cluster.
 * [M7] Deploy operator specific instances of the default backends to separate access of operators vs developers.
 * [M7] Implement the operator CLI to list components and tail logs and metrics.
 
 ## Contributor Contracts
+
 ### Milestones: M8
+
 In this phase, we will define and implement the features for the contributor persona.
-* [M8] Define and implement contracts for plugging in custom logging, metrics, alerting and tracing backends. 
-We will not provide maintenance, rollout processes, etc for third-party monitoring, logging, or tracing extensions, 
-though we may maintain a "contrib" directory for such contributions.
+
+* [M8] Define and implement contracts for plugging in custom logging, metrics, alerting and tracing backends.
+    We will not provide maintenance, rollout processes, etc for third-party monitoring, logging, or tracing extensions,
+    though we may maintain a "contrib" directory for such contributions.
 * [M8] Add an extension for one managed solution (e.g. Stack Driver).
 
 ## M9 and Onwards
+
 * Allow namespace specific instances of default backends for namespace level access control.
 * Implement auto-scaling of the default backends.
 * Implement upgrading of the default backends.
@@ -87,4 +106,5 @@ though we may maintain a "contrib" directory for such contributions.
 * Provide developer samples written in Node.js, Java, Python, PHP, .Net and Ruby.
 
 ## Out of Scope for 2018
+
 * Improving the underlying logging, monitoring, and tracing systems to support multi-tenancy.

--- a/docs/scaling/DEVELOPMENT.md
+++ b/docs/scaling/DEVELOPMENT.md
@@ -14,6 +14,7 @@ Knative Serving Revisions are automatically scaled up and down according incomin
 ## Behavior
 
 Revisions have three autoscaling states which are:
+
 1. **Active** when they are actively serving requests,
 2. **Reserve** when they are scaled down to 0 Pods but is still in service, and
 3. **Retired** when they will no longer receive traffic.
@@ -28,10 +29,11 @@ In the Retired state, the Revision has provisioned resources.  No requests will 
 
 Note: Retired state is currently not set anywhere. See [issue 1203](https://github.com/knative/serving/issues/1203).
 
-## Context 
+## Context
+
 The following diagram illustrates the mechanics of the autoscaler:
 
-```
+```diagram
    +---------------------+
    | ROUTE               |
    |                     |
@@ -60,7 +62,7 @@ The following diagram illustrates the mechanics of the autoscaler:
                               |                                        |
                               | REVISION                               |
                               +----------------------------------------+
-                              
+
 ```
 
 ## Design Goals
@@ -72,6 +74,7 @@ The following diagram illustrates the mechanics of the autoscaler:
 ### Slow Brain / Fast Brain
 
 The Knative Serving Autoscaler is split into two parts:
+
 1. **Fast Brain** that maintains the desired level of concurrent requests per Pod (satisfying [Design Goal #1](#design-goals)), and the
 2. **Slow Brain** that comes up with the desired level based on CPU, memory and latency statistics (satisfying [Design Goal #2](#design-goals)).
 

--- a/docs/scaling/README.md
+++ b/docs/scaling/README.md
@@ -2,7 +2,6 @@
 
 TODO: write developer/operator facing documentation.
 
-
 ## Scale Bounds
 
 There are cases when Operators need to set lower and upper bounds on the number of pods serving their apps (e.g. avoiding cold-start, control compute costs, etc).
@@ -12,10 +11,10 @@ The following annotations can be used on `configuration.revisionTemplate` or `re
 ```yaml
     # +optional
     # When not specified, the revision can scale down to 0 pods
-    autoscaling.knative.dev/minScale: "2"  
+    autoscaling.knative.dev/minScale: "2"
     # +optional
     # When not specified, there's no upper scale bound
-    autoscaling.knative.dev/maxScale: "10"  
+    autoscaling.knative.dev/maxScale: "10"
 ```
 
-You can also use these annotations directly on `kpa` objects. 
+You can also use these annotations directly on `kpa` objects.

--- a/docs/setting-up-a-docker-registry.md
+++ b/docs/setting-up-a-docker-registry.md
@@ -16,8 +16,8 @@ use any Docker registry.
 
 Install the following tools:
 
-1.  [`gcloud`](https://cloud.google.com/sdk/downloads)
-1.  [`docker-credential-gcr`](https://github.com/GoogleCloudPlatform/docker-credential-gcr)
+1. [`gcloud`](https://cloud.google.com/sdk/downloads)
+1. [`docker-credential-gcr`](https://github.com/GoogleCloudPlatform/docker-credential-gcr)
 
     If you installed `gcloud` using the archive or installer, you can install
     `docker-credential-gcr` like this:
@@ -42,7 +42,7 @@ Install the following tools:
 
 ### Setup
 
-1.  If you haven't already set up a GCP project, create one and export its name
+1. If you haven't already set up a GCP project, create one and export its name
     for use in later commands.
 
     ```shell
@@ -50,21 +50,21 @@ Install the following tools:
     gcloud projects create "${PROJECT_ID}"
     ```
 
-1.  Enable the GCR API.
+1. Enable the GCR API.
 
     ```shell
     gcloud --project="${PROJECT_ID}" services enable \
     containerregistry.googleapis.com
     ```
 
-1.  Hook up your GCR credentials. Note that this may complain if you don't have
+1. Hook up your GCR credentials. Note that this may complain if you don't have
     the docker CLI installed, but it is not necessary and should still work.
 
     ```shell
     docker-credential-gcr configure-docker
     ```
 
-1.  If you need to, update your `KO_DOCKER_REPO` and/or `DOCKER_REPO_OVERRIDE`
+1. If you need to, update your `KO_DOCKER_REPO` and/or `DOCKER_REPO_OVERRIDE`
     in your `.bashrc`. It should now be
 
     ```shell

--- a/docs/setting-up-ingress-static-ip.md
+++ b/docs/setting-up-ingress-static-ip.md
@@ -1,11 +1,11 @@
 # Setting Up Static IP for Knative Gateway
 
-Knative uses a shared Gateway to serve all incoming traffic within Knative 
-service mesh, which is the "knative-shared-gateway" Gateway under 
-"knative-serving" namespace. The IP address to access the gateway is the 
-external IP address of the "knative-ingressgateway" service under the 
-"istio-system" namespace. So in order to set static IP for the Knative shared 
-gateway, you just need to set the external IP address of the 
+Knative uses a shared Gateway to serve all incoming traffic within Knative
+service mesh, which is the "knative-shared-gateway" Gateway under
+"knative-serving" namespace. The IP address to access the gateway is the
+external IP address of the "knative-ingressgateway" service under the
+"istio-system" namespace. So in order to set static IP for the Knative shared
+gateway, you just need to set the external IP address of the
 "knative-ingressgateway" service to the static IP you need.
 
 ## Prerequisites
@@ -14,7 +14,7 @@ gateway, you just need to set the external IP address of the
 
 #### Knative on GKE
 
-If you are running Knative cluster on GKE, you can follow the [instructions](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#reserve_new_static) to reserve a REGIONAL 
+If you are running Knative cluster on GKE, you can follow the [instructions](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#reserve_new_static) to reserve a REGIONAL
 IP address. The region of the IP address should be the region your Knative
  cluster is running in (e.g. us-east1, us-central1, etc.).
 
@@ -22,18 +22,19 @@ TODO: add documentation on reserving static IP in other cloud platforms.
 
 ### Prerequisite 2: Deploy Istio And Knative Serving
 
-Follow the [instructions](https://github.com/knative/serving/blob/master/DEVELOPMENT.md) 
+Follow the [instructions](https://github.com/knative/serving/blob/master/DEVELOPMENT.md)
 to deploy Istio and Knative Serving into your cluster.
 
-Once you reach this point, you can start to set up static IP for Knative 
+Once you reach this point, you can start to set up static IP for Knative
 gateway.
 
 ## Set Up Static IP for Knative Gateway
 
 ### Step 1: Update external IP of "knative-ingressgateway" service
 
-Run following command to reset the external IP for the 
+Run following command to reset the external IP for the
 "knative-ingressgateway" service to the static IP you reserved.
+
 ```shell
 kubectl patch svc knative-ingressgateway -n istio-system --patch '{"spec": { "loadBalancerIP": "<your-reserved-static-ip>" }}'
 ```
@@ -41,13 +42,17 @@ kubectl patch svc knative-ingressgateway -n istio-system --patch '{"spec": { "lo
 ### Step 2: Verify static IP address of knative-ingressgateway service
 
 You can check the external IP of the "knative-ingressgateway" service with:
+
 ```shell
 kubectl get svc knative-ingressgateway -n istio-system
 ```
+
 The result should be something like
-```
+
+```console
 NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                      AGE
 knative-ingressgateway   LoadBalancer   10.50.250.120   35.210.48.100   80:32380/TCP,443:32390/TCP,32400:32400/TCP   5h
 ```
-The external IP will be eventually set to the static IP. This process could 
+
+The external IP will be eventually set to the static IP. This process could
 take several minutes.

--- a/docs/spec/normative_examples.md
+++ b/docs/spec/normative_examples.md
@@ -26,7 +26,7 @@ represent final CLI design.
 **_Scenario_**: User deploys a new revision to an existing service
 with a new container image, rolling out automatically to 100%
 
-```
+```console
 $ knative deploy --service my-service
   Deploying app to service [my-service]:
 ✓ Starting
@@ -45,7 +45,6 @@ $ knative deploy --service my-service
   Revision is created, and automatically rolled out to 100% once ready.
 
 ![Automatic Rollout](images/auto_rollout.png)
-
 
 After the initial Route and Configuration have been created (which is shown
 in the
@@ -75,6 +74,7 @@ inheriting previous environment values from the configuration spec:
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -95,6 +95,7 @@ with the new container image:
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
@@ -113,6 +114,7 @@ the Configuration and Service are updated to reflect the new Revision:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
@@ -121,7 +123,7 @@ metadata:
   generation: 1235
  ...
 
-spec: 
+spec:
   ... # same as before, except new container.image
 status:
   latestReadyRevisionName: abc
@@ -132,6 +134,7 @@ status:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -140,7 +143,7 @@ metadata:
   generation: 1452
  ...
 
-spec: 
+spec:
   ... # same as before, except new container.image
 status:
   latestReadyRevisionName: abc
@@ -156,6 +159,7 @@ of the revision:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/def
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
@@ -194,6 +198,7 @@ existing revision `abc` and new revision `def`:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -208,7 +213,7 @@ spec:
 
 status:
   # domain:
-  # oss: my-service.namespace.mydomain.com 
+  # oss: my-service.namespace.mydomain.com
   domain: my-service.namespace.mydomain.com
   # percentages add to 100
   traffic:  # in status, all configurationName refs are dereferenced
@@ -226,6 +231,7 @@ And once reconciled, revision def serves 100% of the traffic :
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -239,7 +245,7 @@ spec:
       percent: 100
 status:
   domain: my-service.default.mydomain.com
-  traffic: 
+  traffic:
   - revisionName: def
     percent: 100
   conditions:
@@ -248,13 +254,12 @@ status:
   ...
 ```
 
-
 ## 2) Creating a new Service with a pre-built container
 
 **Scenario**: User creates a new Service and deploys their first
   Revision based on a pre-built container
 
-```
+```console
 $ knative deploy --service my-service --region us-central1
 ✓ Creating service [my-service] in region [us-central1]
   Deploying app to service [my-service]:
@@ -311,6 +316,7 @@ The client creates the service in `runLatest` mode:
 ```http
 POST /apis/serving.knative.dev/v1alpha1/namespaces/default/services
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -321,7 +327,7 @@ spec:
     configuration:
       revisionTemplate:  # template for building Revision
         metadata: ...
-        spec: 
+        spec:
           container: # k8s core.v1.Container
             image: gcr.io/...
             env:
@@ -338,6 +344,7 @@ objects with the same name as the Service:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -353,6 +360,7 @@ spec:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
@@ -363,7 +371,7 @@ metadata:
 spec:  # Contents from service's spec.runLatest.configuration
   revisionTemplate:
     metadata: ...
-    spec: 
+    spec:
       container: # k8s core.v1.Container
         image: gcr.io/...
         env:
@@ -381,6 +389,7 @@ and metadata from the configuration, as well as new metadata labels:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
@@ -408,6 +417,7 @@ with latestCreatedRevisionName:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
@@ -429,6 +439,7 @@ updated as Ready (to serve), the latestReadyRevisionName is updated:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
@@ -436,12 +447,12 @@ metadata:
   name: my-service
   generation: 1234
   ...
-spec: 
+spec:
   ...  # same as before
 status:
   # the latest created and ready to serve. Watched by route
   latestReadyRevisionName: abc
-  # latest created revision 
+  # latest created revision
   latestCreatedRevisionName: abc
   observedGeneration: 1234
 ```
@@ -454,6 +465,7 @@ new revision `abc`, addressable as
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -486,6 +498,7 @@ The Service also watches the Configuration (and Route) and mirrors their status 
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -493,12 +506,12 @@ metadata:
   name: my-service
   generation: 1
   ...
-spec: 
+spec:
   ...  # same as before
 status:
   # the latest created and ready to serve.
   latestReadyRevisionName: abc
-  # latest created revision 
+  # latest created revision
   latestCreatedRevisionName: abc
   observedGeneration: 1
 ```
@@ -510,7 +523,7 @@ status:
   (env var change) to an existing service, tests the revision, then
   proceeds with a manually controlled rollout to 100%
 
-```
+```console
 $ knative rollout --service my-service strategy manual
 
 $ knative deploy --service my-service --env HELLO="blurg"
@@ -570,6 +583,7 @@ The client updates the service to pin the current revision:
 ```http
 PUT /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -592,6 +606,7 @@ and therefore unchanged).
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -615,6 +630,7 @@ the environment but keeping the same container image:
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -637,6 +653,7 @@ the creation of a new revision:
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/configurations/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
@@ -657,6 +674,7 @@ revision `def`, but different config:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/ghi
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
@@ -689,6 +707,7 @@ verification, etc.
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -724,6 +743,7 @@ updating the service to pin `ghi` as the new revision.
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -734,11 +754,12 @@ spec:
     revisionname: ghi
 ```
 
-This causes the service to update the route to assign 
+This causes the service to update the route to assign.
 
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: route
@@ -763,6 +784,7 @@ point to the same revision. Both names are left in place so that
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route
@@ -797,10 +819,10 @@ status:
 **Scenario**: User deploys a revision to an existing service from
   source rather than a pre-built container
 
-```
+```console
 $ knative deploy --service my-service
   Deploying app to service [my-service]:
-✓ Uploading     [=================] 
+✓ Uploading     [=================]
 ✓ Detected [node-8-9-4] runtime
 ✓ Building
 ✓ Starting
@@ -822,7 +844,6 @@ $ knative deploy --service my-service
 
 ![Build Example](images/build_example.png)
 
-
 Previous examples demonstrated services created with pre-built
 containers. Revisions can also be created by providing build
 information to the service, which results in a container image built
@@ -837,11 +858,12 @@ configuration in the service inlining a build spec:
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
-  name: my-service 
+  name: my-service
 spec:
   runLatest:
     configuration:
@@ -889,6 +911,7 @@ Revision’s status for convenience:
 ```http
 GET /apis/serving.knative.dev/v1alpha1/namespaces/default/revisions/abc
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Revision
@@ -944,10 +967,10 @@ Revision is created which can become ready.
 
 **Scenario**: User deploys a new function revision to an existing service
 
-```
+```console
 $ knative deploy --function index --service my-function
   Deploying function to service [my-function]:
-✓ Uploading     [=================] 
+✓ Uploading     [=================]
 ✓ Detected [node-8-9-4] runtime
 ✓ Building
 ✓ Starting
@@ -994,11 +1017,12 @@ Creating the service with build and function metadata:
 ```http
 POST /apis/serving.knative.dev/v1alpha1/namespaces/default/services
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
-  name: my-function 
+  name: my-function
 spec:
   runLatest:
     configuration:
@@ -1019,7 +1043,7 @@ spec:
               value: gcr.io/...  # destination for image
             - name: _ENTRY_POINT
               value: index  # language dependent, function-only entrypoint
-  
+
       revisionTemplate:  # template for building Revision
         metadata:
           labels:

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -45,7 +45,6 @@ over time, and enables users to easily rollback to a prior revision.
 Revisions that are addressable via a Route will have resource
 utilization proportional to the load they are under.
 
-
 ## Configuration
 
 A **Configuration** describes the desired latest Revision state, and
@@ -78,8 +77,7 @@ The owned Configurations' Ready conditions are surfaced as the Service's
 ConfigurationsReady condition. The owned Routes' Ready conditions are
 surfaced as the Service's RoutesReady condition.
 
-
-# Orchestration
+## Orchestration
 
 The system will be configured to disallow users from creating
 ([NYI](https://github.com/knative/serving/issues/664)) or changing

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -7,13 +7,13 @@ schemas](#resource-yaml-definitions) that make up the Knative Serving API.
 
 Resource paths in the Knative Serving API have the following standard k8s form:
 
-```
+```http
 /apis/{apiGroup}/{apiVersion}/namespaces/{metadata.namespace}/{kind}/{metadata.name}
 ```
 
 For example:
 
-```
+```http
 /apis/serving.knative.dev/v1alpha1/namespaces/default/routes/my-service
 ```
 
@@ -23,13 +23,13 @@ cluster-wide DNS name. While no particular URL scheme is mandated
 mapping), a common implementation would be to use the kubernetes
 namespace mechanism to produce a URL like the following:
 
-```
+```http
 [$revisionname].$route.$namespace.<common knative cluster suffix>
 ```
 
 For example:
 
-```
+```http
 prod.my-service.default.mydomain.com
 ```
 
@@ -52,7 +52,7 @@ metadata:
   name: my-service
   namespace: default
   labels:
-    knative.dev/service: ...  # name of the Service automatically filled in   
+    knative.dev/service: ...  # name of the Service automatically filled in
 
   # system generated meta
   uid: ...
@@ -104,12 +104,10 @@ status:
   observedGeneration: ...  # last generation being reconciled
 ```
 
-
 ### Configuration
 
 For a high-level description of Configurations,
 [see the overview](overview.md#configuration).
-
 
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
@@ -140,7 +138,7 @@ spec:
       annotations: ...
       labels: ...
     spec: ...
-  
+
   revisionTemplate:  # template for building Revision
     metadata: ...
       labels:
@@ -200,7 +198,6 @@ status:
     message: "Unable to start because container is missing and build failed."
   observedGeneration: ...  # last generation being reconciled
 ```
-
 
 ### Revision
 
@@ -310,16 +307,14 @@ status:
   imageDigest: gcr.io/my-project/...@sha256:60ab5...
 ```
 
-
 ## Service
 
 For a high-level description of Services,
 [see the overview](overview.md#service).
 
-
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
-kind: Service	
+kind: Service
 metadata:
   name: myservice
   namespace: default

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -163,7 +163,7 @@ config/monitoring/200-common/300-prometheus/100-scrape-config.yaml:
 
 5.Redeploy prometheus and its configuration:
 
-```sh
+```shell
 kubectl delete -f config/monitoring/200-common/300-prometheus
 kubectl apply -f config/monitoring/200-common/300-prometheus
 ```

--- a/hack/config-release.template
+++ b/hack/config-release.template
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-release
+  namespace: knative-serving
+data:
+  release.knative-version: "KNATIVE-VERSION"
+  releaes.github-commit-id: "GITHUB-COMMIT-ID"

--- a/hack/environments.md
+++ b/hack/environments.md
@@ -10,7 +10,7 @@ This environment is rebuilt by the Steering Committee at the conclusion of a mil
 
 You can configure your access by running:
 
-```
+```shell
 gcloud container clusters get-credentials knative-demo --zone us-central1-a --project knative-environments
 ```
 
@@ -20,7 +20,7 @@ This environment is recreated by a prow periodic job every Saturday 1AM PST, usi
 
 You can configure your access by running:
 
-```
+```shell
 gcloud container clusters get-credentials knative-playground --zone us-central1-a --project knative-environments
 ```
 
@@ -28,7 +28,7 @@ gcloud container clusters get-credentials knative-playground --zone us-central1-
 
 To manually recreate an environment, call the `deploy.sh` script passing the environment name as parameter:
 
-```
+```shell
 ./deploy.sh knative-playground # or
 ./deploy.sh knative-demo
 ```

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -63,7 +63,7 @@ echo "Copying Build release"
 cp "${REPO_ROOT_DIR}/third_party/config/build/release.yaml" "${BUILD_YAML}"
 
 echo "Building Knative Serving"
-ko resolve ${KO_FLAGS} -f config/ >> "${SERVING_YAML}"
+ko resolve ${KO_FLAGS} -f config/ > "${SERVING_YAML}"
 
 echo "Building Monitoring & Logging"
 # Use ko to concatenate them all together.
@@ -72,20 +72,20 @@ ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f config/monitoring/logging/elasticsearch \
     -f third_party/config/monitoring/metrics/prometheus \
     -f config/monitoring/metrics/prometheus \
-    -f config/monitoring/tracing/zipkin >> "${MONITORING_YAML}"
+    -f config/monitoring/tracing/zipkin > "${MONITORING_YAML}"
 
 # Metrics via Prometheus & Grafana
 ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f third_party/config/monitoring/metrics/prometheus \
-    -f config/monitoring/metrics/prometheus >> "${MONITORING_METRIC_PROMETHEUS_YAML}"
+    -f config/monitoring/metrics/prometheus > "${MONITORING_METRIC_PROMETHEUS_YAML}"
 
 # Logs via ElasticSearch, Fluentd & Kibana
 ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f third_party/config/monitoring/logging/elasticsearch \
-    -f config/monitoring/logging/elasticsearch >> "${MONITORING_LOG_ELASTICSEARCH_YAML}"
+    -f config/monitoring/logging/elasticsearch > "${MONITORING_LOG_ELASTICSEARCH_YAML}"
 
 # Traces via Zipkin
-ko resolve ${KO_FLAGS} -R -f config/monitoring/tracing/zipkin >> "${MONITORING_TRACE_ZIPKIN_YAML}"
+ko resolve ${KO_FLAGS} -R -f config/monitoring/tracing/zipkin > "${MONITORING_TRACE_ZIPKIN_YAML}"
 
 echo "Building Release Bundles."
 
@@ -98,19 +98,19 @@ readonly LITE_YAML=release-lite.yaml
 readonly NO_MON_YAML=release-no-mon.yaml
 
 # NO_MON is just build and serving
-cat "${BUILD_YAML}" > "${NO_MON_YAML}"
+cp "${BUILD_YAML}" "${NO_MON_YAML}"
 echo "---" >> "${NO_MON_YAML}"
 cat "${SERVING_YAML}" >> "${NO_MON_YAML}"
 echo "---" >> "${NO_MON_YAML}"
 
 # LITE is NO_MON plus "lean" monitoring
-cat "${NO_MON_YAML}" > "${LITE_YAML}"
+cp "${NO_MON_YAML}" "${LITE_YAML}"
 echo "---" >> "${LITE_YAML}"
 cat "${MONITORING_METRIC_PROMETHEUS_YAML}" >> "${LITE_YAML}"
 echo "---" >> "${LITE_YAML}"
 
 # RELEASE is NO_MON plus full monitoring
-cat "${NO_MON_YAML}" > "${RELEASE_YAML}"
+cp "${NO_MON_YAML}" "${RELEASE_YAML}"
 echo "---" >> "${RELEASE_YAML}"
 cat "${MONITORING_YAML}" >> "${RELEASE_YAML}"
 echo "---" >> "${RELEASE_YAML}"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -127,7 +127,6 @@ echo "Tagging referenced images with ${TAG}."
 tag_images_in_yaml "${RELEASE_YAML}" "${SERVING_RELEASE_GCR}" "${TAG}"
 
 echo "New release built successfully"
-
 if (( ! PUBLISH_RELEASE )); then
  exit 0
 fi

--- a/install/CONFIG.md
+++ b/install/CONFIG.md
@@ -1,6 +1,6 @@
 # Configuring Knative Serving
 
-## Serving multiple domains:
+## Serving multiple domains
 
 Different domain suffixes can be configured based on the route labels.  In order
 to do this, update the config map named `config-domain` in the namespace
@@ -13,7 +13,8 @@ multiple selectors matching your route labels, the one that is most specific
 (has the most number of requirements) will be chosen.
 
 For example, if your config map looks like
-```
+
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,6 +33,7 @@ data:
 ```
 
 then
+
 * when your route has label `app=prod`, then route domain will have the suffix
   `prod.domain.com`
 * when your route has labels `app=staging, version=v2`, then route domain will


### PR DESCRIPTION
Fixes #2128

## Proposed Changes

  * Add a Configmap including the following release information to Knative serving when doing versioned release:
  
       1. Version number `vX.Y.Z`.
       1. Github commit ID where the release was built from.