### PR TITLE
Bring up monitoring for perf tests

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -51,7 +51,6 @@ function install_knative_serving() {
   # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
   kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
   
-  echo ">> Override ${RELEASE_YAML_OVERRIDE}"
   if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
     kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
   else

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -48,10 +48,8 @@ function install_knative_serving() {
   kubectl apply -f "${ISTIO_YAML}" || return 1
 
   echo ">> Bringing up Serving"
-  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
-  kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
-  
   if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
+  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
     kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
   else
     kubectl apply -f "${RELEASE_YAML_OVERRIDE}" || return 1

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -48,8 +48,14 @@ function install_knative_serving() {
   kubectl apply -f "${ISTIO_YAML}" || return 1
 
   echo ">> Bringing up Serving"
-  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
-  kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
+  if [[ "${USE_MONITORING}" = true ]]; then
+    echo ">> Bringing up Serving with Monitoring"
+    kubectl apply -f "${RELEASE_YAML}" || return 1
+  else
+    # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
+    kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
+  fi
+
   if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
     kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
   else

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -48,14 +48,10 @@ function install_knative_serving() {
   kubectl apply -f "${ISTIO_YAML}" || return 1
 
   echo ">> Bringing up Serving"
-  if [[ "${USE_MONITORING}" = true ]]; then
-    echo ">> Bringing up Serving with Monitoring"
-    kubectl apply -f "${RELEASE_YAML}" || return 1
-  else
-    # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
-    kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
-  fi
-
+  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
+  kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
+  
+  echo ">> Override ${RELEASE_YAML_OVERRIDE}"
   if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
     kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
   else
@@ -100,12 +96,6 @@ function uninstall_knative_serving() {
   echo ">> Bringing down Istio"
   kubectl delete --ignore-not-found=true -f ${ISTIO_YAML} || return 1
   kubectl delete --ignore-not-found=true clusterrolebinding cluster-admin-binding
-}
-
-# Creates the prometheus component
-function create_prometheus() {
-  kubectl apply -R -f third_party/config/monitoring/metrics/prometheus \
-    -f config/monitoring/metrics/prometheus
 }
 
 # Create test namespace

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -49,7 +49,7 @@ function install_knative_serving() {
 
   echo ">> Bringing up Serving"
   if [[ -z "${RELEASE_YAML_OVERRIDE}" ]]; then
-  # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
+    # TODO(#2122): Use RELEASE_YAML once we have monitoring e2e.
     kubectl apply -f "${RELEASE_NO_MON_YAML}" || return 1
   else
     kubectl apply -f "${RELEASE_YAML_OVERRIDE}" || return 1

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -19,13 +19,10 @@
 
 source $(dirname $0)/cluster.sh
 
-readonly USE_MONITORING=true
-
 # Deletes everything created on the cluster including all knative and istio components.
 function teardown() {
   # Delete the service now that the test is done
-  kubectl delete --ignore-not-found=true -f ${TEST_APP_YAML}
-  uninstall_knative_serving
+  RELEASE_YAML_OVERRIDE=$RELEASE_YAML uninstall_knative_serving
 }
 
 initialize $@
@@ -36,7 +33,9 @@ header "Setting up environment"
 set +o errexit
 set +o pipefail
 
-install_knative_serving || fail_test "Knative Serving installation failed"
+create_manifests
+
+RELEASE_YAML_OVERRIDE=$RELEASE_YAML install_knative_serving || fail_test "Knative Serving installation failed"
 publish_test_images || fail_test "one or more test images weren't published"
 
 create_namespace || fail_test "cannot create test namespace"

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -19,11 +19,12 @@
 
 source $(dirname $0)/cluster.sh
 
+readonly USE_MONITORING=true
+
 # Deletes everything created on the cluster including all knative and istio components.
 function teardown() {
   # Delete the service now that the test is done
   kubectl delete --ignore-not-found=true -f ${TEST_APP_YAML}
-  uninstall_knative_serving
 }
 
 initialize $@
@@ -35,7 +36,6 @@ set +o errexit
 set +o pipefail
 
 install_knative_serving || fail_test "Knative Serving installation failed"
-create_prometheus || fail_test "Prometheus creation failed"
 publish_test_images || fail_test "one or more test images weren't published"
 
 create_namespace || fail_test "cannot create test namespace"

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -25,6 +25,7 @@ readonly USE_MONITORING=true
 function teardown() {
   # Delete the service now that the test is done
   kubectl delete --ignore-not-found=true -f ${TEST_APP_YAML}
+  uninstall_knative_serving
 }
 
 initialize $@


### PR DESCRIPTION
Creating prometheus needs the monitoring namespace. Installing all monitoring components for perf tests, instead of doign only prometheus instead, which created all the necessary components including prometheus