### PR TITLE
This addresses a subtle race in TestBuildAndServe.

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -205,6 +205,7 @@ func TestBuildAndServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get latest Revision: %v", err)
 	}
+	names.Revision = rev.Name
 	buildName := rev.Spec.BuildRef.Name
 	logger.Infof("Latest ready Revision is %q", rev.Name)
 	logger.Infof("Revision's Build is %q", buildName)


### PR DESCRIPTION
Initialize `names.Revision` to the first revision we create, so that the following calls to `getNextRevisionName` properly walk to the second and third revisions vs. occasionally just the first and second, which leads to the failure mode of the linked issue.

Fixes: https://github.com/knative/serving/issues/2459

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->