### PR TITLE
Adding Default FileSystems conformance test

### DIFF
--- a/test/conformance/filesystem_perm_test.go
+++ b/test/conformance/filesystem_perm_test.go
@@ -1,0 +1,69 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/test"
+)
+
+func verifyPermString(resp string, expected string) error {
+	if len(resp) != len(expected) {
+		return fmt.Errorf("Length of expected and response string don't match. Expected Response: '%s' Received Response: '%s' Expected length: %d Received length: %d",
+			expected, resp, len(expected), len(resp))
+	}
+
+	for index := range expected {
+		if string(expected[index]) != "*" && expected[index] != resp[index]  {
+			return fmt.Errorf("Permission strings don't match at Index : %d. Expected : '%s' Received Response : '%s'",
+				index, expected, resp)
+		}
+	}
+
+	return nil
+}
+
+func TestMustFileSystemPermissions(t *testing.T) {
+	logger := logging.GetContextLogger("TestFileSystemPermissions")
+	clients := setup(t)
+	for key, value := range MustFilePathSpecs {
+		resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageFilePathInfoPath + "?" + test.EnvImageFilePathQueryParam + "=" + key, &test.Options{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var f FilePathInfo
+		err = json.Unmarshal(resp, &f)
+		if err != nil {
+			t.Fatalf("Error unmarshalling response: %v", err)
+		}
+
+		if f.IsDirectory != value.IsDirectory {
+			t.Fatalf("%s isDirectory mismatch. Expect : %t Received : %t", key, value.IsDirectory, f.IsDirectory)
+		}
+
+		if err = verifyPermString(f.PermString[1:], value.PermString); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/test/conformance/runtime_contract_types.go
+++ b/test/conformance/runtime_contract_types.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2018 The Knative Authors
 
@@ -20,14 +18,33 @@ package conformance
 
 //runtime_constract_types.go defines types that encapsulate run-time contract requirements as specified here: https://github.com/knative/serving/blob/master/docs/runtime-contract.md
 
-//ShouldEnvvars defines the environment variables that "SHOULD" be set.
+// ShouldEnvvars defines the environment variables that "SHOULD" be set.
 type ShouldEnvvars struct {
 	Service       string `json:"K_SERVICE"`
 	Configuration string `json:"K_CONFIGURATION"`
 	Revision      string `json:"K_REVISION"`
 }
 
-//MustEnvvars defines environment variables that "MUST" be set.
+// MustEnvvars defines environment variables that "MUST" be set.
 type MustEnvvars struct {
 	Port string `json:"PORT"`
+}
+
+// FilePathInfo data object returned by the environment test-image
+type FilePathInfo struct {
+	FilePath string `json: "FilePath"`
+	IsDirectory bool `json: "IsDirectory"`
+	PermString string `json: "PermString"`
+}
+
+// MustFilePathSpecs specifies the file-paths and expected permissions that MUST be set as specified in the run-time contract.
+var MustFilePathSpecs = map[string]FilePathInfo {
+	"/tmp" : FilePathInfo{
+		IsDirectory : true,
+		PermString: "rw*rw*rw*", // * indicates no specification
+	},
+	"/var/log" : FilePathInfo{
+		IsDirectory: true,
+		PermString: "rw*rw*rw*", // * indicates no specification
+	},
 }

--- a/test/image_constants.go
+++ b/test/image_constants.go
@@ -24,3 +24,10 @@ const EnvImageServerPort = 8080
 
 //EnvImageEnvVarsPath path exposed by environment test-image to fetch environment variables.
 const EnvImageEnvVarsPath = "/envvars"
+
+//EnvImageFilePathInfoPath path exposed by environment test-image to fetch information for filepaths
+const EnvImageFilePathInfoPath = "/filepath"
+
+//EnvImageFilePathQueryParam query param to be used with EnvImageFilePathInfoPath to specify filepath
+const EnvImageFilePathQueryParam = "path"
+

--- a/test/test_images/environment/README.md
+++ b/test/test_images/environment/README.md
@@ -12,6 +12,7 @@ Currently the server exposes:
 
 - /envvars : To provide a JSON payload containing all the environment variables
   set inside the container
+- /filepath?path=<path-to-file>: Provides FileInfo for the <path-to-file> query-param. The JSON payload returned as response is specified in [runtime_contract_types](../../conformance/runtime_contract_types.go)
 
 ## Building
 


### PR DESCRIPTION
This change adds a conformance test to validate Default Filesystems
requirements as specified in the Knative serving runtime-contract. The
test extends the environment test-image to expose filepath?path=<path-to-file>
API to retrieve file information for the path specified as query param.

Note: This conformance test does not test "/dev/log" requirement specified in
the runtime-contract, which will we added in the future.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->