### PR TITLE
Document lifecycle handlers on user-container.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -64,21 +64,6 @@ var (
 			corev1.ResourceCPU: userContainerCPU,
 		},
 	}
-
-	// Add our own PreStop hook here, which should do two things:
-	// - make the container fails the next readinessCheck to avoid
-	//   having more traffic, and
-	// - add a small delay so that the container stays alive a little
-	//   bit longer in case stoppage of traffic is not effective
-	//   immediately.
-	userLifecycle = &corev1.Lifecycle{
-		PreStop: &corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port: intstr.FromInt(queue.RequestQueueAdminPort),
-				Path: queue.RequestQueueQuitPath,
-			},
-		},
-	}
 )
 
 func rewriteUserProbe(p *corev1.Probe) {
@@ -103,7 +88,6 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	userContainer.Resources = userResources
 	userContainer.Ports = userPorts
 	userContainer.VolumeMounts = append(userContainer.VolumeMounts, varLogVolumeMount)
-	userContainer.Lifecycle = userLifecycle
 	userContainer.Env = append(userContainer.Env, userEnv)
 	userContainer.Env = append(userContainer.Env, getKnativeEnvVar(rev)...)
 	// Prefer imageDigest from revision if available

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -65,12 +65,10 @@ var (
 		},
 	}
 
-	// Add our own PreStop hook here, which should do two things:
-	// - make the container fails the next readinessCheck to avoid
-	//   having more traffic, and
-	// - add a small delay so that the container stays alive a little
-	//   bit longer in case stoppage of traffic is not effective
-	//   immediately.
+	// This PreStop hook is actually calling an endpoint on the queue-proxy
+	// because of the way PreStop hooks are called by kubelet. We use this
+	// to block the user-container from exiting before the queue-proxy is ready
+	// to exit so we can guarantee that there are no more requests in flight.
 	userLifecycle = &corev1.Lifecycle{
 		PreStop: &corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -75,6 +75,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -156,6 +157,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -241,6 +243,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -335,6 +338,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -427,6 +431,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -521,6 +526,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -611,6 +617,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -692,6 +699,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -836,6 +844,7 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
+				Lifecycle:    userLifecycle,
 			}, {
 				Name:           queueContainerName,
 				Resources:      queueResources,

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -75,7 +75,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -157,7 +156,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -243,7 +241,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -338,7 +335,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -431,7 +427,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -526,7 +521,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -617,7 +611,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -699,7 +692,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 				Env: []corev1.EnvVar{userEnv,
 					{
 						Name:  "K_REVISION",
@@ -844,7 +836,6 @@ func TestMakePodSpec(t *testing.T) {
 				Resources:    userResources,
 				Ports:        userPorts,
 				VolumeMounts: []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:    userLifecycle,
 			}, {
 				Name:           queueContainerName,
 				Resources:      queueResources,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

~~I was wondering why these lifecycle hooks are there in the first place? We don't document the implementation of a `/quitquitquit` path, neither do we document setting up a seperate admin port. This seems to be a noop for the user-container, thus removing it.~~

**Edit:** Repurposed to document this nifty PreStop hook trick I didn't know about 😄 

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
