### PR TITLE
Wait until no connections are active before shutting down istio-proxy.

### DIFF
--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -347,13 +347,11 @@ data:
       
       containers:
       - name: istio-proxy
-        # PATCH #2: Temporary workaround for https://github.com/knative/serving/issues/2351.
+        # PATCH #2: Graceful shutdown of the istio-proxy.
         lifecycle:
           preStop:
             exec:
-              command:
-              - /bin/sleep
-              - "20"
+              command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
         image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
         "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"
         [[ else -]]

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -352,6 +352,7 @@ data:
           preStop:
             exec:
               command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+        # PATCH #2 ends.
         image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
         "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"
         [[ else -]]

--- a/third_party/istio-1.0.2/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.0.2/prestop-sleep.yaml.patch
@@ -1,8 +1,6 @@
 349a350,356
->         # PATCH #2: Temporary workaround for https://github.com/knative/serving/issues/2351.
+>         # PATCH #2: Graceful shutdown of the istio-proxy.
 >         lifecycle:
 >           preStop:
 >             exec:
->               command:
->               - /bin/sleep
->               - "20"
+>               command: command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']

--- a/third_party/istio-1.0.2/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.0.2/prestop-sleep.yaml.patch
@@ -1,6 +1,7 @@
-349a350,356
+349a350,355
 >         # PATCH #2: Graceful shutdown of the istio-proxy.
 >         lifecycle:
 >           preStop:
 >             exec:
->               command: command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+>               command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+>         # PATCH #2 ends.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is a workaround for #2421.

Due to the absence of graceful shutdown in envoy and istio-pilot-agent, we're querying envoy's statistics API and wait for the amount of active requests to drop to 0 before we allow the proxy to shut down.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Gracefully shutdown istio-proxy sidecars to not drop active connections.
```
