### PR TITLE
Remove extra slash in mount

### DIFF
--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -290,9 +290,9 @@ spec:
         terminationMessagePath: /dev/termination-log
         volumeMounts:
         - name: prometheus-config-volume
-          mountPath: /etc/prometheus/
+          mountPath: /etc/prometheus
         - name: prometheus-storage-volume
-          mountPath: /prometheus/
+          mountPath: /prometheus
       serviceAccountName: prometheus-system
       terminationGracePeriodSeconds: 600
       volumes:


### PR DESCRIPTION
This extra slash seems to be causing issue with containerd 1.1.5:

```
Warning  Failed     5s                kubelet, 10.74.123.3  Error: failed to create containerd container: taking runtime copy of volume: open /var/data/cripersistentstorage/io.containerd.grpc.v1.cri/containers/3eddb2ea07827dc15cfd84ebb74efb3ee2963331615b24732b23102d5e7bbc95/volumes/d84b297ed1fc4ecb41c0a127be39f9a6226bd1f3a95ae3c80c5baf74fa6666ad: no such file or directory
```

See: #3030

Signed-off-by: Doug Davis <dug@us.ibm.com>