### PR TITLE
Re-enable Route prober in the tests

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -196,7 +196,7 @@ func TestRouteCreation(t *testing.T) {
 	if err := test.GetRouteProberError(routeProberErrorChan, logger); err != nil {
 		// Currently the Route prober is flaky. So we just log the error here for future debugging instead of
 		// failing the test.
-		logger.Errorf("Route prober failed with error %s", err)
+		t.Fatalf("Route prober failed with error %s", err)
 	}
 
 }

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -229,7 +229,7 @@ func TestRunLatestService(t *testing.T) {
 	if err := test.GetRouteProberError(routeProberErrorChan, logger); err != nil {
 		// Currently the Route prober is flaky. So we just log the error here for future debugging instead of
 		// failing the test.
-		logger.Errorf("Route prober failed with error %s", err)
+		t.Fatalf("Route prober failed with error %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1903

## Proposed Changes

  * Re-enable Route prober in TestRouteCreation and TestRunLatestService conformance test.

