### PR TITLE
Update Resources Overview documentation

### DIFF
--- a/docs/resources-overview.md
+++ b/docs/resources-overview.md
@@ -1,8 +1,5 @@
 # Resources Overview
 
-For a truly high-level overview,
-[see these slides](https://docs.google.com/presentation/d/1CbwVC7W2JaSxRyltU8CS1bIsrIXu1RrZqvnlMlDaaJE/edit#slide=id.p)
-
 This document provides a high-level description of the resources deployed to a
 Kubernetes cluster in order to run Knative Serving. The exact list of resources
 is going to change frequently during the current phase of active development. In
@@ -12,24 +9,20 @@ which they form.
 
 ## Dependencies
 
-Knative Serving depends on two other projects in order to function:
-[Istio][istio] and the [Build CRD][build-crd]. Istio is responsible for setting
-up the network routing both inside the cluster and ingress into the cluster. The
-Build CRD provides a custom resource for Kubernetes which provides an extensible
-primitive for creating container images from various sources, for example a Git
-repository.
-
-You can find out more about both from their respective websites.
+Knative Serving depends on Istio[istio] in order to function. Istio is responsible for
+setting up the network routing both inside the cluster and ingress into the cluster.
+You can find out more about it from their website:
 
 [istio]: https://istio.io/
-[build-crd]: https://github.com/knative/build
 
 ## Components
 
-There are two primary components to the Knative Serving system. The first is a
+There are four primary components to the Knative Serving system. The first is a
 controller which is responsible for updating the state of the cluster based on
 user input. The second is the webhook component which handles validation of the
-objects and actions performed.
+objects and actions performed. The third is an activator component which brings
+back scaled-to-zero pods and forwards requests. The fourth is the autoscaler
+which scales pods are requests come in.
 
 The controller processes a series of state changes in order to move the system
 from its current, actual state to the state desired by the user.
@@ -42,10 +35,13 @@ To see only objects of a specific type, for example to see the webhook and
 controller deployments inside Knative Serving, you can run
 `kubectl -n knative-serving get deployments`.
 
-The Knative Serving controller creates Kubernetes, Istio, and Build CRD
-resources when Knative Serving resources are created and updated. These
+The Knative Serving controller creates Kubernetes and Istio
+resources when Knative Serving resources are created and updated. It will also
+create Build resources when provided in the Configuration spec. These
 sub-resources will be created in the same namespace as their parent Knative
-Serving resource, _not_ the `knative-serving` namespace.
+Serving resource, _not_ the `knative-serving` namespace. For example, if you
+create a Knative Serivce in namespace 'foo' the cooresponding Istio resources
+will also be in namespace 'foo'.
 
 ## Kubernetes Resource Configs
 
@@ -55,14 +51,15 @@ The various Kubernetes resource configurations are organized as follows:
 # Knative Serving resources
 config/*.yaml
 
-# Knative Serving Monitoring configs
+# Istio release configuration
+third_party/istio-*/install/kubernetes/...
+
+# Knative Serving Monitoring configs (Optional)
 config/monitoring/...
 
-# Build resources
+# Knative Build resources (Optional)
 third_party/config/build/release.yaml
 
-# Istio release configuration
-third_party/istio-0.6.0/install/kubernetes/...
 ```
 
 ## Viewing resources after deploying Knative Serving
@@ -71,8 +68,8 @@ third_party/istio-0.6.0/install/kubernetes/...
 
 To view all of the custom resource definitions created, run
 `kubectl get customresourcedefinitions`. These resources are named according to
-their group, i.e. custom resources required by Knative Serving end with
-`knative.dev`.
+their group, i.e. custom resources created by Knative Serving end with
+`serving.knative.dev` or `internal.knative.dev`.
 
 ### Deployments
 
@@ -84,9 +81,11 @@ For example, given:
 
 ```console
 $ kubectl -n knative-serving get deployments
-NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-controller   1         1         1            1           6m
-webhook      1         1         1            1           6m
+NAME         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+activator    1         1         1            1           5d
+autoscaler   1         1         1            1           5d
+controller   1         1         1            1           5d
+webhook      1         1         1            1           5d
 ```
 
 Based on the desired state shown above, we expect there to be a single pod
@@ -95,14 +94,15 @@ and seeing similar output as shown below:
 
 ```console
 $ kubectl -n knative-serving get pods
-NAME                              READY     STATUS    RESTARTS   AGE
-controller-5bfb798f96-2zjnf   1/1       Running   0          9m
-webhook-64c459569b-v5npx      1/1       Running   0          8m
+NAME                          READY     STATUS    RESTARTS   AGE
+activator-c8495dc9-z7xpz      2/2       Running   0          5d
+autoscaler-66897845df-t5cwg   2/2       Running   0          5d
+controller-699fb46bb5-xhlkg   1/1       Running   0          5d
+webhook-76b87b8459-tzj6r      1/1       Running   0          5d
 ```
 
-Similarly, you can run the same commands in the build-crd (`knative-build`) and
-istio (`istio-system`) namespaces to view the running deployments. To view all
-namespaces, run `kubectl get namespaces`.
+Similarly, you can run the same commands in the istio (`istio-system`) namespaces
+to view the running deployments. To view all namespaces, run `kubectl get namespaces`.
 
 ### Service Accounts and RBAC policies
 

--- a/docs/resources-overview.md
+++ b/docs/resources-overview.md
@@ -9,11 +9,8 @@ which they form.
 
 ## Dependencies
 
-Knative Serving depends on Istio[istio] in order to function. Istio is responsible for
+Knative Serving depends on [Istio](https://istio.io/) in order to function. Istio is responsible for
 setting up the network routing both inside the cluster and ingress into the cluster.
-You can find out more about it from their website:
-
-[istio]: https://istio.io/
 
 ## Components
 
@@ -49,16 +46,16 @@ The various Kubernetes resource configurations are organized as follows:
 
 ```plain
 # Knative Serving resources
-`config/*.yaml`
+config/*.yaml
 
 # Istio release configuration
-`third_party/istio-*/install/kubernetes/...`
+third_party/istio-*/install/kubernetes/...
 
 # Knative Serving Monitoring configs (Optional)
-`config/monitoring/...`
+config/monitoring/...
 
 # Knative Build resources (Optional)
-`third_party/config/build/release.yaml`
+third_party/config/build/release.yaml
 
 ```
 

--- a/docs/resources-overview.md
+++ b/docs/resources-overview.md
@@ -17,11 +17,11 @@ You can find out more about it from their website:
 
 ## Components
 
-There are four primary components to the Knative Serving system. The first is a
-controller which is responsible for updating the state of the cluster based on
-user input. The second is the webhook component which handles validation of the
-objects and actions performed. The third is an activator component which brings
-back scaled-to-zero pods and forwards requests. The fourth is the autoscaler
+There are four primary components to the Knative Serving system. The first is
+the _Controller_ which is responsible for updating the state of the cluster based on
+user input. The second is the _Webhook_ component which handles validation of the
+objects and actions performed. The third is an _Activator_ component which brings
+back scaled-to-zero pods and forwards requests. The fourth is the _Autoscaler_
 which scales pods are requests come in.
 
 The controller processes a series of state changes in order to move the system
@@ -49,16 +49,16 @@ The various Kubernetes resource configurations are organized as follows:
 
 ```plain
 # Knative Serving resources
-config/*.yaml
+`config/*.yaml`
 
 # Istio release configuration
-third_party/istio-*/install/kubernetes/...
+`third_party/istio-*/install/kubernetes/...`
 
 # Knative Serving Monitoring configs (Optional)
-config/monitoring/...
+`config/monitoring/...`
 
 # Knative Build resources (Optional)
-third_party/config/build/release.yaml
+`third_party/config/build/release.yaml`
 
 ```
 


### PR DESCRIPTION
Information in the docuemntation was a bit stale.

* Removed link to outdataed slide deck
* Removed reference to Build CRDs as a dependency (no longer true as of
0.2)
* Added autoscaler and activator as components
* Updated example outputs and filepaths

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->