### PR TITLE
Have queue-proxy enforce revisiontimeout

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -107,6 +107,9 @@ func getTestRevision() *v1alpha1.Revision {
 				TerminationMessagePath: "/dev/null",
 			},
 			ConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
+			TimeoutSeconds: &metav1.Duration{
+				Duration: 60 * time.Second,
+			},
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -61,6 +62,9 @@ func TestMakePodSpec(t *testing.T) {
 				ContainerConcurrency: 1,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -113,6 +117,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "1",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -140,6 +147,9 @@ func TestMakePodSpec(t *testing.T) {
 				ContainerConcurrency: 1,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 			Status: v1alpha1.RevisionStatus{
@@ -195,6 +205,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "1",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -229,6 +242,9 @@ func TestMakePodSpec(t *testing.T) {
 				ContainerConcurrency: 1,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -281,6 +297,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "1",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -316,6 +335,9 @@ func TestMakePodSpec(t *testing.T) {
 							},
 						},
 					},
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -376,6 +398,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "0",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -410,6 +435,9 @@ func TestMakePodSpec(t *testing.T) {
 							},
 						},
 					},
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -469,6 +497,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "0",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -503,6 +534,9 @@ func TestMakePodSpec(t *testing.T) {
 							},
 						},
 					},
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -564,6 +598,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "0",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -596,6 +633,9 @@ func TestMakePodSpec(t *testing.T) {
 							TCPSocket: &corev1.TCPSocketAction{},
 						},
 					},
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -655,6 +695,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "0",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -682,6 +725,9 @@ func TestMakePodSpec(t *testing.T) {
 				ContainerConcurrency: 1,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -736,6 +782,9 @@ func TestMakePodSpec(t *testing.T) {
 				}, {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "1",
+				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
 				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
@@ -810,6 +859,9 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "blah",
 					}},
 				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{},
@@ -871,6 +923,9 @@ func TestMakePodSpec(t *testing.T) {
 					Name:  "CONTAINER_CONCURRENCY",
 					Value: "1",
 				}, {
+					Name:  "REVISION_TIMEOUT_SECONDS",
+					Value: "45",
+				}, {
 					Name: "SERVING_POD",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -919,6 +974,9 @@ func TestMakeDeployment(t *testing.T) {
 				ContainerConcurrency: 1,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -991,6 +1049,9 @@ func TestMakeDeployment(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{},
@@ -1054,6 +1115,9 @@ func TestMakeDeployment(t *testing.T) {
 				ContainerConcurrency: 0,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},
@@ -1124,6 +1188,9 @@ func TestMakeDeployment(t *testing.T) {
 				ContainerConcurrency: 0,
 				Container: corev1.Container{
 					Image: "busybox",
+				},
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
 				},
 			},
 		},

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -109,6 +109,9 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 			Name:  "CONTAINER_CONCURRENCY",
 			Value: strconv.Itoa(int(rev.Spec.ContainerConcurrency)),
 		}, {
+			Name:  "REVISION_TIMEOUT_SECONDS",
+			Value: strconv.Itoa(int(rev.Spec.TimeoutSeconds.Duration.Seconds())),
+		}, {
 			Name: "SERVING_POD",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -51,6 +52,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{},
@@ -83,6 +87,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "1",
 			}, {
+				Name:  "REVISION_TIMEOUT_SECONDS",
+				Value: "45",
+			}, {
 				Name: "SERVING_POD",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -105,6 +112,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{},
@@ -140,6 +150,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "1",
 			}, {
+				Name:  "REVISION_TIMEOUT_SECONDS",
+				Value: "45",
+			}, {
 				Name: "SERVING_POD",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -169,6 +182,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{},
@@ -201,6 +217,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "0",
 			}, {
+				Name:  "REVISION_TIMEOUT_SECONDS",
+				Value: "45",
+			}, {
 				Name: "SERVING_POD",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -223,6 +242,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{
@@ -260,6 +282,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "0",
 			}, {
+				Name:  "REVISION_TIMEOUT_SECONDS",
+				Value: "45",
+			}, {
 				Name: "SERVING_POD",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -282,6 +307,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 10,
+				TimeoutSeconds: &metav1.Duration{
+					Duration: 45 * time.Second,
+				},
 			},
 		},
 		lc: &logging.Config{},
