### PR TITLE
Fix concurrencyModel in api example

### DIFF
--- a/docs/spec/normative_examples.md
+++ b/docs/spec/normative_examples.md
@@ -1056,7 +1056,7 @@ spec:
               value: world
 
           # serializes requests for function. Default value for functions
-          concurrencyModel: SingleThreaded
+          containerConcurrency: 1
           # max time allowed to respond to request
           timeoutSeconds: 20
 ```


### PR DESCRIPTION
I'm not sure if `concurrencyModel: SingleThreaded` was ever a
valid value (per spec.md "Single" is a valid option for this
field).

At any rate, using the new containerConcurrency field for this.

**Release Note**
```release-note
NONE
```
