### PR TITLE
Don't keep ClusterIP in placeholder service spec

### DIFF
--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -22,14 +22,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/logging"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -39,6 +31,13 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources"
 	resourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (c *Reconciler) getClusterIngressForRoute(route *v1alpha1.Route) (*netv1alpha1.ClusterIngress, error) {
@@ -135,9 +134,7 @@ func (c *Reconciler) reconcilePlaceholderService(ctx context.Context, route *v1a
 	} else if err != nil {
 		return err
 	} else {
-		// Make sure that the service has the proper specification
-		// Preserve the ClusterIP field in the Service's Spec, if it has been set.
-		desiredService.Spec.ClusterIP = service.Spec.ClusterIP
+		// Make sure that the service has the proper specification.
 		if !equality.Semantic.DeepEqual(service.Spec, desiredService.Spec) {
 			// Don't modify the informers copy
 			existing := service.DeepCopy()


### PR DESCRIPTION
In #1789 we switched this to an ExternalName Service. Services created in 0.1
will still have ClusterIP set, which is Forbidden for ExternalName Services.
Ensure that we drop the ClusterIP if it is set in the spec.

/lint

Ref https://github.com/knative/serving/issues/2223