### PR TITLE
Change view reporting period to one second in queue proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -294,7 +294,7 @@ func main() {
 		logger.Fatal("Failed to create the Prometheus exporter", zap.Error(err))
 	}
 	view.RegisterExporter(promExporter)
-	view.SetReportingPeriod(queue.ReportingPeriod)
+	view.SetReportingPeriod(queue.ViewReportingPeriod)
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promExporter)
@@ -307,7 +307,7 @@ func main() {
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter()
 
-	reportTicker := time.NewTicker(time.Second).C
+	reportTicker := time.NewTicker(queue.ReporterReportingPeriod).C
 	queue.NewStats(podName, queue.Channels{
 		ReqChan:    reqChan,
 		ReportChan: reportTicker,

--- a/pkg/queue/stats_reporter.go
+++ b/pkg/queue/stats_reporter.go
@@ -30,15 +30,16 @@ import (
 type Measurement int
 
 const (
-	// ReportingPeriod interval of time for reporting.
-	ReportingPeriod = 10 * time.Second
+	// ViewReportingPeriod is the interval of time between reporting aggregated views.
+	ViewReportingPeriod = time.Second
+	// ReporterReportingPeriod is the interval of time between reporting stats by queue proxy.
+	// It should be equal to or larger than ViewReportingPeriod so that no stat
+	// will be dropped if LastValue aggregation is used for a view.
+	ReporterReportingPeriod = time.Second
 
-	// OperationsPerSecondN
-	OperationsPerSecondN = "operations_per_second"
-	// AverageConcurrentRequestsN
-	AverageConcurrentRequestsN = "average_concurrent_requests"
-	// LameDuckN
-	LameDuckN = "lame_duck"
+	operationsPerSecondN       = "operations_per_second"
+	averageConcurrentRequestsN = "average_concurrent_requests"
+	lameDuckN                  = "lame_duck"
 
 	// OperationsPerSecondM number of operations per second.
 	OperationsPerSecondM Measurement = iota
@@ -52,15 +53,15 @@ var (
 	measurements = []*stats.Float64Measure{
 		// TODO(#2524): make reporting period accurate.
 		OperationsPerSecondM: stats.Float64(
-			OperationsPerSecondN,
+			operationsPerSecondN,
 			"Number of operations per second",
 			stats.UnitNone),
 		AverageConcurrentRequestsM: stats.Float64(
-			AverageConcurrentRequestsN,
+			averageConcurrentRequestsN,
 			"Number of requests currently being handled by this pod",
 			stats.UnitNone),
 		LameDuckM: stats.Float64(
-			LameDuckN,
+			lameDuckN,
 			"Indicates this Pod has received a shutdown signal with 1 else 0",
 			stats.UnitNone),
 	}
@@ -177,13 +178,13 @@ func (r *Reporter) UnregisterViews() error {
 		return errors.New("Reporter is not initialized")
 	}
 	var views []*view.View
-	if v := view.Find(OperationsPerSecondN); v != nil {
+	if v := view.Find(operationsPerSecondN); v != nil {
 		views = append(views, v)
 	}
-	if v := view.Find(AverageConcurrentRequestsN); v != nil {
+	if v := view.Find(averageConcurrentRequestsN); v != nil {
 		views = append(views, v)
 	}
-	if v := view.Find(LameDuckN); v != nil {
+	if v := view.Find(lameDuckN); v != nil {
 		views = append(views, v)
 	}
 	view.Unregister(views...)

--- a/pkg/queue/stats_reporter_test.go
+++ b/pkg/queue/stats_reporter_test.go
@@ -114,9 +114,9 @@ func TestReporter_Report(t *testing.T) {
 	if err := reporter.Report(true, float64(39), float64(3)); err != nil {
 		t.Error(err)
 	}
-	checkData(t, LameDuckN, 1, testTagKeyValueMap)
-	checkData(t, OperationsPerSecondN, 39, testTagKeyValueMap)
-	checkData(t, AverageConcurrentRequestsN, 3, testTagKeyValueMap)
+	checkData(t, lameDuckN, 1, testTagKeyValueMap)
+	checkData(t, operationsPerSecondN, 39, testTagKeyValueMap)
+	checkData(t, averageConcurrentRequestsN, 3, testTagKeyValueMap)
 	if err := reporter.UnregisterViews(); err != nil {
 		t.Errorf("Error with unregistering views, %v", err)
 	}


### PR DESCRIPTION
`LastValue` aggregation is used for all metrics emitted by queue proxy. Queue proxy reports data every second. 

Expected:
The view reporting period should be equal to or less than one second so that no data will be dropped. 

Actual:
The view reporting period is 10 seconds(it seems that 5 seconds is maximum for Prometheus exporter and I got the stat changed every 5 seconds). 80% of the stats will be dropped.

Also change some const to package private.