### PR TITLE
Fix timer allocation and expand timeouts in TestScaleToX.

### DIFF
--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -111,7 +111,7 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 	}()
 
 	logger.Info("Reached for loop")
-	timeoutCh := time.After(duration)
+	//timeoutCh := time.After(duration)
 	for {
 		select {
 		case names := <-cleanupCh:
@@ -140,7 +140,7 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 			t.Fatalf("An error occured during the test: %v", err)
 			logger.Info("Done err channel")
 
-		case <-timeoutCh:
+		case <-time.After(duration):
 			logger.Info("Received timeout channel")
 			t.Fatalf("Timed out waiting for %d services to become ready", scale)
 			logger.Info("Done timeout channel")

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -102,10 +102,7 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 	}
 
 	go func() {
-		err := deployGrp.Wait()
-		logger.Info("Finished service creation.")
-
-		if err != nil {
+		if err := deployGrp.Wait(); err != nil {
 			logger.Errorf("An error occurred during service creation: %v", err)
 			errCh <- errors.Wrap(err, "error waiting for endpoints to become ready")
 		} else {
@@ -119,7 +116,7 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 	for {
 		select {
 		case names := <-cleanupCh:
-			logger.Infof("Added %v to cleanup routine.")
+			logger.Infof("Added %v to cleanup routine.", names)
 			test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
 			defer TearDown(clients, names, logger)
 

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -158,7 +158,7 @@ func TestScaleTo10(t *testing.T) {
 	//add test case specific name to its own logger
 	logger := logging.GetContextLogger("TestScaleTo10")
 
-	testScaleToWithin(t, logger, 10, 90*time.Second)
+	testScaleToWithin(t, logger, 10, 30*time.Second)
 }
 
 func TestScaleTo50(t *testing.T) {

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -139,7 +139,7 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 		case err := <-errCh:
 			t.Fatalf("An error occured during the test: %v", err)
 
-		case timeoutCh:
+		case <-timeoutCh:
 			logger.Error("Timeout.")
 			t.Fatalf("Timed out waiting for %d services to become ready", scale)
 		}

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -140,6 +140,7 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 			t.Fatalf("An error occured during the test: %v", err)
 
 		case timeoutCh:
+			logger.Error("Timeout.")
 			t.Fatalf("Timed out waiting for %d services to become ready", scale)
 		}
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2890

This adds some output to the checkloop to be able to tell which signals are reaching there.

It also fixes a bug where the test timeout timer was allocated multiple times, skewing its results.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
