### PR TITLE
Enable GlobalResync for Revision ConfigMaps

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/config/store.go
+++ b/pkg/reconciler/v1alpha1/revision/config/store.go
@@ -49,6 +49,7 @@ type Store struct {
 	*configmap.UntypedStore
 }
 
+// NewStore creates a new store of Configs and optionally calls functions when ConfigMaps are updated for Revisions
 func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value interface{})) *Store {
 	store := &Store{
 		UntypedStore: configmap.NewUntypedStore(

--- a/pkg/reconciler/v1alpha1/revision/config/store.go
+++ b/pkg/reconciler/v1alpha1/revision/config/store.go
@@ -49,7 +49,7 @@ type Store struct {
 	*configmap.UntypedStore
 }
 
-func NewStore(logger configmap.Logger) *Store {
+func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value interface{})) *Store {
 	store := &Store{
 		UntypedStore: configmap.NewUntypedStore(
 			"revision",
@@ -61,6 +61,7 @@ func NewStore(logger configmap.Logger) *Store {
 				autoscaler.ConfigName:   autoscaler.NewConfigFromConfigMap,
 				logging.ConfigName:      logging.NewConfigFromConfigMap,
 			},
+			onAfterStore...,
 		),
 	}
 

--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -22,10 +22,13 @@ import (
 
 const (
 	// UserContainerName is the name of the user-container in the PodSpec
-	UserContainerName    = "user-container"
-	fluentdContainerName = "fluentd-proxy"
-	envoyContainerName   = "istio-proxy"
-	queueContainerName   = "queue-proxy"
+	UserContainerName = "user-container"
+	// FlutentdContainerName is the name of the fluentd sidecar when enabled
+	FluentdContainerName = "fluentd-proxy"
+	// EnvoyContainerName is the name of the envoy sidecar when enabled
+	EnvoyContainerName = "istio-proxy"
+	// QueueContainerName is the name of the queue proxy side car
+	QueueContainerName = "queue-proxy"
 
 	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
 	// TODO(mattmoor): Make this private once we remove revision_test.go

--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -23,7 +23,7 @@ import (
 const (
 	// UserContainerName is the name of the user-container in the PodSpec
 	UserContainerName = "user-container"
-	// FlutentdContainerName is the name of the fluentd sidecar when enabled
+	// FluentdContainerName is the name of the fluentd sidecar when enabled
 	FluentdContainerName = "fluentd-proxy"
 	// EnvoyContainerName is the name of the envoy sidecar when enabled
 	EnvoyContainerName = "istio-proxy"

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -108,7 +108,7 @@ func TestMakePodSpec(t *testing.T) {
 					Value: "svc",
 				}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -195,7 +195,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -286,7 +286,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -381,7 +381,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -485,7 +485,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -587,7 +587,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -691,7 +691,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -791,7 +791,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -882,7 +882,7 @@ func TestMakePodSpec(t *testing.T) {
 						Value: "svc",
 					}},
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,
@@ -925,7 +925,7 @@ func TestMakePodSpec(t *testing.T) {
 					Value: "8080",
 				}},
 			}, {
-				Name:      fluentdContainerName,
+				Name:      FluentdContainerName,
 				Image:     "indiana:jones",
 				Resources: fluentdResources,
 				Env: []corev1.EnvVar{{
@@ -1045,7 +1045,7 @@ func TestMakePodSpec(t *testing.T) {
 				Lifecycle:                userLifecycle,
 				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			}, {
-				Name:           queueContainerName,
+				Name:           QueueContainerName,
 				Resources:      queueResources,
 				Ports:          queuePorts,
 				Lifecycle:      queueLifecycle,

--- a/pkg/reconciler/v1alpha1/revision/resources/fluentd.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/fluentd.go
@@ -119,7 +119,7 @@ func makeFluentdContainer(rev *v1alpha1.Revision, observabilityConfig *config.Ob
 	}
 
 	return &corev1.Container{
-		Name:      fluentdContainerName,
+		Name:      FluentdContainerName,
 		Image:     observabilityConfig.FluentdSidecarImage,
 		Resources: fluentdResources,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/v1alpha1/revision/resources/fluentd_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/fluentd_test.go
@@ -170,7 +170,7 @@ func TestMakeFluentdContainer(t *testing.T) {
 		oc: &config.Observability{},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:      fluentdContainerName,
+			Name:      FluentdContainerName,
 			Resources: fluentdResources,
 			Image:     "",
 			// These changed based on the Revision and configs passed in.
@@ -214,7 +214,7 @@ func TestMakeFluentdContainer(t *testing.T) {
 		oc: &config.Observability{},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:      fluentdContainerName,
+			Name:      FluentdContainerName,
 			Resources: fluentdResources,
 			Image:     "",
 			// These changed based on the Revision and configs passed in.
@@ -253,7 +253,7 @@ func TestMakeFluentdContainer(t *testing.T) {
 		},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:      fluentdContainerName,
+			Name:      FluentdContainerName,
 			Resources: fluentdResources,
 			Image:     "some-test-image",
 			// These changed based on the Revision and configs passed in.

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -85,7 +85,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 	}
 
 	return &corev1.Container{
-		Name:           queueContainerName,
+		Name:           QueueContainerName,
 		Image:          controllerConfig.QueueSidecarImage,
 		Resources:      queueResources,
 		Ports:          queuePorts,

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -65,7 +65,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:           queueContainerName,
+			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
 			Lifecycle:      queueLifecycle,
@@ -132,7 +132,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:           queueContainerName,
+			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
 			Lifecycle:      queueLifecycle,
@@ -205,7 +205,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:           queueContainerName,
+			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
 			Lifecycle:      queueLifecycle,
@@ -275,7 +275,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:           queueContainerName,
+			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
 			Lifecycle:      queueLifecycle,
@@ -340,7 +340,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		want: &corev1.Container{
 			// These are effectively constant
-			Name:           queueContainerName,
+			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
 			Lifecycle:      queueLifecycle,

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -604,4 +605,176 @@ func getPodAnnotationsForConfig(t *testing.T, configMapValue string, configAnnot
 		t.Fatalf("Couldn't get serving deployment: %v", err)
 	}
 	return deployment.Spec.Template.ObjectMeta.Annotations
+}
+
+func TestGlobalResyncOnConfigMapUpdate(t *testing.T) {
+
+	// Test that changes to the ConfigMap result in the desired changes on an existing
+	// deployment and revision.
+	tests := []struct {
+		name              string
+		expected          string
+		configMapToUpdate corev1.ConfigMap
+		wasUpdated        func(string, *v1alpha1.Revision, *appsv1.Deployment) (string, bool)
+	}{{
+		name:     "Update Istio Outbound IP Ranges", // Should update metadata on Deployment
+		expected: "10.0.0.1/24",
+		configMapToUpdate: corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.NetworkConfigName,
+				Namespace: system.Namespace,
+			},
+			Data: map[string]string{
+				"istio.sidecar.includeOutboundIPRanges": "10.0.0.1/24",
+			},
+		},
+		wasUpdated: func(expected string, revision *v1alpha1.Revision, deployment *appsv1.Deployment) (string, bool) {
+			annotations := deployment.Spec.Template.ObjectMeta.Annotations
+			got := annotations[resources.IstioOutboundIPRangeAnnotation]
+			return got, (got == expected)
+		},
+	}, {
+		name:     "Disable Fluentd", // Should remove fluentd from Deployment
+		expected: "",
+		configMapToUpdate: corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace,
+				Name:      config.ObservabilityConfigName,
+			},
+			Data: map[string]string{
+				"logging.enable-var-log-collection": "false",
+			},
+		},
+		wasUpdated: func(expected string, revision *v1alpha1.Revision, deployment *appsv1.Deployment) (string, bool) {
+			for _, c := range deployment.Spec.Template.Spec.Containers {
+				if c.Name == resources.FluentdContainerName {
+					return c.Image, false
+				}
+			}
+			return "", true
+		},
+	}, {
+		name:     "Update LoggingURL", // Should update LogURL on revision
+		expected: "http://log-here.test.com?filter=",
+		configMapToUpdate: corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace,
+				Name:      config.ObservabilityConfigName,
+			},
+			Data: map[string]string{
+				"logging.enable-var-log-collection":     "true",
+				"logging.fluentd-sidecar-image":         testFluentdImage,
+				"logging.fluentd-sidecar-output-config": testFluentdSidecarOutputConfig,
+				"logging.revision-url-template":         "http://log-here.test.com?filter=${REVISION_UID}",
+			},
+		},
+		wasUpdated: func(expected string, revision *v1alpha1.Revision, deployment *appsv1.Deployment) (string, bool) {
+			got := revision.Status.LogURL
+			return got, strings.HasPrefix(got, expected)
+		},
+	}, {
+		name:     "Update Fluentd Image", // Should Fluentd to Deployment
+		expected: "newFluentdImage",
+		configMapToUpdate: corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace,
+				Name:      config.ObservabilityConfigName,
+			},
+			Data: map[string]string{
+				"logging.enable-var-log-collection":     "true",
+				"logging.fluentd-sidecar-image":         "newFluentdImage",
+				"logging.fluentd-sidecar-output-config": testFluentdSidecarOutputConfig,
+			},
+		},
+		wasUpdated: func(expected string, revision *v1alpha1.Revision, deployment *appsv1.Deployment) (string, bool) {
+			var got string
+			for _, c := range deployment.Spec.Template.Spec.Containers {
+				if c.Name == resources.FluentdContainerName {
+					got = c.Image
+					if got == expected {
+						return got, true
+					}
+				}
+			}
+			return got, false
+		},
+	}, {
+		name:     "Update QueueProxy Image", // Should update queueSidecarImage
+		expected: "myAwesomeQueueImage",
+		configMapToUpdate: corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace,
+				Name:      config.ControllerConfigName,
+			},
+			Data: map[string]string{
+				"queueSidecarImage": "myAwesomeQueueImage",
+			},
+		},
+		wasUpdated: func(expected string, revision *v1alpha1.Revision, deployment *appsv1.Deployment) (string, bool) {
+			var got string
+			for _, c := range deployment.Spec.Template.Spec.Containers {
+				if c.Name == resources.QueueContainerName {
+					got = c.Image
+					if got == expected {
+						return got, true
+					}
+				}
+			}
+			return got, false
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			controllerConfig := getTestControllerConfig()
+			kubeClient, servingClient, _, _, controller, kubeInformer, servingInformer, cachingInformer, watcher, _ := newTestControllerWithConfig(t, controllerConfig)
+
+			stopCh := make(chan struct{})
+			defer func() {
+				close(stopCh)
+			}()
+
+			rev := getTestRevision()
+			revClient := servingClient.ServingV1alpha1().Revisions(rev.Namespace)
+			deploymentsClient := kubeClient.Apps().Deployments(rev.Namespace)
+			h := NewHooks()
+
+			h.OnUpdate(&servingClient.Fake, "revisions", func(obj runtime.Object) HookResult {
+				updatedRev := obj.(*v1alpha1.Revision)
+				t.Logf("Revision updated: %v", updatedRev.Name)
+				updatedDeployment, err := deploymentsClient.Get(resourcenames.Deployment(updatedRev), metav1.GetOptions{})
+				if err != nil {
+					t.Error(err)
+				}
+
+				got, wasUpdated := test.wasUpdated(test.expected, updatedRev, updatedDeployment)
+
+				if !wasUpdated {
+					t.Logf("No update occurred. expected: %s got: %s", test.expected, got)
+					return HookIncomplete
+				}
+
+				//Look for expected change
+				return HookComplete
+			})
+
+			servingInformer.Start(stopCh)
+			kubeInformer.Start(stopCh)
+			cachingInformer.Start(stopCh)
+
+			if err := watcher.Start(stopCh); err != nil {
+				t.Fatalf("Failed to start configuration manager: %v", err)
+			}
+
+			go controller.Run(1, stopCh)
+
+			revClient.Create(rev)
+
+			watcher.OnChange(&test.configMapToUpdate)
+
+			if err := h.WaitForHooks(time.Second); err != nil {
+				t.Errorf("%s Global Resync Failed: %v", test.name, err)
+			}
+		})
+	}
 }

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -730,9 +730,7 @@ func TestGlobalResyncOnConfigMapUpdate(t *testing.T) {
 			kubeClient, servingClient, _, _, controller, kubeInformer, servingInformer, cachingInformer, watcher, _ := newTestControllerWithConfig(t, controllerConfig)
 
 			stopCh := make(chan struct{})
-			defer func() {
-				close(stopCh)
-			}()
+			defer close(stopCh)
 
 			rev := getTestRevision()
 			revClient := servingClient.ServingV1alpha1().Revisions(rev.Namespace)


### PR DESCRIPTION
This change enables global resync for the Observability, Network, and
Controller ConfigMaps. This allows for updating sidecar images and
configuration on existing Revisions and Deployments. Updates that
require Pod replacements will be rolled out according to the deployment
RollingUpdate settings.

Fixes #2332
Fixes #976

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Enables updates for existing Revisions and Deployments when Observability, Network, and Controller ConfigMaps change.
```
