### PR TITLE
Set to lameduck metric to 1 if the pod is lameducked

### DIFF
--- a/pkg/queue/stats_reporter.go
+++ b/pkg/queue/stats_reporter.go
@@ -162,7 +162,7 @@ func (r *Reporter) Report(lameDuck bool, operationsPerSecond float64, averageCon
 		return errors.New("StatsReporter is not Initialized yet")
 	}
 	_lameDuck := float64(0)
-	if !lameDuck {
+	if lameDuck {
 		_lameDuck = float64(1)
 	}
 	stats.Record(r.ctx, measurements[LameDuckM].M(_lameDuck))

--- a/pkg/queue/stats_reporter_test.go
+++ b/pkg/queue/stats_reporter_test.go
@@ -114,7 +114,7 @@ func TestReporter_Report(t *testing.T) {
 	if err := reporter.Report(true, float64(39), float64(3)); err != nil {
 		t.Error(err)
 	}
-	checkData(t, LameDuckN, 0, testTagKeyValueMap)
+	checkData(t, LameDuckN, 1, testTagKeyValueMap)
 	checkData(t, OperationsPerSecondN, 39, testTagKeyValueMap)
 	checkData(t, AverageConcurrentRequestsN, 3, testTagKeyValueMap)
 	if err := reporter.UnregisterViews(); err != nil {


### PR DESCRIPTION
Set to lameduck metric to 1 if the pod is lameducked to be consistent with the metric description: `Indicates this Pod has received a shutdown signal with 1 else 0`.
