### PR TITLE
Expose 9090 of revision service for metrics from queue proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -298,7 +298,7 @@ func main() {
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promExporter)
-		http.ListenAndServe(":9090", mux)
+		http.ListenAndServe(fmt.Sprintf(":%d", v1alpha1.RequestQueueMetricsPort), mux)
 	}()
 
 	// Open a websocket connection to the autoscaler

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -147,6 +147,10 @@ const (
 	// RequestQueueMetricsPort specifies the port number for metrics emitted
 	// by queue-proxy.
 	RequestQueueMetricsPort = 9090
+
+	// RequestQueueMetricsPortName specifies the port name to use for metrics
+	// emitted by queue-proxy.
+	RequestQueueMetricsPortName = "queue-metrics"
 )
 
 // RevisionSpec holds the desired state of the Revision (from the client).

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -143,6 +143,10 @@ const (
 	// RequestQueueAdminPort specifies the port number for
 	// health check and lifecyle hooks for queue-proxy.
 	RequestQueueAdminPort = 8022
+
+	// RequestQueueMetricsPort specifies the port number for metrics emitted
+	// by queue-proxy.
+	RequestQueueMetricsPort = 9090
 )
 
 // RevisionSpec holds the desired state of the Revision (from the client).

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -199,7 +199,9 @@ func validateContainerPorts(ports []corev1.ContainerPort) *apis.FieldError {
 	}
 
 	// Don't allow userPort to conflict with QueueProxy sidecar
-	if userPort.ContainerPort == RequestQueuePort || userPort.ContainerPort == RequestQueueAdminPort {
+	if userPort.ContainerPort == RequestQueuePort ||
+		userPort.ContainerPort == RequestQueueAdminPort ||
+		userPort.ContainerPort == RequestQueueMetricsPort {
 		errs = errs.Also(apis.ErrInvalidValue(strconv.Itoa(int(userPort.ContainerPort)), "ContainerPort"))
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -209,6 +209,15 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: apis.ErrInvalidValue("8012", "ports.ContainerPort"),
 	}, {
+		name: "port conflicts with queue proxy metrics",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 9090,
+			}},
+		},
+		want: apis.ErrInvalidValue("9090", "ports.ContainerPort"),
+	}, {
 		name: "has invalid port name",
 		c: corev1.Container{
 			Image: "foo",

--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -42,6 +42,10 @@ const (
 	ServicePortName = "http"
 	// ServicePort is the external port of the service
 	ServicePort = int32(80)
+	// MetricsPortName is the name of the external port of the service for metrics
+	MetricsPortName = "metrics"
+	// MetricsPort is the external port of the service for metrics
+	MetricsPort = int32(9090)
 	AppLabelKey = "app"
 )
 

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -42,6 +42,9 @@ var (
 		// Provides health checks and lifecycle hooks.
 		Name:          v1alpha1.RequestQueueAdminPortName,
 		ContainerPort: int32(v1alpha1.RequestQueueAdminPort),
+	}, {
+		Name:          v1alpha1.RequestQueueMetricsPortName,
+		ContainerPort: int32(v1alpha1.RequestQueueMetricsPort),
 	}}
 	// This handler (1) marks the service as not ready and (2)
 	// adds a small delay before the container is killed.

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -34,6 +34,11 @@ var (
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ServicePort,
 		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: v1alpha1.RequestQueuePortName},
+	}, {
+		Name:       MetricsPortName,
+		Protocol:   corev1.ProtocolTCP,
+		Port:       MetricsPort,
+		TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: v1alpha1.RequestQueueMetricsPort},
 	}}
 )
 

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -33,12 +33,12 @@ var (
 		Name:       ServicePortName,
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ServicePort,
-		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: v1alpha1.RequestQueuePortName},
+		TargetPort: intstr.FromString(v1alpha1.RequestQueuePortName),
 	}, {
 		Name:       MetricsPortName,
 		Protocol:   corev1.ProtocolTCP,
 		Port:       MetricsPort,
-		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: v1alpha1.RequestQueueMetricsPortName},
+		TargetPort: intstr.FromString(v1alpha1.RequestQueueMetricsPortName),
 	}}
 )
 

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -38,7 +38,7 @@ var (
 		Name:       MetricsPortName,
 		Protocol:   corev1.ProtocolTCP,
 		Port:       MetricsPort,
-		TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: v1alpha1.RequestQueueMetricsPort},
+		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: v1alpha1.RequestQueueMetricsPortName},
 	}}
 )
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #2203.

## Proposed Changes

* Expose 9090 port of revision service for metrics from queue proxy and also expose it as `ContainerPort` of Pod. See the [comment](https://github.com/knative/serving/pull/2811#issuecomment-450416348) below for how to access this metrics port if Istio sidecar is injected to customer pods and mTLS is enabled.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
9090 port of revision service is exposed for metrics from queue proxy. 
```
