### PR TITLE
Use WaitForEndpointState instead of ProbeDomain

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -249,7 +249,13 @@ func TestBlueGreenRoute(t *testing.T) {
 	// Since we are updating the route the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
 	logger.Infof("Probing domain %s", greenDomain)
-	if err := test.ProbeDomain(logger, clients, greenDomain); err != nil {
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		logger,
+		greenDomain,
+		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound, http.StatusServiceUnavailable),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", greenDomain, err)
 	}
 

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -183,7 +183,13 @@ func TestRevisionTimeout(t *testing.T) {
 	rev5sDomain := fmt.Sprintf("%s.%s", rev5s.TrafficTarget, route.Status.Domain)
 
 	logger.Infof("Probing domain %s", rev5sDomain)
-	if err := test.ProbeDomain(logger, clients, rev5sDomain); err != nil {
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		logger,
+		rev5sDomain,
+		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound, http.StatusServiceUnavailable),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)
 	}
 

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -95,7 +95,13 @@ func TestSingleConcurrency(t *testing.T) {
 	// Ready does not actually mean Ready for a Route just yet.
 	// See https://github.com/knative/serving/issues/1582
 	logger.Infof("Probing domain %s", domain)
-	if err := test.ProbeDomain(logger, clients, domain); err != nil {
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		logger,
+		domain,
+		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound, http.StatusServiceUnavailable),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 

--- a/test/route.go
+++ b/test/route.go
@@ -64,23 +64,6 @@ func UpdateBlueGreenRoute(logger *logging.BaseLogger, clients *Clients, names, b
 	return clients.ServingClient.Routes.Patch(names.Route, types.JSONPatchType, patchBytes, "")
 }
 
-// ProbeDomain sends requests to a domain until we get a successful
-// response. This ensures the domain is routable before we send it a
-// bunch of traffic.
-func ProbeDomain(logger *logging.BaseLogger, clients *Clients, domain string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, ServingFlags.ResolvableDomain)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
-	if err != nil {
-		return err
-	}
-	// TODO(tcnghia): Replace this probing with Status check when we have them.
-	_, err = client.Poll(req, pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound, http.StatusServiceUnavailable))
-	return err
-}
-
 // RunRouteProber creates and runs a prober as background goroutine to keep polling Route.
 // It stops when getting an error response from Route.
 func RunRouteProber(logger *logging.BaseLogger, clients *Clients, domain string) <-chan error {


### PR DESCRIPTION
In some of our conformance tests, we are using a method called ProbeDomain to check if the route has become healthy. We already have a method WaitForEndpointState that does that same thing. Replace ProbeDomain with WaitForEndpointState in our conformance tests.