### PR TITLE
Rename autoscaler-service port name from 'websocket' to 'http'

### DIFF
--- a/config/autoscaler-service.yaml
+++ b/config/autoscaler-service.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-  - name: websocket
+  - name: http
     port: 8080
     protocol: TCP
     targetPort: 8080


### PR DESCRIPTION
Istio is picky about service port names:

https://istio.io/help/faq/traffic-management/#naming-port-convention

Fixes #2781

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
