### PR TITLE
Add pod name as tag for queue metrics

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -96,7 +96,7 @@ func initEnv() {
 	// TODO(mattmoor): Move this key to be in terms of the KPA.
 	servingRevisionKey = autoscaler.NewKpaKey(servingNamespace, servingRevision)
 	health = &healthServer{alive: true}
-	_reporter, err := queue.NewStatsReporter(servingNamespace, servingConfig, servingRevision)
+	_reporter, err := queue.NewStatsReporter(servingNamespace, servingConfig, servingRevision, podName)
 	if err != nil {
 		logger.Fatal("Failed to create stats reporter", zap.Error(err))
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #2203. Add the pod name as tag for queue metrics to identify the pod in case the metrics are scraped via a service.

Example output using curl:
```shell
# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
# TYPE queue_average_concurrent_requests gauge
queue_average_concurrent_requests{destination_configuration="helloworld-go",destination_namespace="default",destination_pod="helloworld-go-00001-deployment-69d7fd8c5d-66fvh",destination_revision="helloworld-go-00001"} 0
# HELP queue_lame_duck Indicates this Pod has received a shutdown signal with 1 else 0
# TYPE queue_lame_duck gauge
queue_lame_duck{destination_configuration="helloworld-go",destination_namespace="default",destination_pod="helloworld-go-00001-deployment-69d7fd8c5d-66fvh",destination_revision="helloworld-go-00001"} 1
# HELP queue_operations_per_second Number of requests received since last Stat
# TYPE queue_operations_per_second gauge
queue_operations_per_second{destination_configuration="helloworld-go",destination_namespace="default",destination_pod="helloworld-go-00001-deployment-69d7fd8c5d-66fvh",destination_revision="helloworld-go-00001"} 0
```