### PR TITLE
Prevent cryptic errors when closing websocket connections 'normally'.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -261,11 +261,6 @@ func main() {
 		ReportChan: reportTicker,
 		StatChan:   statChan,
 	}, time.Now())
-	defer func() {
-		if statSink != nil {
-			statSink.Close()
-		}
-	}()
 
 	adminServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", queue.RequestQueueAdminPort),
@@ -288,6 +283,11 @@ func main() {
 
 		server.Shutdown(context.Background())
 		adminServer.Shutdown(context.Background())
+
+		if statSink != nil {
+			statSink.Close()
+		}
+
 		os.Exit(0)
 	}()
 

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -132,7 +132,13 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 	for {
 		messageType, msg, err := conn.ReadMessage()
 		if err != nil {
-			s.logger.Infof("Handler exiting on error: %#v", err)
+			// We close abnormally, because we're just closing the connection in the client,
+			// which is okay. There's no value delaying closure of the connection unnecessarily.
+			if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
+				s.logger.Debug("Handler disconnected")
+			} else {
+				s.logger.Errorf("Handler exiting on error: %#v", err)
+			}
 			close(handlerCh)
 			return
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2314 

As per title. We shouldn't be logging error-like messages if there's no error happening really.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
