### PR TITLE
Remove the use system-node-critical priority class 

### DIFF
--- a/config/monitoring/logging/elasticsearch/200-fluentd.yaml
+++ b/config/monitoring/logging/elasticsearch/200-fluentd.yaml
@@ -109,7 +109,6 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: system-node-critical
       serviceAccountName: fluentd-ds
       containers:
       - name: fluentd-ds

--- a/config/monitoring/logging/stackdriver/200-fluentd.yaml
+++ b/config/monitoring/logging/stackdriver/200-fluentd.yaml
@@ -109,7 +109,6 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: system-node-critical
       serviceAccountName: fluentd-ds
       containers:
       - name: fluentd-ds


### PR DESCRIPTION
Remove the use system-node-critical priority class  for fluentd daemonset as k8s 1.11 no longer allows using system priority classes for non-system components. I tried using a custom PriorityClass but this feature is alpha in 1.10 and disabled by default. So for now, I am removing the use of this and will create a tracking issue to fix this once 1.11 becomes more widely available.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2218
