### PR TITLE
Typo with 2018 vs 2019.

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-01-09
+  # HEAD as of 2019-01-09
   revision = "5f162625780f838b56d41f8b0786224f18ff7eb4"
 
 [[override]]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Correct comment in toml file to say the last pkg pull was 2019, not 2018.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
