### PR TITLE
Remove NYI tag for revision timeoutseconds

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -236,7 +236,6 @@ spec:
   # Deprecated in favor of containerConcurrency
   concurrencyModel: Single | Multi
 
-  # NYI: https://github.com/knative/serving/issues/457
   # Many higher-level systems impose a per-request response deadline.
   timeoutSeconds: ...
 
@@ -304,7 +303,7 @@ spec:  # One of "runLatest", "release", "pinned" (DEPRECATED), or "manual"
         spec: # serving.knative.dev/v1alpha1.RevisionSpec
           container: ... # See the Container section below
           containerConcurrency: ... # Optional
-          timeoutSeconds: ...
+          timeoutSeconds: ... # Optional
           serviceAccountName: ...  # Name of the service account the code should run as
 
   # Example, only one of "runLatest", "release", "pinned" (DEPRECATED), or "manual" can be set in practice.
@@ -317,7 +316,7 @@ spec:  # One of "runLatest", "release", "pinned" (DEPRECATED), or "manual"
         spec: # serving.knative.dev/v1alpha1.RevisionSpec
           container: ... # See the Container section below
           containerConcurrency: ... # Optional
-          timeoutSeconds: ...
+          timeoutSeconds: ... # Optional
           serviceAccountName: ...  # Name of the service account the code should run as
 
   # Example, only one of "runLatest", "release", "pinned" (DEPRECATED), or "manual" can be set in practice.
@@ -333,7 +332,7 @@ spec:  # One of "runLatest", "release", "pinned" (DEPRECATED), or "manual"
         spec: # serving.knative.dev/v1alpha1.RevisionSpec
           container: ... # See the Container section below
           containerConcurrency: ... # Optional
-          timeoutSeconds: ...
+          timeoutSeconds: ... # Optional
           serviceAccountName: ...  # Name of the service account the code should run as
 
   # Example, only one of "runLatest", "release", "pinned" (DEPRECATED), or "manual" can be set in practice.


### PR DESCRIPTION
mark field as optional in all places.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
