### PR TITLE
Validate revision image name

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/kmp"
 	networkingv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -148,6 +150,14 @@ func validateContainer(container corev1.Container) *apis.FieldError {
 	}
 	if err := validateProbe(container.LivenessProbe).ViaField("livenessProbe"); err != nil {
 		errs = errs.Also(err)
+	}
+	if _, err := name.ParseReference(container.Image, name.WeakValidation); err != nil {
+		fe := &apis.FieldError{
+			Message: "Failed to parse image reference",
+			Paths:   []string{"image"},
+			Details: fmt.Sprintf("image: %q, error: %v", container.Image, err),
+		}
+		errs = errs.Also(fe)
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -24,14 +24,13 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/knative/pkg/apis"
 )
 
 func TestContainerValidation(t *testing.T) {
@@ -50,14 +49,26 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "invalid container image",
+		c: corev1.Container{
+			Image: "foo:bar:baz",
+		},
+		want: &apis.FieldError{
+			Message: "Failed to parse image reference",
+			Paths:   []string{"image"},
+			Details: "image: \"foo:bar:baz\", error: could not parse reference",
+		},
+	}, {
 		name: "has a name",
 		c: corev1.Container{
-			Name: "foo",
+			Name:  "foo",
+			Image: "foo",
 		},
 		want: apis.ErrDisallowedFields("name"),
 	}, {
 		name: "has resources",
 		c: corev1.Container{
+			Image: "foo",
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceName("cpu"): resource.MustParse("25m"),
@@ -68,6 +79,7 @@ func TestContainerValidation(t *testing.T) {
 	}, {
 		name: "has ports",
 		c: corev1.Container{
+			Image: "foo",
 			Ports: []corev1.ContainerPort{{
 				Name:          "http",
 				ContainerPort: 8080,
@@ -77,6 +89,7 @@ func TestContainerValidation(t *testing.T) {
 	}, {
 		name: "has volumeMounts",
 		c: corev1.Container{
+			Image: "foo",
 			VolumeMounts: []corev1.VolumeMount{{
 				MountPath: "mount/path",
 				Name:      "name",
@@ -86,6 +99,7 @@ func TestContainerValidation(t *testing.T) {
 	}, {
 		name: "has lifecycle",
 		c: corev1.Container{
+			Image:     "foo",
 			Lifecycle: &corev1.Lifecycle{},
 		},
 		want: apis.ErrDisallowedFields("lifecycle"),
@@ -148,7 +162,13 @@ func TestContainerValidation(t *testing.T) {
 			}},
 			Lifecycle: &corev1.Lifecycle{},
 		},
-		want: apis.ErrDisallowedFields("name", "ports", "volumeMounts", "lifecycle"),
+		want: apis.ErrDisallowedFields("name", "ports", "volumeMounts", "lifecycle").Also(
+			&apis.FieldError{
+				Message: "Failed to parse image reference",
+				Paths:   []string{"image"},
+				Details: "image: \"\", error: could not parse reference",
+			},
+		),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #2670

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Tested this, fails synchronously on `kubectl apply -f service.yaml` with:

```
Error from server (InternalError): error when creating "service.yaml": Internal error occurred: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: Failed to parse image reference: spec.runLatest.configuration.revisionTemplate.spec.container.image
image: "gcr.io/jonjohnson-test/helloworld-fortran:foo:bar", error: could not parse reference

```
