### PR TITLE
Make Breaker's initial capacity configurable

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -281,7 +281,7 @@ func main() {
 		if queueDepth < 10 {
 			queueDepth = 10
 		}
-		breaker = queue.NewBreaker(int32(queueDepth), int32(containerConcurrency))
+		breaker = queue.NewBreaker(int32(queueDepth), int32(containerConcurrency), false)
 		logger.Infof("Queue container is starting with queueDepth: %d, containerConcurrency: %d", queueDepth, containerConcurrency)
 	}
 

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -281,7 +281,7 @@ func main() {
 		if queueDepth < 10 {
 			queueDepth = 10
 		}
-		breaker = queue.NewBreaker(int32(queueDepth), int32(containerConcurrency), false)
+		breaker = queue.NewBreaker(int32(queueDepth), int32(containerConcurrency), int32(containerConcurrency))
 		logger.Infof("Queue container is starting with queueDepth: %d, containerConcurrency: %d", queueDepth, containerConcurrency)
 	}
 

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -71,20 +71,20 @@ func (b *Breaker) Maybe(thunk func()) bool {
 	}
 }
 
-// Creates a new semaphore of a given size, could be initially full or empty
+// NewSemaphore creates a new semaphore of a given size, could be initially full or empty
 func NewSemaphore(size int32, empty bool) *Semaphore {
 	ch := make(chan token, size)
 	return &Semaphore{activeRequests: ch, empty: empty}
 }
 
-// Implementation of a semaphore
+// Semaphore is an implementation of a semaphore based on Go channels
 type Semaphore struct {
 	activeRequests chan token
 	empty          bool
 	token          token
 }
 
-// Acquire a lock from the semaphore, potentially blocking
+// Get acquires the lock from the semaphore, potentially blocking
 func (s *Semaphore) Get() {
 	if s.empty {
 		<-s.activeRequests

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -126,7 +126,7 @@ func TestSemaphore_Get_HasNoCapacity(t *testing.T) {
 
 	// wait in case `acquired` changes
 	time.Sleep(semSleepInterval)
-	assertEqual(want, acquired, t)
+	assertEqual(want, atomic.LoadInt32(&acquired), t)
 }
 
 // Test empty semaphore, add capacity, token can be acquired
@@ -139,7 +139,7 @@ func TestSemaphore_Get_HasCapacity(t *testing.T) {
 
 	// to allow `acquired` to change
 	time.Sleep(semSleepInterval)
-	assertEqual(want, acquired, t)
+	assertEqual(want, atomic.LoadInt32(&acquired), t)
 }
 
 //Test all put items can be consumed
@@ -154,7 +154,7 @@ func TestSemaphore_Put(t *testing.T) {
 	sem.Put(2)
 
 	time.Sleep(semSleepInterval)
-	assertEqual(want, acquired, t)
+	assertEqual(want, atomic.LoadInt32(&acquired), t)
 }
 
 // Attempts to perform a concurrent request against the specified breaker.

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -163,7 +163,6 @@ func TestSemaphore_AddCapacity(t *testing.T) {
 	assertEqual(int32(1), sem.capacity, t)
 	sem.Get()
 	sem.AddCapacity(2)
-	assertEqual(int32(2), sem.available, t)
 	assertEqual(int32(3), sem.capacity, t)
 }
 
@@ -171,7 +170,6 @@ func TestSemaphore_ReduceCapacity(t *testing.T) {
 	sem := NewSemaphore(1, 0)
 	sem.AddCapacity(int32(1))
 	sem.ReduceCapacity(1)
-	assertEqual(int32(0), sem.available, t)
 	assertEqual(int32(0), sem.capacity, t)
 }
 
@@ -181,9 +179,9 @@ func (b *Breaker) concurrentRequest(empty bool) request {
 	r := request{lock: &sync.Mutex{}, accepted: make(chan bool, 1)}
 	r.lock.Lock()
 
-	if len(b.sem.waitersQueue) > 0 {
+	if len(b.sem.queue) > 0 {
 		// Expect request to be performed
-		defer waitForQueue(b.sem.waitersQueue, len(b.sem.waitersQueue)-1)
+		defer waitForQueue(b.sem.queue, len(b.sem.queue)-1)
 	} else if len(b.pendingRequests) < cap(b.pendingRequests) {
 		// Expect request to be queued
 		defer waitForQueue(b.pendingRequests, len(b.pendingRequests)+1)

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -167,6 +167,17 @@ func TestSemaphore_AddCapacity(t *testing.T) {
 	assertEqual(int32(3), sem.capacity, t)
 }
 
+// Test the case when we add more capacity then the number of waiting reducers
+func TestSemaphore_AddCapacityLessThenReducers(t *testing.T) {
+	sem := NewSemaphore(2, 2)
+	sem.Acquire()
+	sem.Acquire()
+	sem.ReduceCapacity(2)
+	assertEqual(int32(2), sem.reducers, t)
+	sem.AddCapacity(3)
+	assertEqual(int32(0), sem.reducers, t)
+}
+
 func TestSemaphore_ReduceCapacity(t *testing.T) {
 	want := int32(0)
 	sem := NewSemaphore(1, 0)
@@ -182,7 +193,7 @@ func TestSemaphore_ReduceCapacity_NoCapacity(t *testing.T) {
 	assertEqual(int32(1), sem.reducers, t)
 	sem.Release()
 	assertEqual(int32(0), sem.reducers, t)
-	assertEqual(int32(1), sem.capacity, t)
+	assertEqual(int32(0), sem.capacity, t)
 }
 
 func TestSemaphore_ReduceCapacity_OutOfBound(t *testing.T) {

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -173,6 +173,25 @@ func TestSemaphore_ReduceCapacity(t *testing.T) {
 	assertEqual(int32(0), sem.capacity, t)
 }
 
+func TestSemaphore_ReduceCapacity_NoCapacity(t *testing.T) {
+	sem := NewSemaphore(1, 1)
+	sem.Get()
+	sem.ReduceCapacity(1)
+	assertEqual(int32(1), sem.reducers, t)
+	sem.Put()
+	assertEqual(int32(0), sem.reducers, t)
+	assertEqual(int32(1), sem.capacity, t)
+}
+
+func TestSemaphore_WrongInitialCapacity(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	_ = NewSemaphore(1, 2)
+}
+
 // Attempts to perform a concurrent request against the specified breaker.
 // Will wait for request to either be performed, enqueued or rejected.
 func (b *Breaker) concurrentRequest(empty bool) request {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
This change enables Breaker to throttle requests based on the configured initial capacity which could be <= maxConcurrency. This would allow the reuse of the Breaker's code in the implementation of the Throttler to handle the overflow in the Activator, see https://github.com/knative/serving/issues/2381
Fixes #

## Proposed Changes

  * Move active requests channel to a semaphore struct
  * The breaker modification doesn't affect the Queue behaviour

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
NONE
```
