### PR TITLE
Spec.Generation is Deprecated

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -66,7 +66,7 @@ type PodAutoscalerSpec struct {
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// ConcurrencyModel specifies the desired concurrency model
 	// (Single or Multi) for the scale target. Defaults to Multi.

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -61,10 +61,14 @@ var _ duckv1alpha1.ConditionsAccessor = (*PodAutoscalerStatus)(nil)
 
 // PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).
 type PodAutoscalerSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
+	// when metadata.generation was not being incremented by the api server
+	//
+	// This property will be dropped in future Knative releases and should
+	// not be used - use metadata.generation
+	//
+	// Tracking issue: https://github.com/knative/serving/issues/643
+	//
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 

--- a/pkg/apis/networking/v1alpha1/clusteringress_types.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_types.go
@@ -74,10 +74,14 @@ type ClusterIngressList struct {
 // - Timeout & Retry can be configured.
 // - Headers can be appended.
 type IngressSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
+	// when metadata.generation was not being incremented by the api server
+	//
+	// This property will be dropped in future Knative releases and should
+	// not be used - use metadata.generation
+	//
+	// Tracking issue: https://github.com/knative/serving/issues/643
+	//
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 

--- a/pkg/apis/networking/v1alpha1/clusteringress_types.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_types.go
@@ -79,7 +79,7 @@ type IngressSpec struct {
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// TLS configuration. Currently the ClusterIngress only supports a single TLS
 	// port, 443. If multiple members of this list specify different hosts, they

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -64,7 +64,7 @@ type ConfigurationSpec struct {
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// Build optionally holds the specification for the build to
 	// perform to produce the Revision's container image.

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -59,10 +59,14 @@ var _ duckv1alpha1.ConditionsAccessor = (*ConfigurationStatus)(nil)
 
 // ConfigurationSpec holds the desired state of the Configuration (from the client).
 type ConfigurationSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
+	// when metadata.generation was not being incremented by the api server
+	//
+	// This property will be dropped in future Knative releases and should
+	// not be used - use metadata.generation
+	//
+	// Tracking issue: https://github.com/knative/serving/issues/643
+	//
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -155,10 +155,14 @@ const (
 
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
+	// when metadata.generation was not being incremented by the api server
+	//
+	// This property will be dropped in future Knative releases and should
+	// not be used - use metadata.generation
+	//
+	// Tracking issue: https://github.com/knative/serving/issues/643
+	//
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -160,7 +160,7 @@ type RevisionSpec struct {
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// DeprecatedServingState holds a value describing the desired state the Kubernetes
 	// resources should be in for this Revision.

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -88,10 +88,14 @@ type TrafficTarget struct {
 
 // RouteSpec holds the desired state of the Route (from the client).
 type RouteSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
+	// when metadata.generation was not being incremented by the api server
+	//
+	// This property will be dropped in future Knative releases and should
+	// not be used - use metadata.generation
+	//
+	// Tracking issue: https://github.com/knative/serving/issues/643
+	//
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -93,7 +93,7 @@ type RouteSpec struct {
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// Traffic specifies how to distribute traffic over a collection of Knative Serving Revisions and Configurations.
 	// +optional

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -71,7 +71,7 @@ type ServiceSpec struct {
 	// So, we add Generation here. Once that gets fixed, remove this and use
 	// ObjectMeta.Generation instead.
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// RunLatest defines a simple Service. It will automatically
 	// configure a route that keeps the latest ready revision

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -66,10 +66,14 @@ var _ duckv1alpha1.ConditionsAccessor = (*ServiceStatus)(nil)
 // track the latest ready revision of a configuration or be pinned to a specific
 // revision.
 type ServiceSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
+	// when metadata.generation was not being incremented by the api server
+	//
+	// This property will be dropped in future Knative releases and should
+	// not be used - use metadata.generation
+	//
+	// Tracking issue: https://github.com/knative/serving/issues/643
+	//
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -259,8 +259,8 @@ func ingressWithStatus(name string, generation int64, status v1alpha1.IngressSta
 			},
 		},
 		Spec: v1alpha1.IngressSpec{
-			Generation: generation,
-			Rules:      ingressRules,
+			DeprecatedGeneration: generation,
+			Rules:                ingressRules,
 		},
 		Status: status,
 	}

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -491,7 +491,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1
 			Generation: generation,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation: generation,
+			DeprecatedGeneration: generation,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: revisionSpec,
 			},

--- a/pkg/reconciler/v1alpha1/configuration/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/queueing_test.go
@@ -60,7 +60,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			// TODO(grantr): This is a workaround for generation initialization
-			Generation: 1,
+			DeprecatedGeneration: 1,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					ServiceAccountName: "test-account",

--- a/pkg/reconciler/v1alpha1/configuration/resources/build_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/build_test.go
@@ -60,7 +60,7 @@ func TestBuilds(t *testing.T) {
 				Name:      "build",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 31,
+				DeprecatedGeneration: 31,
 				Build: &v1alpha1.RawExtension{BuildSpec: &buildv1alpha1.BuildSpec{
 					Steps: []corev1.Container{{
 						Image: "busybox",
@@ -116,7 +116,7 @@ func TestBuilds(t *testing.T) {
 				Name:      "build-template",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 42,
+				DeprecatedGeneration: 42,
 				Build: &v1alpha1.RawExtension{BuildSpec: &buildv1alpha1.BuildSpec{
 					Template: &buildv1alpha1.TemplateInstantiationSpec{
 						Name: "buildpacks",

--- a/pkg/reconciler/v1alpha1/configuration/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/names/names.go
@@ -28,7 +28,7 @@ import (
 // This should eventually change to something like
 // '{config-name}-{config.metadata.generation}'
 func DeprecatedRevision(config *v1alpha1.Configuration) string {
-	return fmt.Sprintf("%s-%05d", config.Name, config.Spec.Generation)
+	return fmt.Sprintf("%s-%05d", config.Name, config.Spec.DeprecatedGeneration)
 }
 
 // DeprecatedBuild produces build name in the format

--- a/pkg/reconciler/v1alpha1/configuration/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/names/names_test.go
@@ -39,7 +39,7 @@ func TestNamer(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 42,
+				DeprecatedGeneration: 42,
 			},
 		},
 		f:    DeprecatedRevision,
@@ -52,7 +52,7 @@ func TestNamer(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 31,
+				DeprecatedGeneration: 31,
 			},
 		},
 		f:    DeprecatedRevision,
@@ -65,7 +65,7 @@ func TestNamer(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 16,
+				DeprecatedGeneration: 16,
 			},
 		},
 		f:    DeprecatedBuild,
@@ -78,7 +78,7 @@ func TestNamer(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 999,
+				DeprecatedGeneration: 999,
 				Build: &v1alpha1.RawExtension{
 					BuildSpec: &buildv1alpha1.BuildSpec{},
 				},

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -77,7 +77,7 @@ func RevisionLabelValueForKey(key string, config *v1alpha1.Configuration) string
 	case serving.ServiceLabelKey:
 		return config.Labels[serving.ServiceLabelKey]
 	case serving.DeprecatedConfigurationGenerationLabelKey:
-		return fmt.Sprintf("%d", config.Spec.Generation)
+		return fmt.Sprintf("%d", config.Spec.DeprecatedGeneration)
 	case serving.ConfigurationMetadataGenerationLabelKey:
 		return fmt.Sprintf("%d", config.Generation)
 	}

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -42,7 +42,7 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 10,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 12,
+				DeprecatedGeneration: 12,
 				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
 						Container: corev1.Container{
@@ -86,7 +86,7 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 99,
+				DeprecatedGeneration: 99,
 				Build: &v1alpha1.RawExtension{BuildSpec: &buildv1alpha1.BuildSpec{
 					Steps: []corev1.Container{{
 						Image: "busybox",
@@ -145,7 +145,7 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 99,
+				DeprecatedGeneration: 99,
 				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
@@ -197,7 +197,7 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				Generation: 99,
+				DeprecatedGeneration: 99,
 				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{

--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -77,7 +77,7 @@ func (c *Reconciler) reconcileClusterIngress(
 		return clusterIngress, nil
 	} else if err == nil {
 		// TODO(#642): Remove this (needed to avoid continuous updates)
-		desired.Spec.Generation = clusterIngress.Spec.Generation
+		desired.Spec.DeprecatedGeneration = clusterIngress.Spec.DeprecatedGeneration
 		if !equality.Semantic.DeepEqual(clusterIngress.Spec, desired.Spec) {
 			// Don't modify the informers copy
 			origin := clusterIngress.DeepCopy()

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -107,7 +107,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			// This is a workaround for generation initialization
-			Generation: 1,
+			DeprecatedGeneration: 1,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					Container: corev1.Container{

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -1219,7 +1219,7 @@ func cfg(namespace, name string, co ...ConfigOption) *v1alpha1.Configuration {
 			ResourceVersion: "v1",
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			Generation: 1,
+			DeprecatedGeneration: 1,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					Container: corev1.Container{

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -800,7 +800,7 @@ func getTestConfig(name string) *v1alpha1.Configuration {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			// This is a workaround for generation initialization.
-			Generation: 1,
+			DeprecatedGeneration: 1,
 			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					Container: corev1.Container{

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -276,7 +276,7 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alph
 	ignoreRouteLabelChange(desiredConfig, config)
 
 	// TODO(#642): Remove this (needed to avoid continuous updates)
-	desiredConfig.Spec.Generation = config.Spec.Generation
+	desiredConfig.Spec.DeprecatedGeneration = config.Spec.DeprecatedGeneration
 
 	if configSemanticEquals(desiredConfig, config) {
 		// No differences to reconcile.
@@ -323,7 +323,7 @@ func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Servi
 	}
 
 	// TODO(#642): Remove this (needed to avoid continuous updates).
-	desiredRoute.Spec.Generation = route.Spec.Generation
+	desiredRoute.Spec.DeprecatedGeneration = route.Spec.DeprecatedGeneration
 
 	if routeSemanticEquals(desiredRoute, route) {
 		// No differences to reconcile.

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -398,7 +398,7 @@ func WithGeneration(gen int64) ConfigOption {
 	return func(cfg *v1alpha1.Configuration) {
 		cfg.Generation = gen
 		//TODO(dprotaso) remove this for 0.4 release
-		cfg.Spec.Generation = gen
+		cfg.Spec.DeprecatedGeneration = gen
 	}
 }
 

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -136,13 +136,13 @@ func waitForConfigurationLatestCreatedRevision(clients *test.Clients, names test
 
 func waitForConfigurationLabelsUpdate(clients *test.Clients, names test.ResourceNames, labels map[string]string) error {
 	return test.WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
-		return reflect.DeepEqual(c.Labels, labels) && c.Spec.Generation == c.Status.ObservedGeneration, nil
+		return reflect.DeepEqual(c.Labels, labels) && c.Generation == c.Status.ObservedGeneration, nil
 	}, "ConfigurationMetadataUpdatedWithLabels")
 }
 
 func waitForConfigurationAnnotationsUpdate(clients *test.Clients, names test.ResourceNames, annotations map[string]string) error {
 	return test.WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
-		return reflect.DeepEqual(c.Annotations, annotations) && c.Spec.Generation == c.Status.ObservedGeneration, nil
+		return reflect.DeepEqual(c.Annotations, annotations) && c.Generation == c.Status.ObservedGeneration, nil
 	}, "ConfigurationMetadataUpdatedWithAnnotations")
 }
 


### PR DESCRIPTION
Part of #643

## Proposed Changes

* `Spec.Generation` is now renamed to `Spec.DeprecatedGeneration` to avoid new usages
