### PR TITLE
Guard RequestedPodCount metric against negative values.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
@@ -213,7 +213,10 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, kpa *kpa.PodAuto
 	}
 
 	reporter.Report(autoscaler.ActualPodCountM, float64(got))
-	reporter.Report(autoscaler.RequestedPodCountM, float64(want))
+	// negative "want" values represent an empty metrics pipeline and thus no specific request is being made
+	if want >= 0 {
+		reporter.Report(autoscaler.RequestedPodCountM, float64(want))
+	}
 
 	switch {
 	case want == 0:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2543 

Negative "want" values represent an empty metrics pipeline and thus no specific request is being made. We drop the metric entirely to reflect that in the relevant dashboards.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
