### PR TITLE
Format markdown

### DIFF
--- a/docs/debugging/application-debugging-guide.md
+++ b/docs/debugging/application-debugging-guide.md
@@ -70,50 +70,62 @@ kubectl get clusteringress -o=custom-columns='NAME:.metadata.name,LABELS:.metada
 NAME                   LABELS
 helloworld-go-h5kd4    map[serving.knative.dev/route:helloworld-go serving.knative.dev/routeNamespace:default]
 ```
-The labels `serving.knative.dev/route` and `serving.knative.dev/routeNamespace` will tell
-exactly which Route a ClusterIngress is a child resource of.  Find the one corresponding
-to your Route.  If a ClusterIngress does not exist, the route controller believes
-that the Revisions targeted by your Route/Service isn't ready.  Please proceed to later
-sections to diagnose Revision readiness status.
 
-Otherwise, run the following command to look at the ClusterIngress created for your Route
+The labels `serving.knative.dev/route` and `serving.knative.dev/routeNamespace`
+will tell exactly which Route a ClusterIngress is a child resource of. Find the
+one corresponding to your Route. If a ClusterIngress does not exist, the route
+controller believes that the Revisions targeted by your Route/Service isn't
+ready. Please proceed to later sections to diagnose Revision readiness status.
+
+Otherwise, run the following command to look at the ClusterIngress created for
+your Route
+
 ```
 kubectl get clusteringress <CLUSTERINGRESS_NAME> -o yaml
 ```
-particularly, look at the `status:` section.  If the ClusterIngress is working correctly,
-we should see the condition with `type=Ready` to have `status=True`.  Otherwise, there
-will be error messages.
 
-Now, if ClusterIngress shows status Ready, there must be a corresponding VirtualService.
-Run the following command:
+particularly, look at the `status:` section. If the ClusterIngress is working
+correctly, we should see the condition with `type=Ready` to have `status=True`.
+Otherwise, there will be error messages.
+
+Now, if ClusterIngress shows status Ready, there must be a corresponding
+VirtualService. Run the following command:
+
 ```shell
 kubectl get virtualservice <CLUSTERINGRESS_NAME> -n knative-serving -o yaml
 ```
-the network configuration in VirtualService must match that of ClusterIngress and Route.
-VirtualService currently doesn't expose a Status field, so if one exists and have matching
-configurations with ClusterIngress and Route, you may want to wait a little bit for those
-settings to propagate.
 
-If you are familar with Istio and `istioctl`, you may try using `istioctl` to look deeper
-using Istio [guide](https://istio.io/help/ops/traffic-management/proxy-cmd/).
+the network configuration in VirtualService must match that of ClusterIngress
+and Route. VirtualService currently doesn't expose a Status field, so if one
+exists and have matching configurations with ClusterIngress and Route, you may
+want to wait a little bit for those settings to propagate.
+
+If you are familar with Istio and `istioctl`, you may try using `istioctl` to
+look deeper using Istio
+[guide](https://istio.io/help/ops/traffic-management/proxy-cmd/).
 
 ### Check Ingress status
-Before Knative 0.3 we use a LoadBalancer service call `knative-ingressgateway` to handle
-ingress.  Since Knative 0.3 we now use `istio-ingressgateway` Service.
+
+Before Knative 0.3 we use a LoadBalancer service call `knative-ingressgateway`
+to handle ingress. Since Knative 0.3 we now use `istio-ingressgateway` Service.
 
 To check the IP address of your Ingress, use
+
 ```shell
 kubectl get svc -n istio-system istio-ingressgateway
 ```
-Or replace that with `knative-ingressgateway` if you are using Knative release older than
-0.3.
+
+Or replace that with `knative-ingressgateway` if you are using Knative release
+older than 0.3.
 
 If there is no external IP address, use
+
 ```shell
 kubectl describe svc istio-ingressgateway -n istio-system
 ```
-to see a reason why IP addresses weren't provisioned.  Most likely it is due to a quota
-issue.
+
+to see a reason why IP addresses weren't provisioned. Most likely it is due to a
+quota issue.
 
 ## Check Revision status
 

--- a/docs/spec/normative_examples.md
+++ b/docs/spec/normative_examples.md
@@ -6,14 +6,12 @@ from the smallest, most frequent operations.
 
 Examples in this section illustrate:
 
-* [Automatic rollout of a new Revision to an existing Service with a
-  pre-built container](#1-automatic-rollout-of-a-new-revision-to-existing-service---pre-built-container)
-* [Creating a new Service with a pre-built container](#2-creating-a-new-service-with-a-pre-built-container)
-* [Configuration changes and managed rollout
-  options](#3-managed-release-of-a-new-revision---config-change-only)
-* [Roll back to a known-good revision](#4-roll-back-to-a-known-good-revision)
-* [Creating a revision from source](#5-deploy-a-revision-from-source)
-* [Creating a function from source](#6-deploy-a-function)
+- [Automatic rollout of a new Revision to an existing Service with a pre-built container](#1-automatic-rollout-of-a-new-revision-to-existing-service---pre-built-container)
+- [Creating a new Service with a pre-built container](#2-creating-a-new-service-with-a-pre-built-container)
+- [Configuration changes and managed rollout options](#3-managed-release-of-a-new-revision---config-change-only)
+- [Roll back to a known-good revision](#4-roll-back-to-a-known-good-revision)
+- [Creating a revision from source](#5-deploy-a-revision-from-source)
+- [Creating a function from source](#6-deploy-a-function)
 
 Note that these API operations are identical for both app and function based
 services. (to see the full resource definitions, see the
@@ -292,18 +290,16 @@ creating a new Service, which will create both a Configuration and a new Route
 referring to that configuration. In turn, the Configuration will generate a new
 Revision. Note that these steps may occur in in parallel.
 
-In this getting started example, deploying a first Revision is
-accomplished by creating a new Service, which will create both a
-Configuration and a new Route referring to that configuration. In
-turn, the Configuration will generate a new Revision. Note that these
-steps may occur in in parallel.
+In this getting started example, deploying a first Revision is accomplished by
+creating a new Service, which will create both a Configuration and a new Route
+referring to that configuration. In turn, the Configuration will generate a new
+Revision. Note that these steps may occur in in parallel.
 
-In the `runLatest` style of Service, the Route always references the
-latest ready revision of a Configuration, as this example
-illustrates. This is the most straightforward scenario that many
-Knative Serving customers are expected to use, and is consistent with the
-experience of deploying code that is rolled out immediately.  A Route
-may also directly reference a Revision, which is shown in
+In the `runLatest` style of Service, the Route always references the latest
+ready revision of a Configuration, as this example illustrates. This is the most
+straightforward scenario that many Knative Serving customers are expected to
+use, and is consistent with the experience of deploying code that is rolled out
+immediately. A Route may also directly reference a Revision, which is shown in
 [example 3](#3-managed-release-of-a-new-revision---config-change-only).
 
 The example shows the POST calls issued by the client, followed by several GET
@@ -512,12 +508,11 @@ status:
   observedGeneration: 1
 ```
 
