### PR TITLE
Introduce throttler in the activator (do not use it yet)

### DIFF
--- a/pkg/activator/testing/utils.go
+++ b/pkg/activator/testing/utils.go
@@ -21,11 +21,11 @@ import (
 )
 
 // GetTestEndpointsSubset generates the subsets of endpoints used for testing.
-// It return a list of desired number of subsets including the desired number of hosts per each subset.
+// It returns a list of desired number of subsets including the desired number of hosts per each subset.
 func GetTestEndpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {
 	resp := []v1.EndpointSubset{}
 	if hostsPerSubset > 0 {
-		addresses := GetTestAddresses(hostsPerSubset)
+		addresses := make([]v1.EndpointAddress, hostsPerSubset)
 		subset := v1.EndpointSubset{Addresses: addresses}
 		for s := 0; s < subsets; s++ {
 			resp = append(resp, subset)
@@ -33,12 +33,4 @@ func GetTestEndpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {
 		return resp
 	}
 	return resp
-}
-
-// GetTestAddresses generates endpoint addresses used for testing.
-func GetTestAddresses(hosts int) (endpoints []v1.EndpointAddress) {
-	for i := 0; i < hosts; i++ {
-		endpoints = append(endpoints, v1.EndpointAddress{})
-	}
-	return endpoints
 }

--- a/pkg/activator/testing/utils.go
+++ b/pkg/activator/testing/utils.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// GetTestEndpointsSubset generates the subsets of endpoints used for testing.
+// It return a list of desired number of subsets including the desired number of hosts per each subset.
+func GetTestEndpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {
+	resp := []v1.EndpointSubset{}
+	if hostsPerSubset > 0 {
+		addresses := GetTestAddresses(hostsPerSubset)
+		subset := v1.EndpointSubset{Addresses: addresses}
+		for s := 0; s < subsets; s++ {
+			resp = append(resp, subset)
+		}
+		return resp
+	}
+	return resp
+}
+
+// GetTestAddresses generates endpoint addresses used for testing.
+func GetTestAddresses(hosts int) (endpoints []v1.EndpointAddress) {
+	for i := 0; i < hosts; i++ {
+		endpoints = append(endpoints, v1.EndpointAddress{})
+	}
+	return endpoints
+}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activator
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	v1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/queue"
+	"github.com/knative/serving/pkg/reconciler"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	capacityUpdateFailure = "updating capacity failed"
+	OverloadMessage       = "activator overload"
+)
+
+// ThrottlerParams defines the parameters of the Throttler
+type ThrottlerParams struct {
+	BreakerParams queue.BreakerParams
+	Logger        *zap.SugaredLogger
+	GetEndpoints  func(RevisionID) (int32, error)
+	GetRevision   func(RevisionID) (*v1alpha1.Revision, bool, error)
+}
+
+// NewThrottler creates a new Throttler
+func NewThrottler(params ThrottlerParams) *Throttler {
+	breakers := make(map[RevisionID]*queue.Breaker)
+	return &Throttler{breakers: breakers, breakerParams: params.BreakerParams, logger: params.Logger, getEndpoints: params.GetEndpoints, getRevision: params.GetRevision}
+}
+
+// Throttler keeps the mapping of Revisions to Breakers
+// and allows updating max concurrency dynamically of respective Breakers.
+// Max concurrency is essentially the number of semaphore tokens the Breaker has in rotation.
+// The manipulation of the parameter is done via `UpdateCapacity()` method.
+// It enables the use case to start with max concurrency set to 0 (no requests are sent because no endpoints are available)
+// and gradually increase its value depending on the external condition (e.g. new endpoints become available)
+type Throttler struct {
+	breakers      map[RevisionID]*queue.Breaker
+	breakerParams queue.BreakerParams
+	logger        *zap.SugaredLogger
+	getEndpoints  func(RevisionID) (int32, error)
+	getRevision   func(RevisionID) (*v1alpha1.Revision, bool, error)
+	mux           sync.Mutex
+}
+
+// Remove deletes the breaker from the bookkeeping
+func (t *Throttler) Remove(rev RevisionID) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	delete(t.breakers, rev)
+}
+
+// UpdateCapacity updates the max concurrency of the Breaker corresponding to a revision.
+func (t *Throttler) UpdateCapacity(rev RevisionID, size int32) error {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	_, err := t.updateCapacity(rev, size)
+	return err
+}
+
+// This method updates Breaker's concurrency and requires external synchronization, e.g. use the mux.
+// It create a new breaker and saves it into our bookkeeping if doesn't exist.
+// This is important for not loosing the update signals
+// that came before the requests reached the Activator's Handler.
+func (t *Throttler) updateCapacity(rev RevisionID, size int32) (breaker *queue.Breaker, err error) {
+	revision, exists, err := t.getRevision(rev)
+	if err != nil {
+		return breaker, err
+	}
+	if !exists {
+		return breaker, fmt.Errorf("no revision was found for: %s", rev)
+	}
+	cc := int32(revision.Spec.ContainerConcurrency)
+	// The concurrency is unlimited, thus hand out as many tokens as we can in this breaker.
+	if cc == 0 {
+		cc = t.breakerParams.MaxConcurrency
+	}
+	breaker, ok := t.breakers[rev]
+	if !ok {
+		breaker = queue.NewBreaker(t.breakerParams)
+		t.breakers[rev] = breaker
+	}
+	delta := size*cc - breaker.Capacity()
+	// Do not update throttler's concurrency if the same number of endpoints is received
+	// or the number is negative.
+	if delta <= 0 {
+		return breaker, nil
+	}
+	if err := breaker.UpdateConcurrency(delta); err != nil {
+		return breaker, err
+	}
+	return breaker, nil
+}
+
+// Try potentially registers a new breaker in our bookkeeping
+// and executes the `function` on the Breaker.
+// It returns an error if either breaker doesn't have enough capacity,
+// or breaker's registration didn't succeed, e.g. getting endpoints or update capacity failed.
+func (t *Throttler) Try(rev RevisionID, function func()) error {
+	breaker, err := t.getOrCreateBreaker(rev)
+	if err != nil {
+		return err
+	}
+	if ok := breaker.Maybe(function); !ok {
+		return errors.New(OverloadMessage)
+	}
+	return nil
+}
+
+// Get existing breaker or create a new one.
+// In the latter case fetch the endpoints and update the capacity of the newly created breaker.
+// This avoids a potential deadlock in case if we missed the updates from the Endpoints informer.
+// This could happen because of a restart of the Activator or when a new one is added as part of scale out.
+func (t *Throttler) getOrCreateBreaker(rev RevisionID) (breaker *queue.Breaker, err error) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	breaker, ok := t.breakers[rev]
+	if !ok {
+		size, err := t.getEndpoints(rev)
+		if err != nil {
+			return breaker, err
+		}
+		breaker, err = t.updateCapacity(rev, size)
+		if err != nil {
+			return breaker, err
+		}
+	}
+	return breaker, err
+}
+
+// UpdateEndpoints is a handler function to be used by the Endpoints informer.
+// It updates the endpoints in the Throttler if the number of hosts changed and
+// the revision already exists (we don't want to create/update throttlers for the endpoints
+// that do not belong to any revision).
+func UpdateEndpoints(throttler *Throttler) func(oldObj, newObj interface{}) {
+	return func(oldObj, newObj interface{}) {
+		endpoints := newObj.(*corev1.Endpoints)
+		addresses := EndpointsAddressCount(endpoints.Subsets)
+		revID := RevisionID{endpoints.Namespace, reconciler.GetServingRevisionNameForK8sService(endpoints.Name)}
+		_, exists, err := throttler.getRevision(revID)
+		if err != nil {
+			throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
+			return
+		}
+		// Only update capacity if it is a registered revision.
+		if exists {
+			err := throttler.UpdateCapacity(revID, int32(addresses))
+			if err != nil {
+				throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
+			}
+		}
+	}
+}
+
+// DeleteBreaker is a handler function to be used by the Endpoints informer.
+// It removes the Breaker from the Throttler bookkeeping.
+func DeleteBreaker(throttler *Throttler) func(obj interface{}) {
+	return func(obj interface{}) {
+		rev := obj.(*v1alpha1.Revision)
+		revID := RevisionID{rev.Namespace, rev.Name}
+		throttler.Remove(revID)
+	}
+}
+
+// EndpointsAddressCount returns the total number of addresses registered for the endpoint.
+func EndpointsAddressCount(subsets []corev1.EndpointSubset) int {
+	var total int
+	for _, subset := range subsets {
+		total += len(subset.Addresses)
+	}
+	return total
+}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -143,8 +143,7 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 	if err != nil {
 		return err
 	}
