### PR TITLE
[WIP] Activator daemonset

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -71,16 +71,20 @@ var (
 	reqChan  = make(chan activatorhandler.ReqEvent, requestCountingQueueLength)
 )
 
-func statReporter() {
+func statReporter(stopCh <-chan struct{}) {
 	for {
-		sm := <-statChan
-		if statSink == nil {
-			logger.Error("Stat sink not connected.")
-			continue
-		}
-		err := statSink.Send(sm)
-		if err != nil {
-			logger.Error("Error while sending stat", zap.Error(err))
+		select {
+		case sm := <-statChan:
+			if statSink == nil {
+				logger.Error("Stat sink not connected.")
+				continue
+			}
+			err := statSink.Send(sm)
+			if err != nil {
+				logger.Error("Error while sending stat", zap.Error(err))
+			}
+		case <-stopCh:
+			return
 		}
 	}
 }
@@ -119,8 +123,7 @@ func main() {
 		logger.Fatal("Failed to create stats reporter", zap.Error(err))
 	}
 
-	a := activator.NewRevisionActivator(kubeClient, servingClient, logger, reporter)
-	a = activator.NewDedupingActivator(a)
+	a := activator.NewLocalActivator(servingClient.Serving(), kubeClient, logger)
 
 	// Retry on 503's for up to 60 seconds. The reason is there is
 	// a small delay for k8s to include the ready IP in service.
@@ -133,11 +136,14 @@ func main() {
 	}
 	rt := activatorutil.NewRetryRoundTripper(activatorutil.AutoTransport, logger, backoffSettings, shouldRetry)
 
+	// set up signals so we handle the first shutdown signal gracefully
+	stopCh := signals.SetupSignalHandler()
+
 	// Open a websocket connection to the autoscaler
 	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", "autoscaler", system.Namespace, "8080")
 	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
-	go statReporter()
+	go statReporter(stopCh)
 
 	podName := util.GetRequiredEnvOrFatal("POD_NAME", logger)
 	activatorhandler.NewConcurrencyReporter(podName, activatorhandler.Channels{
@@ -160,13 +166,6 @@ func main() {
 		),
 	}
 
-	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := signals.SetupSignalHandler()
-	go func() {
-		<-stopCh
-		a.Shutdown()
-	}()
-
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace)
 	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
@@ -175,6 +174,12 @@ func main() {
 	if err = configMapWatcher.Start(stopCh); err != nil {
 		logger.Fatalf("failed to start configuration manager: %v", err)
 	}
+
+	go func() {
+		<-stopCh
+		a.Shutdown()
+		// shutdown h2c
+	}()
 
 	h2c.ListenAndServe(":8080", ah)
 }

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -13,20 +13,17 @@
 # limitations under the License.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: activator
   namespace: knative-serving
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: activator
       role: activator
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "true"
       labels:
         app: activator
         role: activator
@@ -58,9 +55,27 @@ spec:
         - name: config-observability
           mountPath: /etc/config-observability
       volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging
-        - name: config-observability
-          configMap:
-            name: config-observability
+      - name: config-logging
+        configMap:
+          name: config-logging
+      - name: config-observability
+        configMap:
+          name: config-observability
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: activator
+  namespace: knative-serving
+spec:
+  selector:
+    app: activator
+  ports:
+  - name: activator
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  - name: metrics
+    protocol: TCP
+    port: 9090
+    targetPort: 9090

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -50,11 +50,17 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
         volumeMounts:
+        - name: localpods
+          mountPath: /etc/localpods
         - name: config-logging
           mountPath: /etc/config-logging
         - name: config-observability
           mountPath: /etc/config-observability
       volumes:
+      - name: localpods
+        hostPath:
+          path: /etc/kubernetes/manifests
+          type: Directory
       - name: config-logging
         configMap:
           name: config-logging

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -58,6 +58,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Scheme: "http",
 		Host:   fmt.Sprintf("%s:%d", ar.Endpoint.FQDN, ar.Endpoint.Port),
 	}
+	a.Logger.Infof("Created proxy for %v", target)
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = a.Transport
 

--- a/pkg/activator/localscheduler.go
+++ b/pkg/activator/localscheduler.go
@@ -1,0 +1,60 @@
+package activator
+
+import (
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	servingv1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	"github.com/knative/serving/pkg/localscheduler"
+)
+
+type LocalActivator struct {
+	servingClient servingv1alpha1.ServingV1alpha1Interface
+	kubeClient    *kubernetes.Clientset
+	logger        *zap.SugaredLogger
+}
+
+func NewLocalActivator(servingClient servingv1alpha1.ServingV1alpha1Interface, kubeClient *kubernetes.Clientset, logger *zap.SugaredLogger) *LocalActivator {
+	la := LocalActivator{
+		servingClient: servingClient,
+		kubeClient:    kubeClient,
+		logger:        logger,
+	}
+	return &la
+}
+
+func (ls *LocalActivator) ActiveEndpoint(namespace, name string) ActivationResult {
+	revCli := ls.servingClient.Revisions(namespace)
+	rev, err := revCli.Get(name, metav1.GetOptions{})
+	serviceName, configurationName := GetServiceAndConfigurationLabels(rev)
+	if err != nil {
+		return ActivationResult{
+			Status: http.StatusInternalServerError,
+			Error:  fmt.Errorf("Failed to get revision %q/%q: %v", namespace, name, err),
+		}
+	} else {
+		if fqdn, port, err := localscheduler.ScheduleAndWaitForEndpoint(rev, ls.kubeClient, ls.logger); err != nil {
+			return ActivationResult{
+				Status: http.StatusInternalServerError,
+				Error:  fmt.Errorf("Failed to obtain local revision endpoint %q/%q: %v", namespace, name, err),
+			}
+		} else {
+			return ActivationResult{
+				Status: http.StatusOK,
+				Endpoint: Endpoint{
+					FQDN: fqdn,
+					Port: port,
+				},
+				ServiceName:       serviceName,
+				ConfigurationName: configurationName,
+			}
+		}
+	}
+}
+
+func (ls *LocalActivator) Shutdown() {
+}

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -153,7 +153,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) ActivationRes
 		}
 	}
 
