### PR TITLE
Add a cluster local gateway to our Istio templates.

### DIFF
--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -12,6 +12,20 @@ cp ../istio-pilot-hpa.yaml install/kubernetes/helm/istio/charts/pilot/templates/
 # Copy CRDs template
 cp install/kubernetes/helm/istio/templates/crds.yaml ../istio-crds.yaml
 
+# Create a custom cluster local gateway, based on the Istio custom-gateway template.
+helm template --namespace=istio-system \
+  --set gateways.custom-gateway.cpu.targetAverageUtilization=60 \
+  --set gateways.custom-gateway.labels.app='cluster-local-gateway' \
+  --set gateways.custom-gateway.labels.istio='cluster-local-gateway' \
+  --set gateways.custom-gateway.type='ClusterIP' \
+  --set gateways.istio-ingressgateway.enabled=false \
+  --set gateways.istio-egressgateway.enabled=false \
+  --set gateways.istio-ilbgateway.enabled=false \
+  install/kubernetes/helm/istio \
+  -f install/kubernetes/helm/istio/values-istio-gateways.yaml \
+  | sed -e "s/custom-gateway/cluster-local-gateway/g" -e "s/customgateway/clusterlocalgateway/g" \
+  > cluster-local-gateway.yaml
+
 # A template with sidecar injection enabled.
 helm template --namespace=istio-system \
   --set sidecarInjectorWebhook.enabled=true \
@@ -26,6 +40,7 @@ helm template --namespace=istio-system \
   --set pilot.autoscaleMax=10 \
   --set pilot.cpu.targetAverageUtilization=60 \
   install/kubernetes/helm/istio > ../istio.yaml
+cat cluster-local-gateway.yaml >> ../istio.yaml
 
 # A liter template, with no sidecar injection.  We could probably remove
 # more from this template.
@@ -38,6 +53,7 @@ helm template --namespace=istio-system \
   `# Disable mixer policy check, since in our template we set no policy.` \
   --set global.disablePolicyChecks=true \
   install/kubernetes/helm/istio > ../istio-lean.yaml
+cat cluster-local-gateway.yaml >> ../istio-lean.yaml
 
 # Clean up.
 cd ..

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -3813,3 +3813,296 @@ spec:
         maxRequestsPerConnection: 10000
 ---
 
+---
+# Source: istio/charts/gateways/templates/serviceaccount.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-local-gateway-service-account
+  namespace: istio-system
+  labels:
+    app: cluster-local-gateway
+    chart: gateways-1.0.1
+    heritage: Tiller
+    release: RELEASE-NAME
+---
+
+---
+# Source: istio/charts/gateways/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: gateways
+    chart: gateways-1.0.1
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: cluster-local-gateway-istio-system
+rules:
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources", "virtualservices", "destinationrules", "gateways"]
+  verbs: ["get", "watch", "list", "update"]
+---
+
+---
+# Source: istio/charts/gateways/templates/clusterrolebindings.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-local-gateway-istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-local-gateway-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: cluster-local-gateway-service-account
+    namespace: istio-system
+---
+
+---
+# Source: istio/charts/gateways/templates/service.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  annotations:
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+  ports:
+    -
+      name: http2
+      port: 80
+      targetPort: 80
+    -
+      name: https
+      port: 443
+    -
+      name: tcp
+      port: 31400
+    -
+      name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    -
+      name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    -
+      name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    -
+      name: http2-grafana
+      port: 15031
+      targetPort: 15031
+---
+
+---
+# Source: istio/charts/gateways/templates/deployment.yaml
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cluster-local-gateway
+        istio: cluster-local-gateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: cluster-local-gateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.0.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 15030
+            - containerPort: 15031
+          args:
+          - proxy
+          - router
+          - -v
+          - "2"
+          - --discoveryRefreshDelay
+          - '1s' #discoveryRefreshDelay
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - cluster-local-gateway
+          - --zipkinAddress
+          - zipkin.istio-system:9411
+          - --statsdUdpAddress
+          - istio-statsd-prom-bridge.istio-system:9125
+          - --proxyAdminPort
+          - "15000"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot.istio-system:8080
+          resources:
+            requests:
+              cpu: 10m
+            
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: clusterlocalgateway-certs
+            mountPath: "/etc/istio/clusterlocalgateway-certs"
+            readOnly: true
+          - name: clusterlocalgateway-ca-certs
+            mountPath: "/etc/istio/clusterlocalgateway-ca-certs"
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.cluster-local-gateway-service-account
+          optional: true
+      - name: clusterlocalgateway-certs
+        secret:
+          secretName: "istio-clusterlocalgateway-certs"
+          optional: true
+      - name: clusterlocalgateway-ca-certs
+        secret:
+          secretName: "istio-clusterlocalgateway-ca-certs"
+          optional: true
+      affinity:      
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+---
+
+---
+# Source: istio/charts/gateways/templates/autoscale.yaml
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+    name: cluster-local-gateway
+    namespace: istio-system
+spec:
+    maxReplicas: 5
+    minReplicas: 1
+    scaleTargetRef:
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      name: cluster-local-gateway
+    metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 60
+---
+
+---
+# Source: istio/charts/telemetry-gateway/templates/gateway.yaml
+
+
+---
+# Source: istio/templates/configmap.yaml
+
+
+---
+# Source: istio/templates/crds.yaml
+# 
+# these CRDs only make sense when pilot is enabled
+#
+
+# these CRDs only make sense when security is enabled
+#
+
+#
+# 
+---
+# Source: istio/templates/install-custom-resources.sh.tpl
+
+
+---
+# Source: istio/templates/sidecar-injector-configmap.yaml
+
+

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -4191,3 +4191,296 @@ spec:
         maxRequestsPerConnection: 10000
 ---
 
