### PR TITLE
Refactor observed-concurrency test.

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -67,7 +67,7 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// Setup Initial Service
 	logger.Info("Creating a new Service in runLatest")
-	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names)
+	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -38,7 +38,7 @@ import (
 // createLatestService creates a service in namespace with the name names.Service
 // that uses the image specified by imagePath
 func createLatestService(logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, imagePath string, revisionTimeoutSeconds int) (*v1alpha1.Service, error) {
-	service := test.LatestService(test.ServingNamespace, names, imagePath)
+	service := test.LatestService(test.ServingNamespace, names, imagePath, &test.Options{})
 	service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{
 		Duration: time.Duration(revisionTimeoutSeconds) * time.Second,
 	}

--- a/test/conformance/runtime_conformance_helper.go
+++ b/test/conformance/runtime_conformance_helper.go
@@ -36,13 +36,13 @@ import (
 )
 
 //fetchEnvInfo creates the service using test_images/environment and fetches environment info defined inside the container dictated by urlPath.
-func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, names* test.ResourceNames) ([]byte, error) {
+func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, names *test.ResourceNames) ([]byte, error) {
 	clients := setup(t)
 
 	logger.Info("Creating a new Service")
 	names.Service = test.AppendRandomString("yashiki", logger)
 	names.Image = "environment"
-	svc, err := test.CreateLatestService(logger, clients, *names)
+	svc, err := test.CreateLatestService(logger, clients, *names, &test.Options{})
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Failed to create Service: %v", err))
 	}
@@ -87,7 +87,7 @@ func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, name
 		logger,
 		url,
 		pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
-			if resp.StatusCode ==  http.StatusOK {
+			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}
 

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -154,7 +154,7 @@ func TestRunLatestService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
 
 	// Setup initial Service
-	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names)
+	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -279,7 +279,7 @@ func TestReleaseService(t *testing.T) {
 	defer tearDown(clients, names)
 	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
 
-	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names)
+	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/crd.go
+++ b/test/crd.go
@@ -111,7 +111,7 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 		spec.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{Duration: options.RevisionTimeout}
 	}
 
-	if options.EnvVars != nil && len(options.EnvVars) > 0 {
+	if options.EnvVars != nil {
 		spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
 	}
 

--- a/test/crd.go
+++ b/test/crd.go
@@ -92,6 +92,32 @@ func BlueGreenRoute(namespace string, names, blue, green ResourceNames) *v1alpha
 	}
 }
 
+// ConfigurationSpec returns the spec of a configuration to be used throughout different
+// CRD helpers.
+func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.ConfigurationSpec {
+	spec := &v1alpha1.ConfigurationSpec{
+		RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			Spec: v1alpha1.RevisionSpec{
+				Container: corev1.Container{
+					Image:     imagePath,
+					Resources: options.ContainerResources,
+				},
+				ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
+			},
+		},
+	}
+
+	if options.RevisionTimeout > 0 {
+		spec.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{Duration: options.RevisionTimeout}
+	}
+
+	if options.EnvVars != nil && len(options.EnvVars) > 0 {
+		spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
+	}
+
+	return spec
+}
+
 // Configuration returns a Configuration object in namespace with the name names.Config
 // that uses the image specified by imagePath.
 func Configuration(namespace string, names ResourceNames, imagePath string, options *Options) *v1alpha1.Configuration {
@@ -100,25 +126,7 @@ func Configuration(namespace string, names ResourceNames, imagePath string, opti
 			Namespace: namespace,
 			Name:      names.Config,
 		},
-		Spec: v1alpha1.ConfigurationSpec{
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-				Spec: v1alpha1.RevisionSpec{
-					Container: corev1.Container{
-						Image:     imagePath,
-						Resources: options.ContainerResources,
-					},
-					ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
-				},
-			},
-		},
-	}
-
-	if options.RevisionTimeout > 0 {
-		config.Spec.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{Duration: options.RevisionTimeout}
-	}
-
-	if options.EnvVars != nil && len(options.EnvVars) > 0 {
-		config.Spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
+		Spec: *ConfigurationSpec(imagePath, options),
 	}
 	return config
 }
