### PR TITLE
SetDefaults at the onset of Reconcile.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
@@ -130,6 +130,12 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.PodAutoscaler) error {
 	logger := logging.FromContext(ctx)
 
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	pa.SetDefaults()
+
 	pa.Status.InitializeConditions()
 	logger.Debug("PA exists")
 

--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa_test.go
@@ -44,7 +44,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: key(testRevision, testNamespace),
 		WantCreates: []metav1.Object{
-			hpa(testRevision, testNamespace, WithHPAClass),
+			hpa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu")),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa(testRevision, testNamespace, WithHPAClass, WithTraffic),
@@ -75,11 +75,13 @@ func TestReconcile(t *testing.T) {
 		Name: "update hpa with target usage",
 		Objects: []runtime.Object{
 			pa(testRevision, testNamespace, WithHPAClass, WithTraffic, WithTargetAnnotation),
-			hpa(testRevision, testNamespace, WithHPAClass),
+			hpa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu")),
 		},
 		Key: key(testRevision, testNamespace),
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: hpa(testRevision, testNamespace, WithHPAClass, WithTargetAnnotation),
+			Object: hpa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"),
+				// Add the target annotation, if missing.
+				WithTargetAnnotation),
 		}},
 	}}
 

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -170,6 +170,12 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.PodAutoscaler) error {
 	logger := logging.FromContext(ctx)
 
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	pa.SetDefaults()
+
 	pa.Status.InitializeConditions()
 	logger.Debug("PA exists")
 

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -173,6 +173,13 @@ func (c *Reconciler) updateStatus(desired *v1alpha1.ClusterIngress) (*v1alpha1.C
 
 func (c *Reconciler) reconcile(ctx context.Context, ci *v1alpha1.ClusterIngress) error {
 	logger := logging.FromContext(ctx)
+
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	ci.SetDefaults()
+
 	ci.Status.InitializeConditions()
 	vs := resources.MakeVirtualService(ci)
 

--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -147,6 +147,13 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configuration) error {
 	logger := logging.FromContext(ctx)
+
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	config.SetDefaults()
+
 	config.Status.InitializeConditions()
 
 	// First, fetch the revision that should exist for the current generation

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -46,6 +46,7 @@ var (
 		Container: corev1.Container{
 			Image: "busybox",
 		},
+		TimeoutSeconds: &metav1.Duration{Duration: 60 * time.Second},
 	}
 )
 

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -342,6 +342,12 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) error {
 	logger := commonlogging.FromContext(ctx)
 
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	rev.SetDefaults()
+
 	rev.Status.InitializeConditions()
 	c.updateRevisionLoggingURL(ctx, rev)
 

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -19,7 +19,6 @@ package revision
 import (
 	"context"
 	"testing"
-	"time"
 
 	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
 	"github.com/knative/pkg/apis/duck"
@@ -726,8 +725,7 @@ func rev(namespace, name string, ro ...RevisionOption) *v1alpha1.Revision {
 			UID:       "test-uid",
 		},
 		Spec: v1alpha1.RevisionSpec{
-			Container:      corev1.Container{Image: "busybox"},
-			TimeoutSeconds: &metav1.Duration{Duration: 60 * time.Second},
+			Container: corev1.Container{Image: "busybox"},
 		},
 	}
 
@@ -758,6 +756,9 @@ func deploy(namespace, name string, co ...configOption) *appsv1.Deployment {
 	}
 
 	rev := rev(namespace, name)
+	// Do this here instead of in `rev` itself to ensure that we populate defaults
+	// before calling MakeDeployment within Reconcile.
+	rev.SetDefaults()
 	return resources.MakeDeployment(rev, config.Logging, config.Network, config.Observability,
 		config.Autoscaler, config.Controller)
 }
@@ -769,6 +770,9 @@ func image(namespace, name string, co ...configOption) *caching.Image {
 	}
 
 	rev := rev(namespace, name)
+	// Do this here instead of in `rev` itself to ensure that we populate defaults
+	// before calling MakeDeployment within Reconcile.
+	rev.SetDefaults()
 	deploy := resources.MakeDeployment(rev, config.Logging, config.Network, config.Observability,
 		config.Autoscaler, config.Controller)
 	img, err := resources.MakeImageCache(rev, deploy)

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -213,6 +213,13 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
+
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	r.SetDefaults()
+
 	r.Status.InitializeConditions()
 
 	logger.Infof("Reconciling route :%v", r)

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -148,6 +148,13 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) error {
 	logger := logging.FromContext(ctx)
+
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed defaults specified.  This won't result
+	// in this getting written back to the API Server, but lets downstream logic make
+	// assumptions about defaulting.
+	service.SetDefaults()
+
 	service.Status.InitializeConditions()
 
 	configName := resourcenames.Configuration(service)

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -88,6 +88,7 @@ var (
 				Container: corev1.Container{
 					Image: "busybox",
 				},
+				TimeoutSeconds: &metav1.Duration{Duration: 60 * time.Second},
 			},
 		},
 	}
@@ -601,6 +602,16 @@ func WithTargetAnnotation(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Annotations = make(map[string]string)
 	}
 	pa.Annotations[autoscaling.TargetAnnotationKey] = "50"
+}
+
+// WithMetricAnnotation adds a metric annotation to the PA.
+func WithMetricAnnotation(metric string) PodAutoscalerOption {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
+		if pa.Annotations == nil {
+			pa.Annotations = make(map[string]string)
+		}
+		pa.Annotations[autoscaling.MetricAnnotationKey] = metric
+	}
 }
 
 // K8sServiceOption enables further configuration of the Kubernetes Service.


### PR DESCRIPTION
As part of chasing https://github.com/knative/serving/issues/639, I ran into a problem with the newly introduced `timeoutSeconds` in the upgrade test.  Basically, the Reconciler has been modified to assume that the *new* defaulting via the webhook was happening, and setting an otherwise `nil` field.  However, in the upgrade test, we reconcile objects that only went through the older webhook, so our defaulting hasn't necessarily run.

To guard against these kinds of assumptions, which may exist all over, I have added a call to `.SetDefaults` at the onset of every `Reconcile`, so that folks can simplify how they think about reconciliation.  These changes will never be propagated back to the API because we only post updated to `.Status` copying the original object for the remainder of the content.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