+---
+# Source: istio/charts/gateways/templates/serviceaccount.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-local-gateway-service-account
+  namespace: istio-system
+  labels:
+    app: cluster-local-gateway
+    chart: gateways-1.0.1
+    heritage: Tiller
+    release: RELEASE-NAME
+---
+
+---
+# Source: istio/charts/gateways/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: gateways
+    chart: gateways-1.0.1
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: cluster-local-gateway-istio-system
+rules:
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources", "virtualservices", "destinationrules", "gateways"]
+  verbs: ["get", "watch", "list", "update"]
+---
+
+---
+# Source: istio/charts/gateways/templates/clusterrolebindings.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-local-gateway-istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-local-gateway-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: cluster-local-gateway-service-account
+    namespace: istio-system
+---
+
+---
+# Source: istio/charts/gateways/templates/service.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  annotations:
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+  ports:
+    -
+      name: http2
+      port: 80
+      targetPort: 80
+    -
+      name: https
+      port: 443
+    -
+      name: tcp
+      port: 31400
+    -
+      name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    -
+      name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    -
+      name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    -
+      name: http2-grafana
+      port: 15031
+      targetPort: 15031
+---
+
+---
+# Source: istio/charts/gateways/templates/deployment.yaml
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cluster-local-gateway
+        istio: cluster-local-gateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: cluster-local-gateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.0.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 15030
+            - containerPort: 15031
+          args:
+          - proxy
+          - router
+          - -v
+          - "2"
+          - --discoveryRefreshDelay
+          - '1s' #discoveryRefreshDelay
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - cluster-local-gateway
+          - --zipkinAddress
+          - zipkin.istio-system:9411
+          - --statsdUdpAddress
+          - istio-statsd-prom-bridge.istio-system:9125
+          - --proxyAdminPort
+          - "15000"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot.istio-system:8080
+          resources:
+            requests:
+              cpu: 10m
+            
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: clusterlocalgateway-certs
+            mountPath: "/etc/istio/clusterlocalgateway-certs"
+            readOnly: true
+          - name: clusterlocalgateway-ca-certs
+            mountPath: "/etc/istio/clusterlocalgateway-ca-certs"
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.cluster-local-gateway-service-account
+          optional: true
+      - name: clusterlocalgateway-certs
+        secret:
+          secretName: "istio-clusterlocalgateway-certs"
+          optional: true
+      - name: clusterlocalgateway-ca-certs
+        secret:
+          secretName: "istio-clusterlocalgateway-ca-certs"
+          optional: true
+      affinity:      
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+---
+
+---
+# Source: istio/charts/gateways/templates/autoscale.yaml
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+    name: cluster-local-gateway
+    namespace: istio-system
+spec:
+    maxReplicas: 5
+    minReplicas: 1
+    scaleTargetRef:
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      name: cluster-local-gateway
+    metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 60
+---
+
+---
+# Source: istio/charts/telemetry-gateway/templates/gateway.yaml
+
+
+---
+# Source: istio/templates/configmap.yaml
+
+
+---
+# Source: istio/templates/crds.yaml
+# 
+# these CRDs only make sense when pilot is enabled
+#
+
+# these CRDs only make sense when security is enabled
+#
+
+#
+# 
+---
+# Source: istio/templates/install-custom-resources.sh.tpl
+
+
+---
+# Source: istio/templates/sidecar-injector-configmap.yaml
+
+


### PR DESCRIPTION
VirtualServices exposed to this gateway will not be accessible outside of the cluster.  However, they would be accessible to pods in the cluster without sidecar injection.

We can leverage this to make cluster-local access of Route and KService possible without having a sidecar proxy.
<!--
Request Prow to automatically lint any go code in this PR:
/assign @ZhiminXiang 
/lint
-->


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
