### PR TITLE
Adapt breaker to be used by activator throttler

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -258,8 +258,9 @@ func main() {
 		if queueDepth < 10 {
 			queueDepth = 10
 		}
-		breaker = queue.NewBreaker(int32(queueDepth), int32(containerConcurrency), int32(containerConcurrency))
-		logger.Infof("Queue container is starting with queueDepth: %d, containerConcurrency: %d", queueDepth, containerConcurrency)
+		params := queue.BreakerParams{QueueDepth: int32(queueDepth), MaxConcurrency: int32(containerConcurrency), InitialCapacity: int32(containerConcurrency)}
+		breaker = queue.NewBreaker(params)
+		logger.Infof("Queue container is starting with %#v", params)
 	}
 
 	logger.Info("Initializing OpenCensus Prometheus exporter")

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -22,6 +22,18 @@ import (
 	"sync"
 )
 
+const (
+	reduceCapacityError = "the capacity that is released must be <= to added capacity"
+	addCapacityError    = "failed to add all capacity to the breaker"
+)
+
+// BreakerParams defines the parameters of the breaker.
+type BreakerParams struct {
+	QueueDepth      int32
+	MaxConcurrency  int32
+	InitialCapacity int32
+}
+
 type token struct{}
 
 // Breaker is a component that enforces a concurrency limit on the
@@ -34,20 +46,20 @@ type Breaker struct {
 }
 
 // NewBreaker creates a Breaker with the desired queue depth,
