### PR TITLE
Wait for Route readiness in TestSingleConcurrency

### DIFF
--- a/test/route.go
+++ b/test/route.go
@@ -45,6 +45,22 @@ func CreateBlueGreenRoute(logger *logging.BaseLogger, clients *Clients, names, b
 	return err
 }
 
+// Probe until we get a successful response. This ensures the domain is
+// routable before we send it a bunch of traffic.
+func ProbeDomain(logger *logging.BaseLogger, clients *Clients, domain string) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, ServingFlags.ResolvableDomain)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+	if err != nil {
+		return err
+	}
+	// TODO(tcnghia): Replace this probing with Status check when we have them.
+	_, err = client.Poll(req, pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound, http.StatusServiceUnavailable))
+	return err
+}
+
 // RunRouteProber creates and runs a prober as background goroutine to keep polling Route.
 // It stops when getting an error response from Route.
 func RunRouteProber(logger *logging.BaseLogger, clients *Clients, domain string) <-chan error {

--- a/test/route.go
+++ b/test/route.go
@@ -45,8 +45,9 @@ func CreateBlueGreenRoute(logger *logging.BaseLogger, clients *Clients, names, b
 	return err
 }
 
-// Probe until we get a successful response. This ensures the domain is
-// routable before we send it a bunch of traffic.
+// ProbeDomain sends requests to a domain until we get a successful
+// response. This ensures the domain is routable before we send it a
+// bunch of traffic.
 func ProbeDomain(logger *logging.BaseLogger, clients *Clients, domain string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, ServingFlags.ResolvableDomain)
 	if err != nil {


### PR DESCRIPTION
TestSingleConcurrency was waiting for the Revision to be Ready but should also wait on the Route to both be Ready and respond successfully to a request before proceeding with the rest of the test.

This pulls `probeDomain` from the blue green test out into `test.ProbeDomain` because, until #1582 is fixed, every test that sends traffic to a Route should probably probe the domain first in some way to prevent flakes.

Fixes #2306 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
