### PR TITLE
Prohibit multiple entries for the same route name.

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -65,7 +65,9 @@ func (rs *RouteSpec) Validate() *apis.FieldError {
 		if ent, ok := trafficMap[tt.Name]; !ok {
 			// No entry exists, so add ours
 			trafficMap[tt.Name] = nt
-		} else if ent.r != nt.r || ent.c != nt.c {
+		} else {
+			// We want only single definition of the route, even if it points
+			// to the same config or revision.
 			errs = errs.Also(&apis.FieldError{
 				Message: fmt.Sprintf("Multiple definitions for %q", tt.Name),
 				Paths: []string{

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -221,7 +221,7 @@ func TestRouteSpecValidation(t *testing.T) {
 			Paths:   []string{"traffic[0].name", "traffic[1].name"},
 		},
 	}, {
-		name: "valid name collision (same revision)",
+		name: "collision (same revision)",
 		rs: &RouteSpec{
 			Traffic: []TrafficTarget{{
 				Name:         "foo",
@@ -233,7 +233,27 @@ func TestRouteSpecValidation(t *testing.T) {
 				Percent:      50,
 			}},
 		},
-		want: nil,
+		want: &apis.FieldError{
+			Message: `Multiple definitions for "foo"`,
+			Paths:   []string{"traffic[0].name", "traffic[1].name"},
+		},
+	}, {
+		name: "collision (same config)",
+		rs: &RouteSpec{
+			Traffic: []TrafficTarget{{
+				Name:              "foo",
+				ConfigurationName: "bar",
+				Percent:           50,
+			}, {
+				Name:              "foo",
+				ConfigurationName: "bar",
+				Percent:           50,
+			}},
+		},
+		want: &apis.FieldError{
+			Message: `Multiple definitions for "foo"`,
+			Paths:   []string{"traffic[0].name", "traffic[1].name"},
+		},
 	}, {
 		name: "invalid total percentage",
 		rs: &RouteSpec{

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -131,6 +131,10 @@ func TestRouteValidation(t *testing.T) {
 }
 
 func TestRouteSpecValidation(t *testing.T) {
+	multipleDefinitionError := &apis.FieldError{
+		Message: `Multiple definitions for "foo"`,
+		Paths:   []string{"traffic[0].name", "traffic[1].name"},
+	}
 	tests := []struct {
 		name string
 		rs   *RouteSpec
@@ -216,10 +220,7 @@ func TestRouteSpecValidation(t *testing.T) {
 				Percent:      50,
 			}},
 		},
-		want: &apis.FieldError{
-			Message: `Multiple definitions for "foo"`,
-			Paths:   []string{"traffic[0].name", "traffic[1].name"},
-		},
+		want: multipleDefinitionError,
 	}, {
 		name: "collision (same revision)",
 		rs: &RouteSpec{
@@ -233,10 +234,7 @@ func TestRouteSpecValidation(t *testing.T) {
 				Percent:      50,
 			}},
 		},
-		want: &apis.FieldError{
-			Message: `Multiple definitions for "foo"`,
-			Paths:   []string{"traffic[0].name", "traffic[1].name"},
-		},
+		want: multipleDefinitionError,
 	}, {
 		name: "collision (same config)",
 		rs: &RouteSpec{
@@ -250,10 +248,7 @@ func TestRouteSpecValidation(t *testing.T) {
 				Percent:           50,
 			}},
 		},
-		want: &apis.FieldError{
-			Message: `Multiple definitions for "foo"`,
-			Paths:   []string{"traffic[0].name", "traffic[1].name"},
-		},
+		want: multipleDefinitionError,
 	}, {
 		name: "invalid total percentage",
 		rs: &RouteSpec{


### PR DESCRIPTION
Even if the revision and/or configuration name is the same.
Old behavior is error prone and does not really add any benefit.


## Proposed Changes

* If the route name was see before, return an error, even if the config/rev name match.
