### PR TITLE
Change TimeoutSeconds to an integer.

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -18,10 +18,8 @@ package v1alpha1
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConfigurationDefaulting(t *testing.T) {
@@ -36,9 +34,7 @@ func TestConfigurationDefaulting(t *testing.T) {
 			Spec: ConfigurationSpec{
 				RevisionTemplate: RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						TimeoutSeconds: &metav1.Duration{
-							Duration: 60 * time.Second,
-						},
+						TimeoutSeconds: defaultTimeout,
 					},
 				},
 			},
@@ -50,9 +46,7 @@ func TestConfigurationDefaulting(t *testing.T) {
 				RevisionTemplate: RevisionTemplateSpec{
 					Spec: RevisionSpec{
 						ContainerConcurrency: 1,
-						TimeoutSeconds: &metav1.Duration{
-							Duration: 99 * time.Second,
-						},
+						TimeoutSeconds:       99,
 					},
 				},
 			},
@@ -62,9 +56,7 @@ func TestConfigurationDefaulting(t *testing.T) {
 				RevisionTemplate: RevisionTemplateSpec{
 					Spec: RevisionSpec{
 						ContainerConcurrency: 1,
-						TimeoutSeconds: &metav1.Duration{
-							Duration: 99 * time.Second,
-						},
+						TimeoutSeconds:       99,
 					},
 				},
 			},

--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -34,7 +34,7 @@ func TestConfigurationDefaulting(t *testing.T) {
 			Spec: ConfigurationSpec{
 				RevisionTemplate: RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						TimeoutSeconds: defaultTimeout,
+						TimeoutSeconds: defaultTimeoutSeconds,
 					},
 				},
 			},

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -16,15 +16,9 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"time"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
 const (
 	// defaultTimeout will be set if timeoutSeconds not specified.
-	defaultTimeout = 60 * time.Second
+	defaultTimeout = 60
 )
 
 func (r *Revision) SetDefaults() {
@@ -38,7 +32,7 @@ func (rs *RevisionSpec) SetDefaults() {
 		rs.ContainerConcurrency = 1
 	}
 
-	if rs.TimeoutSeconds == nil {
-		rs.TimeoutSeconds = &metav1.Duration{Duration: defaultTimeout}
+	if rs.TimeoutSeconds == 0 {
+		rs.TimeoutSeconds = defaultTimeout
 	}
 }

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha1
 
 const (
-	// defaultTimeout will be set if timeoutSeconds not specified.
-	defaultTimeout = 60
+	// defaultTimeoutSeconds will be set if timeoutSeconds not specified.
+	defaultTimeoutSeconds = 60
 )
 
 func (r *Revision) SetDefaults() {
@@ -33,6 +33,6 @@ func (rs *RevisionSpec) SetDefaults() {
 	}
 
 	if rs.TimeoutSeconds == 0 {
-		rs.TimeoutSeconds = defaultTimeout
+		rs.TimeoutSeconds = defaultTimeoutSeconds
 	}
 }

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -33,7 +33,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		want: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds:       defaultTimeout,
+				TimeoutSeconds:       defaultTimeoutSeconds,
 			},
 		},
 	}, {
@@ -58,7 +58,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		want: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds:       defaultTimeout,
+				TimeoutSeconds:       defaultTimeoutSeconds,
 			},
 		},
 	}, {
@@ -73,7 +73,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			Spec: RevisionSpec{
 				ConcurrencyModel:     "Single",
 				ContainerConcurrency: 1,
-				TimeoutSeconds:       defaultTimeout,
+				TimeoutSeconds:       defaultTimeoutSeconds,
 			},
 		},
 	}}

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -18,10 +18,8 @@ package v1alpha1
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRevisionDefaulting(t *testing.T) {
@@ -35,9 +33,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		want: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 60 * time.Second,
-				},
+				TimeoutSeconds:       defaultTimeout,
 			},
 		},
 	}, {
@@ -45,17 +41,13 @@ func TestRevisionDefaulting(t *testing.T) {
 		in: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 99 * time.Second,
-				},
+				TimeoutSeconds:       99,
 			},
 		},
 		want: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 99 * time.Second,
