### PR TITLE
Make our ConfigMaps significantly more self-documenting.

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -20,54 +20,63 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
-  # Static parameters:
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
 
-  # The Revision ContainerConcurrency field specifies the maximum number
-  # of requests the Container can handle at once. Container concurrency
-  # target percentage is how much of that maximum to use in a stable
-  # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
-  # the Autoscaler will try to maintain 7 concurrent connections per pod
-  # on average. A value of 0.7 is chosen because the Autoscaler panics
-  # when concurrency exceeds 2x the desired set point. So we will panic
-  # before we reach the limit.
-  # container-concurrency-target-percentage: "1.0"
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
 
-  # The container concurrency target default is what the Autoscaler will
-  # try to maintain when the Revision specifies unlimited concurrency. A
-  # value of 100 is chosen because it's enough to allow vertical pod
-  # autoscaling to tune resource requests. E.g. maintaining 1 concurrent
-  # "hello world" request doesn't consume enough resources to allow VPA
-  # to achieve efficient resource usage (VPA CPU minimum is 300m).
-  # container-concurrency-target-default: "100"
+    # The Revision ContainerConcurrency field specifies the maximum number
+    # of requests the Container can handle at once. Container concurrency
+    # target percentage is how much of that maximum to use in a stable
+    # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+    # the Autoscaler will try to maintain 7 concurrent connections per pod
+    # on average. A value of 0.7 is chosen because the Autoscaler panics
+    # when concurrency exceeds 2x the desired set point. So we will panic
+    # before we reach the limit.
+    container-concurrency-target-percentage: "1.0"
 
-  # When operating in a stable mode, the autoscaler operates on the
-  # average concurrency over the stable window.
-  # stable-window: "60s"
+    # The container concurrency target default is what the Autoscaler will
+    # try to maintain when the Revision specifies unlimited concurrency. A
+    # value of 100 is chosen because it's enough to allow vertical pod
+    # autoscaling to tune resource requests. E.g. maintaining 1 concurrent
+    # "hello world" request doesn't consume enough resources to allow VPA
+    # to achieve efficient resource usage (VPA CPU minimum is 300m).
+    container-concurrency-target-default: "100"
 
-  # When observed average concurrency during the panic window reaches 2x
-  # the target concurrency, the autoscaler enters panic mode. When
-  # operating in panic mode, the autoscaler operates on the average
-  # concurrency over the panic window.
-  # panic-window: "6s"
+    # When operating in a stable mode, the autoscaler operates on the
+    # average concurrency over the stable window.
+    stable-window: "60s"
 
-  # Max scale up rate limits the rate at which the autoscaler will
-  # increase pod count. It is the maximum ratio of desired pods versus
-  # observed pods.
-  # max-scale-up-rate: "10"
+    # When observed average concurrency during the panic window reaches 2x
+    # the target concurrency, the autoscaler enters panic mode. When
+    # operating in panic mode, the autoscaler operates on the average
+    # concurrency over the panic window.
+    panic-window: "6s"
 
-  # Scale to zero feature flag
-  # enable-scale-to-zero: "true"
+    # Max scale up rate limits the rate at which the autoscaler will
+    # increase pod count. It is the maximum ratio of desired pods versus
+    # observed pods.
+    max-scale-up-rate: "10"
 
-  # Tick interval is the time between autoscaling calculations.
-  # tick-interval: "2s"
+    # Scale to zero feature flag
+    enable-scale-to-zero: "true"
 
-  # Dynamic parameters (take effect when config map is updated):
+    # Tick interval is the time between autoscaling calculations.
+    tick-interval: "2s"
 
-  # Scale to zero grace period is the time an inactive revision is left
-  # running before it is scaled to zero (min: 30s).
-  # scale-to-zero-grace-period: "30s"
+    # Dynamic parameters (take effect when config map is updated):
+
+    # Scale to zero grace period is the time an inactive revision is left
+    # running before it is scaled to zero (min: 30s).
+    scale-to-zero-grace-period: "30s"

--- a/config/config-controller.yaml
+++ b/config/config-controller.yaml
@@ -20,16 +20,25 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
 data:
-  # CONTROLLER CONFIGURATION
-
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   queueSidecarImage: github.com/knative/serving/cmd/queue
 
