### PR TITLE
Allow config ingress gateway

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -396,7 +396,7 @@
   revision = "f0d7bb60956f88d4743f5fea66b5607b96d262c9"
 
 [[projects]]
-  digest = "1:e0f8a12fc45f4fa1087f78d08b15e340ba0fdc43db1e9b92d6229b390b7f3936"
+  digest = "1:d4cee2d9908d4a05064a1680916455c95cba498394c1f6c3aa4f22742f6edc59"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -440,7 +440,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "acfd173abd8d2063ddceedb3487599f97ac93db8"
+  revision = "9a644df00f19da719379ca936c1949f56d8c3eb5"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-11-21
-  revision = "acfd173abd8d2063ddceedb3487599f97ac93db8"
+  # HEAD as of 2018-11-28
+  revision = "9a644df00f19da719379ca936c1949f56d8c3eb5"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -1,18 +1,28 @@
-# We stand up a new Gateway service to receive all external traffic
-# for Knative pods.  These pods are basically standalone Envoy proxy
-# pods to convert all external traffic into cluster traffic.
+# Copyright 2018 The Knative Authors
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# The reason for standing up these pods are because Istio Gateway
-# cannot not share these ingress pods.  Istio provide a default, but
-# we don't want to use it and causing unwanted sharing with users'
-# Gateways if they have some.
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
-# The YAML is cloned from Istio's.  However, in the future we may want
-# to incorporate more of our logic to tailor to our users' specific
-# needs.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Gateway resource here is to attach to a gateway service that
+# receive all external traffic for Knative pods. We don't maintain
+# extra Gateway service and deployment in knative, but use that
+# provided in Istio by default.
+
+# If you want to replace the Gateway service and deployment to that
+# of your own, you'll need to update the label selector and ports
+# fields accordingly.
 
 # This is the shared Gateway for all Knative routes to use.
+
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -20,7 +30,7 @@ metadata:
   namespace: knative-serving
 spec:
   selector:
-    knative: ingressgateway
+    istio: ingressgateway
   servers:
   - port:
       number: 80
@@ -36,231 +46,3 @@ spec:
     - "*"
     tls:
       mode: PASSTHROUGH
----
-# TODO(#1969): We should allow the users to use `istio-ingressgateway` by default,
-#              while having the choice to specify their own Ingress Gateway service
-#              if that isn't enough for them.  That way we can get out of maintaining
-#              these YAML ourselves.
-#
-# This is the Service definition for the ingress pods serving
-# Knative's shared Gateway.
-apiVersion: v1
-kind: Service
-metadata:
-  name: knative-ingressgateway
-  namespace: istio-system
-  annotations:
-  labels:
-    chart: gateways-1.0.1
-    release: RELEASE-NAME
-    heritage: Tiller
-    app: knative-ingressgateway
-    knative: ingressgateway
-spec:
-  type: LoadBalancer
-  selector:
-    app: knative-ingressgateway
-    knative: ingressgateway
-  ports:
-    -
-      name: http2
-      nodePort: 32380
-      port: 80
-      targetPort: 80
-    -
-      name: https
-      nodePort: 32390
-      port: 443
-    -
-      name: tcp
-      nodePort: 32400
-      port: 31400
-    -
-      name: tcp-pilot-grpc-tls
-      port: 15011
-      targetPort: 15011
-    -
-      name: tcp-citadel-grpc-tls
-      port: 8060
-      targetPort: 8060
-    -
-      name: tcp-dns-tls
-      port: 853
-      targetPort: 853
-    -
-      name: http2-prometheus
-      port: 15030
-      targetPort: 15030
-    -
-      name: http2-grafana
-      port: 15031
-      targetPort: 15031
----
-# This is the corresponding Deployment to backed the aforementioned Service.
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: knative-ingressgateway
-  namespace: istio-system
-  labels:
-    chart: gateways-1.0.1
-    release: RELEASE-NAME
-    heritage: Tiller
-    app: knative-ingressgateway
-    knative: ingressgateway
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: knative-ingressgateway
-      knative: ingressgateway
-  template:
-    metadata:
-      labels:
-        app: knative-ingressgateway
-        knative: ingressgateway
-      annotations:
-        sidecar.istio.io/inject: "false"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
-    spec:
-      serviceAccountName: istio-ingressgateway-service-account
-      containers:
-        - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.0.2"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 80
-            - containerPort: 443
-            - containerPort: 31400
-            - containerPort: 15011
-            - containerPort: 8060
-            - containerPort: 853
-            - containerPort: 15030
-            - containerPort: 15031
-          args:
-          - proxy
-          - router
-          - -v
-          - "2"
-          - --discoveryRefreshDelay
-          - '1s' #discoveryRefreshDelay
-          - --drainDuration
-          - '45s' #drainDuration
-          - --parentShutdownDuration
-          - '1m0s' #parentShutdownDuration
-          - --connectTimeout
-          - '10s' #connectTimeout
-          - --serviceCluster
-          - knative-ingressgateway
-          - --zipkinAddress
-          - zipkin:9411
-          - --statsdUdpAddress
-          - istio-statsd-prom-bridge:9125
-          - --proxyAdminPort
-          - "15000"
-          - --controlPlaneAuthPolicy
-          - NONE
-          - --discoveryAddress
-          - istio-pilot:8080
-          resources:
-            requests:
-              cpu: 10m
-
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: ISTIO_META_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          volumeMounts:
-          - name: istio-certs
-            mountPath: /etc/certs
-            readOnly: true
-          - name: ingressgateway-certs
-            mountPath: "/etc/istio/ingressgateway-certs"
-            readOnly: true
-          - name: ingressgateway-ca-certs
-            mountPath: "/etc/istio/ingressgateway-ca-certs"
-            readOnly: true
-      volumes:
-      - name: istio-certs
-        secret:
-          secretName: istio.istio-ingressgateway-service-account
-          optional: true
-      - name: ingressgateway-certs
-        secret:
-          secretName: "istio-ingressgateway-certs"
-          optional: true
-      - name: ingressgateway-ca-certs
-        secret:
-          secretName: "istio-ingressgateway-ca-certs"
-          optional: true
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x
----
-# This is the horizontal pod autoscaler to make sure the ingress Pods
-# scale up to meet traffic demand.
-#
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-    name: knative-ingressgateway
-    namespace: istio-system
-spec:
-    # TODO(1411): Document/fix this.  We are choosing an arbitrary 10 here.
-    maxReplicas: 10
-    minReplicas: 1
-    scaleTargetRef:
-      apiVersion: apps/v1
-      kind: Deployment
-      name: knative-ingressgateway
-    metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 60

