### PR TITLE
fix for lost first event when scaling up from zero

### DIFF
--- a/pkg/activator/util/transports_test.go
+++ b/pkg/activator/util/transports_test.go
@@ -85,6 +85,8 @@ func TestRetryRoundTripper(t *testing.T) {
 	conditions := []RetryCond{
 		RetryStatus(http.StatusInternalServerError),
 		RetryStatus(http.StatusBadRequest),
+		RetryStatus(http.StatusBadGateway),
+		RetryStatus(http.StatusGatewayTimeout),
 	}
 
 	examples := []struct {
@@ -130,6 +132,22 @@ func TestRetryRoundTripper(t *testing.T) {
 		{
 			label:          "retry on condition 2",
 			resp:           resp(http.StatusBadRequest),
+			err:            nil,
+			cond:           conditions,
+			wantAttempts:   2,
+			wantBodyClosed: true,
+		},
+		{
+			label:          "retry on condition 3",
+			resp:           resp(http.StatusGatewayTimeout),
+			err:            nil,
+			cond:           conditions,
+			wantAttempts:   2,
+			wantBodyClosed: true,
+		},
+		{
+			label:          "retry on condition 4",
+			resp:           resp(http.StatusBadGateway),
 			err:            nil,
 			cond:           conditions,
 			wantAttempts:   2,


### PR DESCRIPTION
When scaling up from zero, some applications need additional time to be ready to serve up requests which results in the app/proxy returning a 502.
see: https://github.com/knative/eventing/issues/671#issuecomment-446711743
and: https://github.com/projectriff/riff/issues/1004


<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes # eventing/671

## Proposed Changes

* In addition 503's, wait for 502's and 504's since some applications (like java) may not be ready to serve requests

**Release Note**
NONE

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
