### PR TITLE
Allow VolumeMounts to be specified in Container.

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -331,9 +331,19 @@ serverless workloads. Containers MUST use the provided temporary storage areas
 
 ### Mounts
 
-Platform providers SHOULD NOT allow additional volume mounts. Stateless
-applications should package their dependencies within the container. As
-serverless applications are expected to scale horizontally and statelessly,
+In general, stateless applications should package their dependencies within the
+container and not rely on mutable external state for templates, logging
+configuration, etc. In some cases, it may be necessary for certain application
+settings to be overridden at deploy time (for example, database backends or
+authentication credentials). When these settings need to be loaded via a file,
+read-only mounts of application configuration and secrets are supported by
+`ConfigMap` and `Secrets` volumes. Platform providers MAY apply updates to
+`Secrets` and `ConfigMaps` while the application is running; these updates could
+complicate rollout and rollback. It is up to the developer to choose appropriate
+policies for mounting and updating `ConfigMap` and `Secrets` which are mounted
+as volumes.
+
+As serverless applications are expected to scale horizontally and statelessly,
 per-container volumes are likely to introduce state and scaling bottlenecks and
 are NOT RECOMMENDED.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -155,6 +155,14 @@ spec:
       # is a core.v1.Container; some fields not allowed, such as resources, ports
       container: ... # See the Container section below
 
+      # is a heavily restricted []core.v1.Volume; only the secret and configMap
+      # types are allowed.
+      volumes:
+      - name: foo
+        secret: ...
+      - name: bar
+        configMap: ...
+
       # +optional concurrency strategy.  Defaults to Multi.
       # Deprecated in favor of ContainerConcurrency.
       concurrencyModel: ...
@@ -216,6 +224,14 @@ spec:
     name: foo-bar-00001
 
   container: ... # See the Container section below
+
+  # is a heavily restricted []core.v1.Volume; only the secret and configMap
+  # types are allowed.
+  volumes:
+  - name: foo
+    secret: ...
+  - name: bar
+    configMap: ...
 
   # Name of the service account the code should run as.
   serviceAccountName: ...
@@ -302,6 +318,7 @@ spec:  # One of "runLatest", "release", "pinned" (DEPRECATED), or "manual"
       revisionTemplate:
         spec: # serving.knative.dev/v1alpha1.RevisionSpec
           container: ... # See the Container section below
+          volumes: ... # Optional
           containerConcurrency: ... # Optional
           timeoutSeconds: ... # Optional
           serviceAccountName: ...  # Name of the service account the code should run as
@@ -315,6 +332,7 @@ spec:  # One of "runLatest", "release", "pinned" (DEPRECATED), or "manual"
       revisionTemplate:
         spec: # serving.knative.dev/v1alpha1.RevisionSpec
           container: ... # See the Container section below
+          volumes: ... # Optional
           containerConcurrency: ... # Optional
           timeoutSeconds: ... # Optional
           serviceAccountName: ...  # Name of the service account the code should run as
@@ -331,6 +349,7 @@ spec:  # One of "runLatest", "release", "pinned" (DEPRECATED), or "manual"
       revisionTemplate:
         spec: # serving.knative.dev/v1alpha1.RevisionSpec
           container: ... # See the Container section below
+          volumes: ... # Optional
           containerConcurrency: ... # Optional
           timeoutSeconds: ... # Optional
           serviceAccountName: ...  # Name of the service account the code should run as
@@ -423,6 +442,15 @@ container: # v1.Container
     - containerPort: ...
       name: ... # Optional, one of "http1", "h2c"
       protocol: ... # Optional, one of "", "tcp"
+
+  # This specifies where the volumes present in the RevisionSpec will be mounted into
+  # the container.  Each of the volumes in the ConfigurationSpec must be mounted here
+  # or it is an error.
+  volumeMounts:
+  - name: ... # This must match a name from Volumes
+    mountPath: ... # Where to mount the named Volume.
+    readOnly: ... # Must be True, will default to True, so it may be omitted.
+    # All other fields are disallowed.
 
   livenessProbe: ... # Optional
   readinessProbe: ... # Optional

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -444,7 +444,7 @@ container: # v1.Container
       protocol: ... # Optional, one of "", "tcp"
 
   # This specifies where the volumes present in the RevisionSpec will be mounted into
