### PR TITLE
Fix removing selfLink issue

### DIFF
--- a/test/route.go
+++ b/test/route.go
@@ -54,7 +54,7 @@ func UpdateBlueGreenRoute(logger *logging.BaseLogger, clients *Clients, names, b
 		return nil, err
 	}
 	newRoute := BlueGreenRoute(ServingNamespace, names, blue, green)
-	newRoute.ObjectMeta.ResourceVersion = route.ObjectMeta.ResourceVersion
+	newRoute.ObjectMeta = route.ObjectMeta
 	LogResourceObject(logger, ResourceObjects{Route: newRoute})
 	patchBytes, err := createPatch(route, newRoute)
 	if err != nil {


### PR DESCRIPTION
Copy over all of bluegreen route ObjectMeta during patch.

We were missing SelfLink, which caused kube to complain that we were
trying to remove SelfLink.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
