### PR TITLE
Reformulate the e2e "probing" in terms of SLI/SLO.

### DIFF
--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -140,7 +140,7 @@ func TestRouteCreation(t *testing.T) {
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.
 	prober := test.RunRouteProber(logger, clients, domain)
-	defer test.CheckProberDefault(t, prober)
+	defer test.AssertProberDefault(t, prober)
 
 	logger.Infof("Updating the Configuration to use a different image")
 	objects.Config, err = test.PatchConfigImage(logger, clients, objects.Config, test.ImagePath(pizzaPlanet2))

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -139,7 +139,8 @@ func TestRouteCreation(t *testing.T) {
 	assertResourcesUpdatedWhenRevisionIsReady(t, logger, clients, names, domain, "1", pizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.
-	routeProberErrorChan := test.RunRouteProber(logger, clients, domain)
+	prober := test.RunRouteProber(logger, clients, domain)
+	defer test.CheckProberDefault(t, prober)
 
 	logger.Infof("Updating the Configuration to use a different image")
 	objects.Config, err = test.PatchConfigImage(logger, clients, objects.Config, test.ImagePath(pizzaPlanet2))
@@ -154,11 +155,4 @@ func TestRouteCreation(t *testing.T) {
 	}
 
 	assertResourcesUpdatedWhenRevisionIsReady(t, logger, clients, names, domain, "2", pizzaPlanetText2)
-
-	if err := test.GetRouteProberError(routeProberErrorChan, logger); err != nil {
-		// Currently the Route prober is flaky. So we just log the error here for future debugging instead of
-		// failing the test.
-		t.Fatalf("Route prober failed with error %s", err)
-	}
-
 }

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -180,7 +180,8 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	routeProberErrorChan := test.RunRouteProber(logger, clients, names.Domain)
+	prober := test.RunRouteProber(logger, clients, names.Domain)
+	defer test.CheckProberDefault(t, prober)
 
 	// Update Container Image
 	logger.Info("Updating the Service to use a different image.")
@@ -255,10 +256,6 @@ func TestRunLatestService(t *testing.T) {
 	}
 	if err = validateRunLatestDataPlane(logger, clients, names, strconv.Itoa(v1alpha1.DefaultUserPort)); err != nil {
 		t.Error(err)
-	}
-
-	if err := test.GetRouteProberError(routeProberErrorChan, logger); err != nil {
-		t.Fatalf("Route prober failed with error %s", err)
 	}
 
 	// Update container with user port.

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -181,7 +181,7 @@ func TestRunLatestService(t *testing.T) {
 
 	// We start a background prober to test if Route is always healthy even during Route update.
 	prober := test.RunRouteProber(logger, clients, names.Domain)
-	defer test.CheckProberDefault(t, prober)
+	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
 	logger.Info("Updating the Service to use a different image.")

--- a/test/prober.go
+++ b/test/prober.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// route.go provides methods to perform actions on the route resource.
+
+package test
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/spoof"
+	"golang.org/x/sync/errgroup"
+)
+
+// Prober is the interface for a prober, which checks the result of the probes when stopped.
+type Prober interface {
+	// SLI returns the "service level indicator" for the prober, which is the observed
+	// success rate of the probes.  This will panic if the prober has not been stopped.
+	SLI() (total int64, failures int64)
+
+	// Stop terminates the prober, returning any observed errors.
+	Stop() error
+}
+
+type prober struct {
+	// These shouldn't change after creation
+	logger        *logging.BaseLogger
+	domain        string
+	minimumProbes int64
+
+	// m guards access to these fields
+	m        sync.Mutex
+	requests int64
+	failures int64
+	stopped  bool
+	err      error
+}
+
+// prober implements Prober
+var _ Prober = (*prober)(nil)
+
+// SLI implements Prober
+func (p *prober) SLI() (int64, int64) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	return p.requests, p.failures
+}
+
+// Stop implements Prober
+func (p *prober) Stop() error {
+	for {
+		if done, err := p.isDone(); err != nil {
+			return err
+		} else if done {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (p *prober) isDone() (bool, error) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if p.err != nil {
+		p.stopped = true
+		return true, p.err
+	}
+
+	if p.requests < p.minimumProbes {
+		p.logger.Infof("%q needs more probes; got %d, want %d", p.domain, p.requests, p.minimumProbes)
+		return false, nil
+	}
+
+	p.stopped = true
+	return true, nil
+}
+
+func (p *prober) handleError(err error) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.err = err
+}
+
+func (p *prober) handleResponse(response *spoof.Response) (bool, error) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if p.stopped {
+		return p.stopped, nil
+	}
+
+	p.requests++
+	if response.StatusCode != http.StatusOK {
+		p.logger.Infof("%q got bad status: %d\nHeaders:%v\nBody: %s", p.domain, response.StatusCode,
+			response.Header, string(response.Body))
+		p.failures++
+	}
+
+	// Returning (false, nil) causes SpoofingClient.Poll to retry.
+	// sc.logger.Infof("Retrying for code %v", resp.StatusCode)
+	return p.stopped, nil
+}
+
+// ProberManager is the interface for spawning probers, and checking their results.
+type ProberManager interface {
+	// Spawn creates a new Prober
+	Spawn(domain string) Prober
+
+	// StopAll terminates all probers, returning any observed errors.
+	StopAll() error
+
+	// Check compares each of the prober SLIs against the localSLO and
+	// then the aggregate of the SLIs against the globalSLO
+	Check(t *testing.T, localSLO, globalSLO float64)
+}
+
+type manager struct {
+	// Should not change after creation
+	logger    *logging.BaseLogger
+	clients   *Clients
+	minProbes int64
+
+	m      sync.Mutex
+	probes map[string]Prober
+}
+
+var _ ProberManager = (*manager)(nil)
+
+// Spawn implements ProberManager
+func (m *manager) Spawn(domain string) Prober {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if p, ok := m.probes[domain]; ok {
+		return p
+	}
+
+	m.logger.Infof("Starting Route prober for route domain %s.", domain)
+	p := &prober{logger: m.logger, domain: domain, minimumProbes: m.minProbes}
+	m.probes[domain] = p
+	go func() {
+		client, err := pkgTest.NewSpoofingClient(m.clients.KubeClient, m.logger, domain,
+			ServingFlags.ResolvableDomain)
+		if err != nil {
+			m.logger.Infof("NewSpoofingClient() = %v", err)
+			p.handleError(err)
+			return
+		}
+
+		// RequestTimeout is set to 0 to make the polling infinite.
+		client.RequestTimeout = 0 * time.Minute
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+		if err != nil {
+			m.logger.Infof("NewRequest() = %v", err)
+			p.handleError(err)
+			return
+		}
+
+		// We keep polling Route if the response status is OK.
+		// If the response status is not OK, we stop the prober and
+		// generate error based on the response.z
+		_, err = client.Poll(req, p.handleResponse)
+		if err != nil {
+			m.logger.Infof("Poll() = %v", err)
+			p.handleError(err)
+			return
+		}
+	}()
+	return p
+}
+
+// StopAll implements ProberManager
+func (m *manager) StopAll() error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.logger.Info("Stopping all probers")
+
+	errgrp := &errgroup.Group{}
+	for _, prober := range m.probes {
+		errgrp.Go(prober.Stop)
+	}
+	return errgrp.Wait()
+}
+
+// Check implements ProberManager
+func (m *manager) Check(t *testing.T, localSLO, globalSLO float64) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.logger.Infof("Checking local (%f) and global (%v) SLOs", localSLO, globalSLO)
+
+	var globalTotal, globalFailures int64
+	for domain, prober := range m.probes {
+		total, failures := prober.SLI()
+
+		successRate := float64(total-failures) / float64(total)
+		m.logger.Infof("%q SLI is %f (total: %d, failures: %d)", domain, successRate, total, failures)
+		if successRate < localSLO {
+			t.Errorf("SLI for %q = %f, wanted >= %f", domain, successRate, localSLO)
+		}
+		globalTotal += total
+		globalFailures += failures
+	}
+
+	globalSuccessRate := float64(globalTotal-globalFailures) / float64(globalTotal)
+	m.logger.Infof("global SLI is %f (total: %d, failures: %d)", globalSuccessRate, globalTotal, globalFailures)
+	if globalSuccessRate < globalSLO {
+		t.Errorf("SLI for %q = %f, wanted >= %f", "all", globalSuccessRate, globalSLO)
+	}
+}
+
+func NewProberManager(logger *logging.BaseLogger, clients *Clients, minProbes int64) ProberManager {
+	return &manager{
+		logger:    logger,
+		clients:   clients,
+		minProbes: minProbes,
+		probes:    make(map[string]Prober),
+	}
+}
+
+func RunRouteProber(logger *logging.BaseLogger, clients *Clients, domain string) ProberManager {
+	// Default to 10 probes
+	pm := NewProberManager(logger, clients, 10)
+	pm.Spawn(domain)
+	return pm
+}
+
+func CheckProberDefault(t *testing.T, pm ProberManager) {
+	if err := pm.StopAll(); err != nil {
+		t.Errorf("StopAll() = %v", err)
+	}
+	// Default to 100% correct (typically used in conjunctions with the low probe count above)
+	pm.Check(t, 1.0, 1.0)
+}

