### PR TITLE
Dump state if final call to WaitForXXXState functions fails.

### DIFF
--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -47,13 +47,20 @@ func WaitForRouteState(client *ServingClients, name string, inState func(r *v1al
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		r, err := client.Routes.Get(name, metav1.GetOptions{})
+	var lastState *v1alpha1.Route
+	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		lastState, err = client.Routes.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
-		return inState(r)
+		return inState(lastState)
 	})
+
+	if waitErr != nil {
+		return errors.Wrapf(waitErr, "route %q is not in desired state: %+v", name, lastState)
+	}
+	return nil
 }
 
 // CheckRouteState verifies the status of the Route called name from client
@@ -81,13 +88,20 @@ func WaitForConfigurationState(client *ServingClients, name string, inState func
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		c, err := client.Configs.Get(name, metav1.GetOptions{})
+	var lastState *v1alpha1.Configuration
+	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		lastState, err = client.Configs.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
-		return inState(c)
+		return inState(lastState)
 	})
+
+	if waitErr != nil {
+		return errors.Wrapf(waitErr, "configuration %q is not in desired state: %+v", name, lastState)
+	}
+	return nil
 }
 
 // CheckConfigurationState verifies the status of the Configuration called name from client
@@ -115,22 +129,18 @@ func WaitForRevisionState(client *ServingClients, name string, inState func(r *v
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
+	var lastState *v1alpha1.Revision
 	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		r, err := client.Revisions.Get(name, metav1.GetOptions{})
+		var err error
+		lastState, err = client.Revisions.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
-		return inState(r)
+		return inState(lastState)
 	})
-	// Attempt to add revision Status to error message.
+
 	if waitErr != nil {
-		r, err := client.Revisions.Get(name, metav1.GetOptions{})
-		if err != nil {
-			// Cant' look for Revision, don't append Status to error message.
-			return waitErr
-		}
-		// Wrap error with information about Status.
-		return errors.Wrapf(waitErr, "Status=%#v", r.Status)
+		return errors.Wrapf(waitErr, "revision %q is not in desired state: %+v", name, lastState)
 	}
 	return nil
 }
@@ -160,13 +170,20 @@ func WaitForServiceState(client *ServingClients, name string, inState func(s *v1
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		s, err := client.Services.Get(name, metav1.GetOptions{})
+	var lastState *v1alpha1.Service
+	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		lastState, err = client.Services.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
-		return inState(s)
+		return inState(lastState)
 	})
+
+	if waitErr != nil {
+		return errors.Wrapf(waitErr, "service %q is not in desired state: %+v", name, lastState)
+	}
+	return nil
 }
 
 // CheckServiceState verifies the status of the Service called name from client


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2732

(I'd really rather have those be auto-generated)

## Proposed Changes

* Safe the state of each poll to be able to print it if the polling fails overall.
* Augment the returned error with that last state on error.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
