### PR TITLE
Apply timeout in the queue proxy on 'time to first byte'.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -318,7 +318,7 @@ func main() {
 
 	server = h2c.NewServer(
 		fmt.Sprintf(":%d", queue.RequestQueuePort),
-		http.TimeoutHandler(http.HandlerFunc(handler), time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
+		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler), time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
 
 	go server.ListenAndServe()
 	go setupAdminHandlers(adminServer)

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -70,6 +70,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// The recovery value of a panic is written to this channel to be
 	// propagated (panicked with) again.
 	panicChan := make(chan interface{}, 1)
+	defer close(panicChan)
 
 	tw := &timeoutWriter{w: w}
 	go func() {
@@ -89,6 +90,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case p := <-panicChan:
+			close(done)
 			panic(p)
 		case <-done:
 			return

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -26,8 +26,8 @@ import (
 
 var defaultTimeoutBody = "<html><head><title>Timeout</title></head><body><h1>Timeout</h1></body></html>"
 
-// TimeToFirstByteTimeoutHandler returns a Handler that runs h with the given time limit
-// in which the first byte of the response must be written.
+// TimeToFirstByteTimeoutHandler returns a Handler that runs h with the
+// given time limit in which the first byte of the response must be written.
 //
 // The new Handler calls h.ServeHTTP to handle each request, but if a
 // call runs for longer than its time limit, the handler responds with
@@ -35,6 +35,10 @@ var defaultTimeoutBody = "<html><head><title>Timeout</title></head><body><h1>Tim
 // (If msg is empty, a suitable default message will be sent.)
 // After such a timeout, writes by h to its ResponseWriter will return
 // ErrHandlerTimeout.
+//
+// A panic from the underlying handler is propagated as-is to be able to
+// make use of custom panic behavior by HTTP handlers. See
+// https://golang.org/pkg/net/http/#Handler.
 //
 // The implementation is largely inspired by http.TimeoutHandler.
 func TimeToFirstByteTimeoutHandler(h http.Handler, dt time.Duration, msg string) http.Handler {

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var defaultTimeoutBody = "<html><head><title>Timeout</title></head><body><h1>Timeout</h1></body></html>"
+
+// TimeToFirstByteTimeoutHandler returns a Handler that runs h with the given time limit
+// in which the first byte of the response must be written.
+//
+// The new Handler calls h.ServeHTTP to handle each request, but if a
+// call runs for longer than its time limit, the handler responds with
+// a 503 Service Unavailable error and the given message in its body.
+// (If msg is empty, a suitable default message will be sent.)
+// After such a timeout, writes by h to its ResponseWriter will return
+// ErrHandlerTimeout.
+//
+// The implementation is largely inspired by http.TimeoutHandler.
+func TimeToFirstByteTimeoutHandler(h http.Handler, dt time.Duration, msg string) http.Handler {
+	return &timeoutHandler{
+		handler: h,
+		body:    msg,
+		dt:      dt,
+	}
+}
+
+type timeoutHandler struct {
+	handler http.Handler
+	body    string
+	dt      time.Duration
+}
+
+func (h *timeoutHandler) errorBody() string {
+	if h.body != "" {
+		return h.body
+	}
+	return defaultTimeoutBody
+}
+
+func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, cancelCtx := context.WithCancel(r.Context())
+	defer cancelCtx()
+
+	done := make(chan struct{})
+	tw := &timeoutWriter{w: w}
+	panicChan := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				panicChan <- p
+			}
+		}()
+		h.handler.ServeHTTP(tw, r.WithContext(ctx))
+		close(done)
+	}()
+
+	timeout := time.After(h.dt)
+	for {
+		select {
+		case p := <-panicChan:
+			panic(p)
+		case <-done:
+			return
+		case <-timeout:
+			func() {
+				tw.mu.Lock()
+				defer tw.mu.Unlock()
+
+				// Cancel the handler only if the writer has not yet
+				// been written to.
+				if !tw.wroteOnce {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					io.WriteString(w, h.errorBody())
+					tw.timedOut = true
+					cancelCtx()
+					return
+				}
+			}()
+		}
+	}
+}
+
+type timeoutWriter struct {
+	w http.ResponseWriter
+
+	mu        sync.Mutex
+	timedOut  bool
+	wroteOnce bool
+}
+
+func (tw *timeoutWriter) Header() http.Header { return tw.w.Header() }
+
+func (tw *timeoutWriter) Write(p []byte) (int, error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.timedOut {
+		return 0, http.ErrHandlerTimeout
+	}
+
+	tw.wroteOnce = true
+	return tw.w.Write(p)
+}
+
+func (tw *timeoutWriter) WriteHeader(code int) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.timedOut {
+		return
+	}
+
+	tw.wroteOnce = true
+	tw.w.WriteHeader(code)
+}

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -72,6 +72,9 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 		h.handler.ServeHTTP(tw, r.WithContext(ctx))
+
+		// Closing the channel is not deferred to give the panic recovery
+		// precedence and not successfully complete the request by accident.
 		close(done)
 	}()
 

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -67,8 +67,11 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancelCtx()
 
 	done := make(chan struct{})
