### PR TITLE
Clean up deploy_test

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -39,10 +39,217 @@ import (
 var (
 	one            int32  = 1
 	defaultPortStr string = strconv.Itoa(int(v1alpha1.DefaultUserPort))
+
+	defaultUserContainer = &corev1.Container{
+		Name:                     UserContainerName,
+		Image:                    "busybox",
+		Resources:                userResources,
+		Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
+		VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
+		Lifecycle:                userLifecycle,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Env: []corev1.EnvVar{{
+			Name:  "PORT",
+			Value: "8080",
+		}, {
+			Name:  "K_REVISION",
+			Value: "bar",
+		}, {
+			Name:  "K_CONFIGURATION",
+			Value: "cfg",
+		}, {
+			Name:  "K_SERVICE",
+			Value: "svc",
+		}},
+	}
+
+	defaultQueueContainer = &corev1.Container{
+		Name:           QueueContainerName,
+		Resources:      queueResources,
+		Ports:          queuePorts,
+		Lifecycle:      queueLifecycle,
+		ReadinessProbe: queueReadinessProbe,
+		Env: []corev1.EnvVar{{
+			Name:  "SERVING_NAMESPACE",
+			Value: "foo", // matches namespace
+		}, {
+			Name: "SERVING_CONFIGURATION",
+			// No OwnerReference
+		}, {
+			Name:  "SERVING_REVISION",
+			Value: "bar", // matches name
+		}, {
+			Name:  "SERVING_AUTOSCALER",
+			Value: "autoscaler", // no autoscaler configured.
+		}, {
+			Name:  "SERVING_AUTOSCALER_PORT",
+			Value: "8080",
+		}, {
+			Name:  "CONTAINER_CONCURRENCY",
+			Value: "0",
+		}, {
+			Name:  "REVISION_TIMEOUT_SECONDS",
+			Value: "45",
+		}, {
+			Name: "SERVING_POD",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		}, {
+			Name: "SERVING_LOGGING_CONFIG",
+			// No logging configuration
+		}, {
+			Name: "SERVING_LOGGING_LEVEL",
+			// No logging level
+		}, {
+			Name:  "USER_PORT",
+			Value: "8080",
+		}, {
+			Name:  "SYSTEM_NAMESPACE",
+			Value: system.Namespace(),
+		}},
+	}
+
+	defaultFluentdContainer = &corev1.Container{
+		Name:      FluentdContainerName,
+		Image:     "indiana:jones",
+		Resources: fluentdResources,
+		Env: []corev1.EnvVar{{
+			Name:  "FLUENTD_ARGS",
+			Value: "--no-supervisor -q",
+		}, {
+			Name:  "SERVING_CONTAINER_NAME",
+			Value: UserContainerName,
+		}, {
+			Name: "SERVING_CONFIGURATION",
+			// No owner reference
+		}, {
+			Name:  "SERVING_REVISION",
+			Value: "bar",
+		}, {
+			Name:  "SERVING_NAMESPACE",
+			Value: "foo",
+		}, {
+			Name: "SERVING_POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		}},
+		VolumeMounts: fluentdVolumeMounts,
+	}
+
+	defaultPodSpec = &corev1.PodSpec{
+		Volumes:                       []corev1.Volume{varLogVolume},
+		TerminationGracePeriodSeconds: refInt64(45),
+	}
+
+	defaultDeployment = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar-deployment",
+			Labels: map[string]string{
+				serving.RevisionLabelKey: "bar",
+				serving.RevisionUID:      "1234",
+				AppLabelKey:              "bar",
+			},
+			Annotations: map[string]string{},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+				Kind:               "Revision",
+				Name:               "bar",
+				UID:                "1234",
+				Controller:         &boolTrue,
+				BlockOwnerDeletion: &boolTrue,
+			}},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					serving.RevisionUID: "1234",
+				},
+			},
+			ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						serving.RevisionLabelKey: "bar",
+						serving.RevisionUID:      "1234",
+						AppLabelKey:              "bar",
+					},
+					Annotations: map[string]string{
+						sidecarIstioInjectAnnotation: "true",
+					},
+				},
+				// Spec: filled in by makePodSpec
+			},
+		},
+	}
 )
 
 func refInt64(num int64) *int64 {
 	return &num
+}
+
+type containerModifier func(*corev1.Container)
+type podSpecModifier func(*corev1.PodSpec)
+type deploymentModifier func(*appsv1.Deployment)
+
+func makeTestContainer(defaultContainer *corev1.Container, modifiers ...containerModifier) *corev1.Container {
+	container := defaultContainer.DeepCopy()
+	for _, modifier := range modifiers {
+		modifier(container)
+	}
+	return container
+}
+
+func makeTestUserContainer(modifiers ...containerModifier) *corev1.Container {
+	return makeTestContainer(defaultUserContainer, modifiers...)
+}
+
+func makeTestQueueContainer(modifiers ...containerModifier) *corev1.Container {
+	return makeTestContainer(defaultQueueContainer, modifiers...)
+}
+
+func makeTestFluentdContainer(modifiers ...containerModifier) *corev1.Container {
+	return makeTestContainer(defaultFluentdContainer, modifiers...)
+}
+
+func setContainerEnvVar(name, value string) containerModifier {
+	return func(container *corev1.Container) {
+		for i, envVar := range container.Env {
+			if envVar.Name == name {
+				container.Env[i].Value = value
+				return
+			}
+		}
+
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
+func makeTestPodSpec(containers []corev1.Container, modifiers ...podSpecModifier) *corev1.PodSpec {
+	podSpec := defaultPodSpec.DeepCopy()
+	podSpec.Containers = containers
+
+	for _, modifier := range modifiers {
+		modifier(podSpec)
+	}
+
+	return podSpec
+}
+
+func makeTestDeployment(modifiers ...deploymentModifier) *appsv1.Deployment {
+	deployment := defaultDeployment.DeepCopy()
+	for _, modifier := range modifiers {
+		modifier(deployment)
+	}
+	return deployment
 }
 
 func TestMakePodSpec(t *testing.T) {
@@ -81,82 +288,18 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:      UserContainerName,
-				Image:     "busybox",
-				Resources: userResources,
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          v1alpha1.UserPortName,
-						ContainerPort: 8888,
-					},
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(
+				func(container *corev1.Container) {
+					container.Ports[0].ContainerPort = 8888
 				},
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{{
-					Name:  "PORT",
-					Value: "8888", // match user port
-				}, {
-					Name:  "K_REVISION",
-					Value: "bar",
-				}, {
-					Name:  "K_CONFIGURATION",
-					Value: "cfg",
-				}, {
-					Name:  "K_SERVICE",
-					Value: "svc",
-				}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "1",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8888", // Match user port
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+				setContainerEnvVar("PORT", "8888"),
+			),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "1"),
+				setContainerEnvVar("USER_PORT", "8888"),
+			),
+		}),
 	}, {
 		name: "simple concurrency=single no owner",
 		rev: &v1alpha1.Revision{
@@ -178,76 +321,12 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:                     UserContainerName,
-				Image:                    "busybox",
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "1",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "1"),
+			),
+		}),
 	}, {
 		name: "simple concurrency=single no owner digest resolved",
 		rev: &v1alpha1.Revision{
@@ -272,76 +351,14 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:                     UserContainerName,
-				Image:                    "busybox@sha256:deadbeef",
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "1",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(func(container *corev1.Container) {
+				container.Image = "busybox@sha256:deadbeef"
+			}),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "1"),
+			),
+		}),
 	}, {
 		name: "simple concurrency=single with owner",
 		rev: &v1alpha1.Revision{
@@ -370,76 +387,13 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:                     UserContainerName,
-				Image:                    "busybox",
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name:  "SERVING_CONFIGURATION",
-					Value: "parent-config",
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "1",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(),
+			*makeTestQueueContainer(
+				setContainerEnvVar("SERVING_CONFIGURATION", "parent-config"),
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "1"),
+			),
+		}),
 	}, {
 		name: "simple concurrency=multi http readiness probe",
 		rev: &v1alpha1.Revision{
@@ -469,84 +423,23 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  UserContainerName,
-				Image: "busybox",
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port: intstr.FromInt(v1alpha1.RequestQueuePort),
-							Path: "/",
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(
+				func(container *corev1.Container) {
+					container.ReadinessProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Port: intstr.FromInt(v1alpha1.RequestQueuePort),
+								Path: "/",
+							},
 						},
-					},
+					}
 				},
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "0",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+			),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "0"),
+			),
+		}),
 	}, {
 		name: "concurrency=multi, readinessprobe=shell",
 		rev: &v1alpha1.Revision{
@@ -575,83 +468,22 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  UserContainerName,
-				Image: "busybox",
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						Exec: &corev1.ExecAction{
-							Command: []string{"echo", "hello"},
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(
+				func(container *corev1.Container) {
+					container.ReadinessProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"echo", "hello"},
+							},
 						},
-					},
+					}
 				},
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "0",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+			),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "0"),
+			),
+		}),
 	}, {
 		name: "concurrency=multi, readinessprobe=http",
 		rev: &v1alpha1.Revision{
@@ -680,85 +512,24 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  UserContainerName,
-				Image: "busybox",
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/",
-							// HTTP probes route through the queue
-							Port: intstr.FromInt(v1alpha1.RequestQueuePort),
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(
+				func(container *corev1.Container) {
+					container.ReadinessProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/",
+								// HTTP probes route through the queue
+								Port: intstr.FromInt(v1alpha1.RequestQueuePort),
+							},
 						},
-					},
+					}
 				},
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "0",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+			),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "0"),
+			),
+		}),
 	}, {
 		name: "concurrency=multi, livenessprobe=tcp",
 		rev: &v1alpha1.Revision{
@@ -785,83 +556,22 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  UserContainerName,
-				Image: "busybox",
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(v1alpha1.DefaultUserPort),
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(
+				func(container *corev1.Container) {
+					container.LivenessProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromInt(v1alpha1.DefaultUserPort),
+							},
 						},
-					},
+					}
 				},
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "0",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+			),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "0"),
+			),
+		}),
 	}, {
 		name: "with /var/log collection",
 		rev: &v1alpha1.Revision{
@@ -886,113 +596,27 @@ func TestMakePodSpec(t *testing.T) {
 		},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:                     UserContainerName,
-				Image:                    "busybox",
-				Resources:                userResources,
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-				Env: []corev1.EnvVar{buildUserPortEnv(defaultPortStr),
-					{
-						Name:  "K_REVISION",
-						Value: "bar",
-					}, {
-						Name:  "K_CONFIGURATION",
-						Value: "cfg",
-					}, {
-						Name:  "K_SERVICE",
-						Value: "svc",
-					}},
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "1",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}, {
-				Name:      FluentdContainerName,
-				Image:     "indiana:jones",
-				Resources: fluentdResources,
-				Env: []corev1.EnvVar{{
-					Name:  "FLUENTD_ARGS",
-					Value: "--no-supervisor -q",
-				}, {
-					Name:  "SERVING_CONTAINER_NAME",
-					Value: UserContainerName,
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No owner reference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar",
-				}, {
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo",
-				}, {
-					Name: "SERVING_POD_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.name",
+		want: makeTestPodSpec(
+			[]corev1.Container{
+				*makeTestUserContainer(),
+				*makeTestQueueContainer(
+					setContainerEnvVar("CONTAINER_CONCURRENCY", "1"),
+				),
+				*makeTestFluentdContainer(),
+			},
+			func(podSpec *corev1.PodSpec) {
+				podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+					Name: fluentdConfigMapVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "bar-fluentd",
+							},
 						},
 					},
-				}},
-				VolumeMounts: fluentdVolumeMounts,
-			}},
-			Volumes: []corev1.Volume{varLogVolume, {
-				Name: fluentdConfigMapVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "bar-fluentd",
-						},
-					},
-				},
-			}},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+				})
+			},
+		),
 	}, {
 		name: "complex pod spec",
 		rev: &v1alpha1.Revision{
@@ -1033,95 +657,37 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:    UserContainerName,
-				Image:   "busybox",
-				Command: []string{"/bin/bash"},
-				Args:    []string{"-c", "echo Hello world"},
-				Env: []corev1.EnvVar{{
-					Name:  "FOO",
-					Value: "bar",
-				}, {
-					Name:  "BAZ",
-					Value: "blah",
-				}, {
-					Name:  "PORT",
-					Value: "8080",
-				}, {
-					Name:  "K_REVISION",
-					Value: "bar",
-				}, {
-					Name:  "K_CONFIGURATION",
-					Value: "",
-				}, {
-					Name:  "K_SERVICE",
-					Value: "",
-				}},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("666Mi"),
-						corev1.ResourceCPU:    resource.MustParse("666m"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("888Mi"),
-						corev1.ResourceCPU:    resource.MustParse("888m"),
-					},
+		want: makeTestPodSpec([]corev1.Container{
+			*makeTestUserContainer(
+				func(container *corev1.Container) {
+					container.Command = []string{"/bin/bash"}
+					container.Args = []string{"-c", "echo Hello world"}
+					container.Env = append([]corev1.EnvVar{{
+						Name:  "FOO",
+						Value: "bar",
+					}, {
+						Name:  "BAZ",
+						Value: "blah",
+					}}, container.Env...)
+					container.Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("666Mi"),
+							corev1.ResourceCPU:    resource.MustParse("666m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("888Mi"),
+							corev1.ResourceCPU:    resource.MustParse("888m"),
+						},
+					}
+					container.TerminationMessagePolicy = corev1.TerminationMessageReadFile
 				},
-				Ports:                    buildContainerPorts(v1alpha1.DefaultUserPort),
-				VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
-				Lifecycle:                userLifecycle,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-			}, {
-				Name:           QueueContainerName,
-				Resources:      queueResources,
-				Ports:          queuePorts,
-				Lifecycle:      queueLifecycle,
-				ReadinessProbe: queueReadinessProbe,
-				// These changed based on the Revision and configs passed in.
-				Env: []corev1.EnvVar{{
-					Name:  "SERVING_NAMESPACE",
-					Value: "foo", // matches namespace
-				}, {
-					Name: "SERVING_CONFIGURATION",
-					// No OwnerReference
-				}, {
-					Name:  "SERVING_REVISION",
-					Value: "bar", // matches name
-				}, {
-					Name:  "SERVING_AUTOSCALER",
-					Value: "autoscaler", // no autoscaler configured.
-				}, {
-					Name:  "SERVING_AUTOSCALER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "CONTAINER_CONCURRENCY",
-					Value: "1",
-				}, {
-					Name:  "REVISION_TIMEOUT_SECONDS",
-					Value: "45",
-				}, {
-					Name: "SERVING_POD",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					},
-				}, {
-					Name: "SERVING_LOGGING_CONFIG",
-					// No logging configuration
-				}, {
-					Name: "SERVING_LOGGING_LEVEL",
-					// No logging level
-				}, {
-					Name:  "USER_PORT",
-					Value: "8080",
-				}, {
-					Name:  "SYSTEM_NAMESPACE",
-					Value: system.Namespace(),
-				}},
-			}},
-			Volumes:                       []corev1.Volume{varLogVolume},
-			TerminationGracePeriodSeconds: refInt64(45),
-		},
+				setContainerEnvVar("K_CONFIGURATION", ""),
+				setContainerEnvVar("K_SERVICE", ""),
+			),
+			*makeTestQueueContainer(
+				setContainerEnvVar("CONTAINER_CONCURRENCY", "1"),
+			),
+		}),
 	}}
 
 	for _, test := range tests {
@@ -1164,53 +730,12 @@ func TestMakeDeployment(t *testing.T) {
 				TimeoutSeconds: 45,
 			},
 		},
