### PR TITLE
Don't use deprecated knative-ingressgateway in tests.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:f142393519821f42e957c353a38b5f8ed2ee49311c7f3e2573e329f07c4fd95c"
+  digest = "1:ba30ca58f6253ffaef70943016292d251f8842a82a8091df67eb77ac6a2cb73d"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -477,7 +477,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "076ebf4e56758e76cd87fa402e9478da25ed942e"
+  revision = "994b801b03ef8d71737219345f1861ad74291196"
 
 [[projects]]
   branch = "master"
@@ -1299,6 +1299,8 @@
     "github.com/knative/test-infra/tools/dep-collector",
     "github.com/mattbaird/jsonpatch",
     "github.com/pkg/errors",
+    "github.com/prometheus/client_model/go",
+    "github.com/prometheus/common/expfmt",
     "go.opencensus.io/exporter/prometheus",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-01-18
-  revision = "076ebf4e56758e76cd87fa402e9478da25ed942e"
+  # HEAD as of 2019-01-25
+  revision = "994b801b03ef8d71737219345f1861ad74291196"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
+++ b/vendor/github.com/knative/pkg/metrics/metricskey/constants.go
@@ -50,13 +50,13 @@ var (
 	// KnativeRevisionLabels stores the set of resource labels for resource type knative_revision.
 	// LabelRouteName is added as extra label since it is optional, not in this map.
 	KnativeRevisionLabels = map[string]struct{}{
-		LabelProject:           struct{}{},
-		LabelLocation:          struct{}{},
-		LabelClusterName:       struct{}{},
-		LabelNamespaceName:     struct{}{},
-		LabelServiceName:       struct{}{},
-		LabelConfigurationName: struct{}{},
-		LabelRevisionName:      struct{}{},
+		LabelProject:           {},
+		LabelLocation:          {},
+		LabelClusterName:       {},
+		LabelNamespaceName:     {},
+		LabelServiceName:       {},
+		LabelConfigurationName: {},
+		LabelRevisionName:      {},
 	}
 
 	// ResourceTypeToLabelsMap maps resource type to the set of resource labels
@@ -66,7 +66,7 @@ var (
 
 	// KnativeRevisionMetricsPrefixes stores a set of metrics prefixes that belong to resource type knative_revision
 	KnativeRevisionMetricsPrefixes = map[string]struct{}{
-		"knative.dev/serving/autoscaler": struct{}{},
-		"knative.dev/serving/activator":  struct{}{},
+		"knative.dev/serving/autoscaler": {},
+		"knative.dev/serving/activator":  {},
 	}
 )

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -29,6 +29,7 @@ import (
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
@@ -72,4 +73,16 @@ func WaitForPodListState(client *KubeClient, inState func(p *corev1.PodList) (bo
 		}
 		return inState(p)
 	})
+}
+
+// GetConfigMap gets the knative serving config map.
+func GetConfigMap(client *KubeClient) k8styped.ConfigMapInterface {
+	return client.Kube.CoreV1().ConfigMaps("knative-serving")
+}
+
+// Returns a func that evaluates if a deployment has scaled to 0 pods
+func DeploymentScaledToZeroFunc() func(d *apiv1beta1.Deployment) (bool, error) {
+	return func(d *apiv1beta1.Deployment) (bool, error) {
+		return d.Status.ReadyReplicas == 0, nil
+	}
 }

--- a/vendor/github.com/knative/pkg/test/zipkin/util.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/util.go
@@ -50,8 +50,10 @@ const (
 
 var zipkinPortForwardPID int
 
-// SetupZipkinTracing sets up zipkin tracing which involves a) Setting up port-forwarding from localhost to zipkin pod on the cluster (pid of the process doing Port-Forward is stored in a global variable).
-// b) enable AlwaysSample config for tracing.
+// SetupZipkinTracing sets up zipkin tracing which involves:
+// 1. Setting up port-forwarding from localhost to zipkin pod on the cluster
+//    (pid of the process doing Port-Forward is stored in a global variable).
+// 2. Enable AlwaysSample config for tracing.
 func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 	logger := logging.GetContextLogger("SpoofUtil")
 
@@ -61,7 +63,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 
 	zipkinPods, err := kubeClientset.CoreV1().Pods(ZipkinNamespace).List(metav1.ListOptions{LabelSelector: "app=zipkin"})
 	if err != nil {
-		return fmt.Errorf("Error retrieving Zipkin pod details : %v", err)
+		return fmt.Errorf("Error retrieving Zipkin pod details: %v", err)
 	}
 
 	if len(zipkinPods.Items) == 0 {
@@ -70,8 +72,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 
 	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace="+ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
 	if err = portForwardCmd.Start(); err != nil {
-		return fmt.Errorf("Error starting kubectl port-forward command : %v", err)
-
+		return fmt.Errorf("Error starting kubectl port-forward command: %v", err)
 	}
 	zipkinPortForwardPID = portForwardCmd.Process.Pid
 	logger.Infof("Zipkin port-forward process started with PID: %d", zipkinPortForwardPID)
@@ -79,7 +80,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 	// Applying AlwaysSample config to ensure we propagate zipkin header for every request made by this client.
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
-	logger.Infof("Successfully setup SpoofingClient for Zipkin Tracing")
+	logger.Info("Successfully setup SpoofingClient for Zipkin Tracing")
 
 	return nil
 }
@@ -93,7 +94,7 @@ func CleanupZipkinTracingSetup() error {
 		return fmt.Errorf("Encoutered error killing port-forward process in CleanupZipkingTracingSetup() : %v", err)
 	}
 
-	logger.Infof("Successfully killed Zipkin port-forward process")
+	logger.Info("Successfully killed Zipkin port-forward process")
 	return nil
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

*  Clean up usage of `knative-ingressgateway` in tests since it's deprecated.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
