### PR TITLE
Remove the base route name from hosts in virtualservice

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -45,7 +45,6 @@ var (
 			"test-route.test-ns.svc.cluster.local",
 			"test-route.test-ns.svc",
 			"test-route.test-ns",
-			"test-route",
 		},
 		HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
 			Paths: []v1alpha1.HTTPClusterIngressPath{{

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -73,7 +73,6 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 					"test-route.test-ns.svc.cluster.local",
 					"test-route.test-ns.svc",
 					"test-route.test-ns",
-					"test-route",
 				},
 				HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
 					Paths: []v1alpha1.HTTPClusterIngressPath{{
@@ -132,9 +131,6 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
 			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns"},
-		}, {
-			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -82,7 +82,6 @@ func getRouteDomains(targetName string, r *servingv1alpha1.Route, domain string)
 			names.K8sServiceFullname(r),
 			fmt.Sprintf("%s.%s.svc", r.Name, r.Namespace),
 			fmt.Sprintf("%s.%s", r.Name, r.Namespace),
-			r.Name,
 		}
 		return dedup(domains)
 	}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -87,7 +87,6 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 			"test-route.test-ns.svc.cluster.local",
 			"test-route.test-ns.svc",
 			"test-route.test-ns",
-			"test-route",
 		},
 		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -146,7 +145,6 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		"test-route.test-ns.svc.cluster.local",
 		"test-route.test-ns.svc",
 		"test-route.test-ns",
-		"test-route",
 	}
 	domains := getRouteDomains("", r, base)
 	if diff := cmp.Diff(expected, domains); diff != "" {

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -327,7 +327,6 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				"test-route.test.svc.cluster.local",
 				"test-route.test.svc",
 				"test-route.test",
-				"test-route",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -416,7 +415,6 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 				"test-route.test.svc.cluster.local",
 				"test-route.test.svc",
 				"test-route.test",
-				"test-route",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -499,7 +497,6 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 				"test-route.test.svc.cluster.local",
 				"test-route.test.svc",
 				"test-route.test",
-				"test-route",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -599,7 +596,6 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				"test-route.test.svc.cluster.local",
 				"test-route.test.svc",
 				"test-route.test",
-				"test-route",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -719,7 +715,6 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				"test-route.test.svc.cluster.local",
 				"test-route.test.svc",
 				"test-route.test",
-				"test-route",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

To address #2359 


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
NONE
```

/assign @tcnghia 
