### PR TITLE
Fail with "Reason: NotOwned" when a sub-resource name is taken.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -191,6 +192,13 @@ func (rs *PodAutoscalerStatus) MarkActivating(reason, message string) {
 
 func (rs *PodAutoscalerStatus) MarkInactive(reason, message string) {
 	podCondSet.Manage(rs).MarkFalse(PodAutoscalerConditionActive, reason, message)
+}
+
+// MarkResourceNotOwned changes the "Active" condition to false to reflect that the
+// resource of the given kind and name has already been created, and we do not own it.
+func (rs *PodAutoscalerStatus) MarkResourceNotOwned(kind, name string) {
+	rs.MarkInactive("NotOwned",
+		fmt.Sprintf("There is an existing %s %q that we do not own.", kind, name))
 }
 
 // CanScaleToZero checks whether the pod autoscaler has been in an inactive state

--- a/pkg/apis/networking/v1alpha1/clusteringress_types.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -346,6 +348,13 @@ func (cis *IngressStatus) InitializeConditions() {
 
 func (cis *IngressStatus) MarkNetworkConfigured() {
 	clusterIngressCondSet.Manage(cis).MarkTrue(ClusterIngressConditionNetworkConfigured)
+}
+
+// MarkResourceNotOwned changes the "NetworkConfigured" condition to false to reflect that the
+// resource of the given kind and name has already been created, and we do not own it.
+func (cis *IngressStatus) MarkResourceNotOwned(kind, name string) {
+	clusterIngressCondSet.Manage(cis).MarkFalse(ClusterIngressConditionNetworkConfigured, "NotOwned",
+		fmt.Sprintf("There is an existing %s %q that we do not own.", kind, name))
 }
 
 // MarkLoadBalancerReady marks the Ingress with ClusterIngressConditionLoadBalancerReady,

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -352,6 +352,13 @@ func (rs *RevisionStatus) PropagateBuildStatus(bs duckv1alpha1.KResourceStatus) 
 	}
 }
 
