### PR TITLE
Make revisionID a public struct

### DIFF
--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -41,9 +41,10 @@ type Activator interface {
 	Shutdown()
 }
 
-type revisionID struct {
-	namespace string
-	name      string
+// RevisionID is the combination of namespace and service name
+type RevisionID struct {
+	Namespace string
+	Name      string
 }
 
 // Endpoint is a fully-qualified domain name / port pair for an active revision.

--- a/pkg/activator/dedupe.go
+++ b/pkg/activator/dedupe.go
@@ -32,7 +32,7 @@ var _ Activator = (*dedupingActivator)(nil)
 
 type dedupingActivator struct {
 	mux             sync.Mutex
-	pendingRequests map[revisionID][]chan ActivationResult
+	pendingRequests map[RevisionID][]chan ActivationResult
 	activator       Activator
 	shutdown        bool
 }
@@ -41,13 +41,13 @@ type dedupingActivator struct {
 // activations requests for the same revision id and namespace.
 func NewDedupingActivator(a Activator) Activator {
 	return &dedupingActivator{
-		pendingRequests: make(map[revisionID][]chan ActivationResult),
+		pendingRequests: make(map[RevisionID][]chan ActivationResult),
 		activator:       a,
 	}
 }
 
 func (a *dedupingActivator) ActiveEndpoint(namespace, name string) ActivationResult {
-	id := revisionID{namespace: namespace, name: name}
+	id := RevisionID{Namespace: namespace, Name: name}
 	ch := make(chan ActivationResult, 1)
 	a.dedupe(id, ch)
 	result := <-ch
@@ -66,7 +66,7 @@ func (a *dedupingActivator) Shutdown() {
 	}
 }
 
-func (a *dedupingActivator) dedupe(id revisionID, ch chan ActivationResult) {
+func (a *dedupingActivator) dedupe(id RevisionID, ch chan ActivationResult) {
 	a.mux.Lock()
 	defer a.mux.Unlock()
 	if a.shutdown {
@@ -81,8 +81,8 @@ func (a *dedupingActivator) dedupe(id revisionID, ch chan ActivationResult) {
 	}
 }
 
-func (a *dedupingActivator) activate(id revisionID) {
-	result := a.activator.ActiveEndpoint(id.namespace, id.name)
+func (a *dedupingActivator) activate(id RevisionID) {
+	result := a.activator.ActiveEndpoint(id.Namespace, id.Name)
 	a.mux.Lock()
 	defer a.mux.Unlock()
 	if reqs, ok := a.pendingRequests[id]; ok {

--- a/pkg/activator/dedupe_test.go
+++ b/pkg/activator/dedupe_test.go
@@ -27,7 +27,7 @@ import (
 func TestSingleRevision_SingleRequest_Success(t *testing.T) {
 	want := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
-		map[revisionID]ActivationResult{
+		map[RevisionID]ActivationResult{
 			{testNamespace, testRevision}: {
 				Endpoint: want,
 				Status:   http.StatusOK,
@@ -54,7 +54,7 @@ func TestSingleRevision_SingleRequest_Success(t *testing.T) {
 func TestSingleRevision_MultipleRequests_Success(t *testing.T) {
 	ep := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
-		map[revisionID]ActivationResult{
+		map[RevisionID]ActivationResult{
 			{testNamespace, testRevision}: {
 				Endpoint: ep,
 				Status:   http.StatusOK,
@@ -62,7 +62,7 @@ func TestSingleRevision_MultipleRequests_Success(t *testing.T) {
 		})
 	d := NewDedupingActivator(f)
 
-	got := concurrentTest(d, f, []revisionID{
+	got := concurrentTest(d, f, []RevisionID{
 		{testNamespace, testRevision},
 		{testNamespace, testRevision},
 	})
@@ -88,7 +88,7 @@ func TestMultipleRevisions_MultipleRequests_Success(t *testing.T) {
 	ep1 := Endpoint{"ip1", 8080}
 	ep2 := Endpoint{"ip2", 8080}
 	f := newFakeActivator(t,
-		map[revisionID]ActivationResult{
+		map[RevisionID]ActivationResult{
 			{testNamespace, "rev1"}: {
 				Endpoint: ep1,
 				Status:   http.StatusOK,
@@ -100,7 +100,7 @@ func TestMultipleRevisions_MultipleRequests_Success(t *testing.T) {
 		})
 	d := NewDedupingActivator(f)
 
-	got := concurrentTest(d, f, []revisionID{
+	got := concurrentTest(d, f, []RevisionID{
 		{testNamespace, "rev1"},
 		{testNamespace, "rev2"},
 		{testNamespace, "rev1"},
@@ -131,7 +131,7 @@ func TestMultipleRevisions_MultipleRequests_PartialSuccess(t *testing.T) {
 	status2 := http.StatusInternalServerError
 	error2 := errors.New("test error")
 	f := newFakeActivator(t,
-		map[revisionID]ActivationResult{
+		map[RevisionID]ActivationResult{
 			{testNamespace, "rev1"}: {
 				Endpoint: ep1,
 				Status:   http.StatusOK,
@@ -144,7 +144,7 @@ func TestMultipleRevisions_MultipleRequests_PartialSuccess(t *testing.T) {
 		})
 	d := NewDedupingActivator(f)
 
-	got := concurrentTest(d, f, []revisionID{
+	got := concurrentTest(d, f, []RevisionID{
 		{testNamespace, "rev1"},
 		{testNamespace, "rev2"},
 		{testNamespace, "rev1"},
@@ -173,7 +173,7 @@ func TestSingleRevision_MultipleRequests_FailureRecovery(t *testing.T) {
 	failStatus := http.StatusServiceUnavailable
 	failErr := errors.New("test error")
 	f := newFakeActivator(t,
-		map[revisionID]ActivationResult{
+		map[RevisionID]ActivationResult{
 			{testNamespace, testRevision}: {
 				Endpoint: failEp,
 				Status:   failStatus,
@@ -201,7 +201,7 @@ func TestSingleRevision_MultipleRequests_FailureRecovery(t *testing.T) {
 	// Later activation succeeds
 	successEp := Endpoint{"ip", 8080}
 	successStatus := http.StatusOK
-	f.responses[revisionID{testNamespace, testRevision}] = ActivationResult{
+	f.responses[RevisionID{testNamespace, testRevision}] = ActivationResult{
 		Endpoint: successEp,
 		Status:   successStatus,
 	}
@@ -228,14 +228,14 @@ func TestShutdown_ReturnError(t *testing.T) {
 		newRevisionBuilder(defaultRevisionLabels).build())
 	ep := Endpoint{"ip", 8080}
 	f := newFakeActivator(t,
-		map[revisionID]ActivationResult{
+		map[RevisionID]ActivationResult{
 			{testNamespace, testRevision}: {
 				Endpoint: ep,
 				Status:   http.StatusOK,
 			},
 		})
 	d := NewDedupingActivator(Activator(f))
-	f.hold(revisionID{testNamespace, testRevision})
+	f.hold(RevisionID{testNamespace, testRevision})
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
@@ -257,24 +257,24 @@ func TestShutdown_ReturnError(t *testing.T) {
 
 type fakeActivator struct {
 	t         *testing.T
-	responses map[revisionID]ActivationResult
-	holds     map[revisionID]*sync.WaitGroup
+	responses map[RevisionID]ActivationResult
+	holds     map[RevisionID]*sync.WaitGroup
 
-	record      []revisionID
+	record      []RevisionID
 	recordMutex sync.Mutex
 }
 
-func newFakeActivator(t *testing.T, responses map[revisionID]ActivationResult) *fakeActivator {
+func newFakeActivator(t *testing.T, responses map[RevisionID]ActivationResult) *fakeActivator {
 	return &fakeActivator{
 		t:         t,
 		responses: responses,
-		holds:     make(map[revisionID]*sync.WaitGroup),
-		record:    make([]revisionID, 0),
+		holds:     make(map[RevisionID]*sync.WaitGroup),
+		record:    make([]RevisionID, 0),
 	}
 }
 
 func (f *fakeActivator) ActiveEndpoint(namespace, name string) ActivationResult {
-	id := revisionID{namespace, name}
+	id := RevisionID{namespace, name}
 
 	f.recordMutex.Lock()
 	f.record = append(f.record, id)
@@ -295,7 +295,7 @@ func (f *fakeActivator) Shutdown() {
 	// Nothing to do.
 }
 
-func (f *fakeActivator) hold(id revisionID) {
+func (f *fakeActivator) hold(id RevisionID) {
 	_, ok := f.holds[id]
 
 	if !ok {
@@ -305,13 +305,13 @@ func (f *fakeActivator) hold(id revisionID) {
 	f.holds[id].Add(1)
 }
 
-func (f *fakeActivator) release(id revisionID) {
+func (f *fakeActivator) release(id RevisionID) {
 	if h, ok := f.holds[id]; ok {
 		h.Done()
 	}
 }
 
-func concurrentTest(a Activator, f *fakeActivator, ids []revisionID) []ActivationResult {
+func concurrentTest(a Activator, f *fakeActivator, ids []RevisionID) []ActivationResult {
 	for _, id := range ids {
 		f.hold(id)
 	}
@@ -321,9 +321,9 @@ func concurrentTest(a Activator, f *fakeActivator, ids []revisionID) []Activatio
 	for i, id := range ids {
 		start.Add(1)
 		end.Add(1)
-		go func(index int, id revisionID) {
+		go func(index int, id RevisionID) {
 			start.Done()
-			results[index] = a.ActiveEndpoint(id.namespace, id.name)
+			results[index] = a.ActiveEndpoint(id.Namespace, id.Name)
 			end.Done()
 		}(i, id)
 	}

--- a/pkg/activator/revision.go
+++ b/pkg/activator/revision.go
@@ -61,22 +61,22 @@ func (r *revisionActivator) Shutdown() {
 
 func (r *revisionActivator) activateRevision(namespace, name, key string) (*v1alpha1.Revision, error) {
 	logger := r.logger.With(zap.String(logkey.Key, key))
-	rev := revisionID{
-		namespace: namespace,
-		name:      name,
+	rev := RevisionID{
+		Namespace: namespace,
+		Name:      name,
 	}
 
 	// Get the current revision serving state
-	revisionClient := r.knaClient.ServingV1alpha1().Revisions(rev.namespace)
-	revision, err := revisionClient.Get(rev.name, metav1.GetOptions{})
+	revisionClient := r.knaClient.ServingV1alpha1().Revisions(rev.Namespace)
+	revision, err := revisionClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get the revision")
 	}
 
 	// Wait for the revision to not require activation.
 	if revision.Status.IsActivationRequired() {
-		wi, err := r.knaClient.ServingV1alpha1().Revisions(rev.namespace).Watch(metav1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s", rev.name),
+		wi, err := r.knaClient.ServingV1alpha1().Revisions(rev.Namespace).Watch(metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("metadata.name=%s", rev.Name),
 		})
 		if err != nil {
 			return nil, errors.New("failed to watch the revision")


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->



## Proposed Changes
This is a prereq for https://github.com/knative/serving/issues/2381 and a result of a split of https://github.com/knative/serving/pull/2653. This is rather a cosmetic change and it should not affect the existing behaviour.

* Change the RevisionID to be a public struct since it will be used outside of activator package

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make revisionID a public struct
```