-
 ## 3) Managed release of a new Revision - config change only
 
 **_Scenario_**: User updates configuration with new runtime arguments (env var
-  change) to an existing service, tests the revision, then proceeds with a
-  human-controlled rollout to 100%.
+change) to an existing service, tests the revision, then proceeds with a
+human-controlled rollout to 100%.
 
 ```
 $ knative release --service my-service strategy release
@@ -569,28 +564,27 @@ current,latest    100%     ghi   2018-01-19 12:16    user1         a6f92d1
 
 **Steps**:
 
-* Update the Service to switch from a `runLatest` strategy to a `release`
+- Update the Service to switch from a `runLatest` strategy to a `release`
   strategy.
 
-* Update the Service with the new configuration (env var).
+- Update the Service with the new configuration (env var).
 
-* Update the Service include the new revision in its revision list, which makes
+- Update the Service include the new revision in its revision list, which makes
   it address the new Revision as `candidate`.
 
-* Adjust the `percentRollout` controlling the traffic on `candidate`.
+- Adjust the `percentRollout` controlling the traffic on `candidate`.
 
-* Complete the rollout so the new revision is `current`.
+- Complete the rollout so the new revision is `current`.
 
 **Results:**
 
-* The system creates the new revision from the configuration, addressable at
+- The system creates the new revision from the configuration, addressable at
   `latest.my-service...`, but traffic is not routed to it until the rollout to
   that revision is begun (which marks it as `candidate.my-service...`) and the
   percentage is manually ramped up. Upon completing the rollout, the candidate
   revision is now the current revision.
 
 ![Release mode](images/release_mode.png)
-
 
 In the previous examples, the Service automatically made changes to the
 configuration (newly created Revision) routable when they became ready. While
@@ -599,8 +593,9 @@ simple development flows, the Service can also reference Revisions directly in
 `release` mode to route traffic to two specific revisions: the revision that's
 been running, and the new revision the user would like test or canary a portion
 of traffic to, prior to rolling out entirely. This mode is also useful to roll
-back to a known-good previous revision. (Note: see [Appendix
-B](complex_examples.md) for a semi-automatic variation of managed rollouts).
+back to a known-good previous revision. (Note: see
+[Appendix B](complex_examples.md) for a semi-automatic variation of managed
+rollouts).
 
 The client updates the service to switch to release mode.
 
@@ -616,7 +611,7 @@ metadata:
 spec:
   release:
     revisions: [def]
-    configuration:  # Copied from spec.runLatest.configuration
+    configuration: # Copied from spec.runLatest.configuration
       revisionTemplate:
         spec:
           container:
@@ -639,12 +634,12 @@ metadata:
 spec:
   rollout:
     traffic:
-    - revisionName: def
-      name: current  # addressable as current.my-service.default.mydomain.com
-      percent: 100
-    - configurationName: my-service  # LatestReadyRevision of my-service
-      name: latest  # addressable as latest.my-service.default.mydomain.com
-      percent: 0 # no direct traffic ever.
+      - revisionName: def
+        name: current # addressable as current.my-service.default.mydomain.com
+        percent: 100
+      - configurationName: my-service # LatestReadyRevision of my-service
+        name: latest # addressable as latest.my-service.default.mydomain.com
+        percent: 0 # no direct traffic ever.
 ```
 
 Next, the user updates the Service with the new variables, which causes the
