### PR TITLE
helper funcs for route reconciler to construct ClusterIngress

### DIFF
--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/activator"
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
+	"github.com/knative/serving/pkg/system"
+)
+
+// MakeClusterIngress creates ClusterIngress to set up routing rules. Such ClusterIngress specifies
+// which Hosts that it applies to, as well as the routing rules.
+func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.TrafficConfig) *v1alpha1.ClusterIngress {
+	return &v1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			// As ClusterIngress resource is cluster-scoped,
+			// here we use GenerateName to avoid conflict.
+			GenerateName: names.ClusterIngressPrefix(r),
+			Labels: map[string]string{
+				serving.RouteLabelKey:          r.Name,
+				serving.RouteNamespaceLabelKey: r.Namespace,
+			},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
+		},
+		Spec: makeClusterIngressSpec(r, tc.Targets),
+	}
+}
+
+func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string][]traffic.RevisionTarget) v1alpha1.IngressSpec {
+	// Domain should have been specified in route status
+	// before calling this func.
+	domain := r.Status.Domain
+	names := []string{}
+	for name := range targets {
+		names = append(names, name)
+	}
+	// Sort the names to give things a deterministic ordering.
+	sort.Strings(names)
+	// The routes are matching rule based on domain name to traffic split targets.
+	rules := []v1alpha1.ClusterIngressRule{}
+	for _, name := range names {
+		rules = append(rules, *makeClusterIngressRule(getRouteDomains(name, r, domain), r.Namespace, targets[name]))
+	}
+	return v1alpha1.IngressSpec{
+		Rules: rules,
+	}
+}
+
+func getRouteDomains(targetName string, r *servingv1alpha1.Route, domain string) []string {
+	if targetName == "" {
+		// Nameless traffic targets correspond to many domains: the
+		// Route.Status.Domain, and also various names of the Route's
+		// headless Service.
+		domains := []string{domain,
+			names.K8sServiceFullname(r),
+			fmt.Sprintf("%s.%s.svc", r.Name, r.Namespace),
+			fmt.Sprintf("%s.%s", r.Name, r.Namespace),
+			r.Name,
+		}
+		return dedup(domains)
+	}
+
+	return []string{fmt.Sprintf("%s.%s", targetName, domain)}
+}
+
+// groupTargets group given targets into active ones and inactive ones.
+func groupTargets(targets []traffic.RevisionTarget) (active []traffic.RevisionTarget, inactive []traffic.RevisionTarget) {
+	for _, t := range targets {
+		if t.Active {
+			active = append(active, t)
+		} else {
+			inactive = append(inactive, t)
+		}
+	}
+	return active, inactive
+}
+
+func makeClusterIngressRule(domains []string, ns string, targets []traffic.RevisionTarget) *v1alpha1.ClusterIngressRule {
+	active, inactive := groupTargets(targets)
+	splits := []v1alpha1.ClusterIngressBackendSplit{}
+	for _, t := range active {
+		if t.Percent == 0 {
+			// Don't include 0% routes.
+			continue
+		}
+		splits = append(splits, v1alpha1.ClusterIngressBackendSplit{
+			Backend: &v1alpha1.ClusterIngressBackend{
+				ServiceNamespace: ns,
+				ServiceName:      reconciler.GetServingK8SServiceNameForObj(t.TrafficTarget.RevisionName),
+				ServicePort:      intstr.FromInt(int(revisionresources.ServicePort)),
+			},
+			Percent: t.Percent,
+		})
+	}
+	path := v1alpha1.HTTPClusterIngressPath{
+		Splits: splits,
+		// TODO(lichuqiang): #2201, plumbing to config timeout and retries.
+
+	}
+	path.SetDefaults()
+	return &v1alpha1.ClusterIngressRule{
+		Hosts: domains,
+		HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []v1alpha1.HTTPClusterIngressPath{
+				*addInactive(&path, ns, inactive),
+			},
+		},
+	}
+}
+
+// addInactive constructs Splits for the inactive targets, and add into given IngressPath.
+func addInactive(r *v1alpha1.HTTPClusterIngressPath, ns string, inactive []traffic.RevisionTarget) *v1alpha1.HTTPClusterIngressPath {
+	totalInactivePercent := 0
+	maxInactiveTarget := traffic.RevisionTarget{}
+	for _, t := range inactive {
+		totalInactivePercent += t.Percent
+		if t.Percent >= maxInactiveTarget.Percent {
+			maxInactiveTarget = t
+		}
+	}
+	if totalInactivePercent == 0 {
+		// There is actually no inactive Revisions.
+		return r
+	}
+	r.Splits = append(r.Splits, v1alpha1.ClusterIngressBackendSplit{
+		Backend: &v1alpha1.ClusterIngressBackend{
+			ServiceNamespace: system.Namespace,
+			ServiceName:      activator.K8sServiceName,
+			ServicePort:      intstr.FromInt(int(revisionresources.ServicePort)),
+		},
+		Percent: totalInactivePercent,
+	})
+	r.AppendHeaders = map[string]string{
+		activator.RevisionHeaderName:      maxInactiveTarget.RevisionName,
+		activator.RevisionHeaderNamespace: ns,
+	}
+	return r
+}
+
+func dedup(strs []string) []string {
+	existed := make(map[string]struct{})
+	unique := []string{}
+	for _, s := range strs {
+		if _, ok := existed[s]; !ok {
+			existed[s] = struct{}{}
+			unique = append(unique, s)
+		}
+	}
+	return unique
+}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -1,0 +1,454 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/kmeta"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
+	targets := map[string][]traffic.RevisionTarget{}
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+		Status: v1alpha1.RouteStatus{Domain: "domain.com"},
+	}
+	expected := metav1.ObjectMeta{
+		GenerateName: "test-route-",
+		Labels: map[string]string{
+			serving.RouteLabelKey:          "test-route",
+			serving.RouteNamespaceLabelKey: "test-ns",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			*kmeta.NewControllerRef(r),
+		},
+	}
+	meta := MakeClusterIngress(r, &traffic.TrafficConfig{Targets: targets}).ObjectMeta
+	if diff := cmp.Diff(expected, meta); diff != "" {
+		t.Errorf("Unexpected metadata (-want +got): %v", diff)
+	}
+}
+
+func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
+	targets := map[string][]traffic.RevisionTarget{
+		"": {{
+			TrafficTarget: v1alpha1.TrafficTarget{
+				ConfigurationName: "config",
+				RevisionName:      "v2",
+				Percent:           100,
+			},
+			Active: true,
+		}},
+		"v1": {{
+			TrafficTarget: v1alpha1.TrafficTarget{
+				ConfigurationName: "config",
+				RevisionName:      "v1",
+				Percent:           100,
+			},
+			Active: true,
+		}},
+	}
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+		Status: v1alpha1.RouteStatus{Domain: "domain.com"},
+	}
+	expected := []netv1alpha1.ClusterIngressRule{{
+		Hosts: []string{
+			"domain.com",
+			"test-route.test-ns.svc.cluster.local",
+			"test-route.test-ns.svc",
+			"test-route.test-ns",
+			"test-route",
+		},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "v2-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}, {
+		Hosts: []string{"v1.domain.com"},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "v1-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}}
+	rules := makeClusterIngressSpec(r, targets).Rules
+	if diff := cmp.Diff(expected, rules); diff != "" {
+		fmt.Printf("%+v\n", rules)
+		fmt.Printf("%+v\n", expected)
+		t.Errorf("Unexpected rules (-want +got): %v", diff)
+	}
+}
+
+func TestGetRouteDomains_NamelessTarget(t *testing.T) {
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+	}
+	base := "domain.com"
+	expected := []string{base,
+		"test-route.test-ns.svc.cluster.local",
+		"test-route.test-ns.svc",
+		"test-route.test-ns",
+		"test-route",
+	}
+	domains := getRouteDomains("", r, base)
+	if diff := cmp.Diff(expected, domains); diff != "" {
+		t.Errorf("Unexpected domains  (-want +got): %v", diff)
+	}
+}
+
+func TestGetRouteDomains_NamedTarget(t *testing.T) {
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+	}
+	name := "v1"
+	base := "domain.com"
+	expected := []string{"v1.domain.com"}
+	domains := getRouteDomains(name, r, base)
+	if diff := cmp.Diff(expected, domains); diff != "" {
+		t.Errorf("Unexpected domains  (-want +got): %v", diff)
+	}
+}
+
+// One active target.
+func TestMakeClusterIngressRule_Vanilla(t *testing.T) {
+	targets := []traffic.RevisionTarget{{
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "config",
+			RevisionName:      "revision",
+			Percent:           100,
+		},
+		Active: true,
+	}}
+	domains := []string{"a.com", "b.org"}
+	ns := "test-ns"
+	rule := makeClusterIngressRule(domains, ns, targets)
+	expected := netv1alpha1.ClusterIngressRule{
+		Hosts: []string{
+			"a.com",
+			"b.org",
+		},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "revision-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}
+
+	if diff := cmp.Diff(&expected, rule); diff != "" {
+		t.Errorf("Unexpected rule (-want +got): %v", diff)
+	}
+}
+
+// One active target and a target of zero percent.
+func TestMakeClusterIngressRule_ZeroPercentTarget(t *testing.T) {
+	targets := []traffic.RevisionTarget{{
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "config",
+			RevisionName:      "revision",
+			Percent:           100,
+		},
+		Active: true,
+	}, {
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "new-config",
+			RevisionName:      "new-revision",
+			Percent:           0,
+		},
+		Active: true,
+	}}
+	domains := []string{"test.org"}
+	ns := "test-ns"
+	rule := makeClusterIngressRule(domains, ns, targets)
+	expected := netv1alpha1.ClusterIngressRule{
+		Hosts: []string{"test.org"},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "revision-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}
+
+	if diff := cmp.Diff(&expected, rule); diff != "" {
+		t.Errorf("Unexpected rule (-want +got): %v", diff)
+	}
+}
+
+// Two active targets.
+func TestMakeClusterIngressRule_TwoTargets(t *testing.T) {
+	targets := []traffic.RevisionTarget{{
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "config",
+			RevisionName:      "revision",
+			Percent:           80,
+		},
+		Active: true,
+	}, {
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "new-config",
+			RevisionName:      "new-revision",
+			Percent:           20,
+		},
+		Active: true,
+	}}
+	domains := []string{"test.org"}
+	ns := "test-ns"
+	rule := makeClusterIngressRule(domains, ns, targets)
+	expected := netv1alpha1.ClusterIngressRule{
+		Hosts: []string{"test.org"},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "revision-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 80,
+				}, {
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "new-revision-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 20,
+				}},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}
+
+	if diff := cmp.Diff(&expected, rule); diff != "" {
+		t.Errorf("Unexpected rule (-want +got): %v", diff)
+	}
+}
+
+// Inactive target.
+func TestMakeClusterIngressRule_InactiveTarget(t *testing.T) {
+	targets := []traffic.RevisionTarget{{
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "config",
+			RevisionName:      "revision",
+			Percent:           100,
+		},
+		Active: false,
+	}}
+	domains := []string{"a.com", "b.org"}
+	ns := "test-ns"
+	rule := makeClusterIngressRule(domains, ns, targets)
+	expected := netv1alpha1.ClusterIngressRule{
+		Hosts: []string{
+			"a.com",
+			"b.org",
+		},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "knative-serving",
+						ServiceName:      "activator-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				AppendHeaders: map[string]string{
+					"knative-serving-revision":  "revision",
+					"knative-serving-namespace": "test-ns",
+				},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}
+	if diff := cmp.Diff(&expected, rule); diff != "" {
+		t.Errorf("Unexpected rule (-want +got): %v", diff)
+	}
+}
+
+// Two inactive targets.
+func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
+	targets := []traffic.RevisionTarget{{
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "config",
+			RevisionName:      "revision",
+			Percent:           80,
+		},
+		Active: false,
+	}, {
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "new-config",
+			RevisionName:      "new-revision",
+			Percent:           20,
+		},
+		Active: false,
+	}}
+	domains := []string{"a.com", "b.org"}
+	ns := "test-ns"
+	rule := makeClusterIngressRule(domains, ns, targets)
+	expected := netv1alpha1.ClusterIngressRule{
+		Hosts: []string{
+			"a.com",
+			"b.org",
+		},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "knative-serving",
+						ServiceName:      "activator-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				AppendHeaders: map[string]string{
+					"knative-serving-revision":  "revision",
+					"knative-serving-namespace": "test-ns",
+				},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}
+	if diff := cmp.Diff(&expected, rule); diff != "" {
+		t.Errorf("Unexpected rule (-want +got): %v", diff)
+	}
+}
+
+func TestMakeClusterIngressRule_ZeroPercentTargetInactive(t *testing.T) {
+	targets := []traffic.RevisionTarget{{
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "config",
+			RevisionName:      "revision",
+			Percent:           100,
+		},
+		Active: true,
+	}, {
+		TrafficTarget: v1alpha1.TrafficTarget{
+			ConfigurationName: "new-config",
+			RevisionName:      "new-revision",
+			Percent:           0,
+		},
+		Active: false,
+	}}
+	domains := []string{"test.org"}
+	ns := "test-ns"
+	rule := makeClusterIngressRule(domains, ns, targets)
+	expected := netv1alpha1.ClusterIngressRule{
+		Hosts: []string{"test.org"},
+		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
+			Paths: []netv1alpha1.HTTPClusterIngressPath{{
+				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
+					Backend: &netv1alpha1.ClusterIngressBackend{
+						ServiceNamespace: "test-ns",
+						ServiceName:      "revision-service",
+						ServicePort:      intstr.FromInt(80),
+					},
+					Percent: 100,
+				}},
+				Timeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+				Retries: &netv1alpha1.HTTPRetry{
+					PerTryTimeout: &metav1.Duration{Duration: netv1alpha1.DefaultTimeout},
+					Attempts:      netv1alpha1.DefaultRetryCount,
+				},
+			}},
+		},
+	}
+
+	if diff := cmp.Diff(&expected, rule); diff != "" {
+		t.Errorf("Unexpected rule (-want +got): %v", diff)
+	}
+}