+// MarkResourceNotOwned changes the "ResourcesAvailable" condition to false to reflect that the
+// resource of the given kind and name has already been created, and we do not own it.
+func (rs *RevisionStatus) MarkResourceNotOwned(kind, name string) {
+	revCondSet.Manage(rs).MarkFalse(RevisionConditionResourcesAvailable, "NotOwned",
+		fmt.Sprintf("There is an existing %s %q that we do not own.", kind, name))
+}
+
 func (rs *RevisionStatus) MarkDeploying(reason string) {
 	revCondSet.Manage(rs).MarkUnknown(RevisionConditionResourcesAvailable, reason, "")
 	revCondSet.Manage(rs).MarkUnknown(RevisionConditionContainerHealthy, reason, "")

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -544,6 +544,24 @@ func TestTypicalFlowWithSuspendResume(t *testing.T) {
 	checkConditionSucceededRevision(r.Status, RevisionConditionReady, t)
 }
 
+func TestRevisionNotOwnedStuff(t *testing.T) {
+	r := &Revision{}
+	r.Status.InitializeConditions()
+	checkConditionOngoingRevision(r.Status, RevisionConditionBuildSucceeded, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionResourcesAvailable, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionContainerHealthy, t)
+	checkConditionOngoingRevision(r.Status, RevisionConditionReady, t)
+
+	want := "NotOwned"
+	r.Status.MarkResourceNotOwned("Resource", "mark")
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionResourcesAvailable, t); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+	if got := checkConditionFailedRevision(r.Status, RevisionConditionReady, t); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+}
+
 func checkConditionSucceededRevision(rs RevisionStatus, rct duckv1alpha1.ConditionType, t *testing.T) *duckv1alpha1.Condition {
 	t.Helper()
 	return checkConditionRevision(rs, rct, corev1.ConditionTrue, t)

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -179,6 +181,13 @@ func (rs *RouteStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.
 
 func (rs *RouteStatus) InitializeConditions() {
 	routeCondSet.Manage(rs).InitializeConditions()
+}
+
+// MarkServiceNotOwned changes the IngressReady status to be false with the reason being that
+// there is a pre-existing placeholder service with the name we wanted to use.
+func (rs *RouteStatus) MarkServiceNotOwned(name string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionIngressReady, "NotOwned",
+		fmt.Sprintf("There is an existing placeholder Service %q that we do not own.", name))
 }
 
 func (rs *RouteStatus) MarkTrafficAssigned() {

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -237,6 +239,21 @@ func (ss *ServiceStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha
 // InitializeConditions sets the initial values to the conditions.
 func (ss *ServiceStatus) InitializeConditions() {
 	serviceCondSet.Manage(ss).InitializeConditions()
+}
+
+// MarkConfigurationNotOwned surfaces a failure via the ConfigurationsReady
+// status noting that the Configuration with the name we want has already
+// been created and we do not own it.
+func (ss *ServiceStatus) MarkConfigurationNotOwned(name string) {
+	serviceCondSet.Manage(ss).MarkFalse(ServiceConditionConfigurationsReady, "NotOwned",
+		fmt.Sprintf("There is an existing Configuration %q that we do not own.", name))
+}
+
+// MarkRouteNotOwned surfaces a failure via the RoutesReady status noting that the Route
+// with the name we want has already been created and we do not own it.
+func (ss *ServiceStatus) MarkRouteNotOwned(name string) {
+	serviceCondSet.Manage(ss).MarkFalse(ServiceConditionRoutesReady, "NotOwned",
+		fmt.Sprintf("There is an existing Route %q that we do not own.", name))
 }
 
 // PropagateConfigurationStatus takes the Configuration status and applies its values

--- a/pkg/apis/serving/v1alpha1/service_types_test.go
+++ b/pkg/apis/serving/v1alpha1/service_types_test.go
@@ -507,6 +507,31 @@ func TestRouteUnknownPropagation(t *testing.T) {
 	checkConditionSucceededService(svc.Status, ServiceConditionConfigurationsReady, t)
 }
 
+func TestServiceNotOwnedStuff(t *testing.T) {
+	svc := &Service{}
+	svc.Status.InitializeConditions()
+	checkConditionOngoingService(svc.Status, ServiceConditionReady, t)
+	checkConditionOngoingService(svc.Status, ServiceConditionConfigurationsReady, t)
+	checkConditionOngoingService(svc.Status, ServiceConditionRoutesReady, t)
+
+	want := "NotOwned"
+	svc.Status.MarkRouteNotOwned("mark")
+	if got := checkConditionFailedService(svc.Status, ServiceConditionRoutesReady, t); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+	if got := checkConditionFailedService(svc.Status, ServiceConditionReady, t); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+
+	svc.Status.MarkConfigurationNotOwned("jon")
+	if got := checkConditionFailedService(svc.Status, ServiceConditionConfigurationsReady, t); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+	if got := checkConditionFailedService(svc.Status, ServiceConditionReady, t); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+}
+
 func TestRouteStatusPropagation(t *testing.T) {
 	svc := &Service{}
 	svc.Status.PropagateRouteStatus(RouteStatus{

--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv1informers "k8s.io/client-go/informers/autoscaling/v1"
 	autoscalingv1listers "k8s.io/client-go/listers/autoscaling/v1"
@@ -154,6 +155,10 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 	} else if err != nil {
 		logger.Errorf("Error getting existing HPA %q: %v", desiredHpa.Name, err)
 		return err
+	} else if !metav1.IsControlledBy(hpa, pa) {
+		// Surface an error in the PodAutoscaler's status, and return an error.
+		pa.Status.MarkResourceNotOwned("HorizontalPodAutoscaler", desiredHpa.Name)
+		return fmt.Errorf("PodAutoscaler: %q does not own HPA: %q", pa.Name, desiredHpa.Name)
 	} else {
 		if !equality.Semantic.DeepEqual(desiredHpa.Spec, hpa.Spec) {
 			logger.Infof("Updating HPA %q", desiredHpa.Name)

--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -58,6 +58,10 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 	} else if err != nil {
 		logger.Errorf("Error reconciling deployment %q: %v", deploymentName, err)
 		return err
+	} else if !metav1.IsControlledBy(deployment, rev) {
+		// Surface an error in the revision's status, and return an error.
+		rev.Status.MarkResourceNotOwned("Deployment", deploymentName)
+		return fmt.Errorf("Revision: %q does not own Deployment: %q", rev.Name, deploymentName)
 	} else {
 		// The deployment exists, but make sure that it has the shape that we expect.
 		deployment, _, err = c.checkAndUpdateDeployment(ctx, rev, deployment)
@@ -133,6 +137,10 @@ func (c *Reconciler) reconcileKPA(ctx context.Context, rev *v1alpha1.Revision) e
 	} else if getKPAErr != nil {
 		logger.Errorf("Error reconciling kpa %q: %v", kpaName, getKPAErr)
 		return getKPAErr
+	} else if !metav1.IsControlledBy(kpa, rev) {
+		// Surface an error in the revision's status, and return an error.
+		rev.Status.MarkResourceNotOwned("PodAutoscaler", kpaName)
+		return fmt.Errorf("Revision: %q does not own PodAutoscaler: %q", rev.Name, kpaName)
 	}
 
 	// Reflect the KPA status in our own.
@@ -171,6 +179,10 @@ func (c *Reconciler) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 	} else if err != nil {
 		logger.Errorf("Error reconciling Active Service %q: %v", serviceName, err)
 		return err
+	} else if !metav1.IsControlledBy(service, rev) {
+		// Surface an error in the revision's status, and return an error.
+		rev.Status.MarkResourceNotOwned("Service", serviceName)
+		return fmt.Errorf("Revision: %q does not own Service: %q", rev.Name, serviceName)
 	} else {
 		// If it exists, then make sure if looks as we expect.
 		// It may change if a user edits things around our controller, which we

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -647,7 +647,7 @@ func TestReconcile(t *testing.T) {
 				// When we're missing the OwnerRef for PodAutoscaler we see this update.
 				MarkResourceNotOwned("PodAutoscaler", "missing-owners")),
 		}},
-		// TODO(mattmoor): This seems strange.
+		// TODO(#2900): This should not fire, we're not ready!
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "RevisionReady", "Revision becomes ready upon endpoint %q becoming ready",
 				"missing-owners-service"),

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -588,6 +588,90 @@ func TestReconcile(t *testing.T) {
 				WithSucceededFalse("SomeReason", "This is why the build failed.")),
 		},
 		Key: "foo/failed-build-stable",
+	}, {
+		Name: "ready steady state",
+		// Test the transition that Reconcile makes when Endpoints become ready.
+		// This puts the world into the stable post-reconcile state for an Active
+		// Revision.  It then creates an Endpoints resource with active subsets.
+		// This signal should make our Reconcile mark the Revision as Ready.
+		Objects: []runtime.Object{
+			rev("foo", "steady-ready", WithK8sServiceName, WithLogURL,
+				// When the endpoint and KPA are ready, then we will see the
+				// Revision become ready.
+				MarkRevisionReady),
+			kpa("foo", "steady-ready", WithTraffic),
+			deploy("foo", "steady-ready"),
+			svc("foo", "steady-ready"),
+			endpoints("foo", "steady-ready", WithSubsets),
+			image("foo", "steady-ready"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "RevisionReady", "Revision becomes ready upon endpoint %q becoming ready",
+				"steady-ready-service"),
+		},
+		Key: "foo/steady-ready",
+	}, {
+		Name:    "lost service owner ref",
+		WantErr: true,
+		Objects: []runtime.Object{
+			rev("foo", "missing-owners", WithK8sServiceName, WithLogURL,
+				MarkRevisionReady),
+			kpa("foo", "missing-owners", WithTraffic),
+			deploy("foo", "missing-owners"),
+			svc("foo", "missing-owners", WithK8sSvcOwnersRemoved),
+			endpoints("foo", "missing-owners", WithSubsets),
+			image("foo", "missing-owners"),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rev("foo", "missing-owners", WithK8sServiceName, WithLogURL,
+				MarkRevisionReady,
+				// When we're missing the OwnerRef for Service we see this update.
+				MarkResourceNotOwned("Service", "missing-owners-service")),
+		}},
+		Key: "foo/missing-owners",
+	}, {
+		Name:    "lost kpa owner ref",
+		WantErr: true,
+		Objects: []runtime.Object{
+			rev("foo", "missing-owners", WithK8sServiceName, WithLogURL,
+				MarkRevisionReady),
+			kpa("foo", "missing-owners", WithTraffic, WithPodAutoscalerOwnersRemoved),
+			deploy("foo", "missing-owners"),
+			svc("foo", "missing-owners"),
+			endpoints("foo", "missing-owners", WithSubsets),
+			image("foo", "missing-owners"),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rev("foo", "missing-owners", WithK8sServiceName, WithLogURL,
+				MarkRevisionReady,
+				// When we're missing the OwnerRef for PodAutoscaler we see this update.
+				MarkResourceNotOwned("PodAutoscaler", "missing-owners")),
+		}},
+		// TODO(mattmoor): This seems strange.
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "RevisionReady", "Revision becomes ready upon endpoint %q becoming ready",
+				"missing-owners-service"),
+		},
+		Key: "foo/missing-owners",
+	}, {
+		Name:    "lost deployment owner ref",
+		WantErr: true,
+		Objects: []runtime.Object{
+			rev("foo", "missing-owners", WithK8sServiceName, WithLogURL,
+				MarkRevisionReady),
+			kpa("foo", "missing-owners", WithTraffic),
+			noOwner(deploy("foo", "missing-owners")),
+			svc("foo", "missing-owners"),
+			endpoints("foo", "missing-owners", WithSubsets),
+			image("foo", "missing-owners"),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rev("foo", "missing-owners", WithK8sServiceName, WithLogURL,
+				MarkRevisionReady,
+				// When we're missing the OwnerRef for Deployment we see this update.
+				MarkResourceNotOwned("Deployment", "missing-owners-deployment")),
+		}},
+		Key: "foo/missing-owners",
 	}}
 
 	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {
@@ -752,6 +836,11 @@ func timeoutDeploy(deploy *appsv1.Deployment) *appsv1.Deployment {
 		Status: corev1.ConditionFalse,
 		Reason: "ProgressDeadlineExceeded",
 	}}
