### PR TITLE
Change request logs to be written only for HTTP and GRPC calls

### DIFF
--- a/config/monitoring/logging/elasticsearch/100-istio-requestlogs.yaml
+++ b/config/monitoring/logging/elasticsearch/100-istio-requestlogs.yaml
@@ -55,7 +55,7 @@ metadata:
   name: requestlogtofluentd
   namespace: istio-system
 spec:
-  match: "true"
+  match: context.protocol == "http" || context.protocol == "grpc"
   actions:
    - handler: requestloghandler.fluentd
      instances:

--- a/config/monitoring/logging/stackdriver/100-istio-requestlogs.yaml
+++ b/config/monitoring/logging/stackdriver/100-istio-requestlogs.yaml
@@ -55,7 +55,7 @@ metadata:
   name: requestlogtofluentd
   namespace: istio-system
 spec:
-  match: "true"
+  match: context.protocol == "http" || context.protocol == "grpc"
   actions:
    - handler: requestloghandler.fluentd
      instances:


### PR DESCRIPTION
Change request logs to be written only for HTTP and GRPC calls. Some fields that are logged are not valid for TCP requests and they generate error messages in Istio telemetry pods. This change fixes that. TCP request logs can be added later if there is demand.