### PR TITLE
Re-enable the TestScaleTo50 test.

### DIFF
--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -146,7 +146,6 @@ func TestScaleTo10(t *testing.T) {
 }
 
 func TestScaleTo50(t *testing.T) {
-	t.Skip("Disabled until #2637 is fixed")
 	//add test case specific name to its own logger
 	logger := logging.GetContextLogger("TestScaleTo50")
 


### PR DESCRIPTION
Now that we use HA clusters, I'm going to try re-enabling this and `/test` it a bunch.

Fixes: #2637

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
