### PR TITLE
Fix activator blocking on SIGTERM

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -71,16 +72,20 @@ var (
 	reqChan  = make(chan activatorhandler.ReqEvent, requestCountingQueueLength)
 )
 
-func statReporter() {
+func statReporter(stopCh <-chan struct{}) {
 	for {
-		sm := <-statChan
-		if statSink == nil {
-			logger.Error("Stat sink not connected.")
-			continue
-		}
-		err := statSink.Send(sm)
-		if err != nil {
-			logger.Error("Error while sending stat", zap.Error(err))
+		select {
+		case sm := <-statChan:
+			if statSink == nil {
+				logger.Error("Stat sink not connected.")
+				continue
+			}
+			err := statSink.Send(sm)
+			if err != nil {
+				logger.Error("Error while sending stat", zap.Error(err))
+			}
+		case <-stopCh:
+			return
 		}
 	}
 }
@@ -133,11 +138,14 @@ func main() {
 	}
 	rt := activatorutil.NewRetryRoundTripper(activatorutil.AutoTransport, logger, backoffSettings, shouldRetry)
 
+	// set up signals so we handle the first shutdown signal gracefully
+	stopCh := signals.SetupSignalHandler()
+
 	// Open a websocket connection to the autoscaler
 	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", "autoscaler", system.Namespace, "8080")
 	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
-	go statReporter()
+	go statReporter(stopCh)
 
 	podName := util.GetRequiredEnvOrFatal("POD_NAME", logger)
 	activatorhandler.NewConcurrencyReporter(podName, activatorhandler.Channels{
@@ -160,13 +168,6 @@ func main() {
 		),
 	}
 
-	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := signals.SetupSignalHandler()
-	go func() {
-		<-stopCh
-		a.Shutdown()
-	}()
-
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace)
 	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
@@ -176,5 +177,14 @@ func main() {
 		logger.Fatalf("failed to start configuration manager: %v", err)
 	}
 
-	h2c.ListenAndServe(":8080", ah)
+	srv := h2c.NewServer(":8080", ah)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			logger.Errorf("Error running HTTP server: %v", err)
+		}
+	}()
+
+	<-stopCh
+	a.Shutdown()
+	srv.Shutdown(context.TODO())
 }


### PR DESCRIPTION
activator currently does not shutdown all goroutines on receiving a
SIGTERM.

Fixes: #2573 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
