### PR TITLE
PR template update to encourage creation of Docs issues

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -21,3 +21,13 @@ additional action from users switching to the new release, include the string
 ```release-note
 
 ```
+
+**Documentation Updates**
+
+<!-- If your change requires (or will require) an update to the user-facing documentation, you *must* open a corresponding issue in the Docs repo. If you have time, consider opening a PR to make the change yourself. If no update to the docs is required, put "N" for "Updates needed" and delete the other bullet points in this section. -->
+
+<!-- Create new Docs issues here: https://github.com/knative/docs/issues/new -->
+
+* Updates needed: Y/N
+* Issue created: #
+* PR: #


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Adds Documentation Updates section to PR template
* I'll make a similar change to the PR templates in other repos once we agree on wording/if we want to go this direction
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
