### PR TITLE
Increase default and max revision timeout.

### DIFF
--- a/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// DefaultTimeout will be set if timeout not specified.
-	DefaultTimeout = 5 * time.Minute
+	DefaultTimeout = 20 * time.Minute
 	// DefaultRetryCount will be set if Attempts not specified.
 	DefaultRetryCount = 3
 )

--- a/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// DefaultTimeout will be set if timeout not specified.
-	DefaultTimeout = 20 * time.Minute
+	DefaultTimeout = 10 * time.Minute
 	// DefaultRetryCount will be set if Attempts not specified.
 	DefaultRetryCount = 3
 )

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -18,7 +18,7 @@ package v1alpha1
 
 const (
 	// defaultTimeoutSeconds will be set if timeoutSeconds not specified.
-	defaultTimeoutSeconds = 60
+	defaultTimeoutSeconds = 5 * 60
 )
 
 func (r *Revision) SetDefaults() {

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -548,9 +548,9 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: corev1.Container{
 				Image: "helloworld",
 			},
-			TimeoutSeconds: 600,
+			TimeoutSeconds: 6000,
 		},
-		want: apis.ErrOutOfBoundsValue("600s", "0s",
+		want: apis.ErrOutOfBoundsValue("6000s", "0s",
 			fmt.Sprintf("%ds", int(netv1alpha1.DefaultTimeout.Seconds())),
 			"timeoutSeconds"),
 	}, {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Bump the default and the max revision timeout, since 1min/5min seems small for some application.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
