### PR TITLE
Initial go.mod and go 1.11 modules information

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,6 +98,12 @@ To check out this repository:
 1. Clone it to your machine:
 
 ```shell
+# If you intend to use go 1.11 modules, set GO111MODULE environment variable to on. For example,
+# export GO111MODULE=on
+# Since ko does not handle go 1.11 modules outside of GOPATH currently
+# as described in https://github.com/google/go-containerregistry/issues/298,  
+# it is preferable to use $HOME/go as GOPATH or use the approach of symbolic linking 
+# GOPATH into $HOME/go.
 mkdir -p ${GOPATH}/src/github.com/knative
 cd ${GOPATH}/src/github.com/knative
 git clone git@github.com:${YOUR_GITHUB_USERNAME}/serving.git
@@ -215,7 +221,8 @@ of:
   - Types definitions annotated with `// +k8s:deepcopy-gen=true`.
 
 - **If you change a package's deps** (including adding external dep), then you
-  must run [`./hack/update-deps.sh`](./hack/update-deps.sh).
+  must run [`./hack/update-deps.sh`](./hack/update-deps.sh). If you are using go 1.11 with modules
+  then you must run **`go mod tidy`**.
 
 These are both idempotent, and we expect that running these at `HEAD` to have no
 diffs. Code generation and dependencies are automatically checked to produce no

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,67 @@
+module github.com/knative/serving
+
+require (
+	cloud.google.com/go v0.31.0 // indirect
+	contrib.go.opencensus.io/exporter/stackdriver v0.7.0 // indirect
+	github.com/Azure/azure-sdk-for-go v11.3.0-beta+incompatible // indirect
+	github.com/Azure/go-autorest v10.8.1+incompatible // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/go-connections v0.3.0 // indirect
+	github.com/docker/go-units v0.3.3 // indirect
+	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
+	github.com/ghodss/yaml v1.0.0
+	github.com/go-ini/ini v1.36.0 // indirect
+	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
+	github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4 // indirect
+	github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a // indirect
+	github.com/google/go-cmp v0.2.0
+	github.com/google/go-containerregistry v0.0.0-20180801194910-5f7b0e489541
+	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/googleapis/gnostic v0.1.0 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
+	github.com/gorilla/websocket v1.2.0
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad // indirect
+	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3 // indirect
+	github.com/jtolds/gls v4.2.1+incompatible // indirect
+	github.com/knative/build v0.2.0
+	github.com/knative/caching v0.0.0-20180907165633-f0d7bb60956f
+	github.com/knative/pkg v0.0.0-20181214184433-b04c0947ad2f
+	github.com/knative/test-infra v0.0.0-20181219003734-37f7ad78fbe7
+	github.com/markbates/inflect v1.0.4 // indirect
+	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.8.0
+	github.com/prometheus/client_golang v0.9.0 // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
+	github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c // indirect
+	github.com/spf13/pflag v1.0.2 // indirect
+	go.opencensus.io v0.18.0
+	go.uber.org/atomic v1.3.2
+	go.uber.org/multierr v1.1.0 // indirect
+	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15
+	golang.org/x/crypto v0.0.0-20180112200814-13931e22f9e7 // indirect
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
+	golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	golang.org/x/sys v0.0.0-20181004145325-8469e314837c // indirect
+	golang.org/x/time v0.0.0-20180314180208-26559e0f760e // indirect
+	google.golang.org/api v0.0.0-20181026000445-511bab8e55de // indirect
+	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
+	google.golang.org/grpc v1.16.0 // indirect
+	gopkg.in/inf.v0 v0.9.0 // indirect
+	gopkg.in/ini.v1 v1.39.3 // indirect
+	istio.io/fortio v1.1.0
+	k8s.io/api v0.0.0-20180904230853-4e7be11eab3f
+	k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512
+	k8s.io/client-go v0.0.0-20180910083459-2cefa64ff137
+	k8s.io/kube-openapi v0.0.0-20180108222231-a07b7bbb58e7 // indirect
+	k8s.io/kubernetes v1.10.2 // indirect
+)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Initial go.mod for building with go 1.11 with GO111MODULE environment variable set to "on"
* go.mod was generated by running "go mod init" and "go mod tidy"
* The project was cloned under $HOME/go as the GOPATH since ko does not yet support go 1.11 modules outside GOPATH
* This is just the first step to get started with go 1.11 modules for knative serving.  

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
