### PR TITLE
[RELEASE 0.2] Update test-infra to include knative/test-infra#309 and knative/test-infra#277

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -399,11 +399,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5e92f642157840d27a5fbf1af571f11a8c9b592d7c2233e8ee85c6949c3b342f"
+  digest = "1:3b61cd7da52fd5011a32f833d89cdcf9aabe877952167378013d9bce700f8d55"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "9867364ce974c13d153c367d29e5342dad330e43"
+  revision = "c5490439ff6ffc1132f5aab93b3afca9b226e5a0"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/hack/release.md
+++ b/hack/release.md
@@ -3,34 +3,38 @@
 The `release.sh` script automates the creation of Knative Serving releases,
 either nightly or versioned ones.
 
-By default, the script creates a nightly release but does not publish anywhere.
+By default, the script creates a nightly release but does not publish it
+anywhere.
 
 ## Common flags for cutting releases
 
-The following flags affect the behavior of the script, no matter the type of
-the release.
+The following flags affect the behavior of the script, no matter the type of the
+release.
 
-* `--skip-tests` Do not run tests before building the release. Otherwise,
-build, unit and end-to-end tests are run and they all must pass for the
-release to be built.
-* `--tag-release`, `--notag-release` Tag (or not) the generated images
-with either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or
-`vX.Y.Z` for versioned releases. *For versioned releases, a tag is always
-added.*
-* `--publish`, `--nopublish` Whether the generated images should be published
-to a GCR, and the generated manifests written to a GCS bucket or not. If yes,
-the destination GCR is defined by the environment variable
-`$SERVING_RELEASE_GCR` (defaults to `gcr.io/knative-releases`) and the
-destination GCS bucket is defined by the environment variable
-`$SERVING_RELEASE_GCS` (defaults to `knative-releases/serving`). If no, the
-images will be pushed to the `ko.local` registry, and the manifests written
-to the local disk only (in the repository root directory).
+- `--skip-tests` Do not run tests before building the release. Otherwise, build,
+  unit and end-to-end tests are run and they all must pass for the release to be
+  built.
+- `--tag-release`, `--notag-release` Tag (or not) the generated images with
+  either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
+  versioned releases. _For versioned releases, a tag is always added._
+- `--release-gcs` Defines the GCS bucket where the manifests will be stored. By
+  default, this is `knative-nightly/serving`. This flag is ignored if the
+  release is not being published.
+- `--release-gcr` Defines the GCR where the images will be stored. By default,
+  this is `gcr.io/knative-nightly`. This flag is ignored if the release is not
+  being published.
+- `--publish`, `--nopublish` Whether the generated images should be published to
+  a GCR, and the generated manifests written to a GCS bucket or not. If yes, the
+  `--release-gcs` and `--release-gcr` flags can be used to change the default
+  values of the GCR/GCS used. If no, the images will be pushed to the `ko.local`
+  registry, and the manifests written to the local disk only (in the repository
+  root directory).
 
 ## Creating nightly releases
 
 Nightly releases are built against the current git tree. The behavior of the
-script is defined by the common flags. You must have write access to the GCR
-and GCS bucket the release will be pushed to, unless `--nopublish` is used.
+script is defined by the common flags. You must have write access to the GCR and
+GCS bucket the release will be pushed to, unless `--nopublish` is used.
 
 Examples:
 
@@ -44,29 +48,87 @@ Examples:
 
 ## Creating versioned releases
 
-*Note: only Knative admins can create versioned releases.*
-
 To specify a versioned release to be cut, you must use the `--version` flag.
 Versioned releases are usually built against a branch in the Knative Serving
-repository, specified by the `--branch` flag. 
+repository, specified by the `--branch` flag.
 
