### PR TITLE
removing hard coded cluster.local references

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -132,7 +132,7 @@ type RouteStatus struct {
 
 	// DeprecatedDomainInternal holds the top-level domain that will distribute traffic over the provided
 	// targets from inside the cluster. It generally has the form
-	// {route-name}.{route-namespace}.svc.cluster.local
+	// {route-name}.{route-namespace}.svc.{cluster-domain-name}
 	// DEPRECATED: Use Address instead.
 	// +optional
 	DeprecatedDomainInternal string `json:"domainInternal,omitempty"`

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -183,7 +183,7 @@ type ServiceStatus struct {
 	// From RouteStatus.
 	// DeprecatedDomainInternal holds the top-level domain that will distribute traffic over the provided
 	// targets from inside the cluster. It generally has the form
-	// {route-name}.{route-namespace}.svc.cluster.local
+	// {route-name}.{route-namespace}.svc.{cluster-domain-name}
 	// DEPRECATED: Use Address instead.
 	// +optional
 	DeprecatedDomainInternal string `json:"domainInternal,omitempty"`

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+        "github.com/knative/serving/pkg/utils"
 )
 
 const (
@@ -40,11 +41,11 @@ const (
 var (
 	defaultGateway = Gateway{
 		GatewayName: "knative-ingress-gateway",
-		ServiceURL:  "istio-ingressgateway.istio-system.svc.cluster.local",
+		ServiceURL:  fmt.Sprintf("istio-ingressgateway.istio-system.svc.%s", utils.GetClusterDomainName()),
 	}
 	defaultLocalGateway = Gateway{
 		GatewayName: "cluster-local-gateway",
-		ServiceURL:  "cluster-local-gateway.istio-system.svc.cluster.local",
+		ServiceURL:  fmt.Sprintf("cluster-local-gateway.istio-system.svc.%s", utils.GetClusterDomainName()),
 	}
 )
 
@@ -91,6 +92,7 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 
 // NewIstioFromConfigMap creates an Istio config from the supplied ConfigMap
 func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
+        
 	gateways, err := parseGateways(configMap, GatewayKeyPrefix)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/v1alpha1/route/README.md
+++ b/pkg/reconciler/v1alpha1/route/README.md
@@ -30,11 +30,19 @@ A valid Route object, when reconciled by Knative Route controller, will generate
 the following objects:
 
 - A VirtualService to realize the routing from the Gateway
-  `knative-shared-gateway` to the traffic target referenced in the Route.
+  `knative-ingress-gateway` to the traffic target referenced in the Route.
 - A Service with the same name as the Route, so that we can access the Route
   using `<route-name>.<route-namespace>.svc.<cluster-domain-name>`. This Service has no
   Pod, we use it solely to have a domain name and a cluster IP to be used in the
-  VirtualService.
+  VirtualService. The value of `<cluster-domain-name>` depends on a domain name
+  specified during the installation of the cluster. If no custom domain name was specified, then
+  `cluster.local` should be used as in the following example:
+  
+  `<route-name>.<route-namespace>.svc.cluster.local`
+  
+  otherwise cluster's custom domain name should be used:
+
+  `<route-name>.<route-namespace>.svc.real-domain-name.com`
 
 For example, if we have two Knative Revisions `hello-world-01` and
 `hello-world-02`, and one Route `hello-world` that directs traffic to both

--- a/pkg/reconciler/v1alpha1/route/README.md
+++ b/pkg/reconciler/v1alpha1/route/README.md
@@ -32,7 +32,7 @@ the following objects:
 - A VirtualService to realize the routing from the Gateway
   `knative-shared-gateway` to the traffic target referenced in the Route.
 - A Service with the same name as the Route, so that we can access the Route
-  using `<route-name>.<route-namespace>.svc.cluster.local`. This Service has no
+  using `<route-name>.<route-namespace>.svc.<cluster-domain-name>`. This Service has no
   Pod, we use it solely to have a domain name and a cluster IP to be used in the
   VirtualService.
 


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Removing additional hard coded `cluster.local` references.

```release-note
None
```