+	return deploy
+}
+
+func noOwner(deploy *appsv1.Deployment) *appsv1.Deployment {
+	deploy.OwnerReferences = nil
 	return deploy
 }
 

--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -75,7 +76,9 @@ func (c *Reconciler) reconcileClusterIngress(
 		c.Recorder.Eventf(r, corev1.EventTypeNormal, "Created",
 			"Created ClusterIngress %q", clusterIngress.Name)
 		return clusterIngress, nil
-	} else if err == nil {
+	} else if err != nil {
+		return nil, err
+	} else {
 		// TODO(#642): Remove this (needed to avoid continuous updates)
 		desired.Spec.Generation = clusterIngress.Spec.Generation
 		if !equality.Semantic.DeepEqual(clusterIngress.Spec, desired.Spec) {
@@ -121,6 +124,10 @@ func (c *Reconciler) reconcilePlaceholderService(ctx context.Context, route *v1a
 		c.Recorder.Eventf(route, corev1.EventTypeNormal, "Created", "Created service %q", name)
 	} else if err != nil {
 		return err
+	} else if !metav1.IsControlledBy(service, route) {
+		// Surface an error in the route's status, and return an error.
+		route.Status.MarkServiceNotOwned(name)
+		return fmt.Errorf("Route: %q does not own Service: %q", route.Name, name)
 	} else {
 		// Make sure that the service has the proper specification.
 		if !equality.Semantic.DeepEqual(service.Spec, desiredService.Spec) {

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -369,7 +369,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "config", 1, MarkRevisionReady),
 			simpleReadyIngress(
 				route("default", "unhappy-owner", WithConfigTarget("config"), WithDomain),
-				&traffic.TrafficConfig{
+				&traffic.Config{
 					Targets: map[string][]traffic.RevisionTarget{
 						"": {{
 							TrafficTarget: v1alpha1.TrafficTarget{

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -351,6 +351,53 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "default/steady-state",
 	}, {
+		Name:    "unhappy about ownership of placeholder service",
+		WantErr: true,
+		Objects: []runtime.Object{
+			route("default", "unhappy-owner", WithConfigTarget("config"),
+				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1alpha1.TrafficTarget{
+						RevisionName: "config-00001",
+						Percent:      100,
+					})),
+			cfg("default", "config",
+				WithGeneration(1), WithLatestCreated, WithLatestReady,
+				// The Route controller attaches our label to this Configuration.
+				WithConfigLabel("serving.knative.dev/route", "unhappy-owner"),
+			),
+			rev("default", "config", 1, MarkRevisionReady),
+			simpleReadyIngress(
+				route("default", "unhappy-owner", WithConfigTarget("config"), WithDomain),
+				&traffic.TrafficConfig{
+					Targets: map[string][]traffic.RevisionTarget{
+						"": {{
+							TrafficTarget: v1alpha1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: rev("default", "config", 1).Name,
+								Percent:      100,
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
+			simpleK8sService(route("default", "unhappy-owner", WithConfigTarget("config")),
+				WithK8sSvcOwnersRemoved),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: route("default", "unhappy-owner", WithConfigTarget("config"),
+				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1alpha1.TrafficTarget{
+						RevisionName: "config-00001",
+						Percent:      100,
+					}),
+				// The owner is not us, so we are unhappy.
+				MarkServiceNotOwned),
+		}},
+		Key: "default/unhappy-owner",
+	}, {
 		// This tests that when the Route is labelled differently, it is configured with a
 		// different domain from config-domain.yaml.  This is otherwise a copy of the steady
 		// state test above.

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -535,7 +535,7 @@ func TestReconcile(t *testing.T) {
 				WithInitSvcConditions, MarkRouteNotOwned),
 		}},
 	}, {
-		Name: "runLatest - route and config ready, propagate ready",
+		Name: "runLatest - correct not owned by adding owner refs",
 		// If ready Route/Configuration that weren't owned have OwnerReferences attached,
 		// then a Reconcile will result in the Service becoming happy.
 		Objects: []runtime.Object{

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -507,6 +507,69 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "route-fails"),
 		},
+	}, {
+		Name:    "runLatest - not owned config exists",
+		WantErr: true,
+		Objects: []runtime.Object{
+			svc("run-latest", "foo", WithRunLatestRollout),
+			config("run-latest", "foo", WithRunLatestRollout, WithConfigOwnersRemoved),
+		},
+		Key: "foo/run-latest",
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: svc("run-latest", "foo", WithRunLatestRollout,
+				// The first reconciliation will initialize the status conditions.
+				WithInitSvcConditions, MarkConfigurationNotOwned),
+		}},
+	}, {
+		Name:    "runLatest - not owned route exists",
+		WantErr: true,
+		Objects: []runtime.Object{
+			svc("run-latest", "foo", WithRunLatestRollout),
+			config("run-latest", "foo", WithRunLatestRollout),
+			route("run-latest", "foo", WithRunLatestRollout, WithRouteOwnersRemoved),
+		},
+		Key: "foo/run-latest",
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: svc("run-latest", "foo", WithRunLatestRollout,
+				// The first reconciliation will initialize the status conditions.
+				WithInitSvcConditions, MarkRouteNotOwned),
+		}},
+	}, {
+		Name: "runLatest - route and config ready, propagate ready",
+		// If ready Route/Configuration that weren't owned have OwnerReferences attached,
+		// then a Reconcile will result in the Service becoming happy.
+		Objects: []runtime.Object{
+			svc("new-owner", "foo", WithRunLatestRollout, WithInitSvcConditions,
+				// This service was unhappy with the prior owner situation.
+				MarkConfigurationNotOwned, MarkRouteNotOwned),
+			// The service owns these, which should result in a happy result.
+			route("new-owner", "foo", WithRunLatestRollout, RouteReady,
+				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
+				WithStatusTraffic(v1alpha1.TrafficTarget{
+					RevisionName: "new-owner-00001",
+					Percent:      100,
+				}), MarkTrafficAssigned, MarkIngressReady),
+			config("new-owner", "foo", WithRunLatestRollout, WithGeneration(1),
+				// These turn a Configuration to Ready=true
+				WithLatestCreated, WithLatestReady),
+		},
+		Key: "foo/new-owner",
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: svc("new-owner", "foo", WithRunLatestRollout,
+				WithReadyConfig("new-owner-00001"),
+				// The delta induced by route object.
+				WithReadyRoute, WithSvcStatusDomain, WithSvcStatusAddress,
+				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
+					RevisionName: "new-owner-00001",
+					Percent:      100,
+				})),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "new-owner"),
+		},
+		WantServiceReadyStats: map[string]int{
+			"foo/new-owner": 1,
+		},
 	}}
 
 	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -28,6 +28,8 @@ import (
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	confignames "github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources/names"
+	routenames "github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
+	servicenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -111,6 +113,16 @@ func WithServiceLabel(key, value string) ServiceOption {
 		}
 		service.Labels[key] = value
 	}
