### PR TITLE
Mark ClusterIngress as cluster local based on Route.Status.Domain.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/config/domain_test.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain_test.go
@@ -166,6 +166,9 @@ func TestLookupDomainForLabels(t *testing.T) {
 	}, {
 		labels: map[string]string{},
 		domain: "default.com",
+	}, {
+		labels: map[string]string{"serving.knative.dev/visibility": "cluster-local"},
+		domain: "svc.cluster.local",
 	}}
 
 	for _, expected := range expectations {

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,15 +31,20 @@ import (
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
 	"github.com/knative/serving/pkg/system"
 )
 
+func isClusterLocal(r *servingv1alpha1.Route) bool {
+	return strings.HasSuffix(r.Status.Domain, config.ClusterLocalDomain)
+}
+
 // MakeClusterIngress creates ClusterIngress to set up routing rules. Such ClusterIngress specifies
 // which Hosts that it applies to, as well as the routing rules.
 func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.TrafficConfig) *v1alpha1.ClusterIngress {
-	return &v1alpha1.ClusterIngress{
+	ci := &v1alpha1.ClusterIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			// As ClusterIngress resource is cluster-scoped,
 			// here we use GenerateName to avoid conflict.
@@ -52,6 +58,7 @@ func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.TrafficConfig) *v1
 		},
 		Spec: makeClusterIngressSpec(r, tc.Targets),
 	}
+	return ci
 }
 
 func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string][]traffic.RevisionTarget) v1alpha1.IngressSpec {
@@ -69,10 +76,14 @@ func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string][]traff
 	for _, name := range names {
 		rules = append(rules, *makeClusterIngressRule(getRouteDomains(name, r, domain), r.Namespace, targets[name]))
 	}
-	return v1alpha1.IngressSpec{
+	spec := v1alpha1.IngressSpec{
 		Rules:      rules,
 		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
+	if isClusterLocal(r) {
+		spec.Visibility = v1alpha1.IngressVisibilityClusterLocal
+	}
+	return spec
 }
 
 func getRouteDomains(targetName string, r *servingv1alpha1.Route, domain string) []string {

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -141,6 +141,35 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 	}
 }
 
+func TestMakeClusterIngressSpec_CorrectVisibility(t *testing.T) {
+	cases := []struct {
+		name              string
+		route             v1alpha1.Route
+		expectedVisbility netv1alpha1.IngressVisibility
+	}{{
+		name: "public route",
+		route: v1alpha1.Route{
+			Status: v1alpha1.RouteStatus{Domain: "domain.com"},
+		},
+		expectedVisbility: netv1alpha1.IngressVisibilityExternalIP,
+	}, {
+		name: "private route",
+		route: v1alpha1.Route{
+			Status: v1alpha1.RouteStatus{Domain: "local-route.default.svc.cluster.local"},
+		},
+		expectedVisbility: netv1alpha1.IngressVisibilityClusterLocal,
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := makeClusterIngressSpec(&c.route, nil).Visibility
+			if diff := cmp.Diff(c.expectedVisbility, v); diff != "" {
+				t.Errorf("Unexpected visibility (-want +got): %v", diff)
+			}
+		})
+	}
+	return
+}
+
 func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -295,6 +295,11 @@ func WithAnotherDomain(r *v1alpha1.Route) {
 	r.Status.Domain = fmt.Sprintf("%s.%s.another-example.com", r.Name, r.Namespace)
 }
 
+// WithLocalDomain sets the .Status.Domain field to use `svc.cluster.local` suffix.
+func WithLocalDomain(r *v1alpha1.Route) {
+	r.Status.Domain = fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace)
+}
+
 // WithInitRouteConditions initializes the Service's conditions.
 func WithInitRouteConditions(rt *v1alpha1.Route) {
 	rt.Status.InitializeConditions()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fix of #2127 .

## Proposed Changes

* Mark ClusterIngress as cluster local based on Route.Status.Domain.
* Add label `serving.knative.dev/visibility=cluster-local` to indicate that a Route shouldn't be exposed externally.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Use cluster local ClusterIngress when Route.Status.Domain is set to `svc.cluster.local`.
* Add label `serving.knative.dev/visibility=cluster-local` to indicate that a Route shouldn't be exposed externally
```
