### PR TITLE
Update the vendored test-infra dir

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -428,11 +428,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4d0724515d22c3964ef7bf671c989c45eefb81d71be09c1d8ab74acbdbb2ca94"
+  digest = "1:ced37ff60fb19342d12d2d51c6ac28fe3684240e72210f7b2ab3754fff9e6a1d"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "f710a703baf3ac7e5e9005693fb1c8d61c4eccbb"
+  revision = "48ce29742843637bf0ba9bc5aed78e926e513e13"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -101,6 +101,9 @@ project `$PROJECT_ID` and run the tests against it.
 `K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
 tests against the cluster.
 
+1. You can force running the tests against a specific GKE cluster version by using
+the `--cluster-version` flag and passing a X.Y.Z version as the flag value.
+
 ### Sample end-to-end test script
 
 This script will test that the latest Knative Serving nightly release works. It


### PR DESCRIPTION
Major changes:
* allow specifying a k8s cluster version in E2E tests
* fix tagging of images in releases