### PR TITLE
Networking to own queue and activator

### DIFF
--- a/cmd/queue/OWNERS
+++ b/cmd/queue/OWNERS
@@ -2,6 +2,8 @@
 
 approvers:
 - autoscaling-approvers
+- networking-approvers
 
 reviewers:
 - autoscaling-reviewers
+- networking-reviewers

--- a/pkg/activator/OWNERS
+++ b/pkg/activator/OWNERS
@@ -2,6 +2,8 @@
 
 approvers:
 - autoscaling-approvers
+- networking-approvers
 
 reviewers:
 - autoscaling-reviewers
+- networking-reviewers

--- a/pkg/http/h2c/OWNERS
+++ b/pkg/http/h2c/OWNERS
@@ -2,6 +2,8 @@
 
 approvers:
 - autoscaling-approvers
+- networking-approvers
 
 reviewers:
 - autoscaling-reviewers
+- networking-reviewers

--- a/pkg/queue/OWNERS
+++ b/pkg/queue/OWNERS
@@ -2,6 +2,8 @@
 
 approvers:
 - autoscaling-approvers
+- networking-approvers
 
 reviewers:
 - autoscaling-reviewers
+- networking-reviewers


### PR DESCRIPTION
Add networking-approvers and networking-reviewers to queue and activator components.

<!--
/lint
-->

## Proposed Changes

  * Add Networking WG as owner of the queue and activator components.
  * Leaving Scaling WG as co-owner for now.

**Release Note**
```release-note
NONE
```