-		lc: &logging.Config{},
-		nc: &config.Network{},
-		oc: &config.Observability{},
-		ac: &autoscaler.Config{},
-		cc: &config.Controller{},
-		want: &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar-deployment",
-				Labels: map[string]string{
-					serving.RevisionLabelKey: "bar",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
-				},
-				Annotations: map[string]string{},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
-					Kind:               "Revision",
-					Name:               "bar",
-					UID:                "1234",
-					Controller:         &boolTrue,
-					BlockOwnerDeletion: &boolTrue,
-				}},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &one,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						serving.RevisionUID: "1234",
-					},
-				},
-				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							serving.RevisionLabelKey: "bar",
-							serving.RevisionUID:      "1234",
-							AppLabelKey:              "bar",
-						},
-						Annotations: map[string]string{
-							sidecarIstioInjectAnnotation: "true",
-						},
-					},
-					// Spec: filled in below by makePodSpec
-				},
-			},
-		},
+		lc:   &logging.Config{},
+		nc:   &config.Network{},
+		oc:   &config.Observability{},
+		ac:   &autoscaler.Config{},
+		cc:   &config.Controller{},
+		want: makeTestDeployment(),
 	}, {
 		name: "simple concurrency=multi with owner",
 		rev: &v1alpha1.Revision{
@@ -1234,53 +759,12 @@ func TestMakeDeployment(t *testing.T) {
 				TimeoutSeconds: 45,
 			},
 		},
-		lc: &logging.Config{},
-		nc: &config.Network{},
-		oc: &config.Observability{},
-		ac: &autoscaler.Config{},
-		cc: &config.Controller{},
-		want: &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar-deployment",
-				Labels: map[string]string{
-					serving.RevisionLabelKey: "bar",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
-				},
-				Annotations: map[string]string{},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
-					Kind:               "Revision",
-					Name:               "bar",
-					UID:                "1234",
-					Controller:         &boolTrue,
-					BlockOwnerDeletion: &boolTrue,
-				}},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &one,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						serving.RevisionUID: "1234",
-					},
-				},
-				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							serving.RevisionLabelKey: "bar",
-							serving.RevisionUID:      "1234",
-							AppLabelKey:              "bar",
-						},
-						Annotations: map[string]string{
-							sidecarIstioInjectAnnotation: "true",
-						},
-					},
-					// Spec: filled in below by makePodSpec
-				},
-			},
-		},
+		lc:   &logging.Config{},
+		nc:   &config.Network{},
+		oc:   &config.Observability{},
+		ac:   &autoscaler.Config{},
+		cc:   &config.Controller{},
+		want: makeTestDeployment(),
 	}, {
 		name: "simple concurrency=multi with outbound IP range configured",
 		rev: &v1alpha1.Revision{
@@ -1304,49 +788,9 @@ func TestMakeDeployment(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar-deployment",
-				Labels: map[string]string{
-					serving.RevisionLabelKey: "bar",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
-				},
-				Annotations: map[string]string{},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
-					Kind:               "Revision",
-					Name:               "bar",
-					UID:                "1234",
-					Controller:         &boolTrue,
-					BlockOwnerDeletion: &boolTrue,
-				}},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &one,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						serving.RevisionUID: "1234",
-					},
-				},
-				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							serving.RevisionLabelKey: "bar",
-							serving.RevisionUID:      "1234",
-							AppLabelKey:              "bar",
-						},
-						Annotations: map[string]string{
-							sidecarIstioInjectAnnotation:   "true",
-							IstioOutboundIPRangeAnnotation: "*",
-						},
-					},
-					// Spec: filled in below by makePodSpec
-				},
-			},
-		},
+		want: makeTestDeployment(func(deploy *appsv1.Deployment) {
+			deploy.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "*"
+		}),
 	}, {
 		name: "simple concurrency=multi with outbound IP range override",
 		rev: &v1alpha1.Revision{
@@ -1373,52 +817,10 @@ func TestMakeDeployment(t *testing.T) {
 		oc: &config.Observability{},
 		ac: &autoscaler.Config{},
 		cc: &config.Controller{},
-		want: &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar-deployment",
-				Labels: map[string]string{
-					serving.RevisionLabelKey: "bar",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
-				},
-				Annotations: map[string]string{
-					IstioOutboundIPRangeAnnotation: "10.4.0.0/14,10.7.240.0/20",
-				},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
-					Kind:               "Revision",
-					Name:               "bar",
-					UID:                "1234",
-					Controller:         &boolTrue,
-					BlockOwnerDeletion: &boolTrue,
-				}},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &one,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						serving.RevisionUID: "1234",
-					},
-				},
-				ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							serving.RevisionLabelKey: "bar",
-							serving.RevisionUID:      "1234",
-							AppLabelKey:              "bar",
-						},
-						Annotations: map[string]string{
-							sidecarIstioInjectAnnotation: "true",
-							// The annotation on the Revision should override our global configuration.
-							IstioOutboundIPRangeAnnotation: "10.4.0.0/14,10.7.240.0/20",
-						},
-					},
-					// Spec: filled in below by makePodSpec
-				},
-			},
-		},
+		want: makeTestDeployment(func(deploy *appsv1.Deployment) {
+			deploy.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
+			deploy.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "10.4.0.0/14,10.7.240.0/20"
+		}),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Part 1 of 2. Only changing the want: fields in this PR to show
that the tests haven't been modified. Will follow up with
similar change for test inputs.

Factor out constantly repeated code, making it clear what the
defaults are and what changes are actually being tested in each
test case.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
