### PR TITLE
Fix gofmt, ineffassign, and misspell errors

### DIFF
--- a/pkg/activator/dedupe_test.go
+++ b/pkg/activator/dedupe_test.go
@@ -28,7 +28,7 @@ func TestSingleRevision_SingleRequest_Success(t *testing.T) {
 	want := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{
-			revisionID{testNamespace, testRevision}: {
+			{testNamespace, testRevision}: {
 				Endpoint: want,
 				Status:   http.StatusOK,
 			},
@@ -55,7 +55,7 @@ func TestSingleRevision_MultipleRequests_Success(t *testing.T) {
 	ep := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{
-			revisionID{testNamespace, testRevision}: {
+			{testNamespace, testRevision}: {
 				Endpoint: ep,
 				Status:   http.StatusOK,
 			},
@@ -89,11 +89,11 @@ func TestMultipleRevisions_MultipleRequests_Success(t *testing.T) {
 	ep2 := Endpoint{"ip2", 8080}
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{
-			revisionID{testNamespace, "rev1"}: {
+			{testNamespace, "rev1"}: {
 				Endpoint: ep1,
 				Status:   http.StatusOK,
 			},
-			revisionID{testNamespace, "rev2"}: {
+			{testNamespace, "rev2"}: {
 				Endpoint: ep2,
 				Status:   http.StatusOK,
 			},
@@ -132,11 +132,11 @@ func TestMultipleRevisions_MultipleRequests_PartialSuccess(t *testing.T) {
 	error2 := fmt.Errorf("test error")
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{
-			revisionID{testNamespace, "rev1"}: {
+			{testNamespace, "rev1"}: {
 				Endpoint: ep1,
 				Status:   http.StatusOK,
 			},
-			revisionID{testNamespace, "rev2"}: {
+			{testNamespace, "rev2"}: {
 				Endpoint: Endpoint{},
 				Status:   status2,
 				Error:    error2,
@@ -174,7 +174,7 @@ func TestSingleRevision_MultipleRequests_FailureRecovery(t *testing.T) {
 	failErr := fmt.Errorf("test error")
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{
-			revisionID{testNamespace, testRevision}: {
+			{testNamespace, testRevision}: {
 				Endpoint: failEp,
 				Status:   failStatus,
 				Error:    failErr,
@@ -229,7 +229,7 @@ func TestShutdown_ReturnError(t *testing.T) {
 	ep := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
 		map[revisionID]ActivationResult{
-			revisionID{testNamespace, testRevision}: {
+			{testNamespace, testRevision}: {
 				Endpoint: ep,
 				Status:   http.StatusOK,
 			},

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -38,42 +38,37 @@ func TestMultipleDifferentKeys(t *testing.T) {
 	s.requestStart(pod2)
 
 	now := time.Now()
-	expectStats(t, s.report(now, 2), []*autoscaler.StatMessage{
-		&autoscaler.StatMessage{
-			Key: pod1,
-			Stat: autoscaler.Stat{
-				Time:                      &now,
-				PodName:                   autoscaler.ActivatorPodName,
-				AverageConcurrentRequests: 2.0,
-				RequestCount:              2,
-			},
+	expectStats(t, s.report(now, 2), []*autoscaler.StatMessage{{
+		Key: pod1,
+		Stat: autoscaler.Stat{
+			Time:                      &now,
+			PodName:                   autoscaler.ActivatorPodName,
+			AverageConcurrentRequests: 2.0,
+			RequestCount:              2,
 		},
-		&autoscaler.StatMessage{
-			Key: pod2,
-			Stat: autoscaler.Stat{
-				Time:                      &now,
-				PodName:                   autoscaler.ActivatorPodName,
-				AverageConcurrentRequests: 1.0,
-				RequestCount:              1,
-			},
+	}, {
+		Key: pod2,
+		Stat: autoscaler.Stat{
+			Time:                      &now,
+			PodName:                   autoscaler.ActivatorPodName,
+			AverageConcurrentRequests: 1.0,
+			RequestCount:              1,
 		},
-	})
+	}})
 
 	s.requestEnd(pod2)
 	s.requestEnd(pod1)
 
 	now = time.Now()
-	expectStats(t, s.report(now, 1), []*autoscaler.StatMessage{
-		&autoscaler.StatMessage{
-			Key: pod1,
-			Stat: autoscaler.Stat{
-				Time:                      &now,
-				PodName:                   autoscaler.ActivatorPodName,
-				AverageConcurrentRequests: 1.0,
-				RequestCount:              0, // no new request arrived after reporting
-			},
+	expectStats(t, s.report(now, 1), []*autoscaler.StatMessage{{
+		Key: pod1,
+		Stat: autoscaler.Stat{
+			Time:                      &now,
+			PodName:                   autoscaler.ActivatorPodName,
+			AverageConcurrentRequests: 1.0,
+			RequestCount:              0, // no new request arrived after reporting
 		},
-	})
+	}})
 }
 
 // Test type to hold the bi-directional time channels

--- a/pkg/activator/handler/filtering_handler.go
+++ b/pkg/activator/handler/filtering_handler.go
@@ -27,7 +27,7 @@ type FilteringHandler struct {
 
 func (h *FilteringHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If this header is set the request was sent by the activator itself, thus
-	// we immediatly return a 503 to trigger a retry.
+	// we immediately return a 503 to trigger a retry.
 	if r.Header.Get(activator.RequestCountHTTPHeader) != "" {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -30,7 +30,7 @@ const (
 	//
 	// The parent resource may use its own annotations to choose the
 	// annotation value for the ClusterIngress it uses.  Based on such
-	// value a different reconcilation logic may be used (for examples,
+	// value a different reconciliation logic may be used (for examples,
 	// Istio-based ClusterIngress will reconcile into a VirtualService).
 	IngressClassAnnotationKey = "networking.knative.dev/ingress.class"
 

--- a/pkg/apis/serving/v1alpha1/service_types_test.go
+++ b/pkg/apis/serving/v1alpha1/service_types_test.go
@@ -368,7 +368,7 @@ func TestSetManualStatus(t *testing.T) {
 	checkConditionOngoingService(svc.Status, ServiceConditionConfigurationsReady, t)
 	checkConditionOngoingService(svc.Status, ServiceConditionRoutesReady, t)
 
-	// Going back from manual will result in propogation to reoccur, and should make us ready
+	// Going back from manual will result in propagation to reoccur, and should make us ready
 	svc.Status.PropagateConfigurationStatus(ConfigurationStatus{
 		Conditions: duckv1alpha1.Conditions{{
 			Type:   ConfigurationConditionReady,

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -102,7 +102,7 @@ func (agg *totalAggregation) aggregate(stat Stat) {
 }
 
 // The number of pods that are observable via stats
-// Substracts the activator pod if its not the only pod reporting stats
+// Subtracts the activator pod if its not the only pod reporting stats
 func (agg *totalAggregation) observedPods(now time.Time) float64 {
 	podCount := float64(0.0)
 	for _, pod := range agg.perPodAggregations {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -503,7 +503,7 @@ func newTestAutoscaler(containerConcurrency int) *Autoscaler {
 	scaleToZeroIdlePeriod := 4*time.Minute + 30*time.Second
 	scaleToZeroGracePeriod := 30 * time.Second
 	config := &Config{
-		ContainerConcurrencyTargetPercentage: 1.0, // targetting 100% makes the test easier to read
+		ContainerConcurrencyTargetPercentage: 1.0, // targeting 100% makes the test easier to read
 		ContainerConcurrencyTargetDefault:    10.0,
 		MaxScaleUpRate:                       10.0,
 		StableWindow:                         stableWindow,

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -267,7 +267,7 @@ func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 		done <- struct{}{}
 	})
 
-	m, err = ms.Create(ctx, kpa)
+	_, err = ms.Create(ctx, kpa)
 	if err != nil {
 		t.Errorf("Create() = %v", err)
 	}

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -762,7 +762,7 @@ func TestMakePodSpec(t *testing.T) {
 				}},
 				VolumeMounts: fluentdVolumeMounts,
 			}},
-			Volumes: []corev1.Volume{varLogVolume, corev1.Volume{
+			Volumes: []corev1.Volume{varLogVolume, {
 				Name: fluentdConfigMapVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{

--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -168,7 +168,7 @@ func (c *Reconciler) reconcileTargetRevisions(ctx context.Context, t *traffic.Tr
 	gcConfig := config.FromContext(ctx).GC
 	lpDebounce := gcConfig.StaleRevisionLastpinnedDebounce
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, _ := errgroup.WithContext(ctx)
 	for _, target := range t.Targets {
 		for _, rt := range target {
 			tt := rt.TrafficTarget

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -50,6 +50,9 @@ func updateConfigWithImage(clients *test.Clients, names test.ResourceNames, imag
 		},
 	}
 	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		return err
+	}
 	_, err = clients.ServingClient.Configs.Patch(names.Config, types.JSONPatchType, patchBytes, "")
 	if err != nil {
 		return err


### PR DESCRIPTION
This change fixes the gofmt, ineffassign, and misspell errors reported
by goreportcard.com

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->