### PR TITLE
Remove unused account `autoscaler`

### DIFF
--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -17,10 +17,3 @@ kind: ServiceAccount
 metadata:
   name: controller
   namespace: knative-serving
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: autoscaler
-  namespace: knative-serving
-

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -24,16 +24,3 @@ roleRef:
   kind: ClusterRole
   name: knative-serving-admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: knative-serving-autoscaler-write
-subjects:
-  - kind: ServiceAccount
-    name: autoscaler
-    namespace: knative-serving
-roleRef:
-  kind: ClusterRole
-  name: knative-serving-write
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
/kind cleanup

Fixes #2390

## Proposed Changes

  * Since `autoscaler` ServiceAccount is never used, we can remove it.

**Release Note**
```release-note
NONE
```
