### PR TITLE
More cleanps for the traffic.go for the #2876.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -41,9 +41,9 @@ type Config struct {
 
 	// A list traffic targets, flattened to the Revision level.  This
 	// is used to populate the Route.Status.TrafficTarget field.
-	RevisionTargets []RevisionTarget
+	revisionTargets []RevisionTarget
 
-	// The referred Configurations and Revisions.
+	// The referred `Configuration`s and `Revision`s.
 	Configurations map[string]*v1alpha1.Configuration
 	Revisions      map[string]*v1alpha1.Revision
 }
@@ -67,14 +67,14 @@ func BuildTrafficConfiguration(configLister listers.ConfigurationLister, revList
 
 // GetRevisionTrafficTargets return a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.
 func (t *Config) GetRevisionTrafficTargets() []v1alpha1.TrafficTarget {
-	results := make([]v1alpha1.TrafficTarget, len(t.RevisionTargets))
-	for i, tt := range t.RevisionTargets {
+	results := make([]v1alpha1.TrafficTarget, len(t.revisionTargets))
+	for i, tt := range t.revisionTargets {
 		results[i] = v1alpha1.TrafficTarget{RevisionName: tt.RevisionName, Name: tt.Name, Percent: tt.Percent}
 	}
 	return results
 }
 
-type trafficConfigBuilder struct {
+type configBuilder struct {
 	configLister listers.ConfigurationLister
 	revLister    listers.RevisionLister
 	namespace    string
@@ -94,8 +94,8 @@ type trafficConfigBuilder struct {
 	deferredTargetErr TargetError
 }
 
-func newBuilder(configLister listers.ConfigurationLister, revLister listers.RevisionLister, namespace string) *trafficConfigBuilder {
-	return &trafficConfigBuilder{
+func newBuilder(configLister listers.ConfigurationLister, revLister listers.RevisionLister, namespace string) *configBuilder {
+	return &configBuilder{
 		configLister: configLister,
 		revLister:    revLister,
 		namespace:    namespace,
@@ -106,7 +106,7 @@ func newBuilder(configLister listers.ConfigurationLister, revLister listers.Revi
 	}
 }
 
-func (t *trafficConfigBuilder) getConfiguration(name string) (*v1alpha1.Configuration, error) {
+func (t *configBuilder) getConfiguration(name string) (*v1alpha1.Configuration, error) {
 	if _, ok := t.configurations[name]; !ok {
 		config, err := t.configLister.Configurations(t.namespace).Get(name)
 		if errors.IsNotFound(err) {
@@ -119,7 +119,7 @@ func (t *trafficConfigBuilder) getConfiguration(name string) (*v1alpha1.Configur
 	return t.configurations[name], nil
 }
 
-func (t *trafficConfigBuilder) getRevision(name string) (*v1alpha1.Revision, error) {
+func (t *configBuilder) getRevision(name string) (*v1alpha1.Revision, error) {
 	if _, ok := t.revisions[name]; !ok {
 		rev, err := t.revLister.Revisions(t.namespace).Get(name)
 		if errors.IsNotFound(err) {
@@ -134,13 +134,13 @@ func (t *trafficConfigBuilder) getRevision(name string) (*v1alpha1.Revision, err
 
 // deferTargetError will record a TargetError.  A TargetError with
 // IsFailure()=true will always overwrite a previous TargetError.
-func (t *trafficConfigBuilder) deferTargetError(err TargetError) {
+func (t *configBuilder) deferTargetError(err TargetError) {
 	if t.deferredTargetErr == nil || err.IsFailure() {
 		t.deferredTargetErr = err
 	}
 }
 
-func (t *trafficConfigBuilder) addTrafficTarget(tt *v1alpha1.TrafficTarget) error {
+func (t *configBuilder) addTrafficTarget(tt *v1alpha1.TrafficTarget) error {
 	var err error
 	if tt.RevisionName != "" {
 		err = t.addRevisionTarget(tt)
@@ -158,7 +158,7 @@ func (t *trafficConfigBuilder) addTrafficTarget(tt *v1alpha1.TrafficTarget) erro
 
 // addConfigurationTarget flattens a traffic target to the Revision level, by looking up for the LatestReadyRevisionName
 // on the referred Configuration.  It adds both to the lists of directly referred targets.
-func (t *trafficConfigBuilder) addConfigurationTarget(tt *v1alpha1.TrafficTarget) error {
+func (t *configBuilder) addConfigurationTarget(tt *v1alpha1.TrafficTarget) error {
 	config, err := t.getConfiguration(tt.ConfigurationName)
 	if err != nil {
 		return err
@@ -179,7 +179,7 @@ func (t *trafficConfigBuilder) addConfigurationTarget(tt *v1alpha1.TrafficTarget
 	return nil
 }
 
-func (t *trafficConfigBuilder) addRevisionTarget(tt *v1alpha1.TrafficTarget) error {
+func (t *configBuilder) addRevisionTarget(tt *v1alpha1.TrafficTarget) error {
 	rev, err := t.getRevision(tt.RevisionName)
 	if err != nil {
 		return err
@@ -202,7 +202,7 @@ func (t *trafficConfigBuilder) addRevisionTarget(tt *v1alpha1.TrafficTarget) err
 	return nil
 }
 
-func (t *trafficConfigBuilder) addFlattenedTarget(target RevisionTarget) {
+func (t *configBuilder) addFlattenedTarget(target RevisionTarget) {
 	name := target.TrafficTarget.Name
 	t.revisionTargets = append(t.revisionTargets, target)
 	t.targets[""] = append(t.targets[""], target)
@@ -243,14 +243,14 @@ func consolidateAll(targets map[string][]RevisionTarget) map[string][]RevisionTa
 	return consolidated
 }
 
-func (t *trafficConfigBuilder) build() (*Config, error) {
+func (t *configBuilder) build() (*Config, error) {
 	if t.deferredTargetErr != nil {
 		t.targets = nil
 		t.revisionTargets = nil
 	}
 	return &Config{
 		Targets:         consolidateAll(t.targets),
-		RevisionTargets: t.revisionTargets,
+		revisionTargets: t.revisionTargets,
 		Configurations:  t.configurations,
 		Revisions:       t.revisions,
 	}, t.deferredTargetErr

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package traffic
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -75,6 +74,8 @@ var (
 
 	configLister listers.ConfigurationLister
 	revLister    listers.RevisionLister
+
+	cmpOpts = []cmp.Option{cmp.AllowUnexported(Config{})}
 )
 
 func setUp() {
@@ -133,7 +134,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
@@ -146,8 +147,8 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -167,7 +168,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
@@ -180,8 +181,8 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -202,7 +203,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 				Active: false,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: inactiveConfig.Name,
 				RevisionName:      inactiveRev.Name,
@@ -214,9 +215,9 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 		Revisions:      map[string]*v1alpha1.Revision{inactiveRev.Name: inactiveRev},
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+		t.Errorf("Unexpected error %v", err)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -246,7 +247,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
 				RevisionName:      niceNewRev.Name,
@@ -265,9 +266,10 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
+
 }
 
 // Splitting traffic between a fixed revision and the latest revision (canary).
@@ -297,7 +299,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
@@ -317,9 +319,10 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
+
 }
 
 // Splitting traffic between latest revision and a fixed revision which is also latest.
@@ -384,7 +387,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "one",
 				ConfigurationName: goodConfig.Name,
@@ -414,8 +417,8 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -446,7 +449,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
@@ -466,8 +469,8 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -498,7 +501,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
@@ -518,8 +521,8 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -575,7 +578,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				Active: true,
 			}},
 		},
-		RevisionTargets: []RevisionTarget{{
+		revisionTargets: []RevisionTarget{{
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
@@ -600,9 +603,10 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
+
 }
 
 func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
@@ -623,13 +627,12 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 	}
 	expectedErr := errMissingConfiguration(missingConfig.Name)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected %v, saw %v", expectedErr, err)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
-	}
+
 }
 
 func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
@@ -644,12 +647,10 @@ func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
 	}
 	expectedErr := errUnreadyRevision(unreadyRev)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
-	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -665,12 +666,10 @@ func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
 	}
 	expectedErr := errUnreadyConfiguration(unreadyConfig)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
-	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -686,12 +685,10 @@ func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 	}
 	expectedErr := errUnreadyConfiguration(emptyConfig)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
-	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -713,12 +710,10 @@ func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 	}
 	expectedErr := errUnreadyConfiguration(failedConfig)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
-	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -740,12 +735,10 @@ func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 	}
 	expectedErr := errUnreadyConfiguration(failedConfig)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
-	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -764,12 +757,10 @@ func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 	}
 	expectedErr := errMissingRevision(missingRev.Name)
 	r := getTestRouteWithTrafficTargets(tts)
-	tc, err := BuildTrafficConfiguration(configLister, revLister, r)
-	if expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
 		t.Errorf("Expected %s, saw %s", expectedErr.Error(), err.Error())
-	}
-	if diff := cmp.Diff(expected, tc); diff != "" {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 }
 
@@ -796,9 +787,8 @@ func TestRoundTripping(t *testing.T) {
 	}}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, getTestRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if diff := cmp.Diff(expected, tc.GetRevisionTrafficTargets()); diff != "" {
-		fmt.Printf("%+v\n", tc.GetRevisionTrafficTargets())
-		t.Errorf("Unexpected traffic diff (-want +got): %v", diff)
+	} else if got, want := expected, tc.GetRevisionTrafficTargets(); !cmp.Equal(got, want) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want))
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes
- Unexport revisionTargets. They are not used outside, so let's not
  export it at all.
- The only drawback is that test cmp calls need to be annotated with the
  unexported type, but I think that's alright.
- In addition I changed cmp.Diff to cmp.Equal calls. There's no reason
  to compute the diff which is practically always empty (and Diff calls
  Equal and creates a report if there are diffs).

More to come.

/lint
/cc @tcnghia 



