### PR TITLE
Replace the default cert path with tls.crt

### DIFF
--- a/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_defaults.go
@@ -46,9 +46,9 @@ func (c *IngressSpec) SetDefaults() {
 }
 
 func (t *ClusterIngressTLS) SetDefaults() {
-	// Default Secret key for ServerCertificate is `tls.cert`.
+	// Default Secret key for ServerCertificate is `tls.crt`.
 	if t.ServerCertificate == "" {
-		t.ServerCertificate = "tls.cert"
+		t.ServerCertificate = "tls.crt"
 	}
 	// Default Secret key for PrivateKey is `tls.key`.
 	if t.PrivateKey == "" {

--- a/pkg/apis/networking/v1alpha1/clusteringress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_defaults_test.go
@@ -66,7 +66,7 @@ func TestClusterIngressDefaulting(t *testing.T) {
 					SecretNamespace: "secret-space",
 					SecretName:      "secret-name",
 					// Default secret keys are filled in.
-					ServerCertificate: "tls.cert",
+					ServerCertificate: "tls.crt",
 					PrivateKey:        "tls.key",
 				}},
 				Visibility: IngressVisibilityExternalIP,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes
Replace the default value of ServerCertificate from tls.cert to tls.crt as tls.crt is the default key for the secret "kubernetes.io/tls"


