### PR TITLE
Some readability nits, I didn't get a chance to comment

### DIFF
--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -76,8 +76,7 @@ func (t *Throttler) UpdateCapacity(rev RevisionID, size int32) error {
 		return err
 	}
 	breaker, _ := t.getOrCreateBreaker(rev)
-	err = t.updateCapacity(revision, breaker, size)
-	return err
+	return t.updateCapacity(revision, breaker, size)
 }
 
 // Try potentially registers a new breaker in our bookkeeping
@@ -92,7 +91,7 @@ func (t *Throttler) Try(rev RevisionID, function func()) error {
 			return err
 		}
 	}
-	if ok := breaker.Maybe(function); !ok {
+	if !breaker.Maybe(function) {
 		return errors.New(OverloadMessage)
 	}
 	return nil

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -31,7 +31,6 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -103,7 +102,7 @@ func TestThrottler_UpdateCapacity(t *testing.T) {
 			if s.want > 0 {
 				breaker, _ := throttler.breakers[revID]
 				if got := breaker.Capacity(); got != s.want {
-					t.Errorf("Breaker Capacity = %d, want %d", got, s.want)
+					t.Errorf("Breaker Capacity = %d, want: %d", got, s.want)
 				}
 			}
 		})
@@ -153,7 +152,7 @@ func TestThrottler_Try(t *testing.T) {
 			})
 			if s.wantError != "" {
 				if err == nil {
-					t.Fatal("Expected an error got nil")
+					t.Fatal("Expected error got nil")
 				}
 
 				if got := err.Error(); got != s.wantError {
@@ -184,7 +183,7 @@ func TestThrottler_TryOverload(t *testing.T) {
 			})
 		})
 	}
-	// Give the chance for the goroutines to launch. 
+	// Give the chance for the goroutines to launch.
 	time.Sleep(150 * time.Millisecond)
 	err := th.Try(revID, func() {
 		t.Fatal("This should not have executed")
@@ -196,7 +195,7 @@ func TestThrottler_TryOverload(t *testing.T) {
 	}
 	close(done)
 	if err := g.Wait(); err != nil {
-		t.Errorf("Unexpected error in the parallel requests: %v", err)
+		t.Errorf("Error in the parallel requests: %v", err)
 	}
 }
 
@@ -243,8 +242,8 @@ func TestUpdateEndpoints(t *testing.T) {
 		throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
 		updater := UpdateEndpoints(throttler)
 
-		endpointsBefore := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointBefore, 1)}
-		endpointsAfter := corev1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointsAfter, 1)}
+		endpointsBefore := corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointBefore, 1)}
+		endpointsAfter := corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointsAfter, 1)}
 		updater(&endpointsBefore, &endpointsAfter)
 
 		breaker, _ := throttler.breakers[revID]

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -78,7 +78,6 @@ func NewBreaker(params BreakerParams) *Breaker {
 // already consumed, Maybe returns immediately without calling thunk. If
 // the thunk was executed, Maybe returns true, else false.
 func (b *Breaker) Maybe(thunk func()) bool {
-
 	var t token
 	select {
 	default:


### PR DESCRIPTION
/lint
## Proposed Changes

* tests do "got... want", rather than vice versa
* reduce scope of some variables
* make sure err != nil, before calling err.Error(), otherwise a panic might ensue.
* other minor stuff.

/cc @dgerd @vvraskin 