### PR TITLE
Change some metrics from type float64 to int64

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -108,7 +108,7 @@ func TestActivationHandler(t *testing.T) {
 					Config:     "config-real-name",
 					StatusCode: http.StatusOK,
 					Attempts:   123,
-					Value:      1.0,
+					Value:      1,
 				},
 				{
 					Op:         "ReportResponseTime",
@@ -136,7 +136,7 @@ func TestActivationHandler(t *testing.T) {
 					Config:     "config-real-name",
 					StatusCode: http.StatusOK,
 					Attempts:   1,
-					Value:      1.0,
+					Value:      1,
 				},
 				{
 					Op:         "ReportResponseTime",
@@ -173,7 +173,7 @@ func TestActivationHandler(t *testing.T) {
 					Config:     "config-real-name",
 					StatusCode: http.StatusBadGateway,
 					Attempts:   1,
-					Value:      1.0,
+					Value:      1,
 				},
 				{
 					Op:         "ReportResponseTime",
@@ -202,7 +202,7 @@ func TestActivationHandler(t *testing.T) {
 					Config:     "config-real-name",
 					StatusCode: http.StatusOK,
 					Attempts:   1,
-					Value:      1.0,
+					Value:      1,
 				},
 				{
 					Op:         "ReportResponseTime",
@@ -278,7 +278,7 @@ type reporterCall struct {
 	Revision   string
 	StatusCode int
 	Attempts   int
-	Value      float64
+	Value      int64
 	Duration   time.Duration
 }
 
@@ -286,7 +286,7 @@ type fakeReporter struct {
 	calls []reporterCall
 }
 
-func (f *fakeReporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
+func (f *fakeReporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v int64) error {
 	f.calls = append(f.calls, reporterCall{
 		Op:         "ReportRequestCount",
 		Namespace:  ns,

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -25,33 +25,20 @@ import (
 	"go.opencensus.io/tag"
 )
 
-// Measurement represents the type of the autoscaler metric to be reported
-type Measurement int
-
-const (
-	//RequestCountM is the request count when Activator proxy the request
-	RequestCountM = iota
-
-	// ResponseTimeInMsecM is the response time in millisecond
-	ResponseTimeInMsecM
-)
-
 var (
-	measurements = []*stats.Float64Measure{
-		RequestCountM: stats.Float64(
-			"request_count",
-			"The number of requests that are routed to Activator",
-			stats.UnitNone),
-		ResponseTimeInMsecM: stats.Float64(
-			"request_latencies",
-			"The response time in millisecond",
-			stats.UnitNone),
-	}
+	requestCountM = stats.Int64(
+		"request_count",
+		"The number of requests that are routed to Activator",
+		stats.UnitDimensionless)
+	responseTimeInMsecM = stats.Float64(
+		"request_latencies",
+		"The response time in millisecond",
+		stats.UnitDimensionless)
 )
 
 // StatsReporter defines the interface for sending activator metrics
 type StatsReporter interface {
-	ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error
+	ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v int64) error
 	ReportResponseTime(ns, service, config, rev string, responseCode int, d time.Duration) error
 }
 
@@ -112,13 +99,13 @@ func NewStatsReporter() (*Reporter, error) {
 	err = view.Register(
 		&view.View{
 			Description: "The number of requests that are routed to Activator",
-			Measure:     measurements[RequestCountM],
+			Measure:     requestCountM,
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{r.namespaceTagKey, r.serviceTagKey, r.configTagKey, r.revisionTagKey, r.responseCodeKey, r.responseCodeClassKey, r.numTriesKey},
 		},
 		&view.View{
 			Description: "The response time in millisecond",
-			Measure:     measurements[ResponseTimeInMsecM],
+			Measure:     responseTimeInMsecM,
 			Aggregation: view.Distribution(1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000, 13000, 14000, 15000),
 			TagKeys:     []tag.Key{r.namespaceTagKey, r.serviceTagKey, r.configTagKey, r.revisionTagKey, r.responseCodeClassKey, r.responseCodeKey},
 		},
@@ -132,7 +119,7 @@ func NewStatsReporter() (*Reporter, error) {
 }
 
 // ReportRequestCount captures request count metric with value v.
-func (r *Reporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v float64) error {
+func (r *Reporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v int64) error {
 	if !r.initialized {
 		return errors.New("StatsReporter is not initialized yet")
 	}
@@ -150,7 +137,7 @@ func (r *Reporter) ReportRequestCount(ns, service, config, rev string, responseC
 		return err
 	}
 
-	stats.Record(ctx, measurements[RequestCountM].M(v))
+	stats.Record(ctx, requestCountM.M(v))
 	return nil
 }
 
@@ -173,7 +160,7 @@ func (r *Reporter) ReportResponseTime(ns, service, config, rev string, responseC
 	}
 
 	// convert time.Duration in nanoseconds to milliseconds
-	stats.Record(ctx, measurements[ResponseTimeInMsecM].M(float64(d/time.Millisecond)))
+	stats.Record(ctx, responseTimeInMsecM.M(float64(d/time.Millisecond)))
 	return nil
 }
 

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -33,7 +33,7 @@ var (
 	responseTimeInMsecM = stats.Float64(
 		"request_latencies",
 		"The response time in millisecond",
-		stats.UnitDimensionless)
+		stats.UnitMilliseconds)
 )
 
 // StatsReporter defines the interface for sending activator metrics

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -300,10 +300,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	desiredStablePodCount := desiredStableScalingRatio * stableData.observedPods(now)
 	desiredPanicPodCount := desiredPanicScalingRatio * stableData.observedPods(now)
 
-	a.reporter.Report(ObservedPodCountM, float64(stableData.observedPods(now)))
-	a.reporter.Report(StableRequestConcurrencyM, observedStableConcurrencyPerPod)
-	a.reporter.Report(PanicRequestConcurrencyM, observedPanicConcurrencyPerPod)
-	a.reporter.Report(TargetConcurrencyM, a.target)
+	a.reporter.ReportObservedPodCount(stableData.observedPods(now))
+	a.reporter.ReportStableRequestConcurrency(observedStableConcurrencyPerPod)
+	a.reporter.ReportPanicRequestConcurrency(observedPanicConcurrencyPerPod)
+	a.reporter.ReportTargetRequestConcurrency(a.target)
 
 	logger.Debugf("STABLE: Observed average %0.3f concurrency over %v seconds over %v samples over %v pods.",
 		observedStableConcurrencyPerPod, config.StableWindow, stableData.probeCount, stableData.observedPods(now))
@@ -313,7 +313,6 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	// Stop panicking after the surge has made its way into the stable metric.
 	if a.panicking && a.panicTime.Add(config.StableWindow).Before(now) {
 		logger.Info("Un-panicking.")
-		a.reporter.Report(PanicM, 0)
 		a.panicking = false
 		a.panicTime = nil
 		a.maxPanicPods = 0
@@ -322,7 +321,6 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	// Begin panicking when we cross the 6 second concurrency threshold.
 	if !a.panicking && panicData.observedPods(now) > 0.0 && observedPanicConcurrencyPerPod >= (a.target*2) {
 		logger.Info("PANICKING")
-		a.reporter.Report(PanicM, 1)
 		a.panicking = true
 		a.panicTime = &now
 	}
@@ -331,6 +329,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 
 	if a.panicking {
 		logger.Debug("Operating in panic mode.")
+		a.reporter.ReportPanic(1)
 		if desiredPanicPodCount > a.maxPanicPods {
 			logger.Infof("Increasing pods from %v to %v.", panicData.observedPods(now), int(desiredPanicPodCount))
 			a.panicTime = &now
@@ -339,10 +338,11 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 		desiredPodCount = int32(math.Ceil(a.maxPanicPods))
 	} else {
 		logger.Debug("Operating in stable mode.")
+		a.reporter.ReportPanic(0)
 		desiredPodCount = int32(math.Ceil(desiredStablePodCount))
 	}
 
-	a.reporter.Report(DesiredPodCountM, float64(desiredPodCount))
+	a.reporter.ReportDesiredPodCount(int64(desiredPodCount))
 	return desiredPodCount, true
 }
 

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -495,34 +495,42 @@ type linearSeries struct {
 
 type mockReporter struct{}
 
+// ReportDesiredPodCount of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportDesiredPodCount(v int64) error {
 	return nil
 }
 
+// ReportRequestedPodCount of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportRequestedPodCount(v int64) error {
 	return nil
 }
 
+// ReportActualPodCount of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportActualPodCount(v int64) error {
 	return nil
 }
 
+// ReportObservedPodCount of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportObservedPodCount(v float64) error {
 	return nil
 }
 
+// ReportStableRequestConcurrency of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportStableRequestConcurrency(v float64) error {
 	return nil
 }
 
+// ReportPanicRequestConcurrency of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportPanicRequestConcurrency(v float64) error {
 	return nil
 }
 
+// ReportTargetRequestConcurrency of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportTargetRequestConcurrency(v float64) error {
 	return nil
 }
 
+// ReportPanic of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportPanic(v int64) error {
 	return nil
 }

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -495,7 +495,35 @@ type linearSeries struct {
 
 type mockReporter struct{}
 
-func (r *mockReporter) Report(m Measurement, v float64) error {
+func (r *mockReporter) ReportDesiredPodCount(v int64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportRequestedPodCount(v int64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportActualPodCount(v int64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportObservedPodCount(v float64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportStableRequestConcurrency(v float64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportPanicRequestConcurrency(v float64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportTargetRequestConcurrency(v float64) error {
+	return nil
+}
+
+func (r *mockReporter) ReportPanic(v int64) error {
 	return nil
 }
 

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -31,35 +31,35 @@ var (
 	desiredPodCountM = stats.Int64(
 		"desired_pods",
 		"Number of pods autoscaler wants to allocate",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	requestedPodCountM = stats.Int64(
 		"requested_pods",
 		"Number of pods autoscaler requested from Kubernetes",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	actualPodCountM = stats.Int64(
 		"actual_pods",
 		"Number of pods that are allocated currently",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	observedPodCountM = stats.Float64(
 		"observed_pods",
 		"Number of pods that are observed currently",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	stableRequestConcurrencyM = stats.Float64(
 		"stable_request_concurrency",
 		"Average of requests count per observed pod in each stable window (default 60 seconds)",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	panicRequestConcurrencyM = stats.Float64(
 		"panic_request_concurrency",
 		"Average of requests count per observed pod in each panic window (default 6 seconds)",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	targetRequestConcurrencyM = stats.Float64(
 		"target_concurrency_per_pod",
 		"The desired number of concurrent requests for each pod",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	panicM = stats.Int64(
 		"panic_mode",
 		"1 if autoscaler is in panic mode, 0 otherwise",
-		stats.UnitNone)
+		stats.UnitDimensionless)
 	namespaceTagKey tag.Key
 	configTagKey    tag.Key
 	revisionTagKey  tag.Key

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -27,63 +27,39 @@ import (
 	"go.opencensus.io/tag"
 )
 
-// Measurement represents the type of the autoscaler metric to be reported
-type Measurement int
-
-const (
-	// DesiredPodCountM is used for the pod count that autoscaler wants
-	DesiredPodCountM Measurement = iota
-	// RequestedPodCountM is used for the requested pod count from kubernetes
-	RequestedPodCountM
-	// ActualPodCountM is used for the actual number of pods we have
-	ActualPodCountM
-	// ObservedPodCountM is used for the observed number of pods we have
-	ObservedPodCountM
-	// StableRequestConcurrencyM is the average of requests count per observed pod in each stable window (default 60 seconds)
-	StableRequestConcurrencyM
-	// PanicRequestConcurrencyM is the average of requests count per observed pod in each panic window (default 6 seconds)
-	PanicRequestConcurrencyM
-	// TargetConcurrencyM is the desired number of concurrent requests for each pod
-	TargetConcurrencyM
-	// PanicM is used as a flag to indicate if autoscaler is in panic mode or not
-	PanicM
-)
-
 var (
-	measurements = []*stats.Float64Measure{
-		DesiredPodCountM: stats.Float64(
-			"desired_pods",
-			"Number of pods autoscaler wants to allocate",
-			stats.UnitNone),
-		RequestedPodCountM: stats.Float64(
-			"requested_pods",
-			"Number of pods autoscaler requested from Kubernetes",
-			stats.UnitNone),
-		ActualPodCountM: stats.Float64(
-			"actual_pods",
-			"Number of pods that are allocated currently",
-			stats.UnitNone),
-		ObservedPodCountM: stats.Float64(
-			"observed_pods",
-			"Number of pods that are observed currently",
-			stats.UnitNone),
-		StableRequestConcurrencyM: stats.Float64(
-			"stable_request_concurrency",
-			"Average of requests count per observed pod in each stable window (default 60 seconds)",
-			stats.UnitNone),
-		PanicRequestConcurrencyM: stats.Float64(
-			"panic_request_concurrency",
-			"Average of requests count per observed pod in each panic window (default 6 seconds)",
-			stats.UnitNone),
-		TargetConcurrencyM: stats.Float64(
-			"target_concurrency_per_pod",
-			"The desired number of concurrent requests for each pod",
-			stats.UnitNone),
-		PanicM: stats.Float64(
-			"panic_mode",
-			"1 if autoscaler is in panic mode, 0 otherwise",
-			stats.UnitNone),
-	}
+	desiredPodCountM = stats.Int64(
+		"desired_pods",
+		"Number of pods autoscaler wants to allocate",
+		stats.UnitNone)
+	requestedPodCountM = stats.Int64(
+		"requested_pods",
+		"Number of pods autoscaler requested from Kubernetes",
+		stats.UnitNone)
+	actualPodCountM = stats.Int64(
+		"actual_pods",
+		"Number of pods that are allocated currently",
+		stats.UnitNone)
+	observedPodCountM = stats.Float64(
+		"observed_pods",
+		"Number of pods that are observed currently",
+		stats.UnitNone)
+	stableRequestConcurrencyM = stats.Float64(
+		"stable_request_concurrency",
+		"Average of requests count per observed pod in each stable window (default 60 seconds)",
+		stats.UnitNone)
+	panicRequestConcurrencyM = stats.Float64(
+		"panic_request_concurrency",
+		"Average of requests count per observed pod in each panic window (default 6 seconds)",
+		stats.UnitNone)
+	targetRequestConcurrencyM = stats.Float64(
+		"target_concurrency_per_pod",
+		"The desired number of concurrent requests for each pod",
+		stats.UnitNone)
+	panicM = stats.Int64(
+		"panic_mode",
+		"1 if autoscaler is in panic mode, 0 otherwise",
+		stats.UnitNone)
 	namespaceTagKey tag.Key
 	configTagKey    tag.Key
 	revisionTagKey  tag.Key
@@ -120,49 +96,49 @@ func init() {
 	err = view.Register(
 		&view.View{
 			Description: "Number of pods autoscaler wants to allocate",
-			Measure:     measurements[DesiredPodCountM],
+			Measure:     desiredPodCountM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "Number of pods autoscaler requested from Kubernetes",
-			Measure:     measurements[RequestedPodCountM],
+			Measure:     requestedPodCountM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "Number of pods that are allocated currently",
-			Measure:     measurements[ActualPodCountM],
+			Measure:     actualPodCountM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "Number of pods that are observed currently",
-			Measure:     measurements[ObservedPodCountM],
+			Measure:     observedPodCountM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "Average of requests count in each 60 second stable window",
-			Measure:     measurements[StableRequestConcurrencyM],
+			Measure:     stableRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "Average of requests count in each 6 second panic window",
-			Measure:     measurements[PanicRequestConcurrencyM],
+			Measure:     panicRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "The desired number of concurrent requests for each pod",
-			Measure:     measurements[TargetConcurrencyM],
+			Measure:     targetRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
 			Description: "1 if autoscaler is in panic mode, 0 otherwise",
-			Measure:     measurements[PanicM],
+			Measure:     panicM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
@@ -175,7 +151,14 @@ func init() {
 
 // StatsReporter defines the interface for sending autoscaler metrics
 type StatsReporter interface {
-	Report(m Measurement, v float64) error
+	ReportDesiredPodCount(v int64) error
+	ReportRequestedPodCount(v int64) error
+	ReportActualPodCount(v int64) error
+	ReportObservedPodCount(v float64) error
+	ReportStableRequestConcurrency(v float64) error
+	ReportPanicRequestConcurrency(v float64) error
+	ReportTargetRequestConcurrency(v float64) error
+	ReportPanic(v int64) error
 }
 
 // Reporter holds cached metric objects to report autoscaler metrics
@@ -206,12 +189,51 @@ func NewStatsReporter(podNamespace string, service string, config string, revisi
 	return r, nil
 }
 
-// Report captures value v for measurement m
-func (r *Reporter) Report(m Measurement, v float64) error {
+// ReportDesiredPodCount captures value v for desired pod count measure.
+func (r *Reporter) ReportDesiredPodCount(v int64) error {
+	return r.report(desiredPodCountM.M(v))
+}
+
+// ReportRequestedPodCount captures value v for requested pod count measure.
+func (r *Reporter) ReportRequestedPodCount(v int64) error {
+	return r.report(requestedPodCountM.M(v))
+}
+
+// ReportActualPodCount captures value v for actual pod count measure.
+func (r *Reporter) ReportActualPodCount(v int64) error {
+	return r.report(actualPodCountM.M(v))
+}
+
+// ReportObservedPodCount captures value v for observed pod count measure.
+func (r *Reporter) ReportObservedPodCount(v float64) error {
+	return r.report(observedPodCountM.M(v))
+}
+
+// ReportStableRequestConcurrency captures value v for stable request concurrency measure.
+func (r *Reporter) ReportStableRequestConcurrency(v float64) error {
+	return r.report(stableRequestConcurrencyM.M(v))
+}
+
+// ReportPanicRequestConcurrency captures value v for panic request concurrency measure.
+func (r *Reporter) ReportPanicRequestConcurrency(v float64) error {
+	return r.report(panicRequestConcurrencyM.M(v))
+}
+
+// ReportTargetRequestConcurrency captures value v for target request concurrency measure.
+func (r *Reporter) ReportTargetRequestConcurrency(v float64) error {
+	return r.report(targetRequestConcurrencyM.M(v))
+}
+
+// ReportPanic captures value v for panic mode measure.
+func (r *Reporter) ReportPanic(v int64) error {
+	return r.report(panicM.M(v))
+}
+
+func (r *Reporter) report(m stats.Measurement) error {
 	if !r.initialized {
 		return errors.New("StatsReporter is not initialized yet")
 	}
 
-	stats.Record(r.ctx, measurements[m].M(v))
+	stats.Record(r.ctx, m)
 	return nil
 }

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -42,8 +42,8 @@ func TestNewStatsReporterErrors(t *testing.T) {
 
 func TestReporter_Report(t *testing.T) {
 	r := &Reporter{}
-	if err := r.Report(DesiredPodCountM, 10); err == nil {
-		t.Error("Reporter.Report() expected an error for Report call before init. Got success.")
+	if err := r.ReportDesiredPodCount(10); err == nil {
+		t.Error("Reporter.ReportDesiredPodCount() expected an error for Report call before init. Got success.")
 	}
 
 	r, _ = NewStatsReporter("testns", "testsvc", "testconfig", "testrev")
@@ -55,14 +55,14 @@ func TestReporter_Report(t *testing.T) {
 	}
 
 	// Send statistics only once and observe the results
-	expectSuccess(t, func() error { return r.Report(DesiredPodCountM, 10) })
-	expectSuccess(t, func() error { return r.Report(RequestedPodCountM, 7) })
-	expectSuccess(t, func() error { return r.Report(ActualPodCountM, 5) })
-	expectSuccess(t, func() error { return r.Report(PanicM, 0) })
-	expectSuccess(t, func() error { return r.Report(ObservedPodCountM, 1) })
-	expectSuccess(t, func() error { return r.Report(StableRequestConcurrencyM, 2) })
-	expectSuccess(t, func() error { return r.Report(PanicRequestConcurrencyM, 3) })
-	expectSuccess(t, func() error { return r.Report(TargetConcurrencyM, 0.9) })
+	expectSuccess(t, "ReportDesiredPodCount", func() error { return r.ReportDesiredPodCount(10) })
+	expectSuccess(t, "ReportRequestedPodCount", func() error { return r.ReportRequestedPodCount(7) })
+	expectSuccess(t, "ReportActualPodCount", func() error { return r.ReportActualPodCount(5) })
+	expectSuccess(t, "ReportPanic", func() error { return r.ReportPanic(0) })
+	expectSuccess(t, "ReportObservedPodCount", func() error { return r.ReportObservedPodCount(1) })
+	expectSuccess(t, "ReportStableRequestConcurrency", func() error { return r.ReportStableRequestConcurrency(2) })
+	expectSuccess(t, "ReportPanicRequestConcurrency", func() error { return r.ReportPanicRequestConcurrency(3) })
+	expectSuccess(t, "ReportTargetRequestConcurrency", func() error { return r.ReportTargetRequestConcurrency(0.9) })
 	checkData(t, "desired_pods", wantTags, 10)
 	checkData(t, "requested_pods", wantTags, 7)
 	checkData(t, "actual_pods", wantTags, 5)
@@ -73,58 +73,58 @@ func TestReporter_Report(t *testing.T) {
 	checkData(t, "target_concurrency_per_pod", wantTags, 0.9)
 
 	// All the stats are gauges - record multiple entries for one stat - last one should stick
-	expectSuccess(t, func() error { return r.Report(DesiredPodCountM, 1) })
-	expectSuccess(t, func() error { return r.Report(DesiredPodCountM, 2) })
-	expectSuccess(t, func() error { return r.Report(DesiredPodCountM, 3) })
+	expectSuccess(t, "ReportDesiredPodCount", func() error { return r.ReportDesiredPodCount(1) })
+	expectSuccess(t, "ReportDesiredPodCount", func() error { return r.ReportDesiredPodCount(2) })
+	expectSuccess(t, "ReportDesiredPodCount", func() error { return r.ReportDesiredPodCount(3) })
 	checkData(t, "desired_pods", wantTags, 3)
 
-	expectSuccess(t, func() error { return r.Report(RequestedPodCountM, 4) })
-	expectSuccess(t, func() error { return r.Report(RequestedPodCountM, 5) })
-	expectSuccess(t, func() error { return r.Report(RequestedPodCountM, 6) })
+	expectSuccess(t, "ReportRequestedPodCount", func() error { return r.ReportRequestedPodCount(4) })
+	expectSuccess(t, "ReportRequestedPodCount", func() error { return r.ReportRequestedPodCount(5) })
+	expectSuccess(t, "ReportRequestedPodCount", func() error { return r.ReportRequestedPodCount(6) })
 	checkData(t, "requested_pods", wantTags, 6)
 
-	expectSuccess(t, func() error { return r.Report(ActualPodCountM, 7) })
-	expectSuccess(t, func() error { return r.Report(ActualPodCountM, 8) })
-	expectSuccess(t, func() error { return r.Report(ActualPodCountM, 9) })
+	expectSuccess(t, "ReportActualPodCount", func() error { return r.ReportActualPodCount(7) })
+	expectSuccess(t, "ReportActualPodCount", func() error { return r.ReportActualPodCount(8) })
+	expectSuccess(t, "ReportActualPodCount", func() error { return r.ReportActualPodCount(9) })
 	checkData(t, "actual_pods", wantTags, 9)
 
-	expectSuccess(t, func() error { return r.Report(PanicM, 1) })
-	expectSuccess(t, func() error { return r.Report(PanicM, 0) })
-	expectSuccess(t, func() error { return r.Report(PanicM, 1) })
+	expectSuccess(t, "ReportPanic", func() error { return r.ReportPanic(1) })
+	expectSuccess(t, "ReportPanic", func() error { return r.ReportPanic(0) })
+	expectSuccess(t, "ReportPanic", func() error { return r.ReportPanic(1) })
 	checkData(t, "panic_mode", wantTags, 1)
 
-	expectSuccess(t, func() error { return r.Report(PanicM, 0) })
+	expectSuccess(t, "ReportPanic", func() error { return r.ReportPanic(0) })
 	checkData(t, "panic_mode", wantTags, 0)
 }
 
-func expectSuccess(t *testing.T, f func() error) {
+func expectSuccess(t *testing.T, funcName string, f func() error) {
 	if err := f(); err != nil {
-		t.Errorf("Reporter.Report() expected success but got error %v", err)
+		t.Errorf("Reporter.%v() expected success but got error %v", funcName, err)
 	}
 }
 
 func checkData(t *testing.T, name string, wantTags map[string]string, wantValue float64) {
 	if d, err := view.RetrieveData(name); err != nil {
-		t.Errorf("Reporter.Report() error = %v, wantErr %v", err, false)
+		t.Errorf("Got unexpected errro from view.RetrieveData error: %v", err)
 	} else {
 		if len(d) != 1 {
-			t.Errorf("Reporter.Report() len(d) %v, want %v", len(d), 1)
+			t.Errorf("want 1 data row but got %v", len(d))
 		}
 		for _, got := range d[0].Tags {
 			if want, ok := wantTags[got.Key.Name()]; !ok {
-				t.Errorf("Reporter.Report() got an extra tag %v: %v", got.Key.Name(), got.Value)
+				t.Errorf("got an extra tag %v: %v", got.Key.Name(), got.Value)
 			} else {
 				if got.Value != want {
-					t.Errorf("Reporter.Report() expected a different tag value. key:%v, got: %v, want: %v", got.Key.Name(), got.Value, want)
+					t.Errorf("expected a different tag value. key:%v, got: %v, want: %v", got.Key.Name(), got.Value, want)
 				}
 			}
 		}
 
 		if s, ok := d[0].Data.(*view.LastValueData); !ok {
-			t.Error("Reporter.Report() expected a LastValueData type")
+			t.Error("expected a LastValueData type")
 		} else {
 			if s.Value != (float64)(wantValue) {
-				t.Errorf("Reporter.Report() expected %v got %v. metric: %v", s.Value, (float64)(wantValue), name)
+				t.Errorf("expected value=%v, got=%v for metric %v", (float64)(wantValue), s.Value, name)
 			}
 		}
 	}

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -105,10 +105,10 @@ func expectSuccess(t *testing.T, funcName string, f func() error) {
 
 func checkData(t *testing.T, name string, wantTags map[string]string, wantValue float64) {
 	if d, err := view.RetrieveData(name); err != nil {
-		t.Errorf("Got unexpected errro from view.RetrieveData error: %v", err)
+		t.Errorf("Got unexpected error from view.RetrieveData error: %v", err)
 	} else {
 		if len(d) != 1 {
-			t.Errorf("want 1 data row but got %v", len(d))
+			t.Errorf("want 1 data row but got %d", len(d))
 		}
 		for _, got := range d[0].Tags {
 			if want, ok := wantTags[got.Key.Name()]; !ok {
@@ -123,8 +123,8 @@ func checkData(t *testing.T, name string, wantTags map[string]string, wantValue 
 		if s, ok := d[0].Data.(*view.LastValueData); !ok {
 			t.Error("expected a LastValueData type")
 		} else {
-			if s.Value != (float64)(wantValue) {
-				t.Errorf("expected value=%v, got=%v for metric %v", (float64)(wantValue), s.Value, name)
+			if s.Value != wantValue {
+				t.Errorf("expected value=%v, got=%v for metric %v", wantValue, s.Value, name)
 			}
 		}
 	}

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -108,23 +108,23 @@ func checkData(t *testing.T, name string, wantTags map[string]string, wantValue 
 		t.Errorf("Got unexpected error from view.RetrieveData error: %v", err)
 	} else {
 		if len(d) != 1 {
-			t.Errorf("want 1 data row but got %d", len(d))
+			t.Errorf("Want 1 data row but got %d from view.RetrieveData", len(d))
 		}
 		for _, got := range d[0].Tags {
 			if want, ok := wantTags[got.Key.Name()]; !ok {
-				t.Errorf("got an extra tag %v: %v", got.Key.Name(), got.Value)
+				t.Errorf("Got an extra tag from view.RetrieveData: (%v, %v)", got.Key.Name(), got.Value)
 			} else {
 				if got.Value != want {
-					t.Errorf("expected a different tag value. key:%v, got: %v, want: %v", got.Key.Name(), got.Value, want)
+					t.Errorf("Expected a different tag value from view.RetrieveData for key:%v. Got=%v, want=%v", got.Key.Name(), got.Value, want)
 				}
 			}
 		}
 
 		if s, ok := d[0].Data.(*view.LastValueData); !ok {
-			t.Error("expected a LastValueData type")
+			t.Error("Expected a LastValueData type from view.RetrieveData")
 		} else {
 			if s.Value != wantValue {
-				t.Errorf("expected value=%v, got=%v for metric %v", wantValue, s.Value, name)
+				t.Errorf("Expected value=%v for metric %v from view.RetrieveData, but got=%v", wantValue, name, s.Value)
 			}
 		}
 	}

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -243,10 +243,10 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		return err
 	}
 
-	reporter.Report(autoscaler.ActualPodCountM, float64(got))
+	reporter.ReportActualPodCount(int64(got))
 	// negative "want" values represent an empty metrics pipeline and thus no specific request is being made
 	if want >= 0 {
-		reporter.Report(autoscaler.RequestedPodCountM, float64(want))
+		reporter.ReportRequestedPodCount(int64(want))
 	}
 
 	switch {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Change some activator and autoscaler metrics from `float64` to `int64` according to the metric type the value actually could be. For example, `desired_pods` should only be int value. This is because for some metrics backend, Stackdriver for example, if the metric type of actual value and definition value do not match, if fails to upload data to the backend.
* Create an interface of the autoscaler stats exporter for each metric. 
