### PR TITLE
Consistently use ObservedGeneration across our types and controllers.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -113,6 +113,12 @@ type PodAutoscalerStatus struct {
 	// state of the world.
 	// +optional
 	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty"`
+
+	// ObservedGeneration is the 'Generation' of the PodAutoscaler that
+	// was last processed by the controller. The observed generation is updated
+	// even if the controller failed to process the spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/networking/v1alpha1/clusteringress_types.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_types.go
@@ -261,6 +261,12 @@ type IngressStatus struct {
 	// LoadBalancer contains the current status of the load-balancer.
 	// +optional
 	LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
+
+	// ObservedGeneration is the 'Generation' of the ClusterIngress that
+	// was last processed by the controller. The observed generation is updated
+	// even if the controller failed to process the spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // LoadBalancerStatus represents the status of a load-balancer.

--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
@@ -172,6 +172,7 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 			}
 		}
 	}
+	pa.Status.ObservedGeneration = pa.Generation
 	return nil
 }
 

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -265,6 +265,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		pa.Status.MarkActive()
 	}
 
+	pa.Status.ObservedGeneration = pa.Generation
 	return nil
 }
 

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -199,6 +199,7 @@ func (c *Reconciler) reconcile(ctx context.Context, ci *v1alpha1.ClusterIngress)
 	// is successfully synced.
 	ci.Status.MarkNetworkConfigured()
 	ci.Status.MarkLoadBalancerReady(getLBStatus(gatewayServiceURLFromContext(ctx, ci)))
+	ci.Status.ObservedGeneration = ci.Generation
 	logger.Info("ClusterIngress successfully synced")
 	return nil
 }

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -400,6 +400,7 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 		}
 	}
 
+	rev.Status.ObservedGeneration = rev.Generation
 	return nil
 }
 

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -274,6 +274,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 		return err
 	}
 
+	r.Status.ObservedGeneration = r.Generation
 	logger.Info("Route successfully synced")
 	return nil
 }

--- a/test/states.go
+++ b/test/states.go
@@ -82,19 +82,19 @@ func TODO_ServiceTrafficToRevisionWithInClusterDNS(s *v1alpha1.Service) (bool, e
 // ready to serve traffic. It will return false if the status indicates a state other than deploying
 // or being ready. It will also return false if the type of the condition is unexpected.
 func IsRevisionReady(r *v1alpha1.Revision) (bool, error) {
-	return r.Status.IsReady(), nil
+	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
 // IsServiceReady will check the status conditions of the service and return true if the service is
 // ready. This means that its configurations and routes have all reported ready.
 func IsServiceReady(s *v1alpha1.Service) (bool, error) {
-	return s.Status.IsReady(), nil
+	return s.Generation == s.Status.ObservedGeneration && s.Status.IsReady(), nil
 }
 
 // IsRouteReady will check the status conditions of the route and return true if the route is
 // ready.
 func IsRouteReady(r *v1alpha1.Route) (bool, error) {
-	return r.Status.IsReady(), nil
+	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
 // ConfigurationHasCreatedRevision returns whether the Configuration has created a Revision.


### PR DESCRIPTION
WIP until https://github.com/knative/serving/pull/3075 merges