### PR TITLE
Don't use spec.generation when garbage collecting revisions

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -53,9 +53,9 @@ const (
 	// which Service they are created.
 	ServiceLabelKey = GroupName + "/service"
 
-	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
+	// DeprecatedConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
 	// generation of the Configuration that created this revision
-	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
+	DeprecatedConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
 
 	// BuildHashLabelKey is the label key attached to a Build indicating the
 	// hash of the spec from which they were created.

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -449,29 +449,3 @@ func (r *Revision) GetLastPinned() (time.Time, error) {
 
 	return time.Unix(secs, 0), nil
 }
-
-func (r *Revision) GetConfigurationGeneration() (int64, error) {
-	if r.Labels == nil {
-		return 0, configurationGenerationParseError{
-			Type: LabelParserErrorTypeMissing,
-		}
-	}
-
-	str, ok := r.ObjectMeta.Labels[serving.ConfigurationGenerationLabelKey]
-	if !ok {
-		return 0, configurationGenerationParseError{
-			Type: LabelParserErrorTypeMissing,
-		}
-	}
-
-	gen, err := strconv.ParseInt(str, 10, 64)
-	if err != nil {
-		return 0, configurationGenerationParseError{
-			Type:  LabelParserErrorTypeInvalid,
-			Value: str,
-			Err:   err,
-		}
-	}
-
-	return gen, nil
-}

--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -300,16 +300,16 @@ func (c *Reconciler) gcRevisions(ctx context.Context, config *v1alpha1.Configura
 		return err
 	}
 
+	gcSkipOffset := cfg.StaleRevisionMinimumGenerations
+
+	if gcSkipOffset >= int64(len(revs)) {
+		return nil
+	}
+
 	// Sort by creation timestamp descending
 	sort.Slice(revs, func(i, j int) bool {
 		return revs[j].CreationTimestamp.Before(&revs[i].CreationTimestamp)
 	})
-
-	gcSkipOffset := cfg.StaleRevisionMinimumGenerations
-
-	if int64(len(revs)) < gcSkipOffset {
-		gcSkipOffset = 0
-	}
 
 	for _, rev := range revs[gcSkipOffset:] {
 		if isRevisionStale(ctx, rev, config) {

--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/knative/pkg/configmap"
@@ -290,6 +291,7 @@ func (c *Reconciler) updateStatus(desired *v1alpha1.Configuration) (*v1alpha1.Co
 }
 
 func (c *Reconciler) gcRevisions(ctx context.Context, config *v1alpha1.Configuration) error {
+	cfg := configns.FromContext(ctx).RevisionGC
 	logger := logging.FromContext(ctx)
 
 	selector := labels.Set{serving.ConfigurationLabelKey: config.Name}.AsSelector()
@@ -298,8 +300,22 @@ func (c *Reconciler) gcRevisions(ctx context.Context, config *v1alpha1.Configura
 		return err
 	}
 
+	// Sort by creation timestamp descending
+	sort.Slice(revs, func(i, j int) bool {
+		return revs[j].CreationTimestamp.Before(&revs[i].CreationTimestamp)
+	})
+
+	var expiry *metav1.Time
+
+	minRevisions := cfg.StaleRevisionMinimumGenerations
+	if int64(len(revs)) > minRevisions && minRevisions != 0 {
+		offset := cfg.StaleRevisionMinimumGenerations - 1
+		revisionCreation := revs[offset].CreationTimestamp
+		expiry = &revisionCreation
+	}
+
 	for _, rev := range revs {
-		if isRevisionStale(ctx, rev, config) {
+		if isRevisionStale(ctx, rev, config, expiry) {
 			err := c.ServingClientSet.ServingV1alpha1().Revisions(rev.Namespace).Delete(rev.Name, &metav1.DeleteOptions{})
 			if err != nil {
 				logger.Errorf("Failed to delete stale revision: %v", err)
@@ -310,22 +326,21 @@ func (c *Reconciler) gcRevisions(ctx context.Context, config *v1alpha1.Configura
 	return nil
 }
 
-func isRevisionStale(ctx context.Context, rev *v1alpha1.Revision, config *v1alpha1.Configuration) bool {
+func isRevisionStale(
+	ctx context.Context,
+	rev *v1alpha1.Revision,
+	config *v1alpha1.Configuration,
+	expiry *metav1.Time,
+) bool {
+
 	cfg := configns.FromContext(ctx).RevisionGC
 	logger := logging.FromContext(ctx)
-
-	// maxGen is the maximum generation number we consider for GC
-	maxGen := config.Spec.Generation - cfg.StaleRevisionMinimumGenerations
 
 	if config.Status.LatestReadyRevisionName == rev.Name {
 		return false
 	}
 
-	// Check if rev is within "MinimumGenerations" of latest
-	if gen, err := rev.GetConfigurationGeneration(); err != nil {
-		logger.Errorf("Failed to determine revision configuration generation: %v", err)
-		return false
-	} else if gen > maxGen {
+	if expiry != nil && (expiry.Before(&rev.CreationTimestamp) || expiry.Equal(&rev.CreationTimestamp)) {
 		return false
 	}
 

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -406,6 +406,19 @@ func TestGCReconcile(t *testing.T) {
 				WithLastPinned(tenMinutesAgo)),
 		},
 		Key: "foo/keep-two",
+	}, {
+		Name: "keep stale revision because of minimum generations",
+		Objects: []runtime.Object{
+			cfg("keep-all", "foo", 5554,
+				// Don't set the latest ready revision here
+				// since those by default are always retained
+				WithLatestCreated,
+				WithObservedGen),
+			rev("keep-all", "foo", 5554,
+				WithCreationTimestamp(oldest),
+				WithLastPinned(tenMinutesAgo)),
+		},
+		Key: "foo/keep-all",
 	}}
 
 	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -478,12 +478,9 @@ func TestIsRevisionStale(t *testing.T) {
 	curTime := time.Now()
 	staleTime := curTime.Add(-10 * time.Minute)
 
-	expiryOlderThanStale := metav1.NewTime(staleTime.Add(-1 * time.Second))
-
 	tests := []struct {
 		name      string
 		rev       *v1alpha1.Revision
-		expiry    *metav1.Time
 		latestRev string
 		want      bool
 	}{{
@@ -529,19 +526,6 @@ func TestIsRevisionStale(t *testing.T) {
 		},
 		want: false,
 	}, {
-		name:   "stale revision newer than expiry",
-		expiry: &expiryOlderThanStale,
-		rev: &v1alpha1.Revision{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "myrev",
-				CreationTimestamp: metav1.NewTime(staleTime),
-				Annotations: map[string]string{
-					"serving.knative.dev/lastPinned": fmt.Sprintf("%d", staleTime.Unix()),
-				},
-			},
-		},
-		want: false,
-	}, {
 		name: "stale latest ready revision",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
@@ -575,7 +559,7 @@ func TestIsRevisionStale(t *testing.T) {
 				},
 			}
 
-			got := isRevisionStale(ctx, test.rev, cfg, test.expiry)
+			got := isRevisionStale(ctx, test.rev, cfg)
 
 			if got != test.want {
 				t.Errorf("IsRevisionStale want %v got %v", test.want, got)

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -44,7 +44,7 @@ func MakeRevision(config *v1alpha1.Configuration, buildRef *corev1.ObjectReferen
 
 	configLabels := config.Labels
 	rev.Labels[serving.ServiceLabelKey] = configLabels[serving.ServiceLabelKey]
-	rev.Labels[serving.ConfigurationGenerationLabelKey] = fmt.Sprintf("%v", config.Spec.Generation)
+	rev.Labels[serving.DeprecatedConfigurationGenerationLabelKey] = fmt.Sprintf("%v", config.Spec.Generation)
 
 	// Populate the Configuration Generation annotation.
 	if rev.Annotations == nil {

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -64,9 +64,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:           "build",
-					serving.ConfigurationGenerationLabelKey: "12",
-					serving.ServiceLabelKey:                 "",
+					serving.ConfigurationLabelKey:                     "build",
+					serving.DeprecatedConfigurationGenerationLabelKey: "12",
+					serving.ServiceLabelKey:                           "",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -116,9 +116,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:           "build",
-					serving.ConfigurationGenerationLabelKey: "99",
-					serving.ServiceLabelKey:                 "",
+					serving.ConfigurationLabelKey:                     "build",
+					serving.DeprecatedConfigurationGenerationLabelKey: "99",
+					serving.ServiceLabelKey:                           "",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -169,9 +169,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:           "labels",
-					serving.ConfigurationGenerationLabelKey: "99",
-					serving.ServiceLabelKey:                 "",
+					serving.ConfigurationLabelKey:                     "labels",
+					serving.DeprecatedConfigurationGenerationLabelKey: "99",
+					serving.ServiceLabelKey:                           "",
 
 					"foo": "bar",
 					"baz": "blah",
@@ -219,9 +219,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:           "annotations",
-					serving.ConfigurationGenerationLabelKey: "99",
-					serving.ServiceLabelKey:                 "",
+					serving.ConfigurationLabelKey:                     "annotations",
+					serving.DeprecatedConfigurationGenerationLabelKey: "99",
+					serving.ServiceLabelKey:                           "",
 				},
 				Annotations: map[string]string{
 					"foo": "bar",

--- a/test/states.go
+++ b/test/states.go
@@ -124,9 +124,10 @@ func IsConfigRevisionCreationFailed(c *v1alpha1.Configuration) (bool, error) {
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations
 // on the revision include an annotation for the generation and that the annotation is
 // set to the expected value.
+// TODO(dprotaso) Delete this assertion for the 0.4 release
 func IsRevisionAtExpectedGeneration(expectedGeneration string) func(r *v1alpha1.Revision) (bool, error) {
 	return func(r *v1alpha1.Revision) (bool, error) {
-		if a, ok := r.Labels[serving.ConfigurationGenerationLabelKey]; ok {
+		if a, ok := r.Labels[serving.DeprecatedConfigurationGenerationLabelKey]; ok {
 			if a != expectedGeneration {
 				return true, fmt.Errorf("Expected Revision %s to be labeled with generation %s but was %s instead", r.Name, expectedGeneration, a)
 			}


### PR DESCRIPTION
spec.generation will be deprecated and removed in future versions

