### PR TITLE
Enable websocket upgrade in Istio VirtualService.

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -114,7 +114,8 @@ func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPa
 			Attempts:      http.Retries.Attempts,
 			PerTryTimeout: http.Retries.PerTryTimeout.Duration.String(),
 		},
-		AppendHeaders: http.AppendHeaders,
+		AppendHeaders:    http.AppendHeaders,
+		WebsocketUpgrade: true,
 	}
 }
 

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -162,6 +162,7 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Attempts:      v1alpha1.DefaultRetryCount,
 			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
 		},
+		WebsocketUpgrade: true,
 	}, {
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
@@ -179,6 +180,7 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Attempts:      v1alpha1.DefaultRetryCount,
 			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
 		},
+		WebsocketUpgrade: true,
 	}}
 	routes := MakeVirtualService(ci, []string{}).Spec.Http
 	if diff := cmp.Diff(expected, routes); diff != "" {
@@ -225,6 +227,7 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 			Attempts:      v1alpha1.DefaultRetryCount,
 			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
 		},
+		WebsocketUpgrade: true,
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)
@@ -279,6 +282,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 			Attempts:      v1alpha1.DefaultRetryCount,
 			PerTryTimeout: v1alpha1.DefaultTimeout.String(),
 		},
+		WebsocketUpgrade: true,
 	}
 	if diff := cmp.Diff(&expected, route); diff != "" {
 		t.Errorf("Unexpected route  (-want +got): %v", diff)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Enable websocket upgrade by default in Istio VirtualServices.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