--- a/test/route.go
+++ b/test/route.go
@@ -19,13 +19,7 @@ limitations under the License.
 package test
 
 import (
-	"fmt"
-	"net/http"
-	"time"
-
-	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
-	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -61,53 +55,4 @@ func UpdateBlueGreenRoute(logger *logging.BaseLogger, clients *Clients, names, b
 		return nil, err
 	}
 	return clients.ServingClient.Routes.Patch(names.Route, types.JSONPatchType, patchBytes, "")
-}
-
-// RunRouteProber creates and runs a prober as background goroutine to keep polling Route.
-// It stops when getting an error response from Route.
-func RunRouteProber(logger *logging.BaseLogger, clients *Clients, domain string) <-chan error {
-	logger.Infof("Starting Route prober for route domain %s.", domain)
-	errorChan := make(chan error, 1)
-	go func() {
-		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, ServingFlags.ResolvableDomain)
-		if err != nil {
-			errorChan <- err
-			close(errorChan)
-			return
-		}
-		// ResquestTimeout is set to 0 to make the polling infinite.
-		client.RequestTimeout = 0 * time.Minute
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
-		if err != nil {
-			errorChan <- err
-			close(errorChan)
-			return
-		}
-
-		// We keep polling Route if the response status is OK.
-		// If the response status is not OK, we stop the prober and
-		// generate error based on the response.
-		_, err = client.Poll(req, pkgTest.Retrying(disallowsAny, http.StatusOK))
-		if err != nil {
-			errorChan <- err
-			close(errorChan)
-			return
-		}
-	}()
-	return errorChan
-}
-
-// GetRouteProberError gets the error of route prober.
-func GetRouteProberError(errorChan <-chan error, logger *logging.BaseLogger) error {
-	select {
-	case err := <-errorChan:
-		return err
-	default:
-		logger.Info("No error happens in the Route prober.")
-		return nil
-	}
-}
-
-func disallowsAny(response *spoof.Response) (bool, error) {
-	return true, fmt.Errorf("Get unexpected response %v", response)
 }