+}
+
+// MarkConfigurationNotOwned calls the function of the same name on the Service's status.
+func MarkConfigurationNotOwned(service *v1alpha1.Service) {
+	service.Status.MarkConfigurationNotOwned(servicenames.Configuration(service))
+}
+
+// MarkRouteNotOwned calls the function of the same name on the Service's status.
+func MarkRouteNotOwned(service *v1alpha1.Service) {
+	service.Status.MarkRouteNotOwned(servicenames.Route(service))
 }
 
 // WithPinnedRollout configures the Service to use a "pinned" rollout,
@@ -283,6 +295,16 @@ func WithStatusTraffic(traffic ...v1alpha1.TrafficTarget) RouteOption {
 	}
 }
 
+// WithRouteOwnersRemoved clears the owner references of this Route.
+func WithRouteOwnersRemoved(r *v1alpha1.Route) {
+	r.OwnerReferences = nil
+}
+
+// MarkServiceNotOwned calls the function of the same name on the Service's status.
+func MarkServiceNotOwned(r *v1alpha1.Route) {
+	r.Status.MarkServiceNotOwned(routenames.K8sService(r))
+}
+
 // WithDomain sets the .Status.Domain field to the prototypical domain.
 func WithDomain(r *v1alpha1.Route) {
 	r.Status.Domain = fmt.Sprintf("%s.%s.example.com", r.Name, r.Namespace)
@@ -386,6 +408,11 @@ func WithBuild(cfg *v1alpha1.Configuration) {
 	}
 }
 
