### PR TITLE
RBAC - remove items that aren't actual resources

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["serving.knative.dev"]
-    resources: ["configurations", "configurationgenerations", "routes", "revisions", "revisionuids", "autoscalers", "services"]
+    resources: ["configurations", "routes", "revisions", "services"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["autoscaling.internal.knative.dev"]
     resources: ["podautoscalers"]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The following are not resources in the api group `serving.knative.dev`

- configurationgenerations
- revisionuids
- autoscalers

**Release Note**

```release-note
NONE
```
