### PR TITLE
Don't use go_test_e2e() with performance tests

### DIFF
--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -39,6 +39,8 @@ install_knative_serving "${ISTIO_CRD_YAML}" "${ISTIO_YAML}" "${RELEASE_YAML}" \
 publish_test_images || fail_test "one or more test images weren't published"
 
 # Run the tests
-go_test_e2e -tags=performance -timeout=5m ./test/performance || fail_test
+# We use a plain `go test` because `go_test_e2e()` calls bazel to generate
+# the test summary, thus overwriting our generated performance summary
+go test e2e -v -count=1 -tags=performance -timeout=5m ./test/performance || fail_test
 
 success


### PR DESCRIPTION
`go_test_e2e()` calls bazel to generate the test summary, thus overwriting our generated performance summary.