### PR TITLE
Make it easier to install different Knative versions in E2E tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -443,7 +443,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:27624809aadb079bd3f09ed8e9f1cb9d56887ba707d241a144b531137a35f4f9"
+  digest = "1:77684a2a5fa2b1c519b891ba70fcd44c36c5c2eee28100d3fddf56e0ef17a84b"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -451,7 +451,7 @@
     "tools/testgrid",
   ]
   pruneopts = "UT"
-  revision = "48ce29742843637bf0ba9bc5aed78e926e513e13"
+  revision = "6add8fe8265eaca9e1a218ed0c8701099e6c2c19"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -71,7 +71,6 @@ publish_test_images || fail_test "one or more test images weren't published"
 # Run the tests
 
 header "Running tests"
-create_namespace
 go_test_e2e -timeout=20m ./test/conformance ./test/e2e || fail_test
 
 success

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -35,7 +35,7 @@ set +o pipefail
 # Build Knative, but don't install the default "no monitoring" version
 build_knative_from_source
 install_knative_serving "${ISTIO_CRD_YAML}" "${ISTIO_YAML}" "${RELEASE_YAML}" \
-    fail_test "Knative Serving installation failed"
+    || fail_test "Knative Serving installation failed"
 publish_test_images || fail_test "one or more test images weren't published"
 
 # Run the tests

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -21,8 +21,7 @@ source $(dirname $0)/cluster.sh
 
 # Deletes everything created on the cluster including all knative and istio components.
 function teardown() {
-  # Delete the service now that the test is done
-  RELEASE_YAML_OVERRIDE=$RELEASE_YAML uninstall_knative_serving
+  uninstall_knative_serving
 }
 
 initialize $@
@@ -33,13 +32,13 @@ header "Setting up environment"
 set +o errexit
 set +o pipefail
 
-create_manifests
-
-RELEASE_YAML_OVERRIDE=$RELEASE_YAML install_knative_serving || fail_test "Knative Serving installation failed"
+# Build Knative, but don't install the default "no monitoring" version
+build_knative_from_source
+install_knative_serving "${ISTIO_CRD_YAML}" "${ISTIO_YAML}" "${RELEASE_YAML}" \
+    fail_test "Knative Serving installation failed"
 publish_test_images || fail_test "one or more test images weren't published"
 
-create_namespace || fail_test "cannot create test namespace"
-
+# Run the tests
 go_test_e2e -tags=performance -timeout=5m ./test/performance || fail_test
 
 success

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -44,16 +44,6 @@ function unit_tests() {
   report_go_test ./...
 }
 
-function integration_tests() {
-  local options=""
-  (( EMIT_METRICS )) && options="--emit-metrics"
-  ./test/e2e-tests.sh ${options}
-}
-
-function upgrade_tests() {
-  local options=""
-  (( EMIT_METRICS )) && options="--emit-metrics"
-  ./test/upgrade-tests.sh ${options}
-}
+# We use the default integration test runner.
 
 main $@

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -37,11 +37,11 @@ source $(dirname $0)/cluster.sh
 # version will make tests either:
 # 1. Still pass, meaning we can upgrade from earlier than latest release (good).
 # 2. Fail, which might be remedied by bumping this version.
