### PR TITLE
Have the KPA controller only reconciles KPAs with supported annotation

### DIFF
--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -30,7 +30,12 @@ const (
 	MinScaleAnnotationKey = GroupName + "/minScale"
 	MaxScaleAnnotationKey = GroupName + "/maxScale"
 
+	// HPA is the value of ClassAnnotationKey for PodAutoscaler of HPA.
+	HPA = "hpa"
+	// KPA is the value of ClassAnnotationKey for PodAutoscaler of KPA.
+	KPA = "kpa"
+
 	// KPALabelKey is the label key attached to a K8s Service to hint to the KPA
 	// which services/endpoints should trigger reconciles.
-	KPALabelKey = GroupName + "/kpa"
+	KPALabelKey = GroupName + KPA
 )

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -39,3 +39,8 @@ const (
 	// which services/endpoints should trigger reconciles.
 	KPALabelKey = GroupName + KPA
 )
+
+// SupportedPAClasses is the set of currently supported PodAutoscaler classes.
+var SupportedPAClasses = map[string]struct{}{
+	KPA: struct{}{},
+}

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -37,7 +37,7 @@ const (
 
 	// KPALabelKey is the label key attached to a K8s Service to hint to the KPA
 	// which services/endpoints should trigger reconciles.
-	KPALabelKey = GroupName + KPA
+	KPALabelKey = GroupName + "/" + KPA
 )
 
 // SupportedPAClasses is the set of currently supported PodAutoscaler classes.

--- a/pkg/apis/serving/v1alpha1/metadata_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/metadata_validation_test.go
@@ -18,10 +18,11 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/knative/pkg/apis"
-	"github.com/knative/serving/pkg/apis/autoscaling"
 	"reflect"
 	"testing"
+
+	"github.com/knative/pkg/apis"
+	"github.com/knative/serving/pkg/apis/autoscaling"
 )
 
 func TestValidateScaleBoundAnnotations(t *testing.T) {
@@ -89,6 +90,42 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			err := validateScaleBoundsAnnotations(c.annotations)
+			if !reflect.DeepEqual(c.expectErr, err) {
+				t.Errorf("Expected: '%+v', Got: '%+v'", c.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateScaleClassAnnotations(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		expectErr   *apis.FieldError
+	}{{
+		name:        "nil annotations",
+		annotations: nil,
+		expectErr:   nil,
+	}, {
+		name:        "empty annotations",
+		annotations: map[string]string{},
+		expectErr:   nil,
+	}, {
+		name:        "supportted class",
+		annotations: map[string]string{autoscaling.ClassAnnotationKey: autoscaling.KPA},
+		expectErr:   nil,
+	}, {
+		name:        "unsupportted",
+		annotations: map[string]string{autoscaling.ClassAnnotationKey: "whatever"},
+		expectErr: &apis.FieldError{
+			Message: fmt.Sprintf("Unsupported %q value %q", autoscaling.ClassAnnotationKey, "whatever"),
+			Paths:   []string{autoscaling.ClassAnnotationKey},
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateScaleClassAnnotations(c.annotations)
 			if !reflect.DeepEqual(c.expectErr, err) {
 				t.Errorf("Expected: '%+v', Got: '%+v'", c.expectErr, err)
 			}

--- a/pkg/apis/serving/v1alpha1/metadata_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/metadata_validation_test.go
@@ -111,11 +111,11 @@ func TestValidateScaleClassAnnotations(t *testing.T) {
 		annotations: map[string]string{},
 		expectErr:   nil,
 	}, {
-		name:        "supportted class",
+		name:        "supported class",
 		annotations: map[string]string{autoscaling.ClassAnnotationKey: autoscaling.KPA},
 		expectErr:   nil,
 	}, {
-		name:        "unsupportted",
+		name:        "unsupported",
 		annotations: map[string]string{autoscaling.ClassAnnotationKey: "whatever"},
 		expectErr: &apis.FieldError{
 			Message: fmt.Sprintf("Unsupported %q value %q", autoscaling.ClassAnnotationKey, "whatever"),

--- a/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/autoscaling.go
@@ -136,6 +136,13 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	} else if err != nil {
 		return err
 	}
+	// Don't reconcile for none kpa class PodAutoscaler.
+	if original.Annotations[autoscaling.ClassAnnotationKey] != autoscaling.KPA {
+		logger.Debug("PodAutoscaler %s does not have %q as %q annotation. No reconciling",
+			name, autoscaling.KPA, autoscaling.ClassAnnotationKey)
+		return nil
+	}
+
 	// Don't modify the informer's copy.
 	kpa := original.DeepCopy()
 

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources/names"
@@ -46,9 +47,11 @@ func MakeRevision(config *v1alpha1.Configuration, buildRef *corev1.ObjectReferen
 	rev.Labels[serving.ServiceLabelKey] = configLabels[serving.ServiceLabelKey]
 	rev.Labels[serving.ConfigurationGenerationLabelKey] = fmt.Sprintf("%v", config.Spec.Generation)
 
-	// Populate the Configuration Generation annotation.
 	if rev.Annotations == nil {
 		rev.Annotations = make(map[string]string)
+	}
+	if rev.Annotations[autoscaling.ClassAnnotationKey] == "" {
+		rev.Annotations[autoscaling.ClassAnnotationKey] = autoscaling.KPA
 	}
 
 	// Populate OwnerReferences so that deletes cascade.

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
@@ -53,9 +54,11 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   "no",
-				Name:        "build-00012",
-				Annotations: map[string]string{},
+				Namespace: "no",
+				Name:      "build-00012",
+				Annotations: map[string]string{
+					autoscaling.ClassAnnotationKey: autoscaling.KPA,
+				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -105,9 +108,11 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   "with",
-				Name:        "build-00099",
-				Annotations: map[string]string{},
+				Namespace: "with",
+				Name:      "build-00099",
+				Annotations: map[string]string{
+					autoscaling.ClassAnnotationKey: autoscaling.KPA,
+				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -158,9 +163,11 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   "with",
-				Name:        "labels-00099",
-				Annotations: map[string]string{},
+				Namespace: "with",
+				Name:      "labels-00099",
+				Annotations: map[string]string{
+					autoscaling.ClassAnnotationKey: autoscaling.KPA,
+				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -197,6 +204,7 @@ func TestMakeRevisions(t *testing.T) {
 						Annotations: map[string]string{
 							"foo": "bar",
 							"baz": "blah",
+							autoscaling.ClassAnnotationKey: autoscaling.HPA,
 						},
 					},
 					Spec: v1alpha1.RevisionSpec{
@@ -226,6 +234,7 @@ func TestMakeRevisions(t *testing.T) {
 				Annotations: map[string]string{
 					"foo": "bar",
 					"baz": "blah",
+					autoscaling.ClassAnnotationKey: autoscaling.HPA,
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1928

## Proposed Changes

  * Set annotation `autoscaling.knative.dev/class` to `kpa` if the value is not set, which will be populated to KPA.
  * Make the KPA controller only reconciles KPAs with annotation `autoscaling.knative.dev/class=kpa`
  * Add verification for `autoscaling.knative.dev/class` for input revision template. Currently only `kpa` is supported.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
