### PR TITLE
Use knative/pkg/kmp for non-tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -396,7 +396,7 @@
   revision = "f0d7bb60956f88d4743f5fea66b5607b96d262c9"
 
 [[projects]]
-  digest = "1:74580f9e031cccd10526f3a47a24b10b61c358a690b5f1d531383c4963cf3311"
+  digest = "1:d53b75536c9a0fef9b6d8e7d152fa01841f413518db729216357b10f77b919e5"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -426,6 +426,7 @@
     "configmap",
     "controller",
     "kmeta",
+    "kmp",
     "logging",
     "logging/logkey",
     "logging/testing",
@@ -440,7 +441,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "0e41760cea1d1ce16f4cc311c2d6bd3525bb3da7"
+  revision = "3043da57e9f2d4f8afd664670357a09a80ebebdd"
 
 [[projects]]
   branch = "master"
@@ -1246,6 +1247,7 @@
     "github.com/knative/pkg/configmap",
     "github.com/knative/pkg/controller",
     "github.com/knative/pkg/kmeta",
+    "github.com/knative/pkg/kmp",
     "github.com/knative/pkg/logging",
     "github.com/knative/pkg/logging/logkey",
     "github.com/knative/pkg/logging/testing",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-12-05
-  revision = "0e41760cea1d1ce16f4cc311c2d6bd3525bb3da7"
+  # HEAD as of 2018-12-07
+  revision = "3043da57e9f2d4f8afd664670357a09a80ebebdd"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -19,8 +19,8 @@ package v1alpha1
 import (
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/kmp"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -100,7 +100,13 @@ func (current *PodAutoscaler) CheckImmutableFields(og apis.Immutable) *apis.Fiel
 		return &apis.FieldError{Message: "The provided original was not a PodAutoscaler"}
 	}
 
