### PR TITLE
replacing hard coded cluster.local with variable

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/system"
+	"github.com/knative/serving/pkg/utils"
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
@@ -302,7 +303,7 @@ func main() {
 	}()
 
 	// Open a websocket connection to the autoscaler
-	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s:%d", servingAutoscaler, system.Namespace, servingAutoscalerPort)
+	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.%s:%d", servingAutoscaler, system.Namespace, utils.GetClusterDomainName(), servingAutoscalerPort)
 	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter()

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -27,6 +27,7 @@ import (
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	revisionresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
+	"github.com/knative/serving/pkg/utils"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,7 +120,7 @@ func (r *revisionActivator) getRevisionEndpoint(revision *v1alpha1.Revision) (en
 		return end, errors.Wrapf(err, "Unable to get service %s for revision", serviceName)
 	}
 
-	fqdn := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, revision.Namespace)
+	fqdn := fmt.Sprintf("%s.%s.svc.%s", serviceName, revision.Namespace, utils.GetClusterDomainName())
 
 	// Search for the correct port in all the service ports.
 	port := int32(-1)

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -16,10 +16,17 @@ limitations under the License.
 
 package reconciler
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/knative/eventing/pkg/utils"
+)
 
 func GetK8sServiceFullname(name string, namespace string) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace)
