### PR TITLE
Add GetBuild function to access existing Unstructured Build object

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/resources/build.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/build.go
@@ -31,6 +31,8 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources/names"
 )
 
+// MakeBuild creates an Unstructured Build object from the passed in Configuration and fills
+// in metadata and references based on the Configuration.
 func MakeBuild(config *v1alpha1.Configuration) *unstructured.Unstructured {
 	if config.Spec.Build == nil {
 		return nil
@@ -56,6 +58,7 @@ func MakeBuild(config *v1alpha1.Configuration) *unstructured.Unstructured {
 	return u
 }
 
+// GetBuild extracts an Unstructured Build object from the passed in ConfigurationSpec.
 func GetBuild(configSpec *v1alpha1.ConfigurationSpec) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	if err := configSpec.Build.As(u); err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Add GetBuild function to access existing Unstructured Build object
* this is needed to modify labels or annotations on the Build that is part of a ConfigurationSpec

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
