### PR TITLE
Add reporting of the service updated event.

### DIFF
--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -137,11 +137,14 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err := c.updateStatus(service); err != nil {
-		logger.Warn("Failed to update service status", zap.Error(err))
+	} else if _, uErr := c.updateStatus(service); uErr != nil {
+		logger.Warn("Failed to update service status", zap.Error(uErr))
 		c.Recorder.Eventf(service, corev1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for Service %q: %v", service.Name, err)
-		return err
+			"Failed to update status for Service %q: %v", service.Name, uErr)
+		return uErr
+	} else if err == nil {
+		// If there was a difference and there was no error.
+		c.Recorder.Eventf(service, corev1.EventTypeNormal, "Updated", "Updated Service %q", service.GetName())
 	}
 	return err
 }

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -75,6 +75,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "run-latest"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "run-latest"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "run-latest"),
 		},
 	}, {
 		Name: "pinned - create route and service",
@@ -94,6 +95,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "pinned"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "pinned"),
 		},
 	}, {
 		// Pinned rollouts are deprecated, so test the same functionality
@@ -115,6 +117,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned2"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "pinned2"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "pinned2"),
 		},
 	}, {
 		Name: "release - create route and service",
@@ -134,6 +137,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "release"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release"),
 		},
 	}, {
 		Name: "manual- no creates",
@@ -146,6 +150,9 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithManualStatus),
 		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "manual"),
+		},
 	}, {
 		Name: "runLatest - no updates",
 		Objects: []runtime.Object{
@@ -313,6 +320,9 @@ func TestReconcile(t *testing.T) {
 				// TODO(mattmoor): Add Latest{Created,Ready}
 				WithReadyRoute, WithReadyConfig("all-ready-00001")),
 		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "all-ready"),
+		},
 	}, {
 		Name: "runLatest - config fails, propagate failure",
 		// When config fails, the service should fail.
@@ -330,6 +340,9 @@ func TestReconcile(t *testing.T) {
 				WithReadyRoute, WithFailedConfig(
 					"config-fails-00001", "RevisionFailed", "blah")),
 		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-fails"),
+		},
 	}, {
 		Name: "runLatest - route fails, propagate failure",
 		// When route fails, the service should fail.
@@ -349,6 +362,9 @@ func TestReconcile(t *testing.T) {
 				WithReadyConfig("route-fails-00001"),
 				WithFailedRoute("Propagate me, please", "")),
 		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "route-fails"),
+		},
 	}}
 
 	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {


### PR DESCRIPTION
The even will fire if there was a meaningful update and it succeeded.

In theory, we can report when it failed and report the error as well.

## Proposed Changes

* Report Even when Service update reconciliation

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