--- a/pkg/reconciler/v1alpha1/route/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names.go
@@ -17,6 +17,8 @@ limitations under the License.
 package names
 
 import (
+	"fmt"
+
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/system"
@@ -40,4 +42,10 @@ func VirtualService(route *v1alpha1.Route) string {
 
 func K8sServiceFullname(route *v1alpha1.Route) string {
 	return reconciler.GetK8sServiceFullname(K8sService(route), route.Namespace)
+}
+
+// ClusterIngressPrefix returns GenerateName prefix of the
+// ClusterIngress child resource for given Route.
+func ClusterIngressPrefix(route *v1alpha1.Route) string {
+	return fmt.Sprintf("%s-", route.Name)
 }

--- a/pkg/reconciler/v1alpha1/route/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names_test.go
@@ -60,6 +60,16 @@ func TestNamer(t *testing.T) {
 		},
 		f:    K8sServiceFullname,
 		want: "bar.default.svc.cluster.local",
+	}, {
+		name: "ClusterIngressPrefix",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+			},
+		},
+		f:    ClusterIngressPrefix,
+		want: "bar-",
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/v1alpha1/route/resources/service.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service.go
@@ -17,13 +17,76 @@ limitations under the License.
 package resources
 
 import (
-	"github.com/knative/pkg/kmeta"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
+	"errors"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/kmeta"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 )
+
+var errLoadBalancerNotFound = errors.New("failed to fetch loadbalancer domain/IP from ingress status")
+
+// NewMakeK8sService creates a Service that redirect to the loadbalancer specified
+// in ClusterIngress status. It's owned by the provided v1alpha1.Route.
+// The purpose of this service is to provide a domain name for Istio routing.
+// TODO: It is to replace the "MakeK8sService" func after route reconciler is switched to reconcile
+// ClusterIngress.
+func NewMakeK8sService(route *v1alpha1.Route, ingress *netv1alpha1.ClusterIngress) (*corev1.Service, error) {
+	svcSpec, err := makeServiceSpec(ingress)
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.K8sService(route),
+			Namespace: route.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				// This service is owned by the Route.
+				*kmeta.NewControllerRef(route),
+			},
+		},
+		Spec: *svcSpec,
+	}, nil
+}
+
+func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, error) {
+	ingressStatus := ingress.Status
+	if ingressStatus.LoadBalancer == nil || len(ingressStatus.LoadBalancer.Ingress) == 0 {
+		return nil, errLoadBalancerNotFound
+	}
+	if len(ingressStatus.LoadBalancer.Ingress) > 1 {
+		// Return error as we only support one LoadBalancer currently.
+		return nil, fmt.Errorf("more than one ingress are specified in status(LoadBalancer) of ClusterIngress %s", ingress.Name)
+	}
+	balancer := ingressStatus.LoadBalancer.Ingress[0]
+
+	// Here we decide LoadBalancer information in the order of
+	// DomainInternal > Domain > LoadBalancedIP to prioritize cluster-local,
+	// and domain (since it would change less than IP).
+	switch {
+	case len(balancer.DomainInternal) != 0:
+		return &corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: balancer.DomainInternal,
+		}, nil
+	case len(balancer.Domain) != 0:
+		return &corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: balancer.Domain,
+		}, nil
+	case len(balancer.IP) != 0:
+		// TODO(lichuqiang): deal with LoadBalancer IP.
+		// We'll also need ports info to make it take effect.
+	}
+
+	return nil, errLoadBalancerNotFound
+}
 
 // MakeK8sService creates a Service that targets nothing, owned
 // by the provided v1alpha1.Route.  The purpose of this service is to

