### PR TITLE
Bump knative/pkg to fix a flake.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:88bbd0bbe417c2715669e1f3edcf6f285849fd5019b549f606fc6199cabaed20"
+  digest = "1:f142393519821f42e957c353a38b5f8ed2ee49311c7f3e2573e329f07c4fd95c"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -477,7 +477,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "d3a9e54be7d4213b4018135d82b586de45f6a694"
+  revision = "076ebf4e56758e76cd87fa402e9478da25ed942e"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-01-16
-  revision = "d3a9e54be7d4213b4018135d82b586de45f6a694"
+  # HEAD as of 2019-01-18
+  revision = "076ebf4e56758e76cd87fa402e9478da25ed942e"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
@@ -324,9 +324,10 @@ func (r conditionsImpl) MarkFalse(t ConditionType, reason, messageFormat string,
 // InitializeConditions updates all Conditions in the ConditionSet to Unknown
 // if not set.
 func (r conditionsImpl) InitializeConditions() {
-	for _, t := range append(r.dependents, r.happy) {
+	for _, t := range r.dependents {
 		r.InitializeCondition(t)
 	}
+	r.InitializeCondition(r.happy)
 }
 
 // InitializeCondition updates a Condition to Unknown if not set.

--- a/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
+++ b/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
@@ -18,7 +18,7 @@ const (
 	ResourceTypeKnativeRevision = "knative_revision"
 
 	// LabelProject is the label for project (e.g. GCP GAIA ID, AWS project name)
-	LabelProject = "project"
+	LabelProject = "project_id"
 
 	// LabelLocation is the label for location (e.g. GCE zone, AWS region) where the service is deployed
 	LabelLocation = "location"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2849

As per title, fixed another `append` call to a shared variable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