-	tw := &timeoutWriter{w: w}
+	// The recovery value of a panic is written to this channel to be
+	// propageted (panicked with) again.
 	panicChan := make(chan interface{}, 1)
+
+	tw := &timeoutWriter{w: w}
 	go func() {
 		defer func() {
 			if p := recover(); p != nil {

--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -1,0 +1,98 @@
+package queue
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		timeout        time.Duration
+		handler        func(writeErrors chan error) http.Handler
+		timeoutMessage string
+		wantStatus     int
+		wantBody       string
+		wantWriteError bool
+	}{{
+		name:    "all good",
+		timeout: 10 * time.Second,
+		handler: func(writeErrors chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("hi"))
+			})
+		},
+		wantStatus: http.StatusOK,
+		wantBody:   "hi",
+	}, {
+		name:    "timeout",
+		timeout: 50 * time.Millisecond,
+		handler: func(writeErrors chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(100 * time.Millisecond)
+				_, werr := w.Write([]byte("hi"))
+				writeErrors <- werr
+			})
+		},
+		wantStatus:     http.StatusServiceUnavailable,
+		wantBody:       defaultTimeoutBody,
+		wantWriteError: true,
+	}, {
+		name:    "write then sleep",
+		timeout: 10 * time.Millisecond,
+		handler: func(writeErrors chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				time.Sleep(50 * time.Millisecond)
+				w.Write([]byte("hi"))
+			})
+		},
+		wantStatus: http.StatusOK,
+		wantBody:   "hi",
+	}, {
+		name:    "custom timeout message",
+		timeout: 50 * time.Millisecond,
+		handler: func(writeErrors chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(100 * time.Millisecond)
+				_, werr := w.Write([]byte("hi"))
+				writeErrors <- werr
+			})
+		},
+		timeoutMessage: "request timeout",
+		wantStatus:     http.StatusServiceUnavailable,
+		wantBody:       "request timeout",
+		wantWriteError: true,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			writeErrors := make(chan error, 1)
+			rr := httptest.NewRecorder()
+			handler := TimeToFirstByteTimeoutHandler(test.handler(writeErrors), test.timeout, test.timeoutMessage)
+
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != test.wantStatus {
+				t.Errorf("Handler returned wrong status code: got %v want %v", status, test.wantStatus)
+			}
+
+			if rr.Body.String() != test.wantBody {
+				t.Errorf("Handler returned unexpected body: got %q want %q", rr.Body.String(), test.wantBody)
+			}
+
+			if test.wantWriteError {
+				err := <-writeErrors
+				if err != http.ErrHandlerTimeout {
+					t.Errorf("Expected a timeout error, got %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package queue
 
 import (

--- a/test/test_images/timeout/timeout.go
+++ b/test/test_images/timeout/timeout.go
@@ -34,6 +34,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 
+	// Explicitly flush the already written data to trigger (or not)
+	// the time-to-first-byte timeout.
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
 	// Sleep for a set amount of time before sending response
 	timeout, _ := strconv.Atoi(r.URL.Query().Get("timeout"))
 	time.Sleep(time.Duration(timeout) * time.Millisecond)

--- a/test/test_images/timeout/timeout.go
+++ b/test/test_images/timeout/timeout.go
@@ -26,8 +26,18 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
+	// Sleep for a set amount of time before sending headers
+	if initialTimeout := r.URL.Query().Get("initialTimeout"); initialTimeout != "" {
+		parsed, _ := strconv.Atoi(initialTimeout)
+		time.Sleep(time.Duration(parsed) * time.Millisecond)
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	// Sleep for a set amount of time before sending response
 	timeout, _ := strconv.Atoi(r.URL.Query().Get("timeout"))
 	time.Sleep(time.Duration(timeout) * time.Millisecond)
+
 	fmt.Fprintf(w, "Slept for %d milliseconds", timeout)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2582

## Proposed Changes

* Implemented a custom timeout handler (based on http.TimeoutHandler), that applies a timeout, if no bytes have been written to the connection for `timeout` time.

@tanzeeb this includes setting the StatusCode at the moment, but we can strip that out to only include `Write` calls, if that makes more sense?

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The revision's timeout is now interpreted as 'time to first byte', to support streaming cases.
```
