### PR TITLE
Use the metrics constants in autoscaler and activator stats reporter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -396,7 +396,7 @@
   revision = "f0d7bb60956f88d4743f5fea66b5607b96d262c9"
 
 [[projects]]
-  digest = "1:b028867f15b96c170a232a6f8e17fad9333760a3a42c0578d21ebef9fd13bf2a"
+  digest = "1:e0f8a12fc45f4fa1087f78d08b15e340ba0fdc43db1e9b92d6229b390b7f3936"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -430,6 +430,7 @@
     "logging/logkey",
     "logging/testing",
     "metrics",
+    "metrics/metricskey",
     "signals",
     "test",
     "test/logging",
@@ -439,11 +440,11 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "a5c260df2a830d8f90f82518d9d7e35c4d74c517"
+  revision = "acfd173abd8d2063ddceedb3487599f97ac93db8"
 
 [[projects]]
   branch = "master"
-  digest = "1:124364e4841cc6cccdba11f6d5992c0e4ae0fbf4c4e5a3018aca3587ea4c140c"
+  digest = "1:a294d4d6fda3d2f4b9119eaa9e7965975fed86bfbd7a3ba357069f538a3aba83"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -1248,6 +1249,7 @@
     "github.com/knative/pkg/logging/logkey",
     "github.com/knative/pkg/logging/testing",
     "github.com/knative/pkg/metrics",
+    "github.com/knative/pkg/metrics/metricskey",
     "github.com/knative/pkg/signals",
     "github.com/knative/pkg/test",
     "github.com/knative/pkg/test/logging",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-11-20
