### PR TITLE
Print more information when creating a revision

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -34,6 +34,7 @@ import (
 	configns "github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/config"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources"
 	resourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources/names"
+	errutil "github.com/pkg/errors"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -276,7 +277,7 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1alpha1.Config
 			LabelSelector: fmt.Sprintf("%s=%s", serving.BuildHashLabelKey, buildHash),
 		})
 		if err != nil {
-			return nil, err
+			return nil, errutil.Wrapf(err, "Failed to list GroupVersionResource %+v", gvr)
 		}
 
 		var result *unstructured.Unstructured
@@ -287,7 +288,7 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1alpha1.Config
 			// Otherwise, create a build and reference that.
 			result, err = c.DynamicClientSet.Resource(gvr).Namespace(build.GetNamespace()).Create(build)
 			if err != nil {
-				return nil, err
+				return nil, errutil.Wrapf(err, "Failed to create Build %v", build.GetName())
 			}
 			logger.Infof("Created Build:\n%+v", result.GetName())
 			c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Build %q", result.GetName())

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -252,11 +252,11 @@ func TestReconcile(t *testing.T) {
 			Object: cfg("create-build-failure", "foo", 99998, WithBuild,
 				// When we fail to create a Build it should be surfaced in
 				// the Configuration status.
-				MarkRevisionCreationFailed("inducing failure for create builds")),
+				MarkRevisionCreationFailed(fmt.Sprintf("Failed to create Build %v: %v", "create-build-failure-99998", "inducing failure for create builds"))),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision %q: %v",
-				"create-build-failure-99998", "inducing failure for create builds"),
+				"create-build-failure-99998", fmt.Sprintf("Failed to create Build %v: %v", "create-build-failure-99998", "inducing failure for create builds")),
 		},
 		Key: "foo/create-build-failure",
 	}, {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes insufficient logging when creating Build as part of creating Revision.

## Proposed Changes

* Print some additional information immediately when getting the error.

## Additional information

When some resources are missing and still required for creating a Build as part of creating a Revision (e.g. CRDs such as builds.testing.internal.knative.dev from test/config/300-build.yaml) the controller prints insufficient information. Basically it prints something like `"msg":"Failed to create Revision \"prodpwvlvlcm-00001\": the server could not find the requested resource","knative.dev/controller":"configuration-controller","knative.dev/key":"serving-tests`
It is not clear from the message which resource is missing.
