### PR TITLE
Allow user-defined ports on Configuration

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -118,6 +118,16 @@ const (
 	RevisionContainerConcurrencyMax RevisionContainerConcurrencyType = 1000
 )
 
+const (
+	// UserPortName is the name that will be used for the Port on the
+	// Deployment and Pod created by a Revision. This name will be set regardless of if
+	// a user specifies a port or the default value is chosen.
+	UserPortName = "user-port"
+	// DefaultUserPort is the default port value the QueueProxy will
+	// use for connecting to the user container.
+	DefaultUserPort = 8080
+)
+
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
 	// TODO: Generation does not work correctly with CRD. They are scrubbed

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -77,15 +77,134 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "has ports",
+		name: "has no container ports set",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{},
+		},
+		want: nil,
+	}, {
+		name: "has valid user port http1",
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Name:          "http",
+				Name:          "http1",
+				ContainerPort: 8081,
+			}},
+		},
+		want: nil,
+	}, {
+		name: "has valid user port h2c",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				Name:          "h2c",
+				ContainerPort: 8081,
+			}},
+		},
+		want: nil,
+	}, {
+		name: "has more than one ports with valid names",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				Name:          "h2c",
+				ContainerPort: 8080,
+			}, {
+				Name:          "http1",
+				ContainerPort: 8181,
+			}},
+		},
+		want: &apis.FieldError{
+			Message: "More than one container port is set",
+			Paths:   []string{"ports"},
+			Details: "Only a single port is allowed",
+		},
+	}, {
+		name: "has container port value too large",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 65536,
+			}},
+		},
+		want: apis.ErrOutOfBoundsValue("65536", "1", "65535", "ports.ContainerPort"),
+	}, {
+		name: "has an empty port set",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{}},
+		},
+		want: apis.ErrOutOfBoundsValue("0", "1", "65535", "ports.ContainerPort"),
+	}, {
+		name: "has more than one unnamed port",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 8080,
+			}, {
+				ContainerPort: 8181,
+			}},
+		},
+		want: &apis.FieldError{
+			Message: "More than one container port is set",
+			Paths:   []string{"ports"},
+			Details: "Only a single port is allowed",
+		},
+	}, {
+		name: "has tcp protocol",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				Protocol:      corev1.ProtocolTCP,
 				ContainerPort: 8080,
 			}},
 		},
