### PR TITLE
Clean up logging in controller main files

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -80,12 +80,12 @@ func statReporter(stopCh <-chan struct{}) {
 		select {
 		case sm := <-statChan:
 			if statSink == nil {
-				logger.Error("Stat sink not connected.")
+				logger.Error("Stat sink not connected")
 				continue
 			}
 			err := statSink.Send(sm)
 			if err != nil {
-				logger.Error("Error while sending stat", zap.Error(err))
+				logger.Errorw("Error while sending stat", zap.Error(err))
 			}
 		case <-stopCh:
 			return
@@ -111,20 +111,20 @@ func main() {
 
 	clusterConfig, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		logger.Fatal("Error getting cluster configuration", zap.Error(err))
+		logger.Fatalw("Error getting cluster configuration", zap.Error(err))
 	}
 	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {
-		logger.Fatal("Error building new kubernetes client", zap.Error(err))
+		logger.Fatalw("Error building new kubernetes client", zap.Error(err))
 	}
 	servingClient, err := clientset.NewForConfig(clusterConfig)
 	if err != nil {
-		logger.Fatal("Error building serving clientset", zap.Error(err))
+		logger.Fatalw("Error building serving clientset", zap.Error(err))
 	}
 
 	reporter, err := activator.NewStatsReporter()
 	if err != nil {
-		logger.Fatal("Failed to create stats reporter", zap.Error(err))
+		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
 
 	a := activator.NewRevisionActivator(kubeClient, servingClient, logger)
@@ -177,13 +177,13 @@ func main() {
 	// Watch the observability config map and dynamically update metrics exporter.
 	configMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
 	if err = configMapWatcher.Start(stopCh); err != nil {
-		logger.Fatalf("failed to start configuration manager: %v", err)
+		logger.Fatalw("Failed to start configuration manager", zap.Error(err))
 	}
 
 	srv := h2c.NewServer(":8080", ah)
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
-			logger.Errorf("Error running HTTP server: %v", err)
+			logger.Errorw("Error running HTTP server", zap.Error(err))
 		}
 	}()
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -152,7 +152,7 @@ func main() {
 		hpaInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
-			logger.Fatalf("Failed to wait for cache at index %v to sync", i)
+			logger.Fatalf("Failed to wait for cache at index %d to sync", i)
 		}
 	}
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -80,12 +80,12 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		logger.Fatal("Error building kubeconfig.", zap.Error(err))
+		logger.Fatalw("Error building kubeconfig", zap.Error(err))
 	}
 
 	kubeClientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatal("Error building kubernetes clientset.", zap.Error(err))
+		logger.Fatalw("Error building kubernetes clientset", zap.Error(err))
 	}
 
 	// Watch the logging config map and dynamically update logging levels.
@@ -99,21 +99,21 @@ func main() {
 	scaleClient, err := scale.NewForConfig(cfg, restMapper, dynamic.LegacyAPIPathResolverFunc,
 		scale.NewDiscoveryScaleKindResolver(kubeClientSet.Discovery()))
 	if err != nil {
-		logger.Fatal("Error building scale clientset.", zap.Error(err))
+		logger.Fatalw("Error building scale clientset", zap.Error(err))
 	}
 
 	servingClientSet, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatal("Error building serving clientset.", zap.Error(err))
+		logger.Fatalw("Error building serving clientset", zap.Error(err))
 	}
 
 	rawConfig, err := configmap.Load("/etc/config-autoscaler")
 	if err != nil {
-		logger.Fatalf("Error reading autoscaler configuration: %v", err)
+		logger.Fatalw("Error reading autoscaler configuration", zap.Error(err))
 	}
 	dynConfig, err := autoscaler.NewDynamicConfigFromMap(rawConfig, logger)
 	if err != nil {
-		logger.Fatalf("Error parsing autoscaler configuration: %v", err)
+		logger.Fatalw("Error parsing autoscaler configuration", zap.Error(err))
 	}
 	// Watch the autoscaler config map and dynamically update autoscaler config.
 	configMapWatcher.Watch(autoscaler.ConfigName, dynConfig.Update)
@@ -141,7 +141,7 @@ func main() {
 	kubeInformerFactory.Start(stopCh)
 	servingInformerFactory.Start(stopCh)
 	if err := configMapWatcher.Start(stopCh); err != nil {
-		logger.Fatalf("failed to start watching logging config: %v", err)
+		logger.Fatalw("Failed to start watching logging config", zap.Error(err))
 	}
 
 	// Wait for the caches to be synced before starting controllers.
@@ -152,7 +152,7 @@ func main() {
 		hpaInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
-			logger.Fatalf("failed to wait for cache at index %v to sync", i)
+			logger.Fatalf("Failed to wait for cache at index %v to sync", i)
 		}
 	}
 
@@ -185,7 +185,7 @@ func main() {
 
 	go func() {
 		if err := eg.Wait(); err != nil {
-			logger.Error("Group error.", zap.Error(err))
+			logger.Errorw("Group error.", zap.Error(err))
 		}
 		close(egCh)
 	}()

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -223,7 +223,7 @@ func main() {
 		virtualServiceInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
-			logger.Fatalf("Failed to wait for cache at index %v to sync", i)
+			logger.Fatalf("Failed to wait for cache at index %d to sync", i)
 		}
 	}
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/service"
 	"github.com/knative/serving/pkg/system"
