### PR TITLE
Make test README compatible with a Dockerhub based setup.

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -152,8 +152,9 @@ function uninstall_knative_serving() {
 # Publish all e2e test images in ${REPO_ROOT_DIR}/test/test_images/
 function publish_test_images() {
   echo ">> Publishing test images"
+  # TODO(markusthoemmes): Call upload-test-images.sh?
   local image_dirs="$(find ${REPO_ROOT_DIR}/test/test_images -mindepth 1 -maxdepth 1 -type d)"
   for image_dir in ${image_dirs}; do
-    ko publish -P "github.com/knative/serving/test/test_images/$(basename ${image_dir})" || return 1
+    ko publish -B "github.com/knative/serving/test/test_images/$(basename ${image_dir})" || return 1
   done
 }

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -152,7 +152,6 @@ function uninstall_knative_serving() {
 # Publish all e2e test images in ${REPO_ROOT_DIR}/test/test_images/
 function publish_test_images() {
   echo ">> Publishing test images"
-  kubectl create namespace serving-tests
   local image_dirs="$(find ${REPO_ROOT_DIR}/test/test_images -mindepth 1 -maxdepth 1 -type d)"
   for image_dir in ${image_dirs}; do
     ko publish -P "github.com/knative/serving/test/test_images/$(basename ${image_dir})" || return 1

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -153,9 +153,6 @@ function uninstall_knative_serving() {
 function publish_test_images() {
   echo ">> Publishing test images"
   kubectl create namespace serving-tests
-  # TODO(markusthoemmes): Call upload-test-images.sh?
-  local image_dirs="$(find ${REPO_ROOT_DIR}/test/test_images -mindepth 1 -maxdepth 1 -type d)"
-  for image_dir in ${image_dirs}; do
-    ko publish -B "github.com/knative/serving/test/test_images/$(basename ${image_dir})" || return 1
-  done
+
+  source $(dirname $0)/upload-test-images.sh
 }

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -153,6 +153,5 @@ function uninstall_knative_serving() {
 function publish_test_images() {
   echo ">> Publishing test images"
   kubectl create namespace serving-tests
-
   ${REPO_ROOT_DIR}/test/upload-test-images.sh
 }

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -154,5 +154,5 @@ function publish_test_images() {
   echo ">> Publishing test images"
   kubectl create namespace serving-tests
 
-  source $(dirname $0)/upload-test-images.sh
+  ${REPO_ROOT_DIR}/test/upload-test-images.sh
 }

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -152,6 +152,7 @@ function uninstall_knative_serving() {
 # Publish all e2e test images in ${REPO_ROOT_DIR}/test/test_images/
 function publish_test_images() {
   echo ">> Publishing test images"
+  kubectl create namespace serving-tests
   # TODO(markusthoemmes): Call upload-test-images.sh?
   local image_dirs="$(find ${REPO_ROOT_DIR}/test/test_images -mindepth 1 -maxdepth 1 -type d)"
   for image_dir in ${image_dirs}; do

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -70,7 +70,6 @@ install_knative_serving || fail_test "Knative Serving installation failed"
 publish_test_images || fail_test "one or more test images weren't published"
 
 # Run the tests
-
 header "Running tests"
 
 failed=0

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -22,7 +22,6 @@ package test
 import (
 	"flag"
 	"os"
-	"path"
 
 	"github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
@@ -49,9 +48,8 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
 		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
 
-	defaultRepo := path.Join(os.Getenv("DOCKER_REPO_OVERRIDE"), "github.com/knative/serving/test/test_images")
-	flag.StringVar(&f.DockerRepo, "dockerrepo", defaultRepo,
-		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $DOCKER_REPO_OVERRIDE")
+	flag.StringVar(&f.DockerRepo, "dockerrepo", os.Getenv("DOCKER_REPO_OVERRIDE"),
+		"Provide the uri of the docker repo you have uploaded the test image to using `upload-test-images.sh`. Defaults to $DOCKER_REPO_OVERRIDE")
 
 	flag.StringVar(&f.Tag, "tag", "latest",
 		"Provide the version tag for the test images.")

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -24,7 +24,7 @@ DOCKER_TAG=$1
 
 for image_dir in ${IMAGE_DIRS}; do
   IMAGE="github.com/knative/serving/test/test_images/$(basename ${image_dir})"
-  ko publish -P $IMAGE
+  ko publish -B $IMAGE
   if [ -n "$DOCKER_TAG" ]; then
     IMAGE=$KO_DOCKER_REPO/$IMAGE
     DIGEST=$(docker images | grep $IMAGE | head -1 | awk '{print $2}')


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2715

## Proposed Changes

* Push test-images using just their basepath (that is: The folder they're located in, for example `timeout`). That makes the upload script compatible with Dockerhub.
* Actually default `--dockerrepo` to `DOCKER_REPO_OVERRIDE` as the readmes say.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
