### PR TITLE
Clean up unused structs, variables and constants

### DIFF
--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -34,11 +34,10 @@ import (
 )
 
 const (
-	testNamespace     = "test-namespace"
-	testConfiguration = "test-configuration"
-	testRevision      = "test-rev"
-	testService       = testRevision + "-service"
-	testServiceFQDN   = testService + "." + testNamespace + ".svc.cluster.local"
+	testNamespace   = "test-namespace"
+	testRevision    = "test-rev"
+	testService     = testRevision + "-service"
+	testServiceFQDN = testService + "." + testNamespace + ".svc.cluster.local"
 )
 
 var defaultRevisionLabels map[string]string

--- a/pkg/autoscaler/dynamic_config.go
+++ b/pkg/autoscaler/dynamic_config.go
@@ -27,8 +27,7 @@ type DynamicConfig struct {
 	mutex  sync.RWMutex
 	config interface{} // discourage direct access as this is not goroutine safe
 
-	logger               *zap.SugaredLogger
-	containerConcurrency float64
+	logger *zap.SugaredLogger
 }
 
 func NewDynamicConfig(config *Config, logger *zap.SugaredLogger) *DynamicConfig {

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -36,10 +36,9 @@ import (
 )
 
 const (
-	testRevision    = "test-revision"
-	testNamespace   = "test-namespace"
-	testRevisionKey = "test-namespace/test-revision"
-	testKPAKey      = "test-namespace/test-revision"
+	testRevision  = "test-revision"
+	testNamespace = "test-namespace"
+	testKPAKey    = "test-namespace/test-revision"
 )
 
 func TestMultiScalerScaling(t *testing.T) {
@@ -390,11 +389,6 @@ func (u *fakeUniScaler) checkLastStat(t *testing.T, stat autoscaler.Stat) {
 	if u.lastStat != stat {
 		t.Fatalf("Last statistic recorded was %#v instead of expected statistic %#v", u.lastStat, stat)
 	}
-}
-
-type scaleParameterValues struct {
-	kpa      *kpa.PodAutoscaler
-	replicas int32
 }
 
 func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1alpha1.Revision) *kpa.PodAutoscaler {

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -25,7 +25,6 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"go.uber.org/zap"
 )
 
 // Measurement represents the type of the autoscaler metric to be reported
@@ -182,7 +181,6 @@ type StatsReporter interface {
 // Reporter holds cached metric objects to report autoscaler metrics
 type Reporter struct {
 	ctx         context.Context
-	logger      *zap.SugaredLogger
 	initialized bool
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
I removed the unused entities based on the list I received from the [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) tool:

```
$ unused ./*
activator/revision_test.go:38:2: const testConfiguration is unused (U1000)
autoscaler/dynamic_config.go:31:2: field containerConcurrency is unused (U1000)
autoscaler/multiscaler_test.go:41:2: const testRevisionKey is unused (U1000)
autoscaler/multiscaler_test.go:395:6: type scaleParameterValues is unused (U1000)
autoscaler/stats_reporter.go:185:2: field logger is unused (U1000)
```

Generally it would be more efficient to integrate it into the Prow bot to run the check for each PR.

## Proposed Changes

* clean up unused structs, variables and constants

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
