### PR TITLE
Linter and code cleanups for the service types, service test and utils.

### DIFF
--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -160,6 +160,7 @@ const (
 
 var serviceCondSet = duckv1alpha1.NewLivingConditionSet(ServiceConditionConfigurationsReady, ServiceConditionRoutesReady)
 
+// ServiceStatus represents the Status stanza of the Service resource.
 type ServiceStatus struct {
 	// +optional
 	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty"`
@@ -218,22 +219,28 @@ type ServiceList struct {
 	Items []Service `json:"items"`
 }
 
+// GetGroupVersionKind returns the GetGroupVersionKind.
 func (s *Service) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Service")
 }
 
+// IsReady returns if the service is ready to serve the requested configuration.
 func (ss *ServiceStatus) IsReady() bool {
 	return serviceCondSet.Manage(ss).IsHappy()
 }
 
+// GetCondition returns the condition by name.
 func (ss *ServiceStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.Condition {
 	return serviceCondSet.Manage(ss).GetCondition(t)
 }
 
+// InitializeConditions sets the initial values to the conditions.
 func (ss *ServiceStatus) InitializeConditions() {
 	serviceCondSet.Manage(ss).InitializeConditions()
 }
 
+// PropagateConfigurationStatus takes the Configuration status and applies its values
+// to the Service status.
 func (ss *ServiceStatus) PropagateConfigurationStatus(cs ConfigurationStatus) {
 	ss.LatestReadyRevisionName = cs.LatestReadyRevisionName
 	ss.LatestCreatedRevisionName = cs.LatestCreatedRevisionName
@@ -252,6 +259,8 @@ func (ss *ServiceStatus) PropagateConfigurationStatus(cs ConfigurationStatus) {
 	}
 }
 
+// PropagateRouteStatus takes the Route status and applies its values
+// to the Service status.
 func (ss *ServiceStatus) PropagateRouteStatus(rs RouteStatus) {
 	ss.Domain = rs.Domain
 	ss.DomainInternal = rs.DomainInternal
@@ -276,8 +285,10 @@ func (ss *ServiceStatus) PropagateRouteStatus(rs RouteStatus) {
 // can have TrafficTargets to Configurations not owned by the service. We do not want to falsely
 // report Ready.
 func (ss *ServiceStatus) SetManualStatus() {
-	reason := "Manual"
-	message := "Service is set to Manual, and is not managing underlying resources."
+	const (
+		reason  = "Manual"
+		message = "Service is set to Manual, and is not managing underlying resources."
+	)
 
 	// Clear our fields by creating a new status and copying over only the fields and conditions we want
 	newStatus := &ServiceStatus{}
@@ -290,7 +301,6 @@ func (ss *ServiceStatus) SetManualStatus() {
 	newStatus.DomainInternal = ss.DomainInternal
 
 	*ss = *newStatus
-
 }
 
 // GetConditions returns the Conditions array. This enables generic handling of

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -32,9 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	userPort = int32(8081)
-)
+const userPort = int32(8081)
 
 // Validates the state of Configuration, Revision, and Route objects for a runLatest Service. The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
@@ -168,16 +166,16 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// Validate State after Creation
-	err = validateRunLatestControlPlane(logger, clients, names, "1")
-	if err != nil {
+
+	if err = validateRunLatestControlPlane(logger, clients, names, "1"); err != nil {
 		t.Error(err)
 	}
-	err = validateRunLatestDataPlane(logger, clients, names, pizzaPlanetText1)
-	if err != nil {
+
+	if err = validateRunLatestDataPlane(logger, clients, names, pizzaPlanetText1); err != nil {
 		t.Error(err)
 	}
-	err = validateLabelsPropagation(logger, *objects, names)
-	if err != nil {
+
+	if err = validateLabelsPropagation(logger, *objects, names); err != nil {
 		t.Error(err)
 	}
 
@@ -199,12 +197,11 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// Validate State after Image Update
-	err = validateRunLatestControlPlane(logger, clients, names, "2")
-	if err != nil {
+	if err = validateRunLatestControlPlane(logger, clients, names, "2"); err != nil {
 		t.Error(err)
 	}
-	err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(v1alpha1.DefaultUserPort))
-	if err != nil {
+
+	if err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(v1alpha1.DefaultUserPort)); err != nil {
 		t.Error(err)
 
 	}
@@ -217,8 +214,7 @@ func TestRunLatestService(t *testing.T) {
 			"labelY": "def",
 		},
 	}
-	objects.Service, err = test.PatchServiceRevisionTemplateMetadata(logger, clients, objects.Service, metadata)
-	if err != nil {
+	if objects.Service, err = test.PatchServiceRevisionTemplateMetadata(logger, clients, objects.Service, metadata); err != nil {
 		t.Fatalf("Service %s was not updated with labels in its RevisionTemplateSpec: %v", names.Service, err)
 	}
 
@@ -235,8 +231,7 @@ func TestRunLatestService(t *testing.T) {
 			"annotationB": "456",
 		},
 	}
-	objects.Service, err = test.PatchServiceRevisionTemplateMetadata(logger, clients, objects.Service, metadata)
-	if err != nil {
+	if objects.Service, err = test.PatchServiceRevisionTemplateMetadata(logger, clients, objects.Service, metadata); err != nil {
 		t.Fatalf("Service %s was not updated with annotation in its RevisionTemplateSpec: %v", names.Service, err)
 	}
 
@@ -246,13 +241,11 @@ func TestRunLatestService(t *testing.T) {
 		t.Fatalf("The new revision has not become ready in Service: %v", err)
 	}
 
-	// Validate Service
-	err = validateRunLatestControlPlane(logger, clients, names, "4")
-	if err != nil {
+	// Validate the Service shape.
+	if err = validateRunLatestControlPlane(logger, clients, names, "4"); err != nil {
 		t.Error(err)
 	}
-	err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(v1alpha1.DefaultUserPort))
-	if err != nil {
+	if err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(v1alpha1.DefaultUserPort)); err != nil {
 		t.Error(err)
 	}
 
@@ -260,33 +253,29 @@ func TestRunLatestService(t *testing.T) {
 		t.Fatalf("Route prober failed with error %s", err)
 	}
 
-	// Update container with user port
-	logger.Infof("Updating the port of the user container for service %s", names.Service)
+	// Update container with user port.
+	logger.Infof("Updating the port of the user container for service %s to %d", names.Service, userPort)
 	desiredSvc := objects.Service.DeepCopy()
 	desiredSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Ports = []corev1.ContainerPort{{
 		ContainerPort: userPort,
 	}}
-	objects.Service, err = test.PatchService(logger, clients, objects.Service, desiredSvc)
-	if err != nil {
+	if objects.Service, err = test.PatchService(logger, clients, objects.Service, desiredSvc); err != nil {
 		t.Fatalf("Service %s was not updated with a new port for the user container: %v", names.Service, err)
 	}
 
 	logger.Info("Waiting for the new revision to appear as LatestRevision.")
-	names.Revision, err = test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
+	if names.Revision, err = test.WaitForServiceLatestRevision(clients, names); err != nil {
 		t.Fatalf("The new revision has not become ready in Service: %v", err)
 	}
 
 	// Validate Service
-	err = validateRunLatestControlPlane(logger, clients, names, "5")
-	if err != nil {
-		t.Error(err)
-	}
-	err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(int(userPort)))
-	if err != nil {
+	if err = validateRunLatestControlPlane(logger, clients, names, "5"); err != nil {
 		t.Error(err)
 	}
 
+	if err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(int(userPort))); err != nil {
+		t.Error(err)
+	}
 }
 
 // TestReleaseService creates a Service in runLatest mode and then updates it to release mode. Once in release mode the test
@@ -302,19 +291,19 @@ func TestReleaseService(t *testing.T) {
 	logger := logging.GetContextLogger("TestReleaseService")
 	releaseImagePath2 := test.ImagePath(pizzaPlanet2)
 	releaseImagePath3 := test.ImagePath(helloworld)
-
-	// Expected Text for different revisions
-	expectedFirstRev := pizzaPlanetText1
-	expectedSecondRev := pizzaPlanetText2
-	expectedThirdRev := helloWorldText
-
 	names := test.ResourceNames{
 		Service: test.AppendRandomString("test-release-service-", logger),
 		Image:   pizzaPlanet1,
 	}
-
 	defer tearDown(clients, names)
 	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+
+	// Expected Text for different revisions.
+	const (
+		expectedFirstRev  = pizzaPlanetText1
+		expectedSecondRev = pizzaPlanetText2
+		expectedThirdRev  = helloWorldText
+	)
 
 	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{})
 	if err != nil {
@@ -322,35 +311,32 @@ func TestReleaseService(t *testing.T) {
 	}
 	firstRevision := names.Revision
 
-	// One Revision Specified, current == latest
+	// One Revision Specified, current == latest.
 	logger.Info("Updating Service to ReleaseType using lastCreatedRevision")
 	objects.Service, err = test.PatchReleaseService(logger, clients, objects.Service, []string{firstRevision}, 0)
 	if err != nil {
 		t.Fatalf("Service %s was not updated to release: %v", names.Service, err)
 	}
 
-	// Validate Service
-	logger.Info("Service traffic should go to the first revision and be available on two names traffic targets, 'current' and 'latest'")
+	logger.Info("Service traffic should go to the first revision and be available on two names traffic targets: 'current' and 'latest'")
 	validateDomains(t, logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedFirstRev, expectedFirstRev})
 
-	// One Revision Specified, current != latset
+	// One Revision Specified, current != latest.
 	logger.Info("Updating the Service Spec with a new image")
 	if _, err := test.PatchServiceImage(logger, clients, objects.Service, releaseImagePath2); err != nil {
 		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, releaseImagePath2, err)
 	}
 
 	logger.Info("Since the Service was updated a new Revision will be created")
-	names.Revision, err = test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
+	if names.Revision, err = test.WaitForServiceLatestRevision(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
 	secondRevision := names.Revision
 
-	// Validate Service
 	logger.Info("Since the Service is using release the Route will not be updated, but new revision will be available at 'latest'")
 	validateDomains(t, logger, clients,
 		names.Domain,
@@ -358,14 +344,12 @@ func TestReleaseService(t *testing.T) {
 		[]string{"latest", "current"},
 		[]string{expectedSecondRev, expectedFirstRev})
 
-	// Two Revisions Specified, 50% rollout,  candidate == latest
+	// Two Revisions Specified, 50% rollout, candidate == latest.
 	logger.Info("Updating Service to split traffic between two revisions using Release mode")
-	objects.Service, err = test.PatchReleaseService(logger, clients, objects.Service, []string{firstRevision, secondRevision}, 50)
-	if err != nil {
+	if objects.Service, err = test.PatchReleaseService(logger, clients, objects.Service, []string{firstRevision, secondRevision}, 50); err != nil {
 		t.Fatalf("Service %s was not updated to release: %v", names.Service, err)
 	}
 
-	// Validate Service
 	logger.Info("Traffic should be split between the two revisions and available on three named traffic targets, 'current', 'candidate', and 'latest'")
 	validateDomains(t, logger, clients,
 		names.Domain,
@@ -373,13 +357,12 @@ func TestReleaseService(t *testing.T) {
 		[]string{"candidate", "latest", "current"},
 		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev})
 
-	// Two Revisions Specified, 50% rollout, candidate != latest
+	// Two Revisions Specified, 50% rollout, candidate != latest.
 	logger.Info("Updating the Service Spec with a new image")
 	if _, err := test.PatchServiceImage(logger, clients, objects.Service, releaseImagePath3); err != nil {
 		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, releaseImagePath3, err)
 	}
 
-	// Validate Service
 	logger.Info("Traffic should remain between the two images, and the new revision should be available on the named traffic target 'latest'")
 	validateDomains(t, logger, clients,
 		names.Domain,

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -38,7 +38,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-// Constants for test images located in test/test_images
+// Constants for test images located in test/test_images.
 const (
 	pizzaPlanet1        = "pizzaplanetv1"
 	pizzaPlanet2        = "pizzaplanetv2"
@@ -57,7 +57,7 @@ const (
 	minSplitPercentage = 0.25
 )
 
-// Constants for test image output
+// Constants for test image output.
 const (
 	pizzaPlanetText1 = "What a spaceport!"
 	pizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
@@ -92,6 +92,7 @@ func waitForExpectedResponse(logger *logging.BaseLogger, clients *test.Clients, 
 }
 
 func validateDomains(t *testing.T, logger *logging.BaseLogger, clients *test.Clients, baseDomain string, baseExpected, trafficTargets, targetsExpected []string) {
+	t.Helper()
 	var subdomains []string
 	for _, target := range trafficTargets {
 		subdomains = append(subdomains, fmt.Sprintf("%s.%s", target, baseDomain))
@@ -100,8 +101,7 @@ func validateDomains(t *testing.T, logger *logging.BaseLogger, clients *test.Cli
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
 	logger.Infof("Waiting for route to update domain: %s", subdomains[0])
-	err := waitForExpectedResponse(logger, clients, subdomains[0], targetsExpected[0])
-	if err != nil {
+	if err := waitForExpectedResponse(logger, clients, subdomains[0], targetsExpected[0]); err != nil {
 		t.Fatalf("Error waiting for route to update %s: %v", subdomains[0], targetsExpected[0])
 	}
 
@@ -129,7 +129,6 @@ func validateDomains(t *testing.T, logger *logging.BaseLogger, clients *test.Cli
 			t.Fatalf("Error sending requests: %v", err)
 		}
 	}
-
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {
@@ -187,7 +186,7 @@ func checkResponses(logger *logging.BaseLogger, num int, min int, domain string,
 	for _, ar := range actualResponses {
 		expected := false
 		for _, er := range expectedResponses {
-			if strings.Contains(string(ar), er) {
+			if strings.Contains(ar, er) {
 				counts[er]++
 				expected = true
 			}
@@ -203,15 +202,15 @@ func checkResponses(logger *logging.BaseLogger, num int, min int, domain string,
 	for _, er := range expectedResponses {
 		count := counts[er]
 		if count < min {
-			return fmt.Errorf("domain %s failed: want min %d, got %d for response %q", domain, min, count, er)
+			return fmt.Errorf("domain %s failed: want at least %d, got %d for response %q", domain, min, count, er)
 		}
 
-		logger.Infof("wanted at least %d, got %d requests for domain %s", min, count, domain)
+		logger.Infof("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
 		totalMatches += count
 	}
 	// Verify that the total expected responses match the number of requests made.
 	for badResponse, count := range badCounts {
-		logger.Infof("saw unexpected response %q %d times", badResponse, count)
+		logger.Infof("Saw unexpected response %q %d times.", badResponse, count)
 	}
 	if totalMatches < num {
 		return fmt.Errorf("saw expected responses %d times, wanted %d", totalMatches, num)


### PR DESCRIPTION
## Proposed Changes
In preparation for the logic changes that compute how the ready status
for the service is computed, perform some cleanups.
Mostly styling the code for Go, some comment, logging and error messages
tweaked, etc.

