### PR TITLE
[RELEASE 0.2] Cherry pick #2382

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -399,11 +399,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f42d23c4286880873a951329d5a6002fcb9ee9f7d6c5fd8263ea53df2391acee"
+  digest = "1:4d0724515d22c3964ef7bf671c989c45eefb81d71be09c1d8ab74acbdbb2ca94"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "e7ddaaf7b3c285a538c6dfe061d59b73ace965cf"
+  revision = "f710a703baf3ac7e5e9005693fb1c8d61c4eccbb"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/hack/README.md
+++ b/hack/README.md
@@ -5,6 +5,7 @@ This directory contains several scripts useful in the development process of Kna
 * `boilerplate/add-boilerplate.sh` Adds license boilerplate to *txt* or *go* files in a directory, recursively.
 * `deploy.sh` Deploys Knative Serving to an [environment](environments.md).
 * `diagnose-me.sh` Performs several diagnostic checks on the running Kubernetes cluster, for debugging.
+* `generate-yamls.sh` Builds all the YAMLs that Knative publishes.
 * `release.sh` Creates a new [release](release.md) of Knative Serving.
 * `update-codegen.sh` Updates auto-generated client libraries.
 * `update-deps.sh` Updates Go dependencies.

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -14,47 +14,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script builds all the YAMLs that Knative publishes.  It may be varied
+# This script builds all the YAMLs that Knative publishes. It may be varied
 # between different branches, of what it does, but the following usage must
 # be observed:
 #
 # generate-yamls.sh  <repo-root-dir> <generated-yaml-list>
 #     repo-root-dir         the root directory of the repository.
-#     generated-yaml-list   an output file that contains the list of all
-#                           YAML file.  The first file listed must be our
+#     generated-yaml-list   an output file that will contain the list of all
+#                           YAML files. The first file listed must be our
 #                           manifest that contains all images to be tagged.
-#
-# Different version of release.sh should be able to call this script with
-# such assumption so that the publishing/tagging steps can evolve differently
-# than how the YAMLs are built.
-REPO_ROOT_DIR=$1
-GENERATED_YAML_LIST=$2
 
-# istio.yaml file to upload
-# We publish our own istio.yaml, so users don't need to use helm
-readonly ISTIO_CRD_YAML=./third_party/istio-1.0.2/istio-crds.yaml
-readonly ISTIO_YAML=./third_party/istio-1.0.2/istio.yaml
-readonly ISTIO_LEAN_YAML=./third_party/istio-1.0.2/istio-lean.yaml
+# Different versions of our scripts should be able to call this script with
+# such assumption so that the test/publishing/tagging steps can evolve
+# differently than how the YAMLs are built.
 
-readonly BUILD_YAML=build.yaml
-readonly SERVING_YAML=serving.yaml
-readonly MONITORING_YAML=monitoring.yaml
-readonly MONITORING_METRIC_PROMETHEUS_YAML=monitoring-metrics-prometheus.yaml
-readonly MONITORING_TRACE_ZIPKIN_YAML=monitoring-tracing-zipkin.yaml
-readonly MONITORING_TRACE_ZIPKIN_IN_MEM_YAML=monitoring-tracing-zipkin-in-mem.yaml
-readonly MONITORING_LOG_ELASTICSEARCH_YAML=monitoring-logs-elasticsearch.yaml
+# The following environment variables affect the behavior of this script:
+# * `$KO_FLAGS` Any extra flags that will be passed to ko.
+# * `$YAML_OUTPUT_DIR` Where to put the generated YAML files, otherwise a
+#   random temporary directory will be created. **All existing YAML files in
+#   this directory will be deleted.**
+# * `$KO_DOCKER_REPO` If not set, use ko.local as the registry.
 