-				},
+				TimeoutSeconds:       99,
 			},
 		},
 	}, {
@@ -66,9 +58,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		want: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 60 * time.Second,
-				},
+				TimeoutSeconds:       defaultTimeout,
 			},
 		},
 	}, {
@@ -83,9 +73,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			Spec: RevisionSpec{
 				ConcurrencyModel:     "Single",
 				ContainerConcurrency: 1,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 60 * time.Second,
-				},
+				TimeoutSeconds:       defaultTimeout,
 			},
 		},
 	}}

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -190,7 +190,7 @@ type RevisionSpec struct {
 
 	// TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
 	// +optional
-	TimeoutSeconds *metav1.Duration `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty"`
 }
 
 const (

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/knative/pkg/apis"
@@ -27,7 +26,6 @@ import (
 	networkingv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -63,11 +61,12 @@ func (rs *RevisionSpec) Validate() *apis.FieldError {
 	return errs
 }
 
-func validateTimeoutSeconds(timeoutSeconds *metav1.Duration) *apis.FieldError {
-	if timeoutSeconds != nil {
-		if timeoutSeconds.Duration > networkingv1alpha1.DefaultTimeout ||
-			timeoutSeconds.Duration < 0*time.Second {
-			return apis.ErrOutOfBoundsValue(timeoutSeconds.Duration.String(), "0s", networkingv1alpha1.DefaultTimeout.String(), "timeoutSeconds")
+func validateTimeoutSeconds(timeoutSeconds int64) *apis.FieldError {
+	if timeoutSeconds != 0 {
+		if timeoutSeconds > int64(networkingv1alpha1.DefaultTimeout.Seconds()) || timeoutSeconds < 0 {
+			return apis.ErrOutOfBoundsValue(fmt.Sprintf("%ds", timeoutSeconds), "0s",
+				fmt.Sprintf("%ds", int(networkingv1alpha1.DefaultTimeout.Seconds())),
+				"timeoutSeconds")
 		}
 	}
 	return nil

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
@@ -522,22 +521,22 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: corev1.Container{
 				Image: "helloworld",
 			},
-			TimeoutSeconds: &metav1.Duration{
-				Duration: 600 * time.Second,
-			},
+			TimeoutSeconds: 600,
 		},
-		want: apis.ErrOutOfBoundsValue("10m0s", "0s", netv1alpha1.DefaultTimeout.String(), "timeoutSeconds"),
+		want: apis.ErrOutOfBoundsValue("600s", "0s",
+			fmt.Sprintf("%ds", int(netv1alpha1.DefaultTimeout.Seconds())),
+			"timeoutSeconds"),
 	}, {
 		name: "negative timeout",
 		rs: &RevisionSpec{
 			Container: corev1.Container{
 				Image: "helloworld",
 			},
-			TimeoutSeconds: &metav1.Duration{
-				Duration: -30 * time.Second,
-			},
+			TimeoutSeconds: -30,
 		},
-		want: apis.ErrOutOfBoundsValue("-30s", "0s", netv1alpha1.DefaultTimeout.String(), "timeoutSeconds"),
+		want: apis.ErrOutOfBoundsValue("-30s", "0s",
+			fmt.Sprintf("%ds", int(netv1alpha1.DefaultTimeout.Seconds())),
+			"timeoutSeconds"),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -58,7 +58,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: defaultTimeout,
+								TimeoutSeconds: defaultTimeoutSeconds,
 							},
 						},
 					},
@@ -74,7 +74,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       defaultTimeout,
+								TimeoutSeconds:       defaultTimeoutSeconds,
 							},
 						},
 					},
@@ -88,7 +88,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       defaultTimeout,
+								TimeoutSeconds:       defaultTimeoutSeconds,
 							},
 						},
 					},
@@ -108,7 +108,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: defaultTimeout,
+								TimeoutSeconds: defaultTimeoutSeconds,
 							},
 						},
 					},
@@ -158,7 +158,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: defaultTimeout,
+								TimeoutSeconds: defaultTimeoutSeconds,
 							},
 						},
 					},

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -18,10 +18,8 @@ package v1alpha1
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestServiceDefaulting(t *testing.T) {
@@ -60,9 +58,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 60 * time.Second,
-								},
+								TimeoutSeconds: defaultTimeout,
 							},
 						},
 					},
@@ -78,9 +74,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 60 * time.Second,
-								},
+								TimeoutSeconds:       defaultTimeout,
 							},
 						},
 					},
@@ -94,9 +88,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 60 * time.Second,
-								},
+								TimeoutSeconds:       defaultTimeout,
 							},
 						},
 					},
@@ -116,9 +108,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 60 * time.Second,
-								},
+								TimeoutSeconds: defaultTimeout,
 							},
 						},
 					},