--- a/pkg/reconciler/v1alpha1/route/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service_test.go
@@ -20,12 +20,121 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/knative/pkg/kmeta"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/kmeta"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 )
+
+var (
+	r = &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+	}
+	expectedMeta = metav1.ObjectMeta{
+		Name:      "test-route",
+		Namespace: "test-ns",
+		OwnerReferences: []metav1.OwnerReference{
+			*kmeta.NewControllerRef(r),
+		},
+	}
+)
+
+func TestNewMakeK8SService(t *testing.T) {
+	scenarios := map[string]struct {
+		// Inputs
+		route        *v1alpha1.Route
+		ingress      *netv1alpha1.ClusterIngress
+		expectedSpec corev1.ServiceSpec
+		shouldFail   bool
+	}{
+		"no-loadbalancer": {
+			route: r,
+			ingress: &netv1alpha1.ClusterIngress{
+				Status: netv1alpha1.IngressStatus{},
+			},
+			shouldFail: true,
+		},
+		"empty-loadbalancer": {
+			route: r,
+			ingress: &netv1alpha1.ClusterIngress{
+				Status: netv1alpha1.IngressStatus{
+					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{}},
+					},
+				},
+			},
+			shouldFail: true,
+		},
+		"multi-loadbalancer": {
+			route: r,
+			ingress: &netv1alpha1.ClusterIngress{
+				Status: netv1alpha1.IngressStatus{
+					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{
+							Domain: "domain.com",
+						}, {
+							DomainInternal: "domain.com",
+						}},
+					},
+				},
+			},
+			shouldFail: true,
+		},
+		"ingress-with-domain": {
+			route: r,
+			ingress: &netv1alpha1.ClusterIngress{
+				Status: netv1alpha1.IngressStatus{
+					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{Domain: "domain.com"}},
+					},
+				},
+			},
+			expectedSpec: corev1.ServiceSpec{
+				Type:         corev1.ServiceTypeExternalName,
+				ExternalName: "domain.com",
+			},
+		},
+		"ingress-with-domaininternal": {
+			route: r,
+			ingress: &netv1alpha1.ClusterIngress{
+				Status: netv1alpha1.IngressStatus{
+					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: "knative-ingressgateway.istio-system.svc.cluster.local"}},
+					},
+				},
+			},
+			expectedSpec: corev1.ServiceSpec{
+				Type:         corev1.ServiceTypeExternalName,
+				ExternalName: "knative-ingressgateway.istio-system.svc.cluster.local",
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		service, err := NewMakeK8sService(scenario.route, scenario.ingress)
+		// Validate
+		if scenario.shouldFail && err == nil {
+			t.Errorf("Test %q failed: returned success but expected error", name)
+		}
+		if !scenario.shouldFail {
+			if err != nil {
+				t.Errorf("Test %q failed: returned error: %v", name, err)
+			}
+			if diff := cmp.Diff(expectedMeta, service.ObjectMeta); diff != "" {
+				t.Errorf("Unexpected Metadata  (-want +got): %v", diff)
+			}
+			if diff := cmp.Diff(scenario.expectedSpec, service.Spec); diff != "" {
+				t.Errorf("Unexpected ServiceSpec (-want +got): %v", diff)
+			}
+		}
+	}
+}
 
 func TestMakeK8SService_ValidSpec(t *testing.T) {
 	r := &v1alpha1.Route{

--- a/pkg/reconciler/v1alpha1/route/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/route/resources/virtual_service.go
@@ -55,18 +55,6 @@ func MakeVirtualService(u *v1alpha1.Route, tc *traffic.TrafficConfig) *v1alpha3.
 	}
 }
 