@@ -147,7 +155,7 @@ func ConfigurationWithBuild(namespace string, names ResourceNames, build *v1alph
 
 // LatestService returns a RunLatest Service object in namespace with the name names.Service
 // that uses the image specified by imagePath.
-func LatestService(namespace string, names ResourceNames, imagePath string) *v1alpha1.Service {
+func LatestService(namespace string, names ResourceNames, imagePath string, options *Options) *v1alpha1.Service {
 	return &v1alpha1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -155,15 +163,7 @@ func LatestService(namespace string, names ResourceNames, imagePath string) *v1a
 		},
 		Spec: v1alpha1.ServiceSpec{
 			RunLatest: &v1alpha1.RunLatestType{
-				Configuration: v1alpha1.ConfigurationSpec{
-					RevisionTemplate: v1alpha1.RevisionTemplateSpec{
-						Spec: v1alpha1.RevisionSpec{
-							Container: corev1.Container{
-								Image: imagePath,
-							},
-						},
-					},
-				},
+				Configuration: *ConfigurationSpec(imagePath, options),
 			},
 		},
 	}
@@ -172,7 +172,7 @@ func LatestService(namespace string, names ResourceNames, imagePath string) *v1a
 // LatestServiceWithResources returns a RunLatest Service object in namespace with the name names.Service
 // that uses the image specified by imagePath, and small constant resources.
 func LatestServiceWithResources(namespace string, names ResourceNames, imagePath string) *v1alpha1.Service {
-	svc := LatestService(namespace, names, imagePath)
+	svc := LatestService(namespace, names, imagePath, &Options{})
 	svc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
-	"github.com/knative/test-infra/tools/testgrid"
+	"github.com/knative/test-infra/shared/testgrid"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -20,24 +20,26 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
+	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/test-infra/tools/prometheus"
 	"github.com/knative/test-infra/tools/testgrid"
 	"golang.org/x/sync/errgroup"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	tName       = "TestObservedConcurrency"
-	perfLatency = "perf_latency"
+	perfLatency = "perf_scaleup_latency"
 	concurrency = 5
 	duration    = 1 * time.Minute
 	numThreads  = 1
@@ -52,18 +54,8 @@ func createTestCase(val float32, name string) testgrid.TestCase {
 	return tc
 }
 
-func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	var revisionName string
-	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
-		if s.Status.LatestCreatedRevisionName != names.Revision {
-			revisionName = s.Status.LatestCreatedRevisionName
-			return true, nil
-		}
-		return false, nil
-	}, "ServiceUpdatedWithRevision")
-	return revisionName, err
-}
-
+// generateTraffic loads the given endpoint with the given concurrency for the given duration.
+// All responses are forwarded to a channel, if given.
 func generateTraffic(client *spoof.SpoofingClient, url string, concurrency int, duration time.Duration, resChannel chan *spoof.Response) (int32, error) {
 	var (
 		group    errgroup.Group
@@ -101,6 +93,47 @@ func generateTraffic(client *spoof.SpoofingClient, url string, concurrency int, 
 	return requestsMade, nil
 }
 
+// event represents the start or end of a request
+type event struct {
+	concurrencyModifier int32
+	timestamp           time.Time
+}
+
+// parseResponse parses a string of the form TimeInNano,TimeInNano into the respective
+// start and end event
+func parseResponse(body string) (*event, *event, error) {
+	body = strings.TrimSpace(body)
+	parts := strings.Split(body, ",")
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("failed to parse start duration, body %s", body))
+	}
+
+	end, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("failed to parse end duration, body %s", body))
+	}
+
+	startEvent := &event{1, time.Unix(0, int64(start))}
+	endEvent := &event{-1, time.Unix(0, int64(end))}
+
+	return startEvent, endEvent, nil
+}
+
+// timeToScale calculates the time it took to scale to a given scale, starting from a given
+// time. Returns an error if that scale was never reached.
+func timeToScale(events []*event, start time.Time, desiredScale int32) (time.Duration, error) {
+	var currentConcurrency int32
+	for _, event := range events {
+		currentConcurrency += event.concurrencyModifier
+		if currentConcurrency == desiredScale {
+			return event.timestamp.Sub(start), nil
+		}
+	}
+
+	return 0, fmt.Errorf("desired scale of %d was never reached", desiredScale)
+}
+
 func TestObservedConcurrency(t *testing.T) {
 	// add test case specific name to its own logger
 	logger := logging.GetContextLogger(tName)
@@ -120,64 +153,58 @@ func TestObservedConcurrency(t *testing.T) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, logger, names) }, logger)
 
 	logger.Info("Creating a new Service")
-	svc, err := test.CreateLatestService(logger, clients, names)
+	objs, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{ContainerConcurrency: 1})
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
 
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
-	logger.Info("The Service will be updated with the name of the Revision once it is created")
-	names.Revision, err = waitForServiceLatestCreatedRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
-	}
-
-	logger.Info("When the Service reports as Ready, everything should be ready.")
-	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
-	}
-
-	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Route %s: %v", names.Revision, err)
-	}
-
-	domain := route.Status.Domain
+	domain := objs.Route.Status.Domain
 	endpoint, err := spoof.GetServiceEndpoint(clients.KubeClient.Kube)
 	if err != nil {
 		t.Fatalf("Cannot get service endpoint: %v", err)
 	}
 
 	url := fmt.Sprintf("http://%s/?timeout=1000", *endpoint)
-	resp, err := RunLoadTest(duration, numThreads, concurrency, url, domain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("Generating traffic via fortio failed: %v", err)
+		t.Fatalf("Error creating spoofing client: %v", err)
 	}
 
-	// Wait for prometheus to scrape the data
-	prometheus.AllowPrometheusSync(logger)
+	trafficStart := time.Now()
 
