### PR TITLE
Return error on lastPinned update failures

### DIFF
--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -18,7 +18,6 @@ package route
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -200,16 +199,12 @@ func (c *Reconciler) reconcileTargetRevisions(ctx context.Context, t *traffic.Tr
 				}
 
 				newRev.ObjectMeta.Annotations[serving.RevisionLastPinnedAnnotationKey] = v1alpha1.RevisionLastPinnedString(c.clock.Now())
-				patch, err := duck.CreatePatch(rev, newRev)
-				if err != nil {
-					return err
-				}
-				patchJSON, err := json.Marshal(patch)
+				patch, err := duck.CreateMergePatch(rev, newRev)
 				if err != nil {
 					return err
 				}
 
-				if _, err := c.ServingClientSet.ServingV1alpha1().Revisions(route.Namespace).Patch(rev.Name, types.MergePatchType, patchJSON); err != nil {
+				if _, err := c.ServingClientSet.ServingV1alpha1().Revisions(route.Namespace).Patch(rev.Name, types.MergePatchType, patch); err != nil {
 					c.Logger.Errorf("Unable to set revision annotation: %v", err)
 					return err
 				}

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -222,7 +222,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	// In all cases we will add annotations to the referred targets.  This is so that when they become
 	// routable we can know (through a listener) and attempt traffic configuration again.
 	if err := c.reconcileTargetRevisions(ctx, traffic, r); err != nil {
-		logger.Errorf("Failed to update target revisions: %v", err)
+		return err
 	}
 
 	// Update the information that makes us Targetable.

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -1744,7 +1744,7 @@ func patchLastPinned(namespace, name string) clientgotesting.PatchActionImpl {
 	action.Name = name
 	action.Namespace = namespace
 	lastPinStr := v1alpha1.RevisionLastPinnedString(fakeCurTime)
-	patch := fmt.Sprintf(`[{"op":"replace","path":"/metadata/annotations/serving.knative.dev~1lastPinned","value":%q}]`, lastPinStr)
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"serving.knative.dev/lastPinned":%q}}}`, lastPinStr)
 	action.Patch = []byte(patch)
 	return action
 }


### PR DESCRIPTION
As is we only log an error in this case. Fail the reconciler to ensure
we retry on failures as revisions will otherwise be GCd incorrectly.

Fixes #2368

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
