### PR TITLE
Make Deprecated fields more explicit.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -28,7 +28,7 @@ func (r *Revision) SetDefaults() {
 func (rs *RevisionSpec) SetDefaults() {
 	// When ConcurrencyModel is specified but ContainerConcurrency
 	// is not (0), use the ConcurrencyModel value.
-	if rs.ConcurrencyModel == RevisionRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {
+	if rs.DeprecatedConcurrencyModel == RevisionRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {
 		rs.ContainerConcurrency = 1
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -65,15 +65,15 @@ func TestRevisionDefaulting(t *testing.T) {
 		name: "fall back to concurrency model",
 		in: &Revision{
 			Spec: RevisionSpec{
-				ConcurrencyModel:     "Single",
-				ContainerConcurrency: 0, // unspecified
+				DeprecatedConcurrencyModel: "Single",
+				ContainerConcurrency:       0, // unspecified
 			},
 		},
 		want: &Revision{
 			Spec: RevisionSpec{
-				ConcurrencyModel:     "Single",
-				ContainerConcurrency: 1,
-				TimeoutSeconds:       defaultTimeoutSeconds,
+				DeprecatedConcurrencyModel: "Single",
+				ContainerConcurrency:       1,
+				TimeoutSeconds:             defaultTimeoutSeconds,
 			},
 		},
 	}}

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -173,12 +173,12 @@ type RevisionSpec struct {
 	// +optional
 	DeprecatedServingState DeprecatedRevisionServingStateType `json:"servingState,omitempty"`
 
-	// ConcurrencyModel specifies the desired concurrency model
+	// DeprecatedConcurrencyModel specifies the desired concurrency model
 	// (Single or Multi) for the
 	// Revision. Defaults to Multi.
 	// Deprecated in favor of ContainerConcurrency.
 	// +optional
-	ConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
+	DeprecatedConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
 
 	// ContainerConcurrency specifies the maximum allowed
 	// in-flight (concurrent) requests per container of the Revision.
@@ -198,11 +198,11 @@ type RevisionSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// BuildName optionally holds the name of the Build responsible for
+	// DeprecatedBuildName optionally holds the name of the Build responsible for
 	// producing the container image for its Revision.
 	// DEPRECATED: Use BuildRef instead.
 	// +optional
-	BuildName string `json:"buildName,omitempty"`
+	DeprecatedBuildName string `json:"buildName,omitempty"`
 
 	// BuildRef holds the reference to the build (if there is one) responsible
 	// for producing the container image for this Revision. Otherwise, nil
@@ -304,12 +304,12 @@ func (r *Revision) BuildRef() *corev1.ObjectReference {
 		return buildRef
 	}
 
-	if r.Spec.BuildName != "" {
+	if r.Spec.DeprecatedBuildName != "" {
 		return &corev1.ObjectReference{
 			APIVersion: "build.knative.dev/v1alpha1",
 			Kind:       "Build",
 			Namespace:  r.Namespace,
-			Name:       r.Spec.BuildName,
+			Name:       r.Spec.DeprecatedBuildName,
 		}
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_types_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_types_test.go
@@ -549,7 +549,7 @@ func TestRevisionBuildRefFromName(t *testing.T) {
 			Name:      "foo",
 		},
 		Spec: RevisionSpec{
-			BuildName: "bar-build",
+			DeprecatedBuildName: "bar-build",
 		},
 	}
 	got := *r.BuildRef()
@@ -577,8 +577,8 @@ func TestRevisionBuildRef(t *testing.T) {
 			Name:      "foo",
 		},
 		Spec: RevisionSpec{
-			BuildName: "bar",
-			BuildRef:  &buildRef,
+			DeprecatedBuildName: "bar",
+			BuildRef:            &buildRef,
 		},
 	}
 	got := *r.BuildRef()

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -49,9 +49,9 @@ func (rs *RevisionSpec) Validate() *apis.FieldError {
 	errs := validateContainer(rs.Container).ViaField("container").
 		Also(validateBuildRef(rs.BuildRef).ViaField("buildRef"))
 
-	if err := rs.ConcurrencyModel.Validate().ViaField("concurrencyModel"); err != nil {
+	if err := rs.DeprecatedConcurrencyModel.Validate().ViaField("concurrencyModel"); err != nil {
 		errs = errs.Also(err)
-	} else if err := ValidateContainerConcurrency(rs.ContainerConcurrency, rs.ConcurrencyModel); err != nil {
+	} else if err := ValidateContainerConcurrency(rs.ContainerConcurrency, rs.DeprecatedConcurrencyModel); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -512,7 +512,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: corev1.Container{
 				Image: "helloworld",
 			},
-			ConcurrencyModel: "Multi",
+			DeprecatedConcurrencyModel: "Multi",
 		},
 		want: nil,
 	}, {
@@ -530,7 +530,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: corev1.Container{
 				Image: "helloworld",
 			},
-			ConcurrencyModel: "bogus",
+			DeprecatedConcurrencyModel: "bogus",
 		},
 		want: apis.ErrInvalidValue("bogus", "concurrencyModel"),
 	}, {
@@ -588,7 +588,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: nil,
@@ -604,7 +604,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 					Name:  "kevin",
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.container.name"),
@@ -635,7 +635,7 @@ func TestRevisionValidation(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: nil,
@@ -658,7 +658,7 @@ func TestRevisionValidation(t *testing.T) {
 					Name:  "kevin",
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.container.name"),
@@ -672,7 +672,7 @@ func TestRevisionValidation(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: &apis.FieldError{
@@ -693,7 +693,7 @@ func TestRevisionValidation(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: (&apis.FieldError{
@@ -731,7 +731,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -739,7 +739,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: nil,
@@ -750,7 +750,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old:  &notARevision{},
@@ -766,7 +766,7 @@ func TestImmutableFields(t *testing.T) {
 						},
 					},
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -778,7 +778,7 @@ func TestImmutableFields(t *testing.T) {
 						},
 					},
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: &apis.FieldError{
@@ -796,7 +796,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -804,7 +804,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: &apis.FieldError{
@@ -822,7 +822,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -830,13 +830,13 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Single",
+				DeprecatedConcurrencyModel: "Single",
 			},
 		},
 		want: &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},
-			Details: `{v1alpha1.RevisionSpec}.ConcurrencyModel:
+			Details: `{v1alpha1.RevisionSpec}.DeprecatedConcurrencyModel:
 	-: v1alpha1.RevisionRequestConcurrencyModelType("Single")
 	+: v1alpha1.RevisionRequestConcurrencyModelType("Multi")
 `,
@@ -848,7 +848,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "helloworld",
 				},
-				ConcurrencyModel: "Multi",
+				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -856,13 +856,13 @@ func TestImmutableFields(t *testing.T) {
 				Container: corev1.Container{
 					Image: "busybox",
 				},
-				ConcurrencyModel: "Single",
+				DeprecatedConcurrencyModel: "Single",
 			},
 		},
 		want: &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},
-			Details: `{v1alpha1.RevisionSpec}.ConcurrencyModel:
+			Details: `{v1alpha1.RevisionSpec}.DeprecatedConcurrencyModel:
 	-: v1alpha1.RevisionRequestConcurrencyModelType("Single")
 	+: v1alpha1.RevisionRequestConcurrencyModelType("Multi")
 {v1alpha1.RevisionSpec}.Container.Image:

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -130,12 +130,12 @@ type RouteStatus struct {
 	// +optional
 	Domain string `json:"domain,omitempty"`
 
-	// DomainInternal holds the top-level domain that will distribute traffic over the provided
+	// DeprecatedDomainInternal holds the top-level domain that will distribute traffic over the provided
 	// targets from inside the cluster. It generally has the form
 	// {route-name}.{route-namespace}.svc.cluster.local
 	// DEPRECATED: Use Address instead.
 	// +optional
-	DomainInternal string `json:"domainInternal,omitempty"`
+	DeprecatedDomainInternal string `json:"domainInternal,omitempty"`
 
 	// Address holds the information needed for a Route to be the target of an event.
 	// +optional

--- a/pkg/apis/serving/v1alpha1/service_defaults.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults.go
@@ -23,8 +23,8 @@ func (s *Service) SetDefaults() {
 func (ss *ServiceSpec) SetDefaults() {
 	if ss.RunLatest != nil {
 		ss.RunLatest.Configuration.SetDefaults()
-	} else if ss.Pinned != nil {
-		ss.Pinned.Configuration.SetDefaults()
+	} else if ss.DeprecatedPinned != nil {
+		ss.DeprecatedPinned.Configuration.SetDefaults()
 	} else if ss.Release != nil {
 		ss.Release.Configuration.SetDefaults()
 	}

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -99,12 +99,12 @@ func TestServiceDefaulting(t *testing.T) {
 		name: "pinned",
 		in: &Service{
 			Spec: ServiceSpec{
-				Pinned: &PinnedType{},
+				DeprecatedPinned: &PinnedType{},
 			},
 		},
 		want: &Service{
 			Spec: ServiceSpec{
-				Pinned: &PinnedType{
+				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
@@ -119,7 +119,7 @@ func TestServiceDefaulting(t *testing.T) {
 		name: "pinned - no overwrite",
 		in: &Service{
 			Spec: ServiceSpec{
-				Pinned: &PinnedType{
+				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{
@@ -133,7 +133,7 @@ func TestServiceDefaulting(t *testing.T) {
 		},
 		want: &Service{
 			Spec: ServiceSpec{
-				Pinned: &PinnedType{
+				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
 							Spec: RevisionSpec{

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -85,11 +85,9 @@ type ServiceSpec struct {
 	// +optional
 	RunLatest *RunLatestType `json:"runLatest,omitempty"`
 
-	// Pins this service to a specific revision name. The revision must
-	// be owned by the configuration provided.
-	// PinnedType is DEPRECATED in favor of ReleaseType
+	// DeprecatedPinned is DEPRECATED in favor of ReleaseType
 	// +optional
-	Pinned *PinnedType `json:"pinned,omitempty"`
+	DeprecatedPinned *PinnedType `json:"pinned,omitempty"`
 
 	// Manual mode enables users to start managing the underlying Route and Configuration
 	// resources directly.  This advanced usage is intended as a path for users to graduate
@@ -178,12 +176,12 @@ type ServiceStatus struct {
 	Domain string `json:"domain,omitempty"`
 
 	// From RouteStatus.
-	// DomainInternal holds the top-level domain that will distribute traffic over the provided
+	// DeprecatedDomainInternal holds the top-level domain that will distribute traffic over the provided
 	// targets from inside the cluster. It generally has the form
 	// {route-name}.{route-namespace}.svc.cluster.local
 	// DEPRECATED: Use Address instead.
 	// +optional
-	DomainInternal string `json:"domainInternal,omitempty"`
+	DeprecatedDomainInternal string `json:"domainInternal,omitempty"`
 
 	// Address holds the information needed for a Route to be the target of an event.
 	// +optional
@@ -294,7 +292,7 @@ func (ss *ServiceStatus) MarkRouteNotYetReady() {
 // PropagateRouteStatus propagates route's status to the service's status.
 func (ss *ServiceStatus) PropagateRouteStatus(rs *RouteStatus) {
 	ss.Domain = rs.Domain
-	ss.DomainInternal = rs.DomainInternal
+	ss.DeprecatedDomainInternal = rs.DeprecatedDomainInternal
 	ss.Address = rs.Address
 	ss.Traffic = rs.Traffic
 
@@ -329,7 +327,7 @@ func (ss *ServiceStatus) SetManualStatus() {
 
 	newStatus.Address = ss.Address
 	newStatus.Domain = ss.Domain
-	newStatus.DomainInternal = ss.DomainInternal
+	newStatus.DeprecatedDomainInternal = ss.DeprecatedDomainInternal
 
 	*ss = *newStatus
 }

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -52,9 +52,9 @@ func (ss *ServiceSpec) Validate() *apis.FieldError {
 		set = append(set, "manual")
 		errs = errs.Also(ss.Manual.Validate().ViaField("manual"))
 	}
-	if ss.Pinned != nil {
+	if ss.DeprecatedPinned != nil {
 		set = append(set, "pinned")
-		errs = errs.Also(ss.Pinned.Validate().ViaField("pinned"))
+		errs = errs.Also(ss.DeprecatedPinned.Validate().ViaField("pinned"))
 	}
 
 	if len(set) > 1 {

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -60,7 +60,7 @@ func TestServiceValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: ServiceSpec{
-				Pinned: &PinnedType{
+				DeprecatedPinned: &PinnedType{
 					RevisionName: "asdf",
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
@@ -149,7 +149,7 @@ func TestServiceValidation(t *testing.T) {
 						},
 					},
 				},
-				Pinned: &PinnedType{
+				DeprecatedPinned: &PinnedType{
 					RevisionName: "asdf",
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{
@@ -207,7 +207,7 @@ func TestServiceValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: ServiceSpec{
-				Pinned: &PinnedType{
+				DeprecatedPinned: &PinnedType{
 					RevisionName: "asdf",
 					Configuration: ConfigurationSpec{
 						RevisionTemplate: RevisionTemplateSpec{

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -572,8 +572,8 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
-	if in.Pinned != nil {
-		in, out := &in.Pinned, &out.Pinned
+	if in.DeprecatedPinned != nil {
+		in, out := &in.DeprecatedPinned, &out.DeprecatedPinned
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
@@ -206,7 +206,7 @@ func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxS
 			Annotations: annotations,
 		},
 		Spec: v1alpha1.RevisionSpec{
-			ConcurrencyModel: "Multi",
+			DeprecatedConcurrencyModel: "Multi",
 		},
 	}
 	rev, err := servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -730,7 +730,7 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 				Args:       []string{"hello", "world"},
 				WorkingDir: "/tmp",
 			},
-			ConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelSingle,
+			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelSingle,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -106,8 +106,8 @@ func getTestRevision() *v1alpha1.Revision {
 				},
 				TerminationMessagePath: "/dev/null",
 			},
-			ConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
-			TimeoutSeconds:   60,
+			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
+			TimeoutSeconds:             60,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -239,7 +239,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 
 	// Update the information that makes us Addressable.
 	r.Status.Domain = routeDomain(ctx, r)
-	r.Status.DomainInternal = resourcenames.K8sServiceFullname(r)
+	r.Status.DeprecatedDomainInternal = resourcenames.K8sServiceFullname(r)
 	r.Status.Address = &duckv1alpha1.Addressable{
 		Hostname: resourcenames.K8sServiceFullname(r),
 	}

--- a/pkg/reconciler/v1alpha1/service/resources/configuration.go
+++ b/pkg/reconciler/v1alpha1/service/resources/configuration.go
@@ -41,8 +41,8 @@ func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, erro
 
 	if service.Spec.RunLatest != nil {
 		c.Spec = service.Spec.RunLatest.Configuration
-	} else if service.Spec.Pinned != nil {
-		c.Spec = service.Spec.Pinned.Configuration
+	} else if service.Spec.DeprecatedPinned != nil {
+		c.Spec = service.Spec.DeprecatedPinned.Configuration
 	} else if service.Spec.Release != nil {
 		c.Spec = service.Spec.Release.Configuration
 	} else {

--- a/pkg/reconciler/v1alpha1/service/resources/route.go
+++ b/pkg/reconciler/v1alpha1/service/resources/route.go
@@ -76,9 +76,9 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 			Percent:           100,
 		}
 		c.Spec.Traffic = append(c.Spec.Traffic, tt)
-	} else if service.Spec.Pinned != nil {
+	} else if service.Spec.DeprecatedPinned != nil {
 		tt := v1alpha1.TrafficTarget{
-			RevisionName: service.Spec.Pinned.RevisionName,
+			RevisionName: service.Spec.DeprecatedPinned.RevisionName,
 			Percent:      100,
 		}
 		c.Spec.Traffic = append(c.Spec.Traffic, tt)

--- a/pkg/reconciler/v1alpha1/service/resources/shared_test.go
+++ b/pkg/reconciler/v1alpha1/service/resources/shared_test.go
@@ -93,7 +93,7 @@ func createServiceWithRunLatest() *v1alpha1.Service {
 func createServiceWithPinned() *v1alpha1.Service {
 	s := createServiceMeta()
 	s.Spec = v1alpha1.ServiceSpec{
-		Pinned: &v1alpha1.PinnedType{
+		DeprecatedPinned: &v1alpha1.PinnedType{
 			RevisionName:  testRevisionName,
 			Configuration: createConfiguration(testContainerNamePinned),
 		},

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -132,7 +132,7 @@ func MarkRouteNotOwned(service *v1alpha1.Service) {
 func WithPinnedRollout(name string) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		s.Spec = v1alpha1.ServiceSpec{
-			Pinned: &v1alpha1.PinnedType{
+			DeprecatedPinned: &v1alpha1.PinnedType{
 				RevisionName:  name,
 				Configuration: configSpec,
 			},
@@ -199,7 +199,7 @@ func WithReadyRoute(s *v1alpha1.Service) {
 func WithSvcStatusDomain(s *v1alpha1.Service) {
 	n, ns := s.GetName(), s.GetNamespace()
 	s.Status.Domain = fmt.Sprintf("%s.%s.example.com", n, ns)
-	s.Status.DomainInternal = fmt.Sprintf("%s.%s.svc.cluster.local", n, ns)
+	s.Status.DeprecatedDomainInternal = fmt.Sprintf("%s.%s.svc.cluster.local", n, ns)
 }
 
 // WithSvcStatusAddress updates the service's status with the address.
@@ -332,7 +332,7 @@ func WithDomain(r *v1alpha1.Route) {
 
 // WithDomainInternal sets the .Status.DomainInternal field to the prototypical internal domain.
 func WithDomainInternal(r *v1alpha1.Route) {
-	r.Status.DomainInternal = fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace)
+	r.Status.DeprecatedDomainInternal = fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace)
 }
 
 // WithAddress sets the .Status.Address field to the prototypical internal hostname.
@@ -436,7 +436,7 @@ func WithConfigOwnersRemoved(cfg *v1alpha1.Configuration) {
 // WithConfigConcurrencyModel sets the given Configuration's concurrency model.
 func WithConfigConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) ConfigOption {
 	return func(cfg *v1alpha1.Configuration) {
-		cfg.Spec.RevisionTemplate.Spec.ConcurrencyModel = ss
+		cfg.Spec.RevisionTemplate.Spec.DeprecatedConcurrencyModel = ss
 	}
 }
 
@@ -528,7 +528,7 @@ func MarkResourceNotOwned(kind, name string) RevisionOption {
 // WithRevConcurrencyModel sets the concurrency model on the Revision.
 func WithRevConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) RevisionOption {
 	return func(rev *v1alpha1.Revision) {
-		rev.Spec.ConcurrencyModel = ss
+		rev.Spec.DeprecatedConcurrencyModel = ss
 	}
 }
 

--- a/test/crd.go
+++ b/test/crd.go
@@ -187,8 +187,8 @@ func ReleaseService(svc *v1alpha1.Service, revisions []string, rolloutPercent in
 		config = svc.Spec.RunLatest.Configuration
 	} else if svc.Spec.Release != nil {
 		config = svc.Spec.Release.Configuration
-	} else if svc.Spec.Pinned != nil {
-		config = svc.Spec.Pinned.Configuration
+	} else if svc.Spec.DeprecatedPinned != nil {
+		config = svc.Spec.DeprecatedPinned.Configuration
 	}
 	return &v1alpha1.Service{
 		ObjectMeta: svc.ObjectMeta,

--- a/test/service.go
+++ b/test/service.go
@@ -50,7 +50,7 @@ func validateCreatedServiceStatus(clients *Clients, names *ResourceNames) error 
 			return false, fmt.Errorf("lastCreatedRevision is not present in Service status: %v", s)
 		}
 		names.Revision = s.Status.LatestCreatedRevisionName
-		if s.Status.DomainInternal == "" {
+		if s.Status.DeprecatedDomainInternal == "" {
 			return false, fmt.Errorf("domainInternal is not present in Service status: %v", s)
 		}
 		if s.Status.LatestReadyRevisionName == "" {
@@ -165,8 +165,8 @@ func PatchServiceImage(logger *logging.BaseLogger, clients *Clients, svc *v1alph
 		newSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
 	} else if svc.Spec.Release != nil {
 		newSvc.Spec.Release.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
-	} else if svc.Spec.Pinned != nil {
-		newSvc.Spec.Pinned.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
+	} else if svc.Spec.DeprecatedPinned != nil {
+		newSvc.Spec.DeprecatedPinned.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
 	} else {
 		return nil, fmt.Errorf("UpdateImageService(%v): unable to determine service type", svc)
 	}
@@ -195,8 +195,8 @@ func PatchServiceRevisionTemplateMetadata(logger *logging.BaseLogger, clients *C
 		newSvc.Spec.RunLatest.Configuration.RevisionTemplate.ObjectMeta = metadata
 	} else if svc.Spec.Release != nil {
 		newSvc.Spec.Release.Configuration.RevisionTemplate.ObjectMeta = metadata
-	} else if svc.Spec.Pinned != nil {
-		newSvc.Spec.Pinned.Configuration.RevisionTemplate.ObjectMeta = metadata
+	} else if svc.Spec.DeprecatedPinned != nil {
+		newSvc.Spec.DeprecatedPinned.Configuration.RevisionTemplate.ObjectMeta = metadata
 	} else {
 		return nil, fmt.Errorf("UpdateServiceRevisionTemplateMetadata(%v): unable to determine service type", svc)
 	}


### PR DESCRIPTION
This makes more explicit which of the fields in our v1alpha1 API have been deprecated by making their Go types start with the prefix: `Deprecated*`.

Some of our types already to this, leaving the serialization alone, but it was applied inconsistently.

This fixes the inconsistency.