-  revision = "a5c260df2a830d8f90f82518d9d7e35c4d74c517"
+  # HEAD as of 2018-11-21
+  revision = "acfd173abd8d2063ddceedb3487599f97ac93db8"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
@@ -127,7 +127,7 @@ data:
                      "steppedLine":true,
                      "targets":[  
                         {  
-                           "expr":"sum(autoscaler_actual_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                           "expr":"sum(autoscaler_actual_pod_count{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                            "format":"time_series",
                            "interval":"1s",
                            "intervalFactor":1,
@@ -135,7 +135,7 @@ data:
                            "refId":"A"
                         },
                         {  
-                           "expr":"sum(autoscaler_requested_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                           "expr":"sum(autoscaler_requested_pod_count{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                            "format":"time_series",
                            "interval":"1s",
                            "intervalFactor":1,
@@ -466,14 +466,14 @@ data:
                      "steppedLine":true,
                      "targets":[  
                         {  
-                           "expr":"sum(autoscaler_desired_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"}) ",
+                           "expr":"sum(autoscaler_desired_pod_count{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"}) ",
                            "format":"time_series",
                            "intervalFactor":1,
                            "legendFormat":"Desired Pods",
                            "refId":"A"
                         },
                         {  
-                           "expr":"sum(autoscaler_observed_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                           "expr":"sum(autoscaler_observed_pod_count{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                            "format":"time_series",
                            "intervalFactor":1,
                            "legendFormat":"Observed Pods",
@@ -577,7 +577,7 @@ data:
                      "steppedLine":true,
                      "targets":[  
                         {  
-                           "expr":"sum(autoscaler_observed_stable_concurrency{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                           "expr":"sum(autoscaler_observed_stable_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                            "format":"time_series",
                            "interval":"1s",
                            "intervalFactor":1,
@@ -585,7 +585,7 @@ data:
                            "refId":"A"
                         },
                         {  
-                           "expr":"sum(autoscaler_observed_panic_concurrency{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                           "expr":"sum(autoscaler_observed_panic_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                            "format":"time_series",
                            "interval":"1s",
                            "intervalFactor":1,
@@ -593,7 +593,7 @@ data:
                            "refId":"B"
                         },
                         {  
-                           "expr":"sum(autoscaler_target_concurrency_per_pod{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"})",
+                           "expr":"sum(autoscaler_target_concurrency_per_pod{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                            "format":"time_series",
                            "intervalFactor":1,
                            "legendFormat":"60 Second Target Concurrency",
@@ -690,7 +690,7 @@ data:
                      "steppedLine":true,
                      "targets":[  
                         {  
-                           "expr":"sum(autoscaler_panic_mode{configuration_namespace=\"$namespace\", configuration=\"$configuration\", revision=\"$revision\"} )",
+                           "expr":"sum(autoscaler_panic_mode{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"} )",
                            "format":"time_series",
                            "intervalFactor":1,
                            "legendFormat":"Panic Mode",
@@ -794,7 +794,7 @@ data:
                               "steppedLine":false,
                               "targets":[  
                                  {  
-                                    "expr":"round(sum(increase(activator_revision_request_count{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (response_code))",
+                                    "expr":"round(sum(increase(activator_revision_request_count{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (response_code))",
                                     "format":"time_series",
                                     "intervalFactor":1,
                                     "legendFormat":"{{ response_code }}",
@@ -884,31 +884,31 @@ data:
                               "steppedLine":false,
                               "targets":[  
                                  {  
-                                    "expr":"label_replace(histogram_quantile(0.50, sum(rate(activator_response_time_msec_bucket{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (destination_revision, le)), \"destination_revision\", \"$2\", \"destination_revision\", \"$configuration(-+)(.*)\")",
+                                    "expr":"label_replace(histogram_quantile(0.50, sum(rate(activator_response_time_msec_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
                                     "format":"time_series",
                                     "intervalFactor":1,
-                                    "legendFormat":"{{ destination_revision }} (p50)",
+                                    "legendFormat":"{{ revision_name }} (p50)",
                                     "refId":"A"
                                  },
                                  {  
-                                    "expr":"label_replace(histogram_quantile(0.90, sum(rate(activator_response_time_msec_bucket{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (destination_revision, le)), \"destination_revision\", \"$2\", \"destination_revision\", \"$configuration(-+)(.*)\")",
+                                    "expr":"label_replace(histogram_quantile(0.90, sum(rate(activator_response_time_msec_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
                                     "format":"time_series",
                                     "intervalFactor":1,
-                                    "legendFormat":"{{ destination_revision }} (p90)",
+                                    "legendFormat":"{{ revision_name }} (p90)",
                                     "refId":"B"
                                  },
                                  {  
-                                    "expr":"label_replace(histogram_quantile(0.95, sum(rate(activator_response_time_msec_bucket{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (destination_revision, le)), \"destination_revision\", \"$2\", \"destination_revision\", \"$configuration(-+)(.*)\")",
+                                    "expr":"label_replace(histogram_quantile(0.95, sum(rate(activator_response_time_msec_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
                                     "format":"time_series",
                                     "intervalFactor":1,
-                                    "legendFormat":"{{ destination_revision }} (p95)",
+                                    "legendFormat":"{{ revision_name }} (p95)",
                                     "refId":"C"
                                  },
                                  {  
-                                    "expr":"label_replace(histogram_quantile(0.99, sum(rate(activator_response_time_msec_bucket{destination_namespace=\"$namespace\", destination_configuration=~\"$configuration\",destination_revision=~\"$revision\"}[1m])) by (destination_revision, le)), \"destination_revision\", \"$2\", \"destination_revision\", \"$configuration(-+)(.*)\")",
+                                    "expr":"label_replace(histogram_quantile(0.99, sum(rate(activator_response_time_msec_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
                                     "format":"time_series",
                                     "intervalFactor":1,
-                                    "legendFormat":"{{ destination_revision }} (p99)",
+                                    "legendFormat":"{{ revision_name }} (p99)",
                                     "refId":"D"
                                  }
                               ],
@@ -979,7 +979,7 @@ data:
                   "options":[  
 
                   ],
-                  "query":"label_values(autoscaler_observed_pod_count, configuration_namespace)",
+                  "query":"label_values(autoscaler_observed_pod_count, namespace_name)",
                   "refresh":1,
                   "regex":"",
                   "sort":1,
@@ -1005,7 +1005,7 @@ data:
                   "options":[  
 
                   ],
-                  "query":"label_values(autoscaler_observed_pod_count{configuration_namespace=\"$namespace\"}, configuration)",
+                  "query":"label_values(autoscaler_observed_pod_count{namespace_name=\"$namespace\"}, configuration_name)",
                   "refresh":1,
                   "regex":"",
                   "sort":1,
@@ -1031,7 +1031,7 @@ data:
                   "options":[  
 
                   ],
-                  "query":"label_values(autoscaler_observed_pod_count{configuration_namespace=\"$namespace\", configuration=\"$configuration\"}, revision)",
+                  "query":"label_values(autoscaler_observed_pod_count{namespace_name=\"$namespace\", configuration_name=\"$configuration\"}, revision_name)",
                   "refresh":1,
                   "regex":"",
                   "sort":2,

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/knative/pkg/metrics/metricskey"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -71,22 +72,22 @@ func NewStatsReporter() (*Reporter, error) {
 	var r = &Reporter{}
 
 	// Create the tag keys that will be used to add tags to our measurements.
-	nsTag, err := tag.NewKey("destination_namespace")
+	nsTag, err := tag.NewKey(metricskey.LabelNamespaceName)
 	if err != nil {
 		return nil, err
 	}
 	r.namespaceTagKey = nsTag
-	serviceTag, err := tag.NewKey("destination_service")
+	serviceTag, err := tag.NewKey(metricskey.LabelServiceName)
 	if err != nil {
 		return nil, err
 	}
 	r.serviceTagKey = serviceTag
-	configTag, err := tag.NewKey("destination_configuration")
+	configTag, err := tag.NewKey(metricskey.LabelConfigurationName)
 	if err != nil {
 		return nil, err
 	}
 	r.configTagKey = configTag
-	revTag, err := tag.NewKey("destination_revision")
+	revTag, err := tag.NewKey(metricskey.LabelRevisionName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/knative/pkg/metrics/metricskey"
+
 	"go.opencensus.io/stats/view"
 )
 
@@ -34,12 +36,12 @@ func TestActivatorReporter(t *testing.T) {
 
 	// test ReportRequestCount
 	wantTags2 := map[string]string{
-		"destination_namespace":     "testns",
-		"destination_service":       "testsvc",
-		"destination_configuration": "testconfig",
-		"destination_revision":      "testrev",
-		"response_code":             "200",
-		"num_tries":                 "6",
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       "testsvc",
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+		"response_code":                   "200",
+		"num_tries":                       "6",
 	}
 	expectSuccess(t, func() error { return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 1) })
 	expectSuccess(t, func() error { return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 3) })
@@ -47,11 +49,11 @@ func TestActivatorReporter(t *testing.T) {
 
 	// test ReportResponseTime
 	wantTags3 := map[string]string{
-		"destination_namespace":     "testns",
-		"destination_service":       "testsvc",
-		"destination_configuration": "testconfig",
-		"destination_revision":      "testrev",
-		"response_code":             "200",
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       "testsvc",
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+		"response_code":                   "200",
 	}
 	expectSuccess(t, func() error {
 		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", 200, 1100*time.Millisecond)

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/knative/pkg/metrics/metricskey"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -96,19 +98,19 @@ func init() {
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
 	// - characters are printable US-ASCII
-	namespaceTagKey, err = tag.NewKey("configuration_namespace")
+	namespaceTagKey, err = tag.NewKey(metricskey.LabelNamespaceName)
 	if err != nil {
 		panic(err)
 	}
-	serviceTagKey, err = tag.NewKey("service")
+	serviceTagKey, err = tag.NewKey(metricskey.LabelServiceName)
 	if err != nil {
 		panic(err)
 	}
-	configTagKey, err = tag.NewKey("configuration")
+	configTagKey, err = tag.NewKey(metricskey.LabelConfigurationName)
 	if err != nil {
 		panic(err)
 	}
-	revisionTagKey, err = tag.NewKey("revision")
+	revisionTagKey, err = tag.NewKey(metricskey.LabelRevisionName)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/knative/pkg/metrics/metricskey"
+
 	"go.opencensus.io/stats/view"
 )
 
@@ -47,10 +49,10 @@ func TestReporter_Report(t *testing.T) {
 
 	r, _ = NewStatsReporter("testns", "testsvc", "testconfig", "testrev")
 	wantTags := map[string]string{
-		"configuration_namespace": "testns",
-		"service":                 "testsvc",
-		"configuration":           "testconfig",
-		"revision":                "testrev",
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       "testsvc",
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
 	}
 
 	// Send statistics only once and observe the results

--- a/vendor/github.com/knative/pkg/metrics/doc.go
+++ b/vendor/github.com/knative/pkg/metrics/doc.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics provides Knative utilities for exporting metrics to Stackdriver
+// backend or Prometheus backend based on config-observability settings.
+package metrics

--- a/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
+++ b/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricskey
+
+const (
+	// ResourceTypeKnativeRevision is the Stackdriver resource type for Knative revision
+	ResourceTypeKnativeRevision = "knative_revision"
+
+	// LabelProject is the label for project (e.g. GCP GAIA ID, AWS project name)
+	LabelProject = "project"
+
+	// LabelLocation is the label for location (e.g. GCE zone, AWS region) where the service is deployed
+	LabelLocation = "location"
+
+	// LabelClusterName is the label for immutable name of the cluster
+	LabelClusterName = "cluster_name"
+
+	// LabelNamespaceName is the label for immutable name of the namespace that the service is deployed
+	LabelNamespaceName = "namespace_name"
+
+	// LabelServiceName is the label for the deployed service name
+	LabelServiceName = "service_name"
+
+	// LabelConfigurationName is the label for the configuration which created the monitored revision
+	LabelConfigurationName = "configuration_name"
+
+	// LabelRevisionName is the label for the monitored revision
+	LabelRevisionName = "revision_name"
+
+	// ValueUnknown is the default value if the field is unknown, e.g. project will be unknown if Knative
+	// is not running on GKE.
+	ValueUnknown = "unknown"
+)
+
+var (
+	// KnativeRevisionLabels stores the set of resource labels for resource type knative_revision
+	KnativeRevisionLabels = map[string]struct{}{
+		LabelProject:           struct{}{},
+		LabelLocation:          struct{}{},
+		LabelClusterName:       struct{}{},
+		LabelNamespaceName:     struct{}{},
+		LabelServiceName:       struct{}{},
+		LabelConfigurationName: struct{}{},
+		LabelRevisionName:      struct{}{},
+	}
+
+	// ResourceTypeToLabelsMap maps resource type to the set of resource labels
+	ResourceTypeToLabelsMap = map[string]map[string]struct{}{
+		ResourceTypeKnativeRevision: KnativeRevisionLabels,
+	}
+)


### PR DESCRIPTION
For stackdriver integration, we need to use the fixed set of metrics labels in pkg repo.