### PR TITLE
Reduce a deployments selector to only match the revision uid

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -63,6 +63,10 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 	// Preserve the current scale of the Deployment.
 	deployment.Spec.Replicas = have.Spec.Replicas
 
+	// Preserve the label selector since it's immutable
+	// TODO(dprotaso) Determine other immutable properties
+	deployment.Spec.Selector = have.Spec.Selector
+
 	// If the spec we want is the spec we have, then we're good.
 	if equality.Semantic.DeepEqual(have.Spec, deployment.Spec) {
 		return have, Unchanged, nil

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -1160,9 +1160,7 @@ func TestMakeDeployment(t *testing.T) {
 				Replicas: &one,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						serving.RevisionLabelKey: "bar",
-						serving.RevisionUID:      "1234",
-						AppLabelKey:              "bar",
+						serving.RevisionUID: "1234",
 					},
 				},
 				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
@@ -1232,9 +1230,7 @@ func TestMakeDeployment(t *testing.T) {
 				Replicas: &one,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						serving.RevisionLabelKey: "bar",
-						serving.RevisionUID:      "1234",
-						AppLabelKey:              "bar",
+						serving.RevisionUID: "1234",
 					},
 				},
 				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
@@ -1299,9 +1295,7 @@ func TestMakeDeployment(t *testing.T) {
 				Replicas: &one,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						serving.RevisionLabelKey: "bar",
-						serving.RevisionUID:      "1234",
-						AppLabelKey:              "bar",
+						serving.RevisionUID: "1234",
 					},
 				},
 				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
@@ -1372,9 +1366,7 @@ func TestMakeDeployment(t *testing.T) {
 				Replicas: &one,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						serving.RevisionLabelKey: "bar",
-						serving.RevisionUID:      "1234",
-						AppLabelKey:              "bar",
+						serving.RevisionUID: "1234",
 					},
 				},
 				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,

--- a/pkg/reconciler/v1alpha1/revision/resources/meta.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/meta.go
@@ -44,7 +44,11 @@ func makeLabels(revision *v1alpha1.Revision) map[string]string {
 
 // makeSelector constructs the Selector we will apply to K8s resources.
 func makeSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
-	return &metav1.LabelSelector{MatchLabels: makeLabels(revision)}
+	return &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			serving.RevisionUID: string(revision.UID),
+		},
+	}
 }
 
 // makeAnnotations creates the annotations we will apply to

--- a/pkg/reconciler/v1alpha1/revision/resources/meta_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/meta_test.go
@@ -90,7 +90,10 @@ func TestMakeLabels(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("makeLabels (-want, +got) = %v", diff)
 			}
-			wantSelector := &metav1.LabelSelector{MatchLabels: test.want}
+
+			wantSelector := &metav1.LabelSelector{
+				MatchLabels: map[string]string{serving.RevisionUID: "1234"},
+			}
 			gotSelector := makeSelector(test.rev)
 			if diff := cmp.Diff(wantSelector, gotSelector); diff != "" {
 				t.Errorf("makeLabels (-want, +got) = %v", diff)


### PR DESCRIPTION
Prior the selector criteria would include all the revision's labels.
This would cause reconciliation of a revision's deployment to fail
when a revision label was added/removed.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
