### PR TITLE
remove hard-coded NodePort

### DIFF
--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -74,16 +74,13 @@ spec:
   ports:
     -
       name: http2
-      nodePort: 32380
       port: 80
       targetPort: 80
     -
       name: https
-      nodePort: 32390
       port: 443
     -
       name: tcp
-      nodePort: 32400
       port: 31400
     -
       name: tcp-pilot-grpc-tls


### PR DESCRIPTION
On systems where Istio is already installed its possible that Istio
will grab one of these nodePorts already and the install of Knative
serving will fail with a complaint about trying to use a port that's
already taken.

Signed-off-by: Doug Davis <dug@us.ibm.com>