-	err = t.updateCapacity(revision, breaker, size)
-	if err != nil {
+	if err = t.updateCapacity(revision, breaker, size); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activator
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/knative/pkg/logging/testing"
+	testinghelper "github.com/knative/serving/pkg/activator/testing"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	v1alpha12 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/queue"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	revID = RevisionID{"good-namespace", "good-name"}
+
+	sampleError = "some error"
+
+	existingRevisionGetter = func(concurrency v1alpha1.RevisionContainerConcurrencyType) func(RevisionID) (*v1alpha12.Revision, bool, error) {
+		return func(RevisionID) (*v1alpha12.Revision, bool, error) {
+			revision := &v1alpha12.Revision{Spec: v1alpha12.RevisionSpec{ContainerConcurrency: concurrency}}
+			return revision, true, nil
+		}
+	}
+	nonExistingRevisionGetter = func(RevisionID) (*v1alpha12.Revision, bool, error) {
+		revision := &v1alpha12.Revision{}
+		return revision, false, nil
+	}
+	initCapacity            = int32(0)
+	existingEndpointsGetter = func(RevisionID) (int32, error) {
+		return initCapacity, nil
+	}
+	nonExistingEndpointsGetter = func(RevisionID) (int32, error) {
+		return initCapacity, errors.New(sampleError)
+	}
+)
+
+const (
+	defaultMaxConcurrency = int32(10)
+)
+
+func TestThrottler_UpdateCapacity(t *testing.T) {
+	samples := []struct {
+		label           string
+		revisionGetter  func(RevisionID) (*v1alpha12.Revision, bool, error)
+		endpointsGetter func(RevisionID) (int32, error)
+		maxConcurrency  int32
+		want            int32
+		wantError       string
+	}{
+		{
+			label:           "all good",
+			revisionGetter:  existingRevisionGetter(10),
+			endpointsGetter: existingEndpointsGetter,
+			maxConcurrency:  defaultMaxConcurrency,
+			want:            int32(10),
+		},
+		{
+			label:           "unlimited concurrency",
+			revisionGetter:  existingRevisionGetter(0),
+			endpointsGetter: existingEndpointsGetter,
+			maxConcurrency:  100,
+			want:            int32(100),
+		},
+		{
+			label:           "non-existing revision",
+			revisionGetter:  nonExistingRevisionGetter,
+			endpointsGetter: existingEndpointsGetter,
+			maxConcurrency:  defaultMaxConcurrency,
+			want:            int32(0),
+			wantError:       fmt.Sprintf("no revision was found for: %s", revID),
+		},
+	}
+	for _, s := range samples {
+		t.Run(s.label, func(t *testing.T) {
+			var received string
+			want := s.want
+			throttler := getThrottler(s.maxConcurrency, s.revisionGetter, s.endpointsGetter, t)
+			err := throttler.UpdateCapacity(revID, 1)
+			if s.wantError != "" {
+				received = err.Error()
+			}
+			if received != s.wantError {
+				t.Errorf("Expected error in Update capacity. Want %s, got %s", s.wantError, err.Error())
+			}
+			if want > 0 {
+				breaker, _ := throttler.breakers[revID]
+				got := breaker.Capacity()
+				if got != want {
+					t.Errorf("Unexpected capacity of the breaker. Want %d, got %d", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestThrottler_Try(t *testing.T) {
+	samples := []struct {
+		label           string
+		addCapacity     bool
+		wantBreakers    int32
+		wantError       string
+		revisionGetter  func(RevisionID) (*v1alpha12.Revision, bool, error)
+		endpointsGetter func(RevisionID) (int32, error)
+	}{
+		{
+			label:           "all good",
+			addCapacity:     true,
+			wantBreakers:    int32(1),
+			wantError:       "",
+			revisionGetter:  existingRevisionGetter(10),
+			endpointsGetter: existingEndpointsGetter,
+		},
+		{
+			label:           "non-existing revision",
+			addCapacity:     true,
+			wantBreakers:    int32(0),
+			wantError:       fmt.Sprintf("no revision was found for: %s", revID),
+			revisionGetter:  nonExistingRevisionGetter,
+			endpointsGetter: existingEndpointsGetter,
+		},
+		{
+			label:           "non-existing endpoint",
+			addCapacity:     false,
+			wantBreakers:    int32(0),
+			wantError:       sampleError,
+			revisionGetter:  existingRevisionGetter(10),
+			endpointsGetter: nonExistingEndpointsGetter,
+		},
+	}
+	for _, s := range samples {
+		t.Run(s.label, func(t *testing.T) {
+			var got int32
+			var received string
+			want := s.wantBreakers
+			throttler := getThrottler(defaultMaxConcurrency, s.revisionGetter, s.endpointsGetter, t)
+			if s.addCapacity {
+				throttler.UpdateCapacity(revID, 1)
+			}
+			err := throttler.Try(revID, func() {
+				got++
+			})
+			if s.wantError != "" {
+				received = err.Error()
+			}
+			if received != s.wantError {
+				t.Errorf("Expected error in the Try. Want %s, got %s", s.wantError, received)
+			}
+			if got != want {
+				t.Errorf("Unexpected number of function runs in Try. Want %d, got %d", want, got)
+			}
+		})
+	}
+}
+
+func TestThrottler_Remove(t *testing.T) {
+	throttler := getThrottler(defaultMaxConcurrency, existingRevisionGetter(10), existingEndpointsGetter, t)
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	got := len(throttler.breakers)
+	if got != 1 {
+		t.Errorf("Unexpected number of Breakers was created. Want %d, got %d", 1, got)
+	}
+	throttler.Remove(revID)
+	got = len(throttler.breakers)
+	if got != 0 {
+		t.Errorf("Unexpected number of Breakers was created. Want %d, got %d", 0, got)
+	}
+}
+
+func TestHelper_UpdateEndpoints(t *testing.T) {
+	want := int32(10)
+	throttler := getThrottler(defaultMaxConcurrency, existingRevisionGetter(10), existingEndpointsGetter, t)
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	updater := UpdateEndpoints(throttler)
+
+	endpointsBefore := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(0, 1)}
+	endpointsAfter := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(1, 1)}
+	updater(&endpointsBefore, &endpointsAfter)
+
+	breaker, _ := throttler.breakers[revID]
+	got := breaker.Capacity()
+	if got != want {
+		t.Errorf("Unexpected Breaker capacity received. Want %d, got %d", want, got)
+	}
+}
+
+func TestHelper_UpdateEndpoints_WithDeltaMoreThenOne(t *testing.T) {
+	want := int32(20)
+	throttler := getThrottler(int32(20), existingRevisionGetter(10), existingEndpointsGetter, t)
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	updater := UpdateEndpoints(throttler)
+
+	endpointsBefore := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(0, 1)}
+	endpointsAfter := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(2, 1)}
+	updater(&endpointsBefore, &endpointsAfter)
+
+	breaker, _ := throttler.breakers[revID]
+	got := breaker.Capacity()
+	if got != want {
+		t.Errorf("Unexpected Breaker capacity received. Want %d, got %d", want, got)
+	}
+}
+
+func TestHelper_DeleteBreaker(t *testing.T) {
+	throttler := getThrottler(int32(20), existingRevisionGetter(10), existingEndpointsGetter, t)
+	revision := &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      revID.Name,
+			Namespace: revID.Namespace,
+		},
+	}
+	revID := RevisionID{Namespace: revID.Namespace, Name: revID.Name}
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	if len(throttler.breakers) != 1 {
+		t.Errorf("Breaker map size didn't change. Wanted %d, got %d", 1, len(throttler.breakers))
+	}
+	deleter := DeleteBreaker(throttler)
+	deleter(revision)
+	if len(throttler.breakers) != 0 {
+		t.Error("Breaker map is not empty")
+	}
+}
+
+func getThrottler(maxConcurrency int32, revisionGetter func(RevisionID) (*v1alpha12.Revision, bool, error), endpointsGetter func(RevisionID) (int32, error), t *testing.T) *Throttler {
+	logger := TestLogger(t)
+	params := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: maxConcurrency, InitialCapacity: initCapacity}
+	throttlerParams := ThrottlerParams{BreakerParams: params, Logger: logger, GetRevision: revisionGetter, GetEndpoints: endpointsGetter}
+	return NewThrottler(throttlerParams)
+}

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -67,30 +67,26 @@ func TestThrottler_UpdateCapacity(t *testing.T) {
 		maxConcurrency  int32
 		want            int32
 		wantError       string
-	}{
-		{
-			label:           "all good",
-			revisionGetter:  existingRevisionGetter(10),
-			endpointsGetter: existingEndpointsGetter,
-			maxConcurrency:  defaultMaxConcurrency,
-			want:            int32(10),
-		},
-		{
-			label:           "unlimited concurrency",
-			revisionGetter:  existingRevisionGetter(0),
-			endpointsGetter: existingEndpointsGetter,
-			maxConcurrency:  100,
-			want:            int32(100),
-		},
-		{
-			label:           "non-existing revision",
-			revisionGetter:  nonExistingRevisionGetter,
-			endpointsGetter: existingEndpointsGetter,
-			maxConcurrency:  defaultMaxConcurrency,
-			want:            int32(0),
-			wantError:       sampleError,
-		},
-	}
+	}{{
+		label:           "all good",
+		revisionGetter:  existingRevisionGetter(10),
+		endpointsGetter: existingEndpointsGetter,
+		maxConcurrency:  defaultMaxConcurrency,
+		want:            int32(10),
+	}, {
+		label:           "unlimited concurrency",
+		revisionGetter:  existingRevisionGetter(0),
+		endpointsGetter: existingEndpointsGetter,
+		maxConcurrency:  100,
+		want:            int32(100),
+	}, {
+		label:           "non-existing revision",
+		revisionGetter:  nonExistingRevisionGetter,
+		endpointsGetter: existingEndpointsGetter,
+		maxConcurrency:  defaultMaxConcurrency,
+		want:            int32(0),
+		wantError:       sampleError,
+	}}
 	for _, s := range samples {
 		t.Run(s.label, func(t *testing.T) {
 			want := s.want

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -25,14 +25,17 @@ import (
 
 const suffix = "-service"
 
+// GetK8sServiceFullname returns service full name
 func GetK8sServiceFullname(name string, namespace string) string {
 	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, utils.GetClusterDomainName())
 }
 
+// GetServingK8SServiceNameForObj returns the service name for the object
 func GetServingK8SServiceNameForObj(name string) string {
 	return name + suffix
 }
 
+// GetServingRevisionNameForK8sService returns the revision name from the service name
 func GetServingRevisionNameForK8sService(name string) string {
 	return strings.Split(name, suffix)[0]
 }

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -20,12 +20,19 @@ import (
 	"fmt"
 
 	"github.com/knative/serving/pkg/utils"
+	"strings"
 )
+
+const suffix = "-service"
 
 func GetK8sServiceFullname(name string, namespace string) string {
 	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, utils.GetClusterDomainName())
 }
 
 func GetServingK8SServiceNameForObj(name string) string {
-	return name + "-service"
+	return name + suffix
+}
+
+func GetServingRevisionNameForK8sService(name string) string {
+	return strings.Split(name, suffix)[0]
 }

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -37,5 +37,5 @@ func GetServingK8SServiceNameForObj(name string) string {
 
 // GetServingRevisionNameForK8sService returns the revision name from the service name
 func GetServingRevisionNameForK8sService(name string) string {
-	return strings.Split(name, suffix)[0]
+	return strings.TrimSuffix(name, suffix)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
This PR doesn't change the existing behaviour of the Activator, rather introduces the throttler which will be integrated in the next PRs. This is the result of splitting https://github.com/knative/serving/pull/2653


* Add helper method to generate mock Endpoints for testing.
* Introduce throttler. The throttler manages the map of Breakers that are updated as new Endpoints get available.
* Add unit tests for the throttler.
* Update `names.go` to get revision name from the service, e.g. remove "-service" suffix.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Introduce throttler in the activator.
```
