### PR TITLE
Apply scale bounds before deciding to scale to 0 or not.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler.go
@@ -128,6 +128,22 @@ func (ks *kpaScaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, de
 	}
 	currentScale := scl.Spec.Replicas
 
+	// Scale from zero. When there are no metrics scale to 1.
+	if currentScale == 0 && desiredScale == ScaleUnknown {
+		logger.Debugf("Scaling up from 0 to 1")
+		desiredScale = 1
+	}
+
+	if desiredScale < 0 {
+		logger.Debug("Metrics are not yet being collected.")
+		return desiredScale, nil
+	}
+
+	if newScale := applyBounds(pa.ScaleBounds())(desiredScale); newScale != desiredScale {
+		logger.Debugf("Adjusting desiredScale: %v -> %v", desiredScale, newScale)
+		desiredScale = newScale
+	}
+
 	if desiredScale == 0 {
 		// We should only scale to zero when both of the following conditions are true:
 		//   a) The PA has been active for atleast the stable window, after which it gets marked inactive
@@ -154,22 +170,6 @@ func (ks *kpaScaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, de
 				return desiredScale, nil
 			}
 		}
-	}
-
-	// Scale from zero. When there are no metrics scale to 1.
-	if currentScale == 0 && desiredScale == ScaleUnknown {
-		logger.Debugf("Scaling up from 0 to 1")
-		desiredScale = 1
-	}
-
-	if desiredScale < 0 {
-		logger.Debug("Metrics are not yet being collected.")
-		return desiredScale, nil
-	}
-
-	if newScale := applyBounds(pa.ScaleBounds())(desiredScale); newScale != desiredScale {
-		logger.Debugf("Adjusting desiredScale: %v -> %v", desiredScale, newScale)
-		desiredScale = newScale
 	}
 
 	if desiredScale == currentScale {

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler.go
@@ -157,7 +157,7 @@ func (ks *kpaScaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, de
 	}
 
 	// Scale from zero. When there are no metrics scale to 1.
-	if currentScale == 0 && desiredScale == -1 {
+	if currentScale == 0 && desiredScale == ScaleUnknown {
 		logger.Debugf("Scaling up from 0 to 1")
 		desiredScale = 1
 	}

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler.go
@@ -128,17 +128,6 @@ func (ks *kpaScaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, de
 	}
 	currentScale := scl.Spec.Replicas
 
-	// Scale from zero. When there are no metrics scale to 1.
-	if currentScale == 0 && desiredScale == ScaleUnknown {
-		logger.Debugf("Scaling up from 0 to 1")
-		desiredScale = 1
-	}
-
-	if desiredScale < 0 {
-		logger.Debug("Metrics are not yet being collected.")
-		return desiredScale, nil
-	}
-
 	if newScale := applyBounds(pa.ScaleBounds())(desiredScale); newScale != desiredScale {
 		logger.Debugf("Adjusting desiredScale: %v -> %v", desiredScale, newScale)
 		desiredScale = newScale
@@ -170,6 +159,17 @@ func (ks *kpaScaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, de
 				return desiredScale, nil
 			}
 		}
+	}
+
+	// Scale from zero. When there are no metrics scale to 1.
+	if currentScale == 0 && desiredScale == ScaleUnknown {
+		logger.Debugf("Scaling up from 0 to 1")
+		desiredScale = 1
+	}
+
+	if desiredScale < 0 {
+		logger.Debug("Metrics are not yet being collected.")
+		return desiredScale, nil
 	}
 
 	if desiredScale == currentScale {

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
@@ -90,6 +90,15 @@ func TestKPAScaler(t *testing.T) {
 			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 	}, {
+		label:         "does not scale while activating",
+		startReplicas: 1,
+		scaleTo:       0,
+		wantReplicas:  1,
+		wantScaling:   false,
+		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+			k.Status.MarkActivating("", "")
+		},
+	}, {
 		label:         "scale down to minScale after grace period",
 		startReplicas: 10,
 		scaleTo:       0,

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
@@ -60,7 +60,7 @@ func TestKPAScaler(t *testing.T) {
 		wantReplicas:  1,
 		wantScaling:   false,
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkActive(k, time.Now().Add(-idlePeriod).Add(1*time.Second))
+			kpaMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
 		},
 	}, {
 		label:         "waits to scale to zero after idle period",
@@ -69,7 +69,7 @@ func TestKPAScaler(t *testing.T) {
 		wantReplicas:  1,
 		wantScaling:   false,
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkActive(k, time.Now().Add(-idlePeriod))
+			kpaMarkActive(k, time.Now().Add(-stableWindow))
 		},
 	}, {
 		label:         "waits to scale to zero (just before grace period)",
@@ -97,7 +97,7 @@ func TestKPAScaler(t *testing.T) {
 		wantReplicas:  2,
 		wantScaling:   true,
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkActive(k, time.Now().Add(-idlePeriod))
+			kpaMarkActive(k, time.Now().Add(-stableWindow))
 		},
 	}, {
 		label:         "scales up",

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -44,12 +44,12 @@ import (
 
 var (
 	gracePeriod   = 60 * time.Second
-	idlePeriod    = 9 * time.Minute
+	stableWindow  = 5 * time.Minute
 	configMapData = map[string]string{
 		"max-scale-up-rate":                       "1.0",
 		"container-concurrency-target-percentage": "0.5",
 		"container-concurrency-target-default":    "10.0",
-		"stable-window":                           "5m",
+		"stable-window":                           stableWindow.String(),
 		"panic-window":                            "10s",
 		"scale-to-zero-grace-period":              gracePeriod.String(),
 		"tick-interval":                           "2s",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2695

Huge thanks to @spcxta for finding this and tracking it down.

## Proposed Changes

* Apply scale bounds before the "scale-to-zero" checks are done, to prevent us from entering that logic and thus falsely being marked as "Inactive".
* Update the tests to actually enter all Condition states (we need to use `MarkActive` et. al. to exhibit all states.
* Enhance test-coverage to also cover the "Activating" case.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a performance bug where a request could take very long, even though `minScale` was applied and pods are deployed already.
```
