### PR TITLE
Update the remaining CRDs to print out basic custom columns.

### DIFF
--- a/config/300-clusteringress.yaml
+++ b/config/300-clusteringress.yaml
@@ -28,3 +28,10 @@ spec:
     - knative-internal
     - networking
   scope: Cluster
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"

--- a/config/300-configuration.yaml
+++ b/config/300-configuration.yaml
@@ -31,3 +31,16 @@ spec:
     - config
     - cfg
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"

--- a/config/300-kpa.yaml
+++ b/config/300-kpa.yaml
@@ -30,3 +30,10 @@ spec:
     shortNames:
     - kpa
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"

--- a/config/300-service.yaml
+++ b/config/300-service.yaml
@@ -31,3 +31,19 @@ spec:
     - kservice
     - ksvc
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: Domain
+    type: string
+    JSONPath: .status.domain
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"


### PR DESCRIPTION
The focus is largely on readiness, but I've added some key additional columns where it seemed appropriate.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->