### PR TITLE
Hollow out our ConfigMaps.

### DIFF
--- a/config/999-cache.yaml
+++ b/config/999-cache.yaml
@@ -23,14 +23,3 @@ spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   image: github.com/knative/serving/cmd/queue
----
-apiVersion: caching.internal.knative.dev/v1alpha1
-kind: Image
-metadata:
-  name: fluentd-sidecar
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: devel
-spec:
-  # Cache the fluentd sidecar image
-  image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -19,7 +19,12 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # Static parameters:
 
   # The Revision ContainerConcurrency field specifies the maximum number
@@ -30,9 +35,7 @@ data:
   # on average. A value of 0.7 is chosen because the Autoscaler panics
   # when concurrency exceeds 2x the desired set point. So we will panic
   # before we reach the limit.
-  # TODO(#1956): tune target usage based on empirical data.
-  # TODO(#2016): Revert to 0.7 once incorrect reporting is solved
-  container-concurrency-target-percentage: "1.0"
+  # container-concurrency-target-percentage: "1.0"
 
   # The container concurrency target default is what the Autoscaler will
   # try to maintain when the Revision specifies unlimited concurrency. A
@@ -40,34 +43,31 @@ data:
   # autoscaling to tune resource requests. E.g. maintaining 1 concurrent
   # "hello world" request doesn't consume enough resources to allow VPA
   # to achieve efficient resource usage (VPA CPU minimum is 300m).
-  container-concurrency-target-default: "100"
+  # container-concurrency-target-default: "100"
 
   # When operating in a stable mode, the autoscaler operates on the
   # average concurrency over the stable window.
-  stable-window: "60s"
+  # stable-window: "60s"
 
   # When observed average concurrency during the panic window reaches 2x
   # the target concurrency, the autoscaler enters panic mode. When
   # operating in panic mode, the autoscaler operates on the average
   # concurrency over the panic window.
-  panic-window: "6s"
+  # panic-window: "6s"
 
   # Max scale up rate limits the rate at which the autoscaler will
   # increase pod count. It is the maximum ratio of desired pods versus
   # observed pods.
-  max-scale-up-rate: "10"
+  # max-scale-up-rate: "10"
 
   # Scale to zero feature flag
-  enable-scale-to-zero: "true"
-
-  # This does nothing for now.
-  enable-vertical-pod-autoscaling: "false"
+  # enable-scale-to-zero: "true"
 
   # Tick interval is the time between autoscaling calculations.
-  tick-interval: "2s"
+  # tick-interval: "2s"
 
   # Dynamic parameters (take effect when config map is updated):
 
   # Scale to zero grace period is the time an inactive revision is left
   # running before it is scaled to zero (min: 30s).
-  scale-to-zero-grace-period: "30s"
+  # scale-to-zero-grace-period: "30s"

--- a/config/config-controller.yaml
+++ b/config/config-controller.yaml
@@ -19,6 +19,11 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
 data:
   # CONTROLLER CONFIGURATION
 
@@ -27,4 +32,4 @@ data:
   queueSidecarImage: github.com/knative/serving/cmd/queue
 
   # List of repositories for which tag to digest resolving should be skipped
-  registriesSkippingTagResolving: "ko.local,dev.local"
+  # registriesSkippingTagResolving: "ko.local,dev.local"

--- a/config/config-domain.yaml
+++ b/config/config-domain.yaml
@@ -19,7 +19,12 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # These are example settings of domain.
   # example.org will be used for routes having app=prod.
   # example.org: |
@@ -29,7 +34,7 @@ data:
   # Default value for domain, for routes that does not have app=prod labels.
   # Although it will match all routes, it is the least-specific rule so it
   # will only be used if no other domain matches.
-  example.com: |
+  # example.com: |
 
   # Routes having domain suffix of 'svc.cluster.local' will not be exposed
   # through Ingress. You can define your own label selector to assign that

--- a/config/config-gc.yaml
+++ b/config/config-gc.yaml
@@ -19,13 +19,21 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # Delay after revision creation before considering it for GC
-  stale-revision-create-delay: "24h"
+  # stale-revision-create-delay: "24h"
+  
   # Duration since a route has been pointed at a revision before it should be GC'd
   # This minus lastpinned-debounce be longer than the controller resync period (10 hours)
