### PR TITLE
An attempt to fix some panics in the tests.

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pool
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -76,8 +77,8 @@ func NewWithCapacity(workers, capacity int) Interface {
 // Go implements Interface.
 func (i *impl) Go(w func() error) {
 	select {
-	// This means, we no longer accept new work.
-	// This prevents racy client from panicing.
+		// This means, we no longer accept new work.
+		// This prevents racy client from panicing.
 	case <-i.doneCh:
 		return
 	default:

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -24,6 +24,7 @@ type impl struct {
 	wg     sync.WaitGroup
 	workCh chan func() error
 	errCh  chan error
+	doneCh chan interface{}
 
 	// Ensure that we Wait exactly once and memoize
 	// the result.
@@ -49,6 +50,7 @@ func NewWithCapacity(workers, capacity int) Interface {
 	i := &impl{
 		workCh: make(chan func() error, capacity),
 		errCh:  make(chan error, capacity),
+		doneCh: make(chan interface{}),
 	}
 
 	// Start a go routine for each worker, which:
@@ -73,6 +75,13 @@ func NewWithCapacity(workers, capacity int) Interface {
 
 // Go implements Interface.
 func (i *impl) Go(w func() error) {
+	select {
+	// This means, we no longer accept new work.
+	// This prevents racy client from panicing.
+	case <-i.doneCh:
+		return
+	default:
+	}
 	// Increment the amount of outstanding work we're waiting on.
 	i.wg.Add(1)
 	// Send the work along the queue.
@@ -83,7 +92,7 @@ func (i *impl) Go(w func() error) {
 func (i *impl) Wait() error {
 	i.once.Do(func() {
 		// Stop accepting new work.
-		close(i.workCh)
+		close(i.doneCh)
 
 		// Wait until outstanding work has completed and close the
 		// error channel.  The logic below will drain the error
@@ -92,6 +101,9 @@ func (i *impl) Wait() error {
 		go func() {
 			// Wait for queued work to complete.
 			i.wg.Wait()
+
+			// Now we know there are definitely no new items arriving.
+			close(i.workCh)
 
 			// Close the channel, so that the receive below
 			// completes in the non-error case.

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pool
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -77,8 +76,8 @@ func NewWithCapacity(workers, capacity int) Interface {
 // Go implements Interface.
 func (i *impl) Go(w func() error) {
 	select {
-		// This means, we no longer accept new work.
-		// This prevents racy client from panicing.
+	// This means, we no longer accept new work.
+	// This prevents racy client from panicing.
 	case <-i.doneCh:
 		return
 	default:

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -24,6 +24,30 @@ import (
 	"time"
 )
 
+func TestRacingClose(t *testing.T) {
+	p := NewWithCapacity(1, 5)
+	wg := &sync.WaitGroup{}
+	var cntExecuted int32
+	const n = 5
+	wg.Add(n)
+	go func() {
+		for i := 0; i < n; i++ {
+			p.Go(func() error {
+				atomic.AddInt32(&cntExecuted, 1)
+				return nil
+			})
+			// Introduce delay so that p.Wait() has time to execute.
+			time.Sleep(10 * time.Millisecond)
+			wg.Done()
+		}
+	}()
+	p.Wait()
+	wg.Wait()
+	if cntExecuted == n {
+		t.Error("Not all items were expected to execute")
+	}
+}
+
 func TestParallelismNoErrors(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
We have reports of panics in the tests, which I think are the result of
items being raced to be pushed in the channel after the `workCh` is already closed.
We had those in the scale tests.

Even if that isn't the case for the tests (i.e. more bugs are in the
pool), I think this way it's more reliable.

Question: should Go return error, or just swallow the fact that new work
was not scheduled.

/lint

## Proposed Changes

* Introduce `doneCh`, which is closed immeditately on Wait
* `Go` checks if `doneCh` is triggered and skips work.
* add a unit test

/cc @mattmoor 