### PR TITLE
Add a versioning mechanism for tracking the release of knative components.

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -18,3 +18,4 @@ metadata:
   name: knative-serving
   labels:
     istio-injection: enabled
+    serving.knative.dev/release: devel

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -2,6 +2,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
+  labels:
+    serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -17,3 +17,5 @@ kind: ServiceAccount
 metadata:
   name: controller
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
+  labels:
+    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller

--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: knative-ingress-gateway
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   selector:
     istio: ingressgateway
@@ -31,6 +33,8 @@ kind: Gateway
 metadata:
   name: knative-shared-gateway
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   selector:
     knative: ingressgateway
@@ -66,6 +70,7 @@ metadata:
     heritage: Tiller
     app: knative-ingressgateway
     knative: ingressgateway
+    serving.knative.dev/release: devel
 spec:
   type: LoadBalancer
   selector:
@@ -118,6 +123,7 @@ metadata:
     heritage: Tiller
     app: knative-ingressgateway
     knative: ingressgateway
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -129,6 +135,7 @@ spec:
       labels:
         app: knative-ingressgateway
         knative: ingressgateway
+        serving.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
@@ -261,6 +268,8 @@ kind: HorizontalPodAutoscaler
 metadata:
     name: knative-ingressgateway
     namespace: istio-system
+    labels:
+        serving.knative.dev/release: devel
 spec:
     # TODO(1411): Document/fix this.  We are choosing an arbitrary 10 here.
     maxReplicas: 10

--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -6,6 +6,8 @@ kind: Gateway
 metadata:
   name: cluster-local-gateway
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   selector:
     istio: cluster-local-gateway

--- a/config/300-clusteringress.yaml
+++ b/config/300-clusteringress.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusteringresses.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
 spec:
   group: networking.internal.knative.dev
   version: v1alpha1

--- a/config/300-configuration.yaml
+++ b/config/300-configuration.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-kpa.yaml
+++ b/config/300-kpa.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
 spec:
   group: autoscaling.internal.knative.dev
   version: v1alpha1

--- a/config/300-revision.yaml
+++ b/config/300-revision.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-route.yaml
+++ b/config/300-route.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-service.yaml
+++ b/config/300-service.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
+    serving.knative.dev/release: devel
 spec:
   selector:
     app: activator

--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -17,6 +17,7 @@ kind: Service
 metadata:
   labels:
     app: controller
+    serving.knative.dev/release: devel
   name: controller
   namespace: knative-serving
 spec:

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -17,6 +17,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
+    serving.knative.dev/release: devel
   name: webhook
   namespace: knative-serving
 spec:

--- a/config/999-cache.yaml
+++ b/config/999-cache.yaml
@@ -17,6 +17,8 @@ kind: Image
 metadata:
   name: queue-proxy
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -27,6 +29,8 @@ kind: Image
 metadata:
   name: fluentd-sidecar
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   # Cache the fluentd sidecar image
   image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: activator
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -30,6 +32,7 @@ spec:
       labels:
         app: activator
         role: activator
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/autoscaler-service.yaml
+++ b/config/autoscaler-service.yaml
@@ -17,6 +17,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
+    serving.knative.dev/release: devel
   name: autoscaler
   namespace: knative-serving
 spec:

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: autoscaler
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-autoscaler
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # Static parameters:
 

--- a/config/config-controller.yaml
+++ b/config/config-controller.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-controller
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # CONTROLLER CONFIGURATION
 

--- a/config/config-domain.yaml
+++ b/config/config-domain.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-domain
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # These are example settings of domain.
   # example.org will be used for routes having app=prod.

--- a/config/config-gc.yaml
+++ b/config/config-gc.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-gc
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # Delay after revision creation before considering it for GC
   stale-revision-create-delay: "24h"

--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-istio
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
 

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # Common configuration for all Knative codebase
   zap-logger-config: |

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-network
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # Specifies the IP ranges that Istio sidecar will intercept.
   # Replace this with the IP ranges of your cluster (see below for some examples).

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-observability
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 data:
   # LOGGING CONFIGURATION
 

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: controller
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/config/monitoring/100-namespace.yaml
+++ b/config/monitoring/100-namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel

--- a/config/monitoring/logging/elasticsearch/100-fluentd-configmap.yaml
+++ b/config/monitoring/logging/elasticsearch/100-fluentd-configmap.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-monitoring
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 data:
   100.system.conf: |-
     <system>

--- a/config/monitoring/logging/elasticsearch/100-istio-requestlogs.yaml
+++ b/config/monitoring/logging/elasticsearch/100-istio-requestlogs.yaml
@@ -17,6 +17,8 @@ kind: logentry
 metadata:
   name: requestlog
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   severity: '"Info"'
   timestamp: request.time
@@ -46,6 +48,8 @@ kind: fluentd
 metadata:
   name: requestloghandler
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   address: "fluentd-ds.knative-monitoring:24224"
 ---
