### PR TITLE
Test "/etc/resolv.conf" in filesystem conformance.

### DIFF
--- a/test/conformance/filesystem_perm_test.go
+++ b/test/conformance/filesystem_perm_test.go
@@ -43,27 +43,44 @@ func verifyPermString(resp string, expected string) error {
 	return nil
 }
 
-func TestMustFileSystemPermissions(t *testing.T) {
-	logger := logging.GetContextLogger(t.Name())
-	clients := setup(t)
-	for key, value := range MustFilePathSpecs {
+func testFileSystemPermissions(clients *test.Clients, logger *logging.BaseLogger, paths map[string]FilePathInfo) error {
+	for key, value := range paths {
 		resp, _, err := fetchEnvInfo(clients, logger, test.EnvImageFilePathInfoPath+"?"+test.EnvImageFilePathQueryParam+"="+key, &test.Options{})
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 
 		var f FilePathInfo
 		err = json.Unmarshal(resp, &f)
 		if err != nil {
-			t.Fatalf("Error unmarshalling response: %v", err)
+			return fmt.Errorf("Error unmarshalling response: %v", err)
 		}
 
 		if f.IsDirectory != value.IsDirectory {
-			t.Fatalf("%s isDirectory mismatch. Expect : %t Received : %t", key, value.IsDirectory, f.IsDirectory)
+			return fmt.Errorf("%s isDirectory = %t, want: %t", key, f.IsDirectory, value.IsDirectory)
 		}
 
 		if err = verifyPermString(f.PermString[1:], value.PermString); err != nil {
-			t.Fatal(err)
+			return err
 		}
+	}
+	return nil
+}
+
+// TestMustHaveFileSystemPermissions asserts that the file system has all the MUST have paths and they have appropriate permissions.
+func TestMustHaveFileSystemPermissions(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	clients := setup(t)
+	if err := testFileSystemPermissions(clients, logger, MustFilePathSpecs); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestShouldHaveFileSystemPermissions asserts that the file system has all the SHOULD have paths and they have appropriate permissions.
+func TestShouldHaveFileSystemPermissions(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	clients := setup(t)
+	if err := testFileSystemPermissions(clients, logger, ShouldFilePathSpecs); err != nil {
+		t.Error(err)
 	}
 }

--- a/test/conformance/runtime_contract_types.go
+++ b/test/conformance/runtime_contract_types.go
@@ -47,4 +47,13 @@ var MustFilePathSpecs = map[string]FilePathInfo{
 		IsDirectory: true,
 		PermString:  "rw*rw*rw*", // * indicates no specification
 	},
+	// TODO(#822): Add conformance tests for "/dev/log".
+}
+
+// ShouldFilePathSpecs specifies the file-paths and expected permissions that SHOULD be set as specified in the run-time contract.
+var ShouldFilePathSpecs = map[string]FilePathInfo{
+	"/etc/resolv.conf": {
+		IsDirectory: false,
+		PermString:  "rw*r**r**", // * indicates no specification
+	},
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2976

## Proposed Changes

* Add a ShouldFilePathSpecs with "/etc/resolv.conf" to test/conformance/runtime_contract_types.go,
* Add a TestShouldFileSystemPermissions test case to test/conformance/filesystem_perm_test.go, which works exactly as TestMustFileSystemPermissions.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
