### PR TITLE
Dump webhook logs on test failures

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -46,6 +46,7 @@ function dump_extra_cluster_state() {
   kubectl get revisions -o yaml --all-namespaces
 
   dump_app_logs controller
+  dump_app_logs webhook
   dump_app_logs autoscaler
   dump_app_logs activator
 }


### PR DESCRIPTION
This is needed to better triage https://github.com/knative/serving/issues/2459 from the logs of flakes.

We already log the patch when we think things differ here: https://github.com/knative/pkg/blob/585076ba67e86ccbe9c2c146d49502d7433da7c0/webhook/webhook.go#L642

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

