### PR TITLE
Make e2e tests wait for knative-ingressgateway if exists.

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -111,6 +111,9 @@ function install_knative_serving() {
 
   wait_until_pods_running knative-serving || return 1
   wait_until_pods_running istio-system || return 1
+  if kubectl get -n istio-system knative-ingressgateway; then
+    wait_until_service_has_external_ip istio-system istio-ingressgateway
+  fi
   wait_until_service_has_external_ip istio-system istio-ingressgateway
 }
 

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -111,8 +111,8 @@ function install_knative_serving() {
 
   wait_until_pods_running knative-serving || return 1
   wait_until_pods_running istio-system || return 1
-  if kubectl get -n istio-system knative-ingressgateway; then
-    wait_until_service_has_external_ip istio-system istio-ingressgateway
+  if kubectl get svc -n istio-system knative-ingressgateway > /dev/null 2>&1 ; then
+    wait_until_service_has_external_ip istio-system knative-ingressgateway
   fi
   wait_until_service_has_external_ip istio-system istio-ingressgateway
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

  * Make e2e tests wait for knative-ingressgateway if it exists.  This will make the downgrade tests work with v0.2.2 since it uses `knative-ingressgateway` but test @ HEAD only waits for `istio-ingressgateway`.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