@@ -669,10 +664,10 @@ spec:
             revisionNonce: "l01itSaN0nC3"
         spec:
           container:
-            env:  # k8s-style strategic merge patch, updating a single list value
-            # Image etc. do not change
-            - name: HELLO
-              value: blurg  # changed value
+            env: # k8s-style strategic merge patch, updating a single list value
+              # Image etc. do not change
+              - name: HELLO
+                value: blurg # changed value
 ```
 
 As in the previous example, the configuration is updated to trigger the creation
@@ -717,6 +712,7 @@ The user can then begin the rollout of revision `ghi`:
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -728,17 +724,18 @@ spec:
     rolloutPercent: 0
 ```
 
-This makes the route update the `candidate` name to point to the revision `ghi`. (The
-list of revisions can contain one or two items. If two, the first is `current`
-and the latter is `candidate`.) The new revision will still not receive any traffic,
-but can be accessed for testing, verification, etc under the
-`candidate.my-service...` name.
+This makes the route update the `candidate` name to point to the revision `ghi`.
+(The list of revisions can contain one or two items. If two, the first is
+`current` and the latter is `candidate`.) The new revision will still not
+receive any traffic, but can be accessed for testing, verification, etc under
+the `candidate.my-service...` name.
 
 To put traffic on `ghi`, the user can adjust `rolloutPercent`:
 
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -761,36 +758,36 @@ metadata:
 spec:
   rollout:
     traffic:
