### PR TITLE
Improve the performance of bulk service creation by 60%.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -80,6 +81,10 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error building kubeconfig: %v", err)
 	}
+
+	// We run 6 controllers, so bump the defaults.
+	cfg.QPS = 6 * rest.DefaultQPS
+	cfg.Burst = 6 * rest.DefaultBurst
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
This draws inspiration largely from https://github.com/knative/pkg/pull/173, which prompted me to measure and investigate.  You can see some more detailed timings in that thread.

As we've grown the number of reconciler processes in our controller image, the QPS limits with which we talk to the API server have remained the same.  The meant that it took ~3 min to deploy 50 services, and ~6 min to deploy 100.

This change simply bumps those limits to `{number of reconciler processes} x {default value}` to approximate the limits we'd have if we ran each controller process as a separate Pod.

After applying this change we see a ~60% improvement, it takes ~70 seconds to deploy 50 services, and ~2:30 min to deploy 100.

> Note that it is unlikely that this same level of improvement will apply to less bursty deployments, but the improvement is substantial for bursty deployments.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

cc @alculquicondor @vaikas-google 