### PR TITLE
Fix log extraction after tests.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -36,14 +36,11 @@ function dump_extra_cluster_state() {
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
   echo ">>> Knative Serving controller log:"
-  kubectl -n knative-serving logs "$(get_app_pod controller knative-serving)" -c controller > controller.log
-  cat controller.log
+  kubectl -n knative-serving logs "$(get_app_pod controller knative-serving)" -c controller
   echo ">>> Knative Serving autoscaler log:"
-  kubectl -n knative-serving logs "$(get_app_pod autoscaler knative-serving)" -c autoscaler > autoscaler.log
-  cat autoscaler.log
+  kubectl -n knative-serving logs "$(get_app_pod autoscaler knative-serving)" -c autoscaler
   echo ">>> Knative Serving activator log:"
-  kubectl -n knative-serving logs "$(get_app_pod activator knative-serving)" -c activator > activator.log
-  cat acitvator.log
+  kubectl -n knative-serving logs "$(get_app_pod activator knative-serving)" -c activator
 }
 
 function publish_test_images() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -36,11 +36,14 @@ function dump_extra_cluster_state() {
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
   echo ">>> Knative Serving controller log:"
-  kubectl -n knative-serving logs $(get_app_pod controller knative-serving)
+  kubectl -n knative-serving logs "$(get_app_pod controller knative-serving)" -c controller > controller.log
+  cat controller.log
   echo ">>> Knative Serving autoscaler log:"
-  kubectl -n knative-serving logs $(get_app_pod autoscaler knative-serving)
+  kubectl -n knative-serving logs "$(get_app_pod autoscaler knative-serving)" -c autoscaler > autoscaler.log
+  cat autoscaler.log
   echo ">>> Knative Serving activator log:"
-  kubectl -n knative-serving logs $(get_app_pod activator knative-serving)
+  kubectl -n knative-serving logs "$(get_app_pod activator knative-serving)" -c activator > activator.log
+  cat acitvator.log
 }
 
 function publish_test_images() {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -139,7 +139,7 @@ func setup(t *testing.T) *testContext {
 	clients := Setup(t)
 
 	configMap, err := test.GetConfigMap(clients.KubeClient).Get("config-autoscaler", metav1.GetOptions{})
-	if err != nil {
+	if err == nil {
 		t.Fatalf("Unable to get autoscaler config map: %v", err)
 	}
 	scaleToZeroThreshold, err = time.ParseDuration(configMap.Data["scale-to-zero-threshold"])

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -139,7 +139,7 @@ func setup(t *testing.T) *testContext {
 	clients := Setup(t)
 
 	configMap, err := test.GetConfigMap(clients.KubeClient).Get("config-autoscaler", metav1.GetOptions{})
-	if err == nil {
+	if err != nil {
 		t.Fatalf("Unable to get autoscaler config map: %v", err)
 	}
 	scaleToZeroThreshold, err = time.ParseDuration(configMap.Data["scale-to-zero-threshold"])


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2362

See title. We need to pick the actual container when extracting logs out of our pods.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
