### PR TITLE
Test not scaling to zero with low traffic

### DIFF
--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -30,6 +30,11 @@ import (
 	fakeK8s "k8s.io/client-go/kubernetes/fake"
 )
 
+const (
+	stableWindow = 60 * time.Second
+	panicWindow  = 6 * time.Second
+)
+
 var (
 	kubeClient   = fakeK8s.NewSimpleClientset()
 	kubeInformer = kubeinformers.NewSharedInformerFactory(kubeClient, 0)
@@ -58,7 +63,7 @@ func TestAutoscaler_NoDataAtZero_NoAutoscale(t *testing.T) {
 		linearSeries{
 			startConcurrency: 0,
 			endConcurrency:   0,
-			durationSeconds:  300, // 5 minutes
+			duration:         stableWindow,
 			podCount:         1,
 		})
 
@@ -75,7 +80,7 @@ func TestAutoscaler_StableMode_NoChange(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 10, true)
@@ -89,7 +94,7 @@ func TestAutoscaler_StableMode_SlowIncrease(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   20,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 15, true)
@@ -103,7 +108,7 @@ func TestAutoscaler_StableMode_SlowDecrease(t *testing.T) {
 		linearSeries{
 			startConcurrency: 20,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 15, true)
@@ -117,7 +122,7 @@ func TestAutoscaler_StableModeLowPodCount_NoChange(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         1,
 		})
 	a.expectScale(t, now, 1, true)
@@ -131,18 +136,18 @@ func TestAutoscaler_StableModeNoTraffic_ScaleToZero(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   1,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         1,
 		})
-
 	a.expectScale(t, now, 1, true)
+
 	now = a.recordLinearSeries(
 		t,
 		now,
 		linearSeries{
 			startConcurrency: 0,
 			endConcurrency:   0,
-			durationSeconds:  300, // 5 minutes
+			duration:         stableWindow,
 			podCount:         1,
 		})
 	a.expectScale(t, now, 0, true)
@@ -150,6 +155,32 @@ func TestAutoscaler_StableModeNoTraffic_ScaleToZero(t *testing.T) {
 	// Should not scale to zero again if there is no more traffic.
 	// Note: scale of 1 will be ignored since the autoscaler is not responsible for scaling from 0.
 	a.expectScale(t, now, 0, true)
+}
+
+func TestAutoscaler_StableModeLowTraffic_NoChange(t *testing.T) {
+	a := newTestAutoscaler(10.0)
+
+	now := a.recordLinearSeries(
+		t,
+		time.Now(),
+		linearSeries{
+			startConcurrency: 1,
+			endConcurrency:   1,
+			duration:         time.Second,
+			podCount:         1,
+		})
+	a.expectScale(t, now, 1, true)
+
+	now = a.recordLinearSeries(
+		t,
+		now,
+		linearSeries{
+			startConcurrency: 0,
+			endConcurrency:   0,
+			duration:         stableWindow - time.Second,
+			podCount:         1,
+		})
+	a.expectScale(t, now, 1, true)
 }
 
 func TestAutoscaler_PanicMode_DoublePodCount(t *testing.T) {
@@ -160,7 +191,7 @@ func TestAutoscaler_PanicMode_DoublePodCount(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         10,
 		})
 	now = a.recordLinearSeries(
@@ -169,7 +200,7 @@ func TestAutoscaler_PanicMode_DoublePodCount(t *testing.T) {
 		linearSeries{
 			startConcurrency: 20,
 			endConcurrency:   20,
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 20, true)
@@ -186,7 +217,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   10,
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         1,
 		})
 	a.expectScale(t, now, 6, true)
@@ -196,7 +227,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   10,
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         6,
 		})
 	a.expectScale(t, now, 36, true)
@@ -206,7 +237,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   10,
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         36,
 		})
 	a.expectScale(t, now, 216, true)
@@ -216,7 +247,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   10,
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         216,
 		})
 	a.expectScale(t, now, 1296, true)
@@ -226,7 +257,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   1, // achieved desired concurrency
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         1296,
 		})
 	a.expectScale(t, now, 1296, true)
@@ -240,7 +271,7 @@ func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 10, true)
@@ -250,7 +281,7 @@ func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
 		linearSeries{
 			startConcurrency: 100,
 			endConcurrency:   100,
-			durationSeconds:  6,
+			duration:         panicWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 100, true)
@@ -260,7 +291,7 @@ func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1, // traffic drops off
 			endConcurrency:   1,
-			durationSeconds:  30,
+			duration:         30 * time.Second,
 			podCount:         100,
 		})
 	a.expectScale(t, now, 100, true) // still in panic mode--no decrease
