### PR TITLE
Disable scale-to-zero during activation (#2155)

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/kpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_types.go
@@ -172,6 +172,8 @@ func (rs *PodAutoscalerStatus) MarkInactive(reason, message string) {
 	podCondSet.Manage(rs).MarkFalse(PodAutoscalerConditionActive, reason, message)
 }
 
+// CanScaleToZero checks whether the pod autoscaler has been in an inactive state
+// for at least the specified grace period.
 func (rs *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
 	if cond := rs.GetCondition(PodAutoscalerConditionActive); cond != nil {
 		switch cond.Status {
@@ -184,6 +186,8 @@ func (rs *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
 	return false
 }
 
+// CanMarkInactive checks whether the pod autoscaler has been in an active state
+// for at least the specified idle period.
 func (rs *PodAutoscalerStatus) CanMarkInactive(idlePeriod time.Duration) bool {
 	if cond := rs.GetCondition(PodAutoscalerConditionActive); cond != nil {
 		switch cond.Status {

--- a/pkg/apis/autoscaling/v1alpha1/kpa_types_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/kpa_types_test.go
@@ -132,6 +132,75 @@ func TestCanScaleToZero(t *testing.T) {
 	}
 }
 
+func TestCanMarkInactive(t *testing.T) {
+	cases := []struct {
+		name   string
+		status PodAutoscalerStatus
+		result bool
+		idle   time.Duration
+	}{{
+		name:   "empty status",
+		status: PodAutoscalerStatus{},
+		result: false,
+		idle:   10 * time.Second,
+	}, {
+		name: "inactive condition",
+		status: PodAutoscalerStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   PodAutoscalerConditionActive,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+		result: false,
+		idle:   10 * time.Second,
+	}, {
+		name: "active condition (no LTT)",
+		status: PodAutoscalerStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   PodAutoscalerConditionActive,
+				Status: corev1.ConditionTrue,
+				// No LTT = beginning of time, so for sure we can.
+			}},
+		},
+		result: true,
+		idle:   10 * time.Second,
+	}, {
+		name: "active condition (LTT longer than idle period ago)",
+		status: PodAutoscalerStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   PodAutoscalerConditionActive,
+				Status: corev1.ConditionTrue,
+				LastTransitionTime: apis.VolatileTime{
+					Inner: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+				},
+				// LTT = 30 seconds ago.
+			}},
+		},
+		result: true,
+		idle:   10 * time.Second,
+	}, {
+		name: "active condition (LTT less than idle period ago)",
+		status: PodAutoscalerStatus{
+			Conditions: duckv1alpha1.Conditions{{
+				Type:   PodAutoscalerConditionActive,
+				Status: corev1.ConditionTrue,
+				LastTransitionTime: apis.VolatileTime{
+					Inner: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+				},
+				// LTT = 10 seconds ago.
+			}},
+		},
+		result: false,
+		idle:   30 * time.Second,
+	}}
+
+	for _, tc := range cases {
+		if e, a := tc.result, tc.status.CanMarkInactive(tc.idle); e != a {
+			t.Errorf("%q expected: %v got: %v", tc.name, e, a)
+		}
+	}
+}
+
 func TestIsActivating(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
@@ -185,16 +185,9 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, kpa *kpa.PodAuto
 		return err
 	}
 
-	want := metric.DesiredScale
-
-	// Don't scale-to-zero if the KPA is still activating
-	if want == 0 && kpa.Status.IsActivating() {
-		want = -1
-	}
-
 	// Get the appropriate current scale from the metric, and right size
 	// the scaleTargetRef based on it.
