### PR TITLE
[WIP] Tweak the route prober library to use an interface instead of a channel.

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -139,7 +139,8 @@ func TestRouteCreation(t *testing.T) {
 	assertResourcesUpdatedWhenRevisionIsReady(t, logger, clients, names, domain, "1", pizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.
-	routeProberErrorChan := test.RunRouteProber(logger, clients, domain)
+	prober := test.RunRouteProber(logger, clients, domain)
+	defer prober.Stop(t)
 
 	logger.Infof("Updating the Configuration to use a different image")
 	objects.Config, err = test.PatchConfigImage(logger, clients, objects.Config, test.ImagePath(pizzaPlanet2))
@@ -154,11 +155,4 @@ func TestRouteCreation(t *testing.T) {
 	}
 
 	assertResourcesUpdatedWhenRevisionIsReady(t, logger, clients, names, domain, "2", pizzaPlanetText2)
-
-	if err := test.GetRouteProberError(routeProberErrorChan, logger); err != nil {
-		// Currently the Route prober is flaky. So we just log the error here for future debugging instead of
-		// failing the test.
-		t.Fatalf("Route prober failed with error %s", err)
-	}
-
 }

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -180,7 +180,8 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	routeProberErrorChan := test.RunRouteProber(logger, clients, names.Domain)
+	prober := test.RunRouteProber(logger, clients, names.Domain)
+	defer prober.Stop(t)
 
 	// Update Container Image
 	logger.Info("Updating the Service to use a different image.")
@@ -255,10 +256,6 @@ func TestRunLatestService(t *testing.T) {
 	}
 	if err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(v1alpha1.DefaultUserPort)); err != nil {
 		t.Error(err)
-	}
-
-	if err := test.GetRouteProberError(routeProberErrorChan, logger); err != nil {
-		t.Fatalf("Route prober failed with error %s", err)
 	}
 
 	// Update container with user port.

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -138,13 +138,10 @@ func testScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, dura
 				logger.Info("All services were created successfully.")
 				return
 			}
+
 			// Start probing the domain until the test is complete.
-			probeCh := test.RunRouteProber(logger, clients, domain)
-			defer func(probeCh <-chan error) {
-				if err := test.GetRouteProberError(probeCh, logger); err != nil {
-					t.Fatalf("Route %q prober failed with error: %v", domain, err)
-				}
-			}(probeCh)
+			prober := test.RunRouteProber(logger, clients, domain)
+			defer prober.Stop(t)
 
 		case err := <-errCh:
 			t.Fatalf("An error occured during the test: %v", err)


### PR DESCRIPTION
This is a precursor to reworking the internals of the prober.

WIP until https://github.com/knative/serving/pull/2904 lands