### PR TITLE
Set envoy connection timeout to 10s

### DIFF
--- a/third_party/istio-1.0.2/conn-timeout.yaml.patch
+++ b/third_party/istio-1.0.2/conn-timeout.yaml.patch
@@ -1,0 +1,6 @@
+235a236,240
+>     # Mesh-wide TCP connection timeout between Envoy sidecar and Application.
+>     # If we do not specify the property - the value gets overwritten by mesh.connectTimeout's default (1s).
+>     # This config could be removed once https://github.com/istio/istio/issues/11319 is resolved
+>     connectTimeout: 10s
+> 

--- a/third_party/istio-1.0.2/conn-timeout.yaml.patch
+++ b/third_party/istio-1.0.2/conn-timeout.yaml.patch
@@ -1,6 +1,8 @@
-235a236,240
+235a236,242
+>     # PATCH #3: Adding default connection timeout.
 >     # Mesh-wide TCP connection timeout between Envoy sidecar and Application.
 >     # If we do not specify the property - the value gets overwritten by mesh.connectTimeout's default (1s).
 >     # This config could be removed once https://github.com/istio/istio/issues/11319 is resolved
 >     connectTimeout: 10s
+>     # PATCH #3 ends.
 > 

--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -69,3 +69,7 @@ patch istio-lean.yaml namespace.yaml.patch
 #
 # We need to replace this with some better solution like retries.
 patch istio.yaml prestop-sleep.yaml.patch
+
+# Set the default connection timeout
+# as per https://github.com/istio/istio/issues/11319
+patch istio.yaml conn-timeout.yaml.patch

--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -73,3 +73,4 @@ patch istio.yaml prestop-sleep.yaml.patch
 # Set the default connection timeout
 # as per https://github.com/istio/istio/issues/11319
 patch istio.yaml conn-timeout.yaml.patch
+patch istio-lean.yaml conn-timeout.yaml.patch

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -233,6 +233,13 @@ data:
     # How frequently should Envoy fetch key/cert from NodeAgent.
     sdsRefreshDelay: 15s
 
+    # PATCH #3: Adding default connection timeout.
+    # Mesh-wide TCP connection timeout between Envoy sidecar and Application.
+    # If we do not specify the property - the value gets overwritten by mesh.connectTimeout's default (1s).
+    # This config could be removed once https://github.com/istio/istio/issues/11319 is resolved
+    connectTimeout: 10s
+    # PATCH #3 ends.
+
     #
     defaultConfig:
       #

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -233,12 +233,6 @@ data:
     # How frequently should Envoy fetch key/cert from NodeAgent.
     sdsRefreshDelay: 15s
 
-
-    # Mesh-wide TCP connection timeout between Envoy sidecar and Application
-    # https://github.com/istio/api/blob/1.0.2/mesh/v1alpha1/config.pb.go#L429
-    # Adding this property for compatibility with istio.yaml
-    connectTimeout: 10s
-
     #
     defaultConfig:
       #

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -233,6 +233,12 @@ data:
     # How frequently should Envoy fetch key/cert from NodeAgent.
     sdsRefreshDelay: 15s
 
+
+    # Mesh-wide TCP connection timeout between Envoy sidecar and Application
+    # https://github.com/istio/api/blob/1.0.2/mesh/v1alpha1/config.pb.go#L429
+    # Adding this property for compatibility with istio.yaml
+    connectTimeout: 10s
+
     #
     defaultConfig:
       #

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -233,6 +233,13 @@ data:
     # How frequently should Envoy fetch key/cert from NodeAgent.
     sdsRefreshDelay: 15s
 
+    # PATCH #3: Adding default connection timeout.
+    # Mesh-wide TCP connection timeout between Envoy sidecar and Application.
+    # If we do not specify the property - the value gets overwritten by mesh.connectTimeout's default (1s).
+    # This config could be removed once https://github.com/istio/istio/issues/11319 is resolved
+    connectTimeout: 10s
+    # PATCH #3 ends.
+
     #
     defaultConfig:
       #

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -233,6 +233,10 @@ data:
     # How frequently should Envoy fetch key/cert from NodeAgent.
     sdsRefreshDelay: 15s
 
+    # Mesh-wide TCP connection timeout between Envoy sidecar and Application
+    # https://github.com/istio/api/blob/1.0.2/mesh/v1alpha1/config.pb.go#L429
+    connectTimeout: 10s
+
     #
     defaultConfig:
       #

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -233,10 +233,6 @@ data:
     # How frequently should Envoy fetch key/cert from NodeAgent.
     sdsRefreshDelay: 15s
 
-    # Mesh-wide TCP connection timeout between Envoy sidecar and Application
-    # https://github.com/istio/api/blob/1.0.2/mesh/v1alpha1/config.pb.go#L429
-    connectTimeout: 10s
-
     #
     defaultConfig:
       #


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2988

## Proposed Changes

* Set the envoy connection timeout to 10s

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
I think it was initially intended to have 10s timeout, but the the value used by the envoy dynamic clusters was in fact set to 1s (it seems to be the default). The timeout was easily reached when running several parallel requests which caused envoy sidecar to return a 503.
This change sets a mesh wide connection timeout to 10s.  

```release-note
Prevent envoy 503s when scaling from 0
```
