### PR TITLE
Conformance test coverage for secrets and configs via env var

### DIFF
--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -23,34 +23,32 @@ package conformance
 import (
 	"fmt"
 	"net/http"
-	"testing"
 
-	pkgTest "github.com/knative/pkg/test"
+	"github.com/pkg/errors"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
+	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//fetchEnvInfo creates the service using test_images/environment and fetches environment info defined inside the container dictated by urlPath.
-func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, names *test.ResourceNames) ([]byte, error) {
-	clients := setup(t)
-
+// fetchEnvInfo creates the service using test_images/environment and fetches environment info defined inside the container dictated by urlPath.
+func fetchEnvInfo(clients *test.Clients, logger *logging.BaseLogger, urlPath string, options *test.Options) ([]byte, *test.ResourceNames, error) {
 	logger.Info("Creating a new Service")
+	var names test.ResourceNames
 	names.Service = test.AppendRandomString("yashiki", logger)
 	names.Image = "environment"
-	svc, err := test.CreateLatestService(logger, clients, *names, &test.Options{})
+	svc, err := test.CreateLatestService(logger, clients, names, options)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Failed to create Service: %v", err))
+		return nil, nil, errors.New(fmt.Sprintf("Failed to create Service: %v", err))
 	}
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, *names) }, logger)
-	defer tearDown(clients, *names)
+	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer tearDown(clients, names)
 
 	var revisionName string
 	logger.Info("The Service will be updated with the name of the Revision once it is created")
@@ -62,23 +60,23 @@ func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, name
 		return false, nil
 	}, "ServiceUpdatedWithRevision")
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Service %s was not updated with the new revision: %v", names.Service, err))
+		return nil, nil, errors.New(fmt.Sprintf("Service %s was not updated with the new revision: %v", names.Service, err))
 	}
 	names.Revision = revisionName
 
 	logger.Info("When the Service reports as Ready, everything should be ready.")
 	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
-		return nil, errors.New(fmt.Sprintf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err))
+		return nil, nil, errors.New(fmt.Sprintf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err))
 	}
 
 	logger.Infof("When the Revision can have traffic routed to it, the Route is marked as Ready.")
 	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		return nil, errors.New(fmt.Sprintf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err))
+		return nil, nil, errors.New(fmt.Sprintf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err))
 	}
 
 	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error fetching Route %s: %v", names.Route, err))
+		return nil, nil, errors.New(fmt.Sprintf("Error fetching Route %s: %v", names.Route, err))
 	}
 
 	url := route.Status.Domain + urlPath
@@ -96,8 +94,8 @@ func fetchEnvInfo(t *testing.T, logger *logging.BaseLogger, urlPath string, name
 		"EnvVarsServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Failed before reaching desired state : %v", err))
+		return nil, nil, errors.New(fmt.Sprintf("Failed before reaching desired state : %v", err))
 	}
 
-	return resp.Body, nil
+	return resp.Body, &names, nil
 }

--- a/test/conformance/envpropagation_test.go
+++ b/test/conformance/envpropagation_test.go
@@ -1,0 +1,162 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testKey = "testKey"
+	testValue = "testValue"
+	secretName = "test-secret"
+	configMapName = "test-configmap"
+)
+
+// TestSecretsFromEnv verifies propagation of Secrets through environment variables.
+func TestSecretsFromEnv(t *testing.T) {
+	logger := logging.GetContextLogger("TestEnvSecrets")
+	clients := setup(t)
+
+	//Creating test secret
+	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta {
+			Name: secretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			testKey: testValue,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Info("Successfully created test secret: %v", secret)
+
+	err = fetchEnvironmentAndVerify(clients, logger, corev1.EnvVar{
+		Name: testKey,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: testKey,
+			},
+		},
+	}, cleanupSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestConfigsFromEnv verifies propagation of configs through environment variables.
+func TestConfigsFromEnv(t *testing.T) {
+	logger := logging.GetContextLogger("TestConfigsFromEnv")
+	clients := setup(t)
+
+	//Creating test configMap
+	configMap, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configMapName,
+		},
+		Data: map[string]string{
+			testKey: testValue,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger.Info("Successfully created configMap: %v", configMap)
+
+	err = fetchEnvironmentAndVerify(clients, logger, corev1.EnvVar{
+		Name: testKey,
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector {
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+				Key: testKey,
+			},
+		},
+	}, cleanupConfigMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fetchEnvironmentAndVerify(clients *test.Clients, logger *logging.BaseLogger, envVar corev1.EnvVar, cleanup func(clients *test.Clients) (error)) error {
+	resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageEnvVarsPath, &test.Options{
+		EnvVars: []corev1.EnvVar{envVar},
+	})
+	if err != nil {
+		cleanupError := cleanup(clients)
+		logger.Error(cleanupError)
+		return err
+	}
+
+	var envVars map[string]string
+	err = json.Unmarshal(resp, &envVars)
+	if err != nil {
+		if cleanupError := cleanup(clients); cleanupError != nil {
+			logger.Error(cleanupError)
+		}
+		return err
+	}
+
+	if value, ok := envVars[testKey]; ok {
+		if value != testValue {
+			if cleanupError := cleanup(clients); cleanupError != nil {
+				logger.Error(cleanupError)
+			}
+			return fmt.Errorf("environment value doesn't match. Expected: %s, Found: %s", testValue, value)
+		}
+	} else {
+		if cleanupError := cleanup(clients); cleanupError != nil {
+			logger.Error(cleanupError)
+		}
+		return fmt.Errorf("%s not found in environment variables", testKey)
+	}
+
+	if err = cleanup(clients); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupSecret(clients *test.Clients) error {
+	if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secretName, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupConfigMap(clients *test.Clients) error {
+	if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMapName, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/conformance/envvars_test.go
+++ b/test/conformance/envvars_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/knative/serving/test"
 )
 
-//TestShouldEnvVars verifies environment variables that are declared as "SHOULD be set" in runtime-contract
+// TestShouldEnvVars verifies environment variables that are declared as "SHOULD be set" in runtime-contract
 func TestShouldEnvVars(t *testing.T) {
 	logger := logging.GetContextLogger("TestShouldEnvVars")
-	var names test.ResourceNames
-	resp, err := fetchEnvInfo(t, logger, test.EnvImageEnvVarsPath, &names)
+	clients := setup(t)
+	resp, names, err := fetchEnvInfo(clients, logger, test.EnvImageEnvVarsPath, &test.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,11 +51,11 @@ func TestShouldEnvVars(t *testing.T) {
 	}
 }
 
-//TestMustEnvVars verifies environment variables that are declared as "MUST be set" in runtime-contract
+// TestMustEnvVars verifies environment variables that are declared as "MUST be set" in runtime-contract
 func TestMustEnvVars(t *testing.T) {
 	logger := logging.GetContextLogger("TestMustEnvVars")
-	var names test.ResourceNames
-	resp, err := fetchEnvInfo(t, logger, test.EnvImageEnvVarsPath, &names)
+	clients := setup(t)
+	resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageEnvVarsPath, &test.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This changeset adds conformance test to verify propagation of secrets
and configs(via ConfigMaps) to service container as environment variables.

Test re-uses test_images/environment image to fetch environment variables from
the service. In the process runtime_conformance_helper is renamed to
conformance_helper and fetchEnvInfo() is refactored to support this
change.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #844 