@@ -134,9 +124,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 99 * time.Second,
-								},
+								TimeoutSeconds:       99,
 							},
 						},
 					},
@@ -150,9 +138,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 99 * time.Second,
-								},
+								TimeoutSeconds:       99,
 							},
 						},
 					},
@@ -172,9 +158,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 60 * time.Second,
-								},
+								TimeoutSeconds: defaultTimeout,
 							},
 						},
 					},
@@ -190,9 +174,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 99 * time.Second,
-								},
+								TimeoutSeconds:       99,
 							},
 						},
 					},
@@ -206,9 +188,7 @@ func TestServiceDefaulting(t *testing.T) {
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds: &metav1.Duration{
-									Duration: 99 * time.Second,
-								},
+								TimeoutSeconds:       99,
 							},
 						},
 					},

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -24,7 +24,6 @@ import (
 	build_v1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	duck_v1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -306,15 +305,6 @@ func (in *RevisionSpec) DeepCopyInto(out *RevisionSpec) {
 		}
 	}
 	in.Container.DeepCopyInto(&out.Container)
-	if in.TimeoutSeconds != nil {
-		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.Duration)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -46,7 +46,7 @@ var (
 		Container: corev1.Container{
 			Image: "busybox",
 		},
-		TimeoutSeconds: &metav1.Duration{Duration: 60 * time.Second},
+		TimeoutSeconds: 60,
 	}
 )
 

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -107,9 +107,7 @@ func getTestRevision() *v1alpha1.Revision {
 				TerminationMessagePath: "/dev/null",
 			},
 			ConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
-			TimeoutSeconds: &metav1.Duration{
-				Duration: 60 * time.Second,
-			},
+			TimeoutSeconds:   60,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -131,7 +131,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	rewriteUserProbe(userContainer.ReadinessProbe, userPortInt)
 	rewriteUserProbe(userContainer.LivenessProbe, userPortInt)
 
-	revisionTimeout := int64(rev.Spec.TimeoutSeconds.Duration.Seconds())
+	revisionTimeout := rev.Spec.TimeoutSeconds
 
 	podSpec := &corev1.PodSpec{
 		Containers: []corev1.Container{

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -65,9 +65,7 @@ func TestMakePodSpec(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds:       45,
 				Container: corev1.Container{
 					Image: "busybox",
 					Ports: []corev1.ContainerPort{

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -169,9 +168,7 @@ func TestMakePodSpec(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -258,9 +255,7 @@ func TestMakePodSpec(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 			Status: v1alpha1.RevisionStatus{
 				ImageDigest: "busybox@sha256:deadbeef",
@@ -357,9 +352,7 @@ func TestMakePodSpec(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -454,9 +447,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					},
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -558,9 +549,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					},
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -661,9 +650,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					},
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -764,9 +751,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					},
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -860,9 +845,7 @@ func TestMakePodSpec(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -1007,9 +990,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					},
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -1140,9 +1121,7 @@ func TestMakeDeployment(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -1214,9 +1193,7 @@ func TestMakeDeployment(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -1281,9 +1258,7 @@ func TestMakeDeployment(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},
@@ -1354,9 +1329,7 @@ func TestMakeDeployment(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds: 45,
 			},
 		},
 		lc: &logging.Config{},

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -111,7 +111,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 			Value: strconv.Itoa(int(rev.Spec.ContainerConcurrency)),
 		}, {
 			Name:  "REVISION_TIMEOUT_SECONDS",
-			Value: strconv.Itoa(int(rev.Spec.TimeoutSeconds.Duration.Seconds())),
+			Value: strconv.Itoa(int(rev.Spec.TimeoutSeconds)),
 		}, {
 			Name: "SERVING_POD",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -54,9 +53,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds:       45,
 			},
 		},
 		lc: &logging.Config{},
@@ -121,9 +118,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds:       45,
 			},
 		},
 		lc: &logging.Config{},
@@ -198,9 +193,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds:       45,
 			},
 		},
 		lc: &logging.Config{},