-  # List of repositories for which tag to digest resolving should be skipped
-  # registriesSkippingTagResolving: "ko.local,dev.local"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # List of repositories for which tag to digest resolving should be skipped
+    registriesSkippingTagResolving: "ko.local,dev.local"

--- a/config/config-domain.yaml
+++ b/config/config-domain.yaml
@@ -20,24 +20,40 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
-  # These are example settings of domain.
-  # example.org will be used for routes having app=prod.
-  # example.org: |
-  #   selector:
-  #     app: prod
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
 
-  # Default value for domain, for routes that does not have app=prod labels.
-  # Although it will match all routes, it is the least-specific rule so it
-  # will only be used if no other domain matches.
-  # example.com: |
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
 
-  # Routes having domain suffix of 'svc.cluster.local' will not be exposed
-  # through Ingress. You can define your own label selector to assign that
-  # domain suffix to your Route here, or you can set the label
-  #    "serving.knative.dev/visibility=cluster-local"
-  # to achieve the same effect.
+    # Default value for domain.
+    # Although it will match all routes, it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # These are example settings of domain.
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
+    
+    # Routes having domain suffix of 'svc.cluster.local' will not be exposed
+    # through Ingress. You can define your own label selector to assign that
+    # domain suffix to your Route here, or you can set the label
+    #    "serving.knative.dev/visibility=cluster-local"
+    # to achieve the same effect.  This shows how to make routes having
+    # the label app=secret only exposed to the local cluster.
+    svc.cluster.local: |
+      selector:
+        app: secret
+  

--- a/config/config-gc.yaml
+++ b/config/config-gc.yaml
@@ -20,20 +20,32 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
-  # Delay after revision creation before considering it for GC
-  # stale-revision-create-delay: "24h"
-  
-  # Duration since a route has been pointed at a revision before it should be GC'd
-  # This minus lastpinned-debounce be longer than the controller resync period (10 hours)
-  # stale-revision-timeout: "15h"
-  
-  # Minimum number of generations of revisions to keep before considering for GC
-  # stale-revision-minimum-generations: "1"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
 
-  # To avoid constant updates, we allow an existing annotation to be stale by this amount before we update the timestamp
-  # stale-revision-lastpinned-debounce: "5h"
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # Delay after revision creation before considering it for GC
+    stale-revision-create-delay: "24h"
+
+    # Duration since a route has been pointed at a revision before it should be GC'd
+    # This minus lastpinned-debounce be longer than the controller resync period (10 hours)
+    stale-revision-timeout: "15h"
+
+    # Minimum number of generations of revisions to keep before considering for GC
+    stale-revision-minimum-generations: "1"
+
+    # To avoid constant updates, we allow an existing annotation to be stale by this
+    # amount before we update the timestamp
+    stale-revision-lastpinned-debounce: "5h"

--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -20,19 +20,31 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
+data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
 
-  # Default Knative Gateway after v0.3. It points to the Istio
-  # standard istio-ingressgateway, instead of a custom one that we
-  # used pre-0.3.
-  # gateway.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
 
