### PR TITLE
Warn user if they haven't set K8S_USER_OVERRIDE.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -122,7 +122,7 @@ the setup needed for Knative:
 ```shell
 kubectl create clusterrolebinding cluster-admin-binding \
   --clusterrole=cluster-admin \
-  --user="${K8S_USER_OVERRIDE}"
+  --user="${K8S_USER_OVERRIDE?}"
 ```
 
 ### Deploy Istio


### PR DESCRIPTION
Fixes #2336

## Proposed Changes

  * Don't let the user create a user role binding if they haven't configured a user.

**Release Note**
```release-note
NONE
```
