### PR TITLE
Optimize and unify the code in the webhook for serving.

### DIFF
--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/knative/pkg/apis"
 )
@@ -87,28 +87,22 @@ func (m *ManualType) Validate() *apis.FieldError {
 // Validate validates the fields belonging to ReleaseType
 func (rt *ReleaseType) Validate() *apis.FieldError {
 	var errs *apis.FieldError
-	minRevisions := 1
-	maxRevisions := 2
 
 	numRevisions := len(rt.Revisions)
-	if numRevisions < minRevisions {
+
+	if numRevisions == 0 {
 		errs = errs.Also(apis.ErrMissingField("revisions"))
 	}
-
-	if numRevisions > maxRevisions {
-		outOfRange := &apis.FieldError{
-			Message: fmt.Sprintf("expected number of elements in range [%v, %v], got %v", minRevisions, maxRevisions, numRevisions),
-			Paths:   []string{"revisions"},
-		}
-		errs = errs.Also(outOfRange)
+	if numRevisions > 2 {
+		errs = errs.Also(apis.ErrOutOfBoundsValue(strconv.Itoa(numRevisions), "1", "2", "revisions"))
 	}
 
 	if numRevisions < 2 && rt.RolloutPercent != 0 {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("%v", rt.RolloutPercent), "rolloutPercent"))
+		errs = errs.Also(apis.ErrInvalidValue(strconv.Itoa(rt.RolloutPercent), "rolloutPercent"))
 	}
 
 	if rt.RolloutPercent < 0 || rt.RolloutPercent > 99 {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("%v", rt.RolloutPercent), "rolloutPercent"))
+		errs = errs.Also(apis.ErrOutOfBoundsValue(strconv.Itoa(rt.RolloutPercent), "0", "99", "rolloutPercent"))
 	}
 
 	return errs.Also(rt.Configuration.Validate().ViaField("configuration"))

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -250,10 +250,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: &apis.FieldError{
-			Message: "expected number of elements in range [1, 2], got 3",
-			Paths:   []string{"spec.release.revisions"},
-		},
+		want: apis.ErrOutOfBoundsValue("3", "1", "2", "spec.release.revisions"),
 	}, {
 		name: "invalid release -- rollout greater than 99",
 		s: &Service{
@@ -273,7 +270,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("100", "spec.release.rolloutPercent"),
+		want: apis.ErrOutOfBoundsValue("100", "0", "99", "spec.release.rolloutPercent"),
 	}, {
 		name: "invalid release -- rollout less than 0",
 		s: &Service{
@@ -293,7 +290,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("-50", "spec.release.rolloutPercent"),
+		want: apis.ErrOutOfBoundsValue("-50", "0", "99", "spec.release.rolloutPercent"),
 	}, {
 		name: "invalid release -- non-zero rollout for single revision",
 		s: &Service{


### PR DESCRIPTION
## Proposed Changes

- Replace "%d/%v" to itoa
- we already have value in range error code, so let's reuse it here
- the "constants" that were present in the code didn't help much, so
  remove them.

/cc @jonjohnsonjr @vaikas-google 