### PR TITLE
[RELEASE 0.3] Update test-infra to include knative/test-infra#396

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -68,7 +68,7 @@ function install_knative_serving() {
   fi
   # TODO: Should we install build from a nightly release?
   # The latest released Build is always at this location.
-  INSTALL_BUILD_YAML=https://storage.googleapis.com/knative-releases/build/latest/release.yaml
+  INSTALL_BUILD_YAML=https://storage.googleapis.com/knative-releases/build/latest/build.yaml
 
   echo ">> Installing Knative serving"
   echo "Istio CRD YAML: ${INSTALL_ISTIO_CRD_YAML}"


### PR DESCRIPTION
This is required for keep the release pipeline working.

From knative/test-infra#396:

> **Make --version a standalone flag**
> It can now be used to arbitraly tag any release. To publish a release to GitHub though, --version, --publish and --branch must specified (current behavior).
> Bonus:
> &bullet; rename the BRANCH_RELEASE variable for clarity.
> &bullet; clearly log if release is published to GitHub and if it's being built from a branch.