### PR TITLE
Prevent replacing "default" other than in namespace

### DIFF
--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -76,7 +76,8 @@ func TestHelloWorldFromShell(t *testing.T) {
 	}
 
 	content := strings.Replace(string(yamlBytes), yamlImagePlaceholder, imagePath, -1)
-	content = strings.Replace(string(content), namespacePlaceholder, test.ServingNamespace, -1)
+	content = strings.Replace(string(content), "namespace: "+namespacePlaceholder,
+		"namespace: "+test.ServingNamespace, -1)
 
 	if _, err = newYaml.WriteString(content); err != nil {
 		t.Fatalf("Failed to write new manifest: %v", err)


### PR DESCRIPTION
Fixes the following problem:
The image path is obtained by calling `test.ImagePath("helloworld")` . The path is replaced in the yaml file including Coufiguration and Route. Now if that resulting path includes word "default" it will be replaced again by "serving-namespace" accidentally.
We need to make sure the image path is obtained solely via `test.ImagePath("helloworld")`. This path includes the registry address. We need to make sure it is not changed afterwards. We only want to change the "namespace" declaration.