### PR TITLE
Fix TestGlobalResyncOnUpdateDomainConfigMap getting stuck

### DIFF
--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -1002,7 +1002,11 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 		t.Run(test.expectedDomainSuffix, func(t *testing.T) {
 			test.doThings()
 
-			<-routeModifiedCh
+			select {
+			case <-routeModifiedCh:
+			case <-time.NewTimer(10 * time.Second).C:
+				t.Logf("routeWatcher did not receive a Type==Modified event for %s in 10s", test.expectedDomainSuffix)
+			}
 
 			route, err := routeClient.Get(route.Name, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
Sometimes TestGlobalResyncOnUpdateDomainConfigMap gets stuck while
waiting on a routeModified event which doesn't get delivered via
routeWatcher for a currently unknown reason.

Example:
https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_serving/2000/pull-knative-serving-unit-tests/1055195078827446273/

This should unstuck the test.