### PR TITLE
try to start shutdown without always waiting for a specific time

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -201,13 +201,12 @@ func (h *healthServer) quitHandler(w http.ResponseWriter, r *http.Request) {
 	// no guarantee that container termination is done only after
 	// removal from service is effective, but this has been showed to
 	// alleviate the issue.
-	timer := time.NewTimer(quitSleepSecs * time.Second).C
 	ticker := time.NewTicker(time.Second).C
 
 CheckAllDone:
 	for {
 		select {
-		case <-timer:
+		case <-time.After(quitSleepSecs * time.Second):
 			break CheckAllDone
 		case <-ticker:
 			if stats.GetConcurrency() == 0 {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -201,14 +201,15 @@ func (h *healthServer) quitHandler(w http.ResponseWriter, r *http.Request) {
 	// no guarantee that container termination is done only after
 	// removal from service is effective, but this has been showed to
 	// alleviate the issue.
-	ticker := time.NewTicker(time.Second).C
+	timerChan := time.After(quitSleepSecs * time.Second)
+	tickerChan := time.NewTicker(time.Second).C
 
 CheckAllDone:
 	for {
 		select {
-		case <-time.After(quitSleepSecs * time.Second):
+		case <-timerChan:
 			break CheckAllDone
-		case <-ticker:
+		case <-tickerChan:
 			if stats.GetConcurrency() == 0 {
 				break CheckAllDone
 			}

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -215,8 +215,8 @@ CheckAllDone:
 		}
 	}
 
-	io.WriteString(w, fmt.Sprintf("quit with %d unfinished requests\n", stats.GetConcurrency()))
 	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, fmt.Sprintf("quit with %d unfinished requests\n", stats.GetConcurrency()))
 	io.WriteString(w, "alive: false")
 }
 

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -55,7 +55,7 @@ func (b *Breaker) Maybe(thunk func()) bool {
 	var t token
 	select {
 	default:
-		// Pending request queue is full.  Report failure.
+		// Pending request queue is full. Report failure.
 		return false
 	case b.pendingRequests <- t:
 		// Pending request has capacity.

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -130,6 +130,7 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 	return s
 }
 
+// get the number of consuming request
 func (s *Stats) GetConcurrency() int32 {
 	return s.concurrency
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
Currently, the queue-proxy and user-container had to wait for a specific 20s of timeout to start terminating.

## Proposed Changes
Try to check the concurrency of user-container, is there is no request, then start to terminated, so it need't to wait for a specific 20 second. 
This can help to get rid of setting `quitSleepSecs` in the future, we can just check the concurrency number to decide when to start terminating cause the request has it's own timeout setting.
