### PR TITLE
Try to reduce flakes due to Istio control plane overload

### DIFF
--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -14,6 +14,7 @@ helm template --namespace=istio-system \
   --set sidecarInjectorWebhook.enabled=true \
   --set sidecarInjectorWebhook.enableNamespacesByDefault=true \
   --set global.proxy.autoInject=disabled \
+  --set global.disablePolicyChecks=true \
   --set prometheus.enabled=false \
   install/kubernetes/helm/istio > ../istio.yaml
 
@@ -21,6 +22,7 @@ helm template --namespace=istio-system \
   --set sidecarInjectorWebhook.enabled=false \
   --set global.proxy.autoInject=disabled \
   --set global.omitSidecarInjectorConfigMap=true \
+  --set global.disablePolicyChecks=true \
   --set prometheus.enabled=false \
   install/kubernetes/helm/istio > ../istio-lean.yaml
 

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -214,7 +214,7 @@ data:
   mesh: |-
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: false
+    disablePolicyChecks: true
 
     # Set enableTracing to false to disable request tracing.
     enableTracing: true

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -214,7 +214,7 @@ data:
   mesh: |-
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: false
+    disablePolicyChecks: true
 
     # Set enableTracing to false to disable request tracing.
     enableTracing: true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Attempt to reduce flakes in TestAutoscaleUpDownUp by adding more pilot pods and reduce requests to mixer.

## Proposed Changes

  * Disable policy check to reduce requests to Mixer.
  * Add more pilot pods.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
