### PR TITLE
Filter ClusterIngress by controller class

### DIFF
--- a/pkg/reconciler/filter.go
+++ b/pkg/reconciler/filter.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AnnotationFilterFunc creates a FilterFunc only accepting objects with given annotation key and value
+func AnnotationFilterFunc(key string, value string, allowUnset bool) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		if mo, ok := obj.(metav1.Object); ok {
+			anno := mo.GetAnnotations()
+			annoVal, ok := anno[key]
+			if !ok {
+				return allowUnset
+			}
+			return annoVal == value
+		}
+		return false
+	}
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -39,7 +39,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const controllerAgentName = "clusteringress-controller"
+const (
+	// IstioIngressClassName value for specifying knative's Istio
+	// ClusterIngress reconciler.
+	IstioIngressClassName = "istio.ingress.networking.knative.dev"
+
+	controllerAgentName = "clusteringress-controller"
+)
 
 // Reconciler implements controller.Reconciler for ClusterIngress resources.
 type Reconciler struct {
@@ -69,16 +75,23 @@ func NewController(
 	impl := controller.NewImpl(c, c.Logger, "ClusterIngresses", reconciler.MustNewStatsReporter("ClusterIngress", c.Logger))
 
 	c.Logger.Info("Setting up event handlers")
-	clusterIngressInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    impl.Enqueue,
-		UpdateFunc: controller.PassNew(impl.Enqueue),
-		DeleteFunc: impl.Enqueue,
+	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, IstioIngressClassName, true)
+	clusterIngressInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: myFilterFunc,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    impl.Enqueue,
+			UpdateFunc: controller.PassNew(impl.Enqueue),
+			DeleteFunc: impl.Enqueue,
+		},
 	})
 
-	virtualServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    impl.EnqueueLabelOf("", networking.IngressLabelKey),
-		UpdateFunc: controller.PassNew(impl.EnqueueLabelOf("", networking.IngressLabelKey)),
-		DeleteFunc: impl.EnqueueLabelOf("", networking.IngressLabelKey),
+	virtualServiceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: myFilterFunc,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    impl.EnqueueLabelOf("", networking.IngressLabelKey),
+			UpdateFunc: controller.PassNew(impl.EnqueueLabelOf("", networking.IngressLabelKey)),
+			DeleteFunc: impl.EnqueueLabelOf("", networking.IngressLabelKey),
+		},
 	})
 
 	return impl

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -77,6 +77,13 @@ func TestReconcile(t *testing.T) {
 		Key:                     "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
+		Name:                    "skip ingress not matching class key",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			addAnnotations(ingress("no-virtualservice-yet", 1234),
+				map[string]string{networking.IngressClassAnnotationKey: "fake-controller"}),
+		},
+	}, {
 		Name:                    "create VirtualService matching ClusterIngress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
@@ -165,6 +172,17 @@ func TestReconcile(t *testing.T) {
 			clusterIngressLister: listers.GetClusterIngressLister(),
 		}
 	}))
+}
+
+func addAnnotations(ing *v1alpha1.ClusterIngress, annos map[string]string) *v1alpha1.ClusterIngress {
+	if ing.ObjectMeta.Annotations == nil {
+		ing.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	for k, v := range annos {
+		ing.ObjectMeta.Annotations[k] = v
+	}
+	return ing
 }
 
 func ingressWithStatus(name string, generation int64, status v1alpha1.IngressStatus) *v1alpha1.ClusterIngress {


### PR DESCRIPTION
In order to support pluggable ClusterIngress controllers we need to
filter which of these resources we reconcile based on our class
annotation key.

Fixes: #2322

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
ClusterIngress resource reconcilers are user selectable using the class annotation key.
```