@@ -265,9 +258,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds:       45,
 			},
 		},
 		lc: &logging.Config{
@@ -337,9 +328,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 10,
-				TimeoutSeconds: &metav1.Duration{
-					Duration: 45 * time.Second,
-				},
+				TimeoutSeconds:       45,
 			},
 		},
 		lc: &logging.Config{},

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -88,7 +88,7 @@ var (
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				TimeoutSeconds: &metav1.Duration{Duration: 60 * time.Second},
+				TimeoutSeconds: 60,
 			},
 		},
 	}

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package test
 
 import (
-	"time"
-
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +30,7 @@ type Options struct {
 	EnvVars              []corev1.EnvVar
 	ContainerPorts       []corev1.ContainerPort
 	ContainerConcurrency int
-	RevisionTimeout      time.Duration
+	RevisionTimeout      int64
 	ContainerResources   corev1.ResourceRequirements
 }
 

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -27,11 +27,11 @@ import (
 
 // Options are test setup parameters.
 type Options struct {
-	EnvVars              []corev1.EnvVar
-	ContainerPorts       []corev1.ContainerPort
-	ContainerConcurrency int
-	RevisionTimeout      int64
-	ContainerResources   corev1.ResourceRequirements
+	EnvVars                []corev1.EnvVar
+	ContainerPorts         []corev1.ContainerPort
+	ContainerConcurrency   int
+	RevisionTimeoutSeconds int64
+	ContainerResources     corev1.ResourceRequirements
 }
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -37,11 +37,9 @@ import (
 
 // createLatestService creates a service in namespace with the name names.Service
 // that uses the image specified by imagePath
-func createLatestService(logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, imagePath string, revisionTimeoutSeconds int) (*v1alpha1.Service, error) {
+func createLatestService(logger *logging.BaseLogger, clients *test.Clients, names test.ResourceNames, imagePath string, revisionTimeoutSeconds int64) (*v1alpha1.Service, error) {
 	service := test.LatestService(test.ServingNamespace, names, imagePath, &test.Options{})
-	service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{
-		Duration: time.Duration(revisionTimeoutSeconds) * time.Second,
-	}
+	service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.TimeoutSeconds = revisionTimeoutSeconds
 	test.LogResourceObject(logger, test.ResourceObjects{Service: service})
 	svc, err := clients.ServingClient.Services.Create(service)
 	return svc, err
@@ -51,7 +49,7 @@ func updateConfigWithTimeout(clients *test.Clients, names test.ResourceNames, re
 	patches := []jsonpatch.JsonPatchOperation{{
 		Operation: "replace",
 		Path:      "/spec/revisionTemplate/spec/timeoutSeconds",
-		Value:     (time.Duration(revisionTimeoutSeconds) * time.Second).String(),
+		Value:     revisionTimeoutSeconds,
 	}}
 	patchBytes, err := json.Marshal(patches)
 	if err != nil {

--- a/test/crd.go
+++ b/test/crd.go
@@ -108,7 +108,7 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 	}
 
 	if options.RevisionTimeout > 0 {
-		spec.RevisionTemplate.Spec.TimeoutSeconds = &metav1.Duration{Duration: options.RevisionTimeout}
+		spec.RevisionTemplate.Spec.TimeoutSeconds = options.RevisionTimeout
 	}
 
 	if options.EnvVars != nil {

--- a/test/crd.go
+++ b/test/crd.go
@@ -107,8 +107,8 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 		},
 	}
 
-	if options.RevisionTimeout > 0 {
-		spec.RevisionTemplate.Spec.TimeoutSeconds = options.RevisionTimeout
+	if options.RevisionTimeoutSeconds > 0 {
+		spec.RevisionTemplate.Spec.TimeoutSeconds = options.RevisionTimeoutSeconds
 	}
 
 	if options.EnvVars != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	timeoutExpectedOutput  = "Slept for 0 milliseconds"
-	revisionTimeout        = 45
+	revisionTimeoutSeconds = 45
 	timeoutRequestDuration = 43 * time.Second
 )
 
@@ -49,7 +49,7 @@ func TestDestroyPodInflight(t *testing.T) {
 	var imagePath = test.ImagePath("timeout")
 
 	logger.Info("Creating a new Route and Configuration")
-	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{RevisionTimeout: revisionTimeout})
+	names, err := CreateRouteAndConfig(clients, logger, imagePath, &test.Options{RevisionTimeoutSeconds: revisionTimeoutSeconds})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	timeoutExpectedOutput  = "Slept for 0 milliseconds"
-	revisionTimeout        = 45 * time.Second
+	revisionTimeout        = 45
 	timeoutRequestDuration = 43 * time.Second
 )
 


### PR DESCRIPTION
The name TimeoutSeconds implies certain units, but since it used time.Duration the units were also specified in the value.  This changes the value to an int64 to remedy this.

Fixes: https://github.com/knative/serving/issues/2728

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
