### PR TITLE
Pass annotations from route to clusteringress

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -42,6 +42,7 @@ func MakeVirtualService(ci *v1alpha1.ClusterIngress) *v1alpha3.VirtualService {
 			Name:            names.VirtualService(ci),
 			Namespace:       system.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
+			Annotations:     ci.ObjectMeta.Annotations,
 		},
 		Spec: *makeVirtualServiceSpec(ci),
 	}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -48,6 +48,7 @@ func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.TrafficConfig) *v1
 				serving.RouteNamespaceLabelKey: r.Namespace,
 			},
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
+			Annotations:     r.ObjectMeta.Annotations,
 		},
 		Spec: makeClusterIngressSpec(r, tc.Targets),
 	}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -22,9 +22,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -36,6 +38,9 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
+			Annotations: map[string]string{
+				networking.IngressClassAnnotationKey: clusteringress.IstioIngressClassName,
+			},
 		},
 		Status: v1alpha1.RouteStatus{Domain: "domain.com"},
 	}
@@ -44,6 +49,9 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		Labels: map[string]string{
 			serving.RouteLabelKey:          "test-route",
 			serving.RouteNamespaceLabelKey: "test-ns",
+		},
+		Annotations: map[string]string{
+			networking.IngressClassAnnotationKey: clusteringress.IstioIngressClassName,
 		},
 		OwnerReferences: []metav1.OwnerReference{
 			*kmeta.NewControllerRef(r),


### PR DESCRIPTION
We are going to use route annotations to specify user-defined
clusteringress controllers. This means we need to pass annotations from
routes on to the clusteringress resources they create.

Related-to: #2322

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
