### PR TITLE
Set terminationGrace of a pod according to the timeout of the revision.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -113,13 +113,16 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	rewriteUserProbe(userContainer.ReadinessProbe)
 	rewriteUserProbe(userContainer.LivenessProbe)
 
+	revisionTimeout := int64(rev.Spec.TimeoutSeconds.Duration.Seconds())
+
 	podSpec := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			*userContainer,
 			*makeQueueContainer(rev, loggingConfig, autoscalerConfig, controllerConfig),
 		},
-		Volumes:            []corev1.Volume{varLogVolume},
-		ServiceAccountName: rev.Spec.ServiceAccountName,
+		Volumes:                       []corev1.Volume{varLogVolume},
+		ServiceAccountName:            rev.Spec.ServiceAccountName,
+		TerminationGracePeriodSeconds: &revisionTimeout,
 	}
 
 	// Add Fluentd sidecar and its config map volume if var log collection is enabled.

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -39,6 +39,10 @@ var (
 	one int32 = 1
 )
 
+func refInt64(num int64) *int64 {
+	return &num
+}
+
 func TestMakePodSpec(t *testing.T) {
 	labels := map[string]string{serving.ConfigurationLabelKey: "cfg", serving.ServiceLabelKey: "svc"}
 	tests := []struct {
@@ -132,7 +136,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "simple concurrency=single no owner digest resolved",
@@ -220,7 +225,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "simple concurrency=single with owner",
@@ -312,7 +318,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "simple concurrency=multi http readiness probe",
@@ -413,7 +420,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "concurrency=multi, readinessprobe=shell",
@@ -512,7 +520,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "concurrency=multi, readinessprobe=http",
@@ -613,7 +622,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "concurrency=multi, livenessprobe=tcp",
@@ -710,7 +720,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "with /var/log collection",
@@ -836,6 +847,7 @@ func TestMakePodSpec(t *testing.T) {
 					},
 				},
 			}},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}, {
 		name: "complex pod spec",
@@ -938,7 +950,8 @@ func TestMakePodSpec(t *testing.T) {
 					// No logging level
 				}},
 			}},
-			Volumes: []corev1.Volume{varLogVolume},
+			Volumes:                       []corev1.Volume{varLogVolume},
+			TerminationGracePeriodSeconds: refInt64(45),
 		},
 	}}
 

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -19,6 +19,8 @@ limitations under the License.
 package test
 
 import (
+	"time"
+
 	"github.com/knative/pkg/test/logging"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -27,6 +29,7 @@ import (
 type Options struct {
 	EnvVars              []corev1.EnvVar
 	ContainerConcurrency int
+	RevisionTimeout      time.Duration
 }
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config

--- a/test/crd.go
+++ b/test/crd.go
@@ -103,11 +103,15 @@ func Configuration(namespace string, names ResourceNames, imagePath string, opti
 						Image: imagePath,
 					},
 					ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
-					TimeoutSeconds:       &metav1.Duration{Duration: options.RevisionTimeout},
 				},
 			},
 		},
 	}
+
+	if options.RevisionTimeout > 0 {
+		config.Spec.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{Duration: options.RevisionTimeout}
+	}
+
 	if options.EnvVars != nil && len(options.EnvVars) > 0 {
 		config.Spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
 	}

--- a/test/crd.go
+++ b/test/crd.go
@@ -103,6 +103,7 @@ func Configuration(namespace string, names ResourceNames, imagePath string, opti
 						Image: imagePath,
 					},
 					ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
+					TimeoutSeconds:       &metav1.Duration{Duration: options.RevisionTimeout},
 				},
 			},
 		},

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -36,7 +36,8 @@ import (
 
 const (
 	timeoutExpectedOutput  = "Slept for 0 milliseconds"
-	timeoutRequestDuration = 25 * time.Second
+	revisionTimeout        = 45 * time.Second
+	timeoutRequestDuration = 43 * time.Second
 )
 
 func TestDestroyPodInflight(t *testing.T) {
@@ -48,7 +49,7 @@ func TestDestroyPodInflight(t *testing.T) {
 	var imagePath = test.ImagePath("timeout")
 
 	logger.Info("Creating a new Route and Configuration")
-	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{})
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{RevisionTimeout: revisionTimeout})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1197

As per title. We should give a Pod as much time to shutdown as we give requests on it to complete. That ensures that no connections are dropped due to autoscaling, which may shutdown pods at any time.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Long-running operations are no longer dropped intermittently due to autoscaling.
```
