### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/google/go-cmp/cmp"

--- a/pkg/reconciler/testing/hooks_test.go
+++ b/pkg/reconciler/testing/hooks_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
@@ -31,7 +31,7 @@ import (
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/reconciler/v1alpha1/revision/resolve_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/clients.go
+++ b/test/clients.go
@@ -23,7 +23,7 @@ import (
 	"github.com/knative/serving/pkg/client/clientset/versioned"
 	servingtyped "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	testbuildtyped "github.com/knative/serving/test/client/clientset/versioned/typed/testing/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUpdateConfigurationMetadata(t *testing.T) {

--- a/test/conformance/envvars_test.go
+++ b/test/conformance/envvars_test.go
@@ -41,10 +41,10 @@ func TestShouldEnvVars(t *testing.T) {
 		t.Fatalf("Failed to unmarshall response : %v", err)
 	}
 
-	expectedValues := ShouldEnvvars {
-		Service: names.Service,
-		Configuration : names.Config,
-		Revision : names.Revision,
+	expectedValues := ShouldEnvvars{
+		Service:       names.Service,
+		Configuration: names.Config,
+		Revision:      names.Revision,
 	}
 	if respValues != expectedValues {
 		t.Fatalf("Received response failed to match execpted response. Received: %v Expected: %v", respValues, expectedValues)
@@ -65,7 +65,7 @@ func TestMustEnvVars(t *testing.T) {
 		t.Fatalf("Failed to unmarshall response : %v", err)
 	}
 
-	expectedValues := MustEnvvars {
+	expectedValues := MustEnvvars{
 		// The port value needs to match the port exposed by the test-image.
 		// We currently control them by using a common constant, but any change needs synchronization between this check
 		// and the value used by the test-image.

--- a/test/conformance/runtime_conformance_helper.go
+++ b/test/conformance/runtime_conformance_helper.go
@@ -36,7 +36,7 @@ import (
 )
 
 //fetchEnvInfo creates the service using test_images/environment and fetches environment info defined inside the container dictated by urlPath.
-func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, names* test.ResourceNames) ([]byte, error) {
+func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, names *test.ResourceNames) ([]byte, error) {
 	clients := setup(t)
 
 	logger.Info("Creating a new Service")
@@ -87,7 +87,7 @@ func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, name
 		logger,
 		url,
 		pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
-			if resp.StatusCode ==  http.StatusOK {
+			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}
 

--- a/test/conformance/runtime_contact_types.go
+++ b/test/conformance/runtime_contact_types.go
@@ -22,9 +22,9 @@ package conformance
 
 //ShouldEnvvars defines the environment variables that "SHOULD" be set.
 type ShouldEnvvars struct {
-	Service string `json:"K_SERVICE"`
+	Service       string `json:"K_SERVICE"`
 	Configuration string `json:"K_CONFIGURATION"`
-	Revision string `json:"K_REVISION"`
+	Revision      string `json:"K_REVISION"`
 }
 
 //MustEnvvars defines environment variables that "MUST" be set.

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -29,8 +29,8 @@ import (
 	"strings"
 
 	pkgTest "github.com/knative/pkg/test"
-	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
 	"golang.org/x/sync/errgroup"
 

--- a/test/test_images/environment/environment.go
+++ b/test/test_images/environment/environment.go
@@ -45,8 +45,7 @@ func envvarsHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 	log.Print("Environment test app started.")
-	test.ListenAndServeGracefullyWithPattern(fmt.Sprintf(":%d", test.EnvImageServerPort), map[string]func(w http.ResponseWriter, r *http.Request) {
-		test.EnvImageEnvVarsPath : envvarsHandler,
+	test.ListenAndServeGracefullyWithPattern(fmt.Sprintf(":%d", test.EnvImageServerPort), map[string]func(w http.ResponseWriter, r *http.Request){
+		test.EnvImageEnvVarsPath: envvarsHandler,
 	})
 }
-

--- a/test/util.go
+++ b/test/util.go
@@ -46,7 +46,7 @@ func ImagePath(name string) string {
 // by passing handler to handle requests for "/"
 func ListenAndServeGracefully(addr string, handler func(w http.ResponseWriter, r *http.Request)) {
 	ListenAndServeGracefullyWithPattern(addr, map[string]func(w http.ResponseWriter, r *http.Request){
-		"/" : handler,
+		"/": handler,
 	})
 }
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
