### PR TITLE
Add service.yaml files for test images

### DIFF
--- a/test/test_images/autoscale/README.md
+++ b/test/test_images/autoscale/README.md
@@ -8,6 +8,12 @@ listen on port `8080` and expose a service at `/`.
 When called, the server calculates the highest prime less than 40000000 and
 emits a message.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/autoscale/service.yaml
+++ b/test/test_images/autoscale/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: autoscale-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/autoscale

--- a/test/test_images/bloatingcow/README.md
+++ b/test/test_images/bloatingcow/README.md
@@ -8,6 +8,12 @@ default, listen on port `8080` and expose a service at `/`.
 When called, the server emits a "Moo!" message, if query parameter
 `memory_in_mb` is specified, the app will allocated so many Mbs of memory.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/bloatingcow/service.yaml
+++ b/test/test_images/bloatingcow/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: bloatingcow-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/bloatingcow

--- a/test/test_images/environment/README.md
+++ b/test/test_images/environment/README.md
@@ -16,6 +16,12 @@ Currently the server exposes:
   query-param. The JSON payload returned as response is specified in
   [runtime_contract_types](../../conformance/runtime_contract_types.go)
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/environment/service.yaml
+++ b/test/test_images/environment/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: environment-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/environment

--- a/test/test_images/failing/README.md
+++ b/test/test_images/failing/README.md
@@ -1,0 +1,17 @@
+# Failing test image
+
+This directory contains the test image used to simulate a crashing image.
+
+The image runs for 10 seconds and then exits. It is useful for testing
+readiness probes.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/failing/service.yaml
+++ b/test/test_images/failing/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: failing-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/failing

--- a/test/test_images/helloworld/README.md
+++ b/test/test_images/helloworld/README.md
@@ -7,6 +7,16 @@ default, listen on port `8080` and expose a service at `/`.
 
 When called, the server emits a "hello world" message.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+To run this image as just a Route and Configuration:
+
+`ko apply -f helloworld.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/helloworld/service.yaml
+++ b/test/test_images/helloworld/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: helloworld-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/helloworld

--- a/test/test_images/httpproxy/README.md
+++ b/test/test_images/httpproxy/README.md
@@ -11,6 +11,12 @@ When called, the proxy server redirects request to the target server.
 To use this image, users need to first set the host of the target server that
 the proxy redirects request to by setting environment variable `TARGET_HOST`.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/httpproxy/service.yaml
+++ b/test/test_images/httpproxy/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: helloworld-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/helloworld
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: httpproxy-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/httpproxy
+            env:
+             - name: TARGET_HOST
+               value: "helloworld-test-image.default.svc.cluster.local"
+

--- a/test/test_images/observed-concurrency/README.md
+++ b/test/test_images/observed-concurrency/README.md
@@ -8,6 +8,12 @@ single concurrency model for the service.
 
 Each request will return its serverside start and end-time in nanoseconds.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/observed-concurrency/service.yaml
+++ b/test/test_images/observed-concurrency/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: observed-concurrency-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/observed-concurrency

--- a/test/test_images/pizzaplanetv1/README.md
+++ b/test/test_images/pizzaplanetv1/README.md
@@ -7,6 +7,12 @@ expose a service at `/`.
 
 When called, the server emits the message "What a spaceport!".
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/pizzaplanetv1/service.yaml
+++ b/test/test_images/pizzaplanetv1/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: pizzaplanetv1-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/pizzaplanetv1

--- a/test/test_images/pizzaplanetv2/README.md
+++ b/test/test_images/pizzaplanetv2/README.md
@@ -8,6 +8,12 @@ expose a service at `/`.
 When called, the server emits the message "Re-energize yourself with a slice of
 pepperoni!".
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/pizzaplanetv2/service.yaml
+++ b/test/test_images/pizzaplanetv2/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: pizzaplanetv2-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/pizzaplanetv2

--- a/test/test_images/printport/README.md
+++ b/test/test_images/printport/README.md
@@ -15,6 +15,12 @@ http://$IP
 8080
 ```
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/printport/service.yaml
+++ b/test/test_images/printport/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: printport-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/printport

--- a/test/test_images/singlethreaded/README.md
+++ b/test/test_images/singlethreaded/README.md
@@ -9,6 +9,12 @@ When called, the server sleeps a short period and returns a 200 status if no
 other request is running in the container concurrently. If it does detect
 concurrent requests, it instead returns a 500 status.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/singlethreaded/service.yaml
+++ b/test/test_images/singlethreaded/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: singlethreaded-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/singlethreaded

--- a/test/test_images/timeout/README.md
+++ b/test/test_images/timeout/README.md
@@ -9,6 +9,12 @@ When called, the server sleeps for the amount of milliseconds passed in via the
 query parameter `timeout` and responds with "Slept for X milliseconds` where X
 is the amount of milliseconds passed in.
 
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
 ## Building
 
 For details about building and adding new images, see the

--- a/test/test_images/timeout/service.yaml
+++ b/test/test_images/timeout/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: timeout-test-image
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/serving/test/test_images/timeout


### PR DESCRIPTION
This makes it easier to run a test image outside of the test framework
for developing and debugging. Updated the README.md files to reflect the
addition of the service.yaml.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
