### PR TITLE
Update runtime contract to reflect current behavior

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -366,9 +366,13 @@ such variables will follow demonstrated usage and utility.
 
 ### User
 
-If the developer provides a user to run the process as, the process SHOULD run as this user.
+Developers MAY specify that containers should be run as a specific user or group ID using the `runAsUser` container property.
+If specified, the runtime MUST run the container as the specified user ID if allowed by the platform (see below).
+If no `runAsUser` is specified, a platform-specific default SHALL be used.
+Platform Providers SHOULD document this default behavior.
 
-If the developer does not provide a user to run the process as, the process SHOULD run as `root`.
+Operators and Platform Providers MAY prohibit certain user IDs, such as `root`, from executing code.
+In this case, if the identity selected by the developer is invalid, the container execution MUST be failed.
 
 ### Default Filesystems
 

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -366,8 +366,9 @@ such variables will follow demonstrated usage and utility.
 
 ### User
 
-The user which the process is run as SHOULD be specified by the operator or
-platform provider, rather than the developer.
+If the developer provides a user to run the process as, the process SHOULD run as this user.
+
+If the developer does not provide a user to run the process as, the process SHOULD run as `root`.
 
 ### Default Filesystems
 


### PR DESCRIPTION
Today, Knative runs as `root` if I do not specify a user in my Dockerfile.
And Knative respects the user if I specify it in my Dockerfile.

Note that this does not mean that this is the right thing to do, I think we should investigate deeper if running as `root` is really what we want.