### PR TITLE
Bump upgrade test latest release to 0.2.3

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -37,7 +37,7 @@ source $(dirname $0)/cluster.sh
 # version will make tests either:
 # 1. Still pass, meaning we can upgrade from earlier than latest release (good).
 # 2. Fail, which might be remedied by bumping this version.
-readonly LATEST_SERVING_RELEASE_VERSION=0.2.2
+readonly LATEST_SERVING_RELEASE_VERSION=0.2.3
 
 function install_latest_release() {
   header "Installing Knative latest public release"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
We should probably make this automatic (or maybe just make the release process file an issue to do this?).