### PR TITLE
Reduce the scale-to-zero knobs to 30s/60s.

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -68,4 +68,4 @@ data:
 
   # Scale to zero grace period is the time an inactive revision is left
   # running before it is scaled to zero (min: 30s).
-  scale-to-zero-grace-period: "2m"
+  scale-to-zero-grace-period: "30s"

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -129,7 +129,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key:          "scale-to-zero-grace-period",
 		field:        &lc.ScaleToZeroGracePeriod,
 		optional:     true,
-		defaultValue: 2 * time.Minute,
+		defaultValue: 30 * time.Second,
 	}, {
 		key:   "tick-interval",
 		field: &lc.TickInterval,

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -85,7 +85,7 @@ func TestNewConfig(t *testing.T) {
 			MaxScaleUpRate:                       1.0,
 			StableWindow:                         5 * time.Minute,
 			PanicWindow:                          10 * time.Second,
-			ScaleToZeroGracePeriod:               2 * time.Minute,
+			ScaleToZeroGracePeriod:               30 * time.Second,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -108,7 +108,7 @@ func TestNewConfig(t *testing.T) {
 			MaxScaleUpRate:                       1.0,
 			StableWindow:                         5 * time.Minute,
 			PanicWindow:                          10 * time.Second,
-			ScaleToZeroGracePeriod:               2 * time.Minute,
+			ScaleToZeroGracePeriod:               30 * time.Second,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -131,7 +131,7 @@ func TestNewConfig(t *testing.T) {
 			MaxScaleUpRate:                       1.0,
 			StableWindow:                         5 * time.Minute,
 			PanicWindow:                          10 * time.Second,
-			ScaleToZeroGracePeriod:               2 * time.Minute,
+			ScaleToZeroGracePeriod:               30 * time.Second,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {
@@ -152,7 +152,7 @@ func TestNewConfig(t *testing.T) {
 			MaxScaleUpRate:                       1.0,
 			StableWindow:                         5 * time.Minute,
 			PanicWindow:                          10 * time.Second,
-			ScaleToZeroGracePeriod:               2 * time.Minute,
+			ScaleToZeroGracePeriod:               30 * time.Second,
 			TickInterval:                         2 * time.Second,
 		},
 	}, {


### PR DESCRIPTION
This is to intentionally stress things a bit, but also:
1. We've alleviated several sources of potential flakiness from when the autoscaler test was doing this (e.g. missing informers watch on KPA)
1. We've seen an increase in stability (and anecdotally, I've cranked this down in #2397 and intentionally `/retest`'d it without any relevant flakes)
1. This should reduce the duration of our e2e tests, and enable us to reasonably add more testing like the autoscaler test.

<!--
/lint
-->

/hold
/assign @adrcunha @josephburnett 

WDYT?