-  # the container.  Each of the volumes in the ConfigurationSpec must be mounted here
+  # the container.  Each of the volumes in the RevisionSpec must be mounted here
   # or it is an error.
   volumeMounts:
   - name: ... # This must match a name from Volumes

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -408,7 +408,7 @@ status:
 
 This is a
 [core.v1.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#container-v1-core).
-Some fields are not allowed, such as name and volumeMounts.
+Some fields are not allowed, such as name and lifecycle.
 
 This type is not used on its own but is found composed inside
 [Service](#service), [Configuration](#configuration), and [Revision](#revision).

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -35,4 +35,9 @@ func (rs *RevisionSpec) SetDefaults() {
 	if rs.TimeoutSeconds == 0 {
 		rs.TimeoutSeconds = defaultTimeoutSeconds
 	}
+
+	vms := rs.Container.VolumeMounts
+	for i := range vms {
+		vms[i].ReadOnly = true
+	}
 }

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestRevisionDefaulting(t *testing.T) {
@@ -34,6 +35,33 @@ func TestRevisionDefaulting(t *testing.T) {
 			Spec: RevisionSpec{
 				ContainerConcurrency: 0,
 				TimeoutSeconds:       defaultTimeoutSeconds,
+			},
+		},
+	}, {
+		name: "readonly volumes",
+		in: &Revision{
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Image: "foo",
+					VolumeMounts: []corev1.VolumeMount{{
+						Name: "bar",
+					}},
+				},
+				ContainerConcurrency: 1,
+				TimeoutSeconds:       99,
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Image: "foo",
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:     "bar",
+						ReadOnly: true,
+					}},
+				},
+				ContainerConcurrency: 1,
+				TimeoutSeconds:       99,
 			},
 		},
 	}, {

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -222,7 +222,7 @@ type RevisionSpec struct {
 
 	// Container defines the unit of execution for this Revision.
 	// In the context of a Revision, we disallow a number of the fields of
-	// this Container, including: name, and lifecycle.
+	// this Container, including: name and lifecycle.
 	// See also the runtime contract for more information about the execution
 	// environment:
 	// https://github.com/knative/serving/blob/master/docs/runtime-contract.md

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -222,7 +222,7 @@ type RevisionSpec struct {
 
 	// Container defines the unit of execution for this Revision.
 	// In the context of a Revision, we disallow a number of the fields of
-	// this Container, including: name, resources, ports, and volumeMounts.
+	// this Container, including: name, and lifecycle.
 	// See also the runtime contract for more information about the execution
 	// environment:
 	// https://github.com/knative/serving/blob/master/docs/runtime-contract.md

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -223,10 +223,16 @@ type RevisionSpec struct {
 	// Container defines the unit of execution for this Revision.
 	// In the context of a Revision, we disallow a number of the fields of
 	// this Container, including: name, resources, ports, and volumeMounts.
-	// TODO(mattmoor): Link to the runtime contract tracked by:
-	// https://github.com/knative/serving/issues/627
+	// See also the runtime contract for more information about the execution
+	// environment:
+	// https://github.com/knative/serving/blob/master/docs/runtime-contract.md
 	// +optional
 	Container corev1.Container `json:"container,omitempty"`
+
+	// Volumes defines a set of Kubernetes volumes to be mounted into the
+	// specified Container.  Currently only ConfigMap and Secret volumes are
+	// supported.
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
 	// +optional

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -34,9 +34,12 @@ import (
 
 var (
 	reservedPaths = sets.NewString(
-		"/dev/log",
-		"/var/log",
+		"/",
+		"/dev",
+		"/dev/log", // Should be a domain socket
 		"/tmp",
+		"/var",
+		"/var/log",
 	)
 )
 
@@ -184,6 +187,8 @@ func validateContainer(container corev1.Container, volumes sets.String) *apis.Fi
 				Message: fmt.Sprintf("mountPath %q is a reserved path", filepath.Clean(vm.MountPath)),
 				Paths:   []string{"mountPath"},
 			}).ViaFieldIndex("volumeMounts", i))
+		} else if !filepath.IsAbs(vm.MountPath) {
+			errs = errs.Also(apis.ErrInvalidValue(vm.MountPath, "mountPath").ViaFieldIndex("volumeMounts", i))
 		}
 		if !vm.ReadOnly {
 			errs = errs.Also(apis.ErrMissingField("readOnly").ViaFieldIndex("volumeMounts", i))

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -268,7 +268,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			VolumeMounts: []corev1.VolumeMount{{
-				MountPath: "mount/path",
+				MountPath: "/mount/path",
 				Name:      "the-name",
 				ReadOnly:  true,
 			}},
@@ -290,6 +290,18 @@ func TestContainerValidation(t *testing.T) {
 			Paths:   []string{"mountPath"},
 		}).ViaFieldIndex("volumeMounts", 0),
 	}, {
+		name: "has known volumeMounts, bad mountPath",
+		c: corev1.Container{
+			Image: "foo",
+			VolumeMounts: []corev1.VolumeMount{{
+				MountPath: "not/absolute",
+				Name:      "the-name",
+				ReadOnly:  true,
+			}},
+		},
+		volumes: sets.NewString("the-name"),
+		want:    apis.ErrInvalidValue("not/absolute", "volumeMounts[0].mountPath"),
+	}, {
 		name: "has lifecycle",
 		c: corev1.Container{
 			Image:     "foo",
@@ -301,11 +313,11 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			VolumeMounts: []corev1.VolumeMount{{
-				MountPath: "mount/path",
+				MountPath: "/mount/path",
 				Name:      "the-name",
 				ReadOnly:  true,
 			}, {
-				MountPath: "another/mount/path",
+				MountPath: "/another/mount/path",
 				Name:      "the-name",
 				ReadOnly:  true,
 			}},
@@ -419,6 +431,12 @@ func TestVolumeValidation(t *testing.T) {
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
+		},
+		want: apis.ErrMissingOneOf("secret", "configMap"),
+	}, {
+		name: "no volume source",
+		v: corev1.Volume{
+			Name: "foo",
 		},
 		want: apis.ErrMissingOneOf("secret", "configMap"),
 	}, {
@@ -653,7 +671,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: corev1.Container{
 				Image: "helloworld",
 				VolumeMounts: []corev1.VolumeMount{{
-					MountPath: "mount/path",
+					MountPath: "/mount/path",
 					Name:      "the-name",
 					ReadOnly:  true,
 				}},
@@ -675,7 +693,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: corev1.Container{
 				Image: "helloworld",
 				VolumeMounts: []corev1.VolumeMount{{
-					MountPath: "mount/path",
+					MountPath: "/mount/path",
 					Name:      "the-name",
 					ReadOnly:  true,
 				}},

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -275,6 +275,21 @@ func TestContainerValidation(t *testing.T) {
 		},
 		volumes: sets.NewString("the-name"),
 	}, {
+		name: "has known volumeMounts, but at reserved path",
+		c: corev1.Container{
+			Image: "foo",
+			VolumeMounts: []corev1.VolumeMount{{
+				MountPath: "//var//log//",
+				Name:      "the-name",
+				ReadOnly:  true,
+			}},
+		},
+		volumes: sets.NewString("the-name"),
+		want: (&apis.FieldError{
+			Message: `mountPath "/var/log" is a reserved path`,
+			Paths:   []string{"mountPath"},
+		}).ViaFieldIndex("volumeMounts", 0),
+	}, {
 		name: "has lifecycle",
 		c: corev1.Container{
 			Image:     "foo",

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -305,6 +305,13 @@ func (in *RevisionSpec) DeepCopyInto(out *RevisionSpec) {
 		}
 	}
 	in.Container.DeepCopyInto(&out.Container)
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -142,7 +142,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 			*userContainer,
 			*makeQueueContainer(rev, loggingConfig, autoscalerConfig, controllerConfig),
 		},
-		Volumes:                       []corev1.Volume{varLogVolume},
+		Volumes:                       append([]corev1.Volume{varLogVolume}, rev.Spec.Volumes...),
 		ServiceAccountName:            rev.Spec.ServiceAccountName,
 		TerminationGracePeriodSeconds: &revisionTimeout,
 	}

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -256,7 +256,7 @@ func withLivenessProbe(probe *corev1.Probe) containerOption {
 	}
 }
 
-func prependVolumeMounts(volumeMounts ...corev1.VolumeMount) containerOption {
+func withPrependedVolumeMounts(volumeMounts ...corev1.VolumeMount) containerOption {
 	return func(c *corev1.Container) {
 		c.VolumeMounts = append(volumeMounts, c.VolumeMounts...)
 	}
@@ -273,7 +273,7 @@ func podSpec(containers []corev1.Container, opts ...podSpecOption) *corev1.PodSp
 	return podSpec
 }
 
-func appendVolumes(volumes ...corev1.Volume) podSpecOption {
+func withAppendedVolumes(volumes ...corev1.Volume) podSpecOption {
 	return func(ps *corev1.PodSpec) {
 		ps.Volumes = append(ps.Volumes, volumes...)
 	}
@@ -375,7 +375,7 @@ func TestMakePodSpec(t *testing.T) {
 					container.Ports[0].ContainerPort = 8888
 				},
 				withEnvVar("PORT", "8888"),
-				prependVolumeMounts(corev1.VolumeMount{
+				withPrependedVolumeMounts(corev1.VolumeMount{
 					Name:      "asdf",
 					MountPath: "/asdf",
 				}),
@@ -384,7 +384,7 @@ func TestMakePodSpec(t *testing.T) {
 				withEnvVar("CONTAINER_CONCURRENCY", "1"),
 				withEnvVar("USER_PORT", "8888"),
 			),
-		}, appendVolumes(corev1.Volume{
+		}, withAppendedVolumes(corev1.Volume{
 			Name: "asdf",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -256,6 +256,12 @@ func withLivenessProbe(probe *corev1.Probe) containerOption {
 	}
 }
 
+func prependVolumeMounts(volumeMounts ...corev1.VolumeMount) containerOption {
+	return func(c *corev1.Container) {
+		c.VolumeMounts = append(volumeMounts, c.VolumeMounts...)
+	}
+}
+
 func podSpec(containers []corev1.Container, opts ...podSpecOption) *corev1.PodSpec {
 	podSpec := defaultPodSpec.DeepCopy()
 	podSpec.Containers = containers
@@ -265,6 +271,12 @@ func podSpec(containers []corev1.Container, opts ...podSpecOption) *corev1.PodSp
 	}
 
 	return podSpec
+}
+
+func appendVolumes(volumes ...corev1.Volume) podSpecOption {
+	return func(ps *corev1.PodSpec) {
+		ps.Volumes = append(ps.Volumes, volumes...)
+	}
 }
 
 func deployment(opts ...deploymentOption) *appsv1.Deployment {
@@ -299,11 +311,9 @@ func TestMakePodSpec(t *testing.T) {
 				TimeoutSeconds:       45,
 				Container: corev1.Container{
 					Image: "busybox",
-					Ports: []corev1.ContainerPort{
-						{
-							ContainerPort: 8888,
-						},
-					},
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: 8888,
+					}},
 				},
 			},
 		},
@@ -323,6 +333,65 @@ func TestMakePodSpec(t *testing.T) {
 				withEnvVar("USER_PORT", "8888"),
 			),
 		}),
+	}, {
+		name: "volumes passed through",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+				Labels:    labels,
+			},
+			Spec: v1alpha1.RevisionSpec{
+				ContainerConcurrency: 1,
+				TimeoutSeconds:       45,
+				Container: corev1.Container{
+					Image: "busybox",
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: 8888,
+					}},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      "asdf",
+						MountPath: "/asdf",
+					}},
+				},
+				Volumes: []corev1.Volume{{
+					Name: "asdf",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "asdf",
+						},
+					},
+				}},
+			},
+		},
+		lc: &logging.Config{},
+		oc: &config.Observability{},
+		ac: &autoscaler.Config{},
+		cc: &config.Controller{},
+		want: podSpec([]corev1.Container{
+			userContainer(
+				func(container *corev1.Container) {
+					container.Ports[0].ContainerPort = 8888
+				},
+				withEnvVar("PORT", "8888"),
+				prependVolumeMounts(corev1.VolumeMount{
+					Name:      "asdf",
+					MountPath: "/asdf",
+				}),
+			),
+			queueContainer(
+				withEnvVar("CONTAINER_CONCURRENCY", "1"),
+				withEnvVar("USER_PORT", "8888"),
+			),
+		}, appendVolumes(corev1.Volume{
+			Name: "asdf",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "asdf",
+				},
+			},
+		})),
 	}, {
 		name: "simple concurrency=single no owner",
 		rev: &v1alpha1.Revision{

--- a/test/conformance/volumes_test.go
+++ b/test/conformance/volumes_test.go
@@ -46,7 +46,7 @@ func TestConfigMapVolume(t *testing.T) {
 	// Create the ConfigMap with random text.
 	configMap, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Create(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: text,
+			Name: names.Service, // Give it the same name as the service.
 		},
 		Data: map[string]string{
 			filepath.Base(test.HelloVolumePath): text,
@@ -59,7 +59,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	cleanup := func() {
 		tearDown(clients, names)
-		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(text, nil); err != nil {
+		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
 	}
@@ -81,7 +81,7 @@ func TestConfigMapVolume(t *testing.T) {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: text,
+						Name: configMap.Name,
 					},
 				},
 			},
@@ -121,7 +121,7 @@ func TestSecretVolume(t *testing.T) {
 	// Create the Secret with random text.
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: text,
+			Name: names.Service, // name the Secret the same as the Service.
 		},
 		StringData: map[string]string{
 			filepath.Base(test.HelloVolumePath): text,
@@ -134,7 +134,7 @@ func TestSecretVolume(t *testing.T) {
 
 	cleanup := func() {
 		tearDown(clients, names)
-		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(text, nil); err != nil {
+		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
 	}
@@ -155,7 +155,7 @@ func TestSecretVolume(t *testing.T) {
 			Name: "asdf",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: text,
+					SecretName: secret.Name,
 				},
 			},
 		}}

--- a/test/conformance/volumes_test.go
+++ b/test/conformance/volumes_test.go
@@ -1,0 +1,178 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestConfigMapVolume tests that we echo back the appropriate text from the ConfigMap volume.
+func TestConfigMapVolume(t *testing.T) {
+	clients := setup(t)
+
+	// Add test case specific name to its own logger.
+	logger := logging.GetContextLogger(t.Name())
+
+	names := test.ResourceNames{
+		Service: test.AppendRandomString("cm-volume-", logger),
+		Image:   "hellovolume",
+	}
+
+	text := test.AppendRandomString("hello-volumes-", logger)
+
+	// Create the ConfigMap with random text.
+	configMap, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: text,
+		},
+		Data: map[string]string{
+			filepath.Base(test.HelloVolumePath): text,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger.Info("Successfully created configMap: %v", configMap)
+
+	cleanup := func() {
+		tearDown(clients, names)
+		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(text, nil); err != nil {
+			t.Errorf("ConfigMaps().Delete() = %v", err)
+		}
+	}
+
+	// Clean up on test failure or interrupt
+	defer cleanup()
+	test.CleanupOnInterrupt(cleanup, logger)
+
+	addVolume := func(svc *v1alpha1.Service) {
+		rt := &svc.Spec.RunLatest.Configuration.RevisionTemplate.Spec
+
+		rt.Container.VolumeMounts = []corev1.VolumeMount{{
+			Name:      "asdf",
+			MountPath: filepath.Dir(test.HelloVolumePath),
+		}}
+
+		rt.Volumes = []corev1.Volume{{
+			Name: "asdf",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: text,
+					},
+				},
+			},
+		}}
+	}
+
+	// Setup initial Service
+	if _, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{}, addVolume); err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
+	}
+
+	// Validate State after Creation
+
+	if err = validateRunLatestControlPlane(logger, clients, names, "1"); err != nil {
+		t.Error(err)
+	}
+
+	if err = validateRunLatestDataPlane(logger, clients, names, text); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestSecretVolume tests that we echo back the appropriate text from the Secret volume.
+func TestSecretVolume(t *testing.T) {
+	clients := setup(t)
+
+	// Add test case specific name to its own logger.
+	logger := logging.GetContextLogger(t.Name())
+
+	names := test.ResourceNames{
+		Service: test.AppendRandomString("cm-volume-", logger),
+		Image:   "hellovolume",
+	}
+
+	text := test.AppendRandomString("hello-volumes-", logger)
+
+	// Create the Secret with random text.
+	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: text,
+		},
+		StringData: map[string]string{
+			filepath.Base(test.HelloVolumePath): text,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger.Info("Successfully created secret: %v", secret)
+
+	cleanup := func() {
+		tearDown(clients, names)
+		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(text, nil); err != nil {
+			t.Errorf("Secrets().Delete() = %v", err)
+		}
+	}
+
+	// Clean up on test failure or interrupt
+	defer cleanup()
+	test.CleanupOnInterrupt(cleanup, logger)
+
+	addVolume := func(svc *v1alpha1.Service) {
+		rt := &svc.Spec.RunLatest.Configuration.RevisionTemplate.Spec
+
+		rt.Container.VolumeMounts = []corev1.VolumeMount{{
+			Name:      "asdf",
+			MountPath: filepath.Dir(test.HelloVolumePath),
+		}}
+
+		rt.Volumes = []corev1.Volume{{
+			Name: "asdf",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: text,
+				},
+			},
+		}}
+	}
+
+	// Setup initial Service
+	if _, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{}, addVolume); err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
+	}
+
+	// Validate State after Creation
+
+	if err = validateRunLatestControlPlane(logger, clients, names, "1"); err != nil {
+		t.Error(err)
+	}
+
+	if err = validateRunLatestDataPlane(logger, clients, names, text); err != nil {
+		t.Error(err)
+	}
+}

