### PR TITLE
fix loop endless

### DIFF
--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -88,10 +88,12 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 		}
 		defer wi.Stop()
 		ch := wi.ResultChan()
+
+		timer := time.After(r.readyTimout)
 	RevisionReady:
 		for {
 			select {
-			case <-time.After(r.readyTimout):
+			case <-timer:
 				// last chance to check
 				if revision.Status.IsReady() {
 					break RevisionReady


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
`time.After(r.readyTimout)` used in for loop will cause loop endless. 
cause each time it will create new timer so it will start to record the time from a new moment, so timeout will never happened. That's is to say, the for loop will never break if there is no event captured. 
