### PR TITLE
Add a perf latency test to get latency metrics

### DIFF
--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -27,22 +27,9 @@ import (
 
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	"github.com/knative/test-infra/shared/testgrid"
 )
-
-func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	var revisionName string
-	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
-		if s.Status.LatestCreatedRevisionName != names.Revision {
-			revisionName = s.Status.LatestCreatedRevisionName
-			return true, nil
-		}
-		return false, nil
-	}, "ServiceUpdatedWithRevision")
-	return revisionName, err
-}
 
 func TestPerformanceLatency(t *testing.T) {
 	logger := logging.GetContextLogger("TestPerformanceLatency")

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -1,0 +1,111 @@
+// +build performance
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// latency_test.go brings up a helloworld app and gets the latency metric
+
+package performance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/spoof"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
+	"github.com/knative/serving/test"
+	"github.com/knative/test-infra/shared/testgrid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func waitForServiceLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	var revisionName string
+	err := test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+		if s.Status.LatestCreatedRevisionName != names.Revision {
+			revisionName = s.Status.LatestCreatedRevisionName
+			return true, nil
+		}
+		return false, nil
+	}, "ServiceUpdatedWithRevision")
+	return revisionName, err
+}
+
+func TestPerformanceLatency(t *testing.T) {
+	logger := logging.GetContextLogger("TestPerformanceLatency")
+
+	perfClients, err := Setup(context.Background(), logger, true)
+	if err != nil {
+		t.Fatalf("Cannot initialize performance client: %v", err)
+	}
+
+	names := test.ResourceNames{
+		Service: test.AppendRandomString("helloworld", logger),
+		Image:   "helloworld",
+	}
+	clients := perfClients.E2EClients
+
+	defer TearDown(perfClients, logger, names)
+	test.CleanupOnInterrupt(func() { TearDown(perfClients, logger, names) }, logger)
+
+	logger.Info("Creating a new Service")
+	svc, err := test.CreateLatestService(logger, clients, names, &test.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+
+	names.Route = serviceresourcenames.Route(svc)
+	names.Config = serviceresourcenames.Configuration(svc)
+	logger.Info("The Service will be updated with the name of the Revision once it is created")
+	names.Revision, err = waitForServiceLatestCreatedRevision(clients, names)
+	if err != nil {
+		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+	}
+
+	logger.Info("When the Service reports as Ready, everything should be ready.")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+	}
+
+	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error fetching Route %s: %v", names.Revision, err)
+	}
+
+	domain := route.Status.Domain
+	endpoint, err := spoof.GetServiceEndpoint(clients.KubeClient.Kube)
+	if err != nil {
+		t.Fatalf("Cannot get service endpoint: %v", err)
+	}
+
+	url := fmt.Sprintf("http://%s", *endpoint)
+	resp, err := RunLoadTest(duration, numThreads, concurrency, url, domain)
+	if err != nil {
+		t.Fatalf("Generating traffic via fortio failed: %v", err)
+	}
+
+	// Add latency metrics
+	var tc []testgrid.TestCase
+	for _, p := range resp.DurationHistogram.Percentiles {
+		tc = append(tc, CreatePerfTestCase(float32(p.Value), fmt.Sprintf("p%d", int(p.Percentile)), "TestPerformanceLatency"))
+	}
+
+	if err = testgrid.CreateTestgridXML(tc); err != nil {
+		t.Fatalf("Cannot create output xml: %v", err)
+	}
+}

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -40,21 +40,8 @@ import (
 )
 
 const (
-	tName       = "TestObservedConcurrency"
-	perfLatency = "perf_scaleup_latency"
-	concurrency = 5
-	duration    = 1 * time.Minute
-	numThreads  = 1
+	tName = "TestObservedConcurrency"
 )
-
-func createTestCase(val float32, name string) testgrid.TestCase {
-	tp := []testgrid.TestProperty{{Name: perfLatency, Value: val}}
-	tc := testgrid.TestCase{
-		ClassName:  tName,
-		Name:       fmt.Sprintf("%s/%s", tName, name),
-		Properties: testgrid.TestProperties{Property: tp}}
-	return tc
-}
 
 // generateTraffic loads the given endpoint with the given concurrency for the given duration.
 // All responses are forwarded to a channel, if given.
@@ -206,7 +193,7 @@ func TestObservedConcurrency(t *testing.T) {
 			logger.Infof("Never scaled to %d\n", i)
 		} else {
 			logger.Infof("Took %v to scale to %d\n", toConcurrency, i)
-			tc = append(tc, createTestCase(float32(toConcurrency/time.Millisecond), fmt.Sprintf("to%d", i)))
+			tc = append(tc, CreatePerfTestCase(float32(toConcurrency/time.Millisecond), fmt.Sprintf("to%d", i), tName))
 		}
 	}
 

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -40,7 +40,8 @@ import (
 )
 
 const (
-	tName = "TestObservedConcurrency"
+	tName       = "TestObservedConcurrency"
+	concurrency = 5
 )
 
 // generateTraffic loads the given endpoint with the given concurrency for the given duration.
@@ -162,6 +163,7 @@ func TestObservedConcurrency(t *testing.T) {
 	trafficStart := time.Now()
 
 	responseChannel := make(chan *spoof.Response, 1000)
+
 	logger.Infof("Running %d concurrent requests for %v", concurrency, duration)
 	requestsMade, err := generateTraffic(client, url, concurrency, duration, responseChannel)
 	if err != nil {

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -41,9 +41,7 @@ const (
 	gateway      = "istio-ingressgateway"
 	// Property name used by testgrid.
 	perfLatency = "perf_latency"
-	concurrency = 5
 	duration    = 1 * time.Minute
-	numThreads  = 1
 )
 
 type PerformanceClient struct {

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/test"
 	"github.com/knative/test-infra/shared/prometheus"
+	"github.com/knative/test-infra/shared/testgrid"
 	"istio.io/fortio/fhttp"
 	"istio.io/fortio/periodic"
 
@@ -38,6 +39,11 @@ const (
 	istioNS      = "istio-system"
 	monitoringNS = "knative-monitoring"
 	gateway      = "istio-ingressgateway"
+	// Property name used by testgrid.
+	perfLatency = "perf_latency"
+	concurrency = 5
+	duration    = 1 * time.Minute
+	numThreads  = 1
 )
 
 type PerformanceClient struct {
@@ -89,4 +95,14 @@ func RunLoadTest(duration time.Duration, nThreads, nConnections int, url, domain
 	}
 
 	return fhttp.RunHTTPTest(&opts)
+}
+
+// CreatePerfTestCase creates a perf test case with the provided name and value
+func CreatePerfTestCase(tcVal float32, tcName, tName string) testgrid.TestCase {
+	tp := []testgrid.TestProperty{{Name: perfLatency, Value: tcVal}}
+	tc := testgrid.TestCase{
+		ClassName:  tName,
+		Name:       fmt.Sprintf("%s/%s", tName, tcName),
+		Properties: testgrid.TestProperties{Property: tp}}
+	return tc
 }


### PR DESCRIPTION
The observed concurrency test has been modified to check the time to scale to the reuiqred concurrency. Creating a new test to get request latency metrics instead.

Also, move some common pieces to performance.go