--- a/test/conformance/volumes_test.go
+++ b/test/conformance/volumes_test.go
@@ -53,7 +53,7 @@ func TestConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to create configmap: %v", err)
 	}
 	logger.Info("Successfully created configMap: %v", configMap)
 
@@ -128,7 +128,7 @@ func TestSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to create secret: %v", err)
 	}
 	logger.Info("Successfully created secret: %v", secret)
 

--- a/test/service.go
+++ b/test/service.go
@@ -98,13 +98,13 @@ func getResourceObjects(clients *Clients, names ResourceNames) (*ResourceObjects
 // CreateRunLatestServiceReady creates a new RunLatest Service in state 'Ready'. This function expects Service and Image name passed in through 'names'.
 // Names is updated with the Route and Configuration created by the Service and ResourceObjects is returned with the Service, Route, and Configuration objects.
 // Returns error if the service does not come up correctly.
-func CreateRunLatestServiceReady(logger *logging.BaseLogger, clients *Clients, names *ResourceNames, options *Options) (*ResourceObjects, error) {
+func CreateRunLatestServiceReady(logger *logging.BaseLogger, clients *Clients, names *ResourceNames, options *Options, fopt ...testing.ServiceOption) (*ResourceObjects, error) {
 	if names.Service == "" || names.Image == "" {
 		return nil, fmt.Errorf("expected non-empty Service and Image name; got Service=%v, Image=%v", names.Service, names.Image)
 	}
 
 	logger.Info("Creating a new Service as RunLatest.")
-	svc, err := CreateLatestService(logger, clients, *names, options)
+	svc, err := CreateLatestService(logger, clients, *names, options, fopt...)
 	if err != nil {
 		return nil, err
 	}

--- a/test/test_images/hellovolume/hellovolume.go
+++ b/test/test_images/hellovolume/hellovolume.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/knative/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	content, err := ioutil.ReadFile(test.HelloVolumePath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Hello volume received a request: %s", string(content))
+	fmt.Fprintln(w, string(content))
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Hello volume app started.")
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/test/test_images/hellovolume/service.yaml
+++ b/test/test_images/hellovolume/service.yaml
@@ -1,0 +1,42 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: hello-volume
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            # This is the Go import path for the binary to containerize
+            # and substitute here.
+            image: github.com/knative/serving/test/test_images/hellovolume
+            volumeMounts:
+            - name: foo
+              mountPath: /hello
+          volumes:
+          - name: foo
+            secret:
+              secretName: bar
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bar
+stringData:
+  world: Not the droids you are looking for.

--- a/test/util.go
+++ b/test/util.go
@@ -23,6 +23,10 @@ import (
 	"github.com/knative/pkg/test/logging"
 )
 
+const (
+	HelloVolumePath = "/hello/world"
+)
+
 // util.go provides shared utilities methods across knative serving test
 
 // LogResourceObject logs the resource object with the resource name and value


### PR DESCRIPTION
This extends the knative/serving API to allow for ConfigMaps and Secrets to be mounted as volumes.  All other forms of volume are disallowed.

The container's volume mounts must include all of the provided volumes, they must be ReadOnly (this is defaulted in the webhook), and only a MountPath may be specified.

Related: https://github.com/knative/serving/issues/1504
