### PR TITLE
This change makes Revision reconcile Deployments.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -47,6 +47,50 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revisio
 	return c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Create(deployment)
 }
 
+func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1.Revision, have *appsv1.Deployment) (*appsv1.Deployment, Changed, error) {
+	logger := logging.FromContext(ctx)
+	cfgs := config.FromContext(ctx)
+
+	deployment := resources.MakeDeployment(
+		rev,
+		cfgs.Logging,
+		cfgs.Network,
+		cfgs.Observability,
+		cfgs.Autoscaler,
+		cfgs.Controller,
+	)
+
+	// Preserve the current scale of the Deployment.
+	deployment.Spec.Replicas = have.Spec.Replicas
+
+	// If the spec we want is the spec we have, then we're good.
+	if equality.Semantic.DeepEqual(have.Spec, deployment.Spec) {
+		return have, Unchanged, nil
+	}
+
+	// Otherwise attempt an update (with ONLY the spec changes).
+	desiredDeployment := have.DeepCopy()
+	desiredDeployment.Spec = deployment.Spec
+	d, err := c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Update(desiredDeployment)
+	if err != nil {
+		return nil, Unchanged, err
+	}
+
+	// If what comes back from the update (with defaults applied by the API server) is the same
+	// as what we have then nothing changed.
+	if equality.Semantic.DeepEqual(have.Spec, d.Spec) {
+		return d, Unchanged, nil
+	}
+	diff, err := kmp.SafeDiff(have.Spec, d.Spec)
+	if err != nil {
+		return nil, Unchanged, err
+	}
+
+	// If what comes back has a different spec, then signal the change.
+	logger.Infof("Reconciled deployment diff (-desired, +observed): %v", diff)
+	return d, WasChanged, nil
+}
+
 func (c *Reconciler) createImageCache(ctx context.Context, rev *v1alpha1.Revision, deploy *appsv1.Deployment) (*caching.Image, error) {
 	image, err := resources.MakeImageCache(rev, deploy)
 	if err != nil {

--- a/pkg/reconciler/v1alpha1/revision/resources/meta.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/meta.go
@@ -52,6 +52,11 @@ func makeSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
 func makeAnnotations(revision *v1alpha1.Revision) map[string]string {
 	annotations := make(map[string]string, len(revision.ObjectMeta.Annotations))
 	for k, v := range revision.ObjectMeta.Annotations {
+		// Don't propagate known-volatile annotations on the Revision
+		// (e.g. our lastPinned heartbeat) to the Deployment or Pods.
+		if k == serving.RevisionLastPinnedAnnotationKey {
+			continue
+		}
 		annotations[k] = v
 	}
 	return annotations


### PR DESCRIPTION
Previously we had problems with Deployment reconciliation because of the defaulting performed in the API Server.  With this change we attempt an Update if the Spec is not what we think it should be, but only treat it as a change if the Deployment we get back from the update is different from what we started from.  In this way, we avoid actually changing the deployment and triggering infinite reconciliations.

This change is sufficient for us to trigger Deployment reconciles (e.g. to replace sidecars) when folks apply a new version, but we will need https://github.com/knative/serving/issues/2332 as well for ConfigMap only changes to trigger a similar global resync.

Fixes: https://github.com/knative/serving/issues/639

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->