### PR TITLE
Add a test that verifies that pinned behaviour via Release object

### DIFF
--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -96,6 +96,27 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "pinned"),
 		},
 	}, {
+		// Pinned rollouts are deprecated, so test the same functionality
+		// using Release.
+		Name: "pinned - create route and service - via release",
+		Objects: []runtime.Object{
+			svc("pinned", "foo", WithPinnedRollout2("pinned-0001")),
+		},
+		Key: "foo/pinned",
+		WantCreates: []metav1.Object{
+			config("pinned", "foo", WithPinnedRollout2("pinned-0001")),
+			route("pinned", "foo", WithPinnedRollout2("pinned-0001")),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: svc("pinned", "foo", WithPinnedRollout2("pinned-0001"),
+				// The first reconciliation will initialize the status conditions.
+				WithInitSvcConditions),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "pinned"),
+		},
+	}, {
 		Name: "release - create route and service",
 		Objects: []runtime.Object{
 			svc("release", "foo", WithReleaseRollout("release-00001", "release-00002")),

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -100,21 +100,21 @@ func TestReconcile(t *testing.T) {
 		// using Release.
 		Name: "pinned - create route and service - via release",
 		Objects: []runtime.Object{
-			svc("pinned", "foo", WithReleaseRollout("pinned-0001")),
+			svc("pinned2", "foo", WithReleaseRollout("pinned2-0001")),
 		},
-		Key: "foo/pinned",
+		Key: "foo/pinned2",
 		WantCreates: []metav1.Object{
-			config("pinned", "foo", WithReleaseRollout("pinned-0001")),
-			route("pinned", "foo", WithReleaseRollout("pinned-0001")),
+			config("pinned2", "foo", WithReleaseRollout("pinned2-0001")),
+			route("pinned2", "foo", WithReleaseRollout("pinned2-0001")),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: svc("pinned", "foo", WithReleaseRollout("pinned-0001"),
+			Object: svc("pinned2", "foo", WithReleaseRollout("pinned2-0001"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "pinned"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned2"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "pinned2"),
 		},
 	}, {
 		Name: "release - create route and service",

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -100,15 +100,15 @@ func TestReconcile(t *testing.T) {
 		// using Release.
 		Name: "pinned - create route and service - via release",
 		Objects: []runtime.Object{
-			svc("pinned", "foo", WithPinnedRollout2("pinned-0001")),
+			svc("pinned", "foo", WithReleaseRollout("pinned-0001")),
 		},
 		Key: "foo/pinned",
 		WantCreates: []metav1.Object{
-			config("pinned", "foo", WithPinnedRollout2("pinned-0001")),
-			route("pinned", "foo", WithPinnedRollout2("pinned-0001")),
+			config("pinned", "foo", WithReleaseRollout("pinned-0001")),
+			route("pinned", "foo", WithReleaseRollout("pinned-0001")),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: svc("pinned", "foo", WithPinnedRollout2("pinned-0001"),
+			Object: svc("pinned", "foo", WithReleaseRollout("pinned-0001"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},

--- a/pkg/reconciler/v1alpha1/testing/factory.go
+++ b/pkg/reconciler/v1alpha1/testing/factory.go
@@ -37,8 +37,10 @@ const (
 	maxEventBufferSize = 10
 )
 
+// Ctor functions create a k8s controller with given params.
 type Ctor func(*Listers, reconciler.Options) controller.Reconciler
 
+// MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
 func MakeFactory(ctor Ctor) Factory {
 	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList) {
 		ls := NewListers(r.Objects)

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -116,20 +116,6 @@ func WithPinnedRollout(name string) ServiceOption {
 	}
 }
 
-// WithPinnedRollout2 configures the Service to use a "pinned" rollout,
-// which is pinned to the named revision via ReleaseType.
-func WithPinnedRollout2(name string) ServiceOption {
-	return func(s *v1alpha1.Service) {
-		s.Spec = v1alpha1.ServiceSpec{
-			Release: &v1alpha1.ReleaseType{
-				Revisions:      []string{name},
-				RolloutPercent: 0,
-				Configuration:  configSpec,
-			},
-		}
-	}
-}
-
 // WithReleaseRollout configures the Service to use a "release" rollout,
 // which spans the provided revisions.
 func WithReleaseRollout(names ...string) ServiceOption {

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -104,12 +104,27 @@ func WithRunLatestRollout(s *v1alpha1.Service) {
 
 // WithPinnedRollout configures the Service to use a "pinned" rollout,
 // which is pinned to the named revision.
+// Deprecated, since PinnedType is deprecated.
 func WithPinnedRollout(name string) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		s.Spec = v1alpha1.ServiceSpec{
 			Pinned: &v1alpha1.PinnedType{
 				RevisionName:  name,
 				Configuration: configSpec,
+			},
+		}
+	}
+}
+
+// WithPinnedRollout2 configures the Service to use a "pinned" rollout,
+// which is pinned to the named revision via ReleaseType.
+func WithPinnedRollout2(name string) ServiceOption {
+	return func(s *v1alpha1.Service) {
+		s.Spec = v1alpha1.ServiceSpec{
+			Release: &v1alpha1.ReleaseType{
+				Revisions:      []string{name},
+				RolloutPercent: 0,
+				Configuration:  configSpec,
 			},
 		}
 	}


### PR DESCRIPTION
The PinnedType is deprecated according to the comments,
so verify the same behavior is correct, by following the setup
suggested in the PinnedType docs.

Some minor cleanup along the way.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

  *
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```