@@ -54,6 +58,8 @@ kind: rule
 metadata:
   name: requestlogtofluentd
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   match: "true"
   actions:

--- a/config/monitoring/logging/elasticsearch/200-fluentd.yaml
+++ b/config/monitoring/logging/elasticsearch/200-fluentd.yaml
@@ -21,6 +21,7 @@ metadata:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,6 +31,7 @@ metadata:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 rules:
 - apiGroups:
   - ""
@@ -49,6 +51,7 @@ metadata:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: fluentd-ds
@@ -69,6 +72,7 @@ metadata:
   namespace: knative-monitoring
   labels:
     app: fluentd-ds
+    serving.knative.dev/release: devel
 spec:
   selector:
     app: fluentd-ds
@@ -92,6 +96,7 @@ metadata:
     version: v2.0.4
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -103,6 +108,7 @@ spec:
         app: fluentd-ds
         kubernetes.io/cluster-service: "true"
         version: v2.0.4
+        serving.knative.dev/release: devel
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).

--- a/config/monitoring/logging/stackdriver/100-fluentd-configmap.yaml
+++ b/config/monitoring/logging/stackdriver/100-fluentd-configmap.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-monitoring
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 data:
   100.system.conf: |-
     <system>

--- a/config/monitoring/logging/stackdriver/100-istio-requestlogs.yaml
+++ b/config/monitoring/logging/stackdriver/100-istio-requestlogs.yaml
@@ -17,6 +17,8 @@ kind: logentry
 metadata:
   name: requestlog
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   severity: '"Info"'
   timestamp: request.time
@@ -46,6 +48,8 @@ kind: fluentd
 metadata:
   name: requestloghandler
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   address: "fluentd-ds.knative-monitoring:24224"
 ---
@@ -54,6 +58,8 @@ kind: rule
 metadata:
   name: requestlogtofluentd
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   match: "true"
   actions:

--- a/config/monitoring/logging/stackdriver/200-fluentd.yaml
+++ b/config/monitoring/logging/stackdriver/200-fluentd.yaml
@@ -21,6 +21,7 @@ metadata:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,6 +31,7 @@ metadata:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 rules:
 - apiGroups:
   - ""
@@ -49,6 +51,7 @@ metadata:
     app: fluentd-ds
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: fluentd-ds
@@ -69,6 +72,7 @@ metadata:
   namespace: knative-monitoring
   labels:
     app: fluentd-ds
+    serving.knative.dev/release: devel
 spec:
   selector:
     app: fluentd-ds
@@ -92,6 +96,7 @@ metadata:
     version: v2.0.4
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -103,6 +108,7 @@ spec:
         app: fluentd-ds
         kubernetes.io/cluster-service: "true"
         version: v2.0.4
+        serving.knative.dev/release: devel
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).

