### PR TITLE
Add the missing vendored test-infra/tools/dep-collector

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -428,10 +428,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ced37ff60fb19342d12d2d51c6ac28fe3684240e72210f7b2ab3754fff9e6a1d"
+  digest = "1:936f825660ae0d20d3d3493cdbb3e9d71cf4746fda96d3e18111659b9e12cf43"
   name = "github.com/knative/test-infra"
-  packages = ["."]
-  pruneopts = "T"
+  packages = [
+    "scripts",
+    "tools/dep-collector",
+  ]
+  pruneopts = "UT"
   revision = "48ce29742843637bf0ba9bc5aed78e926e513e13"
 
 [[projects]]
@@ -1210,7 +1213,8 @@
     "github.com/knative/pkg/testing",
     "github.com/knative/pkg/tracker",
     "github.com/knative/pkg/webhook",
-    "github.com/knative/test-infra",
+    "github.com/knative/test-infra/scripts",
+    "github.com/knative/test-infra/tools/dep-collector",
     "github.com/mattbaird/jsonpatch",
     "github.com/pkg/errors",
     "go.opencensus.io/stats",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,8 @@ required = [
   "k8s.io/code-generator/cmd/lister-gen",
   "k8s.io/code-generator/cmd/informer-gen",
   "github.com/knative/caching/pkg/apis/caching",
-  "github.com/knative/test-infra",
+  "github.com/knative/test-infra/scripts",
+  "github.com/knative/test-infra/tools/dep-collector",
 ]
 
 [[override]]
