### PR TITLE
This picks up the latest knative/pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -396,7 +396,7 @@
   revision = "f0d7bb60956f88d4743f5fea66b5607b96d262c9"
 
 [[projects]]
-  digest = "1:d4cee2d9908d4a05064a1680916455c95cba498394c1f6c3aa4f22742f6edc59"
+  digest = "1:74580f9e031cccd10526f3a47a24b10b61c358a690b5f1d531383c4963cf3311"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -440,11 +440,11 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "9a644df00f19da719379ca936c1949f56d8c3eb5"
+  revision = "0e41760cea1d1ce16f4cc311c2d6bd3525bb3da7"
 
 [[projects]]
   branch = "master"
-  digest = "1:d3c877a0f50ca9d2aec77a430c25806b40f10e4618b6e89950e8f7282712badd"
+  digest = "1:f36cb404cd23f6fc1fd4e85e538468658ce991ba73fd1425bd0d1a65de4c3374"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -1263,9 +1263,7 @@
     "github.com/knative/test-infra/tools/testgrid",
     "github.com/mattbaird/jsonpatch",
     "github.com/pkg/errors",
-    "github.com/prometheus/client_golang/api",
-    "github.com/prometheus/client_golang/api/prometheus/v1",
-    "github.com/prometheus/common/model",
+    "go.opencensus.io/exporter/prometheus",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/tag",
@@ -1306,12 +1304,14 @@
     "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/apps/v1",
+    "k8s.io/client-go/informers/autoscaling/v1",
     "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/listers/apps/v1",
+    "k8s.io/client-go/listers/autoscaling/v1",
     "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/plugin/pkg/client/auth/oidc",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-11-28
-  revision = "9a644df00f19da719379ca936c1949f56d8c3eb5"
+  # HEAD as of 2018-12-05
+  revision = "0e41760cea1d1ce16f4cc311c2d6bd3525bb3da7"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/vendor/github.com/knative/pkg/controller/controller.go
+++ b/vendor/github.com/knative/pkg/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -215,10 +214,10 @@ func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	logger := c.logger
 	logger.Info("Starting controller and workers")
 	for i := 0; i < threadiness; i++ {
-		go wait.Until(func() {
+		go func() {
 			for c.processNextWorkItem() {
 			}
-		}, time.Second, stopCh)
+		}()
 	}
 
 	logger.Info("Started workers")
