### PR TITLE
Activator-service should be of type ClusterIP

### DIFF
--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -31,4 +31,3 @@ spec:
     protocol: TCP
     port: 9090
     targetPort: 9090
-  type: NodePort

--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -27,7 +27,9 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 8080
+    nodePort: # empty removing existing value to avoid upgrade error # TODO delete after v0.4
   - name: metrics
     protocol: TCP
     port: 9090
     targetPort: 9090
+    nodePort: # empty removing existing value to avoid upgrade error # TODO delete after v0.4

--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -33,3 +33,4 @@ spec:
     port: 9090
     targetPort: 9090
     nodePort: # empty removing existing value to avoid upgrade error # TODO delete after v0.4
+  type: ClusterIP


### PR DESCRIPTION
vs NodePort

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Turning activator into a ClusterIP service seems to work, but introduces an upgrade problem: running `ko apply -f config/` results in errors like “nodePort is not allowed in services of type ClusterIP”.

Workaround is to delete activator service before installation

## Proposed Changes

* remove `type: NodePort` from activator-service definition

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
action required: delete activator-service from namespace knative-serving before upgrading
```
