### PR TITLE
Gracefully shutdown all test applications.

### DIFF
--- a/test/performance/observed-concurrency/observed_concurrency.go
+++ b/test/performance/observed-concurrency/observed_concurrency.go
@@ -39,9 +39,5 @@ func main() {
 	log.Print("Requests against '/?timeout={TIME_IN_MILLISECONDS}' will sleep for the given time.")
 	log.Print("Each request will return its serverside start and end-time in nanoseconds.")
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/performance/observed-concurrency/observed_concurrency.go
+++ b/test/performance/observed-concurrency/observed_concurrency.go
@@ -17,15 +17,13 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"time"
+
+	"github.com/knative/serving/test"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -42,13 +40,8 @@ func main() {
 	log.Print("Each request will return its serverside start and end-time in nanoseconds.")
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -17,11 +17,15 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
 	"net/http"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -99,6 +103,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	m := http.NewServeMux()
+	server := http.Server{Addr: ":8000", Handler: m}
+	m.HandleFunc("/", handler)
+
+	sigTermChan := make(chan os.Signal)
+	signal.Notify(sigTermChan, syscall.SIGTERM)
+	<-sigTermChan
+	server.Shutdown(context.Background())
 }

--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -107,6 +107,8 @@ func main() {
 	server := http.Server{Addr: ":8000", Handler: m}
 	m.HandleFunc("/", handler)
 
+	go server.ListenAndServe()
+
 	sigTermChan := make(chan os.Signal)
 	signal.Notify(sigTermChan, syscall.SIGTERM)
 	<-sigTermChan

--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -17,16 +17,14 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"math"
 	"net/http"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
+
+	"github.com/knative/serving/test"
 )
 
 // Algorithm from https://stackoverflow.com/a/21854246
@@ -104,13 +102,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -104,7 +104,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8000", Handler: m}
+	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
 	go server.ListenAndServe()

--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -101,9 +101,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/envvars/envvars.go
+++ b/test/test_images/envvars/envvars.go
@@ -17,14 +17,13 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/knative/serving/test"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -40,13 +39,8 @@ func main() {
 	log.Print("Env vars test app started.")
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/envvars/envvars.go
+++ b/test/test_images/envvars/envvars.go
@@ -38,9 +38,5 @@ func main() {
 	flag.Parse()
 	log.Print("Env vars test app started.")
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/helloworld/helloworld.go
+++ b/test/test_images/helloworld/helloworld.go
@@ -17,14 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/knative/serving/test"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -37,13 +35,8 @@ func main() {
 	log.Print("Hello world app started.")
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/helloworld/helloworld.go
+++ b/test/test_images/helloworld/helloworld.go
@@ -17,10 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -32,6 +36,14 @@ func main() {
 	flag.Parse()
 	log.Print("Hello world app started.")
 
-	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	m := http.NewServeMux()
+	server := http.Server{Addr: ":8080", Handler: m}
+	m.HandleFunc("/", handler)
+
+	go server.ListenAndServe()
+
+	sigTermChan := make(chan os.Signal)
+	signal.Notify(sigTermChan, syscall.SIGTERM)
+	<-sigTermChan
+	server.Shutdown(context.Background())
 }

--- a/test/test_images/helloworld/helloworld.go
+++ b/test/test_images/helloworld/helloworld.go
@@ -34,9 +34,5 @@ func main() {
 	flag.Parse()
 	log.Print("Hello world app started.")
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -69,9 +69,5 @@ func main() {
 	targetUrl := fmt.Sprintf("http://%s", targetHost)
 	httpProxy = initialHttpProxy(targetUrl)
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -16,17 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+
+	"github.com/knative/serving/test"
 )
 
 const (
@@ -71,13 +70,8 @@ func main() {
 	httpProxy = initialHttpProxy(targetUrl)
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/pizzaplanetv1/main.go
+++ b/test/test_images/pizzaplanetv1/main.go
@@ -17,9 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -29,6 +33,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	m := http.NewServeMux()
+	server := http.Server{Addr: ":8080", Handler: m}
+	m.HandleFunc("/", handler)
+
+	go server.ListenAndServe()
+
+	sigTermChan := make(chan os.Signal)
+	signal.Notify(sigTermChan, syscall.SIGTERM)
+	<-sigTermChan
+	server.Shutdown(context.Background())
 }

--- a/test/test_images/pizzaplanetv1/main.go
+++ b/test/test_images/pizzaplanetv1/main.go
@@ -17,13 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/knative/serving/test"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -34,13 +32,8 @@ func main() {
 	flag.Parse()
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/pizzaplanetv1/main.go
+++ b/test/test_images/pizzaplanetv1/main.go
@@ -31,9 +31,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/pizzaplanetv2/main.go
+++ b/test/test_images/pizzaplanetv2/main.go
@@ -17,9 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -29,6 +33,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	m := http.NewServeMux()
+	server := http.Server{Addr: ":8080", Handler: m}
+	m.HandleFunc("/", handler)
+
+	go server.ListenAndServe()
+
+	sigTermChan := make(chan os.Signal)
+	signal.Notify(sigTermChan, syscall.SIGTERM)
+	<-sigTermChan
+	server.Shutdown(context.Background())
 }

--- a/test/test_images/pizzaplanetv2/main.go
+++ b/test/test_images/pizzaplanetv2/main.go
@@ -17,13 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/knative/serving/test"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -34,13 +32,8 @@ func main() {
 	flag.Parse()
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }

--- a/test/test_images/pizzaplanetv2/main.go
+++ b/test/test_images/pizzaplanetv2/main.go
@@ -31,9 +31,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/singlethreaded/main.go
+++ b/test/test_images/singlethreaded/main.go
@@ -47,9 +47,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	m := http.NewServeMux()
-	m.HandleFunc("/", handler)
-
-	server := test.NewGracefulServer(":8080", m)
-	server.ListenAndServe()
+	test.ListenAndServeGracefully(":8080", handler)
 }

--- a/test/test_images/singlethreaded/main.go
+++ b/test/test_images/singlethreaded/main.go
@@ -18,15 +18,13 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
 	"sync/atomic"
-	"syscall"
 	"time"
+
+	"github.com/knative/serving/test"
 )
 
 var (
@@ -50,13 +48,8 @@ func main() {
 	flag.Parse()
 
 	m := http.NewServeMux()
-	server := http.Server{Addr: ":8080", Handler: m}
 	m.HandleFunc("/", handler)
 
-	go server.ListenAndServe()
-
-	sigTermChan := make(chan os.Signal)
-	signal.Notify(sigTermChan, syscall.SIGTERM)
-	<-sigTermChan
-	server.Shutdown(context.Background())
+	server := test.NewGracefulServer(":8080", m)
+	server.ListenAndServe()
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Lots of the autoscaling test flakes basically look like a request was killed while being open. Our test images don't actually have graceful shutdown, which I think should be a best practice per #2404. This is supposed to try out if this fixes the flakes in the autoscale tests (which seem to have gotten better though).

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