--- a/test/service.go
+++ b/test/service.go
@@ -27,6 +27,8 @@ import (
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
 
 // TODO(dangerd): Move function to duck.CreateBytePatch
@@ -127,19 +129,11 @@ func CreateRunLatestServiceReady(logger *logging.BaseLogger, clients *Clients, n
 }
 
 // CreateLatestService creates a service in namespace with the name names.Service and names.Image
-func CreateLatestService(logger *logging.BaseLogger, clients *Clients, names ResourceNames, options *Options) (*v1alpha1.Service, error) {
-	service := LatestService(ServingNamespace, names, options)
+func CreateLatestService(logger *logging.BaseLogger, clients *Clients, names ResourceNames, options *Options, fopt ...testing.ServiceOption) (*v1alpha1.Service, error) {
+	service := LatestService(ServingNamespace, names, options, fopt...)
 	LogResourceObject(logger, ResourceObjects{Service: service})
 	svc, err := clients.ServingClient.Services.Create(service)
 	return svc, err
-}
-
-// CreateLatestServiceWithResources creates a service in namespace with the name names.Service
-// that uses the image specified by names.Image
-func CreateLatestServiceWithResources(logger *logging.BaseLogger, clients *Clients, names ResourceNames, options *Options) (*v1alpha1.Service, error) {
-	service := LatestServiceWithResources(ServingNamespace, names, options)
-	LogResourceObject(logger, ResourceObjects{Service: service})
-	return clients.ServingClient.Services.Create(service)
 }
 
 // PatchReleaseService patches an existing service in namespace with the name names.Service


### PR DESCRIPTION
This reformulates the prober logic we use (heavily) during the scale test to operate in terms of SLI (measured success) and SLO (target success) at two levels:
1. Per-probe, which could potentially drift lower.
1. Aggregate, which should be quite high.

As part of this refactoring, I uncovered the source of our woes with this test, which is captured in detail at #2946.  The basic idea is that we disable autoscaling (in particular activation) because it is unreliable at the level of churn that these scale tests create with high values of N.

With N=200, and no mesh (simply what I run day-to-day) I was able to pass 3x in a row with an Aggregate SLI of 100% (no dropped probes).  This is night/day from what we were seeing before.

Fixes: https://github.com/knative/serving/issues/2850

I still need to explore (but out of scope for the above issue):
1. Whether things fail at 200 with the mesh
1. How high we can go with/without the mesh.
1. Raise the high-watermark that we test to be beyond 50

