### PR TITLE
[WIP] Make ingress gateway address configurable for tests running on minikube

### DIFF
--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -74,9 +74,9 @@ func TestCustomResourcesLimits(t *testing.T) {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, want, err)
 	}
 
-	sendPostRequest := func(resolvableDomain bool, domain string, query string) (*spoof.Response, error) {
+	sendPostRequest := func(resolvableDomain bool, domain, ingress, query string) (*spoof.Response, error) {
 		logger.Infof("The domain of request is %s and its query is %s", domain, query)
-		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", resolvableDomain)
+		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, ingress, resolvableDomain)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	pokeCowForMB := func(mb int) error {
-		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, domain, fmt.Sprintf("memory_in_mb=%d", mb))
+		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, domain, test.ServingFlags.IngressAddress, fmt.Sprintf("memory_in_mb=%d", mb))
 		if err != nil {
 			return err
 		}

--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -76,7 +76,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 
 	sendPostRequest := func(resolvableDomain bool, domain string, query string) (*spoof.Response, error) {
 		logger.Infof("The domain of request is %s and its query is %s", domain, query)
-		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, resolvableDomain)
+		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", resolvableDomain)
 		if err != nil {
 			return nil, err
 		}

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -64,7 +64,7 @@ func updateConfigWithTimeout(clients *test.Clients, names test.ResourceNames, re
 
 // sendRequests send a request to "domain", returns error if unexpected response code, nil otherwise.
 func sendRequest(logger *logging.BaseLogger, clients *test.Clients, domain string, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		logger.Infof("Spoofing client failed: %v", err)
 		return err

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -64,12 +64,11 @@ func updateConfigWithTimeout(clients *test.Clients, names test.ResourceNames, re
 
 // sendRequests send a request to "domain", returns error if unexpected response code, nil otherwise.
 func sendRequest(logger *logging.BaseLogger, clients *test.Clients, domain string, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.IngressAddress, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		logger.Infof("Spoofing client failed: %v", err)
 		return err
 	}
-
 	initialSleepMs := initialSleepSeconds * 1000
 	sleepMs := sleepSeconds * 1000
 

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -94,7 +94,7 @@ func TestSingleConcurrency(t *testing.T) {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.IngressAddress, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -94,7 +94,7 @@ func TestSingleConcurrency(t *testing.T) {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -74,7 +74,7 @@ func generateTraffic(ctx *testContext, concurrency int, duration time.Duration) 
 	for i := 0; i < concurrency; i++ {
 		group.Go(func() error {
 			done := time.After(duration)
-			client, err := pkgTest.NewSpoofingClient(ctx.clients.KubeClient, ctx.logger, ctx.domain, test.ServingFlags.ResolvableDomain)
+			client, err := pkgTest.NewSpoofingClient(ctx.clients.KubeClient, ctx.logger, ctx.domain, "", test.ServingFlags.ResolvableDomain)
 			if err != nil {
 				return fmt.Errorf("error creating spoofing client: %v", err)
 			}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -74,7 +74,7 @@ func generateTraffic(ctx *testContext, concurrency int, duration time.Duration) 
 	for i := 0; i < concurrency; i++ {
 		group.Go(func() error {
 			done := time.After(duration)
-			client, err := pkgTest.NewSpoofingClient(ctx.clients.KubeClient, ctx.logger, ctx.domain, "", test.ServingFlags.ResolvableDomain)
+			client, err := pkgTest.NewSpoofingClient(ctx.clients.KubeClient, ctx.logger, ctx.domain, test.ServingFlags.IngressAddress, test.ServingFlags.ResolvableDomain)
 			if err != nil {
 				return fmt.Errorf("error creating spoofing client: %v", err)
 			}

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -87,7 +87,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -87,7 +87,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.IngressAddress, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -58,9 +58,9 @@ func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
 	}}
 }
 
-func sendRequest(resolvableDomain bool, domain string) (*spoof.Response, error) {
+func sendRequest(resolvableDomain bool, domain, ingress string) (*spoof.Response, error) {
 	logger.Infof("The domain of request is %s.", domain)
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", resolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, ingress, resolvableDomain)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	logger.Info("httpproxy is ready.")
 
 	// Send request to httpproxy to trigger the http call from httpproxy Pod to internal service of helloworld app.
-	response, err := sendRequest(test.ServingFlags.ResolvableDomain, httpProxyRoute.Status.Domain)
+	response, err := sendRequest(test.ServingFlags.ResolvableDomain, httpProxyRoute.Status.Domain, test.ServingFlags.IngressAddress)
 	if err != nil {
 		t.Fatalf("Failed to send request to httpproxy: %v", err)
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -60,7 +60,7 @@ func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
 
 func sendRequest(resolvableDomain bool, domain string) (*spoof.Response, error) {
 	logger.Infof("The domain of request is %s.", domain)
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, resolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", resolvableDomain)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -40,6 +40,7 @@ type ServingEnvironmentFlags struct {
 	ResolvableDomain bool   // Resolve Route controller's `domainSuffix`
 	DockerRepo       string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
 	Tag              string // Test images version tag
+	IngressAddress   string
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -53,6 +54,9 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.StringVar(&f.Tag, "tag", "latest",
 		"Provide the version tag for the test images.")
+
+	flag.StringVar(&f.IngressAddress, "ingressaddress", "",
+		"Provide the address of ingress gateway of the knative cluster. Defaults to spoofing the address received from kube client")
 
 	flag.Parse()
 	flag.Set("alsologtostderr", "true")

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -155,7 +155,7 @@ func TestObservedConcurrency(t *testing.T) {
 	}
 
 	url := fmt.Sprintf("http://%s/?timeout=1000", *endpoint)
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.IngressAddress, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -155,7 +155,7 @@ func TestObservedConcurrency(t *testing.T) {
 	}
 
 	url := fmt.Sprintf("http://%s/?timeout=1000", *endpoint)
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, "", test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/prober.go
+++ b/test/prober.go
@@ -166,7 +166,7 @@ func (m *manager) Spawn(domain string) Prober {
 	}
 	m.probes[domain] = p
 	go func() {
-		client, err := pkgTest.NewSpoofingClient(m.clients.KubeClient, m.logger, domain,
+		client, err := pkgTest.NewSpoofingClient(m.clients.KubeClient, m.logger, domain, "",
 			ServingFlags.ResolvableDomain)
 		if err != nil {
 			m.logger.Infof("NewSpoofingClient() = %v", err)

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -47,7 +47,7 @@ func assertServiceResourcesUpdated(t *testing.T, logger *logging.BaseLogger, cli
 		logger,
 		routeDomain,
 		pkgTest.Retrying(pkgTest.EventuallyMatchesBody(expectedText), http.StatusNotFound),
-		"WaitForEndpointToServeText",
+		"WaitForEndpointToServeText", test.ServingFlags.IngressAddress,
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, routeDomain, expectedText, err)

--- a/vendor/github.com/knative/pkg/test/clients.go
+++ b/vendor/github.com/knative/pkg/test/clients.go
@@ -34,8 +34,8 @@ type KubeClient struct {
 }
 
 // NewSpoofingClient returns a spoofing client to make requests
-func NewSpoofingClient(client *KubeClient, logger *logging.BaseLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
-	return spoof.New(client.Kube, logger, domain, resolvable)
+func NewSpoofingClient(client *KubeClient, logger *logging.BaseLogger, domain, ingress string, resolvable bool) (*spoof.SpoofingClient, error) {
+	return spoof.New(client.Kube, logger, domain, ingress, resolvable)
 }
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the

--- a/vendor/github.com/knative/pkg/test/request.go
+++ b/vendor/github.com/knative/pkg/test/request.go
@@ -80,12 +80,12 @@ func EventuallyMatchesBody(expected string) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClient *KubeClient, logger *logging.BaseLogger, domain string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
+func WaitForEndpointState(kubeClient *KubeClient, logger *logging.BaseLogger, domain string, inState spoof.ResponseChecker, desc, ingress string, resolvable bool) (*spoof.Response, error) {
 	metricName := fmt.Sprintf("WaitForEndpointState/%s", desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
-	client, err := NewSpoofingClient(kubeClient, logger, domain, resolvable)
+	client, err := NewSpoofingClient(kubeClient, logger, domain, ingress, resolvable)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2885 

## Proposed Changes

* add a new flag for the tests to specify ingress_ip:port explicitly
* propagate that flag down to the spoofing client

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
