### PR TITLE
Pods are no longer hanging in Terminating state for a long time.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -213,8 +213,6 @@ func createAdminHandlers() *http.ServeMux {
 
 		time.Sleep(quitSleepDuration)
 
-		logger.Info("starting shutdown")
-
 		// Shutdown the proxy server.
 		if server != nil {
 			if err := server.Shutdown(context.Background()); err != nil {
@@ -223,8 +221,6 @@ func createAdminHandlers() *http.ServeMux {
 				logger.Debug("Proxy server shutdown successfully.")
 			}
 		}
-
-		logger.Info("past shutdown")
 	}))
 
 	return mux

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -28,8 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/pkg/signals"
+
+	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/pkg/websocket"
 	"github.com/knative/serving/cmd/util"
 	activatorutil "github.com/knative/serving/pkg/activator/util"
@@ -44,7 +44,6 @@ import (
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -214,6 +213,8 @@ func createAdminHandlers() *http.ServeMux {
 
 		time.Sleep(quitSleepDuration)
 
+		logger.Info("starting shutdown")
+
 		// Shutdown the proxy server.
 		if server != nil {
 			if err := server.Shutdown(context.Background()); err != nil {
@@ -222,6 +223,8 @@ func createAdminHandlers() *http.ServeMux {
 				logger.Debug("Proxy server shutdown successfully.")
 			}
 		}
+
+		logger.Info("past shutdown")
 	}))
 
 	return mux
@@ -298,39 +301,39 @@ func main() {
 		fmt.Sprintf(":%d", v1alpha1.RequestQueuePort),
 		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler), time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
 
-	// An `ErrServerClosed` should not trigger an early exit of
-	// the errgroup below.
-	catchServerError := func(runner func() error) func() error {
-		return func() error {
-			err := runner()
-			if err != http.ErrServerClosed {
-				return err
-			}
-			return nil
+	errChan := make(chan error, 2)
+	// Runs a server created by creator and sends fatal errors to the errChan.
+	// Does not act on the ErrServerClosed error since that indicates we're
+	// already shutting everything down.
+	catchServerError := func(creator func() error) {
+		if err := creator(); err != nil && err != http.ErrServerClosed {
+			errChan <- err
 		}
 	}
 
-	var g errgroup.Group
-	g.Go(catchServerError(server.ListenAndServe))
-	g.Go(catchServerError(adminServer.ListenAndServe))
-	g.Go(func() error {
-		<-signals.SetupSignalHandler()
-		return errors.New("Received SIGTERM")
-	})
+	go catchServerError(server.ListenAndServe)
+	go catchServerError(adminServer.ListenAndServe)
 
-	if err := g.Wait(); err != nil {
-		logger.Errorw("Shutting down", zap.Error(err))
-	}
+	// Blocks until we actually receive a TERM signal or one of the servers
+	// exit unexpectedly. We fold both signals together because we only want
+	// to act on the first of those to reach here.
+	select {
+	case err := <-errChan:
+		logger.Errorw("Failed to bring up queue-proxy, shutting down.", zap.Error(err))
+		os.Exit(1)
+	case <-signals.SetupSignalHandler():
+		logger.Info("Received TERM signal, attempting to gracefully shutdown servers.")
 
-	// Calling server.Shutdown() allows pending requests to
-	// complete, while no new work is accepted.
-	if err := adminServer.Shutdown(context.Background()); err != nil {
-		logger.Errorw("Failed to shutdown admin-server", zap.Error(err))
-	}
+		// Calling server.Shutdown() allows pending requests to
+		// complete, while no new work is accepted.
+		if err := adminServer.Shutdown(context.Background()); err != nil {
+			logger.Errorw("Failed to shutdown admin-server", zap.Error(err))
+		}
 
-	if statSink != nil {
-		if err := statSink.Close(); err != nil {
-			logger.Errorw("Failed to shutdown websocket connection", zap.Error(err))
+		if statSink != nil {
+			if err := statSink.Close(); err != nil {
+				logger.Errorw("Failed to shutdown websocket connection", zap.Error(err))
+			}
 		}
 	}
 }

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -347,7 +347,7 @@ data:
       
       containers:
       - name: istio-proxy
-        # PATCH #2: Graceful shutdown of the istio-proxy.
+        # PATCH #2: Graceful shutdown of the istio-proxy. See https://github.com/istio/istio/issues/7136.
         lifecycle:
           preStop:
             exec:

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -351,7 +351,7 @@ data:
         lifecycle:
           preStop:
             exec:
-              command: ["sh", "-c", 'sleep 20; until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+              command: ["sh", "-c", 'sleep 20; while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l | xargs) -ne 0 ]; do sleep 1; done']
         # PATCH #2 ends.
         image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
         "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"

--- a/third_party/istio-1.0.2/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.0.2/prestop-sleep.yaml.patch
@@ -1,7 +1,7 @@
 349a350,355
->         # PATCH #2: Graceful shutdown of the istio-proxy.
+>         # PATCH #2: Graceful shutdown of the istio-proxy. See https://github.com/istio/istio/issues/7136.
 >         lifecycle:
 >           preStop:
 >             exec:
->               command: ["sh", "-c", 'sleep 20; until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+>               command: ["sh", "-c", 'sleep 20; while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l | xargs) -ne 0 ]; do sleep 1; done']
 >         # PATCH #2 ends.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2897

## Proposed Changes

* Fix the istio-proxy preStop hook. The grep on /clusters wasn't actually working correctly because the "inbound|80|" endpoint is very quickly removed from the /clusters list once the pod starts shutting down. That caused the loop to run forever, until the terminationGrace was over. An alternative way has been shown in an upstream istio issue and I thought that's a pretty clever idea as well!
* Fix the shutdown mechanism of the queue-proxy (again...). The ErrGroup was a mistake, because `Wait` will only return once all `Go` calls return (not on first error). That also means, that `Wait` never returned, because we shutdown the adminServer _after_ we receive the signal and thus after the `Wait` call. Basically, the queue-proxy never reacted to a SIGTERM signal, causing it to stay around until the terminationGrace is over.

Both in conjunction allow the pod to exit and disappear as quickly as possible again.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pods are no longer hanging in Terminating state for a long time.
```
