### PR TITLE
Have Activator key off of Active not Ready.

### DIFF
--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -210,8 +210,9 @@ func (b *revisionBuilder) withReady(ready bool) *revisionBuilder {
 	if ready {
 		b.revision.Status.MarkContainerHealthy()
 		b.revision.Status.MarkResourcesAvailable()
+		b.revision.Status.MarkActive()
 	} else {
-		b.revision.Status.MarkContainerMissing("reasonz")
+		b.revision.Status.MarkInactive("reasonz", "detailz")
 	}
 	return b
 }


### PR DESCRIPTION
This adjusts the condition that the activator keys off of to determine whether it can start forwarding requests to the Revision.  In the current world, this change is just splitting hairs because these conditions end up being largely the same; however, this is relevant cleanup if we want to shift to a world where `Active=False` does not trigger `Ready=False` because requests to the activator would incorrectly see an `IsReady()` Revision and incorrectly forward traffic.

Peripherally related to: https://github.com/knative/serving/issues/2394

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @tcnghia 