### PR TITLE
[WIP] Generate ClusterIngress name based on Route UUID.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -49,7 +49,7 @@ func (c *Reconciler) getClusterIngressForRoute(route *v1alpha1.Route) (*netv1alp
 		return nil, err
 	}
 	if len(ingresses) == 0 {
-		return nil, apierrs.NewNotFound(v1alpha1.Resource("clusteringress"), resourcenames.ClusterIngressPrefix(route) /* prefix of GenerateName here */)
+		return nil, apierrs.NewNotFound(v1alpha1.Resource("clusteringress"), resourcenames.ClusterIngressName(route))
 	}
 
 	if len(ingresses) > 1 {

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -40,9 +40,7 @@ import (
 func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.TrafficConfig) *v1alpha1.ClusterIngress {
 	return &v1alpha1.ClusterIngress{
 		ObjectMeta: metav1.ObjectMeta{
-			// As ClusterIngress resource is cluster-scoped,
-			// here we use GenerateName to avoid conflict.
-			GenerateName: names.ClusterIngressPrefix(r),
+			Name: names.ClusterIngressName(r),
 			Labels: map[string]string{
 				serving.RouteLabelKey:          r.Name,
 				serving.RouteNamespaceLabelKey: r.Namespace,

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -38,6 +38,7 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
+			UID:       "test-uid",
 			Annotations: map[string]string{
 				networking.IngressClassAnnotationKey: clusteringress.IstioIngressClassName,
 			},
@@ -45,7 +46,7 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		Status: v1alpha1.RouteStatus{Domain: "domain.com"},
 	}
 	expected := metav1.ObjectMeta{
-		GenerateName: "test-route-",
+		Name: "test-route-test-ns-test-uid",
 		Labels: map[string]string{
 			serving.RouteLabelKey:          "test-route",
 			serving.RouteNamespaceLabelKey: "test-ns",

--- a/pkg/reconciler/v1alpha1/route/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names.go
@@ -17,7 +17,7 @@ limitations under the License.
 package names
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
@@ -31,8 +31,36 @@ func K8sServiceFullname(route *v1alpha1.Route) string {
 	return reconciler.GetK8sServiceFullname(K8sService(route), route.Namespace)
 }
 
-// ClusterIngressPrefix returns GenerateName prefix of the
-// ClusterIngress child resource for given Route.
-func ClusterIngressPrefix(route *v1alpha1.Route) string {
-	return fmt.Sprintf("%s-", route.Name)
+func prefix(s string, l int) string {
+	if l > len(s) {
+		return s
+	}
+	return string(s[0:l])
+}
+
+// ClusterIngressName returns a name that is based on the Route's
+// name, namespace and UID.  The UID is the most important part, because
+// it ensures the uniqueness of the name.  The Route name and namespace
+// is added for human readability.
+func ClusterIngressName(route *v1alpha1.Route) string {
+	// Kubernetes object names cannot exceed 253 characters.
+	totalLen := 253
+	n, ns, uuid := route.Name, route.Namespace, string(route.ObjectMeta.UID)
+	sep := "-"
+	l := totalLen - len(uuid) - len(n) - 2
+	if l > 0 {
+		// Three-parts name: name-prefix(ns)-uuid.
+		name := strings.Join([]string{n, prefix(ns, l), uuid}, sep)
+		return name
+	}
+	l = totalLen - len(uuid) - 1
+	if l > 0 {
+		// Two-parts name: prefix(name)-uuid.
+		return strings.Join([]string{prefix(n, l), uuid}, sep)
+	}
+	// UUID are only 36 characters long, so this should never happen.
+	// However we leave it here to be safe when UUID may be longer
+	// than 253 characters.  Taking the first 253 characters should be
+	// very unique here.
+	return prefix(uuid, totalLen)
 }

--- a/pkg/reconciler/v1alpha1/route/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names_test.go
@@ -51,15 +51,16 @@ func TestNamer(t *testing.T) {
 		f:    K8sServiceFullname,
 		want: "bar.default.svc.cluster.local",
 	}, {
-		name: "ClusterIngressPrefix",
+		name: "ClusterIngressName",
 		route: &v1alpha1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: "default",
+				UID:       "uid",
 			},
 		},
-		f:    ClusterIngressPrefix,
-		want: "bar-",
+		f:    ClusterIngressName,
+		want: "bar-default-uid",
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -133,7 +133,7 @@ func TestReconcile(t *testing.T) {
 				})),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", ""),
+			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", "becomes-ready-default-routeUID"),
 		},
 		Key: "default/becomes-ready",
 		// TODO(lichuqiang): config namespace validation in resource scope.
@@ -934,7 +934,7 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", ""),
+			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", "named-traffic-split-default-routeUID"),
 		},
 		Key:                     "default/named-traffic-split",
 		SkipNamespaceValidation: true,
@@ -1021,7 +1021,7 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", ""),
+			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", "same-revision-targets-default-routeUID"),
 		},
 		Key:                     "default/same-revision-targets",
 		SkipNamespaceValidation: true,
@@ -1156,6 +1156,7 @@ func route(namespace, name string, ro ...RouteOption) *v1alpha1.Route {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
+			UID:       "routeUID",
 		},
 	}
 	for _, opt := range ro {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Generate ClusterIngress names based on the parent Route' UUID.  This avoids duplicated ClusterIngress creation.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
