### PR TITLE
Add 'WaitForCacheSync' to another flaky test.

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -359,6 +359,9 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 		t.Fatalf("failed to start cluster ingress manager: %v", err)
 	}
 
+	servingInformer.WaitForCacheSync(stopCh)
+	sharedInformer.WaitForCacheSync(stopCh)
+
 	go controller.Run(1, stopCh)
 
 	ingress := ingressWithStatus("config-update", 1234,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Same PR as the last on basically. Did a search for all tests starting these informers this time. Every test that starts an informer **and** then tries to create entities now has the WaitForCacheSync call in it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
