### PR TITLE
webhook can read kube config out of cluster

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"k8s.io/client-go/tools/clientcmd"
 	"log"
 	"net/http"
 	"time"
@@ -43,7 +44,6 @@ import (
 	"github.com/knative/serving/pkg/system"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 const (
@@ -64,6 +64,9 @@ const (
 )
 
 var (
+	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+
 	logger *zap.SugaredLogger
 
 	statSink *websocket.ManagedConnection
@@ -105,9 +108,9 @@ func main() {
 
 	logger.Info("Starting the knative activator")
 
-	clusterConfig, err := rest.InClusterConfig()
+	clusterConfig, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		logger.Fatal("Error getting in cluster configuration", zap.Error(err))
+		logger.Fatal("Error getting cluster configuration", zap.Error(err))
 	}
 	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/client-go/tools/clientcmd"
 	"log"
 	"net/http"
 	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/knative/serving/cmd/util"
 	"github.com/knative/serving/pkg/autoscaler"

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -64,12 +64,12 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+	clusterConfig, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		logger.Fatal("Error building kubeconfig: %v", err)
+		logger.Fatal("Failed to get cluster config", zap.Error(err))
 	}
 
-	kubeClient, err := kubernetes.NewForConfig(cfg)
+	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {
 		logger.Fatal("Failed to get the client set", zap.Error(err))
 	}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"k8s.io/client-go/tools/clientcmd"
 	"log"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"go.uber.org/zap"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes
webhook can read kube config out of cluster