### PR TITLE
Remove the e2e when running go test.

### DIFF
--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -41,6 +41,6 @@ publish_test_images || fail_test "one or more test images weren't published"
 # Run the tests
 # We use a plain `go test` because `go_test_e2e()` calls bazel to generate
 # the test summary, thus overwriting our generated performance summary
-go test e2e -v -count=1 -tags=performance -timeout=5m ./test/performance || fail_test
+go test -v -count=1 -tags=performance -timeout=5m ./test/performance || fail_test
 
 success


### PR DESCRIPTION
This was a typo and not needed. This should just be go test -tags=performance ./test/perfromance/.

Else, it fails with:
can't load package: package e2e: cannot find package "e2e"