### PR TITLE
Format markdown

### DIFF
--- a/pkg/activator/README.md
+++ b/pkg/activator/README.md
@@ -1,12 +1,11 @@
 # About the Activator
 
-The name *activator* is actually a misnomer, since after Knative 0.2,
-the activator no longer activates inactive Revisions.
-
+The name _activator_ is actually a misnomer, since after Knative 0.2, the
+activator no longer activates inactive Revisions.
 
 The only responsibilities of the activator are:
 
-* Receiving & buffering requests for inactive Revisions.
-* Reporting metrics to the autoscaler.
-* Retrying requests to a Revision after the autoscaler scales such Revision
+- Receiving & buffering requests for inactive Revisions.
+- Reporting metrics to the autoscaler.
+- Retrying requests to a Revision after the autoscaler scales such Revision
   based on the reported metrics.

--- a/test/test_images/printport/README.md
+++ b/test/test_images/printport/README.md
@@ -2,7 +2,8 @@
 
 This directory contains the test image used in the user-port e2e test.
 
-The image contains a simple Go webserver, `printport.go`, that will listen on the port defined by environment variable `PORT` and expose a service at `/`.
+The image contains a simple Go webserver, `printport.go`, that will listen on
+the port defined by environment variable `PORT` and expose a service at `/`.
 
 When called, the server emits the port it was called on.
 
@@ -16,6 +17,5 @@ http://$IP
 
 ## Building
 
-For details about building and adding new images, see the [section about test
-images](/test/README.md#test-images).
-
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`