+// WithConfigOwnersRemoved clears the owner references of this Configuration.
+func WithConfigOwnersRemoved(cfg *v1alpha1.Configuration) {
+	cfg.OwnerReferences = nil
+}
+
 // WithConfigConcurrencyModel sets the given Configuration's concurrency model.
 func WithConfigConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) ConfigOption {
 	return func(cfg *v1alpha1.Configuration) {
@@ -460,6 +487,13 @@ func WithBuildRef(name string) RevisionOption {
 			Kind:       "Build",
 			Name:       name,
 		}
+	}
+}
+
+// MarkResourceNotOwned calls the function of the same name on the Revision's status.
+func MarkResourceNotOwned(kind, name string) RevisionOption {
+	return func(rev *v1alpha1.Revision) {
+		rev.Status.MarkResourceNotOwned(kind, name)
 	}
 }
 
@@ -618,6 +652,11 @@ func MarkRevisionReady(r *v1alpha1.Revision) {
 
 type PodAutoscalerOption func(*autoscalingv1alpha1.PodAutoscaler)
 
+// WithPodAutoscalerOwnersRemoved clears the owner references of this PodAutoscaler.
+func WithPodAutoscalerOwnersRemoved(r *autoscalingv1alpha1.PodAutoscaler) {
+	r.OwnerReferences = nil
+}
+
 // WithTraffic updates the PA to reflect it receiving traffic.
 func WithTraffic(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.Status.MarkActive()
@@ -704,6 +743,11 @@ func WithExternalName(name string) K8sServiceOption {
 	return func(svc *corev1.Service) {
 		svc.Spec.ExternalName = name
 	}
+}
+
+// WithK8sSvcOwnersRemoved clears the owner references of this Route.
+func WithK8sSvcOwnersRemoved(svc *corev1.Service) {
+	svc.OwnerReferences = nil
 }
 
 // EndpointsOption enables further configuration of the Kubernetes Endpoints.


### PR DESCRIPTION
In a number of places we rely on fixed names for sub-resources.  In many of those places we potentially mutate the named object regardless of whether we own it.

With this change, in each place I could find (where we rely on fixed naming) we check `metav1.IsControllerBy(it, us)` and if false, we record a negative status because we do not own the child resource.

e.g. something like:
```yaml
conditions:
 - type: Ready
   state: False
   reason: NotOwned
   message: There is an existing Deployment "foo-deployment" that we do not own.
```

Fixes: https://github.com/knative/serving/issues/1299

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
