### PR TITLE
Remove ServingState from Revision.

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -254,6 +254,10 @@ spec:
   # Name of the service account the code should run as.
   serviceAccountName: ...
 
+  # Deprecated and not updated anymore
+  # Used to be the Revision's level of readiness for receiving traffic.
+  servingState: Active | Reserve | Retired
+
   # Some function or server frameworks or application code may be
   # written to expect that each request will be granted a single-tenant
   # process to run (i.e. that the request code is run

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -254,12 +254,6 @@ spec:
   # Name of the service account the code should run as.
   serviceAccountName: ...
 
-  # The Revision's level of readiness for receiving traffic.
-  # This may not be specified at creation (defaults to Active),
-  # and is used by the controllers and activator to enable
-  # scaling to/from 0.
-  servingState: Active | Reserve | Retired
-
   # Some function or server frameworks or application code may be
   # written to expect that each request will be granted a single-tenant
   # process to run (i.e. that the request code is run

--- a/pkg/activator/dedupe_test.go
+++ b/pkg/activator/dedupe_test.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
 func TestSingleRevision_SingleRequest_Success(t *testing.T) {
@@ -170,8 +168,7 @@ func TestMultipleRevisions_MultipleRequests_PartialSuccess(t *testing.T) {
 func TestSingleRevision_MultipleRequests_FailureRecovery(t *testing.T) {
 	_, kna := fakeClients()
 	kna.ServingV1alpha1().Revisions(testNamespace).Create(
-		newRevisionBuilder(defaultRevisionLabels).
-			withServingState(v1alpha1.RevisionServingStateReserve).build())
+		newRevisionBuilder(defaultRevisionLabels).build())
 	failEp := Endpoint{}
 	failStatus := http.StatusServiceUnavailable
 	failErr := fmt.Errorf("test error")
@@ -228,8 +225,7 @@ func TestSingleRevision_MultipleRequests_FailureRecovery(t *testing.T) {
 func TestShutdown_ReturnError(t *testing.T) {
 	_, kna := fakeClients()
 	kna.ServingV1alpha1().Revisions(testNamespace).Create(
-		newRevisionBuilder(defaultRevisionLabels).
-			withServingState(v1alpha1.RevisionServingStateReserve).build())
+		newRevisionBuilder(defaultRevisionLabels).build())
 	ep := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -252,7 +252,7 @@ type fakeReporter struct {
 	calls []reporterCall
 }
 
-func (f *fakeReporter) ReportRequest(ns, service, config, rev, servingState string, v float64) error {
+func (f *fakeReporter) ReportRequest(ns, service, config, rev, string, v float64) error {
 	return nil
 }
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -252,7 +252,7 @@ type fakeReporter struct {
 	calls []reporterCall
 }
 
-func (f *fakeReporter) ReportRequest(ns, service, config, rev, string, v float64) error {
+func (f *fakeReporter) ReportRequest(ns, service, config, rev string, v float64) error {
 	return nil
 }
 

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -76,7 +76,7 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 	}
 
 	serviceName, configurationName := getServiceAndConfigurationLabels(revision)
-	r.reporter.ReportRequest(namespace, serviceName, configurationName, name, string(revision.Spec.ServingState), 1.0)
+	r.reporter.ReportRequest(namespace, serviceName, configurationName, name, 1.0)
 
 	// Wait for the revision to be ready
 	if !revision.Status.IsReady() {

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -52,7 +52,7 @@ func init() {
 
 type mockReporter struct{}
 
-func (r *mockReporter) ReportRequest(ns, service, config, rev, servingState string, v float64) error {
+func (r *mockReporter) ReportRequest(ns, service, config, rev string, v float64) error {
 	return nil
 }
 
@@ -68,7 +68,6 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 	k8s, kna := fakeClients()
 	kna.ServingV1alpha1().Revisions(testNamespace).Create(
 		newRevisionBuilder(defaultRevisionLabels).
-			withServingState(v1alpha1.RevisionServingStateReserve).
 			withReady(false).
 			build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
@@ -120,7 +119,6 @@ func TestActiveEndpoint_Reserve_ReadyTimeoutWithError(t *testing.T) {
 	k8s, kna := fakeClients()
 	kna.ServingV1alpha1().Revisions(testNamespace).Create(
 		newRevisionBuilder(defaultRevisionLabels).
-			withServingState(v1alpha1.RevisionServingStateReserve).
 			withReady(false).
 			build())
 	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
@@ -188,7 +186,6 @@ func newRevisionBuilder(labels map[string]string) *revisionBuilder {
 				Container: corev1.Container{
 					Image: "gcr.io/repo/image",
 				},
-				ServingState: v1alpha1.RevisionServingStateActive,
 			},
 			Status: v1alpha1.RevisionStatus{
 				Conditions: duckv1alpha1.Conditions{{
@@ -206,11 +203,6 @@ func (b *revisionBuilder) build() *v1alpha1.Revision {
 
 func (b *revisionBuilder) withRevisionName(name string) *revisionBuilder {
 	b.revision.ObjectMeta.Name = name
-	return b
-}
-
-func (b *revisionBuilder) withServingState(servingState v1alpha1.RevisionServingStateType) *revisionBuilder {
-	b.revision.Spec.ServingState = servingState
 	return b
 }
 

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -23,7 +23,7 @@ import (
 func TestActivatorReporter(t *testing.T) {
 	r := &Reporter{}
 
-	if err := r.ReportRequest("testns", "testsvc", "testconfig", "testrev", "Reserved", 1); err == nil {
+	if err := r.ReportRequest("testns", "testsvc", "testconfig", "testrev", 1); err == nil {
 		t.Error("Reporter expected an error for Report call before init. Got success.")
 	}
 	if err := r.ReportResponseCount("testns", "testsvc", "testconfig", "testrev", 200, 1, 1); err == nil {
@@ -43,8 +43,8 @@ func TestActivatorReporter(t *testing.T) {
 		"destination_revision":      "testrev",
 		"serving_state":             "Reserved",
 	}
-	expectSuccess(t, func() error { return r.ReportRequest("testns", "testsvc", "testconfig", "testrev", "Reserved", 1) })
-	expectSuccess(t, func() error { return r.ReportRequest("testns", "testsvc", "testconfig", "testrev", "Reserved", 2.0) })
+	expectSuccess(t, func() error { return r.ReportRequest("testns", "testsvc", "testconfig", "testrev", 1) })
+	expectSuccess(t, func() error { return r.ReportRequest("testns", "testsvc", "testconfig", "testrev", 2.0) })
 	checkSumData(t, "revision_request_count", wantTags1, 3)
 
 	// test ReportResponseCount

--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -33,9 +33,7 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				RevisionTemplate: RevisionTemplateSpec{
-					Spec: RevisionSpec{
-						// ServingState is not initialized in this context.
-					},
+					Spec: RevisionSpec{},
 				},
 			},
 		},

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -34,11 +34,7 @@ func (cs *ConfigurationSpec) Validate() *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	var errs *apis.FieldError
-	// In the context of Configuration, serving state may not be specified at all.
 	// TODO(mattmoor): Check ObjectMeta for Name/Namespace/GenerateName
-	if cs.RevisionTemplate.Spec.ServingState != "" {
-		errs = apis.ErrDisallowedFields("revisionTemplate.spec.servingState")
-	}
 
 	if cs.Build == nil {
 		// No build was specified.

--- a/pkg/apis/serving/v1alpha1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation_test.go
@@ -46,20 +46,6 @@ func TestConfigurationSpecValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		// This is a Configuration specific addition to the basic Revision validation.
-		name: "specifies serving state",
-		c: &ConfigurationSpec{
-			RevisionTemplate: RevisionTemplateSpec{
-				Spec: RevisionSpec{
-					ServingState: "Active",
-					Container: corev1.Container{
-						Image: "hellworld",
-					},
-				},
-			},
-		},
-		want: apis.ErrDisallowedFields("revisionTemplate.spec.servingState"),
-	}, {
 		name: "propagate revision failures",
 		c: &ConfigurationSpec{
 			RevisionTemplate: RevisionTemplateSpec{

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -17,12 +17,6 @@ limitations under the License.
 package v1alpha1
 
 func (r *Revision) SetDefaults() {
-	// We only set the default ServingState in the context of Revision
-	// because we want it unspecified in other contexts (e.g. RevisionTemplateSpec).
-	if r.Spec.ServingState == "" {
-		r.Spec.ServingState = RevisionServingStateActive
-	}
-
 	r.Spec.SetDefaults()
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -32,24 +32,18 @@ func TestRevisionDefaulting(t *testing.T) {
 		in:   &Revision{},
 		want: &Revision{
 			Spec: RevisionSpec{
-				// In the context of a Revision we initialize ServingState.
 				ContainerConcurrency: 0,
-				ServingState:         "Active",
 			},
 		},
 	}, {
 		name: "no overwrite",
 		in: &Revision{
 			Spec: RevisionSpec{
-				ContainerConcurrency: 1,
-				ServingState:         "Reserve",
-			},
+				ContainerConcurrency: 1},
 		},
 		want: &Revision{
 			Spec: RevisionSpec{
-				ContainerConcurrency: 1,
-				ServingState:         "Reserve",
-			},
+				ContainerConcurrency: 1},
 		},
 	}, {
 		name: "partially initialized",
@@ -58,9 +52,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		},
 		want: &Revision{
 			Spec: RevisionSpec{
-				ContainerConcurrency: 0,
-				ServingState:         "Active",
-			},
+				ContainerConcurrency: 0},
 		},
 	}, {
 		name: "fall back to concurrency model",
@@ -68,14 +60,12 @@ func TestRevisionDefaulting(t *testing.T) {
 			Spec: RevisionSpec{
 				ConcurrencyModel:     "Single",
 				ContainerConcurrency: 0, // unspecified
-				ServingState:         "Active",
 			},
 		},
 		want: &Revision{
 			Spec: RevisionSpec{
 				ConcurrencyModel:     "Single",
 				ContainerConcurrency: 1,
-				ServingState:         "Active",
 			},
 		},
 	}}

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -69,24 +69,24 @@ type RevisionTemplateSpec struct {
 	Spec RevisionSpec `json:"spec,omitempty"`
 }
 
-// RevisionServingStateType is an enumeration of the levels of serving readiness of the Revision.
+// DeprecatedRevisionServingStateType is an enumeration of the levels of serving readiness of the Revision.
 // See also: https://github.com/knative/serving/blob/master/docs/spec/errors.md#error-conditions-and-reporting
-type RevisionServingStateType string
+type DeprecatedRevisionServingStateType string
 
 const (
 	// The revision is ready to serve traffic. It should have Kubernetes
 	// resources, and the Istio route should be pointed to the given resources.
-	RevisionServingStateActive RevisionServingStateType = "Active"
+	DeprecatedRevisionServingStateActive DeprecatedRevisionServingStateType = "Active"
 	// The revision is not currently serving traffic, but could be made to serve
 	// traffic quickly. It should have Kubernetes resources, but the Istio route
 	// should be pointed to the activator.
-	RevisionServingStateReserve RevisionServingStateType = "Reserve"
+	DeprecatedRevisionServingStateReserve DeprecatedRevisionServingStateType = "Reserve"
 	// The revision has been decommissioned and is not needed to serve traffic
 	// anymore. It should not have any Istio routes or Kubernetes resources.
 	// A Revision may be brought out of retirement, but it may take longer than
 	// it would from a "Reserve" state.
 	// Note: currently not set anywhere. See https://github.com/knative/serving/issues/1203
-	RevisionServingStateRetired RevisionServingStateType = "Retired"
+	DeprecatedRevisionServingStateRetired DeprecatedRevisionServingStateType = "Retired"
 )
 
 // RevisionRequestConcurrencyModelType is an enumeration of the
@@ -123,12 +123,12 @@ type RevisionSpec struct {
 	// +optional
 	Generation int64 `json:"generation,omitempty"`
 
-	// ServingState holds a value describing the desired state the Kubernetes
+	// DeprecatedServingState holds a value describing the desired state the Kubernetes
 	// resources should be in for this Revision.
 	// Users must not specify this when creating a revision. It is expected
 	// that the system will manipulate this based on routability and load.
 	// +optional
-	ServingState RevisionServingStateType `json:"servingState,omitempty"`
+	DeprecatedServingState DeprecatedRevisionServingStateType `json:"servingState,omitempty"`
 
 	// ConcurrencyModel specifies the desired concurrency model
 	// (Single or Multi) for the

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -125,8 +125,8 @@ type RevisionSpec struct {
 
 	// DeprecatedServingState holds a value describing the desired state the Kubernetes
 	// resources should be in for this Revision.
-	// Users must not specify this when creating a revision. It is expected
-	// that the system will manipulate this based on routability and load.
+	// Users must not specify this when creating a revision. These values are no longer
+	// updated by the system.
 	// +optional
 	DeprecatedServingState DeprecatedRevisionServingStateType `json:"servingState,omitempty"`
 

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -42,8 +41,7 @@ func (rs *RevisionSpec) Validate() *apis.FieldError {
 	if equality.Semantic.DeepEqual(rs, &RevisionSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
-	errs := rs.ServingState.Validate().ViaField("servingState").
-		Also(validateContainer(rs.Container).ViaField("container")).
+	errs := validateContainer(rs.Container).ViaField("container").
 		Also(validateBuildRef(rs.BuildRef).ViaField("buildRef"))
 
 	if err := rs.ConcurrencyModel.Validate().ViaField("concurrencyModel"); err != nil {
@@ -191,9 +189,7 @@ func (current *Revision) CheckImmutableFields(og apis.Immutable) *apis.FieldErro
 		return &apis.FieldError{Message: "The provided original was not a Revision"}
 	}
 
-	// The autoscaler is allowed to change ServingState, but consider the rest.
-	ignoreServingState := cmpopts.IgnoreFields(RevisionSpec{}, "ServingState")
-	if diff := cmp.Diff(original.Spec, current.Spec, ignoreServingState); diff != "" {
+	if diff := cmp.Diff(original.Spec, current.Spec); diff != "" {
 		return &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -52,12 +52,12 @@ func (rs *RevisionSpec) Validate() *apis.FieldError {
 	return errs
 }
 
-func (ss RevisionServingStateType) Validate() *apis.FieldError {
+func (ss DeprecatedRevisionServingStateType) Validate() *apis.FieldError {
 	switch ss {
-	case RevisionServingStateType(""),
-		RevisionServingStateRetired,
-		RevisionServingStateReserve,
-		RevisionServingStateActive:
+	case DeprecatedRevisionServingStateType(""),
+		DeprecatedRevisionServingStateRetired,
+		DeprecatedRevisionServingStateReserve,
+		DeprecatedRevisionServingStateActive:
 		return nil
 	default:
 		return apis.ErrInvalidValue(string(ss), apis.CurrentField)

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -343,47 +343,6 @@ func TestContainerConcurrencyValidation(t *testing.T) {
 	}
 }
 
-func TestServingStateValidation(t *testing.T) {
-	tests := []struct {
-		name string
-		ss   RevisionServingStateType
-		want *apis.FieldError
-	}{{
-		name: "active",
-		ss:   "Active",
-		want: nil,
-	}, {
-		name: "reserve",
-		ss:   "Reserve",
-		want: nil,
-	}, {
-		name: "retired",
-		ss:   "Retired",
-		want: nil,
-	}, {
-		name: "empty",
-		ss:   "",
-		want: nil,
-	}, {
-		name: "bogus",
-		ss:   "bogus",
-		want: apis.ErrInvalidValue("bogus", apis.CurrentField),
-	}, {
-		name: "balderdash",
-		ss:   "balderdash",
-		want: apis.ErrInvalidValue("balderdash", apis.CurrentField),
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := test.ss.Validate()
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("Validate (-want, +got) = %v", diff)
-			}
-		})
-	}
-}
-
 func TestRevisionSpecValidation(t *testing.T) {
 	tests := []struct {
 		name string
@@ -398,15 +357,6 @@ func TestRevisionSpecValidation(t *testing.T) {
 			ConcurrencyModel: "Multi",
 		},
 		want: nil,
-	}, {
-		name: "has bad serving state",
-		rs: &RevisionSpec{
-			Container: corev1.Container{
-				Image: "helloworld",
-			},
-			ServingState: "blah",
-		},
-		want: apis.ErrInvalidValue("blah", "servingState"),
 	}, {
 		name: "has bad build ref",
 		rs: &RevisionSpec{
@@ -599,7 +549,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "good (no change)",
 		new: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -608,28 +557,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
-				Container: corev1.Container{
-					Image: "helloworld",
-				},
-				ConcurrencyModel: "Multi",
-			},
-		},
-		want: nil,
-	}, {
-		name: "good (serving state change)",
-		new: &Revision{
-			Spec: RevisionSpec{
-				ServingState: "Active",
-				Container: corev1.Container{
-					Image: "helloworld",
-				},
-				ConcurrencyModel: "Multi",
-			},
-		},
-		old: &Revision{
-			Spec: RevisionSpec{
-				ServingState: "Reserve",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -641,7 +568,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (type mismatch)",
 		new: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -654,7 +580,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (container image change)",
 		new: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -663,7 +588,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "busybox",
 				},
@@ -682,7 +606,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (concurrency model change)",
 		new: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -691,7 +614,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -710,7 +632,6 @@ func TestImmutableFields(t *testing.T) {
 		name: "bad (multiple changes)",
 		new: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Active",
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
@@ -719,7 +640,6 @@ func TestImmutableFields(t *testing.T) {
 		},
 		old: &Revision{
 			Spec: RevisionSpec{
-				ServingState: "Reserve",
 				Container: corev1.Container{
 					Image: "busybox",
 				},

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -50,7 +50,7 @@ func TestMultiScalerScaling(t *testing.T) {
 	})
 	defer close(stopCh)
 
-	revision := newRevision(t, servingClient, v1alpha1.RevisionServingStateActive)
+	revision := newRevision(t, servingClient)
 	kpa := newKPA(t, servingClient, revision)
 	kpaKey := fmt.Sprintf("%s/%s", kpa.Namespace, kpa.Name)
 
@@ -126,7 +126,7 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 	})
 	defer close(stopCh)
 
-	revision := newRevision(t, servingClient, v1alpha1.RevisionServingStateActive)
+	revision := newRevision(t, servingClient)
 	kpa := newKPA(t, servingClient, revision)
 	kpaKey := fmt.Sprintf("%s/%s", kpa.Namespace, kpa.Name)
 
@@ -193,7 +193,7 @@ func TestMultiScalerWithoutScaleToZero(t *testing.T) {
 	})
 	defer close(stopCh)
 
-	revision := newRevision(t, servingClient, v1alpha1.RevisionServingStateActive)
+	revision := newRevision(t, servingClient)
 	kpa := newKPA(t, servingClient, revision)
 	kpaKey := fmt.Sprintf("%s/%s", kpa.Namespace, kpa.Name)
 
@@ -248,7 +248,7 @@ func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 	})
 	defer close(stopCh)
 
-	revision := newRevision(t, servingClient, v1alpha1.RevisionServingStateActive)
+	revision := newRevision(t, servingClient)
 	kpa := newKPA(t, servingClient, revision)
 	kpaKey := fmt.Sprintf("%s/%s", kpa.Namespace, kpa.Name)
 
@@ -302,7 +302,7 @@ func TestMultiScalerRecordsStatistics(t *testing.T) {
 	})
 	defer close(stopCh)
 
-	revision := newRevision(t, servingClient, v1alpha1.RevisionServingStateActive)
+	revision := newRevision(t, servingClient)
 	kpa := newKPA(t, servingClient, revision)
 	kpaKey := fmt.Sprintf("%s/%s", kpa.Namespace, kpa.Name)
 
@@ -407,14 +407,13 @@ func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1alpha1.
 	return kpa
 }
 
-func newRevision(t *testing.T, servingClient clientset.Interface, servingState v1alpha1.RevisionServingStateType) *v1alpha1.Revision {
+func newRevision(t *testing.T, servingClient clientset.Interface) *v1alpha1.Revision {
 	rev := &v1alpha1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testRevision,
 		},
 		Spec: v1alpha1.RevisionSpec{
-			ServingState:     servingState,
 			ConcurrencyModel: "Multi",
 		},
 	}

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
@@ -530,7 +530,6 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.RevisionSpec{
-			ServingState: "Active",
 			Container: corev1.Container{
 				Image:      "gcr.io/repo/image",
 				Command:    []string{"echo"},

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -106,7 +106,6 @@ func getTestRevision() *v1alpha1.Revision {
 				},
 				TerminationMessagePath: "/dev/null",
 			},
-			ServingState:     v1alpha1.RevisionServingStateActive,
 			ConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
 		},
 	}

--- a/pkg/reconciler/v1alpha1/revision/resources/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/kpa_test.go
@@ -36,7 +36,7 @@ func TestMakeKPA(t *testing.T) {
 		rev  *v1alpha1.Revision
 		want *kpa.PodAutoscaler
 	}{{
-		name: "name is bar (ServiceState=Active, Concurrency=1)",
+		name: "name is bar (Concurrency=1)",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -44,7 +44,6 @@ func TestMakeKPA(t *testing.T) {
 				UID:       "1234",
 			},
 			Spec: v1alpha1.RevisionSpec{
-				ServingState:         "Active",
 				ContainerConcurrency: 1,
 			},
 		},
@@ -78,7 +77,7 @@ func TestMakeKPA(t *testing.T) {
 			},
 		},
 	}, {
-		name: "name is baz (ServiceState=Reserve, Concurrency=0)",
+		name: "name is baz (Concurrency=0)",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
@@ -86,7 +85,6 @@ func TestMakeKPA(t *testing.T) {
 				UID:       "4321",
 			},
 			Spec: v1alpha1.RevisionSpec{
-				ServingState:         "Reserve",
 				ContainerConcurrency: 0,
 			},
 		},

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -292,13 +292,12 @@ func addResourcesToInformers(t *testing.T,
 	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
 
 	haveBuild := rev.Spec.BuildRef != nil
-	inActive := rev.Spec.ServingState != "Active"
 
 	ns := rev.Namespace
 
 	kpaName := resourcenames.KPA(rev)
 	kpa, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(rev.Namespace).Get(kpaName, metav1.GetOptions{})
-	if apierrs.IsNotFound(err) && (haveBuild || inActive) {
+	if apierrs.IsNotFound(err) && haveBuild {
 		// If we're doing a Build this won't exist yet.
 	} else if err != nil {
 		t.Errorf("PodAutoscalers.Get(%v) = %v", kpaName, err)
@@ -318,7 +317,7 @@ func addResourcesToInformers(t *testing.T,
 
 	deploymentName := resourcenames.Deployment(rev)
 	deployment, err := kubeClient.AppsV1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
-	if apierrs.IsNotFound(err) && (haveBuild || inActive) {
+	if apierrs.IsNotFound(err) && haveBuild {
 		// If we're doing a Build this won't exist yet.
 	} else if err != nil {
 		t.Errorf("Deployments.Get(%v) = %v", deploymentName, err)
@@ -328,7 +327,7 @@ func addResourcesToInformers(t *testing.T,
 
 	serviceName := resourcenames.K8sService(rev)
 	service, err := kubeClient.CoreV1().Services(ns).Get(serviceName, metav1.GetOptions{})
-	if apierrs.IsNotFound(err) && (haveBuild || inActive) {
+	if apierrs.IsNotFound(err) && haveBuild {
 		// If we're doing a Build this won't exist yet.
 	} else if err != nil {
 		t.Errorf("Services.Get(%v) = %v", serviceName, err)

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -49,27 +49,27 @@ import (
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestReconcile(t *testing.T) {
 	// Create short-hand aliases that pass through the above config and Active to getRev and friends.
-	rev := func(namespace, name, servingState, image string) *v1alpha1.Revision {
-		return getRev(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	rev := func(namespace, name, image string) *v1alpha1.Revision {
+		return getRev(namespace, name, image)
 	}
-	deploy := func(namespace, name, servingState, image string) *appsv1.Deployment {
-		return getDeploy(namespace, name, v1alpha1.RevisionServingStateType(servingState), image, ReconcilerTestConfig())
+	deploy := func(namespace, name, image string) *appsv1.Deployment {
+		return getDeploy(namespace, name, image, ReconcilerTestConfig())
 	}
-	image := func(namespace, name, servingState, image string) *caching.Image {
-		i, err := getImage(namespace, name, v1alpha1.RevisionServingStateType(servingState), image, ReconcilerTestConfig())
+	image := func(namespace, name, image string) *caching.Image {
+		i, err := getImage(namespace, name, image, ReconcilerTestConfig())
 		if err != nil {
 			t.Fatalf("Error building image: %v", err)
 		}
 		return i
 	}
-	kpa := func(namespace, name, servingState, image string) *kpav1alpha1.PodAutoscaler {
-		return getKPA(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	kpa := func(namespace, name, image string) *kpav1alpha1.PodAutoscaler {
+		return getKPA(namespace, name, image)
 	}
-	svc := func(namespace, name, servingState, image string) *corev1.Service {
-		return getService(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	svc := func(namespace, name, image string) *corev1.Service {
+		return getService(namespace, name, image)
 	}
-	endpoints := func(namespace, name, servingState, image string) *corev1.Endpoints {
-		return getEndpoints(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	endpoints := func(namespace, name, image string) *corev1.Endpoints {
+		return getEndpoints(namespace, name, image)
 	}
 
 	table := TableTest{{
@@ -86,21 +86,21 @@ func TestReconcile(t *testing.T) {
 		// We feed in a well formed Revision where none of its sub-resources exist,
 		// and we exect it to create them and initialize the Revision's status.
 		Objects: []runtime.Object{
-			rev("foo", "first-reconcile", "Active", "busybox"),
+			rev("foo", "first-reconcile", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			kpa("foo", "first-reconcile", "Active", "busybox"),
-			deploy("foo", "first-reconcile", "Active", "busybox"),
-			svc("foo", "first-reconcile", "Active", "busybox"),
-			image("foo", "first-reconcile", "Active", "busybox"),
+			kpa("foo", "first-reconcile", "busybox"),
+			deploy("foo", "first-reconcile", "busybox"),
+			svc("foo", "first-reconcile", "busybox"),
+			image("foo", "first-reconcile", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "first-reconcile", "Active", "busybox"),
+				rev("foo", "first-reconcile", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "first-reconcile", "Active", "busybox").Name,
+					ServiceName: svc("foo", "first-reconcile", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -131,21 +131,21 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "revisions"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "update-status-failure", "Active", "busybox"),
-			kpa("foo", "update-status-failure", "Active", "busybox"),
+			rev("foo", "update-status-failure", "busybox"),
+			kpa("foo", "update-status-failure", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			deploy("foo", "update-status-failure", "Active", "busybox"),
-			svc("foo", "update-status-failure", "Active", "busybox"),
-			image("foo", "update-status-failure", "Active", "busybox"),
+			deploy("foo", "update-status-failure", "busybox"),
+			svc("foo", "update-status-failure", "busybox"),
+			image("foo", "update-status-failure", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "update-status-failure", "Active", "busybox"),
+				rev("foo", "update-status-failure", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "update-status-failure", "Active", "busybox").Name,
+					ServiceName: svc("foo", "update-status-failure", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -176,23 +176,23 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "podautoscalers"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "create-kpa-failure", "Active", "busybox"),
+			rev("foo", "create-kpa-failure", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			kpa("foo", "create-kpa-failure", "Active", "busybox"),
-			deploy("foo", "create-kpa-failure", "Active", "busybox"),
-			svc("foo", "create-kpa-failure", "Active", "busybox"),
-			image("foo", "create-kpa-failure", "Active", "busybox"),
+			kpa("foo", "create-kpa-failure", "busybox"),
+			deploy("foo", "create-kpa-failure", "busybox"),
+			svc("foo", "create-kpa-failure", "busybox"),
+			image("foo", "create-kpa-failure", "busybox"),
 			// The user service and autoscaler resources are not created.
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "create-kpa-failure", "Active", "busybox"),
+				rev("foo", "create-kpa-failure", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
 					LogURL:      "http://logger.io/test-uid",
-					ServiceName: svc("foo", "create-kpa-failure", "Active", "busybox").Name,
+					ServiceName: svc("foo", "create-kpa-failure", "busybox").Name,
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
 						Status: "Unknown",
@@ -221,17 +221,17 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "deployments"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "create-user-deploy-failure", "Active", "busybox"),
-			kpa("foo", "create-user-deploy-failure", "Active", "busybox"),
+			rev("foo", "create-user-deploy-failure", "busybox"),
+			kpa("foo", "create-user-deploy-failure", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			deploy("foo", "create-user-deploy-failure", "Active", "busybox"),
+			deploy("foo", "create-user-deploy-failure", "busybox"),
 			// The user service and autoscaler resources are not created.
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "create-user-deploy-failure", "Active", "busybox"),
+				rev("foo", "create-user-deploy-failure", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
@@ -263,22 +263,22 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "services"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "create-user-service-failure", "Active", "busybox"),
-			kpa("foo", "create-user-service-failure", "Active", "busybox"),
+			rev("foo", "create-user-service-failure", "busybox"),
+			kpa("foo", "create-user-service-failure", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			deploy("foo", "create-user-service-failure", "Active", "busybox"),
-			svc("foo", "create-user-service-failure", "Active", "busybox"),
-			image("foo", "create-user-service-failure", "Active", "busybox"),
+			deploy("foo", "create-user-service-failure", "busybox"),
+			svc("foo", "create-user-service-failure", "busybox"),
+			image("foo", "create-user-service-failure", "busybox"),
 			// No autoscaler resources created.
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "create-user-service-failure", "Active", "busybox"),
+				rev("foo", "create-user-service-failure", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "create-user-service-failure", "Active", "busybox").Name,
+					ServiceName: svc("foo", "create-user-service-failure", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -307,9 +307,9 @@ func TestReconcile(t *testing.T) {
 		// are necessary.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "stable-reconcile", "Active", "busybox"),
+				rev("foo", "stable-reconcile", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "stable-reconcile", "Active", "busybox").Name,
+					ServiceName: svc("foo", "stable-reconcile", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -329,10 +329,10 @@ func TestReconcile(t *testing.T) {
 						Reason: "Deploying",
 					}},
 				}),
-			kpa("foo", "stable-reconcile", "Active", "busybox"),
-			deploy("foo", "stable-reconcile", "Active", "busybox"),
-			svc("foo", "stable-reconcile", "Active", "busybox"),
-			image("foo", "stable-reconcile", "Active", "busybox"),
+			kpa("foo", "stable-reconcile", "busybox"),
+			deploy("foo", "stable-reconcile", "busybox"),
+			svc("foo", "stable-reconcile", "busybox"),
+			image("foo", "stable-reconcile", "busybox"),
 		},
 		// No changes are made to any objects.
 		Key: "foo/stable-reconcile",
@@ -343,10 +343,10 @@ func TestReconcile(t *testing.T) {
 		// state (port-Reserve), and verify that no changes are necessary.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "stable-deactivation", "Reserve", "busybox"),
+				rev("foo", "stable-deactivation", "busybox"),
 				// The Revision status matches that of a properly deactivated Revision.
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "stable-deactivation", "Reserve", "busybox").Name,
+					ServiceName: svc("foo", "stable-deactivation", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -366,80 +366,13 @@ func TestReconcile(t *testing.T) {
 						Reason: "Deploying",
 					}},
 				}),
-			kpa("foo", "stable-deactivation", "Reserve", "busybox"),
+			kpa("foo", "stable-deactivation", "busybox"),
 			// The Deployments match what we'd expect of an Reserve revision.
-			deploy("foo", "stable-deactivation", "Reserve", "busybox"),
-			svc("foo", "stable-deactivation", "Reserve", "busybox"),
-			image("foo", "stable-deactivation", "Reserve", "busybox"),
+			deploy("foo", "stable-deactivation", "busybox"),
+			svc("foo", "stable-deactivation", "busybox"),
+			image("foo", "stable-deactivation", "busybox"),
 		},
 		Key: "foo/stable-deactivation",
-	}, {
-		Name: "activate a reserve revision",
-		// Test the transition that's made when Active is set.
-		// We initialize the world to a stable Reserve state, but make the
-		// Revision's ServingState Active.  We then look for the expected
-		// mutations, which should include scaling up the Deployments to
-		// 1 replica each, and recreating the Kubernetes Service resources.
-		Objects: []runtime.Object{
-			makeStatus(
-				rev("foo", "activate-revision", "Active", "busybox"),
-				// The status and state of the world reflect a Reserve Revision,
-				// but it has a ServingState of Active.
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "activate-revision", "Reserve", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: duckv1alpha1.Conditions{{
-						Type:   "Active",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Updating",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Updating",
-					}, {
-						Type:    "Ready",
-						Status:  "False",
-						Reason:  "Inactive",
-						Message: `Revision "activate-revision" is Inactive.`,
-					}},
-				}),
-			kpa("foo", "activate-revision", "Reserve", "busybox"),
-			// The Deployments match what we'd expect of an Reserve revision.
-			deploy("foo", "activate-revision", "Reserve", "busybox"),
-			svc("foo", "activate-revision", "Reserve", "busybox"),
-			image("foo", "activate-revision", "Reserve", "busybox"),
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeStatus(
-				rev("foo", "activate-revision", "Active", "busybox"),
-				// After activating the Revision status looks like this.
-				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "activate-revision", "Active", "busybox").Name,
-					LogURL:      "http://logger.io/test-uid",
-					Conditions: duckv1alpha1.Conditions{{
-						Type:   "Active",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ContainerHealthy",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "Ready",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}, {
-						Type:   "ResourcesAvailable",
-						Status: "Unknown",
-						Reason: "Deploying",
-					}},
-				}),
-		}},
-		Key: "foo/activate-revision",
 	}, {
 		Name: "create resources in reserve",
 		// Test a reconcile of a Revision in the Reserve state.
@@ -447,20 +380,20 @@ func TestReconcile(t *testing.T) {
 		// when it is in a Reserve state and none of its resources exist.  The main
 		// place we should expect this transition to happen is Retired -> Reserve.
 		Objects: []runtime.Object{
-			rev("foo", "create-in-reserve", "Reserve", "busybox"),
+			rev("foo", "create-in-reserve", "busybox"),
 		},
 		WantCreates: []metav1.Object{
-			kpa("foo", "create-in-reserve", "Reserve", "busybox"),
+			kpa("foo", "create-in-reserve", "busybox"),
 			// Only Deployments are created and they have no replicas.
-			deploy("foo", "create-in-reserve", "Reserve", "busybox"),
-			svc("foo", "create-in-reserve", "Reserve", "busybox"),
-			image("foo", "create-in-reserve", "Reserve", "busybox"),
+			deploy("foo", "create-in-reserve", "busybox"),
+			svc("foo", "create-in-reserve", "busybox"),
+			image("foo", "create-in-reserve", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "create-in-reserve", "Reserve", "busybox"),
+				rev("foo", "create-in-reserve", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "create-in-reserve", "Reserve", "busybox").Name,
+					ServiceName: svc("foo", "create-in-reserve", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -495,9 +428,9 @@ func TestReconcile(t *testing.T) {
 		// and declaring a timeout (this is the main difference from that test below).
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "endpoint-created-not-ready", "Active", "busybox"),
+				rev("foo", "endpoint-created-not-ready", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "endpoint-created-not-ready", "Active", "busybox").Name,
+					ServiceName: svc("foo", "endpoint-created-not-ready", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -519,11 +452,11 @@ func TestReconcile(t *testing.T) {
 						LastTransitionTime: apis.VolatileTime{metav1.NewTime(time.Now())},
 					}},
 				}),
-			kpa("foo", "endpoint-created-not-ready", "Active", "busybox"),
-			deploy("foo", "endpoint-created-not-ready", "Active", "busybox"),
-			svc("foo", "endpoint-created-not-ready", "Active", "busybox"),
-			endpoints("foo", "endpoint-created-not-ready", "Active", "busybox"),
-			image("foo", "endpoint-created-not-ready", "Active", "busybox"),
+			kpa("foo", "endpoint-created-not-ready", "busybox"),
+			deploy("foo", "endpoint-created-not-ready", "busybox"),
+			svc("foo", "endpoint-created-not-ready", "busybox"),
+			endpoints("foo", "endpoint-created-not-ready", "busybox"),
+			image("foo", "endpoint-created-not-ready", "busybox"),
 		},
 		// No updates, since the endpoint didn't have meaningful status.
 		Key: "foo/endpoint-created-not-ready",
@@ -535,9 +468,9 @@ func TestReconcile(t *testing.T) {
 		// our Conditions.  We should see an update to put us into a ServiceTimeout state.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "endpoint-created-timeout", "Active", "busybox"),
+				rev("foo", "endpoint-created-timeout", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "endpoint-created-timeout", "Active", "busybox").Name,
+					ServiceName: svc("foo", "endpoint-created-timeout", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -559,17 +492,17 @@ func TestReconcile(t *testing.T) {
 						// on the Endpoints to become ready.
 					}},
 				}),
-			kpa("foo", "endpoint-created-timeout", "Active", "busybox"),
-			deploy("foo", "endpoint-created-timeout", "Active", "busybox"),
-			svc("foo", "endpoint-created-timeout", "Active", "busybox"),
-			endpoints("foo", "endpoint-created-timeout", "Active", "busybox"),
-			image("foo", "endpoint-created-timeout", "Active", "busybox"),
+			kpa("foo", "endpoint-created-timeout", "busybox"),
+			deploy("foo", "endpoint-created-timeout", "busybox"),
+			svc("foo", "endpoint-created-timeout", "busybox"),
+			endpoints("foo", "endpoint-created-timeout", "busybox"),
+			image("foo", "endpoint-created-timeout", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "endpoint-created-timeout", "Active", "busybox"),
+				rev("foo", "endpoint-created-timeout", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "endpoint-created-timeout", "Active", "busybox").Name,
+					ServiceName: svc("foo", "endpoint-created-timeout", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -602,9 +535,9 @@ func TestReconcile(t *testing.T) {
 		// This signal should make our Reconcile mark the Revision as Ready.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "endpoint-ready", "Active", "busybox"),
+				rev("foo", "endpoint-ready", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "endpoint-ready", "Active", "busybox").Name,
+					ServiceName: svc("foo", "endpoint-ready", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -625,7 +558,7 @@ func TestReconcile(t *testing.T) {
 					}},
 				}),
 			addKPAStatus(
-				kpa("foo", "endpoint-ready", "Active", "busybox"),
+				kpa("foo", "endpoint-ready", "busybox"),
 				kpav1alpha1.PodAutoscalerStatus{
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -635,16 +568,16 @@ func TestReconcile(t *testing.T) {
 						Status: "True",
 					}},
 				}),
-			deploy("foo", "endpoint-ready", "Active", "busybox"),
-			svc("foo", "endpoint-ready", "Active", "busybox"),
-			addEndpoint(endpoints("foo", "endpoint-ready", "Active", "busybox")),
-			image("foo", "endpoint-ready", "Active", "busybox"),
+			deploy("foo", "endpoint-ready", "busybox"),
+			svc("foo", "endpoint-ready", "busybox"),
+			addEndpoint(endpoints("foo", "endpoint-ready", "busybox")),
+			image("foo", "endpoint-ready", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "endpoint-ready", "Active", "busybox"),
+				rev("foo", "endpoint-ready", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "endpoint-ready", "Active", "busybox").Name,
+					ServiceName: svc("foo", "endpoint-ready", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -668,9 +601,9 @@ func TestReconcile(t *testing.T) {
 		// Test propagating the KPA status to the Revision.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "kpa-not-ready", "Active", "busybox"),
+				rev("foo", "kpa-not-ready", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "kpa-not-ready", "Active", "busybox").Name,
+					ServiceName: svc("foo", "kpa-not-ready", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -689,7 +622,7 @@ func TestReconcile(t *testing.T) {
 					}},
 				}),
 			addKPAStatus(
-				kpa("foo", "kpa-not-ready", "Active", "busybox"),
+				kpa("foo", "kpa-not-ready", "busybox"),
 				kpav1alpha1.PodAutoscalerStatus{
 					Conditions: duckv1alpha1.Conditions{{
 						Type:    "Active",
@@ -703,16 +636,16 @@ func TestReconcile(t *testing.T) {
 						Message: "This is something longer",
 					}},
 				}),
-			deploy("foo", "kpa-not-ready", "Active", "busybox"),
-			svc("foo", "kpa-not-ready", "Active", "busybox"),
-			addEndpoint(endpoints("foo", "kpa-not-ready", "Active", "busybox")),
-			image("foo", "kpa-not-ready", "Active", "busybox"),
+			deploy("foo", "kpa-not-ready", "busybox"),
+			svc("foo", "kpa-not-ready", "busybox"),
+			addEndpoint(endpoints("foo", "kpa-not-ready", "busybox")),
+			image("foo", "kpa-not-ready", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "kpa-not-ready", "Active", "busybox"),
+				rev("foo", "kpa-not-ready", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "kpa-not-ready", "Active", "busybox").Name,
+					ServiceName: svc("foo", "kpa-not-ready", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:    "Active",
@@ -739,9 +672,9 @@ func TestReconcile(t *testing.T) {
 		// Test propagating the inactivity signal from the KPA to the Revision.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "kpa-inactive", "Active", "busybox"),
+				rev("foo", "kpa-inactive", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "kpa-inactive", "Active", "busybox").Name,
+					ServiceName: svc("foo", "kpa-inactive", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -760,7 +693,7 @@ func TestReconcile(t *testing.T) {
 					}},
 				}),
 			addKPAStatus(
-				kpa("foo", "kpa-inactive", "Active", "busybox"),
+				kpa("foo", "kpa-inactive", "busybox"),
 				kpav1alpha1.PodAutoscalerStatus{
 					Conditions: duckv1alpha1.Conditions{{
 						Type:    "Active",
@@ -774,16 +707,16 @@ func TestReconcile(t *testing.T) {
 						Message: "This thing is inactive.",
 					}},
 				}),
-			deploy("foo", "kpa-inactive", "Active", "busybox"),
-			svc("foo", "kpa-inactive", "Active", "busybox"),
-			addEndpoint(endpoints("foo", "kpa-inactive", "Active", "busybox")),
-			image("foo", "kpa-inactive", "Active", "busybox"),
+			deploy("foo", "kpa-inactive", "busybox"),
+			svc("foo", "kpa-inactive", "busybox"),
+			addEndpoint(endpoints("foo", "kpa-inactive", "busybox")),
+			image("foo", "kpa-inactive", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "kpa-inactive", "Active", "busybox"),
+				rev("foo", "kpa-inactive", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "kpa-inactive", "Active", "busybox").Name,
+					ServiceName: svc("foo", "kpa-inactive", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:    "Active",
@@ -814,9 +747,9 @@ func TestReconcile(t *testing.T) {
 		// services back to our desired specification.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "fix-mutated-service", "Active", "busybox"),
+				rev("foo", "fix-mutated-service", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "fix-mutated-service", "Active", "busybox").Name,
+					ServiceName: svc("foo", "fix-mutated-service", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "ResourcesAvailable",
@@ -834,18 +767,18 @@ func TestReconcile(t *testing.T) {
 						LastTransitionTime: apis.VolatileTime{metav1.NewTime(time.Now())},
 					}},
 				}),
-			kpa("foo", "fix-mutated-service", "Active", "busybox"),
-			deploy("foo", "fix-mutated-service", "Active", "busybox"),
-			changeService(svc("foo", "fix-mutated-service", "Active", "busybox")),
-			endpoints("foo", "fix-mutated-service", "Active", "busybox"),
-			image("foo", "fix-mutated-service", "Active", "busybox"),
+			kpa("foo", "fix-mutated-service", "busybox"),
+			deploy("foo", "fix-mutated-service", "busybox"),
+			changeService(svc("foo", "fix-mutated-service", "busybox")),
+			endpoints("foo", "fix-mutated-service", "busybox"),
+			image("foo", "fix-mutated-service", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			// Reason changes from Deploying to Updating.
 			Object: makeStatus(
-				rev("foo", "fix-mutated-service", "Active", "busybox"),
+				rev("foo", "fix-mutated-service", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "fix-mutated-service", "Active", "busybox").Name,
+					ServiceName: svc("foo", "fix-mutated-service", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -866,7 +799,7 @@ func TestReconcile(t *testing.T) {
 					}},
 				}),
 		}, {
-			Object: svc("foo", "fix-mutated-service", "Active", "busybox"),
+			Object: svc("foo", "fix-mutated-service", "busybox"),
 		}},
 		Key: "foo/fix-mutated-service",
 	}, {
@@ -878,9 +811,9 @@ func TestReconcile(t *testing.T) {
 		},
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "update-user-svc-failure", "Active", "busybox"),
+				rev("foo", "update-user-svc-failure", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "update-user-svc-failure", "Active", "busybox").Name,
+					ServiceName: svc("foo", "update-user-svc-failure", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -901,14 +834,14 @@ func TestReconcile(t *testing.T) {
 						LastTransitionTime: apis.VolatileTime{metav1.NewTime(time.Now())},
 					}},
 				}),
-			kpa("foo", "update-user-svc-failure", "Active", "busybox"),
-			deploy("foo", "update-user-svc-failure", "Active", "busybox"),
-			changeService(svc("foo", "update-user-svc-failure", "Active", "busybox")),
-			endpoints("foo", "update-user-svc-failure", "Active", "busybox"),
-			image("foo", "update-user-svc-failure", "Active", "busybox"),
+			kpa("foo", "update-user-svc-failure", "busybox"),
+			deploy("foo", "update-user-svc-failure", "busybox"),
+			changeService(svc("foo", "update-user-svc-failure", "busybox")),
+			endpoints("foo", "update-user-svc-failure", "busybox"),
+			image("foo", "update-user-svc-failure", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: svc("foo", "update-user-svc-failure", "Active", "busybox"),
+			Object: svc("foo", "update-user-svc-failure", "busybox"),
 		}},
 		Key: "foo/update-user-svc-failure",
 	}, {
@@ -920,9 +853,9 @@ func TestReconcile(t *testing.T) {
 		// status of the Revision.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "deploy-timeout", "Active", "busybox"),
+				rev("foo", "deploy-timeout", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "deploy-timeout", "Active", "busybox").Name,
+					ServiceName: svc("foo", "deploy-timeout", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "ResourcesAvailable",
@@ -940,17 +873,17 @@ func TestReconcile(t *testing.T) {
 						LastTransitionTime: apis.VolatileTime{metav1.NewTime(time.Now())},
 					}},
 				}),
-			kpa("foo", "deploy-timeout", "Active", "busybox"),
-			timeoutDeploy(deploy("foo", "deploy-timeout", "Active", "busybox")),
-			svc("foo", "deploy-timeout", "Active", "busybox"),
-			endpoints("foo", "deploy-timeout", "Active", "busybox"),
-			image("foo", "deploy-timeout", "Active", "busybox"),
+			kpa("foo", "deploy-timeout", "busybox"),
+			timeoutDeploy(deploy("foo", "deploy-timeout", "busybox")),
+			svc("foo", "deploy-timeout", "busybox"),
+			endpoints("foo", "deploy-timeout", "busybox"),
+			image("foo", "deploy-timeout", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "deploy-timeout", "Active", "busybox"),
+				rev("foo", "deploy-timeout", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "deploy-timeout", "Active", "busybox").Name,
+					ServiceName: svc("foo", "deploy-timeout", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -982,12 +915,12 @@ func TestReconcile(t *testing.T) {
 		// the conditions of this Revision.  It is notable that unlike the tests
 		// above, this will include a BuildSucceeded condition.
 		Objects: []runtime.Object{
-			addBuild(rev("foo", "missing-build", "Active", "busybox"), "the-build"),
+			addBuild(rev("foo", "missing-build", "busybox"), "the-build"),
 		},
 		WantErr: true,
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				addBuild(rev("foo", "missing-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "missing-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
@@ -1017,7 +950,7 @@ func TestReconcile(t *testing.T) {
 		// the conditions of this Revision.  It is notable that unlike the tests
 		// above, this will include a BuildSucceeded condition.
 		Objects: []runtime.Object{
-			addBuild(rev("foo", "running-build", "Active", "busybox"), "the-build"),
+			addBuild(rev("foo", "running-build", "busybox"), "the-build"),
 			build("foo", "the-build",
 				duckv1alpha1.Condition{
 					Type:   duckv1alpha1.ConditionSucceeded,
@@ -1026,7 +959,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				addBuild(rev("foo", "running-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "running-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
@@ -1059,7 +992,7 @@ func TestReconcile(t *testing.T) {
 		// the first reconcile of a BYO-Container Revision.
 		Objects: []runtime.Object{
 			makeStatus(
-				addBuild(rev("foo", "done-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "done-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
@@ -1083,16 +1016,16 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			kpa("foo", "done-build", "Active", "busybox"),
-			deploy("foo", "done-build", "Active", "busybox"),
-			svc("foo", "done-build", "Active", "busybox"),
-			image("foo", "done-build", "Active", "busybox"),
+			kpa("foo", "done-build", "busybox"),
+			deploy("foo", "done-build", "busybox"),
+			svc("foo", "done-build", "busybox"),
+			image("foo", "done-build", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				addBuild(rev("foo", "done-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "done-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "done-build", "Active", "busybox").Name,
+					ServiceName: svc("foo", "done-build", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1125,9 +1058,9 @@ func TestReconcile(t *testing.T) {
 		// are necessary.
 		Objects: []runtime.Object{
 			makeStatus(
-				addBuild(rev("foo", "stable-reconcile-with-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "stable-reconcile-with-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "stable-reconcile-with-build", "Active", "busybox").Name,
+					ServiceName: svc("foo", "stable-reconcile-with-build", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1150,14 +1083,14 @@ func TestReconcile(t *testing.T) {
 						Reason: "Deploying",
 					}},
 				}),
-			kpa("foo", "stable-reconcile-with-build", "Active", "busybox"),
+			kpa("foo", "stable-reconcile-with-build", "busybox"),
 			build("foo", "the-build", duckv1alpha1.Condition{
 				Type:   duckv1alpha1.ConditionSucceeded,
 				Status: corev1.ConditionTrue,
 			}),
-			deploy("foo", "stable-reconcile-with-build", "Active", "busybox"),
-			svc("foo", "stable-reconcile-with-build", "Active", "busybox"),
-			image("foo", "stable-reconcile-with-build", "Active", "busybox"),
+			deploy("foo", "stable-reconcile-with-build", "busybox"),
+			svc("foo", "stable-reconcile-with-build", "busybox"),
+			image("foo", "stable-reconcile-with-build", "busybox"),
 		},
 		// No changes are made to any objects.
 		Key: "foo/stable-reconcile-with-build",
@@ -1169,7 +1102,7 @@ func TestReconcile(t *testing.T) {
 		// the BuildSucceeded status and stops.
 		Objects: []runtime.Object{
 			makeStatus(
-				addBuild(rev("foo", "failed-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "failed-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
@@ -1195,7 +1128,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				addBuild(rev("foo", "failed-build", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "failed-build", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
@@ -1229,7 +1162,7 @@ func TestReconcile(t *testing.T) {
 		// Reconcile has nothing to change.
 		Objects: []runtime.Object{
 			makeStatus(
-				addBuild(rev("foo", "failed-build-stable", "Active", "busybox"), "the-build"),
+				addBuild(rev("foo", "failed-build-stable", "busybox"), "the-build"),
 				v1alpha1.RevisionStatus{
 					LogURL: "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
@@ -1289,24 +1222,24 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 	config.Observability.EnableVarLogCollection = true
 
 	// Create short-hand aliases that pass through the above config and Active to getRev and friends.
-	rev := func(namespace, name, servingState, image string) *v1alpha1.Revision {
-		return getRev(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	rev := func(namespace, name, image string) *v1alpha1.Revision {
+		return getRev(namespace, name, image)
 	}
-	deploy := func(namespace, name, servingState, image string) *appsv1.Deployment {
-		return getDeploy(namespace, name, v1alpha1.RevisionServingStateType(servingState), image, config)
+	deploy := func(namespace, name, image string) *appsv1.Deployment {
+		return getDeploy(namespace, name, image, config)
 	}
-	image := func(namespace, name, servingState, image string) *caching.Image {
-		i, err := getImage(namespace, name, v1alpha1.RevisionServingStateType(servingState), image, config)
+	image := func(namespace, name, image string) *caching.Image {
+		i, err := getImage(namespace, name, image, config)
 		if err != nil {
 			t.Fatalf("Error building image: %v", err)
 		}
 		return i
 	}
-	kpa := func(namespace, name, servingState, image string) *kpav1alpha1.PodAutoscaler {
-		return getKPA(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	kpa := func(namespace, name, image string) *kpav1alpha1.PodAutoscaler {
+		return getKPA(namespace, name, image)
 	}
-	svc := func(namespace, name, servingState, image string) *corev1.Service {
-		return getService(namespace, name, v1alpha1.RevisionServingStateType(servingState), image)
+	svc := func(namespace, name, image string) *corev1.Service {
+		return getService(namespace, name, image)
 	}
 
 	table := TableTest{{
@@ -1316,22 +1249,22 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		// and we exect it to create them and initialize the Revision's status.
 		// This is similar to "first-reconcile", but should also create a fluentd configmap.
 		Objects: []runtime.Object{
-			rev("foo", "first-reconcile-var-log", "Active", "busybox"),
+			rev("foo", "first-reconcile-var-log", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			kpa("foo", "first-reconcile-var-log", "Active", "busybox"),
-			deploy("foo", "first-reconcile-var-log", "Active", "busybox"),
-			svc("foo", "first-reconcile-var-log", "Active", "busybox"),
-			resources.MakeFluentdConfigMap(rev("foo", "first-reconcile-var-log", "Active", "busybox"), config.Observability),
-			image("foo", "first-reconcile-var-log", "Active", "busybox"),
+			kpa("foo", "first-reconcile-var-log", "busybox"),
+			deploy("foo", "first-reconcile-var-log", "busybox"),
+			svc("foo", "first-reconcile-var-log", "busybox"),
+			resources.MakeFluentdConfigMap(rev("foo", "first-reconcile-var-log", "busybox"), config.Observability),
+			image("foo", "first-reconcile-var-log", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "first-reconcile-var-log", "Active", "busybox"),
+				rev("foo", "first-reconcile-var-log", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "first-reconcile-var-log", "Active", "busybox").Name,
+					ServiceName: svc("foo", "first-reconcile-var-log", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1361,22 +1294,22 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 			InduceFailure("create", "configmaps"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "create-configmap-failure", "Active", "busybox"),
+			rev("foo", "create-configmap-failure", "busybox"),
 		},
 		WantCreates: []metav1.Object{
 			// The first reconciliation of a Revision creates the following resources.
-			deploy("foo", "create-configmap-failure", "Active", "busybox"),
-			svc("foo", "create-configmap-failure", "Active", "busybox"),
-			resources.MakeFluentdConfigMap(rev("foo", "create-configmap-failure", "Active", "busybox"), config.Observability),
-			image("foo", "create-configmap-failure", "Active", "busybox"),
+			deploy("foo", "create-configmap-failure", "busybox"),
+			svc("foo", "create-configmap-failure", "busybox"),
+			resources.MakeFluentdConfigMap(rev("foo", "create-configmap-failure", "busybox"), config.Observability),
+			image("foo", "create-configmap-failure", "busybox"),
 			// We don't create the autoscaler resources if we fail to create the fluentd configmap
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: makeStatus(
-				rev("foo", "create-configmap-failure", "Active", "busybox"),
+				rev("foo", "create-configmap-failure", "busybox"),
 				// After the first reconciliation of a Revision the status looks like this.
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "create-configmap-failure", "Active", "busybox").Name,
+					ServiceName: svc("foo", "create-configmap-failure", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1402,9 +1335,9 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		// Verify that after creating the things from an initial reconcile that we're stable.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "steady-state", "Active", "busybox"),
+				rev("foo", "steady-state", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "steady-state", "Active", "busybox").Name,
+					ServiceName: svc("foo", "steady-state", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1424,11 +1357,11 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 						Reason: "Deploying",
 					}},
 				}),
-			kpa("foo", "steady-state", "Active", "busybox"),
-			deploy("foo", "steady-state", "Active", "busybox"),
-			svc("foo", "steady-state", "Active", "busybox"),
-			resources.MakeFluentdConfigMap(rev("foo", "steady-state", "Active", "busybox"), config.Observability),
-			image("foo", "steady-state", "Active", "busybox"),
+			kpa("foo", "steady-state", "busybox"),
+			deploy("foo", "steady-state", "busybox"),
+			svc("foo", "steady-state", "busybox"),
+			resources.MakeFluentdConfigMap(rev("foo", "steady-state", "busybox"), config.Observability),
+			image("foo", "steady-state", "busybox"),
 		},
 		Key: "foo/steady-state",
 	}, {
@@ -1436,9 +1369,9 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		// Verify that after creating the things from an initial reconcile that we're stable.
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "update-fluentd-config", "Active", "busybox"),
+				rev("foo", "update-fluentd-config", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "update-fluentd-config", "Active", "busybox").Name,
+					ServiceName: svc("foo", "update-fluentd-config", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1458,25 +1391,25 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 						Reason: "Deploying",
 					}},
 				}),
-			kpa("foo", "update-fluentd-config", "Active", "busybox"),
-			deploy("foo", "update-fluentd-config", "Active", "busybox"),
-			svc("foo", "update-fluentd-config", "Active", "busybox"),
+			kpa("foo", "update-fluentd-config", "busybox"),
+			deploy("foo", "update-fluentd-config", "busybox"),
+			svc("foo", "update-fluentd-config", "busybox"),
 			&corev1.ConfigMap{
 				// Use the ObjectMeta, but discard the rest.
 				ObjectMeta: resources.MakeFluentdConfigMap(
-					rev("foo", "update-fluentd-config", "Active", "busybox"),
+					rev("foo", "update-fluentd-config", "busybox"),
 					config.Observability,
 				).ObjectMeta,
 				Data: map[string]string{
 					"bad key": "bad value",
 				},
 			},
-			image("foo", "update-fluentd-config", "Active", "busybox"),
+			image("foo", "update-fluentd-config", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			// We should see a single update to the configmap we expect.
 			Object: resources.MakeFluentdConfigMap(
-				rev("foo", "update-fluentd-config", "Active", "busybox"),
+				rev("foo", "update-fluentd-config", "busybox"),
 				config.Observability,
 			),
 		}},
@@ -1490,9 +1423,9 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		},
 		Objects: []runtime.Object{
 			makeStatus(
-				rev("foo", "update-configmap-failure", "Active", "busybox"),
+				rev("foo", "update-configmap-failure", "busybox"),
 				v1alpha1.RevisionStatus{
-					ServiceName: svc("foo", "update-configmap-failure", "Active", "busybox").Name,
+					ServiceName: svc("foo", "update-configmap-failure", "busybox").Name,
 					LogURL:      "http://logger.io/test-uid",
 					Conditions: duckv1alpha1.Conditions{{
 						Type:   "Active",
@@ -1512,20 +1445,20 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 						Reason: "Deploying",
 					}},
 				}),
-			deploy("foo", "update-configmap-failure", "Active", "busybox"),
-			svc("foo", "update-configmap-failure", "Active", "busybox"),
+			deploy("foo", "update-configmap-failure", "busybox"),
+			svc("foo", "update-configmap-failure", "busybox"),
 			&corev1.ConfigMap{
 				// Use the ObjectMeta, but discard the rest.
-				ObjectMeta: resources.MakeFluentdConfigMap(rev("foo", "update-configmap-failure", "Active", "busybox"), config.Observability).ObjectMeta,
+				ObjectMeta: resources.MakeFluentdConfigMap(rev("foo", "update-configmap-failure", "busybox"), config.Observability).ObjectMeta,
 				Data: map[string]string{
 					"bad key": "bad value",
 				},
 			},
-			image("foo", "update-configmap-failure", "Active", "busybox"),
+			image("foo", "update-configmap-failure", "busybox"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			// We should see a single update to the configmap we expect.
-			Object: resources.MakeFluentdConfigMap(rev("foo", "update-configmap-failure", "Active", "busybox"), config.Observability),
+			Object: resources.MakeFluentdConfigMap(rev("foo", "update-configmap-failure", "busybox"), config.Observability),
 		}},
 		Key: "foo/update-configmap-failure",
 	}}
@@ -1618,42 +1551,41 @@ func build(namespace, name string, conds ...duckv1alpha1.Condition) *unstructure
 	return u
 }
 
-func getRev(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string) *v1alpha1.Revision {
+func getRev(namespace, name string, image string) *v1alpha1.Revision {
 	return &v1alpha1.Revision{
 		ObjectMeta: om(namespace, name),
 		Spec: v1alpha1.RevisionSpec{
-			Container:    corev1.Container{Image: image},
-			ServingState: servingState,
+			Container: corev1.Container{Image: image},
 		},
 	}
 }
 
-func getDeploy(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string, config *config.Config) *appsv1.Deployment {
+func getDeploy(namespace, name string, image string, config *config.Config) *appsv1.Deployment {
 
-	rev := getRev(namespace, name, servingState, image)
+	rev := getRev(namespace, name, image)
 	return resources.MakeDeployment(rev, config.Logging, config.Network, config.Observability,
 		config.Autoscaler, config.Controller)
 }
 
-func getImage(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string, config *config.Config) (*caching.Image, error) {
-	rev := getRev(namespace, name, servingState, image)
+func getImage(namespace, name string, image string, config *config.Config) (*caching.Image, error) {
+	rev := getRev(namespace, name, image)
 	deploy := resources.MakeDeployment(rev, config.Logging, config.Network, config.Observability,
 		config.Autoscaler, config.Controller)
 	return resources.MakeImageCache(rev, deploy)
 }
 
-func getKPA(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string) *kpav1alpha1.PodAutoscaler {
-	rev := getRev(namespace, name, servingState, image)
+func getKPA(namespace, name string, image string) *kpav1alpha1.PodAutoscaler {
+	rev := getRev(namespace, name, image)
 	return resources.MakeKPA(rev)
 }
 
-func getService(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string) *corev1.Service {
-	rev := getRev(namespace, name, servingState, image)
+func getService(namespace, name string, image string) *corev1.Service {
+	rev := getRev(namespace, name, image)
 	return resources.MakeK8sService(rev)
 }
 
-func getEndpoints(namespace, name string, servingState v1alpha1.RevisionServingStateType, image string) *corev1.Endpoints {
-	service := getService(namespace, name, servingState, image)
+func getEndpoints(namespace, name string, image string) *corev1.Endpoints {
+	service := getService(namespace, name, image)
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: service.Namespace,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

A quick try to remove the ServingState even from Revisions. This worked just fine locally so I'd like to get a Prow run on it. The types stay untouched for now to keep them compatible.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Deprecated `ServingState` on Revisions.
```

/assign @mattmoor 
