### PR TITLE
 Implement E2E test that kills pods under an in-flight request.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	timeoutExpectedOutput  = "Slept for 0 milliseconds"
-	timeoutRequestDuration = 10 * time.Second
+	timeoutRequestDuration = 25 * time.Second
 )
 
 func TestDestroyPodInflight(t *testing.T) {
@@ -124,8 +124,8 @@ func TestDestroyPodInflight(t *testing.T) {
 		// Give the request a bit of time to be established and reach the pod.
 		time.Sleep(timeoutRequestDuration / 2)
 
-		logger.Info("Destroying the revision (also destroys the pods)")
-		return clients.ServingClient.Revisions.Delete(names.Revision, nil)
+		logger.Info("Destroying the configuration (also destroys the pods)")
+		return clients.ServingClient.Configs.Delete(names.Config, nil)
 	})
 
 	if err := g.Wait(); err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -1,0 +1,134 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	timeoutExpectedOutput  = "Slept for 0 milliseconds"
+	timeoutRequestDuration = 10 * time.Second
+)
+
+func TestDestroyPodInflight(t *testing.T) {
+	clients := Setup(t)
+
+	//add test case specific name to its own logger
+	logger := logging.GetContextLogger("TestDestroyPodInflight")
+
+	var imagePath = test.ImagePath("timeout")
+
+	logger.Info("Creating a new Route and Configuration")
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create Route and Configuration: %v", err)
+	}
+	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
+	defer TearDown(clients, names, logger)
+
+	logger.Info("When the Revision can have traffic routed to it, the Route is marked as Ready")
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
+	}
+
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+	}
+	domain := route.Status.Domain
+
+	err = test.WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+		if c.Status.LatestCreatedRevisionName != names.Revision {
+			names.Revision = c.Status.LatestCreatedRevisionName
+			return true, nil
+		}
+		return false, nil
+	}, "ConfigurationUpdatedWithRevision")
+	if err != nil {
+		t.Fatalf("Error obtaining Revision's name %v", err)
+	}
+
+	_, err = pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		logger,
+		domain,
+		pkgTest.Retrying(pkgTest.MatchesBody(timeoutExpectedOutput), http.StatusNotFound),
+		"TimeoutAppServesText",
+		test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
+	}
+
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		t.Fatalf("Error creating spoofing client: %v", err)
+	}
+
+	// The timeout app sleeps for the time passed via the timeout query parameter in milliseconds
+	timeoutRequestDurationInMillis := timeoutRequestDuration / time.Millisecond
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/?timeout=%d", domain, timeoutRequestDurationInMillis), nil)
+	if err != nil {
+		t.Fatalf("Error creating http request: %v", err)
+	}
+
+	g, _ := errgroup.WithContext(context.TODO())
+
+	g.Go(func() error {
+		logger.Info("Sending in a long running request")
+		res, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+
+		if res.StatusCode != 200 {
+			return fmt.Errorf("Expected response to have status 200, had %d", res.StatusCode)
+		}
+		expectedBody := fmt.Sprintf("Slept for %d milliseconds", timeoutRequestDurationInMillis)
+		gotBody := string(res.Body)
+		if gotBody != expectedBody {
+			return fmt.Errorf("Unexpected body, expected: %q got: %q", expectedBody, gotBody)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		// Give the request a bit of time to be established and reach the pod.
+		time.Sleep(timeoutRequestDuration / 2)
+
+		logger.Info("Destroying the revision (also destroys the pods)")
+		return clients.ServingClient.Revisions.Delete(names.Revision, nil)
+	})
+
+	if err := g.Wait(); err != nil {
+		t.Errorf("Something went wrong with the request: %v", err)
+	}
+}

--- a/test/test_images/timeout/README.md
+++ b/test/test_images/timeout/README.md
@@ -1,0 +1,13 @@
+# Helloworld test image
+
+This directory contains the test image used in the helloworld e2e test.
+
+The image contains a simple Go webserver, `helloworld.go`, that will, by default, listen on port `8080` and expose a service at `/`.
+
+When called, the server emits a "hello world" message.
+
+## Building
+
+For details about building and adding new images, see the [section about test
+images](/test/README.md#test-images).
+

--- a/test/test_images/timeout/README.md
+++ b/test/test_images/timeout/README.md
@@ -1,10 +1,10 @@
-# Helloworld test image
+# Timeout test image
 
-This directory contains the test image used in the helloworld e2e test.
+This directory contains the test image used in the destroy pod e2e test.
 
-The image contains a simple Go webserver, `helloworld.go`, that will, by default, listen on port `8080` and expose a service at `/`.
+The image contains a simple Go webserver, `timeout.go`, that will, by default, listen on port `8080` and expose a service at `/`.
 
-When called, the server emits a "hello world" message.
+When called, the server sleeps for the amount of milliseconds passed in via the query parameter `timeout` and responds with "Slept for X milliseconds` where X is the amount of milliseconds passed in.
 
 ## Building
 

--- a/test/test_images/timeout/timeout.go
+++ b/test/test_images/timeout/timeout.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/knative/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	timeout, _ := strconv.Atoi(r.URL.Query().Get("timeout"))
+	time.Sleep(time.Duration(timeout) * time.Millisecond)
+	fmt.Fprintf(w, "Slept for %d milliseconds", timeout)
+}
+
+func main() {
+	test.ListenAndServeGracefully(":8080", handler)
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2448

After fixing a whole lot of pod shutdown problems, I think we want a test to assert that pods are actually shutting down gracefully.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
