### PR TITLE
Fix the revision readiness tests

### DIFF
--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -138,12 +138,13 @@ func (r *revisionActivator) revisionEndpoint(revision *v1alpha1.Revision) (end E
 	}, nil
 }
 
+// ActiveEndpoint activates the revision `name` and returnts the result.
 func (r *revisionActivator) ActiveEndpoint(namespace, name string) ActivationResult {
 	key := fmt.Sprintf("%s/%s", namespace, name)
 	logger := r.logger.With(zap.String(logkey.Key, key))
 	revision, err := r.activateRevision(namespace, name, key)
 	if err != nil {
-		logger.Errorw("failed to activate the revision", zap.Error(err))
+		logger.Errorw("Failed to activate the revision.", zap.Error(err))
 		return ActivationResult{
 			Status: http.StatusInternalServerError,
 			Error:  err,

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -96,6 +96,7 @@ func (r *revisionActivator) activateRevision(namespace, name, key string) (*v1al
 			case event := <-ch:
 				if revision, ok := event.Object.(*v1alpha1.Revision); ok {
 					if revision.Status.IsActivationRequired() {
+						fmt.Print("#### THIS IS HAPPENING!")
 						logger.Infof("Revision %s is not yet ready", name)
 						continue
 					} else {

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -17,7 +17,6 @@ limitations under the License.
 package activator
 
 import (
-	gerrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -130,7 +129,7 @@ func (r *revisionActivator) revisionEndpoint(revision *v1alpha1.Revision) (end E
 		}
 	}
 	if port == -1 {
-		return end, gerrors.New("revision needs external HTTP port")
+		return end, errors.New("revision needs external HTTP port")
 	}
 
 	return Endpoint{

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -96,7 +96,6 @@ func (r *revisionActivator) activateRevision(namespace, name, key string) (*v1al
 			case event := <-ch:
 				if revision, ok := event.Object.(*v1alpha1.Revision); ok {
 					if revision.Status.IsActivationRequired() {
-						fmt.Print("#### THIS IS HAPPENING!")
 						logger.Infof("Revision %s is not yet ready", name)
 						continue
 					} else {

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -17,6 +17,7 @@ limitations under the License.
 package activator
 
 import (
+	gerrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -37,7 +38,7 @@ import (
 var _ Activator = (*revisionActivator)(nil)
 
 type revisionActivator struct {
-	readyTimout time.Duration // for testing
+	readyTimout time.Duration // For testing.
 	kubeClient  kubernetes.Interface
 	knaClient   clientset.Interface
 	logger      *zap.SugaredLogger
@@ -56,11 +57,10 @@ func NewRevisionActivator(kubeClient kubernetes.Interface, servingClient clients
 }
 
 func (r *revisionActivator) Shutdown() {
-	// nothing to do
+	// Nothing to do.
 }
 
-func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.Revision, error) {
-	key := fmt.Sprintf("%s/%s", namespace, name)
+func (r *revisionActivator) activateRevision(namespace, name, key string) (*v1alpha1.Revision, error) {
 	logger := r.logger.With(zap.String(logkey.Key, key))
 	rev := revisionID{
 		namespace: namespace,
@@ -71,7 +71,7 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 	revisionClient := r.knaClient.ServingV1alpha1().Revisions(rev.namespace)
 	revision, err := revisionClient.Get(rev.name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to get revision")
+		return nil, errors.Wrap(err, "unable to get the revision")
 	}
 
 	// Wait for the revision to not require activation.
@@ -80,7 +80,7 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 			FieldSelector: fmt.Sprintf("metadata.name=%s", rev.name),
 		})
 		if err != nil {
-			return nil, errors.New("Failed to watch the revision")
+			return nil, errors.New("failed to watch the revision")
 		}
 		defer wi.Stop()
 		ch := wi.ResultChan()
@@ -92,18 +92,18 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 				if !revision.Status.IsActivationRequired() {
 					break RevisionActive
 				}
-				return nil, errors.New("Timeout waiting for revision to become ready")
+				return nil, errors.New("timeout waiting for the revision to become ready")
 			case event := <-ch:
 				if revision, ok := event.Object.(*v1alpha1.Revision); ok {
 					if revision.Status.IsActivationRequired() {
-						logger.Info("Revision is not yet ready")
+						logger.Infof("Revision %s is not yet ready", name)
 						continue
 					} else {
-						logger.Info("Revision is ready")
+						logger.Infof("Revision %s is ready", name)
 					}
 					break RevisionActive
 				} else {
-					return nil, fmt.Errorf("Unexpected result type for revision: %v", event)
+					return nil, fmt.Errorf("unexpected result type for the revision: %v", event)
 				}
 			}
 		}
@@ -111,13 +111,12 @@ func (r *revisionActivator) activateRevision(namespace, name string) (*v1alpha1.
 	return revision, nil
 }
 
-func (r *revisionActivator) getRevisionEndpoint(revision *v1alpha1.Revision) (end Endpoint, err error) {
-	// Get the revision endpoint
+func (r *revisionActivator) revisionEndpoint(revision *v1alpha1.Revision) (end Endpoint, err error) {
 	services := r.kubeClient.CoreV1().Services(revision.GetNamespace())
 	serviceName := revisionresourcenames.K8sService(revision)
 	svc, err := services.Get(serviceName, metav1.GetOptions{})
 	if err != nil {
-		return end, errors.Wrapf(err, "Unable to get service %s for revision", serviceName)
+		return end, errors.Wrapf(err, "unable to get service %s for revision", serviceName)
 	}
 
 	fqdn := fmt.Sprintf("%s.%s.svc.%s", serviceName, revision.Namespace, utils.GetClusterDomainName())
@@ -131,7 +130,7 @@ func (r *revisionActivator) getRevisionEndpoint(revision *v1alpha1.Revision) (en
 		}
 	}
 	if port == -1 {
-		return end, fmt.Errorf("Revision needs external. Found %v", len(svc.Spec.Ports))
+		return end, gerrors.New("revision needs external HTTP port")
 	}
 
 	return Endpoint{
@@ -143,9 +142,9 @@ func (r *revisionActivator) getRevisionEndpoint(revision *v1alpha1.Revision) (en
 func (r *revisionActivator) ActiveEndpoint(namespace, name string) ActivationResult {
 	key := fmt.Sprintf("%s/%s", namespace, name)
 	logger := r.logger.With(zap.String(logkey.Key, key))
-	revision, err := r.activateRevision(namespace, name)
+	revision, err := r.activateRevision(namespace, name, key)
 	if err != nil {
-		logger.Errorw("Failed to activate the revision.", zap.Error(err))
+		logger.Errorw("failed to activate the revision", zap.Error(err))
 		return ActivationResult{
 			Status: http.StatusInternalServerError,
 			Error:  err,
@@ -153,7 +152,7 @@ func (r *revisionActivator) ActiveEndpoint(namespace, name string) ActivationRes
 	}
 
 	serviceName, configurationName := getServiceAndConfigurationLabels(revision)
-	endpoint, err := r.getRevisionEndpoint(revision)
+	endpoint, err := r.revisionEndpoint(revision)
 	if err != nil {
 		logger.Errorw("Failed to get revision endpoint.", zap.Error(err))
 		return ActivationResult{

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -75,7 +75,7 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 
 	select {
 	case ar := <-ch:
-		want := Endpoint{testServiceFQDN, 8080}
+		want := Endpoint{testServiceFQDN, v1alpha1.DefaultUserPort}
 		if ar.Endpoint != want {
 			t.Errorf("Unexpected endpoint. Want %+v. Got %+v.", want, ar.Endpoint)
 		}
@@ -137,7 +137,7 @@ func TestActiveEndpoint_Reserve_WaitsForReady2Step(t *testing.T) {
 
 	select {
 	case ar := <-ch:
-		want := Endpoint{testServiceFQDN, 8080}
+		want := Endpoint{testServiceFQDN, v1alpha1.DefaultUserPort}
 		if ar.Endpoint != want {
 			t.Errorf("Unexpected endpoint. Want %+v. Got %+v.", want, ar.Endpoint)
 		}
@@ -183,7 +183,7 @@ func TestActiveEndpoint_Reserve_AlreadyReady(t *testing.T) {
 
 	select {
 	case ar := <-ch:
-		want := Endpoint{testServiceFQDN, 8080}
+		want := Endpoint{testServiceFQDN, v1alpha1.DefaultUserPort}
 		if ar.Endpoint != want {
 			t.Errorf("Unexpected endpoint. Want %+v. Got %+v.", want, ar.Endpoint)
 		}
@@ -336,7 +336,7 @@ func newServiceBuilder() *serviceBuilder {
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
 					Name: revisionresources.ServicePortName,
-					Port: 8080,
+					Port: v1alpha1.DefaultUserPort,
 				}, {
 					Name: "anotherport",
 					Port: 9090,

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -96,6 +96,67 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 	}
 }
 
+func TestActiveEndpoint_Reserve_WaitsForReady2Step(t *testing.T) {
+	// This generates two updates, so that the inner loop of the `Watch` can be exercised.
+	k8s, kna := fakeClients()
+	kna.ServingV1alpha1().Revisions(testNamespace).Create(
+		newRevisionBuilder(defaultRevisionLabels).
+			withReady(false).
+			build())
+	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
+
+	ch := make(chan ActivationResult)
+	go func() {
+		ch <- a.ActiveEndpoint(testNamespace, testRevision)
+	}()
+
+	select {
+	case <-ch:
+		t.Error("Unexpected result before revision is ready.")
+	case <-time.After(1200 * time.Millisecond):
+		// Wait long enough, so that ActiveEndpoint Go routine sets up the Watch.
+		// It does fire any events internally, so we have to "sleep".
+	}
+
+	// Partially update the service, to trigger a watch,
+	// which would not finish the loop.
+	rev, _ := kna.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
+	rev.Status.MarkResourcesAvailable()
+	kna.ServingV1alpha1().Revisions(testNamespace).Update(rev)
+
+	// ... and then finally make revision ready after a timeout.
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		rev, _ := kna.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
+		rev.Status.MarkActive()
+		rev.Status.MarkContainerHealthy()
+		kna.ServingV1alpha1().Revisions(testNamespace).Update(rev)
+	}()
+
+	select {
+	case ar := <-ch:
+		want := Endpoint{testServiceFQDN, 8080}
+		if ar.Endpoint != want {
+			t.Errorf("Unexpected endpoint. Want %+v. Got %+v.", want, ar.Endpoint)
+		}
+		if ar.Status != http.StatusOK {
+			t.Errorf("Unexpected error state. Want 0. Got %v.", ar.Status)
+		}
+		if ar.ServiceName != "test-service" {
+			t.Errorf("Unexpected service name. Want test-service. Got %v.", ar.ServiceName)
+		}
+		if ar.ConfigurationName != "test-config" {
+			t.Errorf("Unexpected configuration name. Want test-config. Got %v.", ar.ConfigurationName)
+		}
+		if ar.Error != nil {
+			t.Errorf("Unexpected error. Want nil. Got %v.", ar.Error)
+		}
+	case <-time.After(3 * time.Second):
+		t.Error("Expected result after revision ready.")
+	}
+}
+
 func TestActiveEndpoint_Reserve_AlreadyReady(t *testing.T) {
 	k8s, kna := fakeClients()
 	kna.ServingV1alpha1().Revisions(testNamespace).Create(
@@ -140,6 +201,23 @@ func TestActiveEndpoint_Reserve_AlreadyReady(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Error("Expected result after revision ready @", time.Now())
 	}
+}
+
+func TestActivateEndpoint_NotFound(t *testing.T) {
+	// Tests when revision can't be found.
+	k8s, kna := fakeClients()
+	kna.ServingV1alpha1().Revisions(testNamespace).Create(
+		newRevisionBuilder(defaultRevisionLabels).
+			withReady(false).
+			build())
+	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
+
+	ae := a.ActiveEndpoint(testNamespace, testRevision+"dne")
+	if got, want := ae.Status, http.StatusInternalServerError; got != want {
+		t.Errorf("NotFound revision status: got: %v, want: %v", got, want)
+	}
+
 }
 
 func TestActiveEndpoint_Reserve_ReadyTimeoutWithError(t *testing.T) {

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -137,7 +137,7 @@ func TestActiveEndpoint_Reserve_AlreadyReady(t *testing.T) {
 		if ar.Error != nil {
 			t.Errorf("Unexpected error. Want nil. Got %v.", ar.Error)
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Error("Expected result after revision ready @", time.Now())
 	}
 }

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -114,9 +114,10 @@ func TestActiveEndpoint_Reserve_WaitsForReady2Step(t *testing.T) {
 	select {
 	case <-ch:
 		t.Error("Unexpected result before revision is ready.")
-	case <-time.After(1200 * time.Millisecond):
-		// Wait long enough, so that ActiveEndpoint Go routine sets up the Watch.
-		// It does fire any events internally, so we have to "sleep".
+	case <-time.After(1000 * time.Millisecond):
+		// Wait long enough, so that `ActiveEndpoint()` Go routine above
+		// sets up the `Watch` on the revisions. We need to sleep long enough
+		// for this to happen reliably, otherwise the test will flake.
 	}
 
 	// Partially update the service, to trigger a watch,

--- a/pkg/activator/revision_test.go
+++ b/pkg/activator/revision_test.go
@@ -62,7 +62,9 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 	select {
 	case <-ch:
 		t.Error("Unexpected result before revision is ready.")
-	case <-time.After(100 * time.Microsecond):
+	case <-time.After(1200 * time.Millisecond):
+		// Wait long enough, so that ActiveEndpoint Go routine sets up the Watch.
+		// It does fire any events internally, so we have to "sleep".
 	}
 
 	rev, _ := kna.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
@@ -91,6 +93,52 @@ func TestActiveEndpoint_Reserve_WaitsForReady(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Error("Expected result after revision ready.")
+	}
+}
+
+func TestActiveEndpoint_Reserve_AlreadyReady(t *testing.T) {
+	k8s, kna := fakeClients()
+	kna.ServingV1alpha1().Revisions(testNamespace).Create(
+		newRevisionBuilder(defaultRevisionLabels).
+			withReady(false).
+			build())
+	k8s.CoreV1().Services(testNamespace).Create(newServiceBuilder().build())
+	a := NewRevisionActivator(k8s, kna, TestLogger(t))
+
+	rev, _ := kna.ServingV1alpha1().Revisions(testNamespace).Get(testRevision, metav1.GetOptions{})
+	rev.Status.MarkActive()
+	rev.Status.MarkContainerHealthy()
+	rev.Status.MarkResourcesAvailable()
+	_, err := kna.ServingV1alpha1().Revisions(testNamespace).Update(rev)
+	if err != nil {
+		t.Fatalf("Error updating the revision %s: %v", testRevision, err)
+	}
+
+	ch := make(chan ActivationResult)
+	go func() {
+		ch <- a.ActiveEndpoint(testNamespace, testRevision)
+	}()
+
+	select {
+	case ar := <-ch:
+		want := Endpoint{testServiceFQDN, 8080}
+		if ar.Endpoint != want {
+			t.Errorf("Unexpected endpoint. Want %+v. Got %+v.", want, ar.Endpoint)
+		}
+		if ar.Status != http.StatusOK {
+			t.Errorf("Unexpected error state. Want 0. Got %v.", ar.Status)
+		}
+		if ar.ServiceName != "test-service" {
+			t.Errorf("Unexpected service name. Want test-service. Got %v.", ar.ServiceName)
+		}
+		if ar.ConfigurationName != "test-config" {
+			t.Errorf("Unexpected configuration name. Want test-config. Got %v.", ar.ConfigurationName)
+		}
+		if ar.Error != nil {
+			t.Errorf("Unexpected error. Want nil. Got %v.", ar.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Error("Expected result after revision ready @", time.Now())
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

The tests were not written very well and had a race condition,
wherein the update might have arrived before watch is set up, but
after the read is done. This caused the test to fail intermittently 😩 .
I have split the test in two:
- one that reads already commited ready state
- one that sleeps long enough to setupwatches

In addition I cleaned up the revision.go file to make sure
errors are following GoLang's error string convention and
function names are more go-like, some logging changes,
and finally removed redundant computation of the key.

And probably it's me to blame, when I refactored the test and mismatched the time unit.

p.s. I know much more about k8s fakes than I thought I ever will need. 💫 

/lint


Fixes #3015 



/cc @markusthoemmes @mattmoor 
