### PR TITLE
Only use more than one activator in testing.

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -18,7 +18,7 @@ metadata:
   name: activator
   namespace: knative-serving
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: activator

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -69,6 +69,9 @@ function install_knative_serving() {
   echo ">> Bringing up Serving"
   kubectl apply -f "${INSTALL_RELEASE_YAML}" || return 1
 
+  echo ">> Adding more activator pods."
+  kubectl scale deploy --replicas=2 -n knative-serving activator || return 1
+
   # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
   #
   # However, since network configurations may reach different ingress pods at slightly


### PR DESCRIPTION
Activator is only used once in a while, so we probably want to save
the resource in our released template.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
/assign @mattmoor 
/assign @adrcunha 
-->

## Proposed Changes

  *  Reduce the number of activator used in template.
  *  Scale it up during testing.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
NONE
```
