### PR TITLE
Fixing autoscaler url

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/metrics"
 	"github.com/knative/serving/pkg/system"
+	"github.com/knative/serving/pkg/utils"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 )
@@ -150,7 +151,7 @@ func main() {
 	stopCh := signals.SetupSignalHandler()
 
 	// Open a websocket connection to the autoscaler
-	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.cluster.local:%s", "autoscaler", system.Namespace(), "8080")
+	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.%s:%s", "autoscaler", system.Namespace(), utils.GetClusterDomainName(), "8080")
 	logger.Infof("Connecting to autoscaler at %s", autoscalerEndpoint)
 	statSink = websocket.NewDurableSendingConnection(autoscalerEndpoint)
 	go statReporter(stopCh)


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Activator had a hardcoded  domain name `cluster.local` for autoscaler connection url. This PR changes is for a function which is returning real cluster domain name if a non default domain name is used, otherwise `cluster.local` is used.

```release-note
None
```
