### PR TITLE
Update table test to diff the missing update against its previous state.

### DIFF
--- a/pkg/reconciler/testing/table.go
+++ b/pkg/reconciler/testing/table.go
@@ -18,12 +18,15 @@ package testing
 
 import (
 	"context"
+	"path"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/kmeta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,6 +73,13 @@ type TableRow struct {
 	SkipNamespaceValidation bool
 }
 
+func objKey(o runtime.Object) string {
+	on := o.(kmeta.Accessor)
+	// namespace + name is not unique, and the tests don't populate k8s kind
+	// information, so use GoLang's type name as part of the key.
+	return path.Join(reflect.TypeOf(o).String(), on.GetNamespace(), on.GetName())
+}
+
 // Factory returns a Reconciler.Interface to perform reconciliation in table test and
 // ActionRecorderList/EventList to capture k8s actions/events produced during reconciliation.
 type Factory func(*testing.T, *TableRow) (controller.Reconciler, ActionRecorderList, EventList)
@@ -90,18 +100,27 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 		t.Errorf("Error capturing actions by verb: %q", err)
 	}
 
+	// Previous state is used to diff resource expected state for update requests that were missed.
+	objPrevState := map[string]runtime.Object{}
+	for _, o := range r.Objects {
+		objPrevState[objKey(o)] = o
+	}
+
 	for i, want := range r.WantCreates {
 		if i >= len(actions.Creates) {
 			t.Errorf("Missing create: %#v", want)
 			continue
 		}
 		got := actions.Creates[i]
-		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
-			t.Errorf("unexpected action[%d]: %#v", i, got)
-		}
 		obj := got.GetObject()
+		objPrevState[objKey(obj)] = obj
+
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
+			t.Errorf("Unexpected action[%d]: %#v", i, got)
+		}
+
 		if diff := cmp.Diff(want, obj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
-			t.Errorf("unexpected create (-want +got): %s", diff)
+			t.Errorf("Unexpected create (-want +got): %s", diff)
 		}
 	}
 	if got, want := len(actions.Creates), len(r.WantCreates); got > want {
@@ -112,12 +131,24 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 
 	for i, want := range r.WantUpdates {
 		if i >= len(actions.Updates) {
-			t.Errorf("Missing update: %#v", want.GetObject())
+			wo := want.GetObject()
+			key := objKey(wo)
+			oldObj, ok := objPrevState[key]
+			if !ok {
+				t.Errorf("Object %s was never created: want: %#v", key, wo)
+				continue
+			}
+			t.Errorf("Missing update for %s (-want, +prevState): %s", key,
+				cmp.Diff(oldObj, wo, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
 			continue
 		}
-		got := actions.Updates[i]
-		if diff := cmp.Diff(want.GetObject(), got.GetObject(), ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
-			t.Errorf("unexpected update (-want +got): %s", diff)
+		got := actions.Updates[i].GetObject()
+
+		// Update the object state.
+		objPrevState[objKey(got)] = got
+
+		if diff := cmp.Diff(want.GetObject(), got, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("Unexpected update (-want +got): %s", diff)
 		}
 	}
 	if got, want := len(actions.Updates), len(r.WantUpdates); got > want {
@@ -133,10 +164,10 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 		}
 		got := actions.Deletes[i]
 		if got.GetName() != want.GetName() {
-			t.Errorf("unexpected delete[%d]: %#v", i, got)
+			t.Errorf("Unexpected delete[%d]: %#v", i, got)
 		}
 		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
-			t.Errorf("unexpected delete[%d]: %#v", i, got)
+			t.Errorf("Unexpected delete[%d]: %#v", i, got)
 		}
 	}
 	if got, want := len(actions.Deletes), len(r.WantDeletes); got > want {
@@ -153,13 +184,13 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 
 		got := actions.Patches[i]
 		if got.GetName() != want.GetName() {
-			t.Errorf("unexpected patch[%d]: %#v", i, got)
+			t.Errorf("Unexpected patch[%d]: %#v", i, got)
 		}
 		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
-			t.Errorf("unexpected patch[%d]: %#v", i, got)
+			t.Errorf("Unexpected patch[%d]: %#v", i, got)
 		}
 		if diff := cmp.Diff(string(want.GetPatch()), string(got.GetPatch())); diff != "" {
-			t.Errorf("unexpected patch(-want +got): %s", diff)
+			t.Errorf("Unexpected patch(-want +got): %s", diff)
 		}
 	}
 	if got, want := len(actions.Patches), len(r.WantPatches); got > want {
@@ -205,8 +236,10 @@ func (tt TableTest) Test(t *testing.T, factory Factory) {
 	}
 }
 
-var ignoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
-	return strings.HasSuffix(p.String(), "LastTransitionTime.Inner.Time")
-}, cmp.Ignore())
+var (
+	ignoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.HasSuffix(p.String(), "LastTransitionTime.Inner.Time")
+	}, cmp.Ignore())
 
-var safeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})
+	safeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})
+)


### PR DESCRIPTION
When we have a missing update request it is hard to infer what exact
update was missed and what property should have been updated.
With this we can debug the issue easier.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2489 

## Proposed Changes

  * store the previous object in a map
  * when an update is missing, compare desired state to the last known state.
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
