### PR TITLE
Fix issues in ManagedConnection

### DIFF
--- a/pkg/websocket/connection.go
+++ b/pkg/websocket/connection.go
@@ -151,6 +151,8 @@ func (c *ManagedConnection) keepalive() (err error) {
 				if _, _, err = conn.NextReader(); err != nil {
 					conn.Close()
 				}
+			} else {
+				err = ErrConnectionNotEstablished
 			}
 		}()
 

--- a/pkg/websocket/connection.go
+++ b/pkg/websocket/connection.go
@@ -121,7 +121,8 @@ func (c *ManagedConnection) connect() (err error) {
 		Steps:    20,
 		Jitter:   0.5,
 	}, func() (bool, error) {
-		conn, err := connFactory(c.target)
+		var conn rawConnection
+		conn, err = connFactory(c.target)
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
A new err variable was being created in the inner scope causing
the connect() function to always return nil.

Without this fix, if the connection is unable to established by the end of the ExponentialBackoff then connect() will return nil, which ends up with the code busy-lopping inside keepalive().

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
