### PR TITLE
Fix unsafe access in multiscaler.

### DIFF
--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -201,6 +201,16 @@ func (m *MultiScaler) Watch(fn func(string)) {
 	m.watcher = fn
 }
 
+// Inform sends an update to the registered watcher function, if it is set.
+func (m *MultiScaler) Inform(event string) bool {
+	watcher := m.watcher
+	if watcher != nil {
+		watcher(event)
+		return true
+	}
+	return false
+}
+
 func (m *MultiScaler) createScaler(ctx context.Context, metric *Metric) (*scalerRunner, error) {
 
 	scaler, err := m.uniScalerFactory(metric, m.dynConfig)
@@ -245,7 +255,7 @@ func (m *MultiScaler) createScaler(ctx context.Context, metric *Metric) (*scaler
 				return
 			case desiredScale := <-scaleChan:
 				if runner.updateLatestScale(desiredScale) {
-					m.watcher(metricKey)
+					m.Inform(metricKey)
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2774

Access to the watcher function needs to be guarded in a `nil` check, since it's not guaranteed to be set. I also added goroutine safety for good measure.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