-* `--version` Defines the version of the release, and must be in the form
-`X.Y.Z`, where X, Y and Z are numbers.
-* `--branch` Defines the branch in Knative Serving repository from which the
-release will be built. If not passed, the `master` branch at HEAD will be
-used. This branch must be created before the script is executed, and must be
-in the form `release-X.Y`, where X and Y must match the numbers used in the
-version passed in the `--version` flag. This flag has no effect unless
-`--version` is also passed.
-* `--release-notes` Points to a markdown file containing a description of the
-release. This is optional but highly recommended. It has no effect unless
-`--version` is also passed.
+- `--version` Defines the version of the release, and must be in the form
+  `X.Y.Z`, where X, Y and Z are numbers.
+- `--branch` Defines the branch in Knative Serving repository from which the
+  release will be built. If not passed, the `master` branch at HEAD will be
+  used. This branch must be created before the script is executed, and must be
+  in the form `release-X.Y`, where X and Y must match the numbers used in the
+  version passed in the `--version` flag. This flag has no effect unless
+  `--version` is also passed.
+- `--release-notes` Points to a markdown file containing a description of the
+  release. This is optional but highly recommended. It has no effect unless
+  `--version` is also passed.
+- `--github-token` Points to a text file containing the GitHub token to be used
+  for authentication when publishing the release to GitHub. If this flag is not
+  used and this is the first time you're publishing a versioned release, you'll
+  be prompted for your GitHub username, password, and possibly 2-factor
+  authentication challenge (you must be a Knative admin to have the required
+  publishing permissions).
 