-  # A cluster local gateway to allow pods outside of the mesh to access
-  # Services and Routes not exposing through an ingress.  If the users
-  # do have a service mesh setup, this isn't required.
-  # local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # Default Knative Gateway after v0.3. It points to the Istio
+    # standard istio-ingressgateway, instead of a custom one that we
+    # used pre-0.3.
+    gateway.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+
+    # A cluster local gateway to allow pods outside of the mesh to access
+    # Services and Routes not exposing through an ingress.  If the users
+    # do have a service mesh setup, this isn't required.
+    local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -20,40 +20,51 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
-  # Common configuration for all Knative codebase
-  # zap-logger-config: |
-  #   {
-  #     "level": "info",
-  #     "development": false,
-  #     "outputPaths": ["stdout"],
-  #     "errorOutputPaths": ["stderr"],
-  #     "encoding": "json",
-  #     "encoderConfig": {
-  #       "timeKey": "ts",
-  #       "levelKey": "level",
-  #       "nameKey": "logger",
-  #       "callerKey": "caller",
-  #       "messageKey": "msg",
-  #       "stacktraceKey": "stacktrace",
-  #       "lineEnding": "",
-  #       "levelEncoder": "",
-  #       "timeEncoder": "iso8601",
-  #       "durationEncoder": "",
-  #       "callerEncoder": ""
-  #     }
-  #   }
-  
-  # Log level overrides
-  # For all components except the autoscaler and queue proxy, 
-  # changes are be picked up immediately.
-  # For autoscaler and queue proxy, changes require recreation of the pods.
-  # loglevel.controller: "info"
-  # loglevel.autoscaler: "info"
-  # loglevel.queueproxy: "info"
-  # loglevel.webhook: "info"
-  # loglevel.activator: "info"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # For all components except the autoscaler and queue proxy,
+    # changes are be picked up immediately.
+    # For autoscaler and queue proxy, changes require recreation of the pods.
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,42 +20,56 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
-  # Specifies the IP ranges that Istio sidecar will intercept.
-  # Replace this with the IP ranges of your cluster (see below for some examples).
-  # Separate multiple entries with a comma.
-  # Example: "10.4.0.0/14,10.7.240.0/20"
-  # 
-  # If set to "*" Istio will intercept all traffic within
-  # the cluster as well as traffic that is going outside the cluster.
-  # Traffic going outside the cluster will be blocked unless
-  # necessary egress rules are created. 
-  #
-  # If omitted or set to "", value of global.proxy.includeIPRanges
-  # provided at Istio deployment time is used. In default Knative serving
-  # deployment, global.proxy.includeIPRanges value is set to "*".
-  # 
-  # If an invalid value is passed, "" is used instead.
-  # 
-  # If valid set of IP address ranges are put into this value,
-  # Istio will no longer intercept traffic going to IP addresses
-  # outside the provided ranges and there is no need to specify
-  # egress rules.
-  # 
-  # To determine the IP ranges of your cluster:
-  #   IBM Cloud Private: cat cluster/config.yaml | grep service_cluster_ip_range
-  #   IBM Cloud Kubernetes Service: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
-  #   Google Container Engine (GKE): gcloud container clusters describe XXXXXXX --zone=XXXXXX | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
-  #   Azure Kubernetes Service (AKS): "10.0.0.0/16"
-  #   Azure Container Service (ACS; deprecated): "10.244.0.0/16,10.240.0.0/16"
-  #   Azure Container Service Engine (ACS-Engine; OSS): Configurable, but defaults to "10.0.0.0/16"
-  #   Minikube: "10.0.0.1/24"
-  # 
-  # For more information, visit
-  # https://istio.io/docs/tasks/traffic-management/egress/
-  #
-  # istio.sidecar.includeOutboundIPRanges: "*"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # istio.sidecar.includeOutboundIPRanges specifies the IP ranges that Istio sidecar
+    # will intercept.
+    #
+    # Replace this with the IP ranges of your cluster (see below for some examples).
+    # Separate multiple entries with a comma.
+    # Example: "10.4.0.0/14,10.7.240.0/20"
+    #
+    # If set to "*" Istio will intercept all traffic within
+    # the cluster as well as traffic that is going outside the cluster.
+    # Traffic going outside the cluster will be blocked unless
+    # necessary egress rules are created.
+    #
+    # If omitted or set to "", value of global.proxy.includeIPRanges
+    # provided at Istio deployment time is used. In default Knative serving
+    # deployment, global.proxy.includeIPRanges value is set to "*".
+    #
+    # If an invalid value is passed, "" is used instead.
+    #
+    # If valid set of IP address ranges are put into this value,
+    # Istio will no longer intercept traffic going to IP addresses
+    # outside the provided ranges and there is no need to specify
+    # egress rules.
+    #
+    # To determine the IP ranges of your cluster:
+    #   IBM Cloud Private: cat cluster/config.yaml | grep service_cluster_ip_range
+    #   IBM Cloud Kubernetes Service: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
+    #   Google Container Engine (GKE): gcloud container clusters describe XXXXXXX --zone=XXXXXX | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
+    #   Azure Kubernetes Service (AKS): "10.0.0.0/16"
+    #   Azure Container Service (ACS; deprecated): "10.244.0.0/16,10.240.0.0/16"
+    #   Azure Container Service Engine (ACS-Engine; OSS): Configurable, but defaults to "10.0.0.0/16"
+    #   Minikube: "10.0.0.1/24"
+    #
+    # For more information, visit
+    # https://istio.io/docs/tasks/traffic-management/egress/
+    #
+    istio.sidecar.includeOutboundIPRanges: "*"
+

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -20,86 +20,91 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 
-# This sample data shows the kinds of things that can be set in this ConfigMap,
-# but it should be replaced with proper documentation and a pointer to that left
-# here.  The Knative ConfigMap resources should be left empty for the reasons
-# outlined here: https://github.com/knative/serving/issues/2668
-# data:
-  # LOGGING CONFIGURATION
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
 
