### PR TITLE
Throttle requests in Activator in case of overflow

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -39,13 +39,20 @@ import (
 	"github.com/knative/serving/pkg/activator"
 	activatorhandler "github.com/knative/serving/pkg/activator/handler"
 	activatorutil "github.com/knative/serving/pkg/activator/util"
+	v1alpha12 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	kubeinformers "k8s.io/client-go/informers"
+	corev1 "k8s.io/api/core/v1"
 	"github.com/knative/serving/pkg/http/h2c"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/metrics"
 	"github.com/knative/serving/pkg/system"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"github.com/knative/serving/pkg/queue"
+	"github.com/knative/serving/pkg/reconciler"
 )
 
 const (
@@ -63,6 +70,16 @@ const (
 
 	// Add enough buffer to not block request serving on stats collection
 	requestCountingQueueLength = 100
+
+	// The number of requests that are queued on the breaker before the 503s are sent
+	// the value must be adjusted depending on the actual production requirements
+	breakerQueueDepth = 10000
+
+	// The upper bound for concurrent requests sent to the revision,
+	// as new endpoints show up, the Breakers concurrency increases up to this value
+	breakerMaxConcurrency = 1000
+
+	defaultResyncInterval = 10 * time.Hour
 )
 
 var (
@@ -132,6 +149,73 @@ func main() {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
 
+	// set up signals so we handle the first shutdown signal gracefully
+	stopCh := signals.SetupSignalHandler()
+
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, defaultResyncInterval)
+	servingInformerFactory := servinginformers.NewSharedInformerFactory(servingClient, defaultResyncInterval)
+	endpointInformer := kubeInformerFactory.Core().V1().Endpoints()
+	revisionInformer := servingInformerFactory.Serving().V1alpha1().Revisions()
+
+	go endpointInformer.Informer().Run(stopCh)
+	go revisionInformer.Informer().Run(stopCh)
+
+	params := queue.BreakerParams{QueueDepth: breakerQueueDepth, MaxConcurrency: breakerMaxConcurrency, InitialCapacity: 0}
+
+	// Return the number of endpoints, 0 if no endpoints are found
+	endpointsGetter := func(revID activator.RevisionID) (int32, error) {
+		endpointKey := cache.ExplicitKey(revID.Namespace + "/" + reconciler.GetServingK8SServiceNameForObj(revID.Name))
+		endpoints, exists, err := endpointInformer.Informer().GetIndexer().Get(endpointKey)
+		if err != nil {
+			return 0, fmt.Errorf("Error getting endpoints for revision %v", revID)
+		}
+		if !exists {
+			// no endpoints exist yet
+			return 0, nil
+		}
+		if exists && endpoints != nil {
+			endpoint := endpoints.(*corev1.Endpoints).Subsets
+			addresses := activator.EndpointsAddressCount(endpoint)
+			return int32(addresses), nil
+		}
+		return 0, nil
+	}
+
+	revisionGetter := func(revID activator.RevisionID) (*v1alpha12.Revision, bool, error) {
+		revisionKey := cache.ExplicitKey(revID.Namespace + "/" + revID.Name)
+		rev, exists, err := revisionInformer.Informer().GetIndexer().Get(revisionKey)
+		if exists && rev != nil {
+			return rev.(*v1alpha12.Revision), exists, err
+		}
+		return nil, exists, err
+	}
+
+	throttlerParams := activator.ThrottlerParams{BreakerParams: params, Logger: logger, GetEndpoints: endpointsGetter, GetRevision: revisionGetter}
+	throttler := activator.NewThrottler(throttlerParams)
+
+	endpointInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: activator.UpdateEndpoints(throttler),
+	})
+
+	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: activator.DeleteBreaker(throttler),
+	})
+
+	kubeInformerFactory.Start(stopCh)
+	servingInformerFactory.Start(stopCh)
+
+	logger.Info("Waiting for informer caches to sync")
+
+	informerSyncs := []cache.InformerSynced{
+		endpointInformer.Informer().HasSynced,
+		revisionInformer.Informer().HasSynced,
+	}
+	for i, synced := range informerSyncs {
+		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
+			logger.Fatalf("failed to wait for cache at index %d to sync", i)
+		}
+	}
+
 	a := activator.NewRevisionActivator(kubeClient, servingClient, logger)
 	a = activator.NewDedupingActivator(a)
 
