### PR TITLE
This fixes the name of the cluster ingress created for a Route.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -48,7 +48,7 @@ func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.Config) *v1alpha1.
 		ObjectMeta: metav1.ObjectMeta{
 			// As ClusterIngress resource is cluster-scoped,
 			// here we use GenerateName to avoid conflict.
-			GenerateName: names.ClusterIngressPrefix(r),
+			Name: names.ClusterIngress(r),
 			Labels: map[string]string{
 				serving.RouteLabelKey:          r.Name,
 				serving.RouteNamespaceLabelKey: r.Namespace,

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -39,6 +39,7 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
+			UID:       "1234-5678",
 			Annotations: map[string]string{
 				networking.IngressClassAnnotationKey: clusteringress.IstioIngressClassName,
 			},
@@ -46,7 +47,7 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		Status: v1alpha1.RouteStatus{Domain: "domain.com"},
 	}
 	expected := metav1.ObjectMeta{
-		GenerateName: "test-route-",
+		Name: "route-1234-5678",
 		Labels: map[string]string{
 			serving.RouteLabelKey:          "test-route",
 			serving.RouteNamespaceLabelKey: "test-ns",

--- a/pkg/reconciler/v1alpha1/route/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names.go
@@ -31,8 +31,8 @@ func K8sServiceFullname(route *v1alpha1.Route) string {
 	return reconciler.GetK8sServiceFullname(K8sService(route), route.Namespace)
 }
 
-// ClusterIngressPrefix returns GenerateName prefix of the
-// ClusterIngress child resource for given Route.
-func ClusterIngressPrefix(route *v1alpha1.Route) string {
-	return fmt.Sprintf("%s-", route.Name)
+// ClusterIngress returns the name for the ClusterIngress
+// child resource for the given Route.
+func ClusterIngress(route *v1alpha1.Route) string {
+	return fmt.Sprintf("route-%s", route.UID)
 }

--- a/pkg/reconciler/v1alpha1/route/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/names/names_test.go
@@ -56,10 +56,11 @@ func TestNamer(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: "default",
+				UID:       "1234-5678-910",
 			},
 		},
-		f:    ClusterIngressPrefix,
-		want: "bar-",
+		f:    ClusterIngress,
+		want: "route-1234-5678-910",
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // BuildOption enables further configuration of a Build.
@@ -281,6 +282,13 @@ type RouteOption func(*v1alpha1.Route)
 func WithSpecTraffic(traffic ...v1alpha1.TrafficTarget) RouteOption {
 	return func(r *v1alpha1.Route) {
 		r.Spec.Traffic = traffic
+	}
+}
+
+// WithRouteUID sets the Route's UID
+func WithRouteUID(uid types.UID) RouteOption {
+	return func(r *v1alpha1.Route) {
+		r.ObjectMeta.UID = uid
 	}
 }
 


### PR DESCRIPTION
This change avoids the race that results in the creation of multiple cluster ingress resources.

Fixes: https://github.com/knative/serving/issues/2605

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->