-  # Static parameters:
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
 
-  # enable-var-log-collection defaults to false. A fluentd sidecar
-  # will be set up to collect var log if this flag is true.
-  # logging.enable-var-log-collection: "false"
+    # logging.enable-var-log-collection defaults to false.
+    # A fluentd sidecar will be set up to collect var log if
+    # this flag is true.
+    logging.enable-var-log-collection: false
 
-  # The fluentd sidecar image used to collect logs from /var/log as a sidecar.
-  # Must be presented if logging.enable-var-log-collection is true.
-  # KEEP THIS CONSISTENT WITH 999-cache.yaml
-  # TODO(mattmoor): Devise a way to test that this (and others like it)
-  # stay in sync.
-  # logging.fluentd-sidecar-image: "k8s.gcr.io/fluentd-elasticsearch:v2.0.4"
+    # logging.fluentd-sidecar-image provides the fluentd sidecar image
+    # to inject as a sidecar to collect logs from /var/log.
+    # Must be presented if logging.enable-var-log-collection is true.
+    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
 
-  # The fluentd sidecar output config to specify logging destination.
-  # logging.fluentd-sidecar-output-config: |
-  #   # Parse json log before sending to Elastic Search
-  #   <filter **>
-  #     @type parser
-  #     key_name log
-  #     <parse>
-  #       @type multi_format
-  #       <pattern>
-  #         format json
-  #         time_key fluentd-time # fluentd-time is reserved for structured logs
-  #         time_format %Y-%m-%dT%H:%M:%S.%NZ
-  #       </pattern>
-  #       <pattern>
-  #         format none
-  #         message_key log
-  #       </pattern>
-  #     </parse>
-  #   </filter>
-  #   # Send to Elastic Search
-  #   <match **>
-  #     @id elasticsearch
-  #     @type elasticsearch
-  #     @log_level info
-  #     include_tag_key true
-  #     # Elasticsearch service is in monitoring namespace.
-  #     host elasticsearch-logging.knative-monitoring
-  #     port 9200
-  #     logstash_format true
-  #     <buffer>
-  #       @type file
-  #       path /var/log/fluentd-buffers/kubernetes.system.buffer
-  #       flush_mode interval
-  #       retry_type exponential_backoff
-  #       flush_thread_count 2
-  #       flush_interval 5s
-  #       retry_forever
-  #       retry_max_interval 30
-  #       chunk_limit_size 2M
-  #       queue_limit_length 8
-  #       overflow_action block
-  #     </buffer>
-  #   </match>
+    # logging.fluentd-sidecar-output-config provides the configuration
+    # for the fluentd sidecar, which will be placed into a configmap and
+    # mounted into the fluentd sidecar image.
+    logging.fluentd-sidecar-output-config: |
+      # Parse json log before sending to Elastic Search
+      <filter **>
+        @type parser
+        key_name log
+        <parse>
+          @type multi_format
+          <pattern>
+            format json
+            time_key fluentd-time # fluentd-time is reserved for structured logs
+            time_format %Y-%m-%dT%H:%M:%S.%NZ
+          </pattern>
+          <pattern>
+            format none
+            message_key log
+          </pattern>
+        </parse>
+      </filter>
+      # Send to Elastic Search
+      <match **>
+        @id elasticsearch
+        @type elasticsearch
+        @log_level info
+        include_tag_key true
+        # Elasticsearch service is in monitoring namespace.
+        host elasticsearch-logging.knative-monitoring
+        port 9200
+        logstash_format true
+        <buffer>
+          @type file
+          path /var/log/fluentd-buffers/kubernetes.system.buffer
+          flush_mode interval
+          retry_type exponential_backoff
+          flush_thread_count 2
+          flush_interval 5s
+          retry_forever
+          retry_max_interval 30
+          chunk_limit_size 2M
+          queue_limit_length 8
+          overflow_action block
+        </buffer>
+      </match>
 