-# Build the release
+set -o errexit
+set -o pipefail
+
+readonly YAML_REPO_ROOT=${1:?"First argument must be the repo root dir"}
+readonly YAML_LIST_FILE=${2:?"Second argument must be the output file"}
+
+# Location of istio YAMLs
+readonly ISTIO_CRD_YAML=${YAML_REPO_ROOT}/third_party/istio-1.0.2/istio-crds.yaml
+readonly ISTIO_YAML=${YAML_REPO_ROOT}/third_party/istio-1.0.2/istio.yaml
+readonly ISTIO_LEAN_YAML=${YAML_REPO_ROOT}/third_party/istio-1.0.2/istio-lean.yaml
+
+# Set output directory
+if [[ -z "${YAML_OUTPUT_DIR:-}" ]]; then
+  readonly YAML_OUTPUT_DIR="$(mktemp -d)"
+fi
+rm -fr ${YAML_OUTPUT_DIR}/*.yaml
+
+# Generated Knative component YAML files
+readonly BUILD_YAML=${YAML_OUTPUT_DIR}/build.yaml
+readonly SERVING_YAML=${YAML_OUTPUT_DIR}/serving.yaml
+readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
+readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
+readonly MONITORING_TRACE_ZIPKIN_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin.yaml
+readonly MONITORING_TRACE_ZIPKIN_IN_MEM_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin-in-mem.yaml
+readonly MONITORING_LOG_ELASTICSEARCH_YAML=${YAML_OUTPUT_DIR}/monitoring-logs-elasticsearch.yaml
+
+# Generated Knative "bundled" YAML files
+readonly RELEASE_YAML=${YAML_OUTPUT_DIR}/release.yaml
+readonly RELEASE_LITE_YAML=${YAML_OUTPUT_DIR}/release-lite.yaml
+readonly RELEASE_NO_MON_YAML=${YAML_OUTPUT_DIR}/release-no-mon.yaml
+
+# Flags for all ko commands
+readonly KO_YAML_FLAGS="-P ${KO_FLAGS}"
+
+: ${KO_DOCKER_REPO:="ko.local"}
+export KO_DOCKER_REPO
+
+cd "${YAML_REPO_ROOT}"
 
 echo "Copying Build release"
-cp "${REPO_ROOT_DIR}/third_party/config/build/release.yaml" "${BUILD_YAML}"
+cp "third_party/config/build/release.yaml" "${BUILD_YAML}"
 
 echo "Building Knative Serving"
-ko resolve ${KO_FLAGS} -f config/ > "${SERVING_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/ > "${SERVING_YAML}"
 
 echo "Building Monitoring & Logging"
 # Use ko to concatenate them all together.
-ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f third_party/config/monitoring/logging/elasticsearch \
     -f config/monitoring/logging/elasticsearch \
     -f third_party/config/monitoring/metrics/prometheus \
@@ -62,49 +90,45 @@ ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f config/monitoring/tracing/zipkin > "${MONITORING_YAML}"
 
 # Metrics via Prometheus & Grafana
-ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f third_party/config/monitoring/metrics/prometheus \
     -f config/monitoring/metrics/prometheus > "${MONITORING_METRIC_PROMETHEUS_YAML}"
 
 # Logs via ElasticSearch, Fluentd & Kibana
-ko resolve ${KO_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     -f third_party/config/monitoring/logging/elasticsearch \
     -f config/monitoring/logging/elasticsearch > "${MONITORING_LOG_ELASTICSEARCH_YAML}"
 
 # Traces via Zipkin when ElasticSearch is installed
-ko resolve ${KO_FLAGS} -R -f config/monitoring/tracing/zipkin > "${MONITORING_TRACE_ZIPKIN_YAML}"
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/zipkin > "${MONITORING_TRACE_ZIPKIN_YAML}"
 
 # Traces via Zipkin in Memory when ElasticSearch is not installed
-ko resolve ${KO_FLAGS} -R -f config/monitoring/tracing/zipkin-in-mem >> "${MONITORING_TRACE_ZIPKIN_IN_MEM_YAML}"
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/zipkin-in-mem >> "${MONITORING_TRACE_ZIPKIN_IN_MEM_YAML}"
 
-echo "Building Release Bundles."
-
-# These are the "bundled" yaml files that we publish.
-# Local generated yaml file.
-readonly RELEASE_YAML=release.yaml
-# Local generated lite yaml file.
-readonly LITE_YAML=release-lite.yaml
-# Local generated yaml file without the logging and monitoring components.
-readonly NO_MON_YAML=release-no-mon.yaml
+echo "Building Release bundles"
 
 # NO_MON is just build and serving
-cp "${BUILD_YAML}" "${NO_MON_YAML}"
-echo "---" >> "${NO_MON_YAML}"
-cat "${SERVING_YAML}" >> "${NO_MON_YAML}"
-echo "---" >> "${NO_MON_YAML}"
+cp "${BUILD_YAML}" "${RELEASE_NO_MON_YAML}"
+echo "---" >> "${RELEASE_NO_MON_YAML}"
+cat "${SERVING_YAML}" >> "${RELEASE_NO_MON_YAML}"
+echo "---" >> "${RELEASE_NO_MON_YAML}"
 
 # LITE is NO_MON plus "lean" monitoring
-cp "${NO_MON_YAML}" "${LITE_YAML}"
-echo "---" >> "${LITE_YAML}"
-cat "${MONITORING_METRIC_PROMETHEUS_YAML}" >> "${LITE_YAML}"
-echo "---" >> "${LITE_YAML}"
+cp "${RELEASE_NO_MON_YAML}" "${RELEASE_LITE_YAML}"
+echo "---" >> "${RELEASE_LITE_YAML}"
+cat "${MONITORING_METRIC_PROMETHEUS_YAML}" >> "${RELEASE_LITE_YAML}"
+echo "---" >> "${RELEASE_LITE_YAML}"
 
 # RELEASE is NO_MON plus full monitoring
-cp "${NO_MON_YAML}" "${RELEASE_YAML}"
+cp "${RELEASE_NO_MON_YAML}" "${RELEASE_YAML}"
 echo "---" >> "${RELEASE_YAML}"
 cat "${MONITORING_YAML}" >> "${RELEASE_YAML}"
 echo "---" >> "${RELEASE_YAML}"
 
-readonly YAMLS_TO_PUBLISH="${RELEASE_YAML} ${LITE_YAML} ${NO_MON_YAML} ${SERVING_YAML} ${BUILD_YAML} ${MONITORING_YAML} ${MONITORING_METRIC_PROMETHEUS_YAML} ${MONITORING_LOG_ELASTICSEARCH_YAML} ${MONITORING_TRACE_ZIPKIN_YAML} ${MONITORING_TRACE_ZIPKIN_IN_MEM_YAML} ${ISTIO_CRD_YAML} ${ISTIO_YAML} ${ISTIO_LEAN_YAML}"
+echo "All manifests generated"
 
-echo $YAMLS_TO_PUBLISH | sed "s/ /\n/g" > $GENERATED_YAML_LIST
+# List generated YAML files
+
+ls -1 ${RELEASE_YAML} > ${YAML_LIST_FILE}
+ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${RELEASE_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${ISTIO_CRD_YAML} ${ISTIO_YAML} ${ISTIO_LEAN_YAML} >> ${YAML_LIST_FILE}

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -18,19 +18,39 @@
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
-# Location of istio for the test cluster
-readonly ISTIO_YAML=./third_party/istio-1.0.2/istio.yaml
+CLUSTER_SH_CREATED_MANIFESTS=0
 
-function create_istio() {
-  echo ">> Bringing up Istio"
-  kubectl apply -f ${ISTIO_YAML}
+# Create all manifests required to install Knative Serving.
+function create_manifests() {
+  # Don't generate twice.
+  (( CLUSTER_SH_CREATED_MANIFESTS )) && return 0
+  local YAML_LIST="$(mktemp)"
+  # Generate manifests, capture environment variables pointing to the YAML files.
+  local FULL_OUTPUT="$( \
+      source $(dirname $0)/../hack/generate-yamls.sh ${REPO_ROOT_DIR} ${YAML_LIST} ; \
+      set | grep _YAML=/)"
+  local LOG_OUTPUT="$(echo "${FULL_OUTPUT}" | grep -v _YAML=/)"
+  local ENV_OUTPUT="$(echo "${FULL_OUTPUT}" | grep '^[_0-9A-Z]\+_YAML=/')"
+  [[ -z "${LOG_OUTPUT}" || -z "${ENV_OUTPUT}" ]] && fail_test "Error generating manifests"
+  # Only import the environment variables pointing to the YAML files.
+  echo "${LOG_OUTPUT}"
+  echo -e "Generated manifests:\n${ENV_OUTPUT}"
+  eval "${ENV_OUTPUT}"
+  CLUSTER_SH_CREATED_MANIFESTS=1
 }
 
-function create_serving() {
+# Installs Knative Serving in the current cluster, and waits for it to be ready.
+function install_knative_serving() {
+  export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
+  create_manifests
+  echo ">> Bringing up Istio"
+  kubectl apply -f "${ISTIO_CRD_YAML}"
+  kubectl apply -f "${ISTIO_YAML}"
+
   echo ">> Bringing up Serving"
-  # We still need this for at least one e2e test
-  kubectl apply -f third_party/config/build/release.yaml
-  ko apply -f config/
+  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
+  kubectl apply -f "${RELEASE_NO_MON_YAML}"
+
   # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
   #
   # However, since network configurations may reach different ingress pods at slightly
@@ -43,69 +63,26 @@ function create_serving() {
   # TODO(tcnghia): remove this when https://github.com/istio/istio/issues/882 is fixed.
   echo ">> Patching Istio"
   kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}'
-}
 
-function create_test_resources() {
   echo ">> Creating test resources (test/config/)"
   ko apply -f test/config/
-}
 
-function create_monitoring() {
-  echo ">> Bringing up Monitoring"
-  kubectl apply -R -f config/monitoring/100-namespace.yaml \
-    -f third_party/config/monitoring/logging/elasticsearch \
-    -f config/monitoring/logging/elasticsearch \
-    -f third_party/config/monitoring/metrics/prometheus \
-    -f config/monitoring/metrics/prometheus \
-    -f config/monitoring/tracing/zipkin
-}
-
-function create_everything() {
-  export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
-  create_istio
-  create_serving
-  create_test_resources
-  # TODO(#2122): Re-enable once we have monitoring e2e.
-  # create_monitoring
-}
-
-function delete_istio() {
-  echo ">> Bringing down Istio"
-  kubectl delete --ignore-not-found=true -f ${ISTIO_YAML}
-  kubectl delete clusterrolebinding cluster-admin-binding
-}
-
-function delete_serving() {
-  echo ">> Bringing down Serving"
-  ko delete --ignore-not-found=true -f config/
-  kubectl delete --ignore-not-found=true -f third_party/config/build/release.yaml
-}
-
-function delete_test_resources() {
-  echo ">> Removing test resources (test/config/)"
-  ko delete --ignore-not-found=true -f test/config/
-}
-
-function delete_monitoring() {
-  echo ">> Bringing down Monitoring"
-  kubectl delete --ignore-not-found=true -f config/monitoring/100-namespace.yaml \
-    -f third_party/config/monitoring/logging/elasticsearch \
-    -f config/monitoring/logging/elasticsearch \
-    -f third_party/config/monitoring/metrics/prometheus \
-    -f config/monitoring/metrics/prometheus \
-    -f config/monitoring/tracing/zipkin
-}
-
-function delete_everything() {
-  # TODO(#2122): Re-enable once we have monitoring e2e.
-  # delete_monitoring
-  delete_test_resources
-  delete_serving
-  delete_istio
-}
-
-function wait_until_cluster_up() {
   wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
   wait_until_pods_running istio-system || fail_test "Istio system is not up"
   wait_until_service_has_external_ip istio-system knative-ingressgateway || fail_test "Ingress has no external IP"
+}
+
+# Uninstalls Knative Serving from the current cluster.
+function uninstall_knative_serving() {
+  create_manifests
+  echo ">> Removing test resources (test/config/)"
+  ko delete --ignore-not-found=true -f test/config/
+
+  echo ">> Bringing down Serving"
+  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
+  ko delete --ignore-not-found=true -f "${RELEASE_NO_MON_YAML}"
+
+  echo ">> Bringing down Istio"
+  kubectl delete --ignore-not-found=true -f ${ISTIO_YAML}
+  kubectl delete --ignore-not-found=true clusterrolebinding cluster-admin-binding
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -53,26 +53,25 @@ function publish_test_images() {
 
 # Deletes everything created on the cluster including all knative and istio components.
 function teardown() {
-  delete_everything
+  uninstall_knative_serving
 }
 
 # Script entry point.
 
 initialize $@
 
+header "Setting up environment"
+
 # Fail fast during setup.
 set -o errexit
 set -o pipefail
 
-header "Setting up environment"
-create_everything
+install_knative_serving
 publish_test_images
 
 # Handle test failures ourselves, so we can dump useful info.
 set +o errexit
 set +o pipefail
-
-wait_until_cluster_up
 
 # Run the tests
 

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -3,6 +3,62 @@
 This directory contains helper scripts used by Prow test jobs, as well and
 local development scripts.
 
+## Using the `presubmit-tests.sh` helper script
+
+This is a helper script to run the presubmit tests. To use it:
+
+1. Source this script.
+
+1. Define the functions `build_tests()` and `unit_tests()`. They should run all
+tests (i.e., not fail fast), and return 0 if all passed, 1 if a failure
+occurred. The environment variables `RUN_BUILD_TESTS`, `RUN_UNIT_TESTS` and
+`RUN_INTEGRATION_TESTS` are set to 0 (false) or 1 (true) accordingly. If
+`--emit-metrics` is passed, `EMIT_METRICS` will be set to 1.
+
+1. [optional] Define the function `integration_tests()`, just like the previous
+ones. If you don't define this function, the default action for running the
+integration tests is to call the `./test/e2e-tests.sh` script (passing the
+`--emit-metrics` flag if necessary).
+
+1. [optional] Define the functions `pre_integration_tests()` or
+`post_integration_tests()`. These functions will be called before or after the
+integration tests (either your custom one or the default action) and will cause
+the test to fail if they don't return success.
+
+1. Call the `main()` function passing `$@` (without quotes).
+
+Running the script without parameters, or with the `--all-tests` flag causes
+all tests to be executed, in the right order (i.e., build, then unit, then
+integration tests).
+
+Use the flags `--build-tests`, `--unit-tests` and `--integration-tests` to run
+a specific set of tests. The flag `--emit-metrics` is used to emit metrics when
+running the tests, and is automatically handled by the default action (see
+above).
+
+### Sample presubmit test script
+
+```bash
+source vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+
+function build_tests() {
+  go build .
+}
+
+function unit_tests() {
+  report_go_test .
+}
+
+function pre_integration_tests() {
+  echo "Cleaning up before integration tests"
+  rm -fr ./staging-area
+}
+
+# We use the default integration test runner.
+
+main $@
+```
+
 ## Using the `e2e-tests.sh` helper script
 
 This is a helper script for Knative E2E test scripts. To use it:
@@ -15,6 +71,12 @@ resources.
 1. [optional] Write the `dump_extra_cluster_state()` function. It will be
 called when a test fails, and can dump extra information about the current state
 of the cluster (tipically using `kubectl`).
+
+1. [optional] Write the `parse_flags()` function. It will be called whenever an
+unrecognized flag is passed to the script, allowing you to define your own flags.
+The function must return 0 if the flag is unrecognized, or the number of items
+to skip in the command line if the flag was parsed successfully. For example,
+return 1 for a simple flag, and 2 for a flag with a parameter.
 
 1. Call the `initialize()` function passing `$@` (without quotes).
 
@@ -41,7 +103,9 @@ tests against the cluster.
 
 ### Sample end-to-end test script
 
-This script will test that the latest Knative Serving nightly release works.
+This script will test that the latest Knative Serving nightly release works. It
+defines a special flag (`--no-knative-wait`) that causes the script not to
+wait for Knative Serving to be up before running the tests.
 
 ```bash
 source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -50,11 +114,23 @@ function teardown() {
   echo "TODO: tear down test resources"
 }
 
+function parse_flags() {
+  if [[ "$1" == "--no-knative-wait" ]]; then
+    WAIT_FOR_KNATIVE=0
+    return 1
+  fi
+  return 0
+}
+
+WAIT_FOR_KNATIVE=1
+
 initialize $@
 
 start_latest_knative_serving
 
-wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+if (( WAIT_FOR_KNATIVE )); then
+  wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+fi
 
 # TODO: use go_test_e2e to run the tests.
 kubectl get pods || fail_test

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -23,6 +23,7 @@ readonly SERVING_GKE_VERSION=latest
 readonly SERVING_GKE_IMAGE=cos
 
 # Public images and yaml files.
+readonly KNATIVE_ISTIO_CRD_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio-crds.yaml
 readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
 readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
 readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-releases/build/latest/release.yaml
@@ -64,6 +65,11 @@ function subheader() {
 # Simple warning banner for logging purposes.
 function warning() {
   make_banner "!" "$1"
+}
+
+# Checks whether the given function exists.
+function function_exists() {
+  [[ "$(type -t $1)" == "function" ]]
 }
 
 # Remove ALL images in the given GCR repository.
@@ -172,13 +178,22 @@ function wait_until_routable() {
   return 1
 }
 
-# Returns the name of the pod of the given app.
+# Returns the name of the first pod of the given app.
 # Parameters: $1 - app name.
 #             $2 - namespace (optional).
 function get_app_pod() {
   local namespace=""
   [[ -n $2 ]] && namespace="-n $2"
   kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[0].metadata.name}"
+}
+
+# Returns the name of all pods of the given app.
+# Parameters: $1 - app name.
+#             $2 - namespace (optional).
+function get_app_pods() {
+  local namespace=""
+  [[ -n $2 ]] && namespace="-n $2"
+  kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[*].metadata.name}"
 }
 
 # Sets the given user as cluster admin.
@@ -330,6 +345,7 @@ function report_go_test() {
 function start_latest_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Istio"
+  kubectl apply -f ${KNATIVE_ISTIO_CRD_YAML} || return 1
   kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
   wait_until_pods_running istio-system || return 1
   kubectl label namespace default istio-injection=enabled || return 1
@@ -351,16 +367,18 @@ function start_latest_knative_build() {
 }
 
 # Run a go tool, installing it first if necessary.
-# Parameters: $1 - tool to run.
-#             $2 - tool package for go get.
+# Parameters: $1 - tool package/dir for go get/install.
+#             $2 - tool to run.
 #             $3..$n - parameters passed to the tool.
 function run_go_tool() {
-  local tool=$1
+  local tool=$2
   if [[ -z "$(which ${tool})" ]]; then
-    go get -u $2
+    local action=get
+    [[ $1 =~ ^[\./].* ]] && action=install
+    go ${action} $1
   fi
   shift 2
-  ${tool} $@
+  ${tool} "$@"
 }
 
 # Run dep-collector to update licenses.
@@ -370,7 +388,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool dep-collector github.com/mattmoor/dep-collector $@ > ./${dst}
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.
@@ -379,7 +397,7 @@ function check_licenses() {
   # Fetch the google/licenseclassifier for its license db
   go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  run_go_tool dep-collector github.com/mattmoor/dep-collector -check $@
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
 }
 
 # Run the given linter on the given files, checking it exists first.


### PR DESCRIPTION
From #2382

Now `cluster.sh` will use the same artifacts generated by `release.sh` to test Knative Serving. This will avoid surprises in the future due to having slightly different manifests for Serving when testing or releasing.

Also fixes #2354.