### PR TITLE
Update EnqueueLabelOf usage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -396,7 +396,7 @@
   revision = "f0d7bb60956f88d4743f5fea66b5607b96d262c9"
 
 [[projects]]
-  digest = "1:8fe0262a37faaa3964953ad9f63da62259bb06120e8955f79b0676d6805ccc02"
+  digest = "1:b028867f15b96c170a232a6f8e17fad9333760a3a42c0578d21ebef9fd13bf2a"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -439,7 +439,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "3e52d67e3d58f63f43ad61241b00a9974cb03ecd"
+  revision = "a5c260df2a830d8f90f82518d9d7e35c4d74c517"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-11-13
-  revision = "3e52d67e3d58f63f43ad61241b00a9974cb03ecd"
+  # HEAD as of 2018-11-20
+  revision = "a5c260df2a830d8f90f82518d9d7e35c4d74c517"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -88,9 +88,9 @@ func NewController(
 	virtualServiceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: myFilterFunc,
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    impl.EnqueueLabelOf("", networking.IngressLabelKey),
-			UpdateFunc: controller.PassNew(impl.EnqueueLabelOf("", networking.IngressLabelKey)),
-			DeleteFunc: impl.EnqueueLabelOf("", networking.IngressLabelKey),
+			AddFunc:    impl.EnqueueLabelOfClusterScopedResource(networking.IngressLabelKey),
+			UpdateFunc: controller.PassNew(impl.EnqueueLabelOfClusterScopedResource(networking.IngressLabelKey)),
+			DeleteFunc: impl.EnqueueLabelOfClusterScopedResource(networking.IngressLabelKey),
 		},
 	})
 

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -474,7 +474,7 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Add(endpoints)
 	kpa := getTestReadyKPA(rev)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	f := controller.Reconciler.(*Reconciler).EnqueueEndpointsRevision(controller)
+	f := controller.EnqueueLabelOfNamespaceScopedResource("", serving.RevisionLabelKey)
 	f(endpoints)
 	if err := controller.Reconciler.Reconcile(context.TODO(), KeyOrDie(rev)); err != nil {
 		t.Errorf("Reconcile() = %v", err)

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -135,9 +135,9 @@ func NewControllerWithClock(
 	clusterIngressInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Route")),
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    impl.EnqueueLabelOf(serving.RouteNamespaceLabelKey, serving.RouteLabelKey),
-			UpdateFunc: controller.PassNew(impl.EnqueueLabelOf(serving.RouteNamespaceLabelKey, serving.RouteLabelKey)),
-			DeleteFunc: impl.EnqueueLabelOf(serving.RouteNamespaceLabelKey, serving.RouteLabelKey),
+			AddFunc:    impl.EnqueueLabelOfNamespaceScopedResource(serving.RouteNamespaceLabelKey, serving.RouteLabelKey),
+			UpdateFunc: controller.PassNew(impl.EnqueueLabelOfNamespaceScopedResource(serving.RouteNamespaceLabelKey, serving.RouteLabelKey)),
+			DeleteFunc: impl.EnqueueLabelOfNamespaceScopedResource(serving.RouteNamespaceLabelKey, serving.RouteLabelKey),
 		},
 	})
 

--- a/vendor/github.com/knative/pkg/controller/controller.go
+++ b/vendor/github.com/knative/pkg/controller/controller.go
@@ -136,12 +136,11 @@ func (c *Impl) EnqueueControllerOf(obj interface{}) {
 	}
 }
 
-// EnqueueLabelOf returns with an Enqueue func that takes a resource,
-// identifies its controller resource through given namespace and name labels,
-// converts it into a namespace/name string, and passes that to EnqueueKey.
-// Callers should pass in an empty string as namespace label key for obj
-// whose controller is of cluster-scoped resource.
-func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interface{}) {
+// EnqueueLabelOfNamespaceScopedResource returns with an Enqueue func that
+// takes a resource, identifies its controller resource through given namespace
+// and name labels, converts it into a namespace/name string, and passes that
+// to EnqueueKey. The controller resource must be of namespace-scoped.
+func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel string) func(obj interface{}) {
 	return func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err != nil {
@@ -165,7 +164,36 @@ func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interfa
 				return
 			}
 
-			controllerKey = fmt.Sprintf("%s/%s", controllerNamespace, controllerKey)
+			c.EnqueueKey(fmt.Sprintf("%s/%s", controllerNamespace, controllerKey))
+			return
+		}
+
+		// Pass through namespace of the object itself if no namespace label specified.
+		// This is for the scenario that object and the parent resource are of same namespace,
+		// e.g. to enqueue the revision of an endpoint.
+		c.EnqueueKey(fmt.Sprintf("%s/%s", object.GetNamespace(), controllerKey))
+	}
+}
+
+
+// EnqueueLabelOfClusterScopedResource returns with an Enqueue func
+// that takes a resource, identifies its controller resource through
+// given name label, and passes it to EnqueueKey.
+// The controller resource must be of cluster-scoped.
+func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj interface{}) {
+	return func(obj interface{}) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			c.logger.Error(err)
+			return
+		}
+
+		labels := object.GetLabels()
+		controllerKey, ok := labels[nameLabel]
+		if !ok {
+			c.logger.Infof("Object %s/%s does not have a referring name label %s",
+				object.GetNamespace(), object.GetName(), nameLabel)
+			return
 		}
 
 		c.EnqueueKey(controllerKey)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Follow-up of https://github.com/knative/pkg/pull/166

## Proposed Changes

  * Update controllers to make use of `EnqueueLabelOfNamespaceScopedResource`/`EnqueueLabelOfNamespaceScopedResource` instead of removed `EnqueueLabelOf`



**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
NONE
```