-	if diff := cmp.Diff(original.Spec, current.Spec); diff != "" {
+	if diff, err := kmp.SafeDiff(original.Spec, current.Spec); err != nil {
+		return &apis.FieldError{
+			Message: "Failed to diff PodAutoscaler",
+			Paths:   []string{"spec"},
+			Details: err.Error(),
+		}
+	} else if diff != "" {
 		return &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -20,16 +20,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/kmp"
+	networkingv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
-
-	"github.com/knative/pkg/apis"
-	networkingv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 )
 
 func (rt *Revision) Validate() *apis.FieldError {
@@ -204,11 +202,13 @@ func (current *Revision) CheckImmutableFields(og apis.Immutable) *apis.FieldErro
 		return &apis.FieldError{Message: "The provided original was not a Revision"}
 	}
 
-	quantityComparer := cmp.Comparer(func(x, y resource.Quantity) bool {
-		return x.Cmp(y) == 0
-	})
-
-	if diff := cmp.Diff(original.Spec, current.Spec, quantityComparer); diff != "" {
+	if diff, err := kmp.SafeDiff(original.Spec, current.Spec); err != nil {
+		return &apis.FieldError{
+			Message: "Failed to diff Revision",
+			Paths:   []string{"spec"},
+			Details: err.Error(),
+		}
+	} else if diff != "" {
 		return &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -18,10 +18,11 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/kmp"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
@@ -248,7 +249,11 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alph
 		// No differences to reconcile.
 		return config, nil
 	}
-	logger.Infof("Reconciling configuration diff (-desired, +observed): %v", cmp.Diff(desiredConfig.Spec, config.Spec))
+	diff, err := kmp.SafeDiff(desiredConfig.Spec, config.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff Configuration: %v", err)
+	}
+	logger.Infof("Reconciling configuration diff (-desired, +observed): %v", diff)
 
 	// Don't modify the informers copy.
 	existing := config.DeepCopy()
@@ -285,7 +290,11 @@ func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Servi
 		// No differences to reconcile.
 		return route, nil
 	}
-	logger.Infof("Reconciling route diff (-desired, +observed): %v", cmp.Diff(desiredRoute.Spec, route.Spec))
+	diff, err := kmp.SafeDiff(desiredRoute.Spec, route.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff Route: %v", err)
+	}
+	logger.Infof("Reconciling route diff (-desired, +observed): %v", diff)
 
 	// Don't modify the informers copy.
 	existing := route.DeepCopy()

--- a/vendor/github.com/knative/pkg/apis/field_error.go
+++ b/vendor/github.com/knative/pkg/apis/field_error.go
@@ -133,34 +133,36 @@ func (fe *FieldError) isEmpty() bool {
 	return fe.Message == "" && fe.Details == "" && len(fe.errors) == 0 && len(fe.Paths) == 0
 }
 
-func (fe *FieldError) getNormalizedErrors() []FieldError {
-	// in case we call getNormalizedErrors on a nil object, return just an empty
+// normalized returns a flattened copy of all the errors.
+func (fe *FieldError) normalized() []*FieldError {
+	// In case we call normalized on a nil object, return just an empty
 	// list. This can happen when .Error() is called on a nil object.
 	if fe == nil {
-		return []FieldError(nil)
+		return []*FieldError(nil)
 	}
-	var errors []FieldError
-	// if this FieldError is a leaf,
+
+	// Allocate errors with at least as many objects as we'll get on the first pass.
+	errors := make([]*FieldError, 0, len(fe.errors)+1)
+	// If this FieldError is a leaf,
 	if fe.Message != "" {
-		err := FieldError{
+		errors = append(errors, &FieldError{
 			Message: fe.Message,
 			Paths:   fe.Paths,
 			Details: fe.Details,
-		}
-		errors = append(errors, err)
+		})
 	}
 	// and then collect all other errors recursively.
 	for _, e := range fe.errors {
-		errors = append(errors, e.getNormalizedErrors()...)
+		errors = append(errors, e.normalized()...)
 	}
 	return errors
 }
 
 // Error implements error
 func (fe *FieldError) Error() string {
-	var errs []string
 	// Get the list of errors as a flat merged list.
-	normedErrors := merge(fe.getNormalizedErrors())
+	normedErrors := merge(fe.normalized())
+	errs := make([]string, 0, len(normedErrors))
 	for _, e := range normedErrors {
 		if e.Details == "" {
 			errs = append(errs, fmt.Sprintf("%v: %v", e.Message, strings.Join(e.Paths, ", ")))
@@ -198,7 +200,7 @@ func flatten(path []string) string {
 			if p == CurrentField {
 				continue
 			} else if len(newPath) > 0 && isIndex(p) {
-				newPath[len(newPath)-1] = fmt.Sprintf("%s%s", newPath[len(newPath)-1], p)
+				newPath[len(newPath)-1] += p
 			} else {
 				newPath = append(newPath, p)
 			}
@@ -235,19 +237,18 @@ func containsString(slice []string, s string) bool {
 // FiledErrors. FieldErrors have their Paths combined (and de-duped) if their
 // Message and Details are the same. Merge will not inspect FieldError.errors.
 // Merge will also sort the .Path slice, and the errors slice before returning.
-func merge(errs []FieldError) []FieldError {
+func merge(errs []*FieldError) []*FieldError {
 	// make a map big enough for all the errors.
-	m := make(map[string]FieldError, len(errs))
+	m := make(map[string]*FieldError, len(errs))
 
 	// Convert errs to a map where the key is <message>-<details> and the value
 	// is the error. If an error already exists in the map with the same key,
 	// then the paths will be merged.
 	for _, e := range errs {
-		k := key(&e)
+		k := key(e)
 		if v, ok := m[k]; ok {
 			// Found a match, merge the keys.
 			v.Paths = mergePaths(v.Paths, e.Paths)
-			m[k] = v
 		} else {
 			// Does not exist in the map, save the error.
 			m[k] = e
@@ -255,7 +256,7 @@ func merge(errs []FieldError) []FieldError {
 	}
 
 	// Take the map made previously and flatten it back out again.
-	newErrs := make([]FieldError, 0, len(m))
+	newErrs := make([]*FieldError, 0, len(m))
 	for _, v := range m {
 		// While we have access to the merged paths, sort them too.
 		sort.Slice(v.Paths, func(i, j int) bool { return v.Paths[i] < v.Paths[j] })
@@ -336,7 +337,7 @@ func ErrInvalidKeyName(value, fieldPath string, details ...string) *FieldError {
 	}
 }
 
-// ErrOutOFBoundsValue constructs a FieldError for a field that has received an
+// ErrOutOfBoundsValue constructs a FieldError for a field that has received an
 // out of bound value.
 func ErrOutOfBoundsValue(value, lower, upper, fieldPath string) *FieldError {
 	return &FieldError{

--- a/vendor/github.com/knative/pkg/kmp/diff.go
+++ b/vendor/github.com/knative/pkg/kmp/diff.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmp
+
+import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Commonly used Comparers and other Options go here.
+var defaultOpts []cmp.Option
+
+func init() {
+	defaultOpts = []cmp.Option{
+		cmp.Comparer(func(x, y resource.Quantity) bool {
+			return x.Cmp(y) == 0
+		}),
+	}
+}
+
+// SafeDiff wraps cmp.Diff but recovers from panics and uses custom Comparers for:
+// * k8s.io/apimachinery/pkg/api/resource.Quantity
+func SafeDiff(x, y interface{}, opts ...cmp.Option) (diff string, err error) {
+	// cmp.Diff will panic if we miss something; return error instead of crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered in kmp.SafeDiff: %v", r)
+		}
+	}()
+
+	opts = append(opts, defaultOpts...)
+	diff = cmp.Diff(x, y, opts...)
+
+	return
+}

--- a/vendor/github.com/knative/pkg/kmp/doc.go
+++ b/vendor/github.com/knative/pkg/kmp/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kmp wraps github.com/google/go-cmp with custom Comparers for
+// frequently used kubernetes resources that have unexported fields.
+package kmp


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2622

## Proposed Changes

* Migrate non-test usage of `cmp` to `kmp` to avoid panicking.
