### PR TITLE
remove useless name funcs in route controller

### DIFF
--- a/pkg/reconciler/v1alpha1/route/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names.go
@@ -21,16 +21,7 @@ import (
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
-	"github.com/knative/serving/pkg/system"
 )
-
-var K8sGatewayFullname = reconciler.GetK8sServiceFullname(
-	"knative-shared-gateway",
-	system.Namespace)
-
-var K8sGatewayServiceFullname = reconciler.GetK8sServiceFullname(
-	"knative-ingressgateway",
-	"istio-system")
 
 func K8sService(route *v1alpha1.Route) string {
 	return route.Name

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -32,7 +32,6 @@ import (
 	rtesting "github.com/knative/serving/pkg/reconciler/testing"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources"
-	resourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 	corev1 "k8s.io/api/core/v1"
@@ -354,7 +353,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		Key: "default/ingress-create-failure",
+		Key:                     "default/ingress-create-failure",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "steady state",
@@ -607,7 +606,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		Key: "default/new-latest-ready",
+		Key:                     "default/new-latest-ready",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "failure updating cluster ingress",
@@ -704,7 +703,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		Key: "default/update-ci-failure",
+		Key:                     "default/update-ci-failure",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "reconcile service mutation",
@@ -988,7 +987,7 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 		}},
-		Key: "default/ingress-mutation",
+		Key:                     "default/ingress-mutation",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "switch to a different config",
@@ -1217,7 +1216,7 @@ func TestReconcile(t *testing.T) {
 					}},
 				}),
 		}},
-		Key: "default/pinned-becomes-ready",
+		Key:                     "default/pinned-becomes-ready",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "traffic split becomes ready",
@@ -1308,7 +1307,7 @@ func TestReconcile(t *testing.T) {
 				Percent:           50,
 			}),
 		}},
-		Key: "default/named-traffic-split",
+		Key:                     "default/named-traffic-split",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "same revision targets",
@@ -1408,7 +1407,7 @@ func TestReconcile(t *testing.T) {
 				Percent:      50,
 			}),
 		}},
-		Key: "default/same-revision-targets",
+		Key:                     "default/same-revision-targets",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "change route configuration",
@@ -1502,7 +1501,7 @@ func TestReconcile(t *testing.T) {
 				}},
 			}),
 		}},
-		Key: "default/switch-configs",
+		Key:                     "default/switch-configs",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "Update stale lastPinned",
@@ -1699,7 +1698,7 @@ func readyIngressStatus() netv1alpha1.IngressStatus {
 	status.InitializeConditions()
 	status.MarkNetworkConfigured()
 	status.MarkLoadBalancerReady([]netv1alpha1.LoadBalancerIngressStatus{
-		{DomainInternal: resourcenames.K8sGatewayServiceFullname},
+		{DomainInternal: "knative-ingressgateway.istio-system.svc.cluster.local"},
 	})
 
 	return status

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -1698,7 +1698,7 @@ func readyIngressStatus() netv1alpha1.IngressStatus {
 	status.InitializeConditions()
 	status.MarkNetworkConfigured()
 	status.MarkLoadBalancerReady([]netv1alpha1.LoadBalancerIngressStatus{
-		{DomainInternal: "knative-ingressgateway.istio-system.svc.cluster.local"},
+		{DomainInternal: reconciler.GetK8sServiceFullname("knative-ingressgateway", "istio-system")},
 	})
 
 	return status


### PR DESCRIPTION
This was leftover when moving VirtualService logic to ingress controller.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
NONE
```

/assign @tcnghia 