+	"go.uber.org/zap"
 )
 
 const (
@@ -80,7 +81,7 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		logger.Fatalf("Error building kubeconfig: %v", err)
+		logger.Fatalw("Error building kubeconfig", zap.Error(err))
 	}
 
 	// We run 6 controllers, so bump the defaults.
@@ -89,27 +90,27 @@ func main() {
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building kubernetes clientset: %v", err)
+		logger.Fatalw("Error building kubernetes clientset", zap.Error(err))
 	}
 
 	sharedClient, err := sharedclientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building shared clientset: %v", err)
+		logger.Fatalw("Error building shared clientset", zap.Error(err))
 	}
 
 	servingClient, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building serving clientset: %v", err)
+		logger.Fatalw("Error building serving clientset", zap.Error(err))
 	}
 
 	dynamicClient, err := dynamic.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building build clientset: %v", err)
+		logger.Fatalw("Error building build clientset", zap.Error(err))
 	}
 
 	cachingClient, err := cachingclientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building caching clientset: %v", err)
+		logger.Fatalw("Error building caching clientset", zap.Error(err))
 	}
 
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace)
@@ -202,7 +203,7 @@ func main() {
 	servingInformerFactory.Start(stopCh)
 	cachingInformerFactory.Start(stopCh)
 	if err := configMapWatcher.Start(stopCh); err != nil {
-		logger.Fatalf("failed to start configuration manager: %v", err)
+		logger.Fatalw("failed to start configuration manager", zap.Error(err))
 	}
 
 	// Wait for the caches to be synced before starting controllers.
@@ -222,7 +223,7 @@ func main() {
 		virtualServiceInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
-			logger.Fatalf("failed to wait for cache at index %v to sync", i)
+			logger.Fatalf("Failed to wait for cache at index %v to sync", i)
 		}
 	}
 
@@ -232,7 +233,7 @@ func main() {
 			// We don't expect this to return until stop is called,
 			// but if it does, propagate it back.
 			if runErr := ctrlr.Run(threadsPerController, stopCh); runErr != nil {
-				logger.Fatalf("Error running controller: %v", runErr)
+				logger.Fatalw("Error running controller", zap.Error(runErr))
 			}
 		}(ctrlr)
 	}

--- a/test/controller/main.go
+++ b/test/controller/main.go
@@ -34,6 +34,7 @@ import (
 	clientset "github.com/knative/serving/test/client/clientset/versioned"
 	informers "github.com/knative/serving/test/client/informers/externalversions"
 	"github.com/knative/serving/test/reconciler/build"
+	"go.uber.org/zap"
 )
 
 const (
@@ -55,12 +56,12 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		logger.Fatalf("Error building kubeconfig: %v", err)
+		logger.Fatalw("Error building kubeconfig", zap.Error(err))
 	}
 
 	testingClient, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building testing clientset: %v", err)
+		logger.Fatalw("Error building testing clientset", zap.Error(err))
 	}
 
 	testingInformerFactory := informers.NewSharedInformerFactory(testingClient, time.Second*30)
@@ -86,7 +87,7 @@ func main() {
 		buildInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
-			logger.Fatalf("failed to wait for cache at index %v to sync", i)
+			logger.Fatalf("Failed to wait for cache at index %v to sync", i)
 		}
 	}
 
@@ -96,7 +97,7 @@ func main() {
 			// We don't expect this to return until stop is called,
 			// but if it does, propagate it back.
 			if runErr := ctrlr.Run(threadsPerController, stopCh); runErr != nil {
-				logger.Fatalf("Error running controller: %v", runErr)
+				logger.Fatalw("Error running controller", zap.Error(runErr))
 			}
 		}(ctrlr)
 	}

--- a/test/controller/main.go
+++ b/test/controller/main.go
@@ -87,7 +87,7 @@ func main() {
 		buildInformer.Informer().HasSynced,
 	} {
 		if ok := cache.WaitForCacheSync(stopCh, synced); !ok {
-			logger.Fatalf("Failed to wait for cache at index %v to sync", i)
+			logger.Fatalf("Failed to wait for cache at index %d to sync", i)
 		}
 	}
 


### PR DESCRIPTION
There is a lot of inconsistent use of the Zap logging functionality
throughout the project. This change moves all of the controller main
functions to use the Zap With() syntax when errors are present. This
fixes a bug in output for logging calls that forgot the "w" at the end of
the logging output level, and changes sprintf formatted error messages
to the use context options of Zap.

This change targets just these files to limit conflicts generated by a
larger single commit.

Previous log line without "w" or "f":
{"level":"info","msg":"Previous message.{error 25 0  Example Error}"}
Previous log line with "f":
{"level":"info","msg":"Previous message: Example Error"}
New log line with "w":
{"level":"info","msg":"New Message","error":"Example Error"}

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->