-func dedup(strs []string) []string {
-	existed := make(map[string]struct{})
-	unique := []string{}
-	for _, s := range strs {
-		if _, ok := existed[s]; !ok {
-			existed[s] = struct{}{}
-			unique = append(unique, s)
-		}
-	}
-	return unique
-}
-
 func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.RevisionTarget) v1alpha3.VirtualServiceSpec {
 	domain := u.Status.Domain
 	spec := v1alpha3.VirtualServiceSpec{
@@ -97,24 +85,6 @@ func makeVirtualServiceSpec(u *v1alpha1.Route, targets map[string][]traffic.Revi
 		spec.Http = append(spec.Http, *makeVirtualServiceRoute(getRouteDomains(name, u, domain), u.Namespace, targets[name]))
 	}
 	return spec
-}
-
-func getRouteDomains(targetName string, u *v1alpha1.Route, domain string) []string {
-	var domains []string
-	if targetName == "" {
-		// Nameless traffic targets correspond to many domains: the
-		// Route.Status.Domain, and also various names of the Route's
-		// headless Service.
-		domains = []string{domain,
-			names.K8sServiceFullname(u),
-			fmt.Sprintf("%s.%s.svc", u.Name, u.Namespace),
-			fmt.Sprintf("%s.%s", u.Name, u.Namespace),
-			u.Name,
-		}
-	} else {
-		domains = []string{fmt.Sprintf("%s.%s", targetName, domain)}
-	}
-	return dedup(domains)
 }
 
 func makeVirtualServiceRoute(domains []string, ns string, targets []traffic.RevisionTarget) *v1alpha3.HTTPRoute {

--- a/pkg/reconciler/v1alpha1/route/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/virtual_service_test.go
@@ -159,48 +159,6 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	}
 }
 
