### PR TITLE
Disable TestScaleTo50

### DIFF
--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -146,6 +146,7 @@ func TestScaleTo10(t *testing.T) {
 }
 
 func TestScaleTo50(t *testing.T) {
+	t.Skip("Disabled until #2637 is fixed")
 	//add test case specific name to its own logger
 	logger := logging.GetContextLogger("TestScaleTo50")
 


### PR DESCRIPTION
... until we sort out why it's so unstable in Prow.  The linked issue tracks this.

Related: https://github.com/knative/serving/issues/2637

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
