### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,15 +50,16 @@ To start your environment you'll need to set these environment variables (we
 recommend adding them to your `.bashrc`):
 
 1. `GOPATH`: If you don't have one, simply pick a directory and add
-  `export GOPATH=...`
+   `export GOPATH=...`
 1. `$GOPATH/bin` on `PATH`: This is so that tooling installed via `go get` will
-  work properly.
+   work properly.
 1. `KO_DOCKER_REPO` and `DOCKER_REPO_OVERRIDE`: The docker repository to which
    developer images should be pushed (e.g. `gcr.io/[gcloud-project]`).
-  - **Note**: if you are using docker hub to store your images your
-    `KO_DOCKER_REPO` variable should be `docker.io/<username>`.
-  - **Note**: Currently Docker Hub doesn't let you create subdirs under your
-    username.
+
+- **Note**: if you are using docker hub to store your images your
+  `KO_DOCKER_REPO` variable should be `docker.io/<username>`.
+- **Note**: Currently Docker Hub doesn't let you create subdirs under your
+  username.
 
 `.bashrc` example:
 

--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -28,20 +28,21 @@ gcloud container clusters get-credentials --zone us-east1-d knative-demo
 
 1. [Install required tools](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#before-you-begin)
 1. [Create a Kubernetes cluster with minikube](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#creating-a-kubernetes-cluster)
-1. [Configure your shell environment](../DEVELOPMENT.md#setup-your-environment) to
-   use your minikube cluster:
+1. [Configure your shell environment](../DEVELOPMENT.md#setup-your-environment)
+   to use your minikube cluster:
 
    ```shell
    export K8S_CLUSTER_OVERRIDE='minikube'
    ```
 
 1. Take note of the workarounds required for:
-  - [Installing Istio](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#installing-istio)
-  - [Installing Serving](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#installing-knative-serving)
-  - [Loadbalancer support](#loadbalancer-support-in-minikube)
-  - [`ko`](#minikube-with-ko)
-  - [Images](#enabling-knative-to-use-images-in-minikube)
-  - [GCR](#minikube-with-gcr)
+
+- [Installing Istio](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#installing-istio)
+- [Installing Serving](https://github.com/knative/docs/blob/master/install/Knative-with-Minikube.md#installing-knative-serving)
+- [Loadbalancer support](#loadbalancer-support-in-minikube)
+- [`ko`](#minikube-with-ko)
+- [Images](#enabling-knative-to-use-images-in-minikube)
+- [GCR](#minikube-with-gcr)
 
 ### `LoadBalancer` Support in Minikube
 
@@ -96,10 +97,10 @@ docker tag gcr.io/knative-samples/primer:latest dev.local/knative-samples/primer
 
 You can use Google Container Registry as the registry for a Minikube cluster.
 
-1. [Set up a GCR repo](setting-up-a-docker-registry.md). Export the
-   environment variable `PROJECT_ID` as the name of your project. Also export
-   `GCR_DOMAIN` as the domain name of your GCR repo. This will be either
-   `gcr.io` or a region-specific variant like `us.gcr.io`.
+1. [Set up a GCR repo](setting-up-a-docker-registry.md). Export the environment
+   variable `PROJECT_ID` as the name of your project. Also export `GCR_DOMAIN`
+   as the domain name of your GCR repo. This will be either `gcr.io` or a
+   region-specific variant like `us.gcr.io`.
 
    ```shell
    export PROJECT_ID=knative-demo-project
@@ -185,4 +186,5 @@ Use the same procedure to add imagePullSecrets to service accounts in any
 namespace. Use the `default` service account for pods that do not specify a
 service account.
 
-See also the [private-repo sample README](https://github.com/knative/docs/blob/master/serving/samples/build-private-repo-go/README.md).
+See also the
+[private-repo sample README](https://github.com/knative/docs/blob/master/serving/samples/build-private-repo-go/README.md).

--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -1,16 +1,17 @@
 # Adding tests
 
-If you are [developing knative](../DEVELOPMENT.md) you may need to add or change:
+If you are [developing knative](../DEVELOPMENT.md) you may need to add or
+change:
 
 - [e2e tests](./e2e)
 - [Conformance tests](./conformance)
 
 Both tests can use our [test library](#test-library).
 
-Reviewers of conformance and e2e tests (i.e. [OWNERS](./OWNERS)) are
-responsible for the style and quality of the resulting tests. In order to not
-discourage contributions, when style change are required, the reviewers can make
-the changes themselves.
+Reviewers of conformance and e2e tests (i.e. [OWNERS](./OWNERS)) are responsible
+for the style and quality of the resulting tests. In order to not discourage
+contributions, when style change are required, the reviewers can make the
+changes themselves.
 
 All e2e and conformance tests _must_ be marked with the `e2e`
 [build constraint](https://golang.org/pkg/go/build/) so that `go test ./...` can
@@ -22,8 +23,8 @@ be used to run only [the unit tests](README.md#running-unit-tests), i.e.:
 
 ## Test library
 
-In the [`test`](.) dir you will find several libraries in the `test`
-package you can use in your tests.
+In the [`test`](.) dir you will find several libraries in the `test` package you
+can use in your tests.
 
 This library exists partially in this directory and partially in
 [`knative/pkg/test`](https://github.com/knative/pkg/tree/master/test).


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`