### PR TITLE
Add a Configmap including release information to Knative serving when doing versioned release

### DIFF
--- a/hack/config-release.template
+++ b/hack/config-release.template
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-release
+  namespace: knative-serving
+data:
+  release.knative-version: "KNATIVE-VERSION"
+  releaes.github-commit-id: "GITHUB-COMMIT-ID"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -64,6 +64,13 @@ cp "${REPO_ROOT_DIR}/third_party/config/build/release.yaml" "${BUILD_YAML}"
 
 echo "Building Knative Serving"
 ko resolve ${KO_FLAGS} -f config/ > "${SERVING_YAML}"
+if [[ -n "${RELEASE_VERSION}" ]]; then
+  # Add the configmap including release information
+  COMMIT_ID=$(cat .git/HEAD)
+  echo "---" >> "${SERVING_YAML}"
+  sed -e "s,KNATIVE-VERSION,v${RELEASE_VERSION}," -e "s,GITHUB-COMMIT-ID,${COMMIT_ID}," \
+    ./hack/config-release.template >> "${SERVING_YAML}"
+fi
 
 echo "Building Monitoring & Logging"
 # Use ko to concatenate them all together.


### PR DESCRIPTION
Fixes #2128

## Proposed Changes

  * Add a Configmap including the following release information to Knative serving when doing versioned release:
  
       1. Version number `vX.Y.Z`.
       1. Github commit ID where the release was built from.