### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -30,7 +30,7 @@ type Measurement int
 
 const (
 	// ServiceReadyCountN is the number of services that have become ready.
-	ServiceReadyCountN  = "service_ready_count"
+	ServiceReadyCountN = "service_ready_count"
 	// ServiceReadyLatencyN is the time it takes for a service to become ready since the resource is created.
 	ServiceReadyLatencyN = "service_ready_latency"
 )
@@ -38,9 +38,9 @@ const (
 var (
 	serviceReadyLatencyStat = stats.Int64(
 		ServiceReadyLatencyN,
-			"Time it takes for a service to become ready since created",
-			stats.UnitMilliseconds)
-	serviceReadyCountStat   = stats.Int64(
+		"Time it takes for a service to become ready since created",
+		stats.UnitMilliseconds)
+	serviceReadyCountStat = stats.Int64(
 		ServiceReadyCountN,
 		"Number of services that became ready",
 		stats.UnitDimensionless)
@@ -48,7 +48,6 @@ var (
 	reconcilerTagKey tag.Key
 	keyTagKey        tag.Key
 )
-
 
 func init() {
 	var err error
@@ -100,7 +99,7 @@ func NewStatsReporter(reconciler string) (StatsReporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &reporter{ ctx: ctx }, nil
+	return &reporter{ctx: ctx}, nil
 }
 
 // ReportServiceReady reports the time it took a service to become Ready

--- a/pkg/reconciler/stats_reporter_test.go
+++ b/pkg/reconciler/stats_reporter_test.go
@@ -18,9 +18,10 @@ package reconciler
 
 import (
 	"fmt"
-	"go.opencensus.io/tag"
 	"testing"
 	"time"
+
+	"go.opencensus.io/tag"
 
 	"go.opencensus.io/stats/view"
 )
@@ -62,13 +63,13 @@ func TestReporter_ReportDuration(t *testing.T) {
 	}
 
 	latency := getMetric(t, ServiceReadyLatencyN)
-	if v := latency.Data.(*view.LastValueData).Value;  v != 1000 {
+	if v := latency.Data.(*view.LastValueData).Value; v != 1000 {
 		t.Errorf("expected latency %v, Got %v", 1000, v)
 	}
 	checkTags(t, expectedTags, latency.Tags)
 
 	count := getMetric(t, ServiceReadyCountN)
-	if v := count.Data.(*view.CountData).Value;  v != 1 {
+	if v := count.Data.(*view.CountData).Value; v != 1 {
 		t.Errorf("expected latency %v, Got %v", 1, v)
 	}
 	checkTags(t, expectedTags, count.Tags)

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -722,7 +722,7 @@ type PodOption func(*corev1.Pod)
 func WithFailingContainer(name string, exitCode int, message string) PodOption {
 	return func(pod *corev1.Pod) {
 		pod.Status.ContainerStatuses = []corev1.ContainerStatus{
-			corev1.ContainerStatus{
+			{
 				Name: name,
 				LastTerminationState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -24,13 +24,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
+	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
-	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/conformance/envpropagation_test.go
+++ b/test/conformance/envpropagation_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 const (
-	testKey = "testKey"
-	testValue = "testValue"
-	secretName = "test-secret"
+	testKey       = "testKey"
+	testValue     = "testValue"
+	secretName    = "test-secret"
 	configMapName = "test-configmap"
 )
 
@@ -43,7 +43,7 @@ func TestSecretsFromEnv(t *testing.T) {
 
 	//Creating test secret
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta {
+		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -95,7 +95,7 @@ func TestConfigsFromEnv(t *testing.T) {
 	err = fetchEnvironmentAndVerify(clients, logger, corev1.EnvVar{
 		Name: testKey,
 		ValueFrom: &corev1.EnvVarSource{
-			ConfigMapKeyRef: &corev1.ConfigMapKeySelector {
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: configMapName,
 				},
@@ -108,7 +108,7 @@ func TestConfigsFromEnv(t *testing.T) {
 	}
 }
 
-func fetchEnvironmentAndVerify(clients *test.Clients, logger *logging.BaseLogger, envVar corev1.EnvVar, cleanup func(clients *test.Clients) (error)) error {
+func fetchEnvironmentAndVerify(clients *test.Clients, logger *logging.BaseLogger, envVar corev1.EnvVar, cleanup func(clients *test.Clients) error) error {
 	resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageEnvVarsPath, &test.Options{
 		EnvVars: []corev1.EnvVar{envVar},
 	})

--- a/test/conformance/filesystem_perm_test.go
+++ b/test/conformance/filesystem_perm_test.go
@@ -34,7 +34,7 @@ func verifyPermString(resp string, expected string) error {
 	}
 
 	for index := range expected {
-		if string(expected[index]) != "*" && expected[index] != resp[index]  {
+		if string(expected[index]) != "*" && expected[index] != resp[index] {
 			return fmt.Errorf("Permission strings don't match at Index : %d. Expected : '%s' Received Response : '%s'",
 				index, expected, resp)
 		}
@@ -47,7 +47,7 @@ func TestMustFileSystemPermissions(t *testing.T) {
 	logger := logging.GetContextLogger("TestFileSystemPermissions")
 	clients := setup(t)
 	for key, value := range MustFilePathSpecs {
-		resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageFilePathInfoPath + "?" + test.EnvImageFilePathQueryParam + "=" + key, &test.Options{})
+		resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageFilePathInfoPath+"?"+test.EnvImageFilePathQueryParam+"="+key, &test.Options{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/conformance/runtime_contract_types.go
+++ b/test/conformance/runtime_contract_types.go
@@ -32,19 +32,19 @@ type MustEnvvars struct {
 
 // FilePathInfo data object returned by the environment test-image
 type FilePathInfo struct {
-	FilePath string `json: "FilePath"`
-	IsDirectory bool `json: "IsDirectory"`
-	PermString string `json: "PermString"`
+	FilePath    string `json: "FilePath"`
+	IsDirectory bool   `json: "IsDirectory"`
+	PermString  string `json: "PermString"`
 }
 
 // MustFilePathSpecs specifies the file-paths and expected permissions that MUST be set as specified in the run-time contract.
-var MustFilePathSpecs = map[string]FilePathInfo {
-	"/tmp" : FilePathInfo{
-		IsDirectory : true,
-		PermString: "rw*rw*rw*", // * indicates no specification
-	},
-	"/var/log" : FilePathInfo{
+var MustFilePathSpecs = map[string]FilePathInfo{
+	"/tmp": {
 		IsDirectory: true,
-		PermString: "rw*rw*rw*", // * indicates no specification
+		PermString:  "rw*rw*rw*", // * indicates no specification
+	},
+	"/var/log": {
+		IsDirectory: true,
+		PermString:  "rw*rw*rw*", // * indicates no specification
 	},
 }

--- a/test/image_constants.go
+++ b/test/image_constants.go
@@ -30,4 +30,3 @@ const EnvImageFilePathInfoPath = "/filepath"
 
 //EnvImageFilePathQueryParam query param to be used with EnvImageFilePathInfoPath to specify filepath
 const EnvImageFilePathQueryParam = "path"
-

--- a/test/test_images/environment/environment.go
+++ b/test/test_images/environment/environment.go
@@ -57,9 +57,9 @@ func filepathInfoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := json.Marshal(conformance.FilePathInfo{
-		FilePath: filePath,
+		FilePath:    filePath,
 		IsDirectory: info.IsDir(),
-		PermString: info.Mode().Perm().String(),
+		PermString:  info.Mode().Perm().String(),
 	})
 	if err != nil {
 		fmt.Fprintf(w, fmt.Sprintf("error building response : %v", err))
@@ -71,8 +71,8 @@ func filepathInfoHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 	log.Print("Environment test app started.")
-	test.ListenAndServeGracefullyWithPattern(fmt.Sprintf(":%d", test.EnvImageServerPort), map[string]func(w http.ResponseWriter, r *http.Request) {
-		test.EnvImageEnvVarsPath : envvarsHandler,
-		test.EnvImageFilePathInfoPath : filepathInfoHandler,
+	test.ListenAndServeGracefullyWithPattern(fmt.Sprintf(":%d", test.EnvImageServerPort), map[string]func(w http.ResponseWriter, r *http.Request){
+		test.EnvImageEnvVarsPath:      envvarsHandler,
+		test.EnvImageFilePathInfoPath: filepathInfoHandler,
 	})
 }


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