-// concurrency limit and initial capacity
-func NewBreaker(queueDepth, maxConcurrency, initialCapacity int32) *Breaker {
-	if queueDepth <= 0 {
-		panic(fmt.Sprintf("Queue depth must be greater than 0. Got %v.", queueDepth))
+// concurrency limit and initial capacity.
+func NewBreaker(params BreakerParams) *Breaker {
+	if params.QueueDepth <= 0 {
+		panic(fmt.Sprintf("Queue depth must be greater than 0. Got %v.", params.QueueDepth))
 	}
-	if maxConcurrency < 0 {
-		panic(fmt.Sprintf("Max concurrency must be 0 or greater. Got %v.", maxConcurrency))
+	if params.MaxConcurrency < 0 {
+		panic(fmt.Sprintf("Max concurrency must be 0 or greater. Got %v.", params.QueueDepth))
 	}
-	if initialCapacity < 0 || initialCapacity > maxConcurrency {
-		panic(fmt.Sprintf("Initial capacity must be between 0 and max concurrency. Got %v.", initialCapacity))
+	if params.InitialCapacity < 0 || params.InitialCapacity > params.MaxConcurrency {
+		panic(fmt.Sprintf("Initial capacity must be between 0 and max concurrency. Got %v.", params.InitialCapacity))
 	}
-	sem := NewSemaphore(maxConcurrency, initialCapacity)
+	sem := NewSemaphore(params.MaxConcurrency, params.InitialCapacity)
 	return &Breaker{
-		pendingRequests: make(chan token, queueDepth+maxConcurrency),
+		pendingRequests: make(chan token, params.QueueDepth+params.MaxConcurrency),
 		sem:             sem,
 	}
 }
@@ -76,7 +88,22 @@ func (b *Breaker) Maybe(thunk func()) bool {
 	}
 }
 
-// NewSemaphore creates a semaphore with the desired maximal and initial capacity
+// UpdateConcurrency updates the maximum number of in-flight requests.
+func (b *Breaker) UpdateConcurrency(size int32) (err error) {
+	if size > 0 {
+		err = b.sem.AddCapacity(size)
+	} else {
+		err = b.sem.ReduceCapacity(-size)
+	}
+	return err
+}
+
+// Capacity retrieves the capacity of the breaker.
+func (b *Breaker) Capacity() int32 {
+	return b.sem.capacity
+}
+
+// NewSemaphore creates a semaphore with the desired maximal and initial capacity.
 func NewSemaphore(maxCapacity, initialCapacity int32) *Semaphore {
 	if initialCapacity < 0 || initialCapacity > maxCapacity {
 		panic(fmt.Sprintf("Initial capacity must be between 0 and maximal capacity. Got %v.", initialCapacity))
@@ -89,8 +116,10 @@ func NewSemaphore(maxCapacity, initialCapacity int32) *Semaphore {
 	return &sem
 }
 
-// Semaphore is an implementation of a semaphore based on Go channels
-// The number of available tokens is the number of elements in the buffered channel
+// Semaphore is an implementation of a semaphore based on Go channels.
+// The presence of elements in the `queue` buffered channel correspond to available tokens.
+// Hence the max number of tokens to hand out equals to the size of the channel.
+// `capacity` defines the current number of tokens in the rotation.
 type Semaphore struct {
 	queue    chan token
 	token    token
@@ -99,25 +128,55 @@ type Semaphore struct {
 	mux      sync.Mutex
 }
 
-// Acquire receives the token from the semaphore, potentially blocking
+// Acquire receives the token from the semaphore, potentially blocking.
 func (s *Semaphore) Acquire() {
 	<-s.queue
 }
 
-// Release releases the token to the queue
-// The operation is potentially blocking when the queue is full
+// Release potentially puts the token back to the queue.
+// If the semaphore capacity was reduced in between and is not yet reflected,
+// we remove the tokens from the rotation instead of returning them back.
 func (s *Semaphore) Release() {
-	s.AddCapacity(1)
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	if s.reducers > 0 {
+		s.capacity -= s.reducers
+		s.reducers--
+	} else {
+		// We want to make sure releasing a token is always non-blocking.
+		select {
+		case s.queue <- s.token:
+		default:
+		}
+	}
 }
 
-// ReduceCapacity removes tokens from the rotation
+// AddCapacity increases the number of tokens in the rotation.
+// Increases only if the size is positive, does nothing otherwise.
+// An error is returned if not all capacity could be added to the semaphore.
+// This error could happen when the number of tokens exceeds the semaphore's queue size.
+func (s *Semaphore) AddCapacity(size int32) error {
+	if size > 0 {
+		for i := int32(0); i < size; i++ {
+			select {
+			case s.queue <- s.token:
+				s.capacity++
+			default:
+				return errors.New(addCapacityError)
+			}
+		}
+	}
+	return nil
+}
+
+// ReduceCapacity removes tokens from the rotation.
 // It tries to acquire as many tokens as possible, if there are not enough tokens in the queue,
-// it postpones the operation for the future by increasing the `reducers` counter
+// it postpones the operation for the future by increasing the `reducers` counter.
 func (s *Semaphore) ReduceCapacity(size int32) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	if size > s.capacity {
-		return errors.New("the capacity that is released must be <= to added capacity")
+		return errors.New(reduceCapacityError)
 	}
 	for i := int32(0); i < size; i++ {
 		select {
@@ -128,31 +187,4 @@ func (s *Semaphore) ReduceCapacity(size int32) error {
 		}
 	}
 	return nil
-}
-
-// AddCapacity conditionally adds capacity to the semaphore
-// If there are tokens that must be reduced, release them first
-// Otherwise, add tokens to the queue
-func (s *Semaphore) AddCapacity(size int32) {
-	var leftToAdd int32
-	s.mux.Lock()
-	defer s.mux.Unlock()
-	if s.reducers > 0 {
-		// do not allow reducers to be negative
-		if s.reducers >= size {
-			s.reducers -= size
-			s.capacity -= size
-		} else {
-			leftToAdd = size - s.reducers
-			s.reducers = 0
-		}
-	} else {
-		leftToAdd = size
-	}
-	if leftToAdd > 0 {
-		for i := int32(0); i < leftToAdd; i++ {
-			s.queue <- s.token
-			s.capacity++
-		}
-	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
This PR is a prereq for https://github.com/knative/serving/issues/2381 
1. Replace Breaker params with a struct.
2. Add UpdateConcurrency and Capacity methods to the Breaker (they will be used in the consequent PRs).
3. Split semaphore's capacity operations from acquiring/releasing the token.
4. Add Unit tests or adapt the existing ones.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adapt breaker to be used by activator throttler
```
