### PR TITLE
Immediately send scale-from-zero stat from activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -151,11 +151,10 @@ func main() {
 	go statReporter(stopCh)
 
 	podName := util.GetRequiredEnvOrFatal("POD_NAME", logger)
-	activatorhandler.NewConcurrencyReporter(podName, activatorhandler.Channels{
-		ReqChan:    reqChan,
-		StatChan:   statChan,
-		ReportChan: time.NewTicker(time.Second).C,
-	})
+
+	// Create and run our concurrency reporter
+	cr := activatorhandler.NewConcurrencyReporter(podName, reqChan, time.NewTicker(time.Second).C, statChan)
+	go cr.Run(stopCh)
 
 	ah := &activatorhandler.FilteringHandler{
 		NextHandler: activatorhandler.NewRequestEventHandler(reqChan,

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -20,66 +20,92 @@ import (
 	"time"
 
 	"github.com/knative/serving/pkg/autoscaler"
+	"github.com/knative/serving/pkg/system"
 )
 
-// Channels is a structure for holding the channels for driving Stats.
-// It's just to make the NewStats signature easier to read.
-type Channels struct {
+// ConcurrencyReporter reports stats based on incoming requests and ticks.
+type ConcurrencyReporter struct {
+	podName string
+
 	// Ticks with every request arrived/completed respectively
-	ReqChan chan ReqEvent
+	reqChan chan ReqEvent
 	// Ticks with every stat report request
-	ReportChan <-chan time.Time
+	reportChan <-chan time.Time
 	// Stat reporting channel
-	StatChan chan *autoscaler.StatMessage
+	statChan chan *autoscaler.StatMessage
+
+	clock system.Clock
 }
 
-// NewConcurrencyReporter instantiates a new goroutine that consumes and
-// produces from the given channels.
-// On each tick on the ReportChan, StatMessages will be sent to the
-// StatChan.
-func NewConcurrencyReporter(podName string, channels Channels) {
+// NewConcurrencyReporter creates a ConcurrencyReporter which listens to incoming
+// ReqEvents on reqChan and ticks on reportChan and reports stats on statChan.
+func NewConcurrencyReporter(podName string, reqChan chan ReqEvent, reportChan <-chan time.Time, statChan chan *autoscaler.StatMessage) *ConcurrencyReporter {
+	return NewConcurrencyReporterWithClock(podName, reqChan, reportChan, statChan, system.RealClock{})
+}
 
-	go func() {
-		outstandingRequestsPerKey := make(map[string]int32)
+// NewConcurrencyReporterWithClock instantiates a new concurrency reporter
+// which uses the passed clock.
+func NewConcurrencyReporterWithClock(podName string, reqChan chan ReqEvent, reportChan <-chan time.Time, statChan chan *autoscaler.StatMessage, clock system.Clock) *ConcurrencyReporter {
+	return &ConcurrencyReporter{
+		podName:    podName,
+		reqChan:    reqChan,
+		reportChan: reportChan,
+		statChan:   statChan,
+		clock:      clock,
+	}
+}
 
-		// Contains the number of incoming requests in the current
-		// reporting period, per key.
-		incomingRequestsPerKey := make(map[string]int32)
-		for {
-			select {
-			case event := <-channels.ReqChan:
-				switch event.EventType {
-				case ReqIn:
-					incomingRequestsPerKey[event.Key]++
-					outstandingRequestsPerKey[event.Key]++
-				case ReqOut:
-					outstandingRequestsPerKey[event.Key]--
+func (cr *ConcurrencyReporter) report(now time.Time, key string, concurrency, requestCount int32) {
+	stat := autoscaler.Stat{
+		Time:                      &now,
+		PodName:                   cr.podName,
+		AverageConcurrentRequests: float64(concurrency),
+		RequestCount:              requestCount,
+	}
+
+	// Send the stat to another goroutine to transmit
+	// so we can continue bucketing stats.
+	cr.statChan <- &autoscaler.StatMessage{
+		Key:  key,
+		Stat: stat,
+	}
+}
+
+// Run runs until stopCh is closed and processes events on all incoming channels
+func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
+	// Contains the number of in-flight requests per-key
+	outstandingRequestsPerKey := make(map[string]int32)
+	// Contains the number of incoming requests in the current
+	// reporting period, per key.
+	incomingRequestsPerKey := make(map[string]int32)
+
+	for {
+		select {
+		case event := <-cr.reqChan:
+			switch event.EventType {
+			case ReqIn:
+				incomingRequestsPerKey[event.Key]++
+
+				// Report the first request for a key immediately.
+				if _, ok := outstandingRequestsPerKey[event.Key]; !ok {
+					cr.report(cr.clock.Now(), event.Key, 1, incomingRequestsPerKey[event.Key])
 				}
-			case now := <-channels.ReportChan:
-				for key, concurrency := range outstandingRequestsPerKey {
-					if concurrency == 0 {
-						delete(outstandingRequestsPerKey, key)
-					} else {
-						requestCount := incomingRequestsPerKey[key]
-
-						stat := autoscaler.Stat{
-							Time:                      &now,
-							PodName:                   podName,
-							AverageConcurrentRequests: float64(concurrency),
-							RequestCount:              requestCount,
-						}
-
-						// Send the stat to another goroutine to transmit
-						// so we can continue bucketing stats.
-						channels.StatChan <- &autoscaler.StatMessage{
-							Key:  key,
-							Stat: stat,
-						}
-					}
-				}
-
-				incomingRequestsPerKey = make(map[string]int32)
+				outstandingRequestsPerKey[event.Key]++
+			case ReqOut:
+				outstandingRequestsPerKey[event.Key]--
 			}
+		case now := <-cr.reportChan:
+			for key, concurrency := range outstandingRequestsPerKey {
+				if concurrency == 0 {
+					delete(outstandingRequestsPerKey, key)
+				} else {
+					cr.report(now, key, concurrency, incomingRequestsPerKey[key])
+				}
+			}
+
+			incomingRequestsPerKey = make(map[string]int32)
+		case <-stopCh:
+			return
 		}
-	}()
+	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Upon receiving a request the activator should immediately send a stat to the autoscaler in the scale from zero case - this reduces cold-start time.

Fixes #2659


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Immediately send scale-from-zero stat from activator.
```
