### PR TITLE
Update knative/test-infra to latest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -443,7 +443,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:77684a2a5fa2b1c519b891ba70fcd44c36c5c2eee28100d3fddf56e0ef17a84b"
+  digest = "1:124364e4841cc6cccdba11f6d5992c0e4ae0fbf4c4e5a3018aca3587ea4c140c"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -451,7 +451,7 @@
     "tools/testgrid",
   ]
   pruneopts = "UT"
-  revision = "6add8fe8265eaca9e1a218ed0c8701099e6c2c19"
+  revision = "77db40a851fa3d8366dfdd67ae99098b6cc2be02"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -136,7 +136,7 @@ func TestObservedConcurrency(t *testing.T) {
 		tc = append(tc, createTestCase(float32(val), metric))
 	}
 
-	if err = CreateTestgridXML(tc); err != nil {
+	if err = testgrid.CreateTestgridXML(tc); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)
 	}
 }

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -21,14 +21,12 @@ package performance
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/prometheus"
-	"github.com/knative/test-infra/tools/testgrid"
 	"istio.io/fortio/fhttp"
 	"istio.io/fortio/periodic"
 
@@ -72,20 +70,6 @@ func TearDown(client *PerformanceClient, logger *logging.BaseLogger, names test.
 	if client.PromClient != nil {
 		client.PromClient.Teardown(logger)
 	}
-}
-
-// Get the aritfacts directory where we should put the artifacts
-func getArtifactsDir() string {
-	dir := os.Getenv("ARTIFACTS")
-	if dir == "" {
-		return "./artifacts"
-	}
-	return dir
-}
-
-func CreateTestgridXML(tc []testgrid.TestCase) error {
-	ts := testgrid.TestSuite{TestCases: tc}
-	return testgrid.CreateXMLOutput(ts, getArtifactsDir())
 }
 
 // RunLoadTest runs the load test with fortio and returns the reponse

--- a/vendor/github.com/knative/test-infra/tools/testgrid/testgrid.go
+++ b/vendor/github.com/knative/test-infra/tools/testgrid/testgrid.go
@@ -24,6 +24,12 @@ import (
 	"os"
 )
 
+const (
+	// Default filename to store output that acts as input to testgrid.
+	// Should be of the form junit_*.xml
+	filename = "/junit_knative.xml"
+)
+
 // TestProperty defines a property of the test
 type TestProperty struct {
 	Name  string  `xml:"name,attr"`
@@ -74,7 +80,8 @@ func CreateXMLOutput(ts TestSuite, artifactsDir string) error {
 		return err
 	}
 
-	outputFile := artifactsDir + "/junit_bazel.xml"
+	outputFile := artifactsDir + filename
+	log.Printf("Storing output in %s", outputFile)
 	f, err := os.Create(outputFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
This gets the update to testgrid pkg that uses a different name for the output xml other than junit_bazel.xml.  This is needed as junit_bazel.xml is used by bazel and artifacts generated by the test were being overwritten by prow. 

Also, use the testgrid pkg methods for creating xml from the testcases.