### PR TITLE
Scraper to scrape Revision service for metrics

### DIFF
--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/prometheus/common/expfmt"
+	"go.uber.org/zap"
+)
+
+// StatsScraper defines the interface for collecting Revision metrics
+type StatsScraper interface {
+	Scrape(statsCh chan<- *StatMessage)
+}
+
+// cacheDisabledClient is a http client with cache disabled. It is shared by
+// every goruntime for a revision scraper.
+var cacheDisabledClient = &http.Client{
+	Transport: &http.Transport{
+		// Do not use the cached connection
+		DisableKeepAlives: true,
+	},
+	Timeout: 3 * time.Second,
+}
+
+// ServiceScraper scrapes Revision metrics via a K8S service by sampling.
+type ServiceScraper struct {
+	httpClient *http.Client
+	url        string
+	metric     *Metric
+	metricKey  string
+	logger     *zap.SugaredLogger
+}
+
+// CreateNewServiceScraper creates a new StatsScraper for the Revision which
+// the given Metric is responsible for.
+func CreateNewServiceScraper(metric *Metric, logger *zap.SugaredLogger) (ServiceScraper, error) {
+	return createServiceScraperWithClient(metric, logger, cacheDisabledClient)
+}
+
+func createServiceScraperWithClient(metric *Metric, logger *zap.SugaredLogger, httpClient *http.Client) (ServiceScraper, error) {
+	revName := metric.Labels[serving.RevisionLabelKey]
+	if revName == "" {
+		return ServiceScraper{}, fmt.Errorf("no Revision label found for Metric %s", metric.Name)
+	}
+
+	return ServiceScraper{
+		httpClient: httpClient,
+		url:        fmt.Sprintf("http://%s-service.%s:9090/metrics", revName, metric.Namespace),
+		metric:     metric,
+		metricKey:  NewMetricKey(metric.Namespace, metric.Name),
+		logger:     logger,
+	}, nil
+}
+
+// Scrape call the destination service then send it
+// to the given stats chanel
+func (s *ServiceScraper) Scrape(statsCh chan<- *StatMessage) {
+	stat, err := s.scrapeViaURL()
+	if err != nil {
+		s.logger.Errorf("failed to get metrics: %v", err)
+		return
+	}
+
+	s.sendStatMessage(stat, statsCh)
+}
+
+func (s *ServiceScraper) scrapeViaURL() (Stat, error) {
+	req, err := http.NewRequest("GET", s.url, nil)
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return Stat{}, fmt.Errorf("failed to send GET request for URL %q: %v", s.url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Stat{}, fmt.Errorf("GET request for URL %q returned HTTP status %s", s.url, resp.Status)
+	}
+
+	return extractData(resp)
+}
+
+func extractData(resp *http.Response) (Stat, error) {
+	stat := Stat{}
+	var parser expfmt.TextParser
+	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
+	if err != nil {
+		return stat, fmt.Errorf("reading text format failed: %v", err)
+	}
+
+	now := time.Now()
+	stat.Time = &now
+
+	if metric, ok := metricFamilies["queue_average_concurrent_requests"]; ok {
+		for _, label := range metric.Metric[0].Label {
+			if *label.Name == "destination_pod" {
+				stat.PodName = *label.Value
+				break
+			}
+		}
+		stat.AverageConcurrentRequests = *metric.Metric[0].Gauge.Value
+	} else {
+		return stat, fmt.Errorf("required queue_average_concurrent_requests key, got: %v", metricFamilies)
+	}
+
+	if metric, ok := metricFamilies["queue_operations_per_second"]; ok {
+		stat.RequestCount = int32(*metric.Metric[0].Gauge.Value)
+	} else {
+		return stat, fmt.Errorf("required queue_operations_per_second key, got: %v", metricFamilies)
+	}
+
+	return stat, nil
+}
+
+func (s *ServiceScraper) sendStatMessage(stat Stat, statsCh chan<- *StatMessage) {
+	sm := &StatMessage{
+		Stat: stat,
+		Key:  s.metricKey,
+	}
+	statsCh <- sm
+}

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -30,6 +30,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	httpClientTimeout = 3 * time.Second
+)
+
 // StatsScraper defines the interface for collecting Revision metrics
 type StatsScraper interface {
 	// Scrape scrapes the Revision queue metric endpoint then sends it as a
@@ -44,7 +48,7 @@ var cacheDisabledClient = &http.Client{
 		// Do not use the cached connection
 		DisableKeepAlives: true,
 	},
-	Timeout: 3 * time.Second,
+	Timeout: httpClientTimeout,
 }
 
 // ServiceScraper scrapes Revision metrics via a K8S service by sampling. Which

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -106,7 +106,7 @@ func (s *ServiceScraper) scrapeViaURL() (*Stat, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("GET request for URL %q returned HTTP status %v", s.url, resp.StatusCode)
 	}
 

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -29,6 +29,8 @@ import (
 
 // StatsScraper defines the interface for collecting Revision metrics
 type StatsScraper interface {
+	// Scrape scrapes the Revision queue metric endpoint then sends it as a
+	// StatMessage to the given channel.
 	Scrape(statsCh chan<- *StatMessage)
 }
 
@@ -42,7 +44,8 @@ var cacheDisabledClient = &http.Client{
 	Timeout: 3 * time.Second,
 }
 
-// ServiceScraper scrapes Revision metrics via a K8S service by sampling.
+// ServiceScraper scrapes Revision metrics via a K8S service by sampling. Which
+// pod to be picked up to serve the request is decided by K8S.
 type ServiceScraper struct {
 	httpClient *http.Client
 	url        string

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -123,12 +123,12 @@ func TestScrapeViaURL_ErrorCases(t *testing.T) {
 		name:            "Missing average concurrency",
 		responseCode:    200,
 		responseContext: testQPSContext,
-		expectedErr:     "queue_average_concurrent_requests key not found in response",
+		expectedErr:     "Could not find value for queue_average_concurrent_requests in response",
 	}, {
-		name:            "Missing average concurrency",
+		name:            "Missing QPS",
 		responseCode:    200,
 		responseContext: testAverageConcurrenyContext,
-		expectedErr:     "queue_operations_per_second key not found in response",
+		expectedErr:     "Could not find value for queue_operations_per_second in response",
 	}}
 
 	metric := getTestMetric()

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -46,11 +46,11 @@ queue_operations_per_second{destination_namespace="test-namespace",destination_r
 `
 )
 
-func TestCreateServiceScraperWithClient_HappyCase(t *testing.T) {
+func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
 	metric := getTestMetric()
 	client := newTestClient(nil, nil)
-	if scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client); err != nil {
-		t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+	if scraper, err := newServiceScraperWithClient(&metric, TestLogger(t), client); err != nil {
+		t.Errorf("newServiceScraperWithClient=%v, want no error", err)
 	} else {
 		if scraper.url != testURL {
 			t.Errorf("scraper.url=%v, want %v", scraper.url, testURL)
@@ -61,11 +61,11 @@ func TestCreateServiceScraperWithClient_HappyCase(t *testing.T) {
 	}
 }
 
-func TestCreateServiceScraperWithClient_ReturnErrorIfRevisionLabelIsMissing(t *testing.T) {
+func TestNewServiceScraperWithClient_ReturnErrorIfRevisionLabelIsMissing(t *testing.T) {
 	metric := getTestMetric()
 	metric.Labels = map[string]string{}
 	client := newTestClient(nil, nil)
-	if _, err := createServiceScraperWithClient(&metric, TestLogger(t), client); err != nil {
+	if _, err := newServiceScraperWithClient(&metric, TestLogger(t), client); err != nil {
 		got := err.Error()
 		want := fmt.Sprintf("no Revision label found for Metric %s", testRevision)
 		if got != want {
@@ -79,9 +79,9 @@ func TestCreateServiceScraperWithClient_ReturnErrorIfRevisionLabelIsMissing(t *t
 func TestScrapeViaURL_HappyCase(t *testing.T) {
 	metric := getTestMetric()
 	client := newTestClient(getHTTPResponse(200, testAverageConcurrenyContext+testQPSContext), nil)
-	scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client)
+	scraper, err := newServiceScraperWithClient(&metric, TestLogger(t), client)
 	if err != nil {
-		t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+		t.Errorf("newServiceScraperWithClient=%v, want no error", err)
 	}
 	stat, err := scraper.scrapeViaURL()
 	if err != nil {
@@ -134,16 +134,16 @@ func TestScrapeViaURL_ErrorCases(t *testing.T) {
 	metric := getTestMetric()
 	for _, test := range testCases {
 		client := newTestClient(getHTTPResponse(test.responseCode, test.responseContext), test.responseErr)
-		scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client)
+		scraper, err := newServiceScraperWithClient(&metric, TestLogger(t), client)
 		if err != nil {
-			t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+			t.Errorf("newServiceScraperWithClient=%v, want no error", err)
 		}
 		if _, err := scraper.scrapeViaURL(); err != nil {
 			if err.Error() != test.expectedErr {
 				t.Errorf("Got error message: %v. Want: %v", err.Error(), test.expectedErr)
 			}
 		} else {
-			t.Errorf("Expected error from createServiceScraperWithClient, got nil")
+			t.Errorf("Expected error from newServiceScraperWithClient, got nil")
 		}
 	}
 }
@@ -151,9 +151,9 @@ func TestScrapeViaURL_ErrorCases(t *testing.T) {
 func TestSendStatMessage(t *testing.T) {
 	metric := getTestMetric()
 	client := newTestClient(getHTTPResponse(200, testAverageConcurrenyContext+testQPSContext), nil)
-	scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client)
+	scraper, err := newServiceScraperWithClient(&metric, TestLogger(t), client)
 	if err != nil {
-		t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+		t.Errorf("newServiceScraperWithClient=%v, want no error", err)
 	}
 
 	wantConcurrency := 2.1

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	. "github.com/knative/pkg/logging/testing"
+	"github.com/knative/serving/pkg/apis/serving"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testRevision  = "test-revision"
+	testNamespace = "test-namespace"
+	testKPAKey    = "test-namespace/test-revision"
+	testURL       = "http://test-revision-service.test-namespace:9090/metrics"
+
+	testAverageConcurrenyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
+# TYPE queue_average_concurrent_requests gauge
+queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision"} 2.0
+`
+	testQPSContext = `# HELP queue_operations_per_second Number of requests received since last Stat
+# TYPE queue_operations_per_second gauge
+queue_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision"} 1
+`
+)
+
+func TestCreateServiceScraperWithClient_HappyCase(t *testing.T) {
+	metric := getTestMetric()
+	client := newTestClient(nil, nil)
+	if scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client); err != nil {
+		t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+	} else {
+		if scraper.url != testURL {
+			t.Errorf("scraper.url=%v, want %v", scraper.url, testURL)
+		}
+		if scraper.metricKey != testKPAKey {
+			t.Errorf("scraper.metricKey=%v, want %v", scraper.metricKey, testKPAKey)
+		}
+	}
+}
+
+func TestCreateServiceScraperWithClient_ReturnErrorIfRevisionLabelIsMissing(t *testing.T) {
+	metric := getTestMetric()
+	metric.Labels = map[string]string{}
+	client := newTestClient(nil, nil)
+	if _, err := createServiceScraperWithClient(&metric, TestLogger(t), client); err != nil {
+		got := err.Error()
+		want := fmt.Sprintf("no Revision label found for Metric %s", testRevision)
+		if got != want {
+			t.Errorf("Got error message: %v. Want: %v", got, want)
+		}
+	} else {
+		t.Errorf("Expected error from CreateNewServiceScraper, got nil")
+	}
+}
+
+func TestScrapeViaURL_HappyCase(t *testing.T) {
+	metric := getTestMetric()
+	client := newTestClient(getHTTPResponse(200, testAverageConcurrenyContext+testQPSContext), nil)
+	scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client)
+	if err != nil {
+		t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+	}
+	stat, err := scraper.scrapeViaURL()
+	if err != nil {
+		t.Errorf("scrapeViaURL=%v, want no error", err)
+	}
+	if stat.AverageConcurrentRequests != 2.0 {
+		t.Errorf("stat.AverageConcurrentRequests=%v, want 2.0", stat.AverageConcurrentRequests)
+	}
+	if stat.RequestCount != 1 {
+		t.Errorf("stat.RequestCount=%v, want 1", stat.RequestCount)
+	}
+}
+
+func TestScrapeViaURL_ErrorCases(t *testing.T) {
+	metric := getTestMetric()
+	client := newTestClient(getHTTPResponse(200, testAverageConcurrenyContext+testQPSContext), nil)
+	scraper, err := createServiceScraperWithClient(&metric, TestLogger(t), client)
+	if err != nil {
+		t.Errorf("createServiceScraperWithClient=%v, want no error", err)
+	}
+	stat, err := scraper.scrapeViaURL()
+	if err != nil {
+		t.Errorf("scrapeViaURL=%v, want no error", err)
+	}
+	if stat.AverageConcurrentRequests != 2.0 {
+		t.Errorf("stat.AverageConcurrentRequests=%v, want 2.0", stat.AverageConcurrentRequests)
+	}
+	if stat.RequestCount != 1 {
+		t.Errorf("stat.RequestCount=%v, want 1", stat.RequestCount)
+	}
+}
+
+func getTestMetric() Metric {
+	return Metric{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testRevision,
+			Labels: map[string]string{
+				serving.RevisionLabelKey: testRevision,
+			},
+		},
+	}
+}
+
+func getHTTPResponse(statusCode int, context string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(context)),
+	}
+}
+
+type fakeRoundTripper struct {
+	response      *http.Response
+	responseError error
+}
+
+func (frt fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return frt.response, frt.responseError
+}
+
+func newTestClient(response *http.Response, err error) *http.Client {
+	return &http.Client{
+		Transport: fakeRoundTripper{
+			response:      response,
+			responseError: err,
+		},
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #2203.

## Proposed Changes

* Introduce a scraper to scrap metrics emitted by queue proxy via revision service.