-	promAPI, err := prometheus.PromAPI()
+	responseChannel := make(chan *spoof.Response, 1000)
+	logger.Infof("Running %d concurrent requests for %v", concurrency, duration)
+	requestsMade, err := generateTraffic(client, url, concurrency, duration, responseChannel)
 	if err != nil {
-		logger.Errorf("Cannot setup prometheus API")
+		t.Fatalf("Failed to generate traffic, err: %v", err)
 	}
 
-	// Add latency metrics
-	var tc []testgrid.TestCase
-	for _, p := range resp.DurationHistogram.Percentiles {
-		tc = append(tc, createTestCase(float32(p.Value), fmt.Sprintf("p%f", p.Percentile)))
-	}
-
-	// Add concurrency metrics
-	metrics := []string{"autoscaler_stable_request_concurrency", "autoscaler_panic_request_concurrency", "autoscaler_target_concurrency_per_pod"}
-	for _, metric := range metrics {
-		query := fmt.Sprintf("%s{configuration_namespace=\"%s\", configuration=\"%s\", revision=\"%s\"}", metric, test.ServingNamespace, names.Config, names.Revision)
-		val, err := prometheus.RunQuery(context.Background(), logger, promAPI, query)
+	// Collect all responses, parse their bodies and create the resulting events.
+	var events []*event
+	for i := int32(0); i < requestsMade; i++ {
+		response := <-responseChannel
+		body := string(response.Body)
+		start, end, err := parseResponse(body)
 		if err != nil {
-			logger.Infof("Error querying metric %s: %v", metric, err)
+			logger.Errorf("Failed to parse body")
 		} else {
-			tc = append(tc, createTestCase(float32(val), metric))
+			events = append(events, start, end)
+		}
+	}
+
+	// Sort all events by their timestamp
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].timestamp.Before(events[j].timestamp)
+	})
+
+	var tc []testgrid.TestCase
+	for i := int32(1); i <= concurrency; i++ {
+		toConcurrency, err := timeToScale(events, trafficStart, i)
+		if err != nil {
+			logger.Infof("Never scaled to %d\n", i)
+		} else {
+			logger.Infof("Took %v to scale to %d\n", toConcurrency, i)
+			tc = append(tc, createTestCase(float32(toConcurrency/time.Millisecond), fmt.Sprintf("to%d", i)))
 		}
 	}
 

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -1,3 +1,5 @@
+// +build performance
+
 /*
 Copyright 2018 The Knative Authors
 

--- a/test/service.go
+++ b/test/service.go
@@ -96,13 +96,13 @@ func getResourceObjects(clients *Clients, names ResourceNames) (*ResourceObjects
 // CreateRunLatestServiceReady creates a new RunLatest Service in state 'Ready'. This function expects Service and Image name passed in through 'names'.
 // Names is updated with the Route and Configuration created by the Service and ResourceObjects is returned with the Service, Route, and Configuration objects.
 // Returns error if the service does not come up correctly.
-func CreateRunLatestServiceReady(logger *logging.BaseLogger, clients *Clients, names *ResourceNames) (*ResourceObjects, error) {
+func CreateRunLatestServiceReady(logger *logging.BaseLogger, clients *Clients, names *ResourceNames, options *Options) (*ResourceObjects, error) {
 	if names.Service == "" || names.Image == "" {
 		return nil, fmt.Errorf("expected non-empty Service and Image name; got Service=%v, Image=%v", names.Service, names.Image)
 	}
 
 	logger.Info("Creating a new Service as RunLatest.")
-	svc, err := CreateLatestService(logger, clients, *names)
+	svc, err := CreateLatestService(logger, clients, *names, options)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +127,8 @@ func CreateRunLatestServiceReady(logger *logging.BaseLogger, clients *Clients, n
 }
 
 // CreateLatestService creates a service in namespace with the name names.Service and names.Image
-func CreateLatestService(logger *logging.BaseLogger, clients *Clients, names ResourceNames) (*v1alpha1.Service, error) {
-	service := LatestService(ServingNamespace, names, ImagePath(names.Image))
+func CreateLatestService(logger *logging.BaseLogger, clients *Clients, names ResourceNames, options *Options) (*v1alpha1.Service, error) {
+	service := LatestService(ServingNamespace, names, ImagePath(names.Image), options)
 	LogResourceObject(logger, ResourceObjects{Service: service})
 	svc, err := clients.ServingClient.Services.Create(service)
 	return svc, err

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -38,7 +38,7 @@ func TestRunLatestServicePreUpgrade(t *testing.T) {
 	names.Image = image1
 
 	logger.Info("Creating a new Service")
-	svc, err := test.CreateLatestService(logger, clients, names)
+	svc, err := test.CreateLatestService(logger, clients, names, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The observed-concurrency test has been redone in Golang and since no longer emits the metrics that it should. See https://github.com/knative/serving/issues/1126#issuecomment-400239509 for a detailed description of how it is supposed to work.

## Proposed Changes

* Calculate concurrency metrics based on the timestamps returned by the application.
* Consolidate Configartion CRD in our tests to pass through options.
* Set container concurrency for the performance test to actually see it scale (it used to stay at a scale of 1)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
