### PR TITLE
Add a simple threadpool library

### DIFF
--- a/pkg/pool/OWNERS
+++ b/pkg/pool/OWNERS
@@ -1,0 +1,7 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- serving-api-approvers
+
+reviewers:
+- serving-api-reviewers

--- a/pkg/pool/doc.go
+++ b/pkg/pool/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pool contains a simple threadpool implementation that accepts
+// work in the form of `func() error` function.  The intent is for it to
+// support similar workloads to errgroup, but with a maximum number of
+// concurrent worker threads.
+package pool

--- a/pkg/pool/interface.go
+++ b/pkg/pool/interface.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"golang.org/x/sync/errgroup"
+)
+
+// Interface defines an errgroup-compatible interface for interacting with
+// our threadpool.
+type Interface interface {
+	// Go queues a single unit of work for execution on this pool.
+	Go(func() error)
+
+	// Wait blocks until all work is complete, returning the first
+	// error returned by any of the work.
+	Wait() error
+}
+
+// errgroup.Group implements Interface
+var _ Interface = (*errgroup.Group)(nil)

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"sync"
+)
+
+type impl struct {
+	wg     sync.WaitGroup
+	workCh chan func() error
+	errCh  chan error
+
+	// Ensure that we Wait exactly once and memoize
+	// the result.
+	once   sync.Once
+	result error
+}
+
+// impl implements Interface
+var _ Interface = (*impl)(nil)
+
+// DefaultCapacity is the number of work items or errors that we
+// can queue up before calls to Go will block, or work will
+// block until Wait is called.
+const DefaultCapacity = 50
+
+// New creates a fresh worker pool with the specified size.
+func New(workers int) Interface {
+	return NewWithCapacity(workers, DefaultCapacity)
+}
+
+// NewWithCapacity creates a fresh worker pool with the specified size.
+func NewWithCapacity(workers, capacity int) Interface {
+	i := &impl{
+		workCh: make(chan func() error, capacity),
+		errCh:  make(chan error, capacity),
+	}
+
+	// Start a go routine for each worker, which:
+	// 1. reads off of the work channel,
+	// 2. (optionally) sends errors on the error channel,
+	// 3. marks work as done in our sync.WaitGroup.
+	for idx := 0; idx < workers; idx++ {
+		go func() {
+			for work := range i.workCh {
+				func() {
+					defer i.wg.Done()
+					if err := work(); err != nil {
+						i.errCh <- err
+					}
+				}()
+			}
+		}()
+	}
+
+	return i
+}
+
+// Go implements Interface.
+func (i *impl) Go(w func() error) {
+	// Increment the amount of outstanding work we're waiting on.
+	i.wg.Add(1)
+	// Send the work along the queue.
+	i.workCh <- w
+}
+
+// Wait implements Interface.
+func (i *impl) Wait() error {
+	i.once.Do(func() {
+		// Stop accepting new work.
+		close(i.workCh)
+
+		// Wait until outstanding work has completed and close the
+		// error channel.  The logic below will drain the error
+		// channel in parallel, looking for the close before returning
+		// the first error seen.
+		go func() {
+			// Wait for queued work to complete.
+			i.wg.Wait()
+
+			// Close the channel, so that the receive below
+			// completes in the non-error case.
+			close(i.errCh)
+		}()
+
+		for {
+			// When we drain all of the errors and see the error
+			// channel close, then return the first error we saw.
+			if err, ok := <-i.errCh; !ok {
+				return
+			} else if i.result == nil {
+				// The first time we see an error, squirrel it
+				// away to return when the channel closes.
+				i.result = err
+			}
+		}
+	})
+
+	return i.result
+}

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParallelismNoErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		work int
+	}{{
+		name: "single threaded",
+		size: 1,
+		work: 3,
+	}, {
+		name: "three workers",
+		size: 3,
+		work: 10,
+	}, {
+		name: "ten workers",
+		size: 10,
+		work: 100,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				// m guards max.
+				m      sync.Mutex
+				max    int32
+				active int32
+			)
+
+			// Use our own waitgroup to ensure that the work
+			// can all complete before we block on the error
+			// result.
+			wg := &sync.WaitGroup{}
+
+			worker := func() error {
+				defer wg.Done()
+				na := atomic.AddInt32(&active, 1)
+				defer atomic.AddInt32(&active, -1)
+
+				func() {
+					m.Lock()
+					defer m.Unlock()
+					if max < na {
+						max = na
+					}
+				}()
+
+				// Sleep a small amount to simulate work.  This should be
+				// sufficient to saturate the threadpool before the first
+				// one wakes up.
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			}
+
+			p := New(tc.size)
+			for idx := 0; idx < tc.work; idx++ {
+				wg.Add(1)
+				p.Go(worker)
+			}
+
+			// First wait for the waitgroup to finish, so that
+			// we are sure it isn't the Wait call that flushes
+			// remaining work.
+			wg.Wait()
+
+			if err := p.Wait(); err != nil {
+				t.Errorf("Wait() = %v", err)
+			}
+
+			if err := p.Wait(); err != nil {
+				t.Errorf("Wait() = %v", err)
+			}
+
+			if got, want := max, int32(tc.size); got != want {
+				t.Errorf("max active = %v, wanted %v", got, want)
+			}
+		})
+	}
+}
+
+func TestParallelismWithErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		work int
+	}{{
+		name: "single threaded",
+		size: 1,
+		work: 3,
+	}, {
+		name: "three workers",
+		size: 3,
+		work: 10,
+	}, {
+		name: "ten workers",
+		size: 10,
+		// This is the number of errors that we can buffer before
+		// the test kernel below will deadlock because we need the
+		// pool's Wait call to drain the buffered errors before more
+		// than this can be sent.
+		work: DefaultCapacity + 10, /* size */
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				// m guards max.
+				m      sync.Mutex
+				max    int32
+				active int32
+			)
+
+			// Use our own waitgroup to ensure that the work
+			// can all complete before we block on the error
+			// result.
+			wg := &sync.WaitGroup{}
+
+			errExpected := errors.New("this is what I expect")
+			workerFactory := func(err error) func() error {
+				return func() error {
+					defer wg.Done()
+					na := atomic.AddInt32(&active, 1)
+					defer atomic.AddInt32(&active, -1)
+
+					func() {
+						m.Lock()
+						defer m.Unlock()
+						if max < na {
+							max = na
+						}
+					}()
+
+					// Make the first piece of work finish quickly.
+					if err != errExpected {
+						// Sleep a small amount to simulate work.  This should be
+						// sufficient to saturate the threadpool before the first
+						// one wakes up.
+						time.Sleep(10 * time.Millisecond)
+					}
+					return err
+				}
+			}
+
+			p := New(tc.size)
+
+			// Let the work complete.
+			wg.Add(1)
+			p.Go(workerFactory(errExpected))
+			time.Sleep(10 * time.Millisecond)
+
+			// Change the error we return and queue the remaining work.
+			for idx := 1; idx < tc.work; idx++ {
+				wg.Add(1)
+				p.Go(workerFactory(errors.New("this is not what I expect")))
+			}
+
+			// First wait for the waitgroup to finish, so that
+			// we are sure it isn't the Wait call that flushes
+			// remaining work.
+			wg.Wait()
+
+			if err := p.Wait(); err != errExpected {
+				t.Errorf("Wait() = %v, wanted %v", err, errExpected)
+			}
+
+			if got, want := max, int32(tc.size); got != want {
+				t.Errorf("max active = %v, wanted %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements a simple threadpooling library with the same interface as errgroup.

This will enable us to launch work in a more throttled manner.

I want this so that I can throttle the rate of Service creation requests in the scale test.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->