### PR TITLE
sync gateway label selector on config update

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -37,5 +37,5 @@ rules:
     resources: ["builds"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["networking.istio.io"]
-    resources: ["virtualservices"]
+    resources: ["virtualservices", "gateways"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]

--- a/docs/setting-up-custom-ingress-gateway.md
+++ b/docs/setting-up-custom-ingress-gateway.md
@@ -214,37 +214,13 @@ spec:
                 - s390x
 ```
 
-## Step 2: Update Knative Gateway
+## Step 2: Update Gateway Configmap
 
-Update gateway instance `knative-shared-gateway` under `knative-serving`
+Update gateway configmap `config-istio` under `knative-serving`
 namespace:
 
 ```shell
-kubectl edit gateway knative-shared-gateway -n knative-serving
-```
-
-Replace its label selector with the label of your service:
-
-```
-istio: ingressgateway
-```
-
-For the service above, it should be updated to
-
-```
-custom: ingressgateway
-```
-
-If there is a change in service ports (compared with that of
-`istio-ingressgateway`), update the port info in gateway accordingly.
-
-## Step 3: Update Gateway Configmap
-
-Update gateway configmap `config-ingressgateway` under `knative-serving`
-namespace:
-
-```shell
-kubectl edit configmap config-ingressgateway -n knative-serving
+kubectl edit configmap config-istio -n knative-serving
 ```
 
 Replace the `ingress-gateway` field with fully qualified url of your service:
@@ -253,4 +229,15 @@ For the service above, it should be updated to
 
 ```
 custom-ingressgateway.istio-system.svc.cluster.local
+```
+
+## Step 3: Update Knative Gateway
+
+Label selector of the gateway instance `knative-shared-gateway` under `knative-serving`
+namespace will get updated automatically, but if there is a change in service ports
+(compared with that of `istio-ingressgateway`), you'll need to update the port info
+in gateway accordingly:
+
+```shell
+kubectl edit gateway knative-shared-gateway -n knative-serving
 ```

--- a/pkg/reconciler/v1alpha1/clusteringress/gateway.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/gateway.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusteringress
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/knative/pkg/apis/duck"
+	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
+	istioclients "github.com/knative/pkg/client/clientset/versioned/typed/istio/v1alpha3"
+	"github.com/knative/serving/pkg/system"
+)
+
+var (
+	gatewayName = "knative-shared-gateway"
+	// TODO(lichuqiang): make this configurable.
+	ingressSuffixes = []string{".svc", ".svc.cluster.local"}
+)
+
+func (c *Reconciler) updateGatewayLabelSelector() {
+	// TODO: improve this when we find way to pass in ctx.
+	ctx := context.TODO()
+	ctx = c.configStore.ToContext(ctx)
+
+	ingressUrl := ingressGatewayFromContext(ctx)
+	// Extract ingress service from the URL.
+	for _, suffix := range ingressSuffixes {
+		ingressUrl = strings.TrimSuffix(ingressUrl, suffix)
+	}
+	// The url should be in format of <service-name>.<service-namespace> then.
+	serviceInfo := strings.Split(ingressUrl, ".")
+	if len(serviceInfo) != 2 {
+		c.Logger.Errorf("Failed to update gateway label selector, invalid ingress url: %s", ingressUrl)
+		return
+	}
+	serviceName, serviceNamespace := serviceInfo[0], serviceInfo[1]
+
+	// Fetch the selector to update to from ingress service.
+	service, err := c.KubeClientSet.CoreV1().Services(serviceNamespace).Get(serviceName, metav1.GetOptions{})
+	if err != nil {
+		c.Logger.Errorf("Failed to update gateway label selector, error getting ingress service %s/%s: %v",
+			serviceNamespace, serviceName, err)
+		return
+	}
+	newSelector := service.Spec.Selector
+
+	// Fetch origin selector from gateway.
+	gatewayClient := c.SharedClientSet.NetworkingV1alpha3().Gateways(system.Namespace)
+	gateway, err := gatewayClient.Get(gatewayName, metav1.GetOptions{})
+	if err != nil {
+		c.Logger.Errorf("Failed to update gateway label selector, error getting gateway %s/%s: %v",
+			system.Namespace, gatewayName, err)
+		return
+	}
+	originSelector := gateway.Spec.Selector
+	if equality.Semantic.DeepEqual(newSelector, originSelector) {
+		// Skip when no update in label selector.
+		return
+	}
+
+	if err := setLabelSelectorForGateway(gatewayClient, gateway, newSelector); err != nil {
+		c.Logger.Errorf("Failed to update gateway label selector: %v", err)
+	}
+
+	return
+}
+
+func setLabelSelectorForGateway(
+	gatewayClient istioclients.GatewayInterface,
+	gateway *istiov1alpha3.Gateway,
+	selector map[string]string,
+) error {
+	before, after := gateway, gateway.DeepCopy()
+	after.Spec.Selector = selector
+	patch, err := duck.CreatePatch(before, after)
+	if err != nil {
+		return err
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+
+	_, err = gatewayClient.Patch(gatewayName, types.JSONPatchType, patchBytes)
+	return err
+}

--- a/pkg/reconciler/v1alpha1/clusteringress/gateway.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/gateway.go
@@ -42,15 +42,15 @@ func (c *Reconciler) updateGatewayLabelSelector() {
 	ctx := context.TODO()
 	ctx = c.configStore.ToContext(ctx)
 
-	ingressUrl := ingressGatewayFromContext(ctx)
+	ingressURL := ingressGatewayFromContext(ctx)
 	// Extract ingress service from the URL.
 	for _, suffix := range ingressSuffixes {
-		ingressUrl = strings.TrimSuffix(ingressUrl, suffix)
+		ingressURL = strings.TrimSuffix(ingressURL, suffix)
 	}
 	// The url should be in format of <service-name>.<service-namespace> then.
-	serviceInfo := strings.Split(ingressUrl, ".")
+	serviceInfo := strings.Split(ingressURL, ".")
 	if len(serviceInfo) != 2 {
-		c.Logger.Errorf("Failed to update gateway label selector, invalid ingress url: %s", ingressUrl)
+		c.Logger.Errorf("Failed to update gateway label selector, invalid ingress url: %s", ingressURL)
 		return
 	}
 	serviceName, serviceNamespace := serviceInfo[0], serviceInfo[1]

--- a/pkg/reconciler/v1alpha1/clusteringress/gateway_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/gateway_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusteringress
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/config"
+	"github.com/knative/serving/pkg/system"
+)
+
+var (
+	originLabels = map[string]string{"origin-key": "origin-value"}
+	newLabels    = map[string]string{"new-key": "new-value"}
+)
+
+func TestGatewayUpdateOnConfigChanged(t *testing.T) {
+	kubeClient, sharedClient, _, controller, _, kubeInformer, sharedInformer, _, watcher := newTestSetup(t)
+
+	stopCh := make(chan struct{})
+	defer func() {
+		close(stopCh)
+	}()
+
+	kubeInformer.Start(stopCh)
+	sharedInformer.Start(stopCh)
+	if err := watcher.Start(stopCh); err != nil {
+		t.Fatalf("failed to start cluster ingress manager: %v", err)
+	}
+
+	go controller.Run(1, stopCh)
+
+	gateway := &istiov1alpha3.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: system.Namespace,
+		},
+		Spec: istiov1alpha3.GatewaySpec{
+			Selector: originLabels,
+		},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: newLabels,
+		},
+	}
+
+	gatewayClient := sharedClient.NetworkingV1alpha3().Gateways(system.Namespace)
+	gatewayWatcher, err := gatewayClient.Watch(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Could not create gateway watcher")
+	}
+	defer gatewayWatcher.Stop()
+
+	// Create the test gateway.
+	gatewayClient.Create(gateway)
+
+	// Create the service for test.
+	kubeClient.CoreV1().Services(metav1.NamespaceDefault).Create(service)
+
+	// Test changes in istio config map. Gateway should get updated appropriately.
+	tests := []struct {
+		name           string
+		doThings       func()
+		expectedLabels map[string]string
+		gatewayExist   bool
+		shouldUpdate   bool
+	}{{
+		name: "invalid url",
+		doThings: func() {
+			config := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.IstioConfigName,
+					Namespace: system.Namespace,
+				},
+				Data: map[string]string{
+					config.IngressGatewayKey: "invalid",
+				},
+			}
+			watcher.OnChange(&config)
+		},
+		expectedLabels: originLabels,
+		gatewayExist:   true,
+	}, {
+		name: "service not exist",
+		doThings: func() {
+			config := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.IstioConfigName,
+					Namespace: system.Namespace,
+				},
+				Data: map[string]string{
+					config.IngressGatewayKey: "non-exist.ns.svc.cluster.local",
+				},
+			}
+			watcher.OnChange(&config)
+		},
+		expectedLabels: originLabels,
+		gatewayExist:   true,
+	}, {
+		name: "service not exist",
+		doThings: func() {
+			config := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.IstioConfigName,
+					Namespace: system.Namespace,
+				},
+				Data: map[string]string{
+					config.IngressGatewayKey: "non-exist.ns.svc.cluster.local",
+				},
+			}
+			watcher.OnChange(&config)
+		},
+		expectedLabels: originLabels,
+		gatewayExist:   true,
+	}, {
+		name: "gateway not exist",
+		doThings: func() {
+			config := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.IstioConfigName,
+					Namespace: system.Namespace,
+				},
+				Data: map[string]string{
+					config.IngressGatewayKey: "test-svc.default.svc.cluster.local",
+				},
+			}
+			watcher.OnChange(&config)
+		},
+		expectedLabels: originLabels,
+		gatewayExist:   false,
+	}}
+
+	// TODO(lichuqiang): enable this when client-go dependency is updated
+	// to support JSON patch in fake client.
+	// See https://github.com/kubernetes/client-go/commit/41406bf985e3fa3c5eccd0a7c1fb39e9212340e8
+	/*{
+		name: "valid url with suffix",
+		doThings: func() {
+			config := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.IstioConfigName,
+					Namespace: system.Namespace,
+				},
+				Data: map[string]string{
+					config.IngressGatewayKey: "test-svc.default.svc.cluster.local",
+				},
+			}
+			watcher.OnChange(&config)
+		},
+		expectedLabels: newLabels,
+		gatewayExist:   true,
+		shouldUpdate:   true,
+	}, {
+		name: "valid url without suffix",
+		doThings: func() {
+			config := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.IstioConfigName,
+					Namespace: system.Namespace,
+				},
+				Data: map[string]string{
+					config.IngressGatewayKey: "test-svc.default.svc",
+				},
+			}
+			watcher.OnChange(&config)
+		},
+		expectedLabels: newLabels,
+		gatewayExist:   true,
+		shouldUpdate:   true,
+	}*/
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Init the gateway
+			gatewayClient.Delete(gatewayName, &metav1.DeleteOptions{})
+			if test.gatewayExist {
+				gatewayClient.Create(gateway)
+			}
+			test.doThings()
+
+			// Record the origin events channel length for comparison later.
+			originEvents := len(gatewayWatcher.ResultChan())
+
+			if test.shouldUpdate {
+				timer := time.NewTimer(10 * time.Second)
+			loop:
+				for {
+					select {
+					case event := <-gatewayWatcher.ResultChan():
+						if event.Type == watch.Modified {
+							break loop
+						}
+					case <-timer.C:
+						t.Fatalf("gatewayWatcher did not receive a Type==Modified event in 10s")
+					}
+				}
+			} else {
+				// TODO(lichuqiang): find more reliable way to make sure that
+				// gateway does not get updated.
+				time.Sleep(10 * time.Millisecond)
+				if len(gatewayWatcher.ResultChan()) > originEvents {
+					t.Errorf("Unexpected events on gateway")
+				}
+			}
+
+			if test.gatewayExist {
+				res, err := gatewayClient.Get(gatewayName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Error getting gateway: %v", err)
+				}
+				if !equality.Semantic.DeepEqual(res.Spec.Selector, test.expectedLabels) {
+					t.Errorf("Expected selector %v but saw %v", test.expectedLabels, res.Spec.Selector)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
To address https://github.com/knative/serving/pull/2434#discussion_r235055222

## Proposed Changes

* Update clusteringress controller to update gateway label selector on config change
* Update related docs


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE

```

Clusteringress controller will update gateway label selector on config update automatically with this change; As for the `servers(port)` fields in gateway, the fields can also change, and might not be so regular like that of selector: Users probably only want to expose some of the service ports in the gateway. So users will need to update the fields manually as needed.



