### PR TITLE
Remove images deletion from e2e test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -444,7 +444,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a294d4d6fda3d2f4b9119eaa9e7965975fed86bfbd7a3ba357069f538a3aba83"
+  digest = "1:93d9d7037434ea3f51ba964c20f625ecb7257e0f13b7adda101d77e516d850c9"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -452,7 +452,7 @@
     "tools/testgrid",
   ]
   pruneopts = "UT"
-  revision = "77db40a851fa3d8366dfdd67ae99098b6cc2be02"
+  revision = "2a11b760d21b3a969d80d9ccf18323e1d5ed03a6"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -56,15 +56,8 @@ function teardown_test_resources() {
     teardown
   fi
 
-  # Delete Knative Serving images when using boskos.
-  if (( IS_BOSKOS )); then
-    echo "Images in ${DOCKER_REPO_OVERRIDE}:"
-    gcloud container images list --repository=${DOCKER_REPO_OVERRIDE}
-    delete_gcr_images ${DOCKER_REPO_OVERRIDE}
-  else
-    # Delete the kubernetes source downloaded by kubetest
-    rm -fr kubernetes kubernetes.tar.gz
-  fi
+  # Delete the kubernetes source downloaded by kubetest
+  rm -fr kubernetes kubernetes.tar.gz
 }
 
 # Exit test, dumping current state info.
@@ -362,6 +355,12 @@ function initialize() {
   fi
 
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
+
+  # Safety checks
+
+  if [[ "${DOCKER_REPO_OVERRIDE}" =~ ^gcr.io/knative-(releases|nightly)/?$ ]]; then
+    abort "\$DOCKER_REPO_OVERRIDE is set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
+  fi
 
   readonly RUN_TESTS
   readonly EMIT_METRICS

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -22,12 +22,12 @@
 readonly SERVING_GKE_VERSION=latest
 readonly SERVING_GKE_IMAGE=cos
 
-# Public images and yaml files.
-readonly KNATIVE_ISTIO_CRD_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio-crds.yaml
-readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
-readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
-readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-releases/build/latest/release.yaml
-readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
+# Public latest stable nightly images and yaml files.
+readonly KNATIVE_ISTIO_CRD_YAML=https://storage.googleapis.com/knative-nightly/serving/latest/istio-crds.yaml
+readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-nightly/serving/latest/istio.yaml
+readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-nightly/serving/latest/release.yaml
+readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-nightly/build/latest/release.yaml
+readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-nightly/eventing/latest/release.yaml
 
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then
@@ -100,7 +100,10 @@ function wait_until_object_does_not_exist() {
   fi
   echo -n "Waiting until ${DESCRIPTION} does not exist"
   for i in {1..150}; do  # timeout after 5 minutes
-    kubectl ${KUBECTL_ARGS} > /dev/null 2>&1 || return 0
+    if kubectl ${KUBECTL_ARGS} > /dev/null 2>&1; then
+      echo "\n${DESCRIPTION} does not exist"
+      return 0
+    fi
     echo -n "."
     sleep 2
   done
@@ -182,9 +185,8 @@ function wait_until_routable() {
 # Parameters: $1 - app name.
 #             $2 - namespace (optional).
 function get_app_pod() {
-  local namespace=""
-  [[ -n $2 ]] && namespace="-n $2"
-  kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[0].metadata.name}"
+  local pods=($(get_app_pods $1 $2))
+  echo "${pods[0]}"
 }
 
 # Returns the name of all pods of the given app.

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -68,6 +68,8 @@ function main() {
     kubectl version
     echo ">> go version"
     go version
+    echo ">> git version"
+    git version
   fi
 
   [[ -z $1 ]] && set -- "--all-tests"

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -111,7 +111,8 @@ function parse_flags() {
 
   if (( TAG_RELEASE )); then
     # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --exclude '*')"
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "Error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
@@ -62,7 +62,7 @@ func CollectTransitiveImports(binaries []string) ([]string, error) {
 func qualifyLocalImport(ip string) (string, error) {
 	gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
 	if !strings.HasPrefix(WorkingDir, gopathsrc) {
-		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = ", gopathsrc)
+		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
 	}
 	return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
 }

--- a/vendor/github.com/knative/test-infra/tools/testgrid/testgrid.go
+++ b/vendor/github.com/knative/test-infra/tools/testgrid/testgrid.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	// Default filename to store output that acts as input to testgrid.
+	// Filename to store output that acts as input to testgrid.
 	// Should be of the form junit_*.xml
-	filename = "/junit_knative.xml"
+	Filename = "junit_knative.xml"
 )
 
 // TestProperty defines a property of the test
@@ -80,9 +80,9 @@ func CreateXMLOutput(ts TestSuite, artifactsDir string) error {
 		return err
 	}
 
-	outputFile := artifactsDir + filename
+	outputFile := artifactsDir + "/" + Filename
 	log.Printf("Storing output in %s", outputFile)
-	f, err := os.Create(outputFile)
+	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Old images cleanup is no longer part of e2e test, this functionality will be moved to a separate job runs periodically.

This part is done in knative/test-infra, updating dependencies in this repo to include this update.

Link to the issue in test-infra: https://github.com/knative/test-infra/issues/276

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

  *
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