+      - revisionName: def
+        name: current # addressable as current.my-service.default.mydomain.com
+        percent: 95
+      - revisionName: ghi
+        name: candidate # addressable as candidate.my-service.default.mydomain.com
+        percent: 5
+      - configurationName: my-service # LatestReadyRevision of my-service
+        name: latest # addressable as latest.my-service.default.mydomain.com
+        percent: 0 # no direct traffic ever.
+status:
+  domain: my-service.default.mydomain.com
+  traffic:
     - revisionName: def
-      name: current  # addressable as current.my-service.default.mydomain.com
+      name: current # addressable as current.my-service.default.mydomain.com
       percent: 95
     - revisionName: ghi
       name: candidate # addressable as candidate.my-service.default.mydomain.com
       percent: 5
-    - configurationName: my-service  # LatestReadyRevision of my-service
-      name: latest  # addressable as latest.my-service.default.mydomain.com
-      percent: 0 # no direct traffic ever.
-status:
-  domain: my-service.default.mydomain.com
-  traffic:
-  - revisionName: def
-    name: current  # addressable as current.my-service.default.mydomain.com
-    percent: 95
-  - revisionName: ghi
-    name: candidate # addressable as candidate.my-service.default.mydomain.com
-    percent: 5
-  - configurationName: my-service  # LatestReadyRevision of my-service
-    name: latest
-    percent: 0
+    - configurationName: my-service # LatestReadyRevision of my-service
+      name: latest
+      percent: 0
   conditions:
     - type: Ready
       status: True
 ```
 
 After testing and gradually rolling out the new revision at
-`candidate.my-service.default.mydomain.com`, it can be promoted to a fully-rolled-out
-`current` revision by updating the service to list only `ghi` in the revision
-list.
+`candidate.my-service.default.mydomain.com`, it can be promoted to a
+fully-rolled-out `current` revision by updating the service to list only `ghi`
+in the revision list.
 
 ```http
 PATCH /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
@@ -810,7 +807,8 @@ This causes the service to update the route to assign 100% of traffic to ghi.
 
 Once the update has been completed, if the latest ready revision is the same as
 the current revision, the names `current` and `latest` will point to the same
-revision. The name `candidate` is inactive until you're rolling out a revision again.
+revision. The name `candidate` is inactive until you're rolling out a revision
+again.
 
 Note that throughout this whole process, `latest` remains pointing to the latest
 ready revision of the service. This allows your team to continue to pre-check
@@ -829,21 +827,21 @@ metadata:
 spec:
   rollout:
     traffic:
-    - revisionName: ghi
-      name: current
-      percent: 100
-    - configurationName: my-service  # LatestReadyRevision of my-service
-      name: latest
-      percent: 0
+      - revisionName: ghi
+        name: current
+        percent: 100
+      - configurationName: my-service # LatestReadyRevision of my-service
+        name: latest
+        percent: 0
 status:
   domain: my-service.default.mydomain.com
   traffic:
-  - revisionName: ghi
-    name: current  # addressable as current.my-service.default.mydomain.com
-    percent: 100
-  - configurationName: my-service
-    name: latest # addressable as latest.my-service.default.mydomain.com
-    percent: 0
+    - revisionName: ghi
+      name: current # addressable as current.my-service.default.mydomain.com
+      percent: 100
+    - configurationName: my-service
+      name: latest # addressable as latest.my-service.default.mydomain.com
+      percent: 0
   conditions:
     - type: Ready
       status: True
@@ -862,20 +860,21 @@ Rolled back to revision [abc] serving at [my-service.default.mydomain.com]
 
 **Steps**:
 
