### PR TITLE
golang format tools

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -17,9 +17,9 @@ limitations under the License.
 package queue
 
 import (
+	"errors"
 	"fmt"
 	"sync"
-	"errors"
 )
 
 type token struct{}

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sync/atomic"
 	"errors"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const semSleepInterval = 20 * time.Millisecond


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
