### PR TITLE
Fix downgrade test name

### DIFF
--- a/test/upgrade/service_postdowngrade_test.go
+++ b/test/upgrade/service_postdowngrade_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestRunLatestServicePostupgrade(t *testing.T) {
+func TestRunLatestServicePostDowngrade(t *testing.T) {
 	clients := e2e.Setup(t)
 
 	// Add test case specific name to its own logger.

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestRunLatestServicePostupgrade(t *testing.T) {
+func TestRunLatestServicePostUpgrade(t *testing.T) {
 	clients := e2e.Setup(t)
 
 	// Add test case specific name to its own logger.

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/knative/serving/test/e2e"
 )
 
-func TestRunLatestServicePreupgrade(t *testing.T) {
+func TestRunLatestServicePreUpgrade(t *testing.T) {
 	clients := e2e.Setup(t)
 
 	// Add test case specific name to its own logger.


### PR DESCRIPTION
This was a copy/paste error.
The postdowngrade test was running, but didn't show up in testgrid
because the name collided with another test. Oops!


<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->