-readonly LATEST_SERVING_RELEASE_YAML=0.2.2
+readonly LATEST_SERVING_RELEASE_VERSION=0.2.2
 
 function install_latest_release() {
   header "Installing Knative latest public release"
-  local url="https://github.com/knative/serving/releases/download/v${LATEST_SERVING_RELEASE_YAML}"
+  local url="https://github.com/knative/serving/releases/download/v${LATEST_SERVING_RELEASE_VERSION}"
   install_knative_serving \
     "${url}/istio-crds.yaml" \
     "${url}/istio.yaml" \

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -45,6 +45,9 @@ readonly E2E_CLUSTER_NODES=3
 readonly E2E_CLUSTER_MACHINE=n1-standard-4
 readonly TEST_RESULT_FILE=/tmp/${E2E_BASE_NAME}-e2e-result
 
+# Flag whether test is using a boskos GCP project
+IS_BOSKOS=0
+
 # Tear down the test resources.
 function teardown_test_resources() {
   header "Tearing down test environment"
@@ -53,8 +56,8 @@ function teardown_test_resources() {
     teardown
   fi
 
-  # Delete Knative Serving images when using prow.
-  if (( IS_PROW )); then
+  # Delete Knative Serving images when using boskos.
+  if (( IS_BOSKOS )); then
     echo "Images in ${DOCKER_REPO_OVERRIDE}:"
     gcloud container images list --repository=${DOCKER_REPO_OVERRIDE}
     delete_gcr_images ${DOCKER_REPO_OVERRIDE}
@@ -83,11 +86,12 @@ function go_test_e2e() {
 }
 
 # Download the k8s binaries required by kubetest.
+# Parameters: $1 - GCP project that will host the test cluster.
 function download_k8s() {
   local version=${E2E_CLUSTER_VERSION}
   # Fetch valid versions
   local versions="$(gcloud container get-server-config \
-      --project=${GCP_PROJECT} \
+      --project=$1 \
       --format='value(validMasterVersions)' \
       --region=${E2E_CLUSTER_REGION})"
   local gke_versions=(`echo -n ${versions//;/ /}`)
@@ -118,6 +122,7 @@ function download_k8s() {
     mv kubernetes/client/kubernetes-client-*.tar.gz .
     rm -fr kubernetes
     # Create an empty kubernetes test tarball; we don't use it but kubetest will fetch it
+    # As of August 21 2018 this means avoiding a useless 1.2GB download
     tar -czf kubernetes-test.tar.gz -T /dev/null
   fi
   popd
@@ -128,7 +133,7 @@ function download_k8s() {
 # This is intended to be called when a test fails to provide debugging information.
 function dump_cluster_state() {
   echo "***************************************"
-  echo "***           TEST FAILED           ***"
+  echo "***         E2E TEST FAILED         ***"
   echo "***    Start of information dump    ***"
   echo "***************************************"
   echo ">>> All resources:"
@@ -139,7 +144,7 @@ function dump_cluster_state() {
   kubectl get events --all-namespaces
   function_exists dump_extra_cluster_state && dump_extra_cluster_state
   echo "***************************************"
-  echo "***           TEST FAILED           ***"
+  echo "***         E2E TEST FAILED         ***"
   echo "***     End of information dump     ***"
   echo "***************************************"
 }
@@ -162,10 +167,10 @@ function create_test_cluster() {
     --gcp-network="${E2E_NETWORK_NAME}"
     --gke-environment=prod
   )
-  if (( ! IS_PROW )); then
-    CLUSTER_CREATION_ARGS+=(--gcp-project=${PROJECT_ID:?"PROJECT_ID must be set to the GCP project where the tests are run."})
-  else
+  if (( IS_BOSKOS )); then
     CLUSTER_CREATION_ARGS+=(--gcp-service-account=/etc/service-account/service-account.json)
+  else
+    CLUSTER_CREATION_ARGS+=(--gcp-project=${GCP_PROJECT})
   fi
   # SSH keys are not used, but kubetest checks for their existence.
   # Touch them so if they don't exist, empty files are create to satisfy the check.
@@ -177,15 +182,19 @@ function create_test_cluster() {
   # be a writeable docker repo.
   export K8S_USER_OVERRIDE=
   export K8S_CLUSTER_OVERRIDE=
-  # Get the current GCP project
-  export GCP_PROJECT=${PROJECT_ID}
-  [[ -z ${GCP_PROJECT} ]] && export GCP_PROJECT=$(gcloud config get-value project)
   # Assume test failed (see more details at the end of this script).
   echo -n "1"> ${TEST_RESULT_FILE}
   local test_cmd_args="--run-tests"
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
+  [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
+  # Get the current GCP project for downloading kubernetes
+  local gcloud_project="${GCP_PROJECT}"
+  [[ -z "${gcloud_project}" ]] && gcloud_project="$(gcloud config get-value project)"
+  echo "gcloud project is ${gcloud_project}"
+  (( IS_BOSKOS )) && echo "Using boskos for the test cluster"
+  [[ -n "${GCP_PROJECT}" ]] && echo "GCP project for test cluster is ${GCP_PROJECT}"
   echo "Test script is ${E2E_SCRIPT}"
-  download_k8s || return 1
+  download_k8s ${gcloud_project} || return 1
   # Don't fail test for kubetest, as it might incorrectly report test failure
   # if teardown fails (for details, see success() below)
   set +o errexit
@@ -194,29 +203,31 @@ function create_test_cluster() {
     --up \
     --down \
     --extract local \
-    --gcp-node-image ${SERVING_GKE_IMAGE} \
+    --gcp-node-image "${SERVING_GKE_IMAGE}" \
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}"
   echo "Test subprocess exited with code $?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
+  # Ensure we're using the GCP project used by kubetest
+  gcloud_project="$(gcloud config get-value project)"
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.
   local http_health_checks="$(gcloud compute target-pools list \
-    --project=${GCP_PROJECT} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     grep httpHealthChecks | tr '\n' ' ')"
   local target_pools="$(gcloud compute target-pools list \
-    --project=${GCP_PROJECT} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     tr '\n' ' ')"
   if [[ -n "${target_pools}" ]]; then
     echo "Found leaked target pools, deleting"
-    gcloud compute forwarding-rules delete -q --project=${GCP_PROJECT} --region=${E2E_CLUSTER_REGION} ${target_pools}
-    gcloud compute target-pools delete -q --project=${GCP_PROJECT} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
   fi
   if [[ -n "${http_health_checks}" ]]; then
     echo "Found leaked health checks, deleting"
-    gcloud compute http-health-checks delete -q --project=${GCP_PROJECT} ${http_health_checks}
+    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
   fi
   local result="$(cat ${TEST_RESULT_FILE})"
   echo "Test result code is $result"
@@ -252,6 +263,8 @@ function setup_test_cluster() {
   echo "- User is ${K8S_USER_OVERRIDE}"
   echo "- Docker is ${DOCKER_REPO_OVERRIDE}"
 
+  export KO_DOCKER_REPO="${DOCKER_REPO_OVERRIDE}"
+
   trap teardown_test_resources EXIT
 
   if (( USING_EXISTING_CLUSTER )) && function_exists teardown; then
@@ -276,7 +289,7 @@ function success() {
   # TODO(adrcunha): Get rid of this workaround.
   echo -n "0"> ${TEST_RESULT_FILE}
   echo "**************************************"
-  echo "***        ALL TESTS PASSED        ***"
+  echo "***        E2E TESTS PASSED        ***"
   echo "**************************************"
   exit 0
 }
@@ -284,6 +297,7 @@ function success() {
 RUN_TESTS=0
 EMIT_METRICS=0
 USING_EXISTING_CLUSTER=1
+GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
 
@@ -319,6 +333,11 @@ function initialize() {
     case $parameter in
       --run-tests) RUN_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
+      --gcp-project)
+        shift
+        [[ $# -ge 1 ]] || abort "missing project name after --gcp-project"
+        GCP_PROJECT=$1
+        ;;
       --cluster-version)
         shift
         [[ $# -ge 1 ]] || abort "missing version after --cluster-version"
@@ -326,15 +345,29 @@ function initialize() {
         E2E_CLUSTER_VERSION=$1
         ;;
       *)
-        echo "usage: $0 [--run-tests][--emit-metrics][--cluster-version X.Y.Z]"
+        echo "usage: $0 [--run-tests][--emit-metrics][--cluster-version X.Y.Z][--gcp-project name]"
         abort "unknown option ${parameter}"
         ;;
     esac
     shift
   done
+
+  # Use PROJECT_ID if set, unless --gcp-project was used.
+  if [[ -n "${PROJECT_ID:-}" && -z "${GCP_PROJECT}" ]]; then
+    echo "\$PROJECT_ID is set to '${PROJECT_ID}', using it to run the tests"
+    GCP_PROJECT="${PROJECT_ID}"
+  fi
+  if (( ! IS_PROW )) && [[ -z "${GCP_PROJECT}" ]]; then
+    abort "set \$PROJECT_ID or use --gcp-project to select the GCP project where the tests are run"
+  fi
+
+  (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
+
   readonly RUN_TESTS
   readonly EMIT_METRICS
   readonly E2E_CLUSTER_VERSION
+  readonly GCP_PROJECT
+  readonly IS_BOSKOS
 
   if (( ! RUN_TESTS )); then
     create_test_cluster

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -20,7 +20,7 @@
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Extensions or file patterns that don't require presubmit tests.
-readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS)
+readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS ^OWNERS_ALIASES)
 
 # Options set by command-line flags.
 RUN_BUILD_TESTS=0
@@ -48,6 +48,11 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
+function abort() {
+  echo "error: $@"
+  exit 1
+}
+
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
@@ -65,50 +70,51 @@ function main() {
     go version
   fi
 
-  local all_parameters=$@
-  [[ -z $1 ]] && all_parameters="--all-tests"
+  [[ -z $1 ]] && set -- "--all-tests"
 
-  for parameter in ${all_parameters}; do
+  local TEST_TO_RUN=""
+
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
     case ${parameter} in
+      --build-tests) RUN_BUILD_TESTS=1 ;;
+      --unit-tests) RUN_UNIT_TESTS=1 ;;
+      --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
+      --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
         RUN_UNIT_TESTS=1
         RUN_INTEGRATION_TESTS=1
+        ;;
+      --run-test)
         shift
+        [[ $# -ge 1 ]] || abort "missing executable after --run-test"
+        TEST_TO_RUN=$1
         ;;
-      --build-tests)
-        RUN_BUILD_TESTS=1
-        shift
-        ;;
-      --unit-tests)
-        RUN_UNIT_TESTS=1
-        shift
-        ;;
-      --integration-tests)
-        RUN_INTEGRATION_TESTS=1
-        shift
-        ;;
-      --emit-metrics)
-        EMIT_METRICS=1
-        shift
-        ;;
-      *)
-        echo "error: unknown option ${parameter}"
-        exit 1
-        ;;
+      *) abort "error: unknown option ${parameter}" ;;
     esac
+    shift
   done
 
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
   readonly EMIT_METRICS
+  readonly TEST_TO_RUN
 
   cd ${REPO_ROOT_DIR}
 
   # Tests to be performed, in the right order if --all-tests is passed.
 
   local failed=0
+
+  if [[ -n "${TEST_TO_RUN}" ]]; then
+    if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
+      abort "--run-test must be used alone"
+    fi
+    ${TEST_TO_RUN} || failed=1
+  fi
+
   if (( RUN_BUILD_TESTS )); then
     build_tests || failed=1
   fi
@@ -116,21 +122,38 @@ function main() {
     unit_tests || failed=1
   fi
   if (( RUN_INTEGRATION_TESTS )); then
+    local e2e_failed=0
+    # Run pre-integration tests, if any
     if function_exists pre_integration_tests; then
-      pre_integration_tests || failed=1
+      if ! pre_integration_tests; then
+        failed=1
+        e2e_failed=1
+      fi
     fi
-    if (( ! failed )); then
+    # Don't run integration tests if pre-integration tests failed
+    if (( ! e2e_failed )); then
       if function_exists integration_tests; then
-        integration_tests || failed=1
+        if ! integration_tests; then
+          failed=1
+          e2e_failed=1
+        fi
       else
        local options=""
        (( EMIT_METRICS )) && options="--emit-metrics"
-       ./test/e2e-tests.sh ${options} || failed=1
+       for e2e_test in ./test/e2e-*tests.sh; do
+         echo "Running integration test ${e2e_test}"
+         if ! ${e2e_test} ${options}; then
+           failed=1
+           e2e_failed=1
+         fi
+       done
       fi
     fi
-    if (( ! failed )) && function_exists post_integration_tests; then
+    # Don't run post-integration
+    if (( ! e2e_failed )) && function_exists post_integration_tests; then
       post_integration_tests || failed=1
     fi
   fi
+
   exit ${failed}
 }

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -110,10 +110,8 @@ function parse_flags() {
   fi
 
   if (( TAG_RELEASE )); then
-    local commit="$(git rev-parse --short HEAD)"
-    if [[ "$(git describe --dirty)" == *-dirty ]]; then
-      commit+="-dirty"
-    fi
+    # Get the commit, excluding any tags but keeping the "dirty" flag
+    local commit="$(git describe --always --dirty --exclude '*')"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi

--- a/vendor/github.com/knative/test-infra/tools/testgrid/testgrid.go
+++ b/vendor/github.com/knative/test-infra/tools/testgrid/testgrid.go
@@ -20,6 +20,7 @@ package testgrid
 
 import (
 	"encoding/xml"
+	"log"
 	"os"
 )
 
@@ -47,6 +48,23 @@ type TestCase struct {
 type TestSuite struct {
 	XMLName   xml.Name   `xml:"testsuite"`
 	TestCases []TestCase `xml:"testcase"`
+}
+
+// GetArtifactsDir gets the aritfacts directory where we should put the artifacts.
+// By default, it will look at the env var ARTIFACTS.
+func GetArtifactsDir() string {
+	dir := os.Getenv("ARTIFACTS")
+	if dir == "" {
+		log.Printf("Env variable ARTIFACTS not set. Using './artifacts' instead.")
+		return "./artifacts"
+	}
+	return dir
+}
+
+// CreateTestgridXML junit xml file in the default artifacts directory
+func CreateTestgridXML(tc []TestCase) error {
+	ts := TestSuite{TestCases: tc}
+	return CreateXMLOutput(ts, GetArtifactsDir())
 }
 
 // CreateXMLOutput creates the junit xml file in the provided artifacts directory


### PR DESCRIPTION
Bonuses:
* remove dead/unnecessary code in presubmits
* update upgrade tests to Knative 0.2.2
* update test-infra to the latest version to get
  * --gcp-project for E2E tests
  * --run-test for presubmit tests
  * assorted minor enhancements/fixes