@@ -270,7 +301,7 @@ func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   1,
-			durationSeconds:  31,
+			duration:         31 * time.Second,
 			podCount:         100,
 		})
 	a.expectScale(t, now, 10, true) // back to stable mode
@@ -284,7 +315,7 @@ func TestAutoscaler_NoScaleOnLessThanOnePod(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  10, // 10 seconds of 2 pods
+			duration:         10 * time.Second, // 10 seconds of 2 pods
 			podCount:         2,
 		})
 	now = now.Add(50 * time.Second)
@@ -299,7 +330,7 @@ func TestAutoscaler_PodsAreWeightedBasedOnLatestStatTime(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  30,
+			duration:         30 * time.Second,
 			podCount:         10,
 		})
 	now = now.Add(30 * time.Second)
@@ -349,7 +380,7 @@ func TestAutoscaler_Activator_IsIgnored(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  30,
+			duration:         30 * time.Second,
 			podCount:         10,
 		})
 
@@ -382,7 +413,7 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         1,
 		})
 	a.expectScale(t, now, 1, true)
@@ -414,13 +445,14 @@ func TestAutoscaler_Stats_DenyNoTime(t *testing.T) {
 
 func TestAutoscaler_RateLimit_ScaleUp(t *testing.T) {
 	a := newTestAutoscaler(10.0)
+
 	now := a.recordLinearSeries(
 		t,
 		time.Now(),
 		linearSeries{
 			startConcurrency: 1000,
 			endConcurrency:   1000,
-			durationSeconds:  1,
+			duration:         time.Second,
 			podCount:         1,
 		})
 
@@ -433,7 +465,7 @@ func TestAutoscaler_RateLimit_ScaleUp(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1000,
 			endConcurrency:   1000,
-			durationSeconds:  1,
+			duration:         time.Second,
 			podCount:         10,
 		})
 
@@ -449,7 +481,7 @@ func TestAutoscaler_UseOnePodAsMinimunIfEndpointsNotFound(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1000,
 			endConcurrency:   1000,
-			durationSeconds:  1,
+			duration:         time.Second,
 			podCount:         2,
 		})
 	ep := makeEndpoints()
@@ -465,7 +497,7 @@ func TestAutoscaler_UseOnePodAsMinimunIfEndpointsNotFound(t *testing.T) {
 		linearSeries{
 			startConcurrency: 1000,
 			endConcurrency:   1000,
-			durationSeconds:  1,
+			duration:         time.Second,
 			podCount:         2,
 		})
 	kubeClient.CoreV1().Endpoints(testNamespace).Delete(ep.Name, nil)
@@ -483,7 +515,7 @@ func TestAutoscaler_UpdateTarget(t *testing.T) {
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
-			durationSeconds:  60,
+			duration:         stableWindow,
 			podCount:         10,
 		})
 	a.expectScale(t, now, 10, true)
@@ -496,7 +528,7 @@ func TestAutoscaler_UpdateTarget(t *testing.T) {
 type linearSeries struct {
 	startConcurrency int
 	endConcurrency   int
-	durationSeconds  int
+	duration         time.Duration
 	podCount         int
 	podIdOffset      int
 }
@@ -544,8 +576,6 @@ func (r *mockReporter) ReportPanic(v int64) error {
 }
 
 func newTestAutoscaler(containerConcurrency int) *Autoscaler {
-	stableWindow := 60 * time.Second
-	panicWindow := 6 * time.Second
 	scaleToZeroGracePeriod := 30 * time.Second
 	config := &Config{
 		ContainerConcurrencyTargetPercentage: 1.0, // targeting 100% makes the test easier to read
@@ -569,8 +599,8 @@ func newTestAutoscaler(containerConcurrency int) *Autoscaler {
 // linear series, on the line from start to end concurrency.
 func (a *Autoscaler) recordLinearSeries(test *testing.T, now time.Time, s linearSeries) time.Time {
 	points := make([]int32, 0)
-	for i := 1; i <= s.durationSeconds; i++ {
-		points = append(points, int32(float64(s.startConcurrency)+float64(s.endConcurrency-s.startConcurrency)*(float64(i)/float64(s.durationSeconds))))
+	for i := 1; i <= int(s.duration.Seconds()); i++ {
+		points = append(points, int32(float64(s.startConcurrency)+float64(s.endConcurrency-s.startConcurrency)*(float64(i)/s.duration.Seconds())))
 	}
 	test.Logf("Recording points: %v.", points)
 	for _, point := range points {


### PR DESCRIPTION
* use named constants in the tests instead of magic numbers
* reflect recent changes when scaling to zero is based solely on metrics
from stableWindow (last 60 seconds)