-  stale-revision-timeout: "15h"
+  # stale-revision-timeout: "15h"
+  
   # Minimum number of generations of revisions to keep before considering for GC
-  stale-revision-minimum-generations: "1"
+  # stale-revision-minimum-generations: "1"
+
   # To avoid constant updates, we allow an existing annotation to be stale by this amount before we update the timestamp
-  stale-revision-lastpinned-debounce: "5h"
+  # stale-revision-lastpinned-debounce: "5h"

--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -19,14 +19,20 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
 
   # Default Knative Gateway after v0.3. It points to the Istio
   # standard istio-ingressgateway, instead of a custom one that we
   # used pre-0.3.
-  gateway.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+  # gateway.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+
   # A cluster local gateway to allow pods outside of the mesh to access
   # Services and Routes not exposing through an ingress.  If the users
   # do have a service mesh setup, this isn't required.
-  local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+  # local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -19,36 +19,41 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # Common configuration for all Knative codebase
-  zap-logger-config: |
-    {
-      "level": "info",
-      "development": false,
-      "outputPaths": ["stdout"],
-      "errorOutputPaths": ["stderr"],
-      "encoding": "json",
-      "encoderConfig": {
-        "timeKey": "ts",
-        "levelKey": "level",
-        "nameKey": "logger",
-        "callerKey": "caller",
-        "messageKey": "msg",
-        "stacktraceKey": "stacktrace",
-        "lineEnding": "",
-        "levelEncoder": "",
-        "timeEncoder": "iso8601",
-        "durationEncoder": "",
-        "callerEncoder": ""
-      }
-    }
+  # zap-logger-config: |
+  #   {
+  #     "level": "info",
+  #     "development": false,
+  #     "outputPaths": ["stdout"],
+  #     "errorOutputPaths": ["stderr"],
+  #     "encoding": "json",
+  #     "encoderConfig": {
+  #       "timeKey": "ts",
+  #       "levelKey": "level",
+  #       "nameKey": "logger",
+  #       "callerKey": "caller",
+  #       "messageKey": "msg",
+  #       "stacktraceKey": "stacktrace",
+  #       "lineEnding": "",
+  #       "levelEncoder": "",
+  #       "timeEncoder": "iso8601",
+  #       "durationEncoder": "",
+  #       "callerEncoder": ""
+  #     }
+  #   }
   
   # Log level overrides
   # For all components except the autoscaler and queue proxy, 
   # changes are be picked up immediately.
   # For autoscaler and queue proxy, changes require recreation of the pods.
-  loglevel.controller: "info"
-  loglevel.autoscaler: "info"
-  loglevel.queueproxy: "info"
-  loglevel.webhook: "info"
-  loglevel.activator: "info"
+  # loglevel.controller: "info"
+  # loglevel.autoscaler: "info"
+  # loglevel.queueproxy: "info"
+  # loglevel.webhook: "info"
+  # loglevel.activator: "info"

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -19,7 +19,12 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # Specifies the IP ranges that Istio sidecar will intercept.
   # Replace this with the IP ranges of your cluster (see below for some examples).
   # Separate multiple entries with a comma.
@@ -53,4 +58,4 @@ data:
   # For more information, visit
   # https://istio.io/docs/tasks/traffic-management/egress/
   #
-  istio.sidecar.includeOutboundIPRanges: "*"
+  # istio.sidecar.includeOutboundIPRanges: "*"

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -19,71 +19,76 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-data:
+
+# This sample data shows the kinds of things that can be set in this ConfigMap,
+# but it should be replaced with proper documentation and a pointer to that left
+# here.  The Knative ConfigMap resources should be left empty for the reasons
+# outlined here: https://github.com/knative/serving/issues/2668
+# data:
   # LOGGING CONFIGURATION
 
   # Static parameters:
 
   # enable-var-log-collection defaults to false. A fluentd sidecar
   # will be set up to collect var log if this flag is true.