-  # The revision log url template, where ${REVISION_UID} will be replaced by the actual
-  # revision uid. For the url to work you'll need to set up monitoring and have access to
-  # the kibana dashboard using `kubectl proxy`.
-  # logging.revision-url-template: |
-  #   http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    # This value is what you might use the the Knative monitoring bundle, and provides
+    # access to Kibana after setting up kubectl proxy.
+    logging.revision-url-template: |
+      http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
 
-  # METRICS CONFIGURATION
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
 
-  # metrics.backend-destination field specifies the system metrics destination.
-  # It defaults to prometheus. If this is stackdriver, the metrics will be sent
-  # to stackdriver. "prometheus" and "stackdriver" are supported. This field 
-  # is required.
-  # metrics.backend-destination: "prometheus"
-
-  # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
-  # field is optional. When running on GKE, application default credentials will be
-  # used if this field is not provided.
-  # Note: Using stackdriver will incur additional charges
-  # metrics.stackdriver-project-id: "<your stackdriver project id>" 
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -211,8 +211,11 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestOurConfig(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, ConfigName)
+	cm, example := ConfigMapsFromTestFile(t, ConfigName)
 	if _, err := NewConfigFromConfigMap(cm); err != nil {
-		t.Errorf("NewConfigFromConfigMap() = %v", err)
+		t.Errorf("NewConfigFromConfigMap(actual) = %v", err)
+	}
+	if _, err := NewConfigFromConfigMap(example); err != nil {
+		t.Errorf("NewConfigFromConfigMap(example) = %v", err)
 	}
 }