@@ -77,5 +78,4 @@ required = [
 
 [[prune.project]]
   name = "github.com/knative/test-infra"
-  unused-packages = false
   non-go = false

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -28,9 +28,6 @@ dep ensure
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')
 
-# Keep the only dir in knative/test-infra we're interested in
-find vendor/github.com/knative/test-infra -mindepth 1 -maxdepth 1 ! -name scripts -exec rm -fr {} \;
-
 update_licenses third_party/VENDOR-LICENSE "./cmd/*"
 
 # Patch the Kubernetes dynamic client to fix listing. This patch is from

--- a/vendor/github.com/knative/test-infra/LICENSE
+++ b/vendor/github.com/knative/test-infra/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/knative/test-infra/scripts/dummy.go
+++ b/vendor/github.com/knative/test-infra/scripts/dummy.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scripts
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("This is a dummy go file so `go dep` can be used with knative/test-infra/scripts")
+	fmt.Println("This file can be safely removed if one day this directory contains real, useful go code")
+}

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/README.md
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/README.md
@@ -1,0 +1,88 @@
+# dep-collector
+
+`dep-collector` is a tool for gathering up a collection of licenses for Go
+dependencies that have been pulled into the idiomatic `vendor/` directory.
+The resulting file from running `dep-collector` is intended for inclusion
+in container images to respect the licenses of the included software.
+
+### Basic Usage
+
+You can run `dep-collector` on one or more Go import paths as entrypoints,
+and it will:
+1. Walk the transitive dependencies to identify vendored software packages,
+1. Search for licenses for each vendored dependency,
+1. Dump a file containing the licenses for each vendored import.
+
+For example (single import path):
+```shell
+$ dep-collector .
+===========================================================
+Import: github.com/mattmoor/dep-collector/vendor/github.com/google/licenseclassifier
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+...
+
+```
+
+For example (multiple import paths):
+
+```shell
+$ dep-collector ./cmd/controller ./cmd/sleeper
+
+===========================================================
+Import: github.com/mattmoor/warm-image/vendor/cloud.google.com/go
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+```
+
+### CSV Usage
+
+You can also run `dep-collector` in a mode that produces CSV output,
+including basic classification of the license.
+
+> In order to run dep-collector in this mode, you must first run:
+>   go get github.com/google/licenseclassifier
+
+For example:
+
+```shell
+$ dep-collector -csv .
+github.com/google/licenseclassifier,Static,,https://github.com/mattmoor/dep-collector/blob/master/vendor/github.com/google/licenseclassifier/LICENSE,Apache-2.0
+github.com/google/licenseclassifier/stringclassifier,Static,,https://github.com/mattmoor/dep-collector/blob/master/vendor/github.com/google/licenseclassifier/stringclassifier/LICENSE,Apache-2.0
+github.com/sergi/go-diff,Static,,https://github.com/mattmoor/dep-collector/blob/master/vendor/github.com/sergi/go-diff/LICENSE,MIT
+
+```
+
+The columns here are:
+* Import Path,
+* How the dependency is linked in (always reports "static"),
+* A column for whether any modifications have been made (always empty),
+* The URL by which to access the license file (assumes `master`),
+* A classification of what license this is ([using this](https://github.com/google/licenseclassifier)).
+
+
+### Check mode
+
+`dep-collector` also includes a mode that will check for "forbidden" licenses.
+
+> In order to run dep-collector in this mode, you must first run:
+>   go get github.com/google/licenseclassifier
+
+For example (failing):
+```shell
+$ dep-collector -check ./foo/bar/baz
+2018/07/20 22:01:29 Error checking license collection: Errors validating licenses:
+Found matching forbidden license in "foo.io/bar/vendor/github.com/BurntSushi/toml": WTFPL
+```
+
+For example (passing):
+
+```shell
+$ dep-collector -check .
+2018/07/20 22:29:09 No errors found.
+```

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	gb "go/build"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func CollectTransitiveImports(binaries []string) ([]string, error) {
+	// Perform a simple DFS to collect the binaries' transitive dependencies.
+	visited := make(map[string]struct{})
+	for _, importpath := range binaries {
+		if gb.IsLocalImport(importpath) {
+			ip, err := qualifyLocalImport(importpath)
+			if err != nil {
+				return nil, err
+			}
+			importpath = ip
+		}
+
+		pkg, err := gb.Import(importpath, WorkingDir, gb.ImportComment)
+		if err != nil {
+			return nil, err
+		}
+		if err := visit(pkg, visited); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort the dependencies deterministically.
+	var list sort.StringSlice
+	for ip := range visited {
+		if !strings.Contains(ip, "/vendor/") {
+			// Skip files outside of vendor
+			continue
+		}
+		list = append(list, ip)
+	}
+	list.Sort()
+
+	return list, nil
+}
+
+func qualifyLocalImport(ip string) (string, error) {
+	gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
+	if !strings.HasPrefix(WorkingDir, gopathsrc) {
+		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = ", gopathsrc)
+	}
+	return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
+}
+
+func visit(pkg *gb.Package, visited map[string]struct{}) error {
+	if _, ok := visited[pkg.ImportPath]; ok {
+		return nil
+	}
+	visited[pkg.ImportPath] = struct{}{}
+
+	for _, ip := range pkg.Imports {
+		if ip == "C" {
+			// skip cgo
+			continue
+		}
+		subpkg, err := gb.Import(ip, WorkingDir, gb.ImportComment)
+		if err != nil {
+			return fmt.Errorf("%v\n -> %v", pkg.ImportPath, err)
+		}
+		if !strings.HasPrefix(subpkg.Dir, WorkingDir) {
+			// Skip import paths outside of our workspace (std library)
+			continue
+		}
+		if err := visit(subpkg, visited); err != nil {
+			return fmt.Errorf("%v (%v)\n -> %v", pkg.ImportPath, pkg.Dir, err)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/licenses.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/licenses.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	gb "go/build"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/licenseclassifier"
+)
+
+var LicenseNames = []string{
+	"LICENCE",
+	"LICENSE",
+	"LICENSE.code",
+	"LICENSE.md",
+	"LICENSE.txt",
+	"COPYING",
+	"copyright",
+}
+
+const MatchThreshold = 0.9
+
+type LicenseFile struct {
+	EnclosingImportPath string
+	LicensePath         string
+}
+
+func (lf *LicenseFile) Body() (string, error) {
+	body, err := ioutil.ReadFile(lf.LicensePath)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (lt *LicenseFile) Classify(classifier *licenseclassifier.License) (string, error) {
+	body, err := lt.Body()
+	if err != nil {
+		return "", err
+	}
+	m := classifier.NearestMatch(body)
+	if m == nil {
+		return "", fmt.Errorf("unable to classify license: %v", lt.EnclosingImportPath)
+	}
+	return m.Name, nil
+}
+
+func (lt *LicenseFile) Check(classifier *licenseclassifier.License) error {
+	body, err := lt.Body()
+	if err != nil {
+		return err
+	}
+	ms := classifier.MultipleMatch(body, false)
+	for _, m := range ms {
+		return fmt.Errorf("Found matching forbidden license in %q: %v", lt.EnclosingImportPath, m.Name)
+	}
+	return nil
+}
+
+func (lt *LicenseFile) Entry() (string, error) {
+	body, err := lt.Body()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`
+===========================================================
+Import: %s
+
+%s
+`, lt.EnclosingImportPath, body), nil
+}
+
+func (lt *LicenseFile) CSVRow(classifier *licenseclassifier.License) (string, error) {
+	classification, err := lt.Classify(classifier)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(lt.EnclosingImportPath, "/vendor/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("wrong number of parts splitting import path on %q : %q", "/vendor/", lt.EnclosingImportPath)
+	}
+	return strings.Join([]string{
+		parts[1],
+		"Static",
+		"", // TODO(mattmoor): Modifications?
+		"https://" + parts[0] + "/blob/master/vendor/" + parts[1] + "/" + filepath.Base(lt.LicensePath),
+		classification,
+	}, ","), nil
+}
+
+func findLicense(ip string) (*LicenseFile, error) {
+	pkg, err := gb.Import(ip, WorkingDir, gb.ImportComment)
+	if err != nil {
+		return nil, err
+	}
+	dir := pkg.Dir
+
+	for {
+		// When we reach the root of our workspace, stop searching.
+		if dir == WorkingDir {
+			return nil, fmt.Errorf("unable to find license for %q", pkg.ImportPath)
+		}
+
+		for _, name := range LicenseNames {
+			p := filepath.Join(dir, name)
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
+
+			return &LicenseFile{
+				EnclosingImportPath: ip,
+				LicensePath:         p,
+			}, nil
+		}
+
+		// Walk to the parent directory / import path
+		dir = filepath.Dir(dir)
+		ip = filepath.Dir(ip)
+	}
+}
+
+type LicenseCollection []*LicenseFile
+
+func (lc LicenseCollection) Entries() (string, error) {
+	sections := make([]string, 0, len(lc))
+	for _, key := range lc {
+		entry, err := key.Entry()
+		if err != nil {
+			return "", err
+		}
+		sections = append(sections, entry)
+	}
+	return strings.Join(sections, "\n"), nil
+}
+
+func (lc LicenseCollection) CSV(classifier *licenseclassifier.License) (string, error) {
+	sections := make([]string, 0, len(lc))
+	for _, entry := range lc {
+		row, err := entry.CSVRow(classifier)
+		if err != nil {
+			return "", err
+		}
+		sections = append(sections, row)
+	}
+	return strings.Join(sections, "\n"), nil
+}
+
+func (lc LicenseCollection) Check(classifier *licenseclassifier.License) error {
+	errors := []string{}
+	for _, entry := range lc {
+		if err := entry.Check(classifier); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("Errors validating licenses:\n%v", strings.Join(errors, "\n"))
+}
+
+func CollectLicenses(imports []string) (LicenseCollection, error) {
+	// for each of the import paths, search for a license file.
+	licenseFiles := make(map[string]*LicenseFile)
+	for _, ip := range imports {
+		lf, err := findLicense(ip)
+		if err != nil {
+			return nil, err
+		}
+		licenseFiles[lf.EnclosingImportPath] = lf
+	}
+
+	order := sort.StringSlice{}
+	for key := range licenseFiles {
+		order = append(order, key)
+	}
+	order.Sort()
+
+	licenseTypes := LicenseCollection{}
+	for _, key := range order {
+		licenseTypes = append(licenseTypes, licenseFiles[key])
+	}
+	return licenseTypes, nil
+}

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/main.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/main.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/google/licenseclassifier"
+)
+
+var WorkingDir, _ = os.Getwd()
+
+var (
+	csv   = flag.Bool("csv", false, "Whether to print in CSV format (with slow classification).")
+	check = flag.Bool("check", false, "Whether to just check license files for forbidden licenses.")
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() == 0 {
+		log.Fatalf("Expected a list of import paths, got: %v", flag.Args())
+	}
+
+	// Perform a simple DFS to collect the binaries' transitive dependencies.
+	transitiveImports, err := CollectTransitiveImports(flag.Args())
+	if err != nil {
+		log.Fatalf("Error collecting transitive dependencies: %v", err)
+	}
+
+	// Gather all of the license data from the imports.
+	collection, err := CollectLicenses(transitiveImports)
+	if err != nil {
+		log.Fatalf("Error identifying licenses for transitive dependencies: %v", err)
+	}
+
+	if *check {
+		classifier, err := licenseclassifier.NewWithForbiddenLicenses(MatchThreshold)
+		if err != nil {
+			log.Fatalf("Error creating license classifier: %v", err)
+		}
+		if err := collection.Check(classifier); err != nil {
+			log.Fatalf("Error checking license collection: %v", err)
+		}
+		log.Printf("No errors found.")
+		return
+	}
+
+	if *csv {
+		classifier, err := licenseclassifier.New(MatchThreshold)
+		if err != nil {
+			log.Fatalf("Error creating license classifier: %v", err)
+		}
+		output, err := collection.CSV(classifier)
+		if err != nil {
+			log.Fatalf("Error generating CSV: %v", err)
+		}
+		os.Stdout.Write([]byte(output))
+	} else {
+		entries, err := collection.Entries()
+		if err != nil {
+			log.Fatalf("Error generating entries: %v", err)
+		}
+		os.Stdout.Write([]byte(entries))
+	}
+}


### PR DESCRIPTION
Bonus: there's no need to remove unused test-infra dirs in `update-deps.sh` anymore.