+	clusterDomainName, err := utils.GetClusterDomainName()
+	if err != nil {
+		clusterDomainName = "cluster.local"
+	}
+	return fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomainName)
 }
 
 func GetServingK8SServiceNameForObj(name string) string {

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -18,7 +18,7 @@ package reconciler
 
 import (
 	"fmt"
-	"github.com/knative/eventing/pkg/utils"
+	"github.com/knative/serving/pkg/utils"
 )
 
 func GetK8sServiceFullname(name string, namespace string) string {
@@ -26,7 +26,7 @@ func GetK8sServiceFullname(name string, namespace string) string {
 	if err != nil {
 		clusterDomainName = "cluster.local"
 	}
-	return fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomainName)
+	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomainName)
 }
 
 func GetServingK8SServiceNameForObj(name string) string {

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -22,11 +22,7 @@ import (
 )
 
 func GetK8sServiceFullname(name string, namespace string) string {
-	clusterDomainName, err := utils.GetClusterDomainName()
-	if err != nil {
-		clusterDomainName = "cluster.local"
-	}
-	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomainName)
+	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, utils.GetClusterDomainName())
 }
 
 func GetServingK8SServiceNameForObj(name string) string {

--- a/pkg/reconciler/v1alpha1/route/config/domain.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain.go
@@ -21,20 +21,12 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/knative/serving/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	DomainConfigName = "config-domain"
-
-	// ClusterLocalDomain is the domain suffix used for cluster local
-	// routes. Currently we do not yet have a way to figure out this
-	// information programmatically.
-	//
-	// TODO(nghia): Extract this to a common network reconciler
-	// setting, or find an K8s API to discover this information.
-	ClusterLocalDomain = "svc.cluster.local"
-
 	// VisibilityLabelKey is the label to indicate visibility of Route
 	// and KServices.  It can be an annotation too but since users are
 	// already using labels for domain, it probably best to keep this
@@ -105,9 +97,9 @@ func (c *Domain) LookupDomainForLabels(labels map[string]string) string {
 	domain := ""
 	specificity := -1
 	// If we see VisibilityLabelKey sets with VisibilityClusterLocal, that
-	// will take precedence and the route will get a ClusterLocalDomain.
+	// will take precedence and the route will get a Cluster's Domain Name.
 	if l, _ := labels[VisibilityLabelKey]; l == VisibilityClusterLocal {
-		return ClusterLocalDomain
+		return utils.GetClusterDomainName()
 	}
 	for k, selector := range c.Domains {
 		// Ignore if selector doesn't match, or decrease the specificity.

--- a/pkg/reconciler/v1alpha1/route/config/domain.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain.go
@@ -99,7 +99,7 @@ func (c *Domain) LookupDomainForLabels(labels map[string]string) string {
 	// If we see VisibilityLabelKey sets with VisibilityClusterLocal, that
 	// will take precedence and the route will get a Cluster's Domain Name.
 	if l, _ := labels[VisibilityLabelKey]; l == VisibilityClusterLocal {
-		return utils.GetClusterDomainName()
+		return "svc." + utils.GetClusterDomainName()
 	}
 	for k, selector := range c.Domains {
 		// Ignore if selector doesn't match, or decrease the specificity.

--- a/pkg/reconciler/v1alpha1/route/config/domain_test.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/serving/pkg/system"
+	"github.com/knative/serving/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -168,7 +169,7 @@ func TestLookupDomainForLabels(t *testing.T) {
 		domain: "default.com",
 	}, {
 		labels: map[string]string{"serving.knative.dev/visibility": "cluster-local"},
-		domain: "svc.cluster.local",
+		domain: "svc." + utils.GetClusterDomainName(),
 	}}
 
 	for _, expected := range expectations {

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -31,14 +31,14 @@ import (
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
-	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
 	"github.com/knative/serving/pkg/system"
+	"github.com/knative/serving/pkg/utils"
 )
 
 func isClusterLocal(r *servingv1alpha1.Route) bool {
-	return strings.HasSuffix(r.Status.Domain, config.ClusterLocalDomain)
+	return strings.HasSuffix(r.Status.Domain, utils.GetClusterDomainName())
 }
 
 // MakeClusterIngress creates ClusterIngress to set up routing rules. Such ClusterIngress specifies

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,13 +24,16 @@ import (
 	"strings"
 )
 
+const (
+	resolverFileName = "/etc/resolv.conf"
+)
+
 // GetClusterDomainName returns cluster's domain name or error
 func GetClusterDomainName() (string, error) {
-	_, err := os.Stat("/etc/resolv.conf")
-	if err != nil {
+	if _, err := os.Stat(resolverFileName); err != nil {
 		return "", err
 	}
-	f, err := os.Open("/etc/resolv.conf")
+	f, err := os.Open(resolverFileName)
 	if err != nil {
 		return "", err
 	}
@@ -51,5 +54,5 @@ func getClusterDomainName(r io.Reader) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("/etc/resolv.conf does not seem to be a valid kubernetes resolv.conf file")
+	return "", fmt.Errorf("%s does not seem to be a valid kubernetes resolv.conf file", resolverFileName)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// GetClusterDomainName returns cluster's domain name or error
+func GetClusterDomainName() (string, error) {
+	_, err := os.Stat("/etc/resolv.conf")
+	if err != nil {
+		return "", err
+	}
+	f, err := os.Open("/etc/resolv.conf")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	return getClusterDomainName(f)
+}
+
+func getClusterDomainName(r io.Reader) (string, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		elements := strings.Split(scanner.Text(), " ")
+		if elements[0] == "search" {
+			for i := 1; i < len(elements)-1; i++ {
+				if strings.HasPrefix(elements[i], "svc.") {
+					return strings.Split(elements[i], "svc.")[1], nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("/etc/resolv.conf does not seem to be a valid kubernetes resolv.conf file")
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetDomainName(t *testing.T) {
+	tests := []struct {
+		descr      string
+		resolvConf string
+		domainName string
+		shouldFail bool
+	}{
+		{
+			descr: "all good",
+			resolvConf: `
+nameserver 1.1.1.1
+search default.svc.abc.com svc.abc.com abc.com
+options ndots:5
+`,
+			domainName: "abc.com",
+			shouldFail: false,
+		},
+		{
+			descr: "missing search line",
+			resolvConf: `
+nameserver 1.1.1.1
+options ndots:5
+`,
+			domainName: "",
+			shouldFail: true,
+		},
+		{
+			descr: "non k8s resolv.conf format",
+			resolvConf: `
+nameserver 1.1.1.1
+search  abc.com xyz.com
+options ndots:5
+`,
+			domainName: "",
+			shouldFail: true,
+		},
+	}
+	for _, tt := range tests {
+		dn, err := getClusterDomainName(strings.NewReader(tt.resolvConf))
+		if err != nil {
+			if !tt.shouldFail {
+				t.Errorf("Test %s failed with error: %q but is not supposed to.", tt.descr, err)
+			} else {
+				continue
+			}
+		}
+		if err == nil {
+			if tt.shouldFail {
+				t.Errorf("Test %s succeeded but supposed to fail.", tt.descr)
+				continue
+			}
+			if dn != tt.domainName {
+				t.Errorf("Test %s failed expected %s but got %s", tt.descr, tt.domainName, dn)
+			}
+		}
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -25,8 +25,7 @@ func TestGetDomainName(t *testing.T) {
 	tests := []struct {
 		name       string
 		resolvConf string
-		domainName string
-		shouldFail bool
+		want       string
 	}{
 		{
 			name: "all good",
@@ -35,8 +34,7 @@ nameserver 1.1.1.1
 search default.svc.abc.com svc.abc.com abc.com
 options ndots:5
 `,
-			domainName: "abc.com",
-			shouldFail: false,
+			want: "abc.com",
 		},
 		{
 			name: "missing search line",
@@ -44,8 +42,7 @@ options ndots:5
 nameserver 1.1.1.1
 options ndots:5
 `,
-			domainName: "",
-			shouldFail: true,
+			want: defaultDomainName,
 		},
 		{
 			name: "non k8s resolv.conf format",
@@ -54,27 +51,13 @@ nameserver 1.1.1.1
 search  abc.com xyz.com
 options ndots:5
 `,
-			domainName: "",
-			shouldFail: true,
+			want: defaultDomainName,
 		},
 	}
 	for _, tt := range tests {
-		dn, err := getClusterDomainName(strings.NewReader(tt.resolvConf))
-		if err != nil {
-			if !tt.shouldFail {
-				t.Errorf("Test %s failed with error: %q but is not supposed to.", tt.name, err)
-			} else {
-				continue
-			}
-		}
-		if err == nil {
-			if tt.shouldFail {
-				t.Errorf("Test %s succeeded but supposed to fail.", tt.name)
-				continue
-			}
-			if dn != tt.domainName {
-				t.Errorf("Test %s failed expected %s but got %s", tt.name, tt.domainName, dn)
-			}
+		got := getClusterDomainName(strings.NewReader(tt.resolvConf))
+		if got != tt.want {
+			t.Errorf("Test %s failed expected: %s but got: %s", tt.name, tt.want, got)
 		}
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestGetDomainName(t *testing.T) {
 	tests := []struct {
-		descr      string
+		name       string
 		resolvConf string
 		domainName string
 		shouldFail bool
 	}{
 		{
-			descr: "all good",
+			name: "all good",
 			resolvConf: `
 nameserver 1.1.1.1
 search default.svc.abc.com svc.abc.com abc.com
@@ -39,7 +39,7 @@ options ndots:5
 			shouldFail: false,
 		},
 		{
-			descr: "missing search line",
+			name: "missing search line",
 			resolvConf: `
 nameserver 1.1.1.1
 options ndots:5
@@ -48,7 +48,7 @@ options ndots:5
 			shouldFail: true,
 		},
 		{
-			descr: "non k8s resolv.conf format",
+			name: "non k8s resolv.conf format",
 			resolvConf: `
 nameserver 1.1.1.1
 search  abc.com xyz.com
@@ -62,18 +62,18 @@ options ndots:5
 		dn, err := getClusterDomainName(strings.NewReader(tt.resolvConf))
 		if err != nil {
 			if !tt.shouldFail {
-				t.Errorf("Test %s failed with error: %q but is not supposed to.", tt.descr, err)
+				t.Errorf("Test %s failed with error: %q but is not supposed to.", tt.name, err)
 			} else {
 				continue
 			}
 		}
 		if err == nil {
 			if tt.shouldFail {
-				t.Errorf("Test %s succeeded but supposed to fail.", tt.descr)
+				t.Errorf("Test %s succeeded but supposed to fail.", tt.name)
 				continue
 			}
 			if dn != tt.domainName {
-				t.Errorf("Test %s failed expected %s but got %s", tt.descr, tt.domainName, dn)
+				t.Errorf("Test %s failed expected %s but got %s", tt.name, tt.domainName, dn)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

PR replaces hardcoded cluster.local with a variable which is populated from /etc/resolv.conf with actual cluster's domain name. In case of a failure it falls back to cluster.local

Fixes #https://github.com/knative/eventing/issues/714


```release-note
replacing hardcoded cluster.local with a variable which is populated from /etc/resolv.conf with actual cluster's domain name. In case of a failure it falls back to cluster.local
```
