### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -18,6 +18,7 @@ package reconciler
 
 import (
 	"fmt"
+
 	"github.com/knative/serving/pkg/utils"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