-* Set the service to `release` mode (if it isn't already there), with the
+- Set the service to `release` mode (if it isn't already there), with the
   `revisions` list equal to the revision you need to roll back to. Leave the
   configuration the same (or copy it over from `runLatest` mode, if the service
   wasn't already in `release` mode).
 
 **Results**:
 
-* The Route is updated to put 100% of traffic on your rollback Revision. Your
+- The Route is updated to put 100% of traffic on your rollback Revision. Your
   latest ready Revision remains available for validation under the
   `latest.my-service.defaultdomain.com`-style name.
 
 ```http
 PUT /apis/serving.knative.dev/v1alpha1/namespaces/default/services/my-service
 ```
+
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
@@ -884,7 +883,7 @@ metadata:
 spec:
   release:
     revisions: [abc]
-    configuration:  # Copied from spec.runLatest.configuration if needed
+    configuration: # Copied from spec.runLatest.configuration if needed
       revisionTemplate:
         spec:
           container:

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -388,10 +388,12 @@ status:
 
 ## Container
 
-This is a [core.v1.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#container-v1-core).
+This is a
+[core.v1.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#container-v1-core).
 Some fields are not allowed, such as name and volumeMounts.
 
-This type is not used on its own but is found composed inside [Service](#service), [Configuration](#configuration), and [Revision](#revision).
+This type is not used on its own but is found composed inside
+[Service](#service), [Configuration](#configuration), and [Revision](#revision).
 
 ```yaml
 container: # v1.Container
@@ -401,15 +403,15 @@ container: # v1.Container
   # If buildRef is provided, it is expected that this image will be
   # present when the referenced build is complete.
   image: gcr.io/...
-  command: ['run']
+  command: ["run"]
   args: []
   env:
-  # list of environment vars
-  - name: FOO
-    value: bar
-  - name: HELLO
-    value: world
-  - ...
+    # list of environment vars
+    - name: FOO
+      value: bar
+    - name: HELLO
+      value: world
+    - ...
 
   # Optional, only a single containerPort may be specified.
   # This can be specified to select a specific port for incoming traffic.
@@ -419,11 +421,11 @@ container: # v1.Container
   ports: # core.v1.ContainerPort array
     # Valid range is [1-65535], except 8012 (RequestQueuePort)
     # and 8022 (RequestQueueAdminPort).
-  - containerPort: ... 
-    name: ... # Optional, one of "http1", "h2c"
-    protocol: ... # Optional, one of "", "tcp"
+    - containerPort: ...
+      name: ... # Optional, one of "http1", "h2c"
+      protocol: ... # Optional, one of "", "tcp"
 
-  livenessProbe: ...  # Optional
-  readinessProbe: ...  # Optional
-  resources: ...  # Optional
+  livenessProbe: ... # Optional
+  readinessProbe: ... # Optional
+  resources: ... # Optional
 ```

--- a/install/CONFIG.md
+++ b/install/CONFIG.md
@@ -1,12 +1,13 @@
 # Configuring Knative Serving
 
 ## Cluster local routes
+
 Routes assigned the domain `.svc.cluster.local` will not be exposed to an
-Ingress with an external IP address.  This can be done by specifying a custom
+Ingress with an external IP address. This can be done by specifying a custom
 label selector rule in the following section.
 
-In addition to that, the label `serving.knative.dev/visibility` can be
-set to `cluster-local` in order to achieve the same effect.
+In addition to that, the label `serving.knative.dev/visibility` can be set to
+`cluster-local` in order to achieve the same effect.
 
 ## Serving multiple domains
 

--- a/test/test_images/environment/README.md
+++ b/test/test_images/environment/README.md
@@ -12,7 +12,9 @@ Currently the server exposes:
 
 - /envvars : To provide a JSON payload containing all the environment variables
   set inside the container
-- /filepath?path=<path-to-file>: Provides FileInfo for the <path-to-file> query-param. The JSON payload returned as response is specified in [runtime_contract_types](../../conformance/runtime_contract_types.go)
+- /filepath?path=<path-to-file>: Provides FileInfo for the <path-to-file>
+  query-param. The JSON payload returned as response is specified in
+  [runtime_contract_types](../../conformance/runtime_contract_types.go)
 
 ## Building
 

--- a/vendor/github.com/prometheus/procfs/fixtures/26231/exe
+++ b/vendor/github.com/prometheus/procfs/fixtures/26231/exe
@@ -1,1 +1,1 @@
-/usr/bin/vim
+/../usr/bin/vim


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`