### PR TITLE
Rework the Route sync handler test to avoid flakes.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/route/queueing_test.go
@@ -59,11 +59,6 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 		}},
 	)
 
-	// TODO(grantr): inserting the route at client creation is necessary
-	// because ObjectTracker doesn't fire watches in the 1.9 client. When we
-	// upgrade to 1.10 we can remove the config argument here and instead use the
-	// Create() method.
-
 	// Create fake clients
 	kubeClient := fakekubeclientset.NewSimpleClientset()
 	configMapWatcher := configmap.NewStaticWatcher(&corev1.ConfigMap{
@@ -83,7 +78,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 		Data: map[string]string{},
 	})
 	sharedClient := fakesharedclientset.NewSimpleClientset()
-	servingClient := fakeclientset.NewSimpleClientset(rev, route)
+	servingClient := fakeclientset.NewSimpleClientset()
 
 	// Create informer factories with fake clients. The second parameter sets the
 	// resync period to zero, disabling it.
@@ -132,6 +127,14 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	eg.Go(func() error {
 		return controller.Run(2, stopCh)
 	})
+
+	if _, err := servingClient.ServingV1alpha1().Revisions(rev.Namespace).Create(rev); err != nil {
+		t.Errorf("Unexpected error creating revision: %v", err)
+	}
+
+	if _, err := servingClient.ServingV1alpha1().Routes(route.Namespace).Create(route); err != nil {
+		t.Errorf("Unexpected error creating route: %v", err)
+	}
 
 	if err := h.WaitForHooks(time.Second * 3); err != nil {
 		t.Error(err)


### PR DESCRIPTION
This reworks the Route's sync handler test to try and avoid a flake we see intermittently in Prow.

Related: https://github.com/knative/serving/issues/2462

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->