-  logging.enable-var-log-collection: "false"
+  # logging.enable-var-log-collection: "false"
 
   # The fluentd sidecar image used to collect logs from /var/log as a sidecar.
   # Must be presented if logging.enable-var-log-collection is true.
   # KEEP THIS CONSISTENT WITH 999-cache.yaml
   # TODO(mattmoor): Devise a way to test that this (and others like it)
   # stay in sync.
-  logging.fluentd-sidecar-image: "k8s.gcr.io/fluentd-elasticsearch:v2.0.4"
+  # logging.fluentd-sidecar-image: "k8s.gcr.io/fluentd-elasticsearch:v2.0.4"
 
   # The fluentd sidecar output config to specify logging destination.
-  logging.fluentd-sidecar-output-config: |
-    # Parse json log before sending to Elastic Search
-    <filter **>
-      @type parser
-      key_name log
-      <parse>
-        @type multi_format
-        <pattern>
-          format json
-          time_key fluentd-time # fluentd-time is reserved for structured logs
-          time_format %Y-%m-%dT%H:%M:%S.%NZ
-        </pattern>
-        <pattern>
-          format none
-          message_key log
-        </pattern>
-      </parse>
-    </filter>
-    # Send to Elastic Search
-    <match **>
-      @id elasticsearch
-      @type elasticsearch
-      @log_level info
-      include_tag_key true
-      # Elasticsearch service is in monitoring namespace.
-      host elasticsearch-logging.knative-monitoring
-      port 9200
-      logstash_format true
-      <buffer>
-        @type file
-        path /var/log/fluentd-buffers/kubernetes.system.buffer
-        flush_mode interval
-        retry_type exponential_backoff
-        flush_thread_count 2
-        flush_interval 5s
-        retry_forever
-        retry_max_interval 30
-        chunk_limit_size 2M
-        queue_limit_length 8
-        overflow_action block
-      </buffer>
-    </match>
+  # logging.fluentd-sidecar-output-config: |
+  #   # Parse json log before sending to Elastic Search
+  #   <filter **>
+  #     @type parser
+  #     key_name log
+  #     <parse>
+  #       @type multi_format
+  #       <pattern>
+  #         format json
+  #         time_key fluentd-time # fluentd-time is reserved for structured logs
+  #         time_format %Y-%m-%dT%H:%M:%S.%NZ
+  #       </pattern>
+  #       <pattern>
+  #         format none
+  #         message_key log
+  #       </pattern>
+  #     </parse>
+  #   </filter>
+  #   # Send to Elastic Search
+  #   <match **>
+  #     @id elasticsearch
+  #     @type elasticsearch
+  #     @log_level info
+  #     include_tag_key true
+  #     # Elasticsearch service is in monitoring namespace.
+  #     host elasticsearch-logging.knative-monitoring
+  #     port 9200
+  #     logstash_format true
+  #     <buffer>
+  #       @type file
+  #       path /var/log/fluentd-buffers/kubernetes.system.buffer
+  #       flush_mode interval
+  #       retry_type exponential_backoff
+  #       flush_thread_count 2
+  #       flush_interval 5s
+  #       retry_forever
+  #       retry_max_interval 30
+  #       chunk_limit_size 2M
+  #       queue_limit_length 8
+  #       overflow_action block
+  #     </buffer>
+  #   </match>
 
   # The revision log url template, where ${REVISION_UID} will be replaced by the actual
   # revision uid. For the url to work you'll need to set up monitoring and have access to
   # the kibana dashboard using `kubectl proxy`.
-  logging.revision-url-template: |
-    http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+  # logging.revision-url-template: |
+  #   http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
 
   # METRICS CONFIGURATION
 
@@ -91,7 +96,7 @@ data:
   # It defaults to prometheus. If this is stackdriver, the metrics will be sent
   # to stackdriver. "prometheus" and "stackdriver" are supported. This field 
   # is required.
