### PR TITLE
Keep LameDuck in stat for a smoother migration.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -54,6 +54,10 @@ type Stat struct {
 
 	// Number of requests received since last Stat (approximately QPS).
 	RequestCount int32
+
+	// Lameduck indicates this Pod has received a shutdown signal.
+	// Deprecated and no longer used by newly created Pods.
+	LameDuck bool
 }
 
 // StatMessage wraps a Stat with identifying information so it can be routed

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -155,7 +155,10 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.logger.Debugf("Received stat message: %+v", sm)
-		s.statsCh <- &sm
+		// Drop stats from lameducked pods
+		if !sm.Stat.LameDuck {
+			s.statsCh <- &sm
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This was part of #2931 but dropped in subsequent commits. I approved that PR and then realized about potential implications on the migration path when it already got merged 😢. So here we are:

I think we should leave the LameDuck field intact as part of the metrics that are sent to the autoscaler. That way, we can actively drop metrics from "old" queue-proxies when updating the Knative version, so we don't mess up autoscaling for these upgrade paths.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @yanweiguo 