@@ -145,9 +229,6 @@ func main() {
 		Steps:    maxRetries,
 	}
 	rt := activatorutil.NewRetryRoundTripper(activatorutil.AutoTransport, logger, backoffSettings, shouldRetry)
-
-	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := signals.SetupSignalHandler()
 
 	// Open a websocket connection to the autoscaler
 	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", "autoscaler", system.Namespace(), "8080")
@@ -170,6 +251,7 @@ func main() {
 					Transport: rt,
 					Logger:    logger,
 					Reporter:  reporter,
+					Throttler: throttler,
 				},
 			},
 		),

--- a/pkg/activator/testing/utils.go
+++ b/pkg/activator/testing/utils.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// GenEndpointsSubset generates the subsets of endpoints
+func GenEndpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {
+	resp := []v1.EndpointSubset{}
+	if hostsPerSubset > 0 {
+		addresses := GenAddresses(hostsPerSubset)
+		subset := v1.EndpointSubset{Addresses: addresses}
+		for s := 0; s < subsets; s++ {
+			resp = append(resp, subset)
+		}
+		return resp
+	}
+	return resp
+}
+
+// GenAddresses generates endpoint addresses
+func GenAddresses(hosts int) (endpoints []v1.EndpointAddress) {
+	for i := 0; i < hosts; i++ {
+		endpoints = append(endpoints, v1.EndpointAddress{})
+	}
+	return endpoints
+}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activator
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	v1alpha12 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/queue"
+	"github.com/knative/serving/pkg/reconciler"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	capacityUpdateFailure = "updating capacity failed"
+	OverloadMessage       = "activator overload"
+)
+
+// ThrottlerParams defines the parameters of the Throttler
+type ThrottlerParams struct {
+	BreakerParams queue.BreakerParams
+	Logger        *zap.SugaredLogger
+	GetEndpoints  func(RevisionID) (int32, error)
+	GetRevision   func(RevisionID) (*v1alpha12.Revision, bool, error)
+}
+
+// NewThrottler creates a new Throttler
+func NewThrottler(params ThrottlerParams) *Throttler {
+	breakers := make(map[RevisionID]*queue.Breaker)
+	return &Throttler{breakers: breakers, breakerParams: params.BreakerParams, logger: params.Logger, getEndpoints: params.GetEndpoints, getRevision: params.GetRevision}
+}
+
+// Throttler keeps the mapping of Revisions to Breakers
+// and allows updating max concurrency dynamically of respective Breakers.
+// Max concurrency is essentially the number of semaphore tokens the Breaker has in rotation.
+// The manipulation of the parameter is done via `UpdateCapacity()` method.
+// It enables the use case to start with max concurrency set to 0 (no requests are sent because no endpoints are available)
+// and gradually increase its value depending on the external condition (e.g. new endpoints become available)
+type Throttler struct {
+	breakers      map[RevisionID]*queue.Breaker
+	breakerParams queue.BreakerParams
+	logger        *zap.SugaredLogger
+	getEndpoints  func(RevisionID) (int32, error)
+	getRevision   func(RevisionID) (*v1alpha12.Revision, bool, error)
+	mux           sync.Mutex
+}
+
+// Remove deletes the breaker from the bookkeeping
+func (t *Throttler) Remove(rev RevisionID) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	delete(t.breakers, rev)
+}
+
+// UpdateCapacity updates the max concurrency of the Breaker corresponding to a revision.
+// It create a new breaker and saves into our bookkeeping if doesn't exist.
+// This is important for not loosing the update signals
+// for requests that come before the requests reached the Activator's Handler.
+func (t *Throttler) UpdateCapacity(rev RevisionID, size int32) error {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	_, err := t.updateCapacity(rev, size)
+	return err
+}
+
+// This method updates Breaker's concurrency and requires external synchronization, e.g. use the mux
+func (t *Throttler) updateCapacity(rev RevisionID, size int32) (breaker *queue.Breaker, err error) {
+	revision, exists, err := t.getRevision(rev)
+	if err != nil {
+		return breaker, err
+	}
+	if !exists {
+		return breaker, fmt.Errorf("no revision was found for: %s", rev)
+	}
+	cc := int32(revision.Spec.ContainerConcurrency)
+
+	if cc == 0 {
+		cc = t.breakerParams.MaxConcurrency
+	}
+	breaker, ok := t.breakers[rev]
+	if !ok {
+		breaker = queue.NewBreaker(t.breakerParams)
+		t.breakers[rev] = breaker
+	}
+	delta := size*cc - breaker.Capacity()
+	// Either the same number of endpoints received or
+	// some endpoints that were not registered at this Activator are torn down.
+	// In both cases do not perform the update.
+	if delta == 0 || (delta < 0 && breaker.Capacity() == 0) {
+		return breaker, nil
+	}
+	if err := breaker.UpdateConcurrency(delta); err != nil {
+		return breaker, err
+	}
+	return breaker, nil
+}
+
+// Try potentially registers a new breaker in out bookkeeping
+// and executes the `function` on the Breaker.
+// It returns an error if either breaker doesn't have enough capacity,
+// or breaker's registration didn't succeed, e.g. getting endpoints or update capacity failed
+func (t *Throttler) Try(rev RevisionID, function func()) error {
+	breaker, err := t.getOrCreateBreaker(rev)
+	if err != nil {
+		return err
+	}
+	if ok := breaker.Maybe(function); !ok {
+		return errors.New(OverloadMessage)
+	}
+	return nil
+}
+
+// Get existing one or create a new breaker.
+// In the latter case fetch the endpoints and update the capacity of the newly created breaker
+// This avoids a potential deadlock in case if we missed the updates from the Endpoints informer.
+// This could happen because of a restart of the Activator or when a new one is added because of scale out.
+func (t *Throttler) getOrCreateBreaker(rev RevisionID) (breaker *queue.Breaker, err error) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	breaker, ok := t.breakers[rev]
+	if !ok {
+		size, err := t.getEndpoints(rev)
+		if err != nil {
+			return breaker, err
+		}
+		breaker, err = t.updateCapacity(rev, size)
+		if err != nil {
+			return breaker, err
+		}
+	}
+	return breaker, err
+}
+
+// UpdateEndpoints is a handler function to be used by the Endpoints informer.
+// It updates the endpoints in the Throttler if the number of hosts changed and
+// the revision already exists (we don't want to create/update throttlers for the endpoints
+// that do not belong to any revision)
+func UpdateEndpoints(throttler *Throttler) func(oldObj, newObj interface{}) {
+	return func(oldObj, newObj interface{}) {
+		newEndpoints := newObj.(*corev1.Endpoints)
+		newAddresses := EndpointsAddressCount(newEndpoints.Subsets)
+		revID := RevisionID{newEndpoints.Namespace, reconciler.GetServingRevisionNameForK8sService(newEndpoints.Name)}
+		_, exists, err := throttler.getRevision(revID)
+		if err != nil {
+			throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
+			return
+		}
+		// Only update capacity if it is a registered revision
+		if exists {
+			err := throttler.UpdateCapacity(revID, int32(newAddresses))
+			if err != nil {
+				throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
+			}
+		}
+	}
+}
+
+// DeleteBreaker  is a handler function to be used by the Endpoints informer.
+// It removes the Breaker from the Throttler bookkeeping
+func DeleteBreaker(throttler *Throttler) func(obj interface{}) {
+	return func(obj interface{}) {
+		rev := obj.(*v1alpha12.Revision)
+		revID := RevisionID{rev.Namespace, rev.Name}
+		throttler.Remove(revID)
+	}
+}
+
+// EndpointsAddressCount returns the total number of addresses registered for the endpoint
+func EndpointsAddressCount(subsets []corev1.EndpointSubset) int {
+	var total int
+	for _, subset := range subsets {
+		total += len(subset.Addresses)
+	}
+	return total
+}

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activator
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/knative/pkg/logging/testing"
+	testinghelper "github.com/knative/serving/pkg/activator/testing"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	v1alpha12 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/queue"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	revID = RevisionID{"good-namespace", "good-name"}
+
+	existingRevisionGetter = func(concurrency v1alpha1.RevisionContainerConcurrencyType) func(RevisionID) (*v1alpha12.Revision, bool, error) {
+		return func(RevisionID) (*v1alpha12.Revision, bool, error) {
+			revision := &v1alpha12.Revision{Spec: v1alpha12.RevisionSpec{ContainerConcurrency: concurrency}}
+			return revision, true, nil
+		}
+	}
+	nonExistingRevisionGetter = func(RevisionID) (*v1alpha12.Revision, bool, error) {
+		revision := &v1alpha12.Revision{}
+		return revision, false, nil
+	}
+	initCapacity            = int32(0)
+	existingEndpointsGetter = func(RevisionID) (int32, error) {
+		return initCapacity, nil
+	}
+	nonExistingEndpointsGetter = func(RevisionID) (int32, error) {
+		return initCapacity, errors.New("some error")
+	}
+)
+
+const (
+	defaultMaxConcurrency = int32(10)
+)
+
+func TestThrottler_UpdateCapacity(t *testing.T) {
+	samples := []struct {
+		label           string
+		revisionGetter  func(RevisionID) (*v1alpha12.Revision, bool, error)
+		endpointsGetter func(RevisionID) (int32, error)
+		maxConcurrency  int32
+		want            int32
+		wantError       string
+	}{
+		{
+			label:           "all good",
+			revisionGetter:  existingRevisionGetter(10),
+			endpointsGetter: existingEndpointsGetter,
+			maxConcurrency:  defaultMaxConcurrency,
+			want:            int32(10),
+		},
+		{
+			label:           "unlimited concurrency",
+			revisionGetter:  existingRevisionGetter(0),
+			endpointsGetter: existingEndpointsGetter,
+			maxConcurrency:  100,
+			want:            int32(100),
+		},
+		{
+			label:           "non-existing revision",
+			revisionGetter:  nonExistingRevisionGetter,
+			endpointsGetter: existingEndpointsGetter,
+			maxConcurrency:  defaultMaxConcurrency,
+			want:            int32(0),
+			wantError:       fmt.Sprintf("no revision was found for: %s", revID),
+		},
+	}
+	for _, s := range samples {
+		t.Run(s.label, func(t *testing.T) {
+			var received string
+			want := s.want
+			throttler := getThrottler(s.maxConcurrency, s.revisionGetter, s.endpointsGetter, t)
+			err := throttler.UpdateCapacity(revID, 1)
+			if err != nil {
+				received = err.Error()
+			}
+			if received != s.wantError {
+				t.Errorf("Expected error in the Try. Want %s, got %s", s.wantError, received)
+			}
+			if want > 0 {
+				breaker, _ := throttler.breakers[revID]
+				got := breaker.Capacity()
+				if got != want {
+					t.Errorf("Unexpected capacity of the breaker. Want %d, got %d", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestThrottler_Try(t *testing.T) {
+	samples := []struct {
+		label           string
+		addCapacity     bool
+		wantBreakers    int32
+		wantError       string
+		revisionGetter  func(RevisionID) (*v1alpha12.Revision, bool, error)
+		endpointsGetter func(RevisionID) (int32, error)
+	}{
+		{
+			label:           "all good",
+			addCapacity:     true,
+			wantBreakers:    int32(1),
+			wantError:       "",
+			revisionGetter:  existingRevisionGetter(10),
+			endpointsGetter: existingEndpointsGetter,
+		},
+		{
+			label:           "non-existing revision",
+			addCapacity:     true,
+			wantBreakers:    int32(0),
+			wantError:       fmt.Sprintf("no revision was found for: %s", revID),
+			revisionGetter:  nonExistingRevisionGetter,
+			endpointsGetter: existingEndpointsGetter,
+		},
+		{
+			label:           "non-exsiting endpoint",
+			addCapacity:     false,
+			wantBreakers:    int32(0),
+			wantError:       "some error",
+			revisionGetter:  existingRevisionGetter(10),
+			endpointsGetter: nonExistingEndpointsGetter,
+		},
+	}
+	for _, s := range samples {
+		t.Run(s.label, func(t *testing.T) {
+			var got int32
+			var received string
+			want := s.wantBreakers
+			throttler := getThrottler(defaultMaxConcurrency, s.revisionGetter, s.endpointsGetter, t)
+			if s.addCapacity {
+				throttler.UpdateCapacity(revID, 1)
+			}
+			err := throttler.Try(revID, func() {
+				got++
+			})
+			if err != nil {
+				received = err.Error()
+			}
+			if received != s.wantError {
+				t.Errorf("Expected error in the Try. Want %s, got %s", s.wantError, received)
+			}
+			if got != want {
+				t.Errorf("Unexpected number of function runs in Try. Want %d, got %d", want, got)
+			}
+		})
+	}
+}
+
+func TestThrottler_Remove(t *testing.T) {
+	throttler := getThrottler(defaultMaxConcurrency, existingRevisionGetter(10), existingEndpointsGetter, t)
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	got := len(throttler.breakers)
+	if got != 1 {
+		t.Errorf("Unexpected number of Breakers was created. Want %d, got %d", 1, got)
+	}
+	throttler.Remove(revID)
+	got = len(throttler.breakers)
+	if got != 0 {
+		t.Errorf("Unexpected number of Breakers was created. Want %d, got %d", 0, got)
+	}
+}
+
+func TestHelper_UpdateEndpoints(t *testing.T) {
+	want := int32(10)
+	throttler := getThrottler(defaultMaxConcurrency, existingRevisionGetter(10), existingEndpointsGetter, t)
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	updater := UpdateEndpoints(throttler)
+
+	endpointsBefore := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GenEndpointsSubset(0, 1)}
+	endpointsAfter := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GenEndpointsSubset(1, 1)}
+	updater(&endpointsBefore, &endpointsAfter)
+
+	breaker, _ := throttler.breakers[revID]
+	got := breaker.Capacity()
+	if got != want {
+		t.Errorf("Unexpected Breaker capacity received. Want %d, got %d", want, got)
+	}
+}
+
+func TestHelper_UpdateEndpoints_WithDeltaMoreThenOne(t *testing.T) {
+	want := int32(20)
+	throttler := getThrottler(int32(20), existingRevisionGetter(10), existingEndpointsGetter, t)
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	updater := UpdateEndpoints(throttler)
+
+	endpointsBefore := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GenEndpointsSubset(0, 1)}
+	endpointsAfter := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GenEndpointsSubset(2, 1)}
+	updater(&endpointsBefore, &endpointsAfter)
+
+	breaker, _ := throttler.breakers[revID]
+	got := breaker.Capacity()
+	if got != want {
+		t.Errorf("Unexpected Breaker capacity received. Want %d, got %d", want, got)
+	}
+}
+
+func TestHelper_DeleteBreaker(t *testing.T) {
+	throttler := getThrottler(int32(20), existingRevisionGetter(10), existingEndpointsGetter, t)
+	revision := &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      revID.Name,
+			Namespace: revID.Namespace,
+		},
+	}
+	revID := RevisionID{Namespace: revID.Namespace, Name: revID.Name}
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	if len(throttler.breakers) != 1 {
+		t.Errorf("Breaker map size didn't change. Wanted %d, got %d", 1, len(throttler.breakers))
+	}
+	deleter := DeleteBreaker(throttler)
+	deleter(revision)
+	if len(throttler.breakers) != 0 {
+		t.Error("Breaker map is not empty")
+	}
+}
+
+func getThrottler(maxConcurrency int32, revisionGetter func(RevisionID) (*v1alpha12.Revision, bool, error), endpointsGetter func(RevisionID) (int32, error), t *testing.T) *Throttler {
+	logger := TestLogger(t)
+	params := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: maxConcurrency, InitialCapacity: initCapacity}
+	throttlerParams := ThrottlerParams{BreakerParams: params, Logger: logger, GetRevision: revisionGetter, GetEndpoints: endpointsGetter}
+	return NewThrottler(throttlerParams)
+}

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -20,12 +20,19 @@ import (
 	"fmt"
 
 	"github.com/knative/serving/pkg/utils"
+	"strings"
 )
+
+const suffix = "-service"
 
 func GetK8sServiceFullname(name string, namespace string) string {
 	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, utils.GetClusterDomainName())
 }
 
 func GetServingK8SServiceNameForObj(name string) string {
-	return name + "-service"
+	return name + suffix
+}
+
+func GetServingRevisionNameForK8sService(name string) string {
+	return strings.Split(name, suffix)[0]
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
Throttle requests in Activator, please note that both Deduper and RevisionChecker will be removed in a separate PR. This one is still WIP due to some open questions I'd like to discuss.

## Proposed Changes

* use Breaker to throttle buffered requests proportionally to the number of available endpoints

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
