### PR TITLE
Fix docs link for private-repo in creating cluster

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -186,4 +186,4 @@ Use the same procedure to add imagePullSecrets to service accounts in any
 namespace. Use the `default` service account for pods that do not specify a
 service account.
 
-See also the [private-repo sample README](/sample/private-repos/README.md).
+See also the [private-repo sample README](https://github.com/knative/docs/tree/master/serving/samples/build-private-repo-go).


### PR DESCRIPTION
This link is broken since we moved samples to the docs repo.


<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
