### PR TITLE
Relax the pod count range in TestAutoscaleUpCountPods.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -315,7 +315,10 @@ func assertAutoscaleUpToNumPods(ctx *testContext, numPods int32) {
 	if err := generateTraffic(ctx, int(numPods*10), 30*time.Second); err != nil {
 		ctx.t.Fatalf("Error during initial scale up: %v", err)
 	}
-	assertNumberOfPods(ctx, numPods, numPods+1)
+	// Relaxing the pod count requirement a little bit to avoid being too flaky.
+	minPods := numPods - 1
+	maxPods := numPods + 1
+	assertNumberOfPods(ctx, minPods, maxPods)
 }
 
 func TestAutoscaleUpCountPods(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

  *  I see that the pod count range was too restrictive, and the number of scaled pods may miss the range by 1.  Relaxing this a little bit to avoid being flaky.
 
**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
