### PR TITLE
Tweak the logic in the helper used to access the last time changed.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/helpers.go
+++ b/pkg/reconciler/v1alpha1/revision/helpers.go
@@ -46,11 +46,11 @@ func getIsServiceReady(e *corev1.Endpoints) bool {
 }
 
 func getRevisionLastTransitionTime(r *v1alpha1.Revision) time.Time {
-	condCount := len(r.Status.Conditions)
-	if condCount == 0 {
+	ready := r.Status.GetCondition(v1alpha1.RevisionConditionReady)
+	if ready == nil {
 		return r.CreationTimestamp.Time
 	}
-	return r.Status.Conditions[condCount-1].LastTransitionTime.Inner.Time
+	return ready.LastTransitionTime.Inner.Time
 }
 
 func hasDeploymentTimedOut(deployment *appsv1.Deployment) bool {


### PR DESCRIPTION
Previously this relied on the ordering of Conditions changing to pick up the last-changed condition.  This adjusts that logic to key off of Ready, which generally changes to reflect other transitions.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->