### PR TITLE
Remove arbitrary 20 second sleep in queue-proxy.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -33,9 +33,9 @@ import (
 
 	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/cmd/util"
-	kbufferutil "github.com/knative/serving/pkg/kbuffer/util"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/http/h2c"
+	kbufferutil "github.com/knative/serving/pkg/kbuffer/util"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/system"
@@ -50,11 +50,6 @@ const (
 	statReportingQueueLength = 10
 	// Add enough buffer to not block request serving on stats collection
 	requestCountingQueueLength = 100
-	// Number of seconds the /quitquitquit handler should wait before
-	// returning.  The purpose is to keep the container alive a little
-	// bit longer, that it doesn't go away until the pod is truly
-	// removed from service.
-	quitSleepSecs = 20
 )
 
 var (
@@ -74,6 +69,8 @@ var (
 	h2cProxy  *httputil.ReverseProxy
 	httpProxy *httputil.ReverseProxy
 
+	server *http.Server
+
 	health = &healthServer{alive: true}
 )
 
@@ -92,22 +89,25 @@ func initEnv() {
 func statReporter() {
 	for {
 		s := <-statChan
-		if statSink == nil {
-			logger.Warn("Stat sink not (yet) connected.")
-			continue
-		}
-		if !health.isAlive() {
-			s.LameDuck = true
-		}
-		sm := autoscaler.StatMessage{
-			Stat: *s,
-			Key:  servingRevisionKey,
-		}
-		err := statSink.Send(sm)
-		if err != nil {
+		if err := sendStat(s); err != nil {
 			logger.Error("Error while sending stat", zap.Error(err))
 		}
 	}
+}
+
+// sendStat sends a single StatMessage to the autoscaler.
+func sendStat(s *autoscaler.Stat) error {
+	if statSink == nil {
+		return fmt.Errorf("stat sink not (yet) connected")
+	}
+	if !health.isAlive() {
+		s.LameDuck = true
+	}
+	sm := autoscaler.StatMessage{
+		Stat: *s,
+		Key:  servingRevisionKey,
+	}
+	return statSink.Send(sm)
 }
 
 func proxyForRequest(req *http.Request) *httputil.ReverseProxy {
@@ -183,24 +183,36 @@ func (h *healthServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// quitHandler() is used for preStop hook of queue-proxy. It:
-// - marks the service as not ready, so that requests will no longer
-//   be routed to it,
-// - adds a small delay, so that the container doesn't get killed at
-//   the same time the pod is marked for removal.
+// quitHandler() is used for preStop hook of queue-proxy. It shuts down its main
+// server and blocks until it gets successfully shut down.
+// This endpoint is also called by the user-container to block its shutdown until
+// the queue-proxy's proxy server is shutdown successfully.
 func (h *healthServer) quitHandler(w http.ResponseWriter, r *http.Request) {
-	// First, we want to mark the container as not ready, so that even
-	// if the pod removal (from service) isn't yet effective, the
-	// readinessCheck will still prevent traffic to be routed to this
-	// pod.
+	// First mark the server as unhealthy to cause lameduck metrics being sent
 	h.kill()
-	// However, since both readinessCheck and pod removal from service
-	// is eventually consistent, we add here a small delay to have the
-	// container stay alive a little bit longer after.  We still have
-	// no guarantee that container termination is done only after
-	// removal from service is effective, but this has been showed to
-	// alleviate the issue.
-	time.Sleep(quitSleepSecs * time.Second)
+
+	// Force send one (empty) metric to mark the pod as a lameduck before shutting
+	// it down.
+	now := time.Now()
+	s := &autoscaler.Stat{
+		Time:     &now,
+		PodName:  podName,
+		LameDuck: true,
+	}
+	if err := sendStat(s); err != nil {
+		logger.Error("Error while sending stat", zap.Error(err))
+	}
+
+	// Shutdown the server.
+	currentServer := server
+	if currentServer != nil {
+		if err := currentServer.Shutdown(context.Background()); err != nil {
+			logger.Error("Failed to shutdown proxy-server", zap.Error(err))
+		} else {
+			logger.Debug("Proxy server shutdown successfully.")
+		}
+	}
+
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, "alive: false")
 }
@@ -267,7 +279,7 @@ func main() {
 		Handler: nil,
 	}
 
-	server := h2c.NewServer(
+	server = h2c.NewServer(
 		fmt.Sprintf(":%d", queue.RequestQueuePort),
 		http.HandlerFunc(handler),
 	)
@@ -282,12 +294,7 @@ func main() {
 	<-sigTermChan
 	// Calling server.Shutdown() allows pending requests to
 	// complete, while no new work is accepted.
-	logger.Debug("Received shutdown signal, attempting to gracefully shutdown servers.")
-	if err := server.Shutdown(context.Background()); err != nil {
-		logger.Error("Failed to shutdown proxy-server", zap.Error(err))
-	} else {
-		logger.Debug("Proxy server shutdown successfully.")
-	}
+	logger.Debug("Received TERM signal, attempting to gracefully shutdown servers.")
 	if err := adminServer.Shutdown(context.Background()); err != nil {
 		logger.Error("Failed to shutdown admin-server", zap.Error(err))
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Waiting for 20 seconds before shutting down the queue-proxy is quite arbitrary. This moves the server's shutdown into the quitquitquit handler, so the user-container will block it's own shutdown on it's own upstream being shut down which should nicely stage shutdown between the two.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
* User-container and queue-proxy coordinate their shutdown so that no connection are lost arbitrarily.
```