-		want: apis.ErrDisallowedFields("ports"),
+		want: nil,
+	}, {
+		name: "has invalid protocol",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				Protocol:      "tdp",
+				ContainerPort: 8080,
+			}},
+		},
+		want: apis.ErrInvalidValue("tdp", "ports.Protocol"),
+	}, {
+		name: "has host port",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				HostPort:      80,
+				ContainerPort: 8080,
+			}},
+		},
+		want: apis.ErrDisallowedFields("ports.HostPort"),
+	}, {
+		name: "has host ip",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				HostIP:        "127.0.0.1",
+				ContainerPort: 8080,
+			}},
+		},
+		want: apis.ErrDisallowedFields("ports.HostIP"),
+	}, {
+		name: "has invalid port name",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				Name:          "foobar",
+				ContainerPort: 8080,
+			}},
+		},
+		want: &apis.FieldError{
+			Message: fmt.Sprintf("Port name %v is not allowed", "foobar"),
+			Paths:   []string{"ports"},
+			Details: "Name must be empty, or one of: 'h2c', 'http1'",
+		},
 	}, {
 		name: "has volumeMounts",
 		c: corev1.Container{
@@ -152,17 +271,13 @@ func TestContainerValidation(t *testing.T) {
 		name: "has numerous problems",
 		c: corev1.Container{
 			Name: "foo",
-			Ports: []corev1.ContainerPort{{
-				Name:          "http",
-				ContainerPort: 8080,
-			}},
 			VolumeMounts: []corev1.VolumeMount{{
 				MountPath: "mount/path",
 				Name:      "name",
 			}},
 			Lifecycle: &corev1.Lifecycle{},
 		},
-		want: apis.ErrDisallowedFields("name", "ports", "volumeMounts", "lifecycle").Also(
+		want: apis.ErrDisallowedFields("name", "volumeMounts", "lifecycle").Also(
 			&apis.FieldError{
 				Message: "Failed to parse image reference",
 				Paths:   []string{"image"},

--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -30,8 +30,6 @@ const (
 	// TODO(mattmoor): Make this private once we remove revision_test.go
 	IstioOutboundIPRangeAnnotation = "traffic.sidecar.istio.io/includeOutboundIPRanges"
 
-	userPortName    = "user-port"
-	userPort        = 8080
 	userPortEnvName = "PORT"
 
 	autoscalerPort = 8080

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -48,17 +48,6 @@ var (
 		MountPath: "/var/log",
 	}
 
-	userPorts = []corev1.ContainerPort{{
-		Name:          userPortName,
-		ContainerPort: int32(userPort),
-	}}
-
-	// Expose containerPort as env PORT.
-	userEnv = corev1.EnvVar{
-		Name:  userPortEnvName,
-		Value: strconv.Itoa(userPort),
-	}
-
 	userResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU: userContainerCPU,
@@ -79,7 +68,7 @@ var (
 	}
 )
 
-func rewriteUserProbe(p *corev1.Probe) {
+func rewriteUserProbe(p *corev1.Probe, userPort int) {
 	if p == nil {
 		return
 	}
@@ -123,19 +112,24 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	// If client provides for some resources, override default values
 	applyDefaultResources(userResources, &userContainer.Resources)
 
-	userContainer.Ports = userPorts
 	userContainer.VolumeMounts = append(userContainer.VolumeMounts, varLogVolumeMount)
 	userContainer.Lifecycle = userLifecycle
-	userContainer.Env = append(userContainer.Env, userEnv)
+	userPort := getUserPort(rev)
+	userPortInt := int(userPort)
+	userPortStr := strconv.Itoa(userPortInt)
+	// Replacement is safe as only up to a single port is allowed on the Revision
+	userContainer.Ports = buildContainerPorts(userPort)
+	userContainer.Env = append(userContainer.Env, buildUserPortEnv(userPortStr))
 	userContainer.Env = append(userContainer.Env, getKnativeEnvVar(rev)...)
+
 	// Prefer imageDigest from revision if available
 	if rev.Status.ImageDigest != "" {
 		userContainer.Image = rev.Status.ImageDigest
 	}
 
 	// If the client provides probes, we should fill in the port for them.
-	rewriteUserProbe(userContainer.ReadinessProbe)
-	rewriteUserProbe(userContainer.LivenessProbe)
+	rewriteUserProbe(userContainer.ReadinessProbe, userPortInt)
+	rewriteUserProbe(userContainer.LivenessProbe, userPortInt)
 
 	revisionTimeout := int64(rev.Spec.TimeoutSeconds.Duration.Seconds())
 
@@ -156,6 +150,30 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	}
 
 	return podSpec
+}
+
+func getUserPort(rev *v1alpha1.Revision) int32 {
+	if len(rev.Spec.Container.Ports) == 1 {
+		return rev.Spec.Container.Ports[0].ContainerPort
+	}
+
+	//TODO(#2258): Use container EXPOSE metadata from image before falling back to default value
+
+	return v1alpha1.DefaultUserPort
+}
+
+func buildContainerPorts(userPort int32) []corev1.ContainerPort {
+	return []corev1.ContainerPort{{
+		Name:          v1alpha1.UserPortName,
+		ContainerPort: userPort,
+	}}
+}
+
+func buildUserPortEnv(userPort string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name:  userPortEnvName,
+		Value: userPort,
+	}
 }
 
 func MakeDeployment(rev *v1alpha1.Revision,

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -77,6 +77,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 	}
 
 	autoscalerAddress := "autoscaler"
+	userPort := getUserPort(rev)
 
 	var loggingLevel string
 	if ll, ok := loggingConfig.LoggingLevel["queueproxy"]; ok {
@@ -124,6 +125,9 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 		}, {
 			Name:  "SERVING_LOGGING_LEVEL",
 			Value: loggingLevel,
+		}, {
+			Name:  "USER_PORT",
+			Value: strconv.Itoa(int(userPort)),
 		}},
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -36,12 +37,13 @@ var boolTrue = true
 
 func TestMakeQueueContainer(t *testing.T) {
 	tests := []struct {
-		name string
-		rev  *v1alpha1.Revision
-		lc   *logging.Config
-		ac   *autoscaler.Config
-		cc   *config.Controller
-		want *corev1.Container
+		name     string
+		rev      *v1alpha1.Revision
+		lc       *logging.Config
+		ac       *autoscaler.Config
+		cc       *config.Controller
+		userport *corev1.ContainerPort
+		want     *corev1.Container
 	}{{
 		name: "no owner no autoscaler single",
 		rev: &v1alpha1.Revision{
@@ -60,6 +62,10 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
+		userport: &corev1.ContainerPort{
+			Name:          userPortEnvName,
+			ContainerPort: v1alpha1.DefaultUserPort,
+		},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           queueContainerName,
@@ -100,6 +106,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name: "SERVING_LOGGING_LEVEL",
 				// No logging level
+			}, {
+				Name:  "USER_PORT",
+				Value: strconv.Itoa(v1alpha1.DefaultUserPort),
 			}},
 		},
 	}, {
@@ -121,6 +130,10 @@ func TestMakeQueueContainer(t *testing.T) {
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{
 			QueueSidecarImage: "alpine",
+		},
+		userport: &corev1.ContainerPort{
+			Name:          userPortEnvName,
+			ContainerPort: v1alpha1.DefaultUserPort,
 		},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -163,6 +176,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name: "SERVING_LOGGING_LEVEL",
 				// No logging level
+			}, {
+				Name:  "USER_PORT",
+				Value: strconv.Itoa(v1alpha1.DefaultUserPort),
 			}},
 		},
 	}, {
@@ -190,6 +206,10 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
+		userport: &corev1.ContainerPort{
+			Name:          userPortEnvName,
+			ContainerPort: v1alpha1.DefaultUserPort,
+		},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           queueContainerName,
@@ -230,6 +250,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name: "SERVING_LOGGING_LEVEL",
 				// No logging level
+			}, {
+				Name:  "USER_PORT",
+				Value: strconv.Itoa(v1alpha1.DefaultUserPort),
 			}},
 		},
 	}, {
@@ -255,6 +278,10 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
+		userport: &corev1.ContainerPort{
+			Name:          userPortEnvName,
+			ContainerPort: v1alpha1.DefaultUserPort,
+		},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           queueContainerName,
@@ -295,6 +322,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_LOGGING_LEVEL",
 				Value: "error", // from logging config
+			}, {
+				Name:  "USER_PORT",
+				Value: strconv.Itoa(v1alpha1.DefaultUserPort),
 			}},
 		},
 	}, {
@@ -315,6 +345,10 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
+		userport: &corev1.ContainerPort{
+			Name:          userPortEnvName,
+			ContainerPort: v1alpha1.DefaultUserPort,
+		},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           queueContainerName,
@@ -355,6 +389,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name: "SERVING_LOGGING_LEVEL",
 				// No logging level
+			}, {
+				Name:  "USER_PORT",
+				Value: strconv.Itoa(v1alpha1.DefaultUserPort),
 			}},
 		},
 	}}

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -30,6 +30,7 @@ import (
 // Options are test setup parameters.
 type Options struct {
 	EnvVars              []corev1.EnvVar
+	ContainerPorts       []corev1.ContainerPort
 	ContainerConcurrency int
 	RevisionTimeout      time.Duration
 	ContainerResources   corev1.ResourceRequirements

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -41,14 +41,12 @@ import (
 // Constants for test images located in test/test_images
 const (
 	pizzaPlanet1        = "pizzaplanetv1"
-	pizzaPlanetText1    = "What a spaceport!"
 	pizzaPlanet2        = "pizzaplanetv2"
-	pizzaPlanetText2    = "Re-energize yourself with a slice of pepperoni!"
 	helloworld          = "helloworld"
-	helloWorldText      = "Hello World! How about some tasty noodles?"
 	httpproxy           = "httpproxy"
 	singleThreadedImage = "singlethreaded"
 	timeout             = "timeout"
+	printport           = "printport"
 
 	concurrentRequests = 50
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.
@@ -57,6 +55,13 @@ const (
 	// We expect to see at least 25% of either response since we're routing 50/50.
 	// This might be a bad assumption.
 	minSplitPercentage = 0.25
+)
+
+// Constants for test image output
+const (
+	pizzaPlanetText1 = "What a spaceport!"
+	pizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
+	helloWorldText   = "Hello World! How about some tasty noodles?"
 )
 
 func setup(t *testing.T) *test.Clients {

--- a/test/crd.go
+++ b/test/crd.go
@@ -128,6 +128,9 @@ func Configuration(namespace string, names ResourceNames, imagePath string, opti
 		},
 		Spec: *ConfigurationSpec(imagePath, options),
 	}
+	if options.ContainerPorts != nil && len(options.ContainerPorts) > 0 {
+		config.Spec.RevisionTemplate.Spec.Container.Ports = options.ContainerPorts
+	}
 	return config
 }
 

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -71,13 +71,13 @@ func TestHelloWorldFromShell(t *testing.T) {
 
 	// Populate manifets file with the real path to the container
 	yamlBytes, err := ioutil.ReadFile(appYaml)
+
 	if err != nil {
 		t.Fatalf("Failed to read file %s: %v", appYaml, err)
 	}
 
 	content := strings.Replace(string(yamlBytes), yamlImagePlaceholder, imagePath, -1)
-	content = strings.Replace(string(content), "namespace: "+namespacePlaceholder,
-		"namespace: "+test.ServingNamespace, -1)
+	content = strings.Replace(string(content), namespacePlaceholder, test.ServingNamespace, -1)
 
 	if _, err = newYaml.WriteString(content); err != nil {
 		t.Fatalf("Failed to write new manifest: %v", err)

--- a/test/service.go
+++ b/test/service.go
@@ -176,11 +176,22 @@ func PatchServiceImage(logger *logging.BaseLogger, clients *Clients, svc *v1alph
 	} else {
 		return nil, fmt.Errorf("UpdateImageService(%v): unable to determine service type", svc)
 	}
+	LogResourceObject(logger, ResourceObjects{Service: newSvc})
 	patchBytes, err := createPatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}
 	return clients.ServingClient.Services.Patch(svc.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
+}
+
+// PatchService creates and applies a patch from the diff between curSvc and desiredSvc. Returns the latest service object.
+func PatchService(logger *logging.BaseLogger, clients *Clients, curSvc *v1alpha1.Service, desiredSvc *v1alpha1.Service) (*v1alpha1.Service, error) {
+	LogResourceObject(logger, ResourceObjects{Service: desiredSvc})
+	patchBytes, err := createPatch(curSvc, desiredSvc)
+	if err != nil {
+		return nil, err
+	}
+	return clients.ServingClient.Services.Patch(curSvc.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
 }
 
 // PatchServiceRevisionTemplateMetadata patches an existing service by adding metadata to the service's RevisionTemplateSpec.

--- a/test/test_images/printport/README.md
+++ b/test/test_images/printport/README.md
@@ -1,0 +1,21 @@
+# PrintPort Test Image
+
+This directory contains the test image used in the user-port e2e test.
+
+The image contains a simple Go webserver, `printport.go`, that will listen on the port defined by environment variable `PORT` and expose a service at `/`.
+
+When called, the server emits the port it was called on.
+
+See the example below when the default `8080` port is used:
+
+```
+> curl -H "Host: printport.default.example.com"
+http://$IP
+8080
+```
+
+## Building
+
+For details about building and adding new images, see the [section about test
+images](/test/README.md#test-images).
+

--- a/test/test_images/printport/main.go
+++ b/test/test_images/printport/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Print("PrintPort received a request.")
+	fmt.Fprintln(w, os.Getenv("PORT"))
+}
+
+func main() {
+	flag.Parse()
+	log.Print("PrintPort app started.")
+
+	port, isSet := os.LookupEnv("PORT")
+	if !isSet {
+		log.Fatalln("Environment variable PORT is not set.")
+	}
+
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+}

--- a/test/test_images/printport/printport.yaml
+++ b/test/test_images/printport/printport.yaml
@@ -1,0 +1,47 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1alpha1
+kind: Configuration
+metadata:
+  name: configuration-example
+  namespace: default
+spec:
+  revisionTemplate:
+    metadata:
+      labels:
+        knative.dev/type: app
+    spec:
+      container:
+        # This is the Go import path for the binary to containerize
+        # and substitute here.
+        image: github.com/knative/serving/test_images/printport
+        ports:
+        # Test user-defined port
+        - containerPort: 8888
+        readinessProbe:
+          httpGet:
+            path: /
+          initialDelaySeconds: 3
+          periodSeconds: 3
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: Route
+metadata:
+  name: route-example
+  namespace: default
+spec:
+  traffic:
+  - configurationName: configuration-example
+    percent: 100


### PR DESCRIPTION
This change allows for a user to add a port to their Container object
in Configuration. The single port provided is used by the queue-proxy to
as the port used to connect to the user container. This port is
available as environment variable "PORT" on the user container and
environment variable "USER_PORT" on the queue-proxy.

This change is built upon PR #2190 by Leon-Liangming. It squashes the
following commits:

* change queue-proxy user-port env name
* rebase master, fix uint test
* remove "activator" istio-proxy , set "sidecar.istio.io/inject" to false
* add e2e test for user-port && review comments modify && open acitvator's istio-proxy
* set more validation info about user-port && modify e2e test
* change validation info && e2e test
* more review comments modify
* Allow only 1 unnamed port
* Passing conformance tests

Related to #2258
Fixes #1241 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->