### PR TITLE
Increase default timeout

### DIFF
--- a/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// DefaultTimeout will be set if timeout not specified.
-	DefaultTimeout = 60 * time.Second
+	DefaultTimeout = 5 * 60 * time.Second
 	// DefaultRetryCount will be set if Attempts not specified.
 	DefaultRetryCount = 3
 )


### PR DESCRIPTION
Based on user feedback: long running operations are common for Knative tasks.

**Release Note**

* increase default timeout to 5 minutes
