### PR TITLE
Run both sets of e2e tests in one command.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -72,14 +72,7 @@ publish_test_images || fail_test "one or more test images weren't published"
 # Run the tests
 header "Running tests"
 
-failed=0
-# Run conformance tests, but don't exit if it fails.
-go_test_e2e -timeout=10m ./test/conformance || failed=1
-
-# So that we can also identify failing E2E tests.
-go_test_e2e -timeout=15m ./test/e2e || failed=1
-
-# Require that both set of tests succeeded.
-(( failed )) && fail_test
+# Run conformance tests and e2e tests.
+go_test_e2e -timeout=25m ./test/conformance ./test/e2e && fail_test
 
 success


### PR DESCRIPTION
Since test logs are incrementally output now we no longer need to run
them separately.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
