### PR TITLE
Run goimports

### DIFF
--- a/pkg/apis/serving/v1alpha1/metadata_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/metadata_validation_test.go
@@ -18,10 +18,11 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/knative/pkg/apis"
-	"github.com/knative/serving/pkg/apis/autoscaling"
 	"reflect"
 	"testing"
+
+	"github.com/knative/pkg/apis"
+	"github.com/knative/serving/pkg/apis/autoscaling"
 )
 
 func TestValidateScaleBoundAnnotations(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"github.com/knative/pkg/apis"
 )
 

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -19,12 +19,13 @@ limitations under the License.
 package conformance
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 func TestUpdateConfigurationMetadata(t *testing.T) {

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -19,9 +19,10 @@ limitations under the License.
 package conformance
 
 import (
+	"testing"
+
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/test"
-	"testing"
 
 	// Mysteriously required to support GCP auth (required by k8s libs). Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/test/service.go
+++ b/test/service.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"fmt"
+
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"


### PR DESCRIPTION
Produced via: `goimports -w $(find -name '*.go' | grep -v vendor)`