--- a/docs/setting-up-custom-ingress-gateway.md
+++ b/docs/setting-up-custom-ingress-gateway.md
@@ -1,0 +1,254 @@
+# Setting Up Custom Ingress Gateway
+
+Knative uses a shared Gateway to serve all incoming traffic within Knative
+service mesh, which is the "knative-shared-gateway" Gateway under
+"knative-serving" namespace. By default, we use Istio gateway service `istio-ingressgateway`
+under "istio-system" namespace as its underlying service. You can replace the
+service with that of your own as follows.
+
+## Step 1: Create Gateway Service and Deployment Instance
+
+You'll need to create the gateway service and deployment instance to handle traffic first.
+The simplest way should be making a copy of the Gateway service template in [Istio release](https://github.com/istio/istio/releases).
+
+Here is an example:
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: custom-ingressgateway
+  namespace: istio-system
+  annotations:
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: custom-ingressgateway
+    custom: ingressgateway
+spec:
+  type: LoadBalancer
+  selector:
+    app: custom-ingressgateway
+    custom: ingressgateway
+  ports:
+    -
+      name: http2
+      nodePort: 32380
+      port: 80
+      targetPort: 80
+    -
+      name: https
+      nodePort: 32390
+      port: 443
+    -
+      name: tcp
+      nodePort: 32400
+      port: 31400
+    -
+      name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    -
+      name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    -
+      name: tcp-dns-tls
+      port: 853
+      targetPort: 853
+    -
+      name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    -
+      name: http2-grafana
+      port: 15031
+      targetPort: 15031
+---
+# This is the corresponding Deployment to backed the aforementioned Service.
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: custom-ingressgateway
+  namespace: istio-system
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: custom-ingressgateway
+    custom: ingressgateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: custom-ingressgateway
+      custom: ingressgateway
+  template:
+    metadata:
+      labels:
+        app: custom-ingressgateway
+        custom: ingressgateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: istio-ingressgateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.0.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 853
+            - containerPort: 15030
+            - containerPort: 15031
+          args:
+          - proxy
+          - router
+          - -v
+          - "2"
+          - --discoveryRefreshDelay
+          - '1s' #discoveryRefreshDelay
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - custom-ingressgateway
+          - --zipkinAddress
+          - zipkin:9411
+          - --statsdUdpAddress
+          - istio-statsd-prom-bridge:9125
+          - --proxyAdminPort
+          - "15000"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot:8080
+          resources:
+            requests:
+              cpu: 10m
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: ingressgateway-certs
+            mountPath: "/etc/istio/ingressgateway-certs"
+            readOnly: true
+          - name: ingressgateway-ca-certs
+            mountPath: "/etc/istio/ingressgateway-ca-certs"
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-ingressgateway-service-account
+          optional: true
+      - name: ingressgateway-certs
+        secret:
+          secretName: "istio-ingressgateway-certs"
+          optional: true
+      - name: ingressgateway-ca-certs
+        secret:
+          secretName: "istio-ingressgateway-ca-certs"
+          optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+```
+
+
+## Step 2: Update Knative Gateway
+
+Update gateway instance `knative-shared-gateway` under `knative-serving` namespace:
+
+```shell
+kubectl edit gateway knative-shared-gateway -n knative-serving
+```
+
+Replace its label selector with the label of your service:
+
+```
+istio: ingressgateway
+```
+
+For the service above, it should be updated to
+
+```
+custom: ingressgateway
+```
+
+If there is a change in service ports (compared with that of `istio-ingressgateway`),
+update the port info in gateway accordingly.
+
+## Step 3: Update Gateway Configmap
+
+Update gateway configmap `config-ingressgateway` under `knative-serving` namespace:
+
+```shell
+kubectl edit configmap config-ingressgateway -n knative-serving
+```
+
+Replace the `ingress-gateway` field with fully qualified url of your service:
+
+For the service above, it should be updated to
+
+```
+custom-ingressgateway.istio-system.svc.cluster.local
+```

--- a/docs/setting-up-ingress-static-ip.md
+++ b/docs/setting-up-ingress-static-ip.md
@@ -3,10 +3,13 @@
 Knative uses a shared Gateway to serve all incoming traffic within Knative
 service mesh, which is the "knative-shared-gateway" Gateway under
 "knative-serving" namespace. The IP address to access the gateway is the
-external IP address of the "knative-ingressgateway" service under the
+external IP address of the "istio-ingressgateway" service under the
 "istio-system" namespace. So in order to set static IP for the Knative shared
 gateway, you just need to set the external IP address of the
-"knative-ingressgateway" service to the static IP you need.
+"istio-ingressgateway" service to the static IP you need.
+If the gateway service has been replaced to that of other service, you'll
+need to replace "istio-ingressgateway" with the service name accordingly.
+See [instructions](../setting-up-custom-ingress-gateway.md) for more details.
 
 ## Prerequisites
 
@@ -30,28 +33,28 @@ gateway.
 
 ## Set Up Static IP for Knative Gateway
 
-### Step 1: Update external IP of "knative-ingressgateway" service
+### Step 1: Update external IP of "istio-ingressgateway" service
 
 Run following command to reset the external IP for the
-"knative-ingressgateway" service to the static IP you reserved.
+"istio-ingressgateway" service to the static IP you reserved.
 
 ```shell
-kubectl patch svc knative-ingressgateway -n istio-system --patch '{"spec": { "loadBalancerIP": "<your-reserved-static-ip>" }}'
+kubectl patch svc istio-ingressgateway -n istio-system --patch '{"spec": { "loadBalancerIP": "<your-reserved-static-ip>" }}'
 ```
 
-### Step 2: Verify static IP address of knative-ingressgateway service
+### Step 2: Verify static IP address of istio-ingressgateway service
 
-You can check the external IP of the "knative-ingressgateway" service with:
+You can check the external IP of the "istio-ingressgateway" service with:
 
 ```shell
-kubectl get svc knative-ingressgateway -n istio-system
+kubectl get svc istio-ingressgateway -n istio-system
 ```
 
 The result should be something like
 
 ```console
 NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                      AGE
-knative-ingressgateway   LoadBalancer   10.50.250.120   35.210.48.100   80:32380/TCP,443:32390/TCP,32400:32400/TCP   5h
+istio-ingressgateway   LoadBalancer   10.50.250.120   35.210.48.100   80:31380/TCP,443:31390/TCP,31400:31400/TCP...   5h
 ```
 
 The external IP will be eventually set to the static IP. This process could

--- a/docs/setting-up-ingress-static-ip.md
+++ b/docs/setting-up-ingress-static-ip.md
@@ -53,8 +53,8 @@ kubectl get svc istio-ingressgateway -n istio-system
 The result should be something like
 
 ```console
-NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                      AGE
-istio-ingressgateway   LoadBalancer   10.50.250.120   35.210.48.100   80:31380/TCP,443:31390/TCP,31400:31400/TCP...   5h
+NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                         AGE
+istio-ingressgateway     LoadBalancer   10.50.250.120   35.210.48.100   80:31380/TCP,443:31390/TCP,31400:31400/TCP...   5h
 ```
 
 The external IP will be eventually set to the static IP. This process could

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/names/names.go
@@ -27,11 +27,6 @@ var K8sGatewayFullname = reconciler.GetK8sServiceFullname(
 	"knative-shared-gateway",
 	system.Namespace)
 
-// K8sGatewayServiceFullname is the fully-qualified name of in-cluster Knative gateway.
-var K8sGatewayServiceFullname = reconciler.GetK8sServiceFullname(
-	"knative-ingressgateway",
-	"istio-system")
-
 // VirtualService returns the name of the VirtualService child resource for given ClusterIngress.
 func VirtualService(i *v1alpha1.ClusterIngress) string {
 	return i.Name

--- a/pkg/reconciler/v1alpha1/route/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/service_test.go
@@ -104,13 +104,13 @@ func TestNewMakeK8SService(t *testing.T) {
 			ingress: &netv1alpha1.ClusterIngress{
 				Status: netv1alpha1.IngressStatus{
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
-						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: "knative-ingressgateway.istio-system.svc.cluster.local"}},
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: "istio-ingressgateway.istio-system.svc.cluster.local"}},
 					},
 				},
 			},
 			expectedSpec: corev1.ServiceSpec{
 				Type:         corev1.ServiceTypeExternalName,
-				ExternalName: "knative-ingressgateway.istio-system.svc.cluster.local",
+				ExternalName: "istio-ingressgateway.istio-system.svc.cluster.local",
 			},
 		},
 	}

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -1788,7 +1788,7 @@ func readyIngressStatus() netv1alpha1.IngressStatus {
 	status.InitializeConditions()
 	status.MarkNetworkConfigured()
 	status.MarkLoadBalancerReady([]netv1alpha1.LoadBalancerIngressStatus{
-		{DomainInternal: reconciler.GetK8sServiceFullname("knative-ingressgateway", "istio-system")},
+		{DomainInternal: reconciler.GetK8sServiceFullname("istio-ingressgateway", "istio-system")},
 	})
 
 	return status

--- a/test/README.md
+++ b/test/README.md
@@ -177,7 +177,7 @@ use the domain `example.com`, unless the route has label `app=prod` in which
 case they will use the domain `prod-domain.com`.  Since these domains will not be
 resolvable to deployments in your test cluster, in order to make a request
 against the endpoint, the test use the IP assigned to the service
-`knative-ingressgateway` in the namespace `istio-system` and spoof the `Host` in
+`istio-ingressgateway` in the namespace `istio-system` and spoof the `Host` in
 the header.
 
 If you have configured your cluster to use a resolvable domain, you can use the

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -83,14 +83,14 @@ function install_knative_serving() {
   # We should revisit this when Istio API exposes a Status that we can rely on.
   # TODO(tcnghia): remove this when https://github.com/istio/istio/issues/882 is fixed.
   echo ">> Patching Istio"
-  kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}' || return 1
+  kubectl patch hpa -n istio-system istio-ingressgateway --patch '{"spec": {"maxReplicas": 1}}' || return 1
 
   echo ">> Creating test resources (test/config/)"
   ko apply -f test/config/ || return 1
 
   wait_until_pods_running knative-serving || return 1
   wait_until_pods_running istio-system || return 1
-  wait_until_service_has_external_ip istio-system knative-ingressgateway
+  wait_until_service_has_external_ip istio-system istio-ingressgateway
 }
 
 # Uninstalls Knative Serving from the current cluster.

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -102,7 +102,7 @@ func TestHelloWorldFromShell(t *testing.T) {
 	timeout := ingressTimeout
 	for (serviceIP == "" || serviceHost == "") && timeout >= 0 {
 		serviceHost = noStderrShell("kubectl", "get", "rt", "route-example", "-o", "jsonpath={.status.domain}", "-n", test.ServingNamespace)
-		serviceIP = noStderrShell("kubectl", "get", "svc", "knative-ingressgateway", "-n", "istio-system",
+		serviceIP = noStderrShell("kubectl", "get", "svc", "istio-ingressgateway", "-n", "istio-system",
 			"-o", "jsonpath={.status.loadBalancer.ingress[*]['ip']}")
 		time.Sleep(checkInterval)
 		timeout = timeout - checkInterval

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -37,7 +37,7 @@ import (
 const (
 	istioNS      = "istio-system"
 	monitoringNS = "knative-monitoring"
-	gateway      = "knative-ingressgateway"
+	gateway      = "istio-ingressgateway"
 )
 
 type PerformanceClient struct {

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/addressable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/addressable_types.go
@@ -37,7 +37,6 @@ type Addressable struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-
 // Addressable is an Implementable "duck type".
 var _ duck.Implementable = (*Addressable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
@@ -27,7 +27,6 @@ import (
 // Generation is the schema for the generational portion of the payload
 type Generation int64
 
-
 // Generation is an Implementable "duck type".
 var _ duck.Implementable = (*Generation)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
@@ -41,7 +41,6 @@ type LegacyTargetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-
 // LegacyTargetable is an Implementable "duck type".
 var _ duck.Implementable = (*LegacyTargetable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/retired_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/retired_targetable_types.go
@@ -37,7 +37,6 @@ type Targetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-
 // Targetable is an Implementable "duck type".
 var _ duck.Implementable = (*Targetable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/istio/authentication/v1alpha1/policy_types.go
+++ b/vendor/github.com/knative/pkg/apis/istio/authentication/v1alpha1/policy_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/knative/pkg/apis/istio/common/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +genclient
@@ -127,7 +127,7 @@ type PolicySpec struct {
 	// List rules to select destinations that the policy should be applied on.
 	// If empty, policy will be used on all destinations in the same namespace.
 	Targets []TargetSelector `json:"targets,omitempty"`
-	
+
 	// List of authentication methods that can be used for peer authentication.
 	// They will be evaluated in order; the first validate one will be used to
 	// set peer identity (source.user) and other peer attributes. If none of
@@ -135,14 +135,14 @@ type PolicySpec struct {
 	// request will be rejected with authentication failed error (401).
 	// Leave the list empty if peer authentication is not required
 	Peers []PeerAuthenticationMethod `json:"peers,omitempty"`
-	
+
 	// Set this flag to true to accept request (for peer authentication perspective),
 	// even when none of the peer authentication methods defined above satisfied.
 	// Typically, this is used to delay the rejection decision to next layer (e.g
 	// authorization).
 	// This flag is ignored if no authentication defined for peer (peers field is empty).
 	PeerIsOptional bool `json:"peerIsOptional,omitempty"`
-	
+
 	// List of authentication methods that can be used for origin authentication.
 	// Similar to peers, these will be evaluated in order; the first validate one
 	// will be used to set origin identity and attributes (i.e request.auth.user,
@@ -151,17 +151,17 @@ type PolicySpec struct {
 	// error (401).
 	// Leave the list empty if origin authentication is not required.
 	Origins []OriginAuthenticationMethod `json:"origins,omitempty"`
-	
+
 	// Set this flag to true to accept request (for origin authentication perspective),
 	// even when none of the origin authentication methods defined above satisfied.
 	// Typically, this is used to delay the rejection decision to next layer (e.g
 	// authorization).
 	// This flag is ignored if no authentication defined for origin (origins field is empty).
 	OriginIsOptional bool `json:"originIsOptional,omitempty"`
-	
+
 	// Define whether peer or origin identity should be use for principal. Default
 	// value is USE_PEER.
-	// If peer (or orgin) identity is not available, either because of peer/origin
+	// If peer (or origin) identity is not available, either because of peer/origin
 	// authentication is not defined, or failed, principal will be left unset.
 	// In other words, binding rule does not affect the decision to accept or
 	// reject request.
@@ -173,7 +173,7 @@ type TargetSelector struct {
 	// REQUIRED. The name must be a short name from the service registry. The
 	// fully qualified domain name will be resolved in a platform specific manner.
 	Name string `json:"name"`
-	
+
 	// Specifies the ports on the destination. Leave empty to match all ports
 	// that are exposed.
 	Ports []PortSelector `json:"ports,omitempty"`
@@ -183,12 +183,12 @@ type TargetSelector struct {
 // matching targets for authenticationn policy. This is copied from
 // networking API to avoid dependency.
 type PortSelector struct {
-	// It is requred to specify exactly one of the fields:
+	// It is required to specify exactly one of the fields:
 	// Number or Name
 
 	// Valid port number
 	Number uint32 `json:"number,omitempty"`
-	
+
 	// Port name
 	Name string `json:"name,omitempty"`
 }
@@ -199,11 +199,11 @@ type PortSelector struct {
 // The type can be progammatically determine by checking the type of the
 // "params" field.
 type PeerAuthenticationMethod struct {
-	// It is requred to specify exactly one of the fields:
+	// It is required to specify exactly one of the fields:
 	// Mtls or Jwt
 	// Set if mTLS is used.
 	Mtls *MutualTls `json:"mtls,omitempty"`
-	
+
 	// Set if JWT is used. This option is not yet available.
 	Jwt *Jwt `json:"jwt,omitempty"`
 }
@@ -214,7 +214,7 @@ type Mode string
 const (
 	// Client cert must be presented, connection is in TLS.
 	ModeStrict Mode = "STRICT"
-	
+
 	// Connection can be either plaintext or TLS, and client cert can be omitted.
 	ModePermissive Mode = "PERMISSIVE"
 )
@@ -229,7 +229,7 @@ type MutualTls struct {
 	// be left unset.
 	// When the flag is false (default), request must have client certificate.
 	AllowTls bool `json:"allowTls,omitempty"`
-	
+
 	// Defines the mode of mTLS authentication.
 	Mode Mode `json:"mode,omitempty"`
 }
@@ -256,7 +256,7 @@ type Jwt struct {
 	// Example: https://securetoken.google.com
 	// Example: 1234567-compute@developer.gserviceaccount.com
 	Issuer string `json:"issuer,omitempty"`
-	
+
 	// The list of JWT
 	// [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3).
 	// that are allowed to access. A JWT containing any of these
@@ -272,7 +272,7 @@ type Jwt struct {
 	//   bookstore_web.apps.googleusercontent.com
 	// ```
 	Audiences []string `json:"audiences,omitempty"`
-	
+
 	// URL of the provider's public key set to validate signature of the
 	// JWT. See [OpenID
 	// Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
@@ -285,7 +285,7 @@ type Jwt struct {
 	//
 	// Example: https://www.googleapis.com/oauth2/v1/certs
 	JwksUri string `json:"jwksUri,omitempty"`
-	
+
 	// Two fields below define where to extract the JWT from an HTTP request.
 	//
 	// If no explicit location is specified the following default
@@ -304,7 +304,7 @@ type Jwt struct {
 	// For example, if `header=x-goog-iap-jwt-assertion`, the header
 	// format will be x-goog-iap-jwt-assertion: <JWT>.
 	JwtHeaders []string `json:"jwtHeaders,omitempty"`
-	
+
 	// JWT is sent in a query parameter. `query` represents the
 	// query parameter name.
 	//
@@ -312,9 +312,9 @@ type Jwt struct {
 	JwtParams []string `json:"jwtParams,omitempty"`
 
 	// URL paths that should be excluded from the JWT validation. If the request path is matched,
-  	// the JWT validation will be skipped and the request will proceed regardless.
-  	// This is useful to keep a couple of URLs public for external health checks.
-  	// Example: "/health_check", "/status/cpu_usage".
+	// the JWT validation will be skipped and the request will proceed regardless.
+	// This is useful to keep a couple of URLs public for external health checks.
+	// Example: "/health_check", "/status/cpu_usage".
 	ExcludedPaths []v1alpha1.StringMatch `json:"excludedPaths,omitempty"`
 }
 

--- a/vendor/github.com/knative/pkg/apis/istio/common/v1alpha1/string.go
+++ b/vendor/github.com/knative/pkg/apis/istio/common/v1alpha1/string.go
@@ -19,17 +19,17 @@ package v1alpha1
 // Describes how to match a given string in HTTP headers. Match is
 // case-sensitive.
 type StringMatch struct {
-        // Specified exactly one of the fields below.
+	// Specified exactly one of the fields below.
 
-        // exact string match
-        Exact string `json:"exact,omitempty"`
+	// exact string match
+	Exact string `json:"exact,omitempty"`
 
-        // prefix-based match
-        Prefix string `json:"prefix,omitempty"`
+	// prefix-based match
+	Prefix string `json:"prefix,omitempty"`
 
-        // suffix-based match.
-        Suffix string `json:"prefix,omitempty"`
+	// suffix-based match.
+	Suffix string `json:"prefix,omitempty"`
 
-        // ECMAscript style regex-based match
-        Regex string `json:"regex,omitempty"`
+	// ECMAscript style regex-based match
+	Regex string `json:"regex,omitempty"`
 }

--- a/vendor/github.com/knative/pkg/apis/istio/v1alpha3/destinationrule_types.go
+++ b/vendor/github.com/knative/pkg/apis/istio/v1alpha3/destinationrule_types.go
@@ -117,11 +117,11 @@ type DestinationRuleSpec struct {
 	//
 	// Note that the host field applies to both HTTP and TCP services.
 	Host string `json:"host"`
-	
+
 	// Traffic policies to apply (load balancing policy, connection pool
 	// sizes, outlier detection).
 	TrafficPolicy *TrafficPolicy `json:"trafficPolicy,omitempty"`
-	
+
 	// One or more named sets that represent individual versions of a
 	// service. Traffic policies can be overridden at subset level.
 	Subsets []Subset `json:"subsets,omitempty"`
@@ -133,16 +133,16 @@ type TrafficPolicy struct {
 
 	// Settings controlling the load balancer algorithms.
 	LoadBalancer *LoadBalancerSettings `json:"loadBalancer,omitempty"`
-	
+
 	// Settings controlling the volume of connections to an upstream service
 	ConnectionPool *ConnectionPoolSettings `json:"connectionPool,omitempty"`
-	
+
 	// Settings controlling eviction of unhealthy hosts from the load balancing pool
 	OutlierDetection *OutlierDetection `json:"outlierDetection,omitempty"`
-	
+
 	// TLS related settings for connections to the upstream service.
 	Tls *TLSSettings `json:"tls,omitempty"`
-	
+
 	// Traffic policies specific to individual ports. Note that port level
 	// settings will override the destination-level settings. Traffic
 	// settings specified at the destination-level will not be inherited when
@@ -161,13 +161,13 @@ type PortTrafficPolicy struct {
 	// the same protocol the names should be of the form <protocol-name>-<DNS
 	// label>.
 	Port PortSelector `json:"port"`
-	
+
 	// Settings controlling the load balancer algorithms.
 	LoadBalancer *LoadBalancerSettings `json:"loadBalancer,omitempty"`
-	
+
 	// Settings controlling the volume of connections to an upstream service
 	ConnectionPool *ConnectionPoolSettings `json:"connectionPool,omitempty"`
-	
+
 	// Settings controlling eviction of unhealthy hosts from the load balancing pool
 	OutlierDetection *OutlierDetection `json:"outlierDetection,omitempty"`
 
@@ -207,11 +207,11 @@ type Subset struct {
 	// REQUIRED. Name of the subset. The service name and the subset name can
 	// be used for traffic splitting in a route rule.
 	Name string `json:"port"`
-	
+
 	// REQUIRED. Labels apply a filter over the endpoints of a service in the
 	// service registry. See route rules for examples of usage.
 	Labels map[string]string `json:"labels"`
-	
+
 	// Traffic policies that apply to this subset. Subsets inherit the
 	// traffic policies specified at the DestinationRule level. Settings
 	// specified at the subset level will override the corresponding settings
@@ -254,7 +254,7 @@ type Subset struct {
 //            name: user
 //            ttl: 0s
 type LoadBalancerSettings struct {
-	// It is requred to specify exactly one of the fields:
+	// It is required to specify exactly one of the fields:
 	// Simple or ConsistentHash
 	Simple         SimpleLB          `json:"simple,omitempty"`
 	ConsistentHash *ConsistentHashLB `json:"consistentHash,omitempty"`
@@ -266,17 +266,17 @@ type SimpleLB string
 const (
 	// Round Robin policy. Default
 	SimpleLBRoundRobin SimpleLB = "ROUND_ROBIN"
-	
+
 	// The least request load balancer uses an O(1) algorithm which selects
 	// two random healthy hosts and picks the host which has fewer active
 	// requests.
 	SimpleLBLeastConn SimpleLB = "LEAST_CONN"
-	
+
 	// The random load balancer selects a random healthy host. The random
 	// load balancer generally performs better than round robin if no health
 	// checking policy is configured.
 	SimpleLBRandom SimpleLB = "RANDOM"
-	
+
 	// This option will forward the connection to the original IP address
 	// requested by the caller without doing any form of load
 	// balancing. This option must be used with care. It is meant for
@@ -293,17 +293,17 @@ const (
 // service.
 type ConsistentHashLB struct {
 
-	// It is requred to specify exactly one of the fields as hash key:
+	// It is required to specify exactly one of the fields as hash key:
 	// HttpHeaderName, HttpCookie, or UseSourceIP.
 	// Hash based on a specific HTTP header.
 	HttpHeaderName string `json:"httpHeaderName,omitempty"`
-	
+
 	// Hash based on HTTP cookie.
 	HttpCookie *HTTPCookie `json:"httpCookie,omitempty"`
-	
+
 	// Hash based on the source IP address.
 	UseSourceIp bool `json:"useSourceIp,omitempty"`
-	
+
 	// The minimum number of virtual nodes to use for the hash
 	// ring. Defaults to 1024. Larger ring sizes result in more granular
 	// load distributions. If the number of hosts in the load balancing
@@ -359,7 +359,7 @@ type ConnectionPoolSettings struct {
 type TCPSettings struct {
 	// Maximum number of HTTP1 /TCP connections to a destination host.
 	MaxConnections int32 `json:"maxConnections,omitempty"`
-	
+
 	// TCP connection timeout.
 	ConnectTimeout string `json:"connectTimeout,omitempty"`
 }
@@ -368,14 +368,14 @@ type TCPSettings struct {
 type HTTPSettings struct {
 	// Maximum number of pending HTTP requests to a destination. Default 1024.
 	Http1MaxPendingRequests int32 `json:"http1MaxPendingRequests,omitempty"`
-	
+
 	// Maximum number of requests to a backend. Default 1024.
 	Http2MaxRequests int32 `json:"http2MaxRequests,omitempty"`
-	
+
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive.
 	MaxRequestsPerConnection int32 `json:"maxRequestsPerConnection,omitempty"`
-	
+
 	// Maximum number of retries that can be outstanding to all hosts in a
 	// cluster at a given time. Defaults to 3.
 	MaxRetries int32 `json:"maxRetries,omitempty"`
@@ -421,18 +421,18 @@ type OutlierDetection struct {
 	// accessed over an opaque TCP connection, connect timeouts and
 	// connection error/failure events qualify as an error.
 	ConsecutiveErrors int32 `json:"consecutiveErrors,omitempty"`
-	
+
 	// Time interval between ejection sweep analysis. format:
 	// 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.
 	Interval string `json:"interval,omitempty"`
-	
+
 	// Minimum ejection duration. A host will remain ejected for a period
 	// equal to the product of minimum ejection duration and the number of
 	// times the host has been ejected. This technique allows the system to
 	// automatically increase the ejection period for unhealthy upstream
 	// servers. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 30s.
 	BaseEjectionTime string `json:"baseEjectionTime,omitempty"`
-	
+
 	// Maximum % of hosts in the load balancing pool for the upstream
 	// service that can be ejected. Defaults to 10%.
 	MaxEjectionPercent int32 `json:"maxEjectionPercent,omitempty"`
@@ -488,29 +488,29 @@ type TLSSettings struct {
 	// REQUIRED: Indicates whether connections to this port should be secured
 	// using TLS. The value of this field determines how TLS is enforced.
 	Mode TLSmode `json:"mode"`
-	
+
 	// REQUIRED if mode is `MUTUAL`. The path to the file holding the
 	// client-side TLS certificate to use.
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	ClientCertificate string `json:"clientCertificate,omitempty"`
-	
+
 	// REQUIRED if mode is `MUTUAL`. The path to the file holding the
 	// client's private key.
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	PrivateKey string `json:"privateKey,omitempty"`
-	
+
 	// OPTIONAL: The path to the file containing certificate authority
 	// certificates to use in verifying a presented server certificate. If
 	// omitted, the proxy will not verify the server's certificate.
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `json:"caCertificates,omitempty"`
-	
+
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server
 	// certificate's subject alt name matches one of the specified values.
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	SubjectAltNames []string `json:"subjectAltNames,omitempty"`
-	
+
 	// SNI string to present to the server during TLS handshake.
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	Sni string `json:"sni,omitempty"`
@@ -525,11 +525,11 @@ const (
 
 	// Originate a TLS connection to the upstream endpoint.
 	TLSmodeSimple TLSmode = "SIMPLE"
-	
+
 	// Secure connections to the upstream using mutual TLS by presenting
 	// client certificates for authentication.
 	TLSmodeMutual TLSmode = "MUTUAL"
-	
+
 	// Secure connections to the upstream using mutual TLS by presenting
 	// client certificates for authentication.
 	// Compared to Mutual mode, this mode uses certificates generated

--- a/vendor/github.com/knative/pkg/apis/istio/v1alpha3/virtualservice_types.go
+++ b/vendor/github.com/knative/pkg/apis/istio/v1alpha3/virtualservice_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha3
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/knative/pkg/apis/istio/common/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +genclient

--- a/vendor/github.com/knative/pkg/controller/controller.go
+++ b/vendor/github.com/knative/pkg/controller/controller.go
@@ -151,7 +151,7 @@ func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel s
 		labels := object.GetLabels()
 		controllerKey, ok := labels[nameLabel]
 		if !ok {
-			c.logger.Infof("Object %s/%s does not have a referring name label %s",
+			c.logger.Debugf("Object %s/%s does not have a referring name label %s",
 				object.GetNamespace(), object.GetName(), nameLabel)
 			return
 		}
@@ -159,7 +159,7 @@ func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel s
 		if namespaceLabel != "" {
 			controllerNamespace, ok := labels[namespaceLabel]
 			if !ok {
-				c.logger.Infof("Object %s/%s does not have a referring namespace label %s",
+				c.logger.Debugf("Object %s/%s does not have a referring namespace label %s",
 					object.GetNamespace(), object.GetName(), namespaceLabel)
 				return
 			}
@@ -174,7 +174,6 @@ func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel s
 		c.EnqueueKey(fmt.Sprintf("%s/%s", object.GetNamespace(), controllerKey))
 	}
 }
-
 
 // EnqueueLabelOfClusterScopedResource returns with an Enqueue func
 // that takes a resource, identifies its controller resource through
@@ -191,7 +190,7 @@ func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj in
 		labels := object.GetLabels()
 		controllerKey, ok := labels[nameLabel]
 		if !ok {
-			c.logger.Infof("Object %s/%s does not have a referring name label %s",
+			c.logger.Debugf("Object %s/%s does not have a referring name label %s",
 				object.GetNamespace(), object.GetName(), nameLabel)
 			return
 		}

--- a/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
+++ b/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
@@ -46,13 +46,13 @@ const (
 var (
 	// KnativeRevisionLabels stores the set of resource labels for resource type knative_revision
 	KnativeRevisionLabels = map[string]struct{}{
-		LabelProject:           struct{}{},
-		LabelLocation:          struct{}{},
-		LabelClusterName:       struct{}{},
-		LabelNamespaceName:     struct{}{},
-		LabelServiceName:       struct{}{},
-		LabelConfigurationName: struct{}{},
-		LabelRevisionName:      struct{}{},
+		LabelProject:           {},
+		LabelLocation:          {},
+		LabelClusterName:       {},
+		LabelNamespaceName:     {},
+		LabelServiceName:       {},
+		LabelConfigurationName: {},
+		LabelRevisionName:      {},
 	}
 
 	// ResourceTypeToLabelsMap maps resource type to the set of resource labels

--- a/vendor/github.com/knative/pkg/test/zipkin/util.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/util.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/knative/pkg/test/logging"
 	"go.opencensus.io/trace"
-	"k8s.io/client-go/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -68,7 +68,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 		return errors.New("No Zipkin Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup")
 	}
 
-	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace=" + ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
+	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace="+ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
 	if err = portForwardCmd.Start(); err != nil {
 		return fmt.Errorf("Error starting kubectl port-forward command : %v", err)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1969

## Proposed Changes

  * add clusteringress config
  * update ingress reconciler to watch the configmap
  * remove knative-ingressgateway usage
  * add docs to tell how to set up gateway

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
- Remove `knative-ingressgateway`.
- Allow users to choose an alternative gateway other than `istio-ingressgateway`. 
```

/area networking
/kind feature
