### PR TITLE
Fix checkMapKeysNotPresent to checkNoKeysPresent and log the offending keys

### DIFF
--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -79,7 +79,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 	}
 
 	err = test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
-		return checkMapKeysNotPresent(cfg.Labels, r.Labels), nil
+		return checkKeysPresent(cfg.Labels, r.Labels, t), nil
 	})
 	if err != nil {
 		t.Errorf("The labels for Revision %s of Configuration %s should not have been updated: %v", names.Revision, names.Config, err)
@@ -107,7 +107,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 	}
 
 	err = test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
-		return checkMapKeysNotPresent(cfg.Annotations, r.Annotations), nil
+		return checkKeysPresent(cfg.Annotations, r.Annotations, t), nil
 	})
 	if err != nil {
 		t.Errorf("The annotations for Revision %s of Configuration %s should not have been updated: %v", names.Revision, names.Config, err)
@@ -146,11 +146,19 @@ func waitForConfigurationAnnotationsUpdate(clients *test.Clients, names test.Res
 	}, "ConfigurationMetadataUpdatedWithAnnotations")
 }
 
-func checkMapKeysNotPresent(expected map[string]string, actual map[string]string) bool {
+// checkKeysPresent returns true if all the keys from `expected` are present in `actual`.
+// checkKeysPresent logs to `t.Log` all the missing keys.
+func checkKeysPresent(expected map[string]string, actual map[string]string, t *testing.T) bool {
+	t.Helper()
+	m := []string{}
 	for k := range expected {
 		if _, ok := actual[k]; ok {
-			return false
+			m = append(m, k)
 		}
+	}
+	if len(m) > 0 {
+		t.Logf("The following keys were missing: %v", m)
+		return false
 	}
 	return true
 }

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -152,7 +152,7 @@ func checkKeysPresent(expected map[string]string, actual map[string]string, t *t
 	t.Helper()
 	m := []string{}
 	for k := range expected {
-		if _, ok := actual[k]; ok {
+		if _, ok := actual[k]; !ok {
 			m = append(m, k)
 		}
 	}

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -79,7 +79,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 	}
 
 	err = test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
-		return checkKeysPresent(cfg.Labels, r.Labels, t), nil
+		return checkNoKeysPresent(cfg.Labels, r.Labels, t), nil
 	})
 	if err != nil {
 		t.Errorf("The labels for Revision %s of Configuration %s should not have been updated: %v", names.Revision, names.Config, err)
@@ -107,7 +107,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 	}
 
 	err = test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
-		return checkKeysPresent(cfg.Annotations, r.Annotations, t), nil
+		return checkNoKeysPresent(cfg.Annotations, r.Annotations, t), nil
 	})
 	if err != nil {
 		t.Errorf("The annotations for Revision %s of Configuration %s should not have been updated: %v", names.Revision, names.Config, err)
@@ -146,19 +146,16 @@ func waitForConfigurationAnnotationsUpdate(clients *test.Clients, names test.Res
 	}, "ConfigurationMetadataUpdatedWithAnnotations")
 }
 
-// checkKeysPresent returns true if all the keys from `expected` are present in `actual`.
-// checkKeysPresent logs to `t.Log` all the missing keys.
-func checkKeysPresent(expected map[string]string, actual map[string]string, t *testing.T) bool {
+// checkNoKeysPresent returns true if _no_ keys from `expected`, are present in `actual`.
+// checkNoKeysPresent will log the offending keys to t.Log.
+func checkNoKeysPresent(expected map[string]string, actual map[string]string, t *testing.T) bool {
 	t.Helper()
-	m := []string{}
+	present := []string{}
 	for k := range expected {
-		if _, ok := actual[k]; !ok {
-			m = append(m, k)
+		if _, ok := actual[k]; ok {
+			present = append(present, k)
 		}
 	}
-	if len(m) > 0 {
-		t.Logf("The following keys were missing: %v", m)
-		return false
-	}
-	return true
+	t.Logf("Unexpected keys: %v", present)
+	return len(present) == 0
 }


### PR DESCRIPTION
## Proposed Changes
1.Rename the function to be more explicit.
2. Make it log to t.Log the offending keys, since that helps with
   debugging as well.
3. Verified the test still passes.

/lint
