### PR TITLE
Don't create builds unless the BuildSpec changes.

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -108,6 +108,33 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "foo/validation-failure",
 	}, {
+		Name: "elide build when a matching one already exists",
+		Objects: []runtime.Object{
+			cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec),
+			// An existing build is reused!
+			resources.MakeBuild(cfgWithBuild("something-else", "foo", 12345, &buildSpec)),
+		},
+		WantCreates: []metav1.Object{
+			resources.MakeRevision(cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec), &corev1.ObjectReference{
+				APIVersion: "build.knative.dev/v1alpha1",
+				Kind:       "Build",
+				Name:       "something-else-12345",
+			}),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: cfgWithBuildAndStatus("need-rev-and-build", "foo", 99998, &buildSpec,
+				v1alpha1.ConfigurationStatus{
+					LatestCreatedRevisionName: "need-rev-and-build-99998",
+					ObservedGeneration:        99998,
+					Conditions: duckv1alpha1.Conditions{{
+						Type:   v1alpha1.ConfigurationConditionReady,
+						Status: corev1.ConditionUnknown,
+					}},
+				},
+			),
+		}},
+		Key: "foo/need-rev-and-build",
+	}, {
 		Name: "create revision matching generation with build",
 		Objects: []runtime.Object{
 			cfgWithBuild("need-rev-and-build", "foo", 99998, &buildSpec),

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -42,13 +42,11 @@ func createRouteAndConfig(logger *logging.BaseLogger, clients *test.Clients, nam
 }
 
 func updateConfigWithImage(clients *test.Clients, names test.ResourceNames, imagePaths []string) error {
-	patches := []jsonpatch.JsonPatchOperation{
-		{
-			Operation: "replace",
-			Path:      "/spec/revisionTemplate/spec/container/image",
-			Value:     imagePaths[1],
-		},
-	}
+	patches := []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/spec/revisionTemplate/spec/container/image",
+		Value:     imagePaths[1],
+	}}
 	patchBytes, err := json.Marshal(patches)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
/lint
-->
Things like EnvVar updates should not trigger a fresh build, when a Build is specified in the ConfigurationSpec.  This builds on prior changes to lookup a pre-existing build with the same spec before creating its own.  This modifies the Build e2e tests to each perform an env-var only update to the configuration, and check that there are no differences in the resulting BuildRef.

Fixes: https://github.com/knative/serving/issues/439

WIP until https://github.com/knative/serving/pull/2401 (and it's dependencies) merge