### PR TITLE
Add http webhook server to record and return coverage for API resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -501,7 +501,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bb4a0cc53257bd07bb82b201d3afcf61c6c5ae51e91b2011a7484a91a9bb163a"
+  digest = "1:beeb3d165276e534f861adcf839cf2b5bc3b79bc467690b10000de40348deb7e"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -512,9 +512,13 @@
     "shared/prow",
     "shared/testgrid",
     "tools/dep-collector",
+    "tools/webhook-apicoverage/coveragecalculator",
+    "tools/webhook-apicoverage/resourcetree",
+    "tools/webhook-apicoverage/view",
+    "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "bf7e4dd5a226f5758e0eedd7370b99d33d464910"
+  revision = "25878c03cd9ee57043ef1129215b8a9c4b864071"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"
@@ -1330,6 +1334,11 @@
     "github.com/knative/test-infra/shared/prometheus",
     "github.com/knative/test-infra/shared/testgrid",
     "github.com/knative/test-infra/tools/dep-collector",
+    "github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator",
+    "github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree",
+    "github.com/knative/test-infra/tools/webhook-apicoverage/view",
+    "github.com/knative/test-infra/tools/webhook-apicoverage/webhook",
+    "github.com/markbates/inflect",
     "github.com/mattbaird/jsonpatch",
     "github.com/pkg/errors",
     "github.com/prometheus/client_model/go",
@@ -1345,6 +1354,8 @@
     "golang.org/x/net/http2",
     "golang.org/x/net/http2/h2c",
     "golang.org/x/sync/errgroup",
+    "k8s.io/api/admission/v1beta1",
+    "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/apps/v1",
     "k8s.io/api/autoscaling/v1",
     "k8s.io/api/core/v1",

--- a/test/apicoverage-webhook/Dockerfile
+++ b/test/apicoverage-webhook/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.10.2
+LABEL maintainer "Dushyanth Chickabasapa <dushyanthsc@google.com"
+RUN apt-get update && apt-get install -y --no-install-recommends
+
+COPY apicoverage-webhook /apicoverage-webhook
+RUN mkdir -p /go/resources
+COPY ignoredfields.yaml /go/resources/ignoredfields.yaml
+
+ENTRYPOINT ["/apicoverage-webhook"]

--- a/test/apicoverage-webhook/Makefile
+++ b/test/apicoverage-webhook/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REGISTRY ?= gcr.io
+PROJECT_ID ?= knative-tests/test-infra
+PUSH ?= docker push
+
+PROJECT_NAME=apicoverage-webhook
+
+apicoverage-webhook: clean
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+	docker build -t "$(REGISTRY)/$(PROJECT_ID)/$(PROJECT_NAME):latest" .
+	$(PUSH) "$(REGISTRY)/$(PROJECT_ID)/$(PROJECT_NAME):latest"
+
+clean:
+	rm -f $(PROJECT_NAME)

--- a/test/apicoverage-webhook/README.md
+++ b/test/apicoverage-webhook/README.md
@@ -1,0 +1,18 @@
+# Serving Webhook based API Coverage Image
+
+This directory contains the HTTP Server image used in Webhook based API
+coverage tool. Core infra pieces for the tool comes from [test-infra](
+https://github.com/knative/test-infra/tree/master/tools/webhook-apicoverage).
+Knative serving specific pieces of the tool (such as rules, ignored fields)
+resides in this directory:
+
+1. [Coverage Rules](coverage_rules.go): contains all the apicoverage rules
+   specified for knative serving.
+1. [Display Rules](display_rules.go): contains all the display rules
+   used by knative serving to display json type like result.
+1. [Webhook Handlers](webhook_handlers.go): containes all the handlers that
+   the HTTP server exposes.
+1. [Ignored Fields](ignoredfields.yaml): Yaml file specifies all the fields
+   that are ignored for API Coverage calculation.
+1. [Webhook Server](webhook_server.go): contains the HTTP server used by
+   the webhhok.

--- a/test/apicoverage-webhook/coverage_rules.go
+++ b/test/apicoverage-webhook/coverage_rules.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree"
+)
+
+// TODO(https://github.com/knative/test-infra/issues/448): evaluate refactoring common, shared code.
+// coverage_rules.go contains all the apicoverage rules specified for knative serving.
+
+// IgnoreLowerLevelMetaFields rule ignores metadata nodes that are at a level lower than 2.
+// This is done to ensure we only have ObjectMeta and TypeMeta coverage details for higherlevel
+// types like Service, Route and not for nodes which appear in spec.
+func IgnoreLowerLevelMetaFields(node resourcetree.NodeInterface) bool {
+	lowerCaseFieldName := strings.ToLower(node.GetData().Field)
+	if (strings.Contains(lowerCaseFieldName, "objectmeta") || strings.Contains(lowerCaseFieldName, "typemeta")) &&
+		len(strings.Split(node.GetData().NodePath, ".")) > 2 {
+		return false
+	}
+	return true
+}
+
+// IgnoreCoreV1Fields rule ignores core.v1 as they would be covered in package based traversal.
+func IgnoreCoreV1Fields(node resourcetree.NodeInterface) bool {
+	return !strings.HasSuffix(node.GetData().FieldType.PkgPath(), "core/v1")
+}
+
+func getNodeRules() resourcetree.NodeRules {
+	return resourcetree.NodeRules{
+		Rules: []func(node resourcetree.NodeInterface) bool{
+			IgnoreLowerLevelMetaFields,
+			IgnoreCoreV1Fields,
+		},
+	}
+}
+
+// IgnoreDeprecatedFields ignores fields that are prefixed with the word "deprecated"
+func IgnoreDeprecatedFields(fieldName string) bool {
+	return !strings.HasPrefix(strings.ToLower(fieldName), "deprecated")
+}
+
+func getFieldRules() resourcetree.FieldRules {
+	return resourcetree.FieldRules{
+		Rules : []func(fieldName string) bool {
+			IgnoreDeprecatedFields,
+		},
+	}
+}

--- a/test/apicoverage-webhook/display_rules.go
+++ b/test/apicoverage-webhook/display_rules.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// display_rules.go contains all the display rules specified by knative serving to display json type like result display.
+
+// PackageDisplayRule rule specifies how package name needs to be displayed for json type like result display
+func PackageDisplayRule(packageName string) string {
+	if packageName != "" {
+		tokens := strings.Split(packageName, ".")
+		if len(tokens) >= 2 {
+			// As package names are built using reflect.Type.PackagePath, they are long.
+			// For better readability displaying only last two words of the package path. e.g. serving.v1aplha1
+			return strings.Join(tokens[len(tokens) - 2:], ".")
+		}
+	}
+	return packageName
+}
+
+// FieldDisplayRule rule specifies how the field needs to be displayed for json type like result display.
+func FieldDisplayRule(field *coveragecalculator.FieldCoverage) string {
+	var buffer strings.Builder
+	buffer.WriteString("\t" + field.Field)
+	if field.Ignored {
+		buffer.WriteString("\tIgnored")
+	} else {
+		buffer.WriteString("\tCovered: " + strconv.FormatBool(field.Coverage))
+		if len(field.Values) > 0 && !strings.Contains(strings.ToLower(field.Field), "uid") {
+			buffer.WriteString("\tValues: [" + strings.Join(field.Values, ",") + "]")
+		}
+	}
+	buffer.WriteString("\n")
+	return buffer.String()
+}

--- a/test/apicoverage-webhook/ignoredfields.yaml
+++ b/test/apicoverage-webhook/ignoredfields.yaml
@@ -1,0 +1,23 @@
+- package: serving.v1alpha1
+  type: ServiceSpec
+  fields:
+    - Pinned
+- package: serving.v1alpha1
+  type: RevisionSpec
+  fields:
+    - ConcurrencyModel
+    - BuildName
+- package: core.v1
+  type: Container
+  fields:
+    - Name
+    - VolumeDevices
+    - VolumeMounts
+- package: meta.v1
+  type: ObjectMeta
+  fields:
+    - DeletionTimestamp
+    - Initializers
+    - Finalizers
+    - ClusterName
+    - DeletionGracePeriodSeconds

