### PR TITLE
Refactor shutdown logic in queue-proxy.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -74,7 +74,7 @@ var (
 	h2cProxy  *httputil.ReverseProxy
 	httpProxy *httputil.ReverseProxy
 
-	health *healthServer = &healthServer{alive: true}
+	health = &healthServer{alive: true}
 )
 
 func initEnv() {
@@ -272,25 +272,28 @@ func main() {
 		http.HandlerFunc(handler),
 	)
 
-	// Add a SIGTERM handler to gracefully shutdown the servers during
-	// pod termination.
+	go server.ListenAndServe()
+	go setupAdminHandlers(adminServer)
+
+	// Shutdown logic and signal handling
 	sigTermChan := make(chan os.Signal)
 	signal.Notify(sigTermChan, syscall.SIGTERM)
-	go func() {
-		<-sigTermChan
-		// Calling server.Shutdown() allows pending requests to
-		// complete, while no new work is accepted.
+	// Blocks until we actually receive a TERM signal.
+	<-sigTermChan
+	// Calling server.Shutdown() allows pending requests to
+	// complete, while no new work is accepted.
+	logger.Debug("Received shutdown signal, attempting to gracefully shutdown servers.")
+	if err := server.Shutdown(context.Background()); err != nil {
+		logger.Error("Failed to shutdown proxy-server", zap.Error(err))
+	}
+	logger.Debug("Proxy server shutdown successfully.")
+	if err := adminServer.Shutdown(context.Background()); err != nil {
+		logger.Error("Failed to shutdown admin-server", zap.Error(err))
+	}
 
-		server.Shutdown(context.Background())
-		adminServer.Shutdown(context.Background())
-
-		if statSink != nil {
-			statSink.Close()
+	if statSink != nil {
+		if err := statSink.Close(); err != nil {
+			logger.Error("Failed to shutdown websocket connection", zap.Error(err))
 		}
-
-		os.Exit(0)
-	}()
-
-	go server.ListenAndServe()
-	setupAdminHandlers(adminServer)
+	}
 }

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -285,8 +285,9 @@ func main() {
 	logger.Debug("Received shutdown signal, attempting to gracefully shutdown servers.")
 	if err := server.Shutdown(context.Background()); err != nil {
 		logger.Error("Failed to shutdown proxy-server", zap.Error(err))
+	} else {
+		logger.Debug("Proxy server shutdown successfully.")
 	}
-	logger.Debug("Proxy server shutdown successfully.")
 	if err := adminServer.Shutdown(context.Background()); err != nil {
 		logger.Error("Failed to shutdown admin-server", zap.Error(err))
 	}


### PR DESCRIPTION
The shutdown logic of the queue-proxy is very important for error-less operation, especially when it comes to gracefully shutting down the http proxy-server.

This makes the order of the logic more obvious and adds logging throughout for easier debugability.

## Motivation
This was an itch for me when I was debugging for #2365 because it was hard to follow and convince myself that the logic was actually okay.

In the old code, the main method was blocking on the **adminServer**'s `ListenAndServe` method, so when we shutdown the proxy-server the application actually kept running because the adminServer has not yet been closed. I'm not 100% sure if the statSink's `Close` logic was ever in effect because of this, since shutting down the adminServer would've caused the program to exit immediately.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
None
```
