### PR TITLE
golang format tools

### DIFF
--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -92,7 +92,7 @@ func parallelScaleFromZero(logger *logging.BaseLogger, count int) ([]time.Durati
 		testNames[i] = &test.ResourceNames{
 			Service: test.AppendRandomString(fmt.Sprintf("%s-%d", serviceName, i), logger),
 			// The crd.go helpers will convert to the actual image path.
-			Image:   helloWorldImage,
+			Image: helloWorldImage,
 		}
 	}
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