-	want, err = c.kpaScaler.Scale(ctx, kpa, want)
+	want, err := c.kpaScaler.Scale(ctx, kpa, metric.DesiredScale)
 	if err != nil {
 		logger.Errorf("Error scaling target: %v", err)
 		return err

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling_test.go
@@ -44,6 +44,7 @@ import (
 
 var (
 	gracePeriod = 60 * time.Second
+	idlePeriod  = 9 * time.Minute
 )
 
 func newConfigWatcher() configmap.Watcher {
@@ -59,7 +60,7 @@ func newConfigWatcher() configmap.Watcher {
 				"container-concurrency-target-default":    "10.0",
 				"stable-window":                           "5m",
 				"panic-window":                            "10s",
-				"scale-to-zero-threshold":                 "10m",
+				"scale-to-zero-threshold":                 time.Duration(idlePeriod + gracePeriod).String(),
 				"scale-to-zero-grace-period":              gracePeriod.String(),
 				"tick-interval":                           "2s",
 			},

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
@@ -56,13 +56,27 @@ func TestKPAScaler(t *testing.T) {
 		wantScaling   bool
 		kpaMutation   func(*kpa.PodAutoscaler)
 	}{{
-		label:         "waits to scale to zero (after idle period)",
+		label:         "waits to scale to zero (just before idle period)",
 		startReplicas: 1,
 		scaleTo:       0,
 		wantReplicas:  1,
 		wantScaling:   false,
 		kpaMutation: func(k *kpa.PodAutoscaler) {
 			ltt := time.Now().Add(-idlePeriod).Add(1 * time.Second)
+			k.Status.Conditions = duckv1alpha1.Conditions{{
+				Type:               "Active",
+				Status:             "True",
+				LastTransitionTime: apis.VolatileTime{metav1.NewTime(ltt)},
+			}}
+		},
+	}, {
+		label:         "waits to scale to zero after idle period",
+		startReplicas: 1,
+		scaleTo:       0,
+		wantReplicas:  1,
+		wantScaling:   false,
+		kpaMutation: func(k *kpa.PodAutoscaler) {
+			ltt := time.Now().Add(-idlePeriod)
 			k.Status.Conditions = duckv1alpha1.Conditions{{
 				Type:               "Active",
 				Status:             "True",
@@ -79,7 +93,7 @@ func TestKPAScaler(t *testing.T) {
 			ltt := time.Now().Add(-gracePeriod).Add(1 * time.Second)
 			k.Status.Conditions = duckv1alpha1.Conditions{{
 				Type:               "Active",
-				Status:             "True",
+				Status:             "False",
 				LastTransitionTime: apis.VolatileTime{metav1.NewTime(ltt)},
 			}}
 		},

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa_scaler_test.go
@@ -56,14 +56,18 @@ func TestKPAScaler(t *testing.T) {
 		wantScaling   bool
 		kpaMutation   func(*kpa.PodAutoscaler)
 	}{{
-		label:         "waits to scale to zero (fresh)",
+		label:         "waits to scale to zero (after idle period)",
 		startReplicas: 1,
 		scaleTo:       0,
 		wantReplicas:  1,
 		wantScaling:   false,
-		kpaMutation: func(kpa *kpa.PodAutoscaler) {
-			// Sets LTT to time.Now()
-			kpa.Status.MarkInactive("foo", "bar")
+		kpaMutation: func(k *kpa.PodAutoscaler) {
+			ltt := time.Now().Add(-idlePeriod).Add(1 * time.Second)
+			k.Status.Conditions = duckv1alpha1.Conditions{{
+				Type:               "Active",
+				Status:             "True",
+				LastTransitionTime: apis.VolatileTime{metav1.NewTime(ltt)},
+			}}
 		},
 	}, {
 		label:         "waits to scale to zero (just before grace period)",
@@ -75,7 +79,7 @@ func TestKPAScaler(t *testing.T) {
 			ltt := time.Now().Add(-gracePeriod).Add(1 * time.Second)
 			k.Status.Conditions = duckv1alpha1.Conditions{{
 				Type:               "Active",
-				Status:             "False",
+				Status:             "True",
 				LastTransitionTime: apis.VolatileTime{metav1.NewTime(ltt)},
 			}}
 		},


### PR DESCRIPTION
Currently the autoscaler will start the scale-to-zero countdown
immediately after a pod has started. This causes problems for pods that
take a while to become ready, and in pathological cases where the pod
startup time is longer than the scale-to-zero threshold, the pod is
never able to serve requests.

This fix modifies the autoscaling reconciler to ignore request metrics
until atleast one pod has successfully started and has been idle for
atleast the `scale-to-zero-idle-period` (`scale-to-zero-threshold` -
`scale-to-zero-grace-period`).

Fixes #2155 