@@ -313,6 +341,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "10",
+			}, {
+				Name:  "REVISION_TIMEOUT_SECONDS",
+				Value: "45",
 			}, {
 				Name: "SERVING_POD",
 				ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -19,6 +19,7 @@ package revision
 import (
 	"context"
 	"testing"
+	"time"
 
 	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
 	"github.com/knative/pkg/apis/duck"
@@ -693,6 +694,7 @@ func rev(namespace, name string, ro ...RevisionOption) *v1alpha1.Revision {
 		},
 		Spec: v1alpha1.RevisionSpec{
 			Container: corev1.Container{Image: "busybox"},
+			TimeoutSeconds: &metav1.Duration{Duration: 60 * time.Second},
 		},
 	}
 

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -1,0 +1,208 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
+	"github.com/knative/serving/test"
+	"github.com/mattbaird/jsonpatch"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// createLatestService creates a service in namespace with the name names.Service
+// that uses the image specified by imagePath
+func createLatestService(logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, imagePath string, revisionTimeoutSeconds int) (*v1alpha1.Service, error) {
+	service := test.LatestService(test.ServingNamespace, names, imagePath)
+	service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{
+		Duration: time.Duration(revisionTimeoutSeconds) * time.Second,
+	}
+	test.LogResourceObject(logger, test.ResourceObjects{Service: service})
+	svc, err := clients.ServingClient.Services.Create(service)
+	return svc, err
+}
+
+func updateConfigWithTimeout(clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int) error {
+	patches := []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/spec/revisionTemplate/spec/timeoutSeconds",
+		Value:     (time.Duration(revisionTimeoutSeconds) * time.Second).String(),
+	}}
+	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		return err
+	}
+	_, err = clients.ServingClient.Configs.Patch(names.Config, types.JSONPatchType, patchBytes, "")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// sendRequests send a request to "domain", returns error if unexpected response code, nil otherwise.
+func sendRequest(logger *logging.BaseLogger, clients *test.Clients, domain string, sleepSeconds int, expectedResponseCode int) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		logger.Infof("Spoofing client failed: %v", err)
+		return err
+	}
+
+	start := time.Now().UnixNano()
+	defer func() {
+		end := time.Now().UnixNano()
+		logger.Infof("domain: %v, sleep: %v, request elapsed %.2f ms", domain, sleepSeconds*1000, float64(end-start)/1e6)
+	}()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s?timeout=%v", domain, sleepSeconds*1000), nil)
+	if err != nil {
+		logger.Infof("Failed new request: %v", err)
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Infof("Failed request err: %v", err)
+		return err
+	}
+
+	logger.Infof("Response status code: %v, expected: %v", resp.StatusCode, expectedResponseCode)
+	if expectedResponseCode != resp.StatusCode {
+		return fmt.Errorf("got response status code %v, wanted %v", resp.StatusCode, expectedResponseCode)
+	}
+	return nil
+}
+
+func TestRevisionTimeout(t *testing.T) {
+	clients := setup(t)
+
+	// Add test case specific name to its own logger.
+	logger := logging.GetContextLogger("TestRevisionTimeout")
+
+	imagePath := test.ImagePath(timeout)
+
+	var names, rev2s, rev5s test.ResourceNames
+	names.Service = test.AppendRandomString("timeout", logger)
+
+	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer tearDown(clients, names)
+
+	logger.Info("Creating a new Service in runLatest")
+	svc, err := createLatestService(logger, clients, names, imagePath, 2)
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+	names.Route = serviceresourcenames.Route(svc)
+	names.Config = serviceresourcenames.Configuration(svc)
+
+	logger.Info("The Service will be updated with the name of the Revision once it is created")
+	revisionName, err := waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+	}
+	rev2s.Revision = revisionName
+
+	logger.Info("When the Service reports as Ready, everything should be ready")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+
+	logger.Info("Updating to a Manual Service to allow configuration and route to be manually modified")
+	_, err = test.UpdateManualService(logger, clients, svc)
+	if err != nil {
+		t.Fatalf("Failed to update Service %s: %v", names.Service, err)
+	}
+
+	logger.Infof("Updating the Configuration to use a different revision timeout")
+	err = updateConfigWithTimeout(clients, names, 5)
+	if err != nil {
+		t.Fatalf("Patch update for Configuration %s with new timeout 5s failed: %v", names.Config, err)
+	}
+
+	// getNextRevisionName waits for names.Revision to change, so we set it to the rev2s revision and wait for the (new) rev5s revision.
+	names.Revision = rev2s.Revision
+
+	logger.Infof("Since the Configuration was updated a new Revision will be created and the Configuration will be updated")
+	rev5s.Revision, err = getNextRevisionName(clients, names)
+	if err != nil {
+		t.Fatalf("Configuration %s was not updated with the Revision with timeout 5s: %v", names.Config, err)
+	}
+
+	logger.Infof("Waiting for revision %q to be ready", rev2s.Revision)
+	if err := test.WaitForRevisionState(clients.ServingClient, rev2s.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
+		t.Fatalf("The Revision %q still can't serve traffic: %v", rev2s.Revision, err)
+	}
+	logger.Infof("Waiting for revision %q to be ready", rev5s.Revision)
+	if err := test.WaitForRevisionState(clients.ServingClient, rev5s.Revision, test.IsRevisionReady, "RevisionIsReady"); err != nil {
+		t.Fatalf("The Revision %q still can't serve traffic: %v", rev5s.Revision, err)
+	}
+
+	// Set names for traffic targets to make them directly routable.
+	rev2s.TrafficTarget = "rev2s"
+	rev5s.TrafficTarget = "rev5s"
+
+	logger.Infof("Updating Route")
+	if _, err := test.UpdateBlueGreenRoute(logger, clients, names, rev2s, rev5s); err != nil {
+		t.Fatalf("Failed to create Route: %v", err)
+	}
+
+	logger.Infof("Wait for the route domains to be ready")
+	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
+	}
+
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+	}
+
+	rev2sDomain := fmt.Sprintf("%s.%s", rev2s.TrafficTarget, route.Status.Domain)
+	rev5sDomain := fmt.Sprintf("%s.%s", rev5s.TrafficTarget, route.Status.Domain)
+
+	logger.Infof("Probing domain %s", rev5sDomain)
+	if err := test.ProbeDomain(logger, clients, rev5sDomain); err != nil {
+		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)
+	}
+
+	if err := sendRequest(logger, clients, rev2sDomain, 0, http.StatusOK); err != nil {
+		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
+	}
+	if err := sendRequest(logger, clients, rev5sDomain, 0, http.StatusOK); err != nil {
+		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
+	}
+	if err := sendRequest(logger, clients, rev2sDomain, 7, http.StatusServiceUnavailable); err != nil {
+		t.Errorf("Did not fail request with sleep 7s with revision timeout 2s: %v", err)
+	}
+	if err := sendRequest(logger, clients, rev5sDomain, 7, http.StatusServiceUnavailable); err != nil {
+		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
+	}
+	if err := sendRequest(logger, clients, rev2sDomain, 3, http.StatusServiceUnavailable); err != nil {
+		t.Errorf("Did not fail request with sleep 3s with revision timeout 2s: %v", err)
+	}
+	if err := sendRequest(logger, clients, rev5sDomain, 3, http.StatusOK); err != nil {
+		t.Errorf("Failed request with sleep 3s with revision timeout 5s: %v", err)
+	}
+}

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -33,6 +33,7 @@ const (
 	pizzaPlanet2 = "pizzaplanetv2"
 	helloworld   = "helloworld"
 	httpproxy    = "httpproxy"
+	timeout      = "timeout"
 )
 
 func setup(t *testing.T) *test.Clients {


### PR DESCRIPTION
Pass RevisionTimeoutSeconds down to queue-proxy and have it timeout the request.

Add conformance test to ensure request timeouts are handled.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #457, #1818 


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
