### PR TITLE
Provide more context if an image cannot be pulled.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -367,6 +367,12 @@ func (rs *RevisionStatus) SetConditions(conditions duckv1alpha1.Conditions) {
 	rs.Conditions = conditions
 }
 
+// RevisionContainerMissingMessage constructs the status message if a given image
+// cannot be pulled correctly.
+func RevisionContainerMissingMessage(image string, message string) string {
+	return fmt.Sprintf("Unable to fetch image %q: %s", image, message)
+}
+
 const (
 	AnnotationParseErrorTypeMissing = "Missing"
 	AnnotationParseErrorTypeInvalid = "Invalid"

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -18,6 +18,7 @@ package revision
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -330,7 +331,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 	}
 	digest, err := c.resolver.Resolve(rev.Spec.Container.Image, opt, cfgs.Controller.RegistriesSkippingTagResolving)
 	if err != nil {
-		rev.Status.MarkContainerMissing(err.Error())
+		rev.Status.MarkContainerMissing(fmt.Sprintf("Unable to resolve image: %q: %s", rev.Spec.Container.Image, err.Error()))
 		return err
 	}
 

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -18,7 +18,6 @@ package revision
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -331,7 +330,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 	}
 	digest, err := c.resolver.Resolve(rev.Spec.Container.Image, opt, cfgs.Controller.RegistriesSkippingTagResolving)
 	if err != nil {
-		rev.Status.MarkContainerMissing(fmt.Sprintf("Unable to resolve image: %q: %s", rev.Spec.Container.Image, err.Error()))
+		rev.Status.MarkContainerMissing(v1alpha1.RevisionContainerMissingMessage(rev.Spec.Container.Image, err.Error()))
 		return err
 	}
 

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -384,7 +384,7 @@ func TestResolutionFailed(t *testing.T) {
 			Type:               ct,
 			Status:             corev1.ConditionFalse,
 			Reason:             "ContainerMissing",
-			Message:            errorMessage,
+			Message:            v1alpha1.RevisionContainerMissingMessage(rev.Spec.Container.Image, errorMessage),
 			LastTransitionTime: got.LastTransitionTime,
 			Severity:           "Error",
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Give an image resolution error a bit more context.

I personally stumbled over the `ContainerMissing` error messages a few times, since they generally provided no context on which operation caused to throw a "401: authentication required".

This also more closely conforms to https://github.com/knative/serving/blob/master/docs/spec/errors.md#container-image-not-present-in-repository

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