-func TestGetRouteDomains_NamelessTarget(t *testing.T) {
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-			Labels: map[string]string{
-				"route": "test-route",
-			},
-		},
-	}
-	base := "domain.com"
-	expected := []string{base,
-		"test-route.test-ns.svc.cluster.local",
-		"test-route.test-ns.svc",
-		"test-route.test-ns",
-		"test-route",
-	}
-	domains := getRouteDomains("", r, base)
-	if diff := cmp.Diff(expected, domains); diff != "" {
-		t.Errorf("Unexpected domains  (-want +got): %v", diff)
-	}
-}
-
-func TestGetRouteDomains_NamedTarget(t *testing.T) {
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-			Labels: map[string]string{
-				"route": "test-route",
-			},
-		},
-	}
-	name := "v1"
-	base := "domain.com"
-	expected := []string{"v1.domain.com"}
-	domains := getRouteDomains(name, r, base)
-	if diff := cmp.Diff(expected, domains); diff != "" {
-		t.Errorf("Unexpected domains  (-want +got): %v", diff)
-	}
-}
-
 // One active target.
 func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 	targets := []traffic.RevisionTarget{{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #1963
Follow-up #2189

## Proposed Changes

  * helper funcs to construct clusteringress
  * create placeholder service according to ingress status

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
update route reconciler to create ClusterIngress instead of VirtualService
```

/area networking

/assign @tcnghia @mattmoor 