### PR TITLE
Add a prestop sleep to avoid istio-proxy terminating too quickly.

### DIFF
--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -33,3 +33,8 @@ rm istio-${ISTIO_VERSION}-linux.tar.gz
 # run one kubectl command to install istio.
 patch istio.yaml namespace.yaml.patch
 patch istio-lean.yaml namespace.yaml.patch
+
+# Add in the prestop sleep to workaround https://github.com/knative/serving/issues/2351.
+#
+# We need to replace this with some better solution like retries.
+patch istio.yaml prestop-sleep.yaml.patch

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -347,6 +347,13 @@ data:
       
       containers:
       - name: istio-proxy
+        # PATCH #2: Temporary workaround for https://github.com/knative/serving/issues/2351.
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "20"
         image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
         "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"
         [[ else -]]

--- a/third_party/istio-1.0.2/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.0.2/prestop-sleep.yaml.patch
@@ -1,0 +1,8 @@
+349a350,356
+>         # PATCH #2: Temporary workaround for https://github.com/knative/serving/issues/2351.
+>         lifecycle:
+>           preStop:
+>             exec:
+>               command:
+>               - /bin/sleep
+>               - "20"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/area networking
/lint
-->

## Proposed Changes

  * Add a prestop sleep to avoid `istio-proxy` sidecar terminating too quickly during scaling down.  This is an attempt to temporarily reduce flakiness of the autoscaling test, while we investigate a better solution (https://github.com/knative/serving/issues/2351)