-	serviceName, configurationName := getServiceAndConfigurationLabels(revision)
+	serviceName, configurationName := GetServiceAndConfigurationLabels(revision)
 	endpoint, err := r.getRevisionEndpoint(revision)
 	if err != nil {
 		logger.Error("Failed to get revision endpoint.", zap.Error(err))
@@ -174,7 +174,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) ActivationRes
 	}
 }
 
-func getServiceAndConfigurationLabels(rev *v1alpha1.Revision) (string, string) {
+func GetServiceAndConfigurationLabels(rev *v1alpha1.Revision) (string, string) {
 	if rev.Labels == nil {
 		return "", ""
 	}

--- a/pkg/localscheduler/schedule.go
+++ b/pkg/localscheduler/schedule.go
@@ -1,0 +1,210 @@
+package localscheduler
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/queue"
+)
+
+// TODO(greghaynes): This should be shared with pkg/reconciler/v1alpha1/revision/resources
+const (
+	knativeRevisionEnvVariableKey      = "K_REVISION"
+	knativeConfigurationEnvVariableKey = "K_CONFIGURATION"
+	knativeServiceEnvVariableKey       = "K_SERVICE"
+
+	varLogVolumeName = "varlog"
+
+	userContainerName = "user-container"
+
+	userPortName    = "user-port"
+	userPort        = 8080
+	userPortEnvName = "PORT"
+)
+
+var (
+	userContainerCPU = resource.MustParse("400m")
+
+	varLogVolume = corev1.Volume{
+		Name: varLogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	varLogVolumeMount = corev1.VolumeMount{
+		Name:      varLogVolumeName,
+		MountPath: "/var/log",
+	}
+
+	userPorts = []corev1.ContainerPort{{
+		Name:          userPortName,
+		ContainerPort: int32(userPort),
+	}}
+
+	// Expose containerPort as env PORT.
+	userEnv = corev1.EnvVar{
+		Name:  userPortEnvName,
+		Value: strconv.Itoa(userPort),
+	}
+
+	userResources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: userContainerCPU,
+		},
+	}
+)
+
+func getKnativeEnvVar(rev *v1alpha1.Revision) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  knativeRevisionEnvVariableKey,
+			Value: rev.Name,
+		},
+		{
+			Name:  knativeConfigurationEnvVariableKey,
+			Value: rev.Labels[serving.ConfigurationLabelKey],
+		},
+		{
+			Name:  knativeServiceEnvVariableKey,
+			Value: rev.Labels[serving.ServiceLabelKey],
+		},
+	}
+}
+
+func createPodSpec(rev *v1alpha1.Revision) *corev1.PodSpec {
+	userContainer := rev.Spec.Container.DeepCopy()
+	// Adding or removing an overwritten corev1.Container field here? Don't forget to
+	// update the validations in pkg/webhook.validateContainer.
+	userContainer.Name = userContainerName
+	userContainer.Resources = userResources
+	userContainer.Ports = userPorts
+	userContainer.VolumeMounts = append(userContainer.VolumeMounts, varLogVolumeMount)
+	userContainer.Env = append(userContainer.Env, userEnv)
+	userContainer.Env = append(userContainer.Env, getKnativeEnvVar(rev)...)
+	// Prefer imageDigest from revision if available
+	if rev.Status.ImageDigest != "" {
+		userContainer.Image = rev.Status.ImageDigest
+	}
+
+	// If the client provides probes, we should fill in the port for them.
+	rewriteUserProbe(userContainer.ReadinessProbe)
+	rewriteUserProbe(userContainer.LivenessProbe)
+
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			*userContainer,
+		},
+		Volumes:            []corev1.Volume{varLogVolume},
+		ServiceAccountName: rev.Spec.ServiceAccountName,
+	}
+
+	return podSpec
+}
+
+func rewriteUserProbe(p *corev1.Probe) {
+	if p == nil {
+		return
+	}
+	switch {
+	case p.HTTPGet != nil:
+		// For HTTP probes, we route them through the queue container
+		// so that we know the queue proxy is ready/live as well.
+		p.HTTPGet.Port = intstr.FromInt(queue.RequestQueuePort)
+	case p.TCPSocket != nil:
+		p.TCPSocket.Port = intstr.FromInt(userPort)
+	}
+}
+
+func schedule(rev *v1alpha1.Revision, podName, nonce string, logger *zap.SugaredLogger) error {
+	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme,
+		scheme.Scheme)
+
+	ps := createPodSpec(rev)
+	podDef := corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: rev.ObjectMeta.Namespace,
+			Annotations: map[string]string{
+				"sidecar.istio.io/inject": "false",
+			},
+			Labels: map[string]string{
+				"localpod-nonce": nonce,
+			},
+		},
+		Spec: *ps,
+	}
+
+	f, err := os.Create(fmt.Sprintf("/etc/localpods/%s", podName))
+	if err != nil {
+		logger.Errorf("Opening local pod definition (%q): %v", rev.Name, err)
+	}
+	defer f.Close()
+	err = s.Encode(&podDef, f)
+	if err != nil {
+		logger.Errorf("Writing local pod definition (%q): %v", rev.Name, err)
+	}
+	logger.Info("Write out local schedul pod spec")
+	return nil
+}
+
+func ScheduleAndWaitForEndpoint(rev *v1alpha1.Revision, kubeClient *kubernetes.Clientset, logger *zap.SugaredLogger) (string, int32, error) {
+	podName := fmt.Sprintf("localpod-%s-%s", rev.ObjectMeta.Namespace, rev.Name)
+
+	// TODO(greghaynes) Use a real nonce here or come up with a better way to find our local pod
+	if err := schedule(rev, podName, "1234", logger); err != nil {
+		return "", 0, err
+	}
+
+	podCli := kubeClient.Core().Pods(rev.ObjectMeta.Namespace)
+	wi, err := podCli.Watch(metav1.ListOptions{})
+	if err != nil {
+		return "", 0, err
+	}
+	defer wi.Stop()
+
+	logger.Infof("Waiting for pod %q/%q to become ready", rev.ObjectMeta.Namespace, podName)
+	ch := wi.ResultChan()
+	for {
+		select {
+		case <-time.After(120 * time.Second):
+			return "", 0, fmt.Errorf("Timed out waiting for locally scheduled pod (%q) to become ready.", podName)
+		case event := <-ch:
+			if pod, ok := event.Object.(*corev1.Pod); ok {
+				if pod.ObjectMeta.Labels != nil && pod.ObjectMeta.Labels["localpod-nonce"] == "1234" {
+					logger.Debug("Got event for our pod (%v/%v). Status = %v, IP = %v.", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase, pod.Status.PodIP)
+					if pod.Status.Phase != corev1.PodRunning {
+						logger.Debug("Ignoring pod due to not runing status.")
+						continue
+					}
+					if pod.Status.PodIP == "" {
+						return "", 0, fmt.Errorf("Locally scheduled pod is running but podIP is not set")
+					}
+					logger.Debug("Returning running pod.")
+					return pod.Status.PodIP, 8080, nil
+				} else {
+					logger.Debug("Ignoring event for pod %q/%q", pod.ObjectMeta.Namespace, pod.Name)
+				}
+			} else {
+				return "", 0, fmt.Errorf("Unexpected pod event type while waiting for locally scheduled pod: %v.", event)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2497
Fixes #2498

## Proposed Changes

  * Run activator as a daemonset
  * Create handler for activator which creates a revision pod using the static-pod kubelet api.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Local scheduling of pods on cold-start for better cold-start fastpathing.
```