--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-efficiency.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-efficiency.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-knative-efficiency
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 data:
   knative-control-plane-efficiency-dashboard.json: |+
     {

--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-reconciler.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-reconciler.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-knative-reconciler
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 data:
   knative-reconciler-dashboard.json: |+
     {

--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: scaling-config
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 data:
   scaling-dashboard.json: |+
       {  

--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-definition-knative
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 data:
   revision-dashboard.json: |+
     {

--- a/config/monitoring/metrics/prometheus/100-grafana.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: grafana-datasources
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 data:
   prometheus.yaml: |+
     datasources:
@@ -33,6 +35,8 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboards
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 data:
   dashboards.yaml: |+
     - name: 'knative'
@@ -139,6 +143,7 @@ metadata:
   namespace: knative-monitoring
   labels:
     app: grafana
+    serving.knative.dev/release: devel
 spec:
   type: NodePort
   ports:
@@ -153,6 +158,8 @@ kind: Deployment
 metadata:
   name: grafana
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -162,6 +169,7 @@ spec:
     metadata:
       labels:
         app: grafana
+        serving.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/monitoring/metrics/prometheus/100-istio-metrics.yaml
+++ b/config/monitoring/metrics/prometheus/100-istio-metrics.yaml
@@ -17,6 +17,8 @@ kind: metric
 metadata:
   name: revisionrequestcount
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   value: "1"
   dimensions:
@@ -34,6 +36,8 @@ kind: metric
 metadata:
   name: revisionrequestduration
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   value: response.duration | "0ms"
   dimensions:
@@ -51,6 +55,8 @@ kind: metric
 metadata:
   name: revisionrequestsize
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   value: request.size | 0
   dimensions:
@@ -68,6 +74,8 @@ kind: metric
 metadata:
   name: revisionresponsesize
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   value: response.size | 0
   dimensions:
@@ -85,6 +93,8 @@ kind: prometheus
 metadata:
   name: revisionpromhandler
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   metrics:
   - name: revision_request_count
@@ -152,6 +162,7 @@ metadata:
   namespace: istio-system
   labels:
     istio-protocol: http
+    serving.knative.dev/release: devel
 spec:
   actions:
   - handler: revisionpromhandler.prometheus

--- a/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
+++ b/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
@@ -18,6 +18,7 @@ metadata:
   name: prometheus-scrape-config
   labels:
     name: prometheus-scrape-config
+    serving.knative.dev/release: devel
   namespace: knative-monitoring
 data:
   prometheus.yml: |-

--- a/config/monitoring/metrics/prometheus/200-kube-controller-metrics.yaml
+++ b/config/monitoring/metrics/prometheus/200-kube-controller-metrics.yaml
@@ -19,6 +19,7 @@ metadata:
   name: kube-controller-manager
   labels:
     app: kube-controller-manager
+    serving.knative.dev/release: devel
 spec:
   selector:
     k8s-app: kube-controller-manager

--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-monitoring
   labels:
     app: prometheus
+    serving.knative.dev/release: devel
 spec:
   clusterIP: None
   ports:
@@ -36,12 +37,16 @@ kind: ServiceAccount
 metadata:
   name: prometheus-system
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-system
   namespace: default
+  labels:
+    serving.knative.dev/release: devel
 rules:
 - apiGroups: [""]
   resources:
@@ -60,6 +65,8 @@ kind: Role
 metadata:
   name: prometheus-system
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 rules:
 - apiGroups: [""]
   resources:
@@ -78,6 +85,8 @@ kind: Role
 metadata:
   name: prometheus-system
   namespace: kube-system
+  labels:
+    serving.knative.dev/release: devel
 rules:
 - apiGroups: [""]
   resources:
@@ -91,6 +100,8 @@ kind: Role
 metadata:
   name: prometheus-system
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 rules:
 - apiGroups: [""]
   resources:
@@ -110,6 +121,8 @@ kind: ClusterRole
 metadata:
   name: prometheus-system
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 rules:
 - apiGroups: [""]
   resources:
@@ -132,6 +145,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-system
   namespace: default
+  labels:
+    serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -146,6 +161,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-system
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -160,6 +177,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-system
   namespace: kube-system
+  labels:
+    serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -174,6 +193,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-system
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -187,6 +208,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-system
+  labels:
+    serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -201,6 +224,8 @@ kind: Service
 metadata:
   name: prometheus-system-np
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 spec:
   type: NodePort
   selector:
@@ -214,6 +239,8 @@ kind: StatefulSet
 metadata:
   name: prometheus-system
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 2
   podManagementPolicy: Parallel
@@ -225,6 +252,7 @@ spec:
     metadata:
       labels:
         app: prometheus
+        serving.knative.dev/release: devel
     spec:
       containers:
       - args:

--- a/config/monitoring/metrics/stackdriver/100-stackdriver-serviceentry.yaml
+++ b/config/monitoring/metrics/stackdriver/100-stackdriver-serviceentry.yaml
@@ -16,6 +16,8 @@ kind: ServiceEntry
 metadata:
   name: googleapis
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 spec:
   hosts:
   - "*.googleapis.com"
@@ -31,6 +33,8 @@ kind: ServiceEntry
 metadata:
   name: metadata-server-gke
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 spec:
   hosts:
   - metadata
@@ -51,6 +55,8 @@ kind: ServiceEntry
 metadata:
   name: metadata-server
   namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
 spec:
   hosts:
   - metadata.google.internal

--- a/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
@@ -19,6 +19,8 @@ metadata:
   # istio assumes that zipkin is installed in istio-system namespace - 
   # we have to install to istio-system until istio allows overriding this behavior.
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   ports:
   - name: http
@@ -31,6 +33,8 @@ kind: Deployment
 metadata:
   name: zipkin
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -40,6 +44,7 @@ spec:
     metadata:
       labels:
         app: zipkin
+        serving.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/config/monitoring/tracing/zipkin/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin/100-zipkin.yaml
@@ -19,6 +19,8 @@ metadata:
   # istio assumes that zipkin is installed in istio-system namespace - 
   # we have to install to istio-system until istio allows overriding this behavior.
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   ports:
   - name: http
@@ -31,6 +33,8 @@ kind: Deployment
 metadata:
   name: zipkin
   namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -40,6 +44,7 @@ spec:
     metadata:
       labels:
         app: zipkin
+        serving.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: webhook
   namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Adds a label, `serving.knative.dev/release`, to all the yaml, and sets the tag during release to the ${TAG} value, if present. This should make it easier to identify what release is currently running in a cluster, and clean up old components after an upgrade.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Adds a label, `serving.knative.dev/release`, to all the yaml, and sets the tag during release to the ${TAG} value.
* Development builds will be tagged with a `devel` label.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Adds a label, `serving.knative.dev/rrelease` to knative serving components.
```