-If this is the first time you're cutting a versioned release, you'll be prompted
-for your GitHub username, password, and possibly 2-factor authentication
-challenge before the release is published.
-
-The release will be published in the *Releases* page of the Knative Serving
-repository, with the title *Knative Serving release vX.Y.Z* and the given
-release notes. It will also be tagged *vX.Y.Z* (both on GitHub and as a git
+The release will be published in the _Releases_ page of the Knative Serving
+repository, with the title _Knative Serving release vX.Y.Z_ and the given
+release notes. It will also be tagged _vX.Y.Z_ (both on GitHub and as a git
 annotated tag).
+
+Example:
+
+```bash
+# Create and publish a versioned release.
+./hack/release.sh --publish --tag-release \
+  --release-gcr gcr.io/knative-releases \
+  --release-gcs knative-releases/serving \
+  --version 0.3.0 \
+  --branch release-0.3 \
+  --release-notes $HOME/docs/release-notes-0.3.md
+```
+
+## Creating incremental build releases ("dot releases")
+
+An incremental build release (aka "dot release") is a versioned release built
+automatically based on changes in the latest release branch, with the build
+number increased.
+
+For example, if the latest release on release branch `release-0.2` is `v0.2.1`,
+creating an incremental build release will result in `v0.2.2`.
+
+To specify an incremental build release to be cut, you must use the
+`--dot-release` flag. The latest branch and release version will be
+automatically detected and used.
+
+_Note 1: when using the `--dot-release` flag, the flags `--nopublish` and
+`--notag-release` have no effect. The release is always tagged and published._
+
+_Note 2: if the release branch has no new commits since its last release was
+cut, the script successfully exits with a warning, and no release will be
+created._
+
+The following flags are useful when creating incremental build releases:
+
+- `--branch` Restricts the incremental build release to the given branch. If not
+  passed, the latest branch will be automatically detected and used.
+- `--release-notes` Points to a markdown file containing a description of the
+  release. If not passed, the notes will be copied from the previous release.
+- `--github-token` Points to a text file containing the GitHub token to be used
+  for authentication when publishing the release to GitHub. If this flag is not
+  used and this is the first time you're publishing a versioned release, you'll
+  be prompted for your GitHub username, password, and possibly 2-factor
+  authentication challenge (you must be a Knative admin to have the required
+  publishing permissions).
+
+Like any regular versioned release, an incremental build release is published in
+the _Releases_ page of the Knative Serving repository.
+
+Example:
+
+```bash
+# Create and publish a new dot release.
+./hack/release.sh \
+  --dot-release \
+  --release-gcr gcr.io/knative-releases \
+  --release-gcs knative-releases/serving
+```

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -163,8 +163,14 @@ also overrides the value of the `TAG` variable as `v<version>`.
 it's empty and `master` HEAD will be considered the release branch.
     * `RELEASE_NOTES`: contains the filename with the release notes if `--release-notes`
 was passed. The release notes is a simple markdown file.
+    * `RELEASE_GCS_BUCKET`: contains the GCS bucket name to store the manifests if
+`--release-gcs` was passed, otherwise the default value `knative-nightly/<repo>` will be
+used. It is empty if `--publish` was not passed.
+    * `KO_DOCKER_REPO`: contains the GCR to store the images if `--release-gcr` was
+passed, otherwise the default value `gcr.io/knative-nightly` will be used. It is set to
+`ko.local` if `--publish` was not passed.
     * `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically
-by the run_validation_tests() function.
+by the `run_validation_tests()` function.
     * `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
 variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
     * `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
@@ -186,14 +192,12 @@ initialize $@
 run_validation_tests ./test/presubmit-tests.sh
 
 # config/ contains the manifests
-KO_DOCKER_REPO=gcr.io/knative-foo
 ko resolve ${KO_FLAGS} -f config/ > release.yaml
 
-tag_images_in_yaml release.yaml $KO_DOCKER_REPO $TAG
+tag_images_in_yaml release.yaml
 
 if (( PUBLISH_RELEASE )); then
-  # gs://knative-foo hosts the manifest
-  publish_yaml release.yaml knative-foo $TAG
+  publish_yaml release.yaml
 fi
 
 branch_release "Knative Foo" release.yaml

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -48,11 +48,6 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
-function abort() {
-  echo "error: $@"
-  exit 1
-}
-
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
@@ -68,6 +63,10 @@ function main() {
     kubectl version
     echo ">> go version"
     go version
+    echo ">> git version"
+    git version
+    echo ">> bazel version"
+    bazel version 2> /dev/null
   fi
 
   [[ -z $1 ]] && set -- "--all-tests"

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -25,27 +25,32 @@ function banner() {
     make_banner "@" "$1"
 }
 
-# Tag images in the yaml file with a tag. If not tag is passed, does nothing.
+# Tag images in the yaml file if $TAG is not empty.
+# $KO_DOCKER_REPO is the registry containing the images to tag with $TAG.
 # Parameters: $1 - yaml file to parse for images.
-#             $2 - registry where the images are stored.
-#             $3 - tag to apply (optional).
 function tag_images_in_yaml() {
-  [[ -z $3 ]] && return 0
-  local src_dir="${GOPATH}/src/"
-  local BASE_PATH="${REPO_ROOT_DIR/$src_dir}"
-  echo "Tagging images under '${BASE_PATH}' with $3"
-  for image in $(grep -o "$2/${BASE_PATH}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
-    gcloud -q container images add-tag ${image} ${image%%@*}:$3
+  [[ -z ${TAG} ]] && return 0
+  local SRC_DIR="${GOPATH}/src/"
+  local DOCKER_BASE="${KO_DOCKER_REPO}/${REPO_ROOT_DIR/$SRC_DIR}"
+  echo "Tagging images under '${DOCKER_BASE}' with ${TAG}"
+  for image in $(grep -o "${DOCKER_BASE}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
+    gcloud -q container images add-tag ${image} ${image%%@*}:${TAG}
   done
 }
 
-# Copy the given yaml file to a GCS bucket. Image is tagged :latest, and optionally :$2.
+# Copy the given yaml file to the $RELEASE_GCS_BUCKET bucket's "latest" directory.
+# If $TAG is not empty, also copy it to $RELEASE_GCS_BUCKET bucket's "previous" directory.
 # Parameters: $1 - yaml file to copy.
-#             $2 - destination bucket name.
-#             $3 - tag to apply (optional).
 function publish_yaml() {
-  gsutil cp $1 gs://$2/latest/
-  [[ -n $3 ]] && gsutil cp $1 gs://$2/previous/$3/ || true
+  function verbose_gsutil_cp {
+    local DEST="gs://${RELEASE_GCS_BUCKET}/$2/"
+    echo "Publishing $1 to ${DEST}"
+    gsutil cp $1 ${DEST}
+  }
+  verbose_gsutil_cp $1 latest
+  if [[ -n ${TAG} ]]; then
+    verbose_gsutil_cp $1 previous/${TAG}
+  fi
 }
 
 # These are global environment variables.
@@ -57,11 +62,31 @@ TAG=""
 RELEASE_VERSION=""
 RELEASE_NOTES=""
 RELEASE_BRANCH=""
+RELEASE_GCS_BUCKET=""
 KO_FLAGS=""
+export KO_DOCKER_REPO=""
 
-function abort() {
-  echo "error: $@"
-  exit 1
+# Convenience function to run the hub tool.
+# Parameters: $1..$n - arguments to hub.
+function hub_tool() {
+  run_go_tool github.com/github/hub hub $@
+}
+
+# Return the master version of a release.
+# For example, "v0.2.1" returns "0.2"
+# Parameters: $1 - release version label.
+function master_version() {
+  local release="${1//v/}"
+  local tokens=(${release//\./ })
+  echo "${tokens[0]}.${tokens[1]}"
+}
+
+# Return the release build number of a release.
+# For example, "v0.2.1" returns "1".
+# Parameters: $1 - release version label.
+function release_build_number() {
+  local tokens=(${1//\./ })
+  echo "${tokens[2]}"
 }
 
 # Parses flags and sets environment variables accordingly.
@@ -71,15 +96,41 @@ function parse_flags() {
   RELEASE_NOTES=""
   RELEASE_BRANCH=""
   KO_FLAGS="-P"
+  KO_DOCKER_REPO="gcr.io/knative-nightly"
+  RELEASE_GCS_BUCKET="knative-nightly/$(basename ${REPO_ROOT_DIR})"
+  local has_gcr_flag=0
+  local has_gcs_flag=0
+  local is_dot_release=0
+
   cd ${REPO_ROOT_DIR}
   while [[ $# -ne 0 ]]; do
     local parameter=$1
-    case $parameter in
+    case ${parameter} in
       --skip-tests) SKIP_TESTS=1 ;;
       --tag-release) TAG_RELEASE=1 ;;
       --notag-release) TAG_RELEASE=0 ;;
       --publish) PUBLISH_RELEASE=1 ;;
       --nopublish) PUBLISH_RELEASE=0 ;;
+      --dot-release) is_dot_release=1 ;;
+      --github-token)
+        shift
+        [[ $# -ge 1 ]] || abort "missing token file after --github-token"
+        [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
+        export GITHUB_TOKEN="$(cat $1)"
+        [[ -n "${GITHUB_TOKEN}" ]] || abort "file $1 is empty"
+        ;;
+      --release-gcr)
+        shift
+        [[ $# -ge 1 ]] || abort "missing GCR after --release-gcr"
+        KO_DOCKER_REPO=$1
+        has_gcr_flag=1
+        ;;
+      --release-gcs)
+        shift
+        [[ $# -ge 1 ]] || abort "missing GCS bucket after --release-gcs"
+        RELEASE_GCS_BUCKET=$1
+        has_gcs_flag=1
+        ;;
       --version)
         shift
         [[ $# -ge 1 ]] || abort "missing version after --version"
@@ -103,15 +154,64 @@ function parse_flags() {
     shift
   done
 
+  # Setup dot releases
+  if (( is_dot_release )); then
+    echo "Dot release requested"
+    TAG_RELEASE=1
+    PUBLISH_RELEASE=1
+    # List latest release
+    local releases # don't combine with the line below, or $? will be 0
+    releases="$(hub_tool release)"
+    [[ $? -eq 0 ]] || abort "cannot list releases"
+    # If --release-branch passed, restrict to that release
+    if [[ -n "${RELEASE_BRANCH}" ]]; then
+      local version_filter="v${RELEASE_BRANCH##release-}"
+      echo "Dot release will be generated for ${version_filter}"
+      releases="$(echo "${releases}" | grep ^${version_filter})"
+    fi
+    local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r | head -1)"
+    [[ -n "${last_version}" ]] || abort "no previous release exist"
+    if [[ -z "${RELEASE_BRANCH}" ]]; then
+      echo "Last release is ${last_version}"
+      # Determine branch
+      local major_minor_version="$(master_version ${last_version})"
+      RELEASE_BRANCH="release-${major_minor_version}"
+      echo "Last release branch is ${RELEASE_BRANCH}"
+    fi
+    # Ensure there are new commits in the branch, otherwise we don't create a new release
+    local last_release_commit="$(git rev-list -n 1 ${last_version})"
+    local release_branch_commit="$(git rev-list -n 1 ${RELEASE_BRANCH})"
+    if [[ "${last_release_commit}" == "${release_branch_commit}" ]]; then
+      echo "*** Branch ${RELEASE_BRANCH} is at commit ${release_branch_commit}"
+      echo "*** Branch ${RELEASE_BRANCH} has no new cherry-picks since release ${last_version}"
+      echo "*** No dot release will be generated, as no changes exist"
+      exit 0
+    fi
+    # Create new release version number
+    local last_build="$(release_build_number ${last_version})"
+    RELEASE_VERSION="${major_minor_version}.$(( last_build + 1 ))"
+    echo "Will create release ${RELEASE_VERSION} at commit ${release_branch_commit}"
+    # If --release-notes not used, copy from the latest release
+    if [[ -z "${RELEASE_NOTES}" ]]; then
+      RELEASE_NOTES="$(mktemp)"
+      hub_tool release show -f "%b" ${last_version} > ${RELEASE_NOTES}
+      echo "Release notes from ${last_version} copied to ${RELEASE_NOTES}"
+    fi
+  fi
+
   # Update KO_DOCKER_REPO and KO_FLAGS if we're not publishing.
   if (( ! PUBLISH_RELEASE )); then
+    (( has_gcr_flag )) && echo "Not publishing the release, GCR flag is ignored"
+    (( has_gcs_flag )) && echo "Not publishing the release, GCS flag is ignored"
     KO_DOCKER_REPO="ko.local"
     KO_FLAGS="-L ${KO_FLAGS}"
+    RELEASE_GCS_BUCKET=""
   fi
 
   if (( TAG_RELEASE )); then
     # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --exclude '*')"
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "Error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi
@@ -130,6 +230,8 @@ function parse_flags() {
   readonly RELEASE_VERSION
   readonly RELEASE_NOTES
   readonly RELEASE_BRANCH
+  readonly RELEASE_GCS_BUCKET
+  readonly KO_DOCKER_REPO
 }
 
 # Run tests (unless --skip-tests was passed). Conveniently displays a banner indicating so.
@@ -148,6 +250,25 @@ function run_validation_tests() {
 # Initialize everything (flags, workspace, etc) for a release.
 function initialize() {
   parse_flags $@
+  # Log what will be done and where.
+  banner "Release configuration"
+  echo "- Destination GCR: ${KO_DOCKER_REPO}"
+  (( SKIP_TESTS )) && echo "- Tests will NOT be run" || echo "- Tests will be run"
+  if (( TAG_RELEASE )); then
+    echo "- Artifacts will tagged '${TAG}'"
+  else
+    echo "- Artifacts WILL NOT be tagged"
+  fi
+  if (( PUBLISH_RELEASE )); then
+    echo "- Release WILL BE published to '${RELEASE_GCS_BUCKET}'"
+  else
+    echo "- Release will not be published"
+  fi
+  if (( BRANCH_RELEASE )); then
+    echo "- Release WILL BE branched from '${RELEASE_BRANCH}'"
+  fi
+  [[ -n "${RELEASE_NOTES}" ]] && echo "- Release notes are generated from '${RELEASE_NOTES}'"
+
   # Checkout specific branch, if necessary
   if (( BRANCH_RELEASE )); then
     git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
@@ -174,7 +295,7 @@ function branch_release() {
   fi
   git tag -a ${TAG} -m "${title}"
   git push $(git remote get-url upstream) tag ${TAG}
-  run_go_tool github.com/github/hub hub release create \
+  hub_tool release create \
       --prerelease \
       ${attachments[@]} \
       --file=${description} \


### PR DESCRIPTION
These are required due to changes in the GCR ACLs and service accounts.
Because of the update, #2625 must be also cherrypicked or `release.sh` will be broken.

From knative/test-infra#309

> **When creating a test cluster on Prow, use the default service account**
> This way the Prow config file is the canonical way to specify the service account.

From knative/test-infra#277

> **Don't delete images after an E2E test finishes**
> Part of #276

From #2625

> **Update test-infra to include latest features of release.sh**
> Major changes:
> * use flags instead of environment variables for setting GCR/GCS
> * log configuration at the start of the process
> * be more verbose when tagging/publishing