### PR TITLE
Propagate label changes from Service to child Route and Config.

### DIFF
--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -253,6 +253,9 @@ func configSemanticEquals(config, desiredConfig *v1alpha1.Configuration) bool {
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Labels, config.ObjectMeta.Labels)
 }
 
+// mergeRouteLabel sets desiredConfig[serving.RouteLabelKey] to same
+// as config[serving.RouteLabelKey], so that we do nothing about
+// configuration label serving.RouteLabelKey in our reconciliation.
 func mergeRouteLabel(desiredConfig, config *v1alpha1.Configuration) {
 	routeLabel, existed := config.ObjectMeta.Labels[serving.RouteLabelKey]
 	if !existed {
@@ -268,7 +271,10 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alph
 	if err != nil {
 		return nil, err
 	}
-	// Route label is automatically set by another reconciler.
+	// Route label is automatically set by another reconciler.  We
+	// want to ignore that label in our reconciliation here by setting
+	// desiredConfig[serving.RouteLabelKey] to the same as
+	// config[serving.RouteLabelKey].
 	mergeRouteLabel(desiredConfig, config)
 
 	// TODO(#642): Remove this (needed to avoid continuous updates)

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -247,9 +247,9 @@ func (c *Reconciler) createConfiguration(service *v1alpha1.Service) (*v1alpha1.C
 	return c.ServingClientSet.ServingV1alpha1().Configurations(service.Namespace).Create(cfg)
 }
 
-func hasConfigChanges(config, desiredConfig *v1alpha1.Configuration) bool {
-	return !equality.Semantic.DeepEqual(desiredConfig.Spec, config.Spec) ||
-		!equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Labels, config.ObjectMeta.Labels)
+func configSemanticEquals(config, desiredConfig *v1alpha1.Configuration) bool {
+	return equality.Semantic.DeepEqual(desiredConfig.Spec, config.Spec) &&
+		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Labels, config.ObjectMeta.Labels)
 }
 
 func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alpha1.Service, config *v1alpha1.Configuration) (*v1alpha1.Configuration, error) {
@@ -262,7 +262,7 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alph
 	// TODO(#642): Remove this (needed to avoid continuous updates)
 	desiredConfig.Spec.Generation = config.Spec.Generation
 
-	if !hasConfigChanges(config, desiredConfig) {
+	if configSemanticEquals(config, desiredConfig) {
 		// No differences to reconcile.
 		return config, nil
 	}
@@ -291,9 +291,9 @@ func (c *Reconciler) createRoute(service *v1alpha1.Service) (*v1alpha1.Route, er
 	return c.ServingClientSet.ServingV1alpha1().Routes(service.Namespace).Create(route)
 }
 
-func hasRouteChanges(route, desiredRoute *v1alpha1.Route) bool {
-	return !equality.Semantic.DeepEqual(desiredRoute.Spec, route.Spec) ||
-		!equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Labels, route.ObjectMeta.Labels)
+func routeSemanticEquals(route, desiredRoute *v1alpha1.Route) bool {
+	return equality.Semantic.DeepEqual(desiredRoute.Spec, route.Spec) &&
+		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Labels, route.ObjectMeta.Labels)
 }
 
 func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Service, route *v1alpha1.Route) (*v1alpha1.Route, error) {
@@ -309,7 +309,7 @@ func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Servi
 	// TODO(#642): Remove this (needed to avoid continuous updates).
 	desiredRoute.Spec.Generation = route.Spec.Generation
 
-	if !hasRouteChanges(route, desiredRoute) {
+	if routeSemanticEquals(route, desiredRoute) {
 		// No differences to reconcile.
 		return route, nil
 	}

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -278,7 +278,7 @@ func TestReconcile(t *testing.T) {
 			Object: route("update-route-and-config", "foo", WithRunLatestRollout),
 		}},
 	}, {
-		Name: "runLatest - update route and service labels",
+		Name: "runLatest - update route and config labels",
 		Objects: []runtime.Object{
 			// Mutate the Service to add some more labels
 			svc("update-route-and-config-labels", "foo", WithRunLatestRollout, WithInitSvcConditions, WithServiceLabel("new-label", "new-value")),

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -292,6 +292,23 @@ func TestReconcile(t *testing.T) {
 			Object: route("update-route-and-config-labels", "foo", WithRunLatestRollout, WithRouteLabel("new-label", "new-value")),
 		}},
 	}, {
+		Name: "runLatest - update route config labels ignoring serving.knative.dev/route",
+		Objects: []runtime.Object{
+			// Mutate the Service to add some more labels
+			svc("update-child-labels-ignore-route-label", "foo",
+				WithRunLatestRollout, WithInitSvcConditions, WithServiceLabel("new-label", "new-value")),
+			config("update-child-labels-ignore-route-label", "foo",
+				WithRunLatestRollout, WithConfigLabel("serving.knative.dev/route", "update-child-labels-ignore-route-label")),
+			route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout),
+		},
+		Key: "foo/update-child-labels-ignore-route-label",
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: config("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithConfigLabel("new-label", "new-value"),
+				WithConfigLabel("serving.knative.dev/route", "update-child-labels-ignore-route-label")),
+		}, {
+			Object: route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithRouteLabel("new-label", "new-value")),
+		}},
+	}, {
 		Name: "runLatest - bad config update",
 		Objects: []runtime.Object{
 			// There is no spec.{runLatest,pinned} in this Service, which triggers the error

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -18,6 +18,8 @@ package service
 
 import (
 	"fmt"
+	"testing"
+
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	fakesharedclientset "github.com/knative/pkg/client/clientset/versioned/fake"
 	"github.com/knative/pkg/controller"
@@ -32,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
-	"testing"
 )
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
@@ -275,6 +276,20 @@ func TestReconcile(t *testing.T) {
 			Object: config("update-route-and-config", "foo", WithRunLatestRollout),
 		}, {
 			Object: route("update-route-and-config", "foo", WithRunLatestRollout),
+		}},
+	}, {
+		Name: "runLatest - update route and service labels",
+		Objects: []runtime.Object{
+			// Mutate the Service to add some more labels
+			svc("update-route-and-config-labels", "foo", WithRunLatestRollout, WithInitSvcConditions, WithServiceLabel("new-label", "new-value")),
+			config("update-route-and-config-labels", "foo", WithRunLatestRollout),
+			route("update-route-and-config-labels", "foo", WithRunLatestRollout),
+		},
+		Key: "foo/update-route-and-config-labels",
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: config("update-route-and-config-labels", "foo", WithRunLatestRollout, WithConfigLabel("new-label", "new-value")),
+		}, {
+			Object: route("update-route-and-config-labels", "foo", WithRunLatestRollout, WithRouteLabel("new-label", "new-value")),
 		}},
 	}, {
 		Name: "runLatest - bad config update",

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -103,6 +103,16 @@ func WithRunLatestRollout(s *v1alpha1.Service) {
 	}
 }
 
+// WithServiceLabel attaches a particular label to the service.
+func WithServiceLabel(key, value string) ServiceOption {
+	return func(service *v1alpha1.Service) {
+		if service.Labels == nil {
+			service.Labels = make(map[string]string)
+		}
+		service.Labels[key] = value
+	}
+}
+
 // WithPinnedRollout configures the Service to use a "pinned" rollout,
 // which is pinned to the named revision.
 // Deprecated, since PinnedType is deprecated.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2783 

## Proposed Changes

* Propagate changes in Service labels to child Route and Config.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE
```
