### PR TITLE
Guard against wrong class in KPA and HPA controllers.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
@@ -103,6 +103,11 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
+	if original.Class() != autoscaling.HPA {
+		logger.Warn("Ignoring non-hpa-class PA")
+		return nil
+	}
+
 	// Don't modify the informer's copy.
 	pa := original.DeepCopy()
 	// Reconcile this copy of the pa and then write back any status

--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa_test.go
@@ -50,6 +50,12 @@ func TestReconcile(t *testing.T) {
 			Object: pa(testRevision, testNamespace, WithHPAClass, WithTraffic),
 		}},
 	}, {
+		Name: "do not create hpa when non-hpa-class pod autoscaler",
+		Objects: []runtime.Object{
+			pa(testRevision, testNamespace, WithKPAClass),
+		},
+		Key: key(testRevision, testNamespace),
+	}, {
 		Name:    "delete when pa does not exist",
 		Objects: []runtime.Object{},
 		Key:     key(testRevision, testNamespace),

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -142,6 +142,11 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
+	if original.Class() != autoscaling.KPA {
+		logger.Warn("Ignoring non-kpa-class PA")
+		return nil
+	}
+
 	// Don't modify the informer's copy.
 	pa := original.DeepCopy()
 

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/knative/pkg/configmap"
 	. "github.com/knative/pkg/logging/testing"
+	"github.com/knative/serving/pkg/apis/autoscaling"
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
@@ -149,6 +150,66 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 
 	if fakeMetrics.deleteBeforeCreate.Load() {
 		t.Fatal("Delete ran before OnPresent")
+	}
+}
+
+func TestNonKpaClass(t *testing.T) {
+	kubeClient := fakeK8s.NewSimpleClientset()
+	servingClient := fakeKna.NewSimpleClientset()
+
+	stopCh := make(chan struct{})
+	createdCh := make(chan struct{})
+	defer close(createdCh)
+
+	opts := reconciler.Options{
+		KubeClientSet:    kubeClient,
+		ServingClientSet: servingClient,
+		Logger:           TestLogger(t),
+	}
+
+	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
+	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+
+	scaleClient := &scalefake.FakeScaleClient{}
+	kpaScaler := NewKPAScaler(servingClient, scaleClient, TestLogger(t), newConfigWatcher())
+
+	fakeMetrics := newTestKPAMetrics(createdCh, stopCh)
+	ctl := NewController(&opts,
+		servingInformer.Autoscaling().V1alpha1().PodAutoscalers(),
+		kubeInformer.Core().V1().Endpoints(),
+		fakeMetrics,
+		kpaScaler,
+	)
+
+	rev := newTestRevision(testNamespace, testRevision)
+	rev.Annotations = map[string]string{
+		autoscaling.ClassAnnotationKey: autoscaling.HPA, // non "kpa" class
+	}
+
+	servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
+	kpa := revisionresources.MakeKPA(rev)
+	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
+	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
+	reconcileDone := make(chan struct{})
+	go func() {
+		defer close(reconcileDone)
+		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
+		if err != nil {
+			t.Errorf("Reconcile() = %v", err)
+		}
+	}()
+
+	// Wait for reconcile to finish
+	select {
+	case <-reconcileDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Reconciliation timed out")
+	}
+
+	// Verify no KPAMetrics were created
+	if fakeMetrics.createCallCount.Load() != 0 {
+		t.Errorf("Unexpected KPAMetrics created")
 	}
 }
 


### PR DESCRIPTION
<!--
/lint
-->

Fixes #2604

For some reason, the AnnotationFilterFunc are not guarding HPA and KPA class PodAutoscaler controllers from getting other class PAs (#2606 to fix it).

## Proposed Changes

  * Guard against a wrong class PodAutoscaler slipping through the AnnotationFilterFunc
  * Brings back unit tests as well

**Release Note**
```release-note
NONE
```