@@ -235,74 +234,52 @@ func (c *Impl) processNextWorkItem() bool {
 	if shutdown {
 		return false
 	}
+	key := obj.(string)
 
-	// We wrap this block in a func so we can defer c.base.WorkQueue.Done.
-	err := func(obj interface{}) error {
-		startTime := time.Now()
-		// Send the metrics for the current queue depth
-		c.statsReporter.ReportQueueDepth(int64(c.WorkQueue.Len()))
+	startTime := time.Now()
+	// Send the metrics for the current queue depth
+	c.statsReporter.ReportQueueDepth(int64(c.WorkQueue.Len()))
 
-		// We call Done here so the workqueue knows we have finished
-		// processing this item. We also must remember to call Forget if we
-		// do not want this work item being re-queued. For example, we do
-		// not call Forget if a transient error occurs, instead the item is
-		// put back on the workqueue and attempted again after a back-off
-		// period.
-		defer c.WorkQueue.Done(obj)
+	// We call Done here so the workqueue knows we have finished
+	// processing this item. We also must remember to call Forget if
+	// reconcile succeeds. If a transient error occurs, we do not call
+	// Forget and put the item back to the queue with an increased
+	// delay.
+	defer c.WorkQueue.Done(key)
 
-		// We expect strings to come off the workqueue. These are of the
-		// form namespace/name. We do this as the delayed nature of the
-		// workqueue means the items in the informer cache may actually be
-		// more up to date that when the item was initially put onto the
-		// workqueue.
-		key, ok := obj.(string)
-		if !ok {
-			// As the item in the workqueue is actually invalid, we call
-			// Forget here else we'd go into a loop of attempting to
-			// process a work item that is invalid.
-			c.WorkQueue.Forget(obj)
-			c.logger.Errorf("expected string in workqueue but got %#v", obj)
-			c.statsReporter.ReportReconcile(time.Now().Sub(startTime), "[InvalidKeyType]", falseString)
-			return nil
+	var err error
+	defer func() {
+		status := trueString
+		if err != nil {
+			status = falseString
 		}
+		c.statsReporter.ReportReconcile(time.Now().Sub(startTime), key, status)
+	}()
 
-		var err error
-		defer func() {
-			status := trueString
-			if err != nil {
-				status = falseString
-			}
-			c.statsReporter.ReportReconcile(time.Now().Sub(startTime), key, status)
-		}()
+	// Embed the key into the logger and attach that to the context we pass
+	// to the Reconciler.
+	logger := c.logger.With(zap.String(logkey.Key, key))
+	ctx := logging.WithLogger(context.TODO(), logger)
 
-		// Embed the key into the logger and attach that to the context we pass
-		// to the Reconciler.
-		logger := c.logger.With(zap.String(logkey.Key, key))
-		ctx := logging.WithLogger(context.TODO(), logger)
-
-		// Run Reconcile, passing it the namespace/name string of the
-		// resource to be synced.
-		if err = c.Reconciler.Reconcile(ctx, key); err != nil {
-			c.handleErr(err, key)
-			return fmt.Errorf("error syncing %q: %v", key, err)
-		}
-
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
-		c.WorkQueue.Forget(obj)
-		c.logger.Infof("Successfully synced %q", key)
-		return nil
-	}(obj)
-
-	if err != nil {
-		c.logger.Error(zap.Error(err))
+	// Run Reconcile, passing it the namespace/name string of the
+	// resource to be synced.
+	if err = c.Reconciler.Reconcile(ctx, key); err != nil {
+		c.handleErr(err, key)
+		logger.Errorf("Reconcile failed. Time taken: %v.", time.Now().Sub(startTime))
 		return true
 	}
+
+	// Finally, if no error occurs we Forget this item so it does not
+	// have any delay when another change happens.
+	c.WorkQueue.Forget(key)
+	logger.Infof("Reconcile succeeded. Time taken: %v.", time.Now().Sub(startTime))
 
 	return true
 }
 
-func (c *Impl) handleErr(err error, key interface{}) {
+func (c *Impl) handleErr(err error, key string) {
+	c.logger.Error(zap.Error(err))
+
 	// Re-queue the key if it's an transient error.
 	if !IsPermanentError(err) {
 		c.WorkQueue.AddRateLimited(key)

--- a/vendor/github.com/knative/pkg/controller/stats_reporter.go
+++ b/vendor/github.com/knative/pkg/controller/stats_reporter.go
@@ -123,7 +123,7 @@ func (r *reporter) ReportReconcile(duration time.Duration, key, success string) 
 	}
 
 	stats.Record(ctx, reconcileCountStat.M(1))
-	stats.Record(ctx, reconcileLatencyStat.M(int64(duration)))
+	stats.Record(ctx, reconcileLatencyStat.M(int64(duration/time.Millisecond)))
 	return nil
 }
 

--- a/vendor/github.com/knative/pkg/metrics/config.go
+++ b/vendor/github.com/knative/pkg/metrics/config.go
@@ -19,7 +19,9 @@ package metrics
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -28,15 +30,17 @@ import (
 const (
 	backendDestinationKey   = "metrics.backend-destination"
 	stackdriverProjectIDKey = "metrics.stackdriver-project-id"
+	reportingPeriodKey      = "metrics.reporting-period-seconds"
 )
 
-type MetricsBackend string
+// metricsBackend specifies the backend to use for metrics
+type metricsBackend string
 
 const (
-	// The metrics backend is stackdriver
-	Stackdriver MetricsBackend = "stackdriver"
-	// The metrics backend is prometheus
-	Prometheus MetricsBackend = "prometheus"
+	// Stackdriver is used for Stackdriver backend
+	Stackdriver metricsBackend = "stackdriver"
+	// Prometheus is used for Prometheus backend
+	Prometheus metricsBackend = "prometheus"
 )
 
 type metricsConfig struct {
@@ -45,10 +49,13 @@ type metricsConfig struct {
 	// The component that emits the metrics. e.g. "activator", "autoscaler".
 	component string
 	// The metrics backend destination.
-	backendDestination MetricsBackend
+	backendDestination metricsBackend
 	// The stackdriver project ID where the stats data are uploaded to. This is
 	// not the GCP project ID.
 	stackdriverProjectID string
+	// reportingPeriod specifies the interval between reporting aggregated views.
+	// If duration is less than or equal to zero, it enables the default behavior.
+	reportingPeriod time.Duration
 }
 
 func getMetricsConfig(m map[string]string, domain string, component string, logger *zap.SugaredLogger) (*metricsConfig, error) {
@@ -57,7 +64,7 @@ func getMetricsConfig(m map[string]string, domain string, component string, logg
 	if !ok {
 		return nil, errors.New("metrics.backend-destination key is missing")
 	}
-	lb := MetricsBackend(strings.ToLower(backend))
+	lb := metricsBackend(strings.ToLower(backend))
 	switch lb {
 	case Stackdriver, Prometheus:
 		mc.backendDestination = lb
@@ -70,6 +77,25 @@ func getMetricsConfig(m map[string]string, domain string, component string, logg
 	// metrics exporter.
 	if mc.backendDestination == Stackdriver {
 		mc.stackdriverProjectID = m[stackdriverProjectIDKey]
+	}
+
+	// If reporting period is specified, use the value from the configuration.
+	// If not, set a default value based on the selected backend.
+	// Each exporter makes different promises about what the lowest supported
+	// reporting period is. For Stackdriver, this value is 1 minute.
+	// For Prometheus, we will use a lower value since the exporter doesn't
+	// push anything but just responds to pull requests, and shorter durations
+	// do not really hurt the performance and we rely on the scraping configuration.
+	if repStr, ok := m[reportingPeriodKey]; ok && repStr != "" {
+		if repInt, err := strconv.Atoi(repStr); err == nil {
+			mc.reportingPeriod = time.Duration(repInt) * time.Second
+		} else {
+			return nil, fmt.Errorf("Invalid reporting-period-seconds value \"%s\"", repStr)
+		}
+	} else if mc.backendDestination == Stackdriver {
+		mc.reportingPeriod = 60 * time.Second
+	} else if mc.backendDestination == Prometheus {
+		mc.reportingPeriod = 5 * time.Second
 	}
 
 	if domain == "" {
@@ -118,5 +144,10 @@ func isMetricsConfigChanged(newConfig *metricsConfig) bool {
 	} else if newConfig.backendDestination == Stackdriver && newConfig.stackdriverProjectID != cc.stackdriverProjectID {
 		return true
 	}
+
+	if cc.reportingPeriod != newConfig.reportingPeriod {
+		return true
+	}
+
 	return false
 }

--- a/vendor/github.com/knative/pkg/metrics/exporter.go
+++ b/vendor/github.com/knative/pkg/metrics/exporter.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/exporter/prometheus"
@@ -137,7 +136,12 @@ func setCurMetricsExporterAndConfig(e view.Exporter, c *metricsConfig) {
 	metricsMux.Lock()
 	defer metricsMux.Unlock()
 	view.RegisterExporter(e)
-	view.SetReportingPeriod(60 * time.Second)
+	if c != nil {
+		view.SetReportingPeriod(c.reportingPeriod)
+	} else {
+		// Setting to 0 enables the default behavior.
+		view.SetReportingPeriod(0)
+	}
 	curMetricsExporter = e
 	curMetricsConfig = c
 }


### PR DESCRIPTION
I'm hopeful that this will reduce flakes in the upgrade testing because of the changes it picks up in the webhook, which was rejecting status updates when reconciling old objects with new fields that have defaulting (e.g. `timeoutSeconds`).

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
