### PR TITLE
Rename kbuffer revision_response_count to revision_request_count

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
@@ -761,97 +761,6 @@ data:
                               "datasource":"prometheus",
                               "fill":1,
                               "gridPos":{  
-                                 "h":11,
-                                 "w":24,
-                                 "x":0,
-                                 "y":1
-                              },
-                              "id":22,
-                              "legend":{  
-                                 "avg":false,
-                                 "current":false,
-                                 "max":false,
-                                 "min":false,
-                                 "show":true,
-                                 "total":false,
-                                 "values":false
-                              },
-                              "lines":true,
-                              "linewidth":1,
-                              "links":[  
-
-                              ],
-                              "nullPointMode":"null",
-                              "percentage":false,
-                              "pointradius":5,
-                              "points":false,
-                              "renderer":"flot",
-                              "seriesOverrides":[  
-
-                              ],
-                              "spaceLength":10,
-                              "stack":false,
-                              "steppedLine":false,
-                              "targets":[  
-                                 {  
-                                    "expr":"label_replace(sum(increase(kbuffer_revision_request_count{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (destination_revision), \"destination_revision\", \"$2\", \"destination_revision\", \"$configuration(-+)(.*)\")",
-                                    "format":"time_series",
-                                    "interval":"",
-                                    "intervalFactor":1,
-                                    "legendFormat":"{{destination_revision}}",
-                                    "refId":"A"
-                                 }
-                              ],
-                              "thresholds":[  
-
-                              ],
-                              "timeFrom":null,
-                              "timeShift":null,
-                              "title":"Request Count in last minute by Revision",
-                              "tooltip":{  
-                                 "shared":true,
-                                 "sort":0,
-                                 "value_type":"individual"
-                              },
-                              "type":"graph",
-                              "xaxis":{  
-                                 "buckets":null,
-                                 "mode":"time",
-                                 "name":null,
-                                 "show":true,
-                                 "values":[  
-
-                                 ]
-                              },
-                              "yaxes":[  
-                                 {  
-                                    "format":"none",
-                                    "label":null,
-                                    "logBase":1,
-                                    "max":null,
-                                    "min":"0",
-                                    "show":true
-                                 },
-                                 {  
-                                    "format":"short",
-                                    "label":null,
-                                    "logBase":1,
-                                    "max":null,
-                                    "min":null,
-                                    "show":true
-                                 }
-                              ]
-                           },
-                           {  
-                              "aliasColors":{  
-
-                              },
-                              "bars":false,
-                              "dashLength":10,
-                              "dashes":false,
-                              "datasource":"prometheus",
-                              "fill":1,
-                              "gridPos":{  
                                  "h":10,
                                  "w":24,
                                  "x":0,
@@ -885,7 +794,7 @@ data:
                               "steppedLine":false,
                               "targets":[  
                                  {  
-                                    "expr":"round(sum(increase(kbuffer_revision_response_count{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (response_code))",
+                                    "expr":"round(sum(increase(kbuffer_revision_request_count{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (response_code))",
                                     "format":"time_series",
                                     "intervalFactor":1,
                                     "legendFormat":"{{ response_code }}",
@@ -897,7 +806,7 @@ data:
                               ],
                               "timeFrom":null,
                               "timeShift":null,
-                              "title":"Response Count in last minute by Response Code",
+                              "title":"Request Count in last minute by Response Code",
                               "tooltip":{  
                                  "shared":true,
                                  "sort":0,

--- a/pkg/kbuffer/handler/handler.go
+++ b/pkg/kbuffer/handler/handler.go
@@ -21,9 +21,9 @@ import (
 	"strconv"
 	"time"
 
+	pkghttp "github.com/knative/serving/pkg/http"
 	"github.com/knative/serving/pkg/kbuffer"
 	"github.com/knative/serving/pkg/kbuffer/util"
-	pkghttp "github.com/knative/serving/pkg/http"
 	"go.uber.org/zap"
 )
 
@@ -86,7 +86,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	httpStatus := capture.statusCode
 	duration := time.Now().Sub(start)
 
-	a.Reporter.ReportResponseCount(namespace, ar.ServiceName, ar.ConfigurationName, name, httpStatus, attempts, 1.0)
+	a.Reporter.ReportRequestCount(namespace, ar.ServiceName, ar.ConfigurationName, name, httpStatus, attempts, 1.0)
 	a.Reporter.ReportResponseTime(namespace, ar.ServiceName, ar.ConfigurationName, name, httpStatus, duration)
 }
 

--- a/pkg/kbuffer/handler/handler_test.go
+++ b/pkg/kbuffer/handler/handler_test.go
@@ -101,7 +101,7 @@ func TestActivationHandler(t *testing.T) {
 			attempts:  "123",
 			reporterCalls: []reporterCall{
 				{
-					Op:         "ReportResponseCount",
+					Op:         "ReportRequestCount",
 					Namespace:  "real-namespace",
 					Revision:   "real-name",
 					Service:    "service-real-name",
@@ -129,7 +129,7 @@ func TestActivationHandler(t *testing.T) {
 			wantErr:   nil,
 			reporterCalls: []reporterCall{
 				{
-					Op:         "ReportResponseCount",
+					Op:         "ReportRequestCount",
 					Namespace:  "real-namespace",
 					Revision:   "real-name",
 					Service:    "service-real-name",
@@ -166,7 +166,7 @@ func TestActivationHandler(t *testing.T) {
 			wantErr:   errors.New("request error"),
 			reporterCalls: []reporterCall{
 				{
-					Op:         "ReportResponseCount",
+					Op:         "ReportRequestCount",
 					Namespace:  "real-namespace",
 					Revision:   "real-name",
 					Service:    "service-real-name",
@@ -195,7 +195,7 @@ func TestActivationHandler(t *testing.T) {
 			attempts:  "hi there",
 			reporterCalls: []reporterCall{
 				{
-					Op:         "ReportResponseCount",
+					Op:         "ReportRequestCount",
 					Namespace:  "real-namespace",
 					Revision:   "real-name",
 					Service:    "service-real-name",
@@ -286,13 +286,9 @@ type fakeReporter struct {
 	calls []reporterCall
 }
 
-func (f *fakeReporter) ReportRequest(ns, service, config, rev string, v float64) error {
-	return nil
-}
-
-func (f *fakeReporter) ReportResponseCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
+func (f *fakeReporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
 	f.calls = append(f.calls, reporterCall{
-		Op:         "ReportResponseCount",
+		Op:         "ReportRequestCount",
 		Namespace:  ns,
 		Service:    service,
 		Config:     config,

--- a/pkg/kbuffer/revision.go
+++ b/pkg/kbuffer/revision.go
@@ -75,9 +75,6 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 		return nil, errors.Wrap(err, "Unable to get revision")
 	}
 
-	serviceName, configurationName := getServiceAndConfigurationLabels(revision)
-	r.reporter.ReportRequest(namespace, serviceName, configurationName, name, 1.0)
-
 	// Wait for the revision to not require activation.
 	if revision.Status.IsActivationRequired() {
 		wi, err := r.knaClient.ServingV1alpha1().Revisions(rev.namespace).Watch(metav1.ListOptions{

--- a/pkg/kbuffer/revision_test.go
+++ b/pkg/kbuffer/revision_test.go
@@ -52,11 +52,7 @@ func init() {
 
 type mockReporter struct{}
 
-func (r *mockReporter) ReportRequest(ns, service, config, rev string, v float64) error {
-	return nil
-}
-
-func (r *mockReporter) ReportResponseCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
+func (r *mockReporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
 	return nil
 }
 

--- a/pkg/kbuffer/stats_reporter.go
+++ b/pkg/kbuffer/stats_reporter.go
@@ -39,7 +39,7 @@ var (
 	measurements = []*stats.Float64Measure{
 		RequestCountM: stats.Float64(
 			"revision_request_count",
-			"The request count when KBuffer proxy the request",
+			"The number of requests that are routed to KBuffer",
 			stats.UnitNone),
 		ResponseTimeInMsecM: stats.Float64(
 			"response_time_msec",
@@ -104,7 +104,7 @@ func NewStatsReporter() (*Reporter, error) {
 	// Create view to see our measurements.
 	err = view.Register(
 		&view.View{
-			Description: "The request count when KBuffer proxy the request",
+			Description: "The number of requests that are routed to KBuffer",
 			Measure:     measurements[RequestCountM],
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{r.namespaceTagKey, r.serviceTagKey, r.configTagKey, r.revisionTagKey, r.responseCodeKey, r.numTriesKey},

--- a/pkg/kbuffer/stats_reporter.go
+++ b/pkg/kbuffer/stats_reporter.go
@@ -28,11 +28,8 @@ import (
 type Measurement int
 
 const (
-	// RequestCountM is the requests count that are routed to the activator
-	RequestCountM Measurement = iota
-
-	//ResponseCountM is the response count when activator proxy the request
-	ResponseCountM
+	//RequestCountM is the request count when KBuffer proxy the request
+	RequestCountM = iota
 
 	// ResponseTimeInMsecM is the response time in millisecond
 	ResponseTimeInMsecM
@@ -42,11 +39,7 @@ var (
 	measurements = []*stats.Float64Measure{
 		RequestCountM: stats.Float64(
 			"revision_request_count",
-			"The number of requests that are routed to the activator",
-			stats.UnitNone),
-		ResponseCountM: stats.Float64(
-			"revision_response_count",
-			"The response count when activator proxy the request",
+			"The request count when KBuffer proxy the request",
 			stats.UnitNone),
 		ResponseTimeInMsecM: stats.Float64(
 			"response_time_msec",
@@ -57,8 +50,7 @@ var (
 
 // StatsReporter defines the interface for sending activator metrics
 type StatsReporter interface {
-	ReportRequest(ns, service, config, rev string, v float64) error
-	ReportResponseCount(ns, service, config, rev string, responseCode, numTries int, v float64) error
+	ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error
 	ReportResponseTime(ns, service, config, rev string, responseCode int, d time.Duration) error
 }
 
@@ -112,14 +104,8 @@ func NewStatsReporter() (*Reporter, error) {
 	// Create view to see our measurements.
 	err = view.Register(
 		&view.View{
-			Description: "The number of requests that are routed to the activator",
+			Description: "The request count when KBuffer proxy the request",
 			Measure:     measurements[RequestCountM],
-			Aggregation: view.Sum(),
-			TagKeys:     []tag.Key{r.namespaceTagKey, r.serviceTagKey, r.configTagKey, r.revisionTagKey},
-		},
-		&view.View{
-			Description: "The response count when activator proxy the request",
-			Measure:     measurements[ResponseCountM],
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{r.namespaceTagKey, r.serviceTagKey, r.configTagKey, r.revisionTagKey, r.responseCodeKey, r.numTriesKey},
 		},
@@ -138,28 +124,8 @@ func NewStatsReporter() (*Reporter, error) {
 	return r, nil
 }
 
-// ReportRequest captures request metrics
-func (r *Reporter) ReportRequest(ns, service, config, rev string, v float64) error {
-	if !r.initialized {
-		return errors.New("StatsReporter is not initialized yet")
-	}
-
-	ctx, err := tag.New(
-		context.Background(),
-		tag.Insert(r.namespaceTagKey, ns),
-		tag.Insert(r.serviceTagKey, service),
-		tag.Insert(r.configTagKey, config),
-		tag.Insert(r.revisionTagKey, rev))
-	if err != nil {
-		return err
-	}
-
-	stats.Record(ctx, measurements[RequestCountM].M(v))
-	return nil
-}
-
-// ReportResponseCount captures response count metric with value v.
-func (r *Reporter) ReportResponseCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
+// ReportRequestCount captures request count metric with value v.
+func (r *Reporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
 	if !r.initialized {
 		return errors.New("StatsReporter is not initialized yet")
 	}
@@ -176,7 +142,7 @@ func (r *Reporter) ReportResponseCount(ns, service, config, rev string, response
 		return err
 	}
 
-	stats.Record(ctx, measurements[ResponseCountM].M(v))
+	stats.Record(ctx, measurements[RequestCountM].M(v))
 	return nil
 }
 

--- a/pkg/kbuffer/stats_reporter_test.go
+++ b/pkg/kbuffer/stats_reporter_test.go
@@ -23,10 +23,7 @@ import (
 func TestKBufferReporter(t *testing.T) {
 	r := &Reporter{}
 
-	if err := r.ReportRequest("testns", "testsvc", "testconfig", "testrev", 1); err == nil {
-		t.Error("Reporter expected an error for Report call before init. Got success.")
-	}
-	if err := r.ReportResponseCount("testns", "testsvc", "testconfig", "testrev", 200, 1, 1); err == nil {
+	if err := r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 1, 1); err == nil {
 		t.Error("Reporter expected an error for Report call before init. Got success.")
 	}
 
@@ -35,19 +32,7 @@ func TestKBufferReporter(t *testing.T) {
 		t.Error("Failed to create a new reporter.")
 	}
 
-	// test ReportRequest
-	wantTags1 := map[string]string{
-		"destination_namespace":     "testns",
-		"destination_service":       "testsvc",
-		"destination_configuration": "testconfig",
-		"destination_revision":      "testrev",
-		"serving_state":             "Reserved",
-	}
-	expectSuccess(t, func() error { return r.ReportRequest("testns", "testsvc", "testconfig", "testrev", 1) })
-	expectSuccess(t, func() error { return r.ReportRequest("testns", "testsvc", "testconfig", "testrev", 2.0) })
-	checkSumData(t, "revision_request_count", wantTags1, 3)
-
-	// test ReportResponseCount
+	// test ReportRequestCount
 	wantTags2 := map[string]string{
 		"destination_namespace":     "testns",
 		"destination_service":       "testsvc",
@@ -56,9 +41,9 @@ func TestKBufferReporter(t *testing.T) {
 		"response_code":             "200",
 		"num_tries":                 "6",
 	}
-	expectSuccess(t, func() error { return r.ReportResponseCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 1) })
-	expectSuccess(t, func() error { return r.ReportResponseCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 3) })
-	checkSumData(t, "revision_response_count", wantTags2, 4)
+	expectSuccess(t, func() error { return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 1) })
+	expectSuccess(t, func() error { return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 3) })
+	checkSumData(t, "revision_request_count", wantTags2, 4)
 
 	// test ReportResponseTime
 	wantTags3 := map[string]string{

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -18,17 +18,17 @@ package metrics
 
 import (
 	"github.com/knative/pkg/metrics"
-	"github.com/knative/serving/pkg/apis/serving"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	ObservabilityConfigName = "config-observability"
+	metricsDomain           = "knative.dev/serving"
 )
 
 // UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
 // when a config map is updated
 func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
-	return metrics.UpdateExporterFromConfigMap(serving.GroupName, component, logger)
+	return metrics.UpdateExporterFromConfigMap(metricsDomain, component, logger)
 }


### PR DESCRIPTION
## Proposed Changes
  * Delete kbuffer revision_request_count, which doesn't provide value. It's covered by the existing response_count.
  * Rename kbuffer revision_response_count to revision_request_count to match istio revision_request_count.
  * Based on Stackdriver requirement, change metrics domain from "serving.knative.dev" to "knative.dev/serving".