### PR TITLE
Pull in the knative/pkg update to make Severity less scary.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:cb6532baa0e943f01726c540e1a89f3caac8d8c0e8fdfcf172b357a77e63c6b1"
+  digest = "1:4eeeaf55912485c9a68cf37b119693a58173cd06b41cabf92ba758fc47ca273b"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -477,7 +477,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "cc3cc546fee76ddbb55cdb2c90e0a2871c9eef78"
+  revision = "298debc821c24bef5375b22ff7513079603df4dc"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,8 +23,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-01-29
-  revision = "cc3cc546fee76ddbb55cdb2c90e0a2871c9eef78"
+  # HEAD as of 2019-01-30
+  revision = "298debc821c24bef5375b22ff7513079603df4dc"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -130,15 +130,15 @@ func TestReconcile(t *testing.T) {
 					Conditions: duckv1alpha1.Conditions{{
 						Type:     v1alpha1.ClusterIngressConditionLoadBalancerReady,
 						Status:   corev1.ConditionTrue,
-						Severity: "Error",
+						Severity: duckv1alpha1.ConditionSeverityError,
 					}, {
 						Type:     v1alpha1.ClusterIngressConditionNetworkConfigured,
 						Status:   corev1.ConditionTrue,
-						Severity: "Error",
+						Severity: duckv1alpha1.ConditionSeverityError,
 					}, {
 						Type:     v1alpha1.ClusterIngressConditionReady,
 						Status:   corev1.ConditionTrue,
-						Severity: "Error",
+						Severity: duckv1alpha1.ConditionSeverityError,
 					}},
 				},
 			),
@@ -181,15 +181,15 @@ func TestReconcile(t *testing.T) {
 					Conditions: duckv1alpha1.Conditions{{
 						Type:     v1alpha1.ClusterIngressConditionLoadBalancerReady,
 						Status:   corev1.ConditionTrue,
-						Severity: "Error",
+						Severity: duckv1alpha1.ConditionSeverityError,
 					}, {
 						Type:     v1alpha1.ClusterIngressConditionNetworkConfigured,
 						Status:   corev1.ConditionTrue,
-						Severity: "Error",
+						Severity: duckv1alpha1.ConditionSeverityError,
 					}, {
 						Type:     v1alpha1.ClusterIngressConditionReady,
 						Status:   corev1.ConditionTrue,
-						Severity: "Error",
+						Severity: duckv1alpha1.ConditionSeverityError,
 					}},
 				},
 			),

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -387,7 +387,7 @@ func TestResolutionFailed(t *testing.T) {
 			Reason:             "ContainerMissing",
 			Message:            v1alpha1.RevisionContainerMissingMessage(rev.Spec.Container.Image, errorMessage),
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
@@ -464,7 +464,7 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 			Status:             corev1.ConditionUnknown,
 			Reason:             "Deploying",
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)
@@ -491,7 +491,7 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 			Type:               ct,
 			Status:             corev1.ConditionTrue,
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected revision conditions diff (-want +got): %v", diff)

--- a/pkg/reconciler/v1alpha1/route/traffic/errors_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/errors_test.go
@@ -48,7 +48,7 @@ func TestMarkBadTrafficTarget_Missing(t *testing.T) {
 			Reason:             "RevisionMissing",
 			Message:            `Revision "missing-rev" referenced in traffic not found.`,
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected condition diff (-want +got): %v", diff)
@@ -80,7 +80,7 @@ func TestMarkBadTrafficTarget_NotYetReady(t *testing.T) {
 			Reason:             "RevisionMissing",
 			Message:            `Configuration "unready-config" is waiting for a Revision to become ready.`,
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected condition diff (-want +got): %v", diff)
@@ -112,7 +112,7 @@ func TestMarkBadTrafficTarget_ConfigFailedToBeReady(t *testing.T) {
 			Reason:             "RevisionMissing",
 			Message:            `Configuration "failed-config" does not have any ready Revision.`,
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected condition diff (-want +got): %v", diff)
@@ -136,7 +136,7 @@ func TestMarkBadTrafficTarget_RevisionFailedToBeReady(t *testing.T) {
 			Reason:             "RevisionMissing",
 			Message:            `Revision "failed-revision" failed to become ready.`,
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected condition diff (-want +got): %v", diff)
@@ -168,7 +168,7 @@ func TestMarkBadTrafficTarget_RevisionNotYetReady(t *testing.T) {
 			Reason:             "RevisionMissing",
 			Message:            `Revision "unready-revision" is not yet ready.`,
 			LastTransitionTime: got.LastTransitionTime,
-			Severity:           "Error",
+			Severity:           duckv1alpha1.ConditionSeverityError,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected condition diff (-want +got): %v", diff)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -47,8 +47,10 @@ type ConditionSeverity string
 
 const (
 	// ConditionSeverityError specifies that a failure of a condition type
-	// should be viewed as an error.
-	ConditionSeverityError ConditionSeverity = "Error"
+	// should be viewed as an error.  As "Error" is the default for conditions
+	// we use the empty string (coupled with omitempty) to avoid confusion in
+	// the case where the condition is in state "True" (aka nothing is wrong).
+	ConditionSeverityError ConditionSeverity = ""
 	// ConditionSeverityWarning specifies that a failure of a condition type
 	// should be viewed as a warning, but that things could still work.
 	ConditionSeverityWarning ConditionSeverity = "Warning"

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -75,9 +75,9 @@ func WaitForPodListState(client *KubeClient, inState func(p *corev1.PodList) (bo
 	})
 }
 
-// GetConfigMap gets the knative serving config map.
-func GetConfigMap(client *KubeClient) k8styped.ConfigMapInterface {
-	return client.Kube.CoreV1().ConfigMaps("knative-serving")
+// GetConfigMap gets the configmaps for a given namespace
+func GetConfigMap(client *KubeClient, namespace string) k8styped.ConfigMapInterface {
+	return client.Kube.CoreV1().ConfigMaps(namespace)
 }
 
 // Returns a func that evaluates if a deployment has scaled to 0 pods


### PR DESCRIPTION
With this change, `Severity: Error` is always written to the API Server as `Severity: ""`.

This is a backwards compatible change because for (drumroll) backwards compatibility in clients, we elected to make `"Error"` the default when omitted (so that the previously 100% terminal world w/o `Severity` mapped cleanly onto the new world).

Fixes: https://github.com/knative/serving/issues/2507