### PR TITLE
golang format tools

### DIFF
--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -24,13 +24,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
+	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
-	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/conformance/envpropagation_test.go
+++ b/test/conformance/envpropagation_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 const (
-	testKey = "testKey"
-	testValue = "testValue"
-	secretName = "test-secret"
+	testKey       = "testKey"
+	testValue     = "testValue"
+	secretName    = "test-secret"
 	configMapName = "test-configmap"
 )
 
@@ -43,7 +43,7 @@ func TestSecretsFromEnv(t *testing.T) {
 
 	//Creating test secret
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta {
+		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -95,7 +95,7 @@ func TestConfigsFromEnv(t *testing.T) {
 	err = fetchEnvironmentAndVerify(clients, logger, corev1.EnvVar{
 		Name: testKey,
 		ValueFrom: &corev1.EnvVarSource{
-			ConfigMapKeyRef: &corev1.ConfigMapKeySelector {
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: configMapName,
 				},
@@ -108,7 +108,7 @@ func TestConfigsFromEnv(t *testing.T) {
 	}
 }
 
-func fetchEnvironmentAndVerify(clients *test.Clients, logger *logging.BaseLogger, envVar corev1.EnvVar, cleanup func(clients *test.Clients) (error)) error {
+func fetchEnvironmentAndVerify(clients *test.Clients, logger *logging.BaseLogger, envVar corev1.EnvVar, cleanup func(clients *test.Clients) error) error {
 	resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageEnvVarsPath, &test.Options{
 		EnvVars: []corev1.EnvVar{envVar},
 	})


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
