### PR TITLE
Use a single replica for both gateways

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -95,6 +95,9 @@ function install_knative_serving() {
   # TODO(tcnghia): remove this when https://github.com/istio/istio/issues/882 is fixed.
   echo ">> Patching Istio"
   kubectl patch hpa -n istio-system istio-ingressgateway --patch '{"spec": {"maxReplicas": 1}}' || return 1
+  if kubectl get svc -n istio-system knative-ingressgateway > /dev/null 2>&1 ; then
+    kubectl patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}' || return 1
+  fi
 
   # There are reports of Envoy failing (503) when istio-pilot is overloaded.
   # We generously add more pilot instances here to verify if we can reduce flakes.


### PR DESCRIPTION
Fixes: https://github.com/knative/serving/issues/2681

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @tcnghia 