--- a/test/apicoverage-webhook/webhook_handlers.go
+++ b/test/apicoverage-webhook/webhook_handlers.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"container/list"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree"
+	"github.com/knative/test-infra/tools/webhook-apicoverage/view"
+	"go.uber.org/zap"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+const (
+	// ResourceQueryParam query param name to provide the resource.
+	ResourceQueryParam = "resource"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+// APICoverageRecorder type contains resource tree to record API coverage for resources.
+type APICoverageRecorder struct {
+	Decoder runtime.Decoder
+	Logger *zap.SugaredLogger
+	resourceForest resourcetree.ResourceForest
+}
+
+func (a *APICoverageRecorder) init() {
+	a.resourceForest = resourcetree.ResourceForest {
+		Version: "v1alpha1",
+		ConnectedNodes: make(map[string]*list.List),
+		TopLevelTrees: make(map[string]resourcetree.ResourceTree),
+	}
+	a.addResourceTree("Service", reflect.TypeOf(v1alpha1.Service{}))
+	a.addResourceTree("Configuration", reflect.TypeOf(v1alpha1.Configuration{}))
+	a.addResourceTree("Route", reflect.TypeOf(v1alpha1.Route{}))
+	a.addResourceTree("Revision", reflect.TypeOf(v1alpha1.Revision{}))
+}
+
+func (a *APICoverageRecorder) addResourceTree(resource string, t reflect.Type) {
+	tree := resourcetree.ResourceTree{
+		ResourceName: resource,
+		Forest: &a.resourceForest,
+	}
+	tree.BuildResourceTree(t)
+	a.resourceForest.TopLevelTrees[resource] = tree
+}
+
+func (a *APICoverageRecorder) recordCoverage(review *v1beta1.AdmissionReview) {
+	var (
+		v reflect.Value
+		resource string
+		err error
+	)
+
+	switch schemaType := review.Request.Kind.Kind; schemaType {
+	case "Service":
+		resource = "Service"
+		svc := v1alpha1.Service{}
+		err = json.Unmarshal(review.Request.Object.Raw, &svc)
+		// Even if err is encountered we would just reflect on an empty object.
+		v = reflect.ValueOf(svc)
+	case "Configuration":
+		resource = "Configuration"
+		conf := v1alpha1.Configuration{}
+		err = json.Unmarshal(review.Request.Object.Raw, &conf)
+		v = reflect.ValueOf(conf)
+	case "Route":
+		resource = "Configuration"
+		route := v1alpha1.Route{}
+		err = json.Unmarshal(review.Request.Object.Raw, &route)
+		v = reflect.ValueOf(route)
+	case "Revision":
+		resource = "Revision"
+		revision := v1alpha1.Revision{}
+		err = json.Unmarshal(review.Request.Object.Raw, &revision)
+		v = reflect.ValueOf(revision)
+	default:
+		return
+	}
+
+	if err != nil {
+		a.Logger.Errorf("Error unmarshalling %s Obj. Request Obj: %s Error: %v", resource, string(review.Request.Object.Raw), err)
+		return
+	}
+
+	resourceTree := a.resourceForest.TopLevelTrees[resource]
+	resourceTree.UpdateCoverage(v)
+}
+
+// Since we are not actually validating any API resource object we always return true here.
+func (a *APICoverageRecorder) appendReviewResponse(review *v1beta1.AdmissionReview) {
+	review.Response = &v1beta1.AdmissionResponse{
+		Allowed: true,
+		Result: &v1.Status{
+			Message: "Welcome aboard!",
+		},
+	}
+}
+
+// RecordResourceCoverage is handler method that records resource coverage.
+func (a *APICoverageRecorder) RecordResourceCoverage(w http.ResponseWriter, r *http.Request) {
+	var body []byte
+	if data, err := ioutil.ReadAll(r.Body); err == nil {
+		body = data
+	}
+
+	review := &v1beta1.AdmissionReview{}
+	_, _, err := a.Decoder.Decode(body, nil, review)
+	if err != nil {
+		a.Logger.Errorf("Can't decode request: %v", err)
+	}
+	a.recordCoverage(review)
+	a.appendReviewResponse(review)
+	responseInBytes, err := json.Marshal(review)
+
+	if _, err := w.Write(responseInBytes); err != nil {
+		a.Logger.Errorf("%v", err)
+	}
+}
+
+// GetResourceCoverage retrieves resource coverage data for the passed in resource via query param.
+func (a *APICoverageRecorder) GetResourceCoverage(w http.ResponseWriter, r *http.Request) {
+	resource := r.URL.Query().Get(ResourceQueryParam)
+	if _, ok := a.resourceForest.TopLevelTrees[resource]; !ok {
+		fmt.Fprintf(w, "Resource information not found for resource: %s", resource)
+		return
+	}
+
+	var ignoreFields coveragecalculator.IgnoredFields
+	ignoreFieldsFilePath := "resources/ignoredfields.yaml"
+	if err := ignoreFields.ReadFromFile(ignoreFieldsFilePath); err != nil {
+		fmt.Fprintf(w, "Error reading file: %s", ignoreFieldsFilePath)
+	}
+
+	tree := a.resourceForest.TopLevelTrees[resource]
+	typeCoverage := tree.BuildCoverageData(getNodeRules(), getFieldRules(), ignoreFields)
+
+	jsonLikeDisplay := view.GetJSONTypeDisplay(typeCoverage, view.DisplayRules{
+		PackageNameRule: PackageDisplayRule,
+		FieldRule: FieldDisplayRule,
+	})
+	fmt.Fprint(w, jsonLikeDisplay)
+}

--- a/test/apicoverage-webhook/webhook_server.go
+++ b/test/apicoverage-webhook/webhook_server.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/signals"
+	"github.com/knative/pkg/webhook"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/system"
+	webhook_helper "github.com/knative/test-infra/tools/webhook-apicoverage/webhook"
+	"github.com/markbates/inflect"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// Common name used for service, deployment and webhook.
+	componentCommonName = "apicoverage-webhook"
+	// API path to retrieve resource coverage.
+	resourceCoveragePath = "/resourcecoverage"
+)
+
+var (
+	// Using serving namespace.
+	servingNamespace = os.Getenv(system.NamespaceEnvKey)
+)
+
+func getValidatorRules() ([]admissionregistrationv1beta1.RuleWithOperations) {
+	handlers:= map[schema.GroupVersionKind]webhook.GenericCRD{
+		v1alpha1.SchemeGroupVersion.WithKind("Revision"):      &v1alpha1.Revision{},
+		v1alpha1.SchemeGroupVersion.WithKind("Configuration"): &v1alpha1.Configuration{},
+		v1alpha1.SchemeGroupVersion.WithKind("Route"):         &v1alpha1.Route{},
+		v1alpha1.SchemeGroupVersion.WithKind("Service"):       &v1alpha1.Service{},
+	}
+
+	var rules []admissionregistrationv1beta1.RuleWithOperations
+	for gvk := range handlers {
+		plural := strings.ToLower(inflect.Pluralize(gvk.Kind))
+
+		rules = append(rules, admissionregistrationv1beta1.RuleWithOperations{
+			Operations: []admissionregistrationv1beta1.OperationType{
+				admissionregistrationv1beta1.Create,
+				admissionregistrationv1beta1.Update,
+			},
+			Rule: admissionregistrationv1beta1.Rule{
+				APIGroups:   []string{gvk.Group},
+				APIVersions: []string{gvk.Version},
+				Resources:   []string{plural},
+			},
+		})
+	}
+	return rules
+}
+
+func buildWebhookConfiguration() *webhook_helper.APICoverageWebhook {
+	cm, err := configmap.Load("/etc/config-logging")
+	if err != nil {
+		log.Fatalf("Error loading logging configuration: %v", err)
+	}
+
+	config, err := logging.NewConfigFromMap(cm)
+	if err != nil {
+		log.Fatalf("Error parsing logging configuration: %v", err)
+	}
+	logger, _ := logging.NewLoggerFromConfig(config, "webhook")
+
+	clusterConfig, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("Failed to get in cluster config: %v", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
+	if err != nil {
+		log.Fatalf("Failed to get client set: %v", err)
+	}
+
+	return &webhook_helper.APICoverageWebhook{
+		Logger: logger,
+		KubeClient: kubeClient,
+		FailurePolicy: admissionregistrationv1beta1.Fail,
+		ClientAuth: tls.NoClientCert,
+		RegistrationDelay: time.Second * 2,
+		Port: 443,
+		Namespace: servingNamespace,
+		DeploymentName: componentCommonName,
+		ServiceName: componentCommonName,
+		WebhookName: componentCommonName + ".knative.serving.dev",
+	}
+}
+
+func main() {
+	webhook := buildWebhookConfiguration()
+
+	ac := APICoverageRecorder {
+		Decoder: codecs.UniversalDeserializer(),
+		Logger: webhook.Logger,
+	}
+	ac.init()
+
+	m := http.NewServeMux()
+	m.HandleFunc("/", ac.RecordResourceCoverage)
+	m.HandleFunc(resourceCoveragePath, ac.GetResourceCoverage)
+
+	webhook.SetupWebhook(m, getValidatorRules(), signals.SetupSignalHandler())
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/README.md
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/README.md
@@ -1,0 +1,23 @@
+# Coverage Calculator
+
+`coveragecalculator` package contains types and helper methods pertaining to
+coverage calculation.
+
+[TypeCoverage](coveragedata.go) is a type to represent coverage data for a
+particular API object type. This is the wire contract between the webhook
+server running inside the K8s cluster and any client using the API-Coverage
+tool. All API calls into the webhook-server would return response containing
+this object to represent coverage data.
+
+[IgnoredFields](ignorefields.go) type provides ability for individual repos to
+specify fields that they would like the API Coverage tool to ignore for
+coverage calculation. Individual repos are expected to provide a .yaml
+file providing fields that they would like to ignore and use helper method
+`ReadFromFile(filePath)` to read and intialize this type. `FieldIgnored()` can
+then be called by providing `packageName`, `typeName` and `FieldName` to check
+if the field needs to be ignored.
+
+[CalculateCoverage](calculator.go) method provides a capability to calculate
+coverage values. This method takes an array of [TypeCoverage](coveragedata.go)
+and iterates over them to aggreage coverage values. The aggregate result is
+encapsulated inside [CoverageValues](calculator.go) and returned.

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/calculator.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/calculator.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coveragecalculator
+
+// CoverageValues encapsulates all the coverage related values.
+type CoverageValues struct {
+	TotalFields int
+	CoveredFields int
+	IgnoredFields int
+}
+
+// CalculateTypeCoverage calculates aggregate coverage values based on provided []TypeCoverage
+func CalculateTypeCoverage(typeCoverage []TypeCoverage) *CoverageValues {
+	cv := CoverageValues{}
+	for _, coverage := range typeCoverage {
+		for _, field := range coverage.Fields {
+			if field.Ignored {
+				cv.IgnoredFields++
+			} else {
+				cv.TotalFields++
+				if field.Coverage {
+					cv.CoveredFields++
+				}
+			}
+		}
+	}
+	return &cv
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/coveragedata.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/coveragedata.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coveragecalculator
+
+// FieldCoverage represents coverage data for a field.
+type FieldCoverage struct {
+	Field string `json:"Field"`
+	Values []string `json:"Values"`
+	Coverage bool `json:"Covered"`
+	Ignored bool `json:"Ignored"`
+}
+
+// Merge operation merges the field coverage data when multiple nodes represent the same type. (e.g. ConnectedNodes traversal)
+func (f *FieldCoverage) Merge(coverage bool, values []string) {
+	if coverage {
+		f.Coverage = coverage
+		f.Values = append(f.Values, values...)
+	}
+}
+
+// TypeCoverage encapsulates type information and field coverage.
+type TypeCoverage struct {
+	Package string `json:"Package"`
+	Type string `json:"Type"`
+	Fields map[string]*FieldCoverage `json:"Fields"`
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/ignorefields.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator/ignorefields.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coveragecalculator
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// IgnoredFields encapsulates fields to be ignored in a package for API coverage calculation.
+type IgnoredFields struct {
+	ignoredFields map[string]map[string]bool
+}
+
+
+// This type is used for deserialization from the input .yaml file
+type inputIgnoredFields struct {
+	Package string `yaml:"package"`
+	Type string `yaml:"type"`
+	Fields []string `yaml:"fields"`
+}
+
+// ReadFromFile is a utility method that can be used by repos to read .yaml input file into
+// IgnoredFields type.
+func (ig *IgnoredFields) ReadFromFile(filePath string) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("Error reading file: %s Error : %v", filePath, err)
+	}
+
+	var inputEntries []inputIgnoredFields
+	err = yaml.Unmarshal(data, &inputEntries)
+	if err != nil {
+		return fmt.Errorf("Error unmarshalling ignoredfields input yaml file: %s Content: %s Error: %v", filePath, string(data), err)
+	}
+
+	ig.ignoredFields = map[string]map[string]bool {}
+
+	for _, entry := range inputEntries {
+		if _, ok := ig.ignoredFields[entry.Package]; !ok {
+			ig.ignoredFields[entry.Package] = map[string]bool{}
+		}
+
+		for _, field := range entry.Fields {
+			ig.ignoredFields[entry.Package][entry.Type + "." + field] = true
+		}
+	}
+	return nil
+}
+
+// FieldIgnored method given a package, type and field returns true if the field is marked ignored.
+func (ig *IgnoredFields) FieldIgnored(packageName string, typeName string, fieldName string) bool {
+	if ig.ignoredFields != nil {
+		for key, value := range ig.ignoredFields {
+			if strings.HasSuffix(packageName, key) {
+				if _, ok := value[typeName + "." + fieldName]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/README.md
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/README.md
@@ -1,0 +1,60 @@
+# Resource Tree
+
+resourcetree package contains types and interfaces that define a resource
+tree(n-ary tree based representation of an API resource). Each resource
+tree is composed of nodes which have data encapsulated inside [nodeData](node.go)
+and operations that can be performed on each node in the interface [NodeInterface](node.go).
+Type of a node is logically defined by reflect.Kind. Each node type is expected
+to satisfy the [NodeInterface](node.go) interface.
+
+## Resource Forest
+
+[ResourceForest](resourceforest.go) groups all resource trees that are part
+of an API version into a single construct and defines operations that span
+across them. As an example for Knative Serving, we will have individual
+resource trees for Configuration, Revision, Route and Service, and they
+are encapsulated inside a resource forest under version v1alpha1. Example
+of an operation that spans resource trees would be to get coverage details
+for outlined types connected using ConnectedNodes.
+
+ConnectedNodes represent connections between nodes that are of same
+type(reflect.Type) and belong to same package but span across different
+trees or branches of same tree. An example of ConnectedNodes would be
+v1alpha1.Route.Spec.Traffic and v1alpha1.Route.Status.Traffic, both these
+Traffic fields are of type v1alpha1.TrafficTarget, but are present in different
+paths inside the resource tree. ConnectedNodes connects these two nodes, and
+an outlining of this type would present the coverage across the two branches
+and gives a unified view of what fields are covered.
+
+## Type Analysis
+
+A Resource tree is built using reflect.Type Each node type is expected to
+implement NodeInterface method *buildChildNodes(t reflect.Type)*. Inside
+this method each node creates child nodes based on its type, for e.g.
+StructKindNode creates one child for each field defined in the struct.
+Type analysis are defined inside [typeanalyzer_tests](buildChildNodes_test.go)
+
+## Value Analysis
+
+A Resource tree is updated using reflect.Value Each node type is expected
+to implement NodeInterface method *updateCoverage(v reflect.Value)*.
+Inisde this method each node updates its nodeData.covered field based on
+whether the reflect.Value parameter being passed is set or not.
+
+## Rules
+
+To define traversal pattern on a [resourcetree](../resourcetree/resourcetree.go)
+`coveragecalculator` package supports defining rules that are applied during
+apicoverage walk-through. Currently the tool supports two types of Rule objects:
+
+  1. `NodeRules`: Enforces node level semantics. e.g.: Avoid traversing any type
+    that belong to a particular package. To enforce this rule, the repo would
+    define an object that implements the [NodeRule](rule.go) interface's
+    `Apply(nodeInterface  resourcetree.NodeInterface) bool` method and pass that
+    onto the `resourcetree` traversal routine.
+
+  1. `FieldRules`: Enforces field level semantics. e.g. Avoid calculating
+    coverage for any field that starts with prefix `deprecated`. To enforce this
+    rule, the repo would define an object that implements [FieldRule](rule.go)
+    interface's `Apply(fieldName string) bool` method and pass that onto the
+    `resourcetree` traversal routine.

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/arraykindnode.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/arraykindnode.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+const (
+	arrayNodeNameSuffix = "-arr"
+)
+
+// ArrayKindNode represents resource tree node of types reflect.Kind.Array and reflect.Kind.Slice
+type ArrayKindNode struct {
+	NodeData
+	arrKind reflect.Kind // Array type e.g. []int will store reflect.Kind.Int. This is required for type-expansion and value-evaluation decisions.
+}
+
+// GetData returns node data
+func (a *ArrayKindNode ) GetData() NodeData {
+	return a.NodeData
+}
+
+func (a *ArrayKindNode ) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	a.NodeData.initialize(field, parent, t, rt)
+	a.arrKind = t.Elem().Kind()
+}
+
+func (a *ArrayKindNode) buildChildNodes(t reflect.Type) {
+	childName := a.Field + arrayNodeNameSuffix
+	childNode := a.Tree.createNode(childName, a, t.Elem())
+	a.Children[childName] = childNode
+	childNode.buildChildNodes(t.Elem())
+}
+
+func (a *ArrayKindNode) updateCoverage(v reflect.Value) {
+	if !v.IsNil() {
+		a.Covered = true
+		for i := 0; i < v.Len(); i++ {
+			a.Children[a.Field + arrayNodeNameSuffix].updateCoverage(v.Index(i))
+		}
+	}
+}
+
+func (a *ArrayKindNode) buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+	fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) {
+	if a.arrKind == reflect.Struct {
+		a.Children[a.Field + arrayNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules, ignoredFields)
+	}
+}
+
+func (a *ArrayKindNode) getValues() ([]string) {
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// BasicTypeKindNode represents resource tree node of basic types like int, float, etc.
+type BasicTypeKindNode struct {
+	NodeData
+	values map[string]bool // Values seen for this node. Useful for enum types.
+	possibleEnum bool // Flag to indicate if this is a possible enum.
+}
+
+// GetData returns node data
+func (b *BasicTypeKindNode) GetData() NodeData {
+	return b.NodeData
+}
+
+func (b *BasicTypeKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	b.NodeData.initialize(field, parent, t, rt)
+	b.values = make(map[string]bool)
+	b.NodeData.LeafNode = true
+}
+
+func (b *BasicTypeKindNode) buildChildNodes(t reflect.Type) {
+	// Treating bools as possible enums to support tighter coverage information.
+	if t.Name() != t.Kind().String() || b.FieldType.Kind() == reflect.Bool {
+		b.possibleEnum = true
+	}
+}
+
+func (b *BasicTypeKindNode) updateCoverage(v reflect.Value) {
+	if value := b.string(v); len(value) > 0 {
+		if b.possibleEnum || b.FieldType.Kind() == reflect.Bool {
+			b.addValue(value)
+		}
+		b.Covered = true
+	}
+}
+
+// no-op as the coverage is calculated as field coverage in parent node.
+func (b *BasicTypeKindNode) buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+	fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) {}
+
+func (b *BasicTypeKindNode) string(v reflect.Value) string {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Int() != 0 {
+			return strconv.Itoa(int(v.Int()))
+		}
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if v.Uint() != 0 {
+			return strconv.FormatUint(v.Uint(), 10)
+		}
+	case reflect.Float32, reflect.Float64:
+		if v.Float() != 0 {
+			return fmt.Sprintf("%f", v.Float())
+		}
+	case reflect.String:
+		if v.Len() != 0 {
+			return v.String()
+		}
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	}
+
+	return ""
+}
+
+func (b *BasicTypeKindNode) addValue(value string) {
+	if _, ok := b.values[value]; !ok {
+		b.values[value] = true
+	}
+}
+
+func (b *BasicTypeKindNode) getValues() ([]string) {
+	if b.possibleEnum {
+		values := []string{}
+		for key := range b.values {
+			values = append(values, key)
+		}
+		return values
+	}
+
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/node.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/node.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// node.go contains types and interfaces pertaining to nodes inside resource tree.
+
+// NodeInterface defines methods that can be performed on each node in the resource tree.
+type NodeInterface interface {
+	GetData() NodeData
+	initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree)
+	buildChildNodes(t reflect.Type)
+	updateCoverage(v reflect.Value)
+	buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+		fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields)
+	getValues() ([]string)
+}
+
+// NodeData is the data stored in each node of the resource tree.
+type NodeData struct {
+	Field string // Represents the Name of the field e.g. field name inside the struct.
+	Tree *ResourceTree // Reference back to the resource tree. Required for cross-tree traversal(connected nodes traversal)
+	FieldType reflect.Type // Required as type information is not available during tree traversal.
+	NodePath string // Path in the resource tree reaching this node.
+	Parent NodeInterface // Link back to parent.
+	Children map[string]NodeInterface // Child nodes are keyed using field names(nodeData.field).
+	LeafNode bool // Storing this as an additional field because type-analysis determines the value, which gets used later in value-evaluation
+	Covered bool
+}
+
+func (nd *NodeData) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	nd.Field = field
+	nd.Tree = rt
+	nd.Parent = parent
+	nd.FieldType = t
+	nd.Children = make(map[string]NodeInterface)
+
+	if parent != nil {
+		nd.NodePath = parent.GetData().NodePath + "." + field
+	} else {
+		nd.NodePath = field
+	}
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/otherkindnode.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/otherkindnode.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// OtherKindNode represents nodes in the resource tree of types like maps, interfaces, etc
+type OtherKindNode struct {
+	NodeData
+}
+
+// GetData returns node data
+func (o *OtherKindNode) GetData() NodeData {
+	return o.NodeData
+}
+
+func (o *OtherKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	o.NodeData.initialize(field, parent, t, rt)
+	o.NodeData.LeafNode = true
+}
+
+func (o *OtherKindNode) buildChildNodes(t reflect.Type) {}
+
+func (o *OtherKindNode) updateCoverage(v reflect.Value) {
+	if !v.IsNil() {
+		o.Covered = true
+	}
+}
+
+// no-op as the coverage is calculated as field coverage in parent node.
+func (o * OtherKindNode) buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+	fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) {}
+
+func (o *OtherKindNode) getValues() ([]string) {
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+const (
+	ptrNodeNameSuffix = "-ptr"
+)
+
+// PtrKindNode represents nodes in the resource tree of type reflect.Kind.Ptr, reflect.Kind.UnsafePointer, etc.
+type PtrKindNode struct {
+	NodeData
+	objKind reflect.Kind // Type of the object being pointed to. Eg: *int will store reflect.Kind.Int. This is required for type-expansion and value-evaluation decisions.
+}
+
+// GetData returns node data
+func (p *PtrKindNode) GetData() NodeData {
+	return p.NodeData
+}
+
+func (p *PtrKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	p.NodeData.initialize(field, parent, t, rt)
+	p.objKind = t.Elem().Kind()
+}
+
+func (p *PtrKindNode) buildChildNodes(t reflect.Type) {
+	childName := p.Field + ptrNodeNameSuffix
+	childNode := p.Tree.createNode(childName, p, t.Elem())
+	p.Children[childName] = childNode
+	childNode.buildChildNodes(t.Elem())
+}
+
+func (p *PtrKindNode) updateCoverage(v reflect.Value) {
+	if !v.IsNil() {
+		p.Covered = true
+		p.Children[p.Field + ptrNodeNameSuffix].updateCoverage(v.Elem())
+	}
+}
+
+func (p *PtrKindNode) buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+	fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) {
+	if p.objKind == reflect.Struct {
+		p.Children[p.Field + ptrNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules, ignoredFields)
+	}
+}
+
+func (p *PtrKindNode) getValues() ([]string) {
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/resourceforest.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/resourceforest.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"container/list"
+	"reflect"
+	"strings"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// ResourceForest represents the top-level forest that contains individual resource trees for top-level resource types and all connected nodes across resource trees.
+type ResourceForest struct {
+	Version string
+	TopLevelTrees map[string]ResourceTree // Key is ResourceTree.ResourceName
+	ConnectedNodes map[string]*list.List // Head of the linked list keyed by nodeData.fieldType.pkg + nodeData.fieldType.Name()
+}
+
+// getConnectedNodeCoverage calculates the outlined coverage for a Type using ConnectedNodes linkedlist. We traverse through each element in the linkedlist and merge
+// coverage data into a single coveragecalculator.TypeCoverage object.
+func (r *ResourceForest) getConnectedNodeCoverage(fieldType reflect.Type, fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) (coveragecalculator.TypeCoverage) {
+	packageName := strings.Replace(fieldType.PkgPath(), "/", ".", -1)
+	coverage := coveragecalculator.TypeCoverage {
+		Type: fieldType.Name(),
+		Package: packageName,
+		Fields : make(map[string]*coveragecalculator.FieldCoverage),
+	}
+
+	if value, ok := r.ConnectedNodes[fieldType.PkgPath() + "." + fieldType.Name()]; ok {
+		for elem := value.Front(); elem != nil; elem = elem.Next() {
+			node := elem.Value.(NodeInterface)
+			for field, v := range node.GetData().Children {
+				if fieldRules.Apply(field) {
+					if _, ok := coverage.Fields[field]; !ok {
+						coverage.Fields[field] = &coveragecalculator.FieldCoverage {
+							Field: field,
+							Ignored: ignoredFields.FieldIgnored(packageName, fieldType.Name(), field),
+						}
+					}
+					// merge values across the list.
+					coverage.Fields[field].Merge(v.GetData().Covered, v.getValues())
+				}
+			}
+		}
+	}
+	return coverage
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"container/list"
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// ResourceTree encapsulates a tree corresponding to a resource type.
+type ResourceTree struct {
+	ResourceName string
+	Root NodeInterface
+	Forest *ResourceForest
+}
+
+func (r *ResourceTree) createNode(field string, parent NodeInterface, t reflect.Type) NodeInterface {
+	var n NodeInterface
+	switch t.Kind() {
+	case reflect.Struct:
+		n = new(StructKindNode)
+	case reflect.Array, reflect.Slice:
+		n = new(ArrayKindNode)
+	case reflect.Ptr, reflect.UnsafePointer, reflect.Uintptr:
+		n = new(PtrKindNode)
+	case reflect.Bool, reflect.String, reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n = new(BasicTypeKindNode)
+	default:
+		n = new(OtherKindNode) // Maps, interfaces, etc
+	}
+
+	n.initialize(field, parent, t, r)
+
+	if len(t.PkgPath()) != 0 {
+		typeName := t.PkgPath() + "." + t.Name()
+		if _, ok := r.Forest.ConnectedNodes[typeName]; !ok {
+			r.Forest.ConnectedNodes[typeName] = list.New()
+		}
+		r.Forest.ConnectedNodes[typeName].PushBack(n)
+	}
+
+	return n
+}
+
+// BuildResourceTree builds a resource tree by calling into analyzeType method starting from root.
+func (r *ResourceTree) BuildResourceTree(t reflect.Type) {
+	r.Root = r.createNode(r.ResourceName, nil, t)
+	r.Root.buildChildNodes(t)
+}
+
+// UpdateCoverage updates coverage data in the resource tree based on the provided reflect.Value
+func (r *ResourceTree) UpdateCoverage(v reflect.Value) {
+	r.Root.updateCoverage(v)
+}
+
+// BuildCoverageData calculates the coverage information for a resource tree by applying provided Node and Field rules.
+func (r *ResourceTree) BuildCoverageData(nodeRules NodeRules, fieldRules FieldRules,
+	ignoredFields coveragecalculator.IgnoredFields) ([]coveragecalculator.TypeCoverage) {
+	typeCoverage := []coveragecalculator.TypeCoverage{}
+	r.Root.buildCoverageData(&typeCoverage, nodeRules, fieldRules, ignoredFields)
+	return typeCoverage
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/rule.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/rule.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+// rule.go contains different rules that can be defined to control resource tree traversal.
+
+// NodeRules encapsulates all the node level rules defined by a repo.
+type NodeRules struct {
+	Rules []func(nodeInterface NodeInterface) bool
+}
+
+// Apply runs all the rules defined by a repo against a node.
+func (n *NodeRules) Apply(node NodeInterface) bool {
+	for _, rule := range n.Rules {
+		if !rule(node) {
+			return false
+		}
+	}
+	return true
+}
+
+// FieldRules encapsulates all the field level rules defined by a repo.
+type FieldRules struct {
+	Rules []func(fieldName string) bool
+}
+
+// Apply runs all the rules defined by a repo against a field.
+func (f *FieldRules) Apply(fieldName string) bool {
+	for _, rule := range f.Rules {
+		if !rule(fieldName) {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/structkindnode.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/structkindnode.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"reflect"
+)
+
+const (
+	v1TimeType = "v1.Time"
+	volatileTimeType = "apis.VolatileTime"
+)
+
+// StructKindNode represents nodes in the resource tree of type reflect.Kind.Struct
+type StructKindNode struct {
+	NodeData
+}
+
+// GetData returns node data
+func (s *StructKindNode) GetData() NodeData {
+	return s.NodeData
+}
+
+func (s *StructKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	s.NodeData.initialize(field, parent, t, rt)
+}
+
+func (s *StructKindNode) buildChildNodes(t reflect.Type) {
+	// For types that are part of the standard package, we treat them as leaf nodes and don't expand further.
+	// https://golang.org/pkg/reflect/#StructField.
+	if len(s.FieldType.PkgPath()) == 0 {
+		s.LeafNode = true
+		return
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		var childNode NodeInterface
+		if s.isTimeNode(t.Field(i).Type) {
+			childNode = new(TimeTypeNode)
+			childNode.initialize(t.Field(i).Name, s, t.Field(i).Type, s.Tree)
+		} else {
+			childNode = s.Tree.createNode(t.Field(i).Name, s, t.Field(i).Type)
+		}
+		s.Children[t.Field(i).Name] = childNode
+		childNode.buildChildNodes(t.Field(i).Type)
+	}
+}
+
+func (s *StructKindNode) isTimeNode(t reflect.Type) bool {
+	if t.Kind() == reflect.Struct {
+		return t.String() == v1TimeType || t.String() == volatileTimeType
+	} else if t.Kind() == reflect.Ptr {
+		return t.Elem().String() == v1TimeType || t.String() == volatileTimeType
+	} else {
+		return false
+	}
+}
+
+func (s *StructKindNode) updateCoverage(v reflect.Value) {
+	if v.IsValid() {
+		s.Covered = true
+		if !s.LeafNode {
+			for i := 0; i < v.NumField(); i++ {
+				s.Children[v.Type().Field(i).Name].updateCoverage(v.Field(i))
+			}
+		}
+	}
+}
+
+func (s *StructKindNode) buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+	fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) {
+	if len(s.Children) == 0 {
+		return
+	}
+
+	coverage := s.Tree.Forest.getConnectedNodeCoverage(s.FieldType, fieldRules, ignoredFields)
+	*typeCoverage = append(*typeCoverage, coverage)
+
+	for field := range coverage.Fields {
+		node := s.Children[field]
+		if !coverage.Fields[field].Ignored && node.GetData().Covered && nodeRules.Apply(node) {
+			node.buildCoverageData(typeCoverage, nodeRules, fieldRules, ignoredFields)
+		}
+	}
+}
+
+func (s *StructKindNode) getValues() ([]string) {
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/test_util.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/test_util.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+//test_util contains types defined and used by types and their corresponding verification methods.
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+const (
+	basicTypeName = "BasicType"
+	ptrTypeName = "PtrType"
+	arrayTypeName = "ArrayType"
+	otherTypeName = "OtherType"
+	combinedTypeName = "CombinedType"
+)
+
+type baseType struct {
+	field1 string
+	field2 int16
+}
+
+type ptrType struct {
+	structPtr *baseType
+	basePtr *float32
+}
+
+type arrayType struct {
+	structArr []baseType
+	baseArr []bool
+}
+
+type otherType struct {
+	structMap map[string]baseType
+	baseMap map[string]string
+}
+
+type combinedNodeType struct {
+	b baseType
+	a arrayType
+	p ptrType
+}
+
+func getBaseTypeValue() baseType {
+	return baseType{
+		field1: "test",
+	}
+}
+
+func getPtrTypeValueAllCovered() ptrType {
+	f := new(float32)
+	*f = 3.142
+	b := getBaseTypeValue()
+	return ptrType {
+		basePtr: f,
+		structPtr: &b,
+	}
+}
+
+func getPtrTypeValueSomeCovered() ptrType {
+	b := getBaseTypeValue()
+	return ptrType {
+		structPtr: &b,
+	}
+}
+
+func getArrValueAllCovered() arrayType {
+	b1 := getBaseTypeValue()
+	b2 := baseType{
+		field2: 32,
+	}
+
+	return arrayType{
+		structArr: []baseType{b1, b2},
+		baseArr: []bool{true, false},
+	}
+}
+
+func getArrValueSomeCovered() arrayType {
+	return arrayType{
+		structArr: []baseType{getBaseTypeValue()},
+	}
+}
+
+func getOtherTypeValue() otherType {
+	m := make(map[string]baseType)
+	m["test"] = getBaseTypeValue()
+	return otherType {
+		structMap: m,
+	}
+}
+
+func getTestTree(treeName string, t reflect.Type) *ResourceTree {
+	forest := ResourceForest{
+		Version: "TestVersion",
+		ConnectedNodes: make(map[string]*list.List),
+		TopLevelTrees: make(map[string]ResourceTree),
+	}
+
+	tree := ResourceTree{
+		ResourceName: treeName,
+		Forest: &forest,
+	}
+
+	tree.BuildResourceTree(t)
+	forest.TopLevelTrees[treeName] = tree
+	return &tree
+}
+
+func verifyBaseTypeNode(logPrefix string, data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("%s Expected 2 Children got only : %d", logPrefix, len(data.Children))
+	}
+
+	if value, ok := data.Children["field1"]; ok {
+		n := value.GetData()
+		if !n.LeafNode || n.FieldType.Kind() != reflect.String || n.FieldType.PkgPath() != "" || len(n.Children) != 0 {
+			return fmt.Errorf("%s Unexpected field: field1. Expected LeafNode:true, Kind: %s, pkgPath: '' Children: 0 Found LeafNode: %t Kind: %s pkgPath: %s Children:%d",
+				logPrefix, reflect.String, n.LeafNode, n.FieldType.Kind(), n.FieldType.PkgPath(), len(n.Children))
+		}
+	} else {
+		return fmt.Errorf("%s field1 child Not found", logPrefix)
+	}
+
+	return nil
+}
+
+func verifyPtrNode(data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("Expected 2 Children got: %d", len(data.Children))
+	}
+
+	child := data.Children["structPtr"]
+	if len(child.GetData().Children) != 1 {
+		return fmt.Errorf("Unexpected size for field:structPtr. Expected : 1, Found : %d", len(child.GetData().Children))
+	}
+
+	child = child.GetData().Children["structPtr-ptr"]
+	if err := verifyBaseTypeNode("child structPtr-ptr: ", child.GetData()); err != nil {
+		return err
+	}
+
+	child = data.Children["basePtr"]
+	if len(child.GetData().Children) != 1 {
+		return fmt.Errorf("Unexpected size for field:basePtr. Expected : 1 Found : %d", len(child.GetData().Children))
+	}
+
+	child = child.GetData().Children["basePtr-ptr"]
+	d := child.GetData()
+	if d.FieldType.Kind() != reflect.Float32 || !d.LeafNode || d.FieldType.PkgPath() != "" || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:basePtr-ptr: Expected: Kind: %s, LeafNode: true, pkgPath: '' Children: 0 Found Kind: %s, LeafNode: %t, pkgPath: %s Children:%d",
+			reflect.Float32, d.FieldType.Kind(), d.LeafNode, d.FieldType.PkgPath(), len(d.Children))
+	}
+
+	return nil
+}
+
+func verifyArrayNode(data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("Expected 2 Children got: %d", len(data.Children))
+	}
+
+	child := data.Children["structArr"]
+	d := child.GetData()
+	if d.FieldType.Kind() != reflect.Slice {
+		return fmt.Errorf("Unexpected kind for field:structArr: Expected : %s Found: %s", reflect.Slice, d.FieldType.Kind())
+	} else if len(d.Children) != 1 {
+		return fmt.Errorf("Unexpected number of Children for field:structArr: Expected : 1 Found : %d", len(d.Children))
+	}
+
+	child = child.GetData().Children["structArr-arr"]
+	if err := verifyBaseTypeNode("child structArr-arr:", child.GetData()); err != nil {
+		return err
+	}
+
+	child = data.Children["baseArr"]
+	d = child.GetData()
+	if d.FieldType.Kind() != reflect.Slice {
+		return fmt.Errorf("Unexpected kind for field:baseArr: Expected : %s Found : %s", reflect.Slice, d.FieldType.Kind())
+	} else if len(d.Children) != 1 {
+		return fmt.Errorf("Unexpected number of Children for field:baseArr: Expected : 1 Found : %d", len(d.Children))
+	}
+
+	child = child.GetData().Children["baseArr-arr"]
+	d = child.GetData()
+	if d.FieldType.Kind() != reflect.Bool || !d.LeafNode || d.FieldType.PkgPath() != "" || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:baseArr-arr Expected kind: %s, LeafNode: true, pkgPath: '', Children:0 Found: kind: %s, LeafNode: %t, pkgPath: %s, Children:%d",
+			reflect.Bool, d.FieldType.Kind(), d.LeafNode, d.FieldType.PkgPath(), len(d.Children))
+	}
+
+	return nil
+}
+
+func verifyOtherTypeNode(data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("OtherTypeVerification: Expected 2 Children got: %d", len(data.Children))
+	}
+
+	child := data.Children["structMap"]
+	d := child.GetData()
+	if d.FieldType.Kind() != reflect.Map || !d.LeafNode || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:structMap - Expected Kind: %s, LeafNode: true, Children:0 Found Kind: %s, LeafNode: %t, Children: %d",
+			reflect.Map, d.FieldType.Kind(), d.LeafNode, len(d.Children))
+	}
+
+	child = data.Children["baseMap"]
+	d = child.GetData()
+	if d.FieldType.Kind() != reflect.Map || !d.LeafNode || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:structMap - Expected Kind: %s, LeafNode: true, Children: 0 Found kind: %s, LeafNode: %t, Children: %d",
+			reflect.Map, d.FieldType.Kind(), d.LeafNode, len(d.Children))
+	}
+
+	return nil
+}
+
+func verifyResourceForest(forest *ResourceForest) error {
+	if len(forest.ConnectedNodes) != 4 {
+		return fmt.Errorf("Invalid number of connected nodes found. Expected : 4, Found : %d", len(forest.ConnectedNodes))
+	}
+
+	baseType := reflect.TypeOf(baseType{})
+	if value, found := forest.ConnectedNodes[baseType.PkgPath() + "." + baseType.Name()]; !found {
+		return errors.New("Cannot find baseType{} connectedNode")
+	} else if value.Len() != 3 {
+			return fmt.Errorf("Invalid length of baseType{} Node. Expected : 3 Found : %d", value.Len())
+	}
+
+	arrayType := reflect.TypeOf(arrayType{})
+	if value, found := forest.ConnectedNodes[arrayType.PkgPath() + "." + arrayType.Name()]; !found {
+		return errors.New("Cannot find arrayType{} connectedNode")
+	} else if value.Len() != 1 {
+		return fmt.Errorf("Invalid length of arrayType{} Node. Expected : 1 Found : %d", value.Len())
+	}
+
+	return nil
+}
+
+func verifyBaseTypeValue(logPrefix string, node NodeInterface) error {
+	if !node.GetData().Covered {
+		return errors.New(logPrefix + " Node marked as not-Covered. Expected to be Covered")
+	}
+
+	if !node.GetData().Children["field1"].GetData().Covered {
+		return errors.New(logPrefix + " field1 marked as not-Covered. Expected to be Covered")
+	}
+
+	if node.GetData().Children["field2"].GetData().Covered {
+		return errors.New(logPrefix + " field2 marked as Covered. Expected to be not-Covered")
+	}
+
+	return nil
+}
+
+func verifyPtrValueAllCovered(node NodeInterface) error {
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
+	}
+
+	child := node.GetData().Children["basePtr"]
+	if !child.GetData().Covered {
+		return errors.New("field:base_ptr marked as not-Covered. Expected to be Covered")
+	}
+
+	if !child.GetData().Children["basePtr" + ptrNodeNameSuffix].GetData().Covered {
+		return errors.New("field:basePtr" + ptrNodeNameSuffix + "marked as not-Covered. Expected to be Covered" )
+	}
+
+	child = node.GetData().Children["structPtr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structPtr marked as not-Covered. Expected to be Covered")
+	}
+
+	if err := verifyBaseTypeValue("field:structPtr" + ptrNodeNameSuffix, child.GetData().Children["structPtr" + ptrNodeNameSuffix]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyPtrValueSomeCovered(node NodeInterface) error {
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
+	}
+
+	child := node.GetData().Children["basePtr"]
+	if child.GetData().Covered {
+		return errors.New("field:basePtr marked as Covered. Expected to be not-Covered")
+	}
+
+	if child.GetData().Children["basePtr" + ptrNodeNameSuffix].GetData().Covered {
+		return errors.New("field:basePtr" + ptrNodeNameSuffix + "marked as Covered. Expected to be not-Covered" )
+	}
+
+	child = node.GetData().Children["structPtr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structPtr marked as not-Covered. Expected to be Covered")
+	}
+
+	if err := verifyBaseTypeValue("field:structPtr" + ptrNodeNameSuffix, child.GetData().Children["structPtr" + ptrNodeNameSuffix]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyArryValueAllCovered(node NodeInterface) error {
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
+	}
+
+	child := node.GetData().Children["baseArr"]
+	if !child.GetData().Covered {
+		return errors.New("field:baseArr marked as not-Covered. Expected to be Covered")
+	}
+
+	if !child.GetData().Children["baseArr" + arrayNodeNameSuffix].GetData().Covered {
+		return errors.New("field:baseArr" + arrayNodeNameSuffix + " marked as not-Covered. Expected to be Covered" )
+	}
+
+	child = node.GetData().Children["structArr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structArr marked as not-Covered. Expected to be Covered")
+	}
+
+	child = child.GetData().Children["structArr" + arrayNodeNameSuffix]
+	if !child.GetData().Covered {
+		return errors.New("structArr" + arrayNodeNameSuffix + " marked as not-Covered. Expected to be Covered")
+	}
+
+	if !child.GetData().Children["field1"].GetData().Covered {
+		return errors.New("structArr" + arrayNodeNameSuffix + ".field1 marked as not-Covered. Expected to be Covered")
+	}
+
+	if !child.GetData().Children["field2"].GetData().Covered {
+		return errors.New("structArr" + arrayNodeNameSuffix +".field1 marked as not-Covered. Expected to be Covered")
+	}
+
+	return nil
+}
+
+func verifyArrValueSomeCovered(node NodeInterface) error {
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
+	}
+
+	child := node.GetData().Children["baseArr"]
+	if child.GetData().Covered {
+		return errors.New("field:baseArr marked as Covered. Expected to be not-Covered")
+	}
+
+	if child.GetData().Children["baseArr" + arrayNodeNameSuffix].GetData().Covered {
+		return errors.New("field:baseArr" + arrayNodeNameSuffix + " marked as Covered. Expected to be not-Covered" )
+	}
+
+	child = node.GetData().Children["structArr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structArr marked as not-Covered. Expected to be Covered")
+	}
+
+	if err := verifyBaseTypeValue("field:structArr" + arrayNodeNameSuffix, child.GetData().Children["structArr" + arrayNodeNameSuffix]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyOtherTypeValue(node NodeInterface) error {
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
+	}
+
+	if !node.GetData().Children["structMap"].GetData().Covered {
+		return errors.New("field:structMap marked as not-Covered. Expected to be Covered")
+	}
+
+	if node.GetData().Children["baseMap"].GetData().Covered {
+		return errors.New("field:baseMap marked as Covered. Expected to be not-Covered")
+	}
+
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/timetypenode.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree/timetypenode.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// TimeTypeNode is a node type that encapsulates fields that are internally time based. E.g metav1.ObjectMeta.CreationTimestamp or metav1.ObjectMeta.DeletionTimestamp.
+// These are internally of type metav1.Time which use standard time type, but their values are specified as timestamp strings with parsing logic to create time objects. For
+// use-case we only care if the value is set, so we create TimeTypeNodes and mark them as leafnodes.
+type TimeTypeNode struct {
+	NodeData
+}
+
+// GetData returns node data
+func (ti *TimeTypeNode) GetData() NodeData {
+	return ti.NodeData
+}
+
+func (ti *TimeTypeNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	ti.NodeData.initialize(field, parent, t, rt)
+	ti.LeafNode = true
+}
+
+func (ti *TimeTypeNode) buildChildNodes(t reflect.Type) {}
+
+func (ti *TimeTypeNode) updateCoverage(v reflect.Value) {
+	if v.Type().Kind() == reflect.Struct && v.IsValid() {
+		ti.Covered = true
+	} else if v.Type().Kind() == reflect.Ptr && !v.IsNil() {
+		ti.Covered = true
+	}
+}
+
+// no-op as the coverage is calculated as field coverage in parent node.
+func (ti *TimeTypeNode) buildCoverageData(typeCoverage *[]coveragecalculator.TypeCoverage, nodeRules NodeRules,
+	fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) {}
+
+func (ti *TimeTypeNode) getValues() ([]string) {
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/view/README.md
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/view/README.md
@@ -1,0 +1,24 @@
+# View
+
+This package contains types and helper methods that repos can use to display
+API Coverage results.
+
+[DisplayRules](rule.go) provides a mechanism for repos to define their own
+display rules. DisplayHelper methods can use these rules to define how to
+display results.
+
+`GetJSONTypeDisplay()` is a utility method that can be used by repos to get a
+JSON like textual display of API Coverage. This method takes an array of
+[TypeCoverage](../coveragecalculator/coveragedata.go) and [DisplayRules](rule.go)
+object and returns a string representing its coverage in the format:
+
+```
+Package: <PackageName>
+Type: <TypeName>
+{
+    <FieldName> <Ignored>/<Coverage:TrueorFalse> [Values]
+    ....
+    ....
+    ....
+}
+```

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/view/jsontype_display.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/view/jsontype_display.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// GetJSONTypeDisplay is a helper method to display API Coverage details in json-like format.
+func GetJSONTypeDisplay(coverageData []coveragecalculator.TypeCoverage, displayRules DisplayRules) string {
+	var buffer strings.Builder
+	for _, typeCoverage := range coverageData {
+		packageName := typeCoverage.Package
+		if displayRules.PackageNameRule != nil {
+			packageName = displayRules.PackageNameRule(packageName)
+		}
+
+		typeName := typeCoverage.Type
+		if displayRules.TypeNameRule != nil {
+			typeName = displayRules.TypeNameRule(typeName)
+		}
+
+		buffer.WriteString("Package: " + packageName + "\n")
+		buffer.WriteString("Type: " + typeName + "\n")
+		buffer.WriteString("\n{\n")
+
+		for _, fieldCoverage := range typeCoverage.Fields {
+			fieldDisplay := defaultTypeDisplay(fieldCoverage)
+			if displayRules.FieldRule != nil {
+				fieldDisplay = displayRules.FieldRule(fieldCoverage)
+			}
+			buffer.WriteString(fieldDisplay)
+		}
+
+		buffer.WriteString("}\n\n")
+	}
+
+	return buffer.String()
+}
+
+func defaultTypeDisplay(field *coveragecalculator.FieldCoverage) string {
+	var buffer strings.Builder
+	buffer.WriteString("\t" + field.Field)
+	if field.Ignored {
+		buffer.WriteString("\tIgnored")
+	} else {
+		buffer.WriteString("\tCovered: " + strconv.FormatBool(field.Coverage))
+		if len(field.Values) > 0 {
+			buffer.WriteString("\tValues: [" + strings.Join(field.Values, ",") + "]")
+		}
+	}
+	buffer.WriteString("\n")
+	return buffer.String()
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/view/rule.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/view/rule.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import "github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+
+// DisplayRules provides a mechanism for repos to define their own display rules.
+// DisplayHelper methods can use these rules to define how to display results.
+type DisplayRules struct {
+	PackageNameRule func(packageName string) string
+	TypeNameRule func(typeName string) string
+	FieldRule func(coverage *coveragecalculator.FieldCoverage) string
+}

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/webhook/README.md
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/webhook/README.md
@@ -1,0 +1,30 @@
+# Webhook
+
+Webhook based API-Coverage tool uses [ValidatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook)
+which is a web-server that the K8 API-Server calls into for every API-Object
+update to verify if the object is valid before storing it into its datastore.
+Each validation request has the json representation of the object being
+created/modified, that the tool uses to capture coverage data. `webhook`
+package inside this folder provides a mechanism for individual repos to
+setup ValidatingAdmissionWebhook.
+
+[APICoverageWebhook](webhook.go) type inside the package encapsulates
+necessary configuration details and helper methods required to setup
+the webhook. Each repo is expected to call into `SetupWebhook()`
+providing following three parameters:
+
+1. `http.Handler`: This is the http handler (that implements `ServeHTTP(
+   w http.ResponseWriter, r *http.Request)`) that the web server
+  created by APICoverageWebhook uses.
+1. `rules`: This is an array of `RuleWithOperations` objects
+ from the `k8s.io/api/admissionregistration/v1beta1` package
+ that the webhook uses for validation on each API Object update.
+ e.g: knative-serving while calling this method would
+ provide rules that will handle API Objects like `Service`,
+ `Configuration`, `Route` and `Revision`.
+
+1. `stop` channel: Channel to terminate webhook's web server.
+
+`SetupWebhook()` method in its implementation creates a TLS based web server
+and registers the webhook by creating a ValidatingWebhookConfiguration
+object inside the K8 cluster.

--- a/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/webhook/webhook.go
+++ b/vendor/github.com/knative/test-infra/tools/webhook-apicoverage/webhook/webhook.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/knative/pkg/webhook"
+	"github.com/knative/serving/pkg/system"
+	"go.uber.org/zap"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	// GroupVersionKind for deployment to be used to set the webhook's owner reference.
+	deploymentKind = extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment")
+	servingNamespace = os.Getenv(system.NamespaceEnvKey)
+)
+
+// APICoverageWebhook encapsulates necessary configuration details for the api-coverage webhook.
+type APICoverageWebhook struct {
+	// WebhookName is the name of the validation webhook we create to intercept API calls.
+	WebhookName string
+
+	// ServiceName is the name of K8 service under which the webhook runs.
+	ServiceName string
+
+	// DeploymentName is the deployment name for the webhook.
+	DeploymentName string
+
+	// Namespace is the namespace in which everything above lives.
+	Namespace string
+
+	// Port where the webhook is served.
+	Port int
+
+	// RegistrationDelay controls how long validation requests
+	// occurs after the webhook is started. This is used to avoid
+	// potential races where registration completes and k8s apiserver
+	// invokes the webhook before the HTTP server is started.
+	RegistrationDelay time.Duration
+
+	// ClientAuthType declares the policy the webhook server will follow for TLS Client Authentication.
+	ClientAuth tls.ClientAuthType
+
+	// CaCert is the CA Cert for the webhook server.
+	CaCert []byte
+
+	// FailurePolicy policy governs the webhook validation decisions.
+	FailurePolicy admissionregistrationv1beta1.FailurePolicyType
+
+	// Logger is the configured logger for the webhook.
+	Logger *zap.SugaredLogger
+
+	// KubeClient is the K8 client to the target cluster.
+	KubeClient kubernetes.Interface
+}
+
+func (acw *APICoverageWebhook) generateServerConfig() (*tls.Config , error) {
+	serverKey, serverCert, caCert, err := webhook.CreateCerts(context.Background(), acw.ServiceName, acw.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating webhook certificates: %v", err)
+	}
+
+	cert, err := tls.X509KeyPair(serverCert, serverKey)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating X509 Key pair for webhook server: %v", err)
+	}
+
+	acw.CaCert = caCert
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth: acw.ClientAuth,
+	}, nil
+}
+
+func (acw *APICoverageWebhook) getWebhookServer(handler http.Handler) (*http.Server, error) {
+	tlsConfig, err := acw.generateServerConfig()
+	if err != nil {
+		// generateServerConfig() is expected to provided explanatory error message.
+		return nil, err
+	}
+
+	return &http.Server{
+		Handler:	handler,
+		Addr: fmt.Sprintf(":%d", acw.Port),
+		TLSConfig: tlsConfig,
+	},  nil
+}
+
+func (acw *APICoverageWebhook) registerWebhook(rules []admissionregistrationv1beta1.RuleWithOperations) error {
+	webhook := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: acw.WebhookName,
+			Namespace: servingNamespace,
+		},
+		Webhooks: []admissionregistrationv1beta1.Webhook{{
+			Name:  acw.WebhookName,
+			Rules: rules,
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
+					Namespace: servingNamespace,
+					Name: acw.ServiceName,
+				},
+				CABundle: acw.CaCert,
+			},
+			FailurePolicy: &acw.FailurePolicy,
+		},
+		},
+	}
+
+	deployment, err := acw.KubeClient.ExtensionsV1beta1().Deployments(servingNamespace).Get(acw.DeploymentName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving Deployment Extension object: %v", err)
+	}
+	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
+	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
+
+	_, err = acw.KubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(webhook)
+	if err != nil {
+		return fmt.Errorf("Error creating ValidatingWebhookConfigurations object: %v", err)
+	}
+
+	return nil
+}
+
+// SetupWebhook sets up the webhook with the provided http.handler, webhook-rules and stop channel.
+func (acw *APICoverageWebhook) SetupWebhook(handler http.Handler, rules []admissionregistrationv1beta1.RuleWithOperations, stop <-chan struct{}) error {
+	server, err := acw.getWebhookServer(handler)
+	if err != nil {
+		return fmt.Errorf("Webhook server object creation failed: %v", err)
+	}
+
+	select {
+	case <-time.After(acw.RegistrationDelay):
+		err = acw.registerWebhook(rules)
+		if err != nil {
+			return fmt.Errorf("Webhook registration failed: %v", err)
+		}
+		acw.Logger.Info("Successfully registered webhook")
+	case <-stop:
+		return nil
+	}
+
+	serverBootstrapErrCh := make(chan struct{})
+	go func() {
+		if err := server.ListenAndServeTLS("", ""); err != nil {
+			acw.Logger.Error("ListenAndServeTLS for admission webhook returned error", zap.Error(err))
+			close(serverBootstrapErrCh)
+			return
+		}
+		acw.Logger.Info("Successfully started webhook server")
+	}()
+
+	select {
+	case <-stop:
+		return server.Close()
+	case <-serverBootstrapErrCh:
+		return errors.New("webhook server bootstrap failed")
+	}
+}


### PR DESCRIPTION
This change adds validation webhook to use the apicoverage tool. The webhook would only by installed in specific prow job built to calculate api-coverage in knative e2e and conformance tests. The prow job related changes will be added in future iteration, this change only adds the webhook and corresponding handlers.

Running dep-ensure to pull knative/test-infra code that has webhook-apicoverage has resulted in update of vendor directory and Gopkg.lock.