### PR TITLE
Wait for informers to start to fix test flakes.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -725,6 +725,7 @@ func TestGlobalResyncOnConfigMapUpdate(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			controllerConfig := getTestControllerConfig()
 			kubeClient, servingClient, _, _, controller, kubeInformer, servingInformer, cachingInformer, watcher, _ := newTestControllerWithConfig(t, controllerConfig)
@@ -759,6 +760,10 @@ func TestGlobalResyncOnConfigMapUpdate(t *testing.T) {
 			servingInformer.Start(stopCh)
 			kubeInformer.Start(stopCh)
 			cachingInformer.Start(stopCh)
+
+			servingInformer.WaitForCacheSync(stopCh)
+			kubeInformer.WaitForCacheSync(stopCh)
+			cachingInformer.WaitForCacheSync(stopCh)
 
 			if err := watcher.Start(stopCh); err != nil {
 				t.Fatalf("Failed to start configuration manager: %v", err)

--- a/pkg/reconciler/v1alpha1/route/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/route/queueing_test.go
@@ -123,6 +123,9 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	servingInformer.Start(stopCh)
 	configMapWatcher.Start(stopCh)
 
+	kubeInformer.WaitForCacheSync(stopCh)
+	servingInformer.WaitForCacheSync(stopCh)
+
 	// Run the controller.
 	eg.Go(func() error {
 		return controller.Run(2, stopCh)

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -928,6 +928,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.expectedDomainSuffix, func(t *testing.T) {
 			_, servingClient, controller, _, kubeInformer, servingInformer, watcher := newTestSetup(t)
 
@@ -952,6 +953,10 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 
 			servingInformer.Start(stopCh)
 			kubeInformer.Start(stopCh)
+
+			servingInformer.WaitForCacheSync(stopCh)
+			kubeInformer.WaitForCacheSync(stopCh)
+
 			if err := watcher.Start(stopCh); err != nil {
 				t.Fatalf("failed to start configuration manager: %v", err)
 			}
@@ -962,8 +967,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			route := getTestRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
 			route.Labels = map[string]string{"app": "prod"}
 
-			routeClient := servingClient.ServingV1alpha1().Routes(route.Namespace)
-			routeClient.Create(route)
+			servingClient.ServingV1alpha1().Routes(route.Namespace).Create(route)
 
 			test.doThings(watcher)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2443 
Fixes #2462

Two very annoying unit test flakes, **hopefully** fixed.

## Proposed Changes

* Wait for the informers to actually start and sync before creating entities.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
