### PR TITLE
Fix scale-from-zero perf test units

### DIFF
--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -147,7 +147,7 @@ func testGrid(s *stats, tName string) error {
 	val := float32(s.avg.Seconds())
 	tc = append(tc, CreatePerfTestCase(val, "Average", tName))
 	ts := junit.TestSuites{}
-	ts.AddTestSuite(&junit.TestSuite{Name: "TestPerformanceLatency", TestCases: tc})
+	ts.AddTestSuite(&junit.TestSuite{Name: tName, TestCases: tc})
 	return testgrid.CreateXMLOutput(&ts, tName)
 }
 

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -144,10 +144,10 @@ func getStats(durations []time.Duration) *stats {
 
 func testGrid(s *stats, tName string) error {
 	var tc []junit.TestCase
-	val := float32(s.avg.Seconds() / 1000)
+	val := float32(s.avg.Seconds())
 	tc = append(tc, CreatePerfTestCase(val, "Average", tName))
 	ts := junit.TestSuites{}
-	ts.AddTestSuite( &junit.TestSuite{Name:"TestPerformanceLatency", TestCases:tc} )
+	ts.AddTestSuite(&junit.TestSuite{Name: "TestPerformanceLatency", TestCases: tc})
 	return testgrid.CreateXMLOutput(&ts, tName)
 }
 


### PR DESCRIPTION
Testgrid seems to expect seconds output which it then displays in
miliseconds.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
