### PR TITLE
Drop the vestigial tracker from labeler.

### DIFF
--- a/pkg/reconciler/v1alpha1/labeler/labeler.go
+++ b/pkg/reconciler/v1alpha1/labeler/labeler.go
@@ -24,7 +24,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/knative/pkg/tracker"
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
@@ -42,7 +41,6 @@ type Reconciler struct {
 	routeLister         listers.RouteLister
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
-	tracker             tracker.Interface
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -70,16 +68,6 @@ func NewRouteToConfigurationController(
 		AddFunc:    impl.Enqueue,
 		UpdateFunc: controller.PassNew(impl.Enqueue),
 		DeleteFunc: impl.Enqueue,
-	})
-
-	c.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
-	configInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.tracker.OnChanged,
-		UpdateFunc: controller.PassNew(c.tracker.OnChanged),
-	})
-	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.tracker.OnChanged,
-		UpdateFunc: controller.PassNew(c.tracker.OnChanged),
 	})
 
 	return impl

--- a/pkg/reconciler/v1alpha1/labeler/labeler_test.go
+++ b/pkg/reconciler/v1alpha1/labeler/labeler_test.go
@@ -31,7 +31,6 @@ import (
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/reconciler"
-	rtesting "github.com/knative/serving/pkg/reconciler/testing"
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
 
@@ -136,7 +135,6 @@ func TestReconcile(t *testing.T) {
 			routeLister:         listers.GetRouteLister(),
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
-			tracker:             &rtesting.NullTracker{},
 		}
 	}))
 }


### PR DESCRIPTION
This was leftover from a copy/paste of the Route controller.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->