### PR TITLE
Readd a 20 second sleep before shutting down a user-level container.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -50,6 +50,11 @@ const (
 	statReportingQueueLength = 10
 	// Add enough buffer to not block request serving on stats collection
 	requestCountingQueueLength = 100
+	// Duration the /quitquitquit handler should wait before returning.
+	// This is to give Istio a little bit more time to remove the pod
+	// from its configuration and propagate that to all istio-proxies
+	// in the mesh.
+	quitSleepDuration = 20 * time.Second
 )
 
 var (
@@ -204,6 +209,8 @@ func (h *healthServer) quitHandler(w http.ResponseWriter, r *http.Request) {
 	if err := sendStat(s); err != nil {
 		logger.Error("Error while sending stat", zap.Error(err))
 	}
+
+	time.Sleep(quitSleepDuration)
 
 	// Shutdown the server.
 	currentServer := server

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -351,7 +351,7 @@ data:
         lifecycle:
           preStop:
             exec:
-              command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+              command: ["sh", "-c", 'sleep 20; until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
         # PATCH #2 ends.
         image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
         "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"

--- a/third_party/istio-1.0.2/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.0.2/prestop-sleep.yaml.patch
@@ -3,5 +3,5 @@
 >         lifecycle:
 >           preStop:
 >             exec:
->               command: ["sh", "-c", 'until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+>               command: ["sh", "-c", 'sleep 20; until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
 >         # PATCH #2 ends.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

As Istio updates its proxy configurations asynchronously, traffic might still be sent to pods that are already shutting down, even though Kubernetes has removed the endpoints from the underlying service already. Adding some sleep before shutting the containers down seems to make the situation a bit more stable, but its quite unsatisfactory.

https://github.com/istio/istio/issues/7665 for reference.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