--- a/pkg/gc/config_test.go
+++ b/pkg/gc/config_test.go
@@ -26,13 +26,14 @@ import (
 )
 
 func TestOurConfig(t *testing.T) {
+	actual, example := ConfigMapsFromTestFile(t, "config-gc")
 	for _, tt := range []struct {
 		name string
 		fail bool
 		want Config
 		data *corev1.ConfigMap
 	}{{
-		name: "Standard config",
+		name: "actual config",
 		fail: false,
 		want: Config{
 			StaleRevisionCreateDelay:        24 * time.Hour,
@@ -40,7 +41,17 @@ func TestOurConfig(t *testing.T) {
 			StaleRevisionMinimumGenerations: 1,
 			StaleRevisionLastpinnedDebounce: 5 * time.Hour,
 		},
-		data: ConfigMapFromTestFile(t, "config-gc"),
+		data: actual,
+	}, {
+		name: "example config",
+		fail: false,
+		want: Config{
+			StaleRevisionCreateDelay:        24 * time.Hour,
+			StaleRevisionTimeout:            15 * time.Hour,
+			StaleRevisionMinimumGenerations: 1,
+			StaleRevisionLastpinnedDebounce: 5 * time.Hour,
+		},
+		data: example,
 	}, {
 		name: "With value overrides",
 		want: Config{

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -159,13 +159,18 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestOurConfig(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, ConfigName)
-	cfg, err := NewConfigFromConfigMap(cm)
-	if err != nil {
+	cm, example := ConfigMapsFromTestFile(t, ConfigName)
+
+	if cfg, err := NewConfigFromConfigMap(cm); err != nil {
 		t.Errorf("Expected no errors. got: %v", err)
+	} else if cfg == nil {
+		t.Errorf("NewConfigFromConfigMap(actual) = %v, want non-nil", cfg)
 	}
-	if cfg == nil {
-		t.Errorf("NewConfigFromConfigMap() = %v, want non-nil", cfg)
+
+	if cfg, err := NewConfigFromConfigMap(example); err != nil {
+		t.Errorf("Expected no errors. got: %v", err)
+	} else if cfg == nil {
+		t.Errorf("NewConfigFromConfigMap(example) = %v, want non-nil", cfg)
 	}
 }
 

--- a/pkg/reconciler/testing/configmap.go
+++ b/pkg/reconciler/testing/configmap.go
@@ -16,17 +16,31 @@ package testing
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+// TODO(mattmoor): Move this into `knative/pkg/configmap`
+const exampleKey = "_example"
 
 // ConfigMapFromTestFile creates a v1.ConfigMap from a YAML file
 // It loads the YAML file from the testdata folder.
 func ConfigMapFromTestFile(t *testing.T, name string, allowed ...string) *corev1.ConfigMap {
+	t.Helper()
+
+	cm, _ := ConfigMapsFromTestFile(t, name, allowed...)
+	return cm
+}
+
+// configMapsFromTestFile creates two corev1.ConfigMap resources from the config
+// file read from the testdata directory:
+// 1. The raw configmap read in.
+// 2. A second version of the configmap augmenting `data:` with what's parsed from the value of `_example:`
+func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*corev1.ConfigMap, *corev1.ConfigMap) {
 	t.Helper()
 
 	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", name))
@@ -34,38 +48,51 @@ func ConfigMapFromTestFile(t *testing.T, name string, allowed ...string) *corev1
 		t.Fatalf("ReadFile() = %v", err)
 	}
 
-	var cm corev1.ConfigMap
+	var orig corev1.ConfigMap
 
 	// Use github.com/ghodss/yaml since it reads json struct
 	// tags so things unmarshal properly
-	if err := yaml.Unmarshal(b, &cm); err != nil {
+	if err := yaml.Unmarshal(b, &orig); err != nil {
 		t.Fatalf("yaml.Unmarshal() = %v", err)
 	}
 
-	if len(cm.Data) != len(allowed) {
+	// We expect each of the allowed keys, and a key holding an example
+	// configuration for us to validate.
+	allowed = append(allowed, exampleKey)
+
+	if len(orig.Data) != len(allowed) {
 		// See here for why we only check in empty ConfigMaps:
 		// https://github.com/knative/serving/issues/2668
-		t.Errorf("Data = %v, wanted allowed", cm.Data)
+		t.Errorf("Data = %v, wanted %v", orig.Data, allowed)
 	}
 	allow := sets.NewString(allowed...)
-	for key := range cm.Data {
+	for key := range orig.Data {
 		if !allow.Has(key) {
 			t.Errorf("Encountered key %q in %q that wasn't on the allowed list", key, name)
 		}
 	}
+	// With the length and membership checks, we know that the keyspace matches.
 
-	// If the ConfigMap has no data entries, then make sure we don't have
-	// a `data:` key, or it will undo the whole motivation for leaving the
-	// data empty: https://github.com/knative/serving/issues/2668
-	if len(cm.Data) == 0 {
-		var u unstructured.Unstructured
-		if err := yaml.Unmarshal(b, &u); err != nil {
-			t.Errorf("yaml.Unmarshal(%q) = %v", name, err)
-		}
-		if _, ok := u.Object["data"]; ok {
-			t.Errorf("%q should omit its empty `data:` section.", name)
+	exampleBody := orig.Data[exampleKey]
+	// Check that exampleBody does not have lines that end in a trailing space,
+	for i, line := range strings.Split(exampleBody, "\n") {
+		if strings.HasSuffix(line, " ") {
+			t.Errorf("line %d of %q example contains trailing spaces", i, name)
 		}
 	}
 
-	return &cm
+	// Parse exampleBody into exemplar.Data
+	exemplar := orig.DeepCopy()
+	if err := yaml.Unmarshal([]byte(exampleBody), &exemplar.Data); err != nil {
+		t.Fatalf("yaml.Unmarshal() = %v", err)
+	}
+	// Augment the sample with actual configuration
+	for k, v := range orig.Data {
+		if _, ok := exemplar.Data[k]; ok {
+			continue
+		}
+		exemplar.Data[k] = v
+	}
+
+	return &orig, exemplar
 }

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
@@ -28,10 +28,14 @@ import (
 )
 
 func TestIstio(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, IstioConfigName)
+	cm, example := ConfigMapsFromTestFile(t, IstioConfigName)
 
 	if _, err := NewIstioFromConfigMap(cm); err != nil {
-		t.Errorf("NewIstioFromConfigMap() = %v", err)
+		t.Errorf("NewIstioFromConfigMap(actual) = %v", err)
+	}
+
+	if _, err := NewIstioFromConfigMap(example); err != nil {
+		t.Errorf("NewIstioFromConfigMap(example) = %v", err)
 	}
 }
 

--- a/pkg/reconciler/v1alpha1/revision/config/controller_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/controller_test.go
@@ -30,10 +30,14 @@ import (
 var noSidecarImage = ""
 
 func TestControllerConfigurationFromFile(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, ControllerConfigName, queueSidecarImageKey)
+	cm, example := ConfigMapsFromTestFile(t, ControllerConfigName, queueSidecarImageKey)
 
 	if _, err := NewControllerConfigFromConfigMap(cm); err != nil {
-		t.Errorf("NewControllerConfigFromConfigMap() = %v", err)
+		t.Errorf("NewControllerConfigFromConfigMap(actual) = %v", err)
+	}
+
+	if _, err := NewControllerConfigFromConfigMap(example); err != nil {
+		t.Errorf("NewControllerConfigFromConfigMap(example) = %v", err)
 	}
 }
 

--- a/pkg/reconciler/v1alpha1/revision/config/network_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/network_test.go
@@ -28,10 +28,13 @@ import (
 )
 
 func TestOurNetwork(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, NetworkConfigName)
+	cm, example := ConfigMapsFromTestFile(t, NetworkConfigName)
 
 	if _, err := NewNetworkFromConfigMap(cm); err != nil {
-		t.Errorf("NewNetworkFromConfigMap() = %v", err)
+		t.Errorf("NewNetworkFromConfigMap(actual) = %v", err)
+	}
+	if _, err := NewNetworkFromConfigMap(example); err != nil {
+		t.Errorf("NewNetworkFromConfigMap(example) = %v", err)
 	}
 }
 

--- a/pkg/reconciler/v1alpha1/revision/config/observability_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/observability_test.go
@@ -28,10 +28,14 @@ import (
 )
 
 func TestOurObservability(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, ObservabilityConfigName)
+	cm, example := ConfigMapsFromTestFile(t, ObservabilityConfigName)
 
 	if _, err := NewObservabilityFromConfigMap(cm); err != nil {
-		t.Errorf("NewObservabilityFromConfigMap() = %v", err)
+		t.Errorf("NewObservabilityFromConfigMap(actual) = %v", err)
+	}
+
+	if _, err := NewObservabilityFromConfigMap(example); err != nil {
+		t.Errorf("NewObservabilityFromConfigMap(example) = %v", err)
 	}
 }
 

--- a/pkg/reconciler/v1alpha1/route/config/domain.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain.go
@@ -38,6 +38,10 @@ const (
 	// DefaultDomain holds the domain that Route's live under by default
 	// when no label selector-based options apply.
 	DefaultDomain = "example.com"
+
+	// The key that holds our example configuration.
+	// TODO(mattmoor): We should get this from knative/pkg/configmap
+	exampleKey = "_example"
 )
 
 // LabelSelector represents map of {key,value} pairs. A single {key,value} in the
@@ -76,6 +80,9 @@ func NewDomainFromConfigMap(configMap *corev1.ConfigMap) (*Domain, error) {
 	c := Domain{Domains: map[string]*LabelSelector{}}
 	hasDefault := false
 	for k, v := range configMap.Data {
+		if k == exampleKey {
+			continue
+		}
 		labelSelector := LabelSelector{}
 		err := yaml.Unmarshal([]byte(v), &labelSelector)
 		if err != nil {

--- a/pkg/reconciler/v1alpha1/route/config/domain_test.go
+++ b/pkg/reconciler/v1alpha1/route/config/domain_test.go
@@ -184,8 +184,11 @@ func TestLookupDomainForLabels(t *testing.T) {
 }
 
 func TestOurDomain(t *testing.T) {
-	cm := ConfigMapFromTestFile(t, DomainConfigName)
+	cm, example := ConfigMapsFromTestFile(t, DomainConfigName)
 	if _, err := NewDomainFromConfigMap(cm); err != nil {
-		t.Errorf("NewDomainFromConfigMap() = %v", err)
+		t.Errorf("NewDomainFromConfigMap(actual) = %v", err)
+	}
+	if _, err := NewDomainFromConfigMap(example); err != nil {
+		t.Errorf("NewDomainFromConfigMap(example) = %v", err)
 	}
 }


### PR DESCRIPTION
We expect advanced users to `kubectl edit` our configmaps to turn knobs, but a lot of the rich documentation we have in `config/config-*.yaml` is stripped by the time we are editting it on the cluster.

This incorporates a trick that @tcnghia and I devised that enables us to:
1. Preserve the rich documentation in the configmap at `kubectl edit` time,
1. Validate that the examples can be properly processed.

Our unit testing should now validate:
1. That every configmap has this `_example` block,
1. That every configmap's `_example` block would be well-structured if put into `data:`, and
1. That the `_example` block has no trailing whitespace (to work around a yaml roundtripping limitation so the presentation is as we want)

Fixes: https://github.com/knative/serving/issues/3066