### PR TITLE
Add upgrade test

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -49,7 +49,11 @@ function install_knative_serving() {
 
   echo ">> Bringing up Serving"
   # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
-  kubectl apply -f "${RELEASE_NO_MON_YAML}"
+  if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
+    kubectl apply -f "${RELEASE_NO_MON_YAML}"
+  else
+    kubectl apply -f "${RELEASE_YAML_OVERRIDE}"
+  fi
 
   # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
   #
@@ -80,7 +84,11 @@ function uninstall_knative_serving() {
 
   echo ">> Bringing down Serving"
   # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
-  ko delete --ignore-not-found=true -f "${RELEASE_NO_MON_YAML}"
+  if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
+    ko delete --ignore-not-found=true -f "${RELEASE_NO_MON_YAML}"
+  else
+    ko delete --ignore-not-found=true -f "${RELEASE_YAML_OVERRIDE}"
+  fi
 
   echo ">> Bringing down Istio"
   kubectl delete --ignore-not-found=true -f ${ISTIO_YAML}

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -50,4 +50,10 @@ function integration_tests() {
   ./test/e2e-tests.sh ${options}
 }
 
+function upgrade_tests() {
+  local options=""
+  (( EMIT_METRICS )) && options="--emit-metrics"
+  ./test/upgrade-tests.sh ${options}
+}
+
 main $@

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -92,11 +92,9 @@ install_head
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout=5m ./test/upgrade || fail_test
 
-# TODO(#2373): Once this is released, we can test downgrades too.
-#
-# install_latest_release
-#
-# header "Running postdowngrade tests"
-# go_test_e2e -tags=postdowngrade -timeout=5m ./test/upgrade || fail_test
+install_latest_release
+
+header "Running postdowngrade tests"
+go_test_e2e -tags=postdowngrade -timeout=5m ./test/upgrade || fail_test
 
 success

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs the end-to-end tests against Knative Serving built from source.
+# It is started by prow for each PR. For convenience, it can also be executed manually.
+
+# If you already have the *_OVERRIDE environment variables set, call
+# this script with the --run-tests arguments and it will start knative in
+# the cluster and run the tests.
+
+# Calling this script without arguments will create a new cluster in
+# project $PROJECT_ID, start knative in it, run the tests and delete the
+# cluster.
+
+source $(dirname $0)/cluster.sh
+
+# Latest serving release. This is intentionally hardcoded so that we can test
+# upgrade/downgrade on release branches (or even arbitrary commits).
+#
+# Unfortunately, that means we'll need to manually bump this version when we
+# make new releases.
+#
+# Fortunately, that's not *too* terrible, because forgetting to bump this
+# version will make tests either:
+# 1. Still pass, meaning we can upgrade from earlier than latest release (good).
+# 2. Fail, which might be remedied by bumping this version.
+readonly SERVING_RELEASE_YAML=https://github.com/knative/serving/releases/download/v0.2.0/release-no-mon.yaml
+
+# Cribbed from e2e-tests.sh
+# TODO(#2320): Remove this.
+function publish_test_images() {
+  echo ">> Publishing test images"
+  image_dirs="$(find ${REPO_ROOT_DIR}/test/test_images -mindepth 1 -maxdepth 1 -type d)"
+  for image_dir in ${image_dirs}; do
+    ko publish -P "github.com/knative/serving/test/test_images/$(basename ${image_dir})"
+  done
+}
+
+function install_latest_release() {
+  header "Installing latest release"
+  set -o errexit
+  set -o pipefail
+  RELEASE_YAML_OVERRIDE=${SERVING_RELEASE_YAML} install_knative_serving
+  set +o errexit
+  set +o pipefail
+}
+
+function install_head() {
+  header "Installing HEAD"
+  set -o errexit
+  set -o pipefail
+  install_knative_serving
+  set +o errexit
+  set +o pipefail
+
+}
+
+# Deletes everything created on the cluster including all knative and istio components.
+function teardown() {
+  uninstall_knative_serving
+  RELEASE_YAML_OVERRIDE=${SERVING_RELEASE_YAML} uninstall_knative_serving
+}
+
+# Script entry point.
+
+initialize $@
+
+header "Setting up environment"
+kubectl create namespace serving-tests
+publish_test_images
+
+install_latest_release
+
+header "Running preupgrade tests"
+go_test_e2e -tags=preupgrade -timeout=5m ./test/upgrade || fail_test
+
+install_head
+
+header "Running postupgrade tests"
+go_test_e2e -tags=postupgrade -timeout=5m ./test/upgrade || fail_test
+
+# TODO(#2373): Once this is released, we can test downgrades too.
+#
+# install_latest_release
+#
+# header "Running postdowngrade tests"
+# go_test_e2e -tags=postdowngrade -timeout=5m ./test/upgrade || fail_test
+
+success

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -65,7 +65,6 @@ function install_head() {
   install_knative_serving
   set +o errexit
   set +o pipefail
-
 }
 
 # Deletes everything created on the cluster including all knative and istio components.

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -37,7 +37,7 @@ source $(dirname $0)/cluster.sh
 # version will make tests either:
 # 1. Still pass, meaning we can upgrade from earlier than latest release (good).
 # 2. Fail, which might be remedied by bumping this version.
-readonly SERVING_RELEASE_YAML=https://github.com/knative/serving/releases/download/v0.2.0/release-no-mon.yaml
+readonly SERVING_RELEASE_YAML=https://github.com/knative/serving/releases/download/v0.2.1/release-no-mon.yaml
 
 # Cribbed from e2e-tests.sh
 # TODO(#2320): Remove this.

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -1,0 +1,58 @@
+# Upgrade Tests
+
+In order to get coverage for the upgrade process from an operator’s perspective,
+we need an additional suite of tests that perform a complete knative upgrade.
+Running these tests on every commit will ensure that we don’t introduce any
+non-upgradeable changes, so every commit should be releasable.
+
+This is inspired by kubernetes
+[upgrade testing](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#version-skewed-and-upgrade-testing).
+
+These tests are a pretty big hammer in that they cover more than just version
+changes, but it’s one of the only ways to make sure we don’t accidentally make
+breaking changes for now.
+
+## Flow
+
+We’d like to validate that the upgrade doesn’t break any resources (they still
+respond to requests) and doesn't break our installation (we can still update
+resources).
+
+At a high level, we want to do this:
+
+1. Install the latest knative release.
+1. Create some resources.
+1. Install knative at HEAD.
+1. Test those resources, verify that we didn’t break anything.
+1. Install the previous release (downgrade).
+1. Test those resources (again), verify that we didn’t break anything.
+
+To achieve that, we just have three separate build tags:
+
+1. Install the latest release from GitHub.
+1. Run the `preupgrade` tests in this directory.
+1. Install at HEAD (`ko apply -f config/`).
+1. Run the `postupgrade` tests in this directory.
+1. Install the latest release from GitHub.
+1. Run the `postdowngrade` tests in this directory.
+
+## Tests
+
+### Service test
+
+This was stolen from the conformance tests but stripped down to check fewer
+things.
+
+#### preupgrade
+
+Create a RunLatest Service pointing to `image1`, ensure it responds correctly.
+
+#### postupgrade
+
+Ensure the Service still responds correctly after upgrading.
+Update it to point to `image2`, ensure it responds correctly.
+
+#### postdowngrade
+
+Ensure the Service still responds correctly after downgrading.
+Update it to point back to `image1`, ensure it responds correctly.

--- a/test/upgrade/service_postdowngrade_test.go
+++ b/test/upgrade/service_postdowngrade_test.go
@@ -1,0 +1,71 @@
+// +build postdowngrade
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
+	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/e2e"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRunLatestServicePostupgrade(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	// Add test case specific name to its own logger.
+	logger := logging.GetContextLogger("TestRunLatestServicePostDowngrade")
+
+	var names test.ResourceNames
+	names.Service = serviceName
+
+	logger.Infof("Getting service %q", names.Service)
+	svc, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Service: %v", err)
+	}
+	names.Route = serviceresourcenames.Route(svc)
+	names.Config = serviceresourcenames.Configuration(svc)
+	names.Revision = svc.Status.LatestCreatedRevisionName
+
+	routeDomain := svc.Status.Domain
+
+	logger.Info("Check that we can hit the old service and get the old response.")
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "2", "Re-energize yourself with a slice of pepperoni!")
+
+	logger.Info("Updating the Service to use a different image")
+	if _, err := test.UpdateServiceImage(clients, svc, test.ImagePath(image1)); err != nil {
+		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, test.ImagePath(image1), err)
+	}
+
+	logger.Info("Since the Service was updated a new Revision will be created and the Service will be updated")
+	revisionName, err := waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, image2, err)
+	}
+	names.Revision = revisionName
+
+	logger.Info("When the Service reports as Ready, everything should be ready.")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "1", "What a spaceport!")
+}

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -1,0 +1,71 @@
+// +build postupgrade
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
+	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/e2e"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRunLatestServicePostupgrade(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	// Add test case specific name to its own logger.
+	logger := logging.GetContextLogger("TestRunLatestServicePostUpgrade")
+
+	var names test.ResourceNames
+	names.Service = serviceName
+
+	logger.Infof("Getting service %q", names.Service)
+	svc, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Service: %v", err)
+	}
+	names.Route = serviceresourcenames.Route(svc)
+	names.Config = serviceresourcenames.Configuration(svc)
+	names.Revision = svc.Status.LatestCreatedRevisionName
+
+	routeDomain := svc.Status.Domain
+
+	logger.Info("Check that we can hit the old service and get the old response.")
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "1", "What a spaceport!")
+
+	logger.Info("Updating the Service to use a different image")
+	if _, err := test.UpdateServiceImage(clients, svc, test.ImagePath(image2)); err != nil {
+		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, test.ImagePath(image2), err)
+	}
+
+	logger.Info("Since the Service was updated a new Revision will be created and the Service will be updated")
+	revisionName, err := waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, image2, err)
+	}
+	names.Revision = revisionName
+
+	logger.Info("When the Service reports as Ready, everything should be ready.")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "2", "Re-energize yourself with a slice of pepperoni!")
+}

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -1,0 +1,65 @@
+// +build preupgrade
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
+	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/e2e"
+)
+
+func TestRunLatestServicePreupgrade(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	// Add test case specific name to its own logger.
+	logger := logging.GetContextLogger("TestRunLatestServicePreUpgrade")
+
+	var names test.ResourceNames
+	names.Service = serviceName
+
+	logger.Info("Creating a new Service")
+	svc, err := test.CreateLatestService(logger, clients, names, test.ImagePath(image1))
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+	names.Route = serviceresourcenames.Route(svc)
+	names.Config = serviceresourcenames.Configuration(svc)
+
+	logger.Info("The Service will be updated with the name of the Revision once it is created")
+	revisionName, err := waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+	}
+	names.Revision = revisionName
+
+	logger.Info("The Service will be updated with the domain of the Route once it is created")
+	routeDomain, err := waitForServiceDomain(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the new route: %v", names.Service, err)
+	}
+
+	logger.Info("When the Service reports as Ready, everything should be ready.")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+	assertServiceResourcesUpdated(t, logger, clients, names, routeDomain, "1", "What a spaceport!")
+}

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package upgrade
 
 import (

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -1,0 +1,62 @@
+package upgrade
+
+import (
+	"net/http"
+	"testing"
+
+	// Mysteriously required to support GCP auth (required by k8s libs).
+	// Apparently just importing it is enough. @_@ side effects @_@.
+	// https://github.com/kubernetes/client-go/issues/242
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+)
+
+const (
+	image1 = "pizzaplanetv1"
+	image2 = "pizzaplanetv2"
+
+	serviceName = "pizzaplanet-upgrade-service"
+)
+
+// Shamelessly cribbed from conformance/service_test.
+func assertServiceResourcesUpdated(t *testing.T, logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, routeDomain, expectedGeneration, expectedText string) {
+	// TODO(#1178): Remove "Wait" from all checks below this point.
+	_, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		logger,
+		routeDomain,
+		pkgTest.Retrying(pkgTest.EventuallyMatchesBody(expectedText), http.StatusNotFound),
+		"WaitForEndpointToServeText",
+		test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, routeDomain, expectedText, err)
+	}
+}
+
+func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	var revisionName string
+	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+		if s.Status.LatestCreatedRevisionName != names.Revision {
+			revisionName = s.Status.LatestCreatedRevisionName
+			return true, nil
+		}
+		return false, nil
+	}, "ServiceUpdatedWithRevision")
+	return revisionName, err
+}
+
+func waitForServiceDomain(clients *test.Clients, names test.ResourceNames) (string, error) {
+	var routeDomain string
+	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+		if s.Status.Domain != "" {
+			routeDomain = s.Status.Domain
+			return true, nil
+		}
+		return false, nil
+	}, "ServiceUpdatedWithDomain")
+	return routeDomain, err
+}


### PR DESCRIPTION
These install the previous release, run some tests, install HEAD, run
some tests, install the previous release (again), and run some final
tests. This allows us to test that we don't break things between
releases.

The (currently) one test being run is a stripped down form of the
conformance service_test. We don't validate as many things, just that it
works at all.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2223
Fixes #2224 