### PR TITLE
Use `kubectl autoscale` to set number of activator pods.

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -79,7 +79,9 @@ function install_knative_serving() {
   kubectl apply -f "${INSTALL_RELEASE_YAML}" || return 1
 
   echo ">> Adding more activator pods."
-  kubectl scale deploy --replicas=2 -n knative-serving activator || return 1
+  # This command would fail if the HPA already exist, like during upgrade test.
+  # Therefore we don't exit on failure, and don't log an error message.
+  kubectl autoscale deploy --min=2 --max=2 -n knative-serving activator 2>/dev/null
 
   # Due to the lack of Status in Istio, we have to ignore failures in initial requests.
   #


### PR DESCRIPTION
This avoids the failure when the activator deployment is modified too many times, like during upgrade tests.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
/assign @jonjohnsonjr 
-->

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