-  metrics.backend-destination: "prometheus"
+  # metrics.backend-destination: "prometheus"
 
   # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
   # field is optional. When running on GKE, application default credentials will be

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -17,16 +17,15 @@ limitations under the License.
 package autoscaler
 
 import (
-	"fmt"
-	"io/ioutil"
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
 
 func TestTargetConcurrency(t *testing.T) {
@@ -80,6 +79,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 		},
 		want: &Config{
+			EnableScaleToZero:                    true,
 			ContainerConcurrencyTargetPercentage: 0.5,
 			ContainerConcurrencyTargetDefault:    10.0,
 			MaxScaleUpRate:                       1.0,
@@ -92,7 +92,6 @@ func TestNewConfig(t *testing.T) {
 		name: "with toggles on",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
-			"enable-vertical-pod-autoscaling":         "true",
 			"max-scale-up-rate":                       "1.0",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
@@ -102,7 +101,6 @@ func TestNewConfig(t *testing.T) {
 		},
 		want: &Config{
 			EnableScaleToZero:                    true,
-			EnableVPA:                            true,
 			ContainerConcurrencyTargetPercentage: 0.5,
 			ContainerConcurrencyTargetDefault:    10.0,
 			MaxScaleUpRate:                       1.0,
@@ -115,7 +113,6 @@ func TestNewConfig(t *testing.T) {
 		name: "with toggles on strange casing",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "TRUE",
-			"enable-vertical-pod-autoscaling":         "True",
 			"max-scale-up-rate":                       "1.0",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
@@ -125,7 +122,6 @@ func TestNewConfig(t *testing.T) {
 		},
 		want: &Config{
 			EnableScaleToZero:                    true,
-			EnableVPA:                            true,
 			ContainerConcurrencyTargetPercentage: 0.5,
 			ContainerConcurrencyTargetDefault:    10.0,
 			MaxScaleUpRate:                       1.0,
@@ -138,7 +134,6 @@ func TestNewConfig(t *testing.T) {
 		name: "with toggles explicitly off",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "false",
-			"enable-vertical-pod-autoscaling":         "False",
 			"max-scale-up-rate":                       "1.0",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
@@ -159,7 +154,6 @@ func TestNewConfig(t *testing.T) {
 		name: "with explicit grace period",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "false",
-			"enable-vertical-pod-autoscaling":         "False",
 			"max-scale-up-rate":                       "1.0",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
@@ -177,26 +171,6 @@ func TestNewConfig(t *testing.T) {
 			ScaleToZeroGracePeriod:               30 * time.Second,
 			TickInterval:                         2 * time.Second,
 		},
-	}, {
-		name: "missing required float field",
-		input: map[string]string{
-			"container-concurrency-target-percentage": "0.5",
-			"container-concurrency-target-default":    "10.0",
-			"stable-window":                           "5m",
-			"panic-window":                            "10s",
-			"tick-interval":                           "2s",
-		},
-		wantErr: true,
-	}, {
-		name: "missing required duration field",
-		input: map[string]string{
-			"max-scale-up-rate":                       "1.0",
-			"container-concurrency-target-percentage": "0.5",
-			"container-concurrency-target-default":    "10.0",
-			"stable-window":                           "5m",
-			"tick-interval":                           "2s",
-		},
-		wantErr: true,
 	}, {
 		name: "malformed float",
 		input: map[string]string{
@@ -237,15 +211,8 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestOurConfig(t *testing.T) {
-	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", ConfigName))
-	if err != nil {
-		t.Errorf("ReadFile() = %v", err)
-	}
-	var cm corev1.ConfigMap
-	if err := yaml.Unmarshal(b, &cm); err != nil {
-		t.Errorf("yaml.Unmarshal() = %v", err)
-	}
-	if _, err := NewConfigFromConfigMap(&cm); err != nil {
+	cm := ConfigMapFromTestFile(t, ConfigName)
+	if _, err := NewConfigFromConfigMap(cm); err != nil {
 		t.Errorf("NewConfigFromConfigMap() = %v", err)
 	}
 }

--- a/pkg/gc/config_test.go
+++ b/pkg/gc/config_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/knative/serving/pkg/reconciler/testing"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestOurConfig(t *testing.T) {
@@ -29,44 +30,52 @@ func TestOurConfig(t *testing.T) {
 		name string
 		fail bool
 		want Config
-		data string
-	}{
-		{
-			"Standard config",
-			false,
-			Config{
-				StaleRevisionCreateDelay:        24 * time.Hour,
-				StaleRevisionTimeout:            15 * time.Hour,
-				StaleRevisionMinimumGenerations: 1,
-				StaleRevisionLastpinnedDebounce: 5 * time.Hour,
-			},
-			"config-gc",
-		}, {
-			"Defaulted config",
-			false,
-			Config{
-				StaleRevisionCreateDelay:        24 * time.Hour,
-				StaleRevisionTimeout:            15 * time.Hour,
-				StaleRevisionMinimumGenerations: 1,
-				StaleRevisionLastpinnedDebounce: 5 * time.Hour,
-			},
-			"config-gc-defaults",
-		}, {
-			"Invalid duration",
-			true,
-			Config{},
-			"config-fail-duration",
-		}, {
-			"Invalid duration",
-			true,
-			Config{},
-			"config-fail-minimum-generations",
+		data *corev1.ConfigMap
+	}{{
+		name: "Standard config",
+		fail: false,
+		want: Config{
+			StaleRevisionCreateDelay:        24 * time.Hour,
+			StaleRevisionTimeout:            15 * time.Hour,
+			StaleRevisionMinimumGenerations: 1,
+			StaleRevisionLastpinnedDebounce: 5 * time.Hour,
 		},
-	} {
+		data: ConfigMapFromTestFile(t, "config-gc"),
+	}, {
+		name: "With value overrides",
+		want: Config{
+			StaleRevisionCreateDelay:        15 * time.Hour,
+			StaleRevisionTimeout:            15 * time.Hour,
+			StaleRevisionMinimumGenerations: 10,
+			StaleRevisionLastpinnedDebounce: 5 * time.Hour,
+		},
+		data: &corev1.ConfigMap{
+			Data: map[string]string{
+				"stale-revision-create-delay":        "15h",
+				"stale-revision-minimum-generations": "10",
+			},
+		},
+	}, {
+		name: "Invalid duration",
+		fail: true,
+		want: Config{},
+		data: &corev1.ConfigMap{
+			Data: map[string]string{
+				"stale-revision-create-delay": "invalid",
+			},
+		},
+	}, {
+		name: "Invalid minimum generation",
+		fail: true,
+		want: Config{},
+		data: &corev1.ConfigMap{
+			Data: map[string]string{
+				"stale-revision-minimum-generations": "invalid",
+			},
+		},
+	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := ConfigMapFromTestFile(t, tt.data)
-			testConfig, err := NewConfigFromConfigMap(cm)
-
+			testConfig, err := NewConfigFromConfigMap(tt.data)
 			if tt.fail != (err != nil) {
 				t.Errorf("Unexpected error value: %v", err)
 			}

--- a/pkg/gc/testdata/config-fail-duration.yaml
+++ b/pkg/gc/testdata/config-fail-duration.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-gc
-  namespace: knative-serving
-data:
-    stale-revision-create-delay: invalid

--- a/pkg/gc/testdata/config-fail-minimum-generations.yaml
+++ b/pkg/gc/testdata/config-fail-minimum-generations.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-gc
-  namespace: knative-serving
-data:
-    stale-revision-minimum-generations: invalid

--- a/pkg/gc/testdata/config-gc-defaults.yaml
+++ b/pkg/gc/testdata/config-gc-defaults.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-gc
-  namespace: knative-serving
-data: {}

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -17,11 +17,8 @@ limitations under the License.
 package logging
 
 import (
-	"fmt"
-	"io/ioutil"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/system"
 	_ "github.com/knative/serving/pkg/system/testing"
@@ -29,6 +26,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
 
 func TestNewLogger(t *testing.T) {
@@ -128,7 +127,7 @@ func TestNewConfigNoEntry(t *testing.T) {
 		t.Errorf("Expected no errors. got: %v", err)
 	}
 	if got := c.LoggingConfig; got == "" {
-		t.Error("LoggingConfig got empty")
+		t.Error("LoggingConfig = empty, want not empty")
 	}
 	if got, want := len(c.LoggingLevel), len(components); got != want {
 		t.Errorf("len(LoggingLevel) = %d, want %d", got, want)
@@ -160,15 +159,8 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestOurConfig(t *testing.T) {
-	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", ConfigName))
-	if err != nil {
-		t.Errorf("ReadFile() = %v", err)
-	}
-	var cm corev1.ConfigMap
-	if err := yaml.Unmarshal(b, &cm); err != nil {
-		t.Errorf("yaml.Unmarshal() = %v", err)
-	}
-	cfg, err := NewConfigFromConfigMap(&cm)
+	cm := ConfigMapFromTestFile(t, ConfigName)
+	cfg, err := NewConfigFromConfigMap(cm)
 	if err != nil {
 		t.Errorf("Expected no errors. got: %v", err)
 	}

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
@@ -42,15 +42,18 @@ func TestGatewayConfiguration(t *testing.T) {
 		wantIstio interface{}
 		config    *corev1.ConfigMap
 	}{{
-		name:      "gateway configuration with no network input",
-		wantErr:   true,
-		wantIstio: (*Istio)(nil),
+		name: "gateway configuration with no network input",
+		wantIstio: &Istio{
+			IngressGateways: []Gateway{defaultGateway},
+			LocalGateways:   []Gateway{defaultLocalGateway},
+		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),
 				Name:      IstioConfigName,
 			},
-		}}, {
+		},
+	}, {
 		name:      "gateway configuration with invalid url",
 		wantErr:   true,
 		wantIstio: (*Istio)(nil),
@@ -62,15 +65,16 @@ func TestGatewayConfiguration(t *testing.T) {
 			Data: map[string]string{
 				"gateway.invalid": "_invalid",
 			},
-		}}, {
+		},
+	}, {
 		name:    "gateway configuration with valid url",
 		wantErr: false,
 		wantIstio: &Istio{
 			IngressGateways: []Gateway{{
-				GatewayName: "knative-ingress-gateway",
-				ServiceURL:  "istio-ingressgateway.istio-system.svc.cluster.local",
+				GatewayName: "knative-ingress-freeway",
+				ServiceURL:  "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
-			LocalGateways: []Gateway{},
+			LocalGateways: []Gateway{defaultLocalGateway},
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -78,10 +82,29 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:      IstioConfigName,
 			},
 			Data: map[string]string{
-				"gateway.knative-ingress-gateway": "istio-ingressgateway.istio-system.svc.cluster.local",
+				"gateway.knative-ingress-freeway": "istio-ingressfreeway.istio-system.svc.cluster.local",
 			},
-		}},
-	}
+		},
+	}, {
+		name:    "local gateway configuration with valid url",
+		wantErr: false,
+		wantIstio: &Istio{
+			IngressGateways: []Gateway{defaultGateway},
+			LocalGateways: []Gateway{{
+				GatewayName: "knative-ingress-backroad",
+				ServiceURL:  "istio-ingressbackroad.istio-system.svc.cluster.local",
+			}},
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"local-gateway.knative-ingress-backroad": "istio-ingressbackroad.istio-system.svc.cluster.local",
+			},
+		},
+	}}
 
 	for _, tt := range gatewayConfigTests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/revision/config/controller.go
+++ b/pkg/reconciler/v1alpha1/revision/config/controller.go
@@ -42,7 +42,10 @@ func NewControllerConfigFromMap(configMap map[string]string) (*Controller, error
 
 	if registries, ok := configMap[registriesSkippingTagResolving]; !ok {
 		// It is ok if registries are missing
-		nc.RegistriesSkippingTagResolving = make(map[string]struct{})
+		nc.RegistriesSkippingTagResolving = map[string]struct{}{
+			"ko.local":  struct{}{},
+			"dev.local": struct{}{},
+		}
 	} else {
 		nc.RegistriesSkippingTagResolving = toStringSet(registries, ",")
 	}

--- a/pkg/reconciler/v1alpha1/revision/config/controller_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/controller_test.go
@@ -30,7 +30,7 @@ import (
 var noSidecarImage = ""
 
 func TestControllerConfigurationFromFile(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, ControllerConfigName)
+	cm := ConfigMapFromTestFile(t, ControllerConfigName, queueSidecarImageKey)
 
 	if _, err := NewControllerConfigFromConfigMap(cm); err != nil {
 		t.Errorf("NewControllerConfigFromConfigMap() = %v", err)

--- a/pkg/reconciler/v1alpha1/revision/config/network.go
+++ b/pkg/reconciler/v1alpha1/revision/config/network.go
@@ -71,6 +71,7 @@ func NewNetworkFromConfigMap(configMap *corev1.ConfigMap) (*Network, error) {
 	nc := &Network{}
 	if ipr, ok := configMap.Data[IstioOutboundIPRangesKey]; !ok {
 		// It is OK for this to be absent, we will elide the annotation.
+		nc.IstioOutboundIPRanges = "*"
 	} else if normalizedIpr, err := validateAndNormalizeOutboundIPRanges(ipr); err != nil {
 		return nil, err
 	} else {

--- a/pkg/reconciler/v1alpha1/revision/config/network_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/network_test.go
@@ -42,9 +42,11 @@ func TestNetworkConfiguration(t *testing.T) {
 		wantController interface{}
 		config         *corev1.ConfigMap
 	}{{
-		name:           "network configuration with no network input",
-		wantErr:        false,
-		wantController: &Network{},
+		name:    "network configuration with no network input",
+		wantErr: false,
+		wantController: &Network{
+			IstioOutboundIPRanges: "*",
+		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),

--- a/pkg/reconciler/v1alpha1/revision/config/observability.go
+++ b/pkg/reconciler/v1alpha1/revision/config/observability.go
@@ -25,6 +25,8 @@ import (
 
 const (
 	ObservabilityConfigName = "config-observability"
+
+	defaultLogURLTemplate = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
 )
 
 // Observability contains the configuration defined in the observability ConfigMap.
@@ -33,7 +35,7 @@ type Observability struct {
 	// collect logs under /var/log/.
 	EnableVarLogCollection bool
 
-	// TODO(#818): Use the fluentd deamon set to collect /var/log.
+	// TODO(#818): Use the fluentd daemon set to collect /var/log.
 	// FluentdSidecarImage is the name of the image used for the fluentd sidecar
 	// injected into the revision pod. It is used only when enableVarLogCollection
 	// is true.
@@ -60,11 +62,14 @@ func NewObservabilityFromConfigMap(configMap *corev1.ConfigMap) (*Observability,
 		return nil, fmt.Errorf("Received bad Observability ConfigMap, want %q when %q is true",
 			"logging.fluentd-sidecar-image", "logging.enable-var-log-collection")
 	}
+
 	if fsoc, ok := configMap.Data["logging.fluentd-sidecar-output-config"]; ok {
 		oc.FluentdSidecarOutputConfig = fsoc
 	}
 	if rut, ok := configMap.Data["logging.revision-url-template"]; ok {
 		oc.LoggingURLTemplate = rut
+	} else {
+		oc.LoggingURLTemplate = defaultLogURLTemplate
 	}
 	return oc, nil
 }

--- a/pkg/reconciler/v1alpha1/revision/config/observability_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/observability_test.go
@@ -67,7 +67,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 		wantErr: false,
 		wantController: &Observability{
 			EnableVarLogCollection: false,
-			LoggingURLTemplate:     "",
+			LoggingURLTemplate:     defaultLogURLTemplate,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -91,14 +91,16 @@ func TestObservabilityConfiguration(t *testing.T) {
 	}}
 
 	for _, tt := range observabilityConfigTests {
-		actualController, err := NewObservabilityFromConfigMap(tt.config)
+		t.Run(tt.name, func(t *testing.T) {
+			actualController, err := NewObservabilityFromConfigMap(tt.config)
 
-		if (err != nil) != tt.wantErr {
-			t.Fatalf("Test: %q; NewObservabilityFromConfigMap() error = %v, WantErr %v", tt.name, err, tt.wantErr)
-		}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Test: %q; NewObservabilityFromConfigMap() error = %v, WantErr %v", tt.name, err, tt.wantErr)
+			}
 
-		if diff := cmp.Diff(actualController, tt.wantController); diff != "" {
-			t.Fatalf("Test: %q; want %v, but got %v", tt.name, tt.wantController, actualController)
-		}
+			if diff := cmp.Diff(actualController, tt.wantController); diff != "" {
+				t.Fatalf("Test: %q; want %v, but got %v", tt.name, tt.wantController, actualController)
+			}
+		})
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/config/store_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/store_test.go
@@ -31,7 +31,7 @@ import (
 func TestStoreLoadWithContext(t *testing.T) {
 	store := NewStore(TestLogger(t))
 
-	controllerConfig := ConfigMapFromTestFile(t, ControllerConfigName)
+	controllerConfig := ConfigMapFromTestFile(t, ControllerConfigName, queueSidecarImageKey)
 	networkConfig := ConfigMapFromTestFile(t, NetworkConfigName)
 	observabilityConfig := ConfigMapFromTestFile(t, ObservabilityConfigName)
 	loggingConfig := ConfigMapFromTestFile(t, logging.ConfigName)
@@ -84,7 +84,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 func TestStoreImmutableConfig(t *testing.T) {
 	store := NewStore(TestLogger(t))
 
-	store.OnConfigChanged(ConfigMapFromTestFile(t, ControllerConfigName))
+	store.OnConfigChanged(ConfigMapFromTestFile(t, ControllerConfigName, queueSidecarImageKey))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, NetworkConfigName))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, ObservabilityConfigName))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, logging.ConfigName))

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -553,7 +553,7 @@ func TestIstioOutboundIPRangesInjection(t *testing.T) {
 	// An invalid IP range
 	in = "10.10.10.10/33"
 	annotations = getPodAnnotationsForConfig(t, in, "")
-	if got, ok := annotations[resources.IstioOutboundIPRangeAnnotation]; ok {
+	if got, ok := annotations[resources.IstioOutboundIPRangeAnnotation]; !ok {
 		t.Fatalf("Expected to have no %v annotation for invalid option %v. But found value %v", resources.IstioOutboundIPRangeAnnotation, want, got)
 	}
 

--- a/pkg/reconciler/v1alpha1/route/config/domain.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -36,6 +35,9 @@ const (
 	// that will result to the Route/KService getting a cluster local
 	// domain suffix.
 	VisibilityClusterLocal = "cluster-local"
+	// DefaultDomain holds the domain that Route's live under by default
+	// when no label selector-based options apply.
+	DefaultDomain = "example.com"
 )
 
 // LabelSelector represents map of {key,value} pairs. A single {key,value} in the
@@ -85,7 +87,7 @@ func NewDomainFromConfigMap(configMap *corev1.ConfigMap) (*Domain, error) {
 		}
 	}
 	if !hasDefault {
-		return nil, fmt.Errorf("Config %#v must have a default domain", configMap.Data)
+		c.Domains[DefaultDomain] = &LabelSelector{}
 	}
 	return &c, nil
 }

--- a/test/e2e/testdata/config-autoscaler.yaml
+++ b/test/e2e/testdata/config-autoscaler.yaml
@@ -1,0 +1,1 @@
+../../../config/config-autoscaler.yaml


### PR DESCRIPTION
This change hollows out the ConfigMaps that we use with Knative
in order to walk a very fine line that enables us to deploy
knative/serving via `ko` or `kubectl apply` while still preserving
edits made to the serving ConfigMaps.  This fine line is dancing
around the way the `kubectl apply` annotation
`kubectl.kubernetes.io/last-applied-configuration` is used to update
resources.

Essentially, this annotation is attached with the body of the current
apply, and subsequent applications take it upon themselves to remove
keys that were present in the prior apply, but not in the current apply.

By reserving all of our ConfigMap keys to be specified by the user
via `kubectl edit cm -nknative-serving config-foo`, which does not
update the annotation, we ensure that subsequent applies won't remove
the keys because those keys were never a part of the previous apply.

One of the key scenarios this unlocks is the ability to preserve
users' domain settings in `config-domain.yaml` across applies.

Fixes: https://github.com/knative/serving/issues/2668

This is WIP until the supporting change https://github.com/knative/pkg/pull/258 is merged and this is updated to pull from `knative/pkg`.