### PR TITLE
Add conformance test to validate sys parameters are read-only

### DIFF
--- a/test/conformance/sysctl_test.go
+++ b/test/conformance/sysctl_test.go
@@ -1,0 +1,61 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/test"
+)
+
+// TestShouldHaveSysctlReadOnly verifies that the /proc/sys filesystem mounted within the container
+// is read-only.
+func TestShouldHaveSysctlReadOnly(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	clients := setup(t)
+	ri, err := fetchRuntimeInfo(clients, logger, &test.Options{})
+	if err != nil {
+		t.Fatalf("Error fetching runtime info: %v", err)
+	}
+
+	mounts := ri.Host.Mounts
+
+	for _, mount := range mounts {
+		if mount.Error != "" {
+			t.Fatalf("Error getting mount information: %v", mount.Error)
+		}
+		if mount.Path == "/proc/sys" {
+			if got, want := mount.Type, "proc"; got != want {
+				t.Errorf("mount.Type = %v, wanted: %v", mount.Type, want)
+			}
+			if got, want := mount.Device, "proc"; got != want {
+				t.Errorf("mount.Device = %v, wanted: %v", mount.Device, want)
+			}
+			for _, option := range mount.Options {
+				// Read Only must be present in options list
+				if option == "ro" {
+					return
+				}
+			}
+			t.Fatalf("mount.Options = %v, wanted: ro", mount.Options)
+		}
+	}
+	t.Fatalf("/proc/sys missing from mount list")
+}

--- a/test/test_images/runtime/handlers/cgroup.go
+++ b/test/test_images/runtime/handlers/cgroup.go
@@ -49,7 +49,7 @@ func cgroups(paths ...string) []*types.Cgroup {
 			continue
 		}
 		cs := strings.Trim(string(bc), "\n")
-		ic, err := strconv.Atoi(string(cs))
+		ic, err := strconv.Atoi(cs)
 		if err != nil {
 			cgroups = append(cgroups, &types.Cgroup{Name: path, Error: err.Error()})
 			continue

--- a/test/test_images/runtime/handlers/cgroup.go
+++ b/test/test_images/runtime/handlers/cgroup.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Knative Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/knative/serving/test/types"
+)
+
+// cgroupPaths is the set of cgroups probed and returned to the
+// client as Cgroups.
+var cgroupPaths = []string{
+	"/sys/fs/cgroup/memory/memory.limit_in_bytes",
+	"/sys/fs/cgroup/cpu/cpu.cfs_period_us",
+	"/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
+	"/sys/fs/cgroup/cpu/cpu.shares"}
+
+var (
+	yes = true
+	no  = false
+)
+
+func cgroups(paths ...string) []*types.Cgroup {
+	var cgroups []*types.Cgroup
+	for _, path := range paths {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			cgroups = append(cgroups, &types.Cgroup{Name: path, Error: err.Error()})
+			continue
+		}
+
+		bc, err := ioutil.ReadFile(path)
+		if err != nil {
+			cgroups = append(cgroups, &types.Cgroup{Name: path, Error: err.Error()})
+			continue
+		}
+		cs := strings.Trim(string(bc), "\n")
+		ic, err := strconv.Atoi(string(cs))
+		if err != nil {
+			cgroups = append(cgroups, &types.Cgroup{Name: path, Error: err.Error()})
+			continue
+		}
+
+		// Try to write to the Cgroup. We expect this to fail as a cheap
+		// method for read-only validation
+		newValue := []byte{'9'}
+		err = ioutil.WriteFile(path, newValue, 420)
+		if err != nil {
+			cgroups = append(cgroups, &types.Cgroup{Name: path, Value: &ic, ReadOnly: &yes})
+		} else {
+			cgroups = append(cgroups, &types.Cgroup{Name: path, Value: &ic, ReadOnly: &no})
+		}
+	}
+	return cgroups
+}

--- a/test/test_images/runtime/handlers/env.go
+++ b/test/test_images/runtime/handlers/env.go
@@ -14,24 +14,15 @@ limitations under the License.
 package handlers
 
 import (
-	"log"
-	"net/http"
-
-	"github.com/knative/serving/test/types"
+	"os"
+	"strings"
 )
 
-func runtimeHandler(w http.ResponseWriter, r *http.Request) {
-	log.Println("Retrieving Runtime Information")
-	w.Header().Set("Content-Type", "application/json")
-
-	k := &types.RuntimeInfo{
-		Request: requestInfo(r),
-		Host: &types.HostInfo{EnvVars: env(),
-			Files:   fileInfo(filePaths...),
-			Cgroups: cgroups(cgroupPaths...),
-			Mounts:  mounts(),
-		},
+func env() map[string]string {
+	envMap := map[string]string{}
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		envMap[pair[0]] = pair[1]
 	}
-
-	writeJSON(w, k)
+	return envMap
 }

--- a/test/test_images/runtime/handlers/file.go
+++ b/test/test_images/runtime/handlers/file.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Knative Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"os"
+
+	"github.com/knative/serving/test/types"
+)
+
+// filePaths is the set of filepaths probed and returned to the
+// client as FileInfo.
+var filePaths = []string{"/tmp",
+	"/var/log",
+	"/dev/log",
+	"/etc/hosts",
+	"/etc/hostname",
+	"/etc/resolv.conf"}
+
+func fileInfo(paths ...string) []*types.FileInfo {
+	var infoList []*types.FileInfo
+
+	for _, path := range paths {
+		file, err := os.Stat(path)
+		if err != nil {
+			infoList = append(infoList, &types.FileInfo{Name: path, Error: err.Error()})
+			continue
+		}
+		size := file.Size()
+		dir := file.IsDir()
+		infoList = append(infoList, &types.FileInfo{Name: path,
+			Size:    &size,
+			Mode:    file.Mode().String(),
+			ModTime: file.ModTime(),
+			IsDir:   &dir})
+	}
+	return infoList
+}

--- a/test/test_images/runtime/handlers/mount.go
+++ b/test/test_images/runtime/handlers/mount.go
@@ -22,8 +22,6 @@ import (
 )
 
 func mounts() []*types.Mount {
-	var mounts []*types.Mount
-
 	file, err := os.Open("/proc/mounts")
 	if err != nil {
 		return []*types.Mount{{Error: err.Error()}}
@@ -31,6 +29,7 @@ func mounts() []*types.Mount {
 	defer file.Close()
 
 	sc := bufio.NewScanner(file)
+	var mounts []*types.Mount
 	for sc.Scan() {
 		ml := sc.Text()
 		// Each line should be:

--- a/test/test_images/runtime/handlers/mount.go
+++ b/test/test_images/runtime/handlers/mount.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Knative Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/knative/serving/test/types"
+)
+
+func mounts() []*types.Mount {
+	var mounts []*types.Mount
+
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return []*types.Mount{{Error: err.Error()}}
+	}
+	defer file.Close()
+
+	sc := bufio.NewScanner(file)
+	for sc.Scan() {
+		ml := sc.Text()
+		// Each line should be:
+		// Device Path Type Options Unused Unused
+		// sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+		ms := strings.Split(ml, " ")
+		if len(ms) < 6 {
+			return []*types.Mount{{Error: "unknown /proc/mounts format"}}
+		}
+		mounts = append(mounts, &types.Mount{
+			Device:  ms[0],
+			Path:    ms[1],
+			Type:    ms[2],
+			Options: strings.Split(ms[3], ",")})
+	}
+
+	if err := sc.Err(); err != nil {
+		// Don't return partial list of mounts on error
+		return []*types.Mount{{Error: err.Error()}}
+	}
+
+	return mounts
+}

--- a/test/test_images/runtime/handlers/request.go
+++ b/test/test_images/runtime/handlers/request.go
@@ -14,24 +14,35 @@ limitations under the License.
 package handlers
 
 import (
-	"log"
+	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/knative/serving/test/types"
 )
 
-func runtimeHandler(w http.ResponseWriter, r *http.Request) {
-	log.Println("Retrieving Runtime Information")
-	w.Header().Set("Content-Type", "application/json")
-
-	k := &types.RuntimeInfo{
-		Request: requestInfo(r),
-		Host: &types.HostInfo{EnvVars: env(),
-			Files:   fileInfo(filePaths...),
-			Cgroups: cgroups(cgroupPaths...),
-			Mounts:  mounts(),
-		},
+func headers(r *http.Request) map[string]string {
+	headerMap := map[string]string{}
+	for name, headers := range r.Header {
+		name = strings.ToLower(name)
+		for i, h := range headers {
+			if len(headers) > 1 {
+				headerMap[fmt.Sprintf("%s[%d]", name, i)] = h
+			} else {
+				headerMap[fmt.Sprintf("%s", name)] = h
+			}
+		}
 	}
+	return headerMap
+}
 
-	writeJSON(w, k)
+func requestInfo(r *http.Request) *types.RequestInfo {
+	return &types.RequestInfo{
+		Ts:      time.Now(),
+		URI:     r.RequestURI,
+		Host:    r.Host,
+		Method:  r.Method,
+		Headers: headers(r),
+	}
 }

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -47,6 +47,8 @@ type HostInfo struct {
 	EnvVars map[string]string `json:"envs"`
 	// Cgroups is a list of cgroup information.
 	Cgroups []*Cgroup `json:"cgroups"`
+	// Mounts is a list of mounted volume information, or error.
+	Mounts []*Mount `json:"mounts"`
 }
 
 // FileInfo contains the metadata for a given file.
@@ -73,6 +75,20 @@ type Cgroup struct {
 	Value *int `json:"value",optional`
 	// ReadOnly is true if the cgroup was not writable.
 	ReadOnly *bool `json:"readOnly",optional`
+	// Error is the String representation of the error returned obtaining the information.
+	Error string `json:"error",optional`
+}
+
+// Mount contains information about a given mount.
+type Mount struct {
+	// Device is the device that is mounted
+	Device string `json:"device",optional`
+	// Path is the location where the volume is mounted
+	Path string `json:"path",optional`
+	// Type is the filesystem type (i.e. sysfs, proc, tmpfs, ext4, overlay, etc.)
+	Type string `json:"type",optional`
+	// Options is the mount options set (i.e. rw, nosuid, relatime, etc.)
+	Options []string `json:"options",optional`
 	// Error is the String representation of the error returned obtaining the information.
 	Error string `json:"error",optional`
 }

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -56,15 +56,15 @@ type FileInfo struct {
 	// Name is the full filename.
 	Name string `json:"name"`
 	// Size is the length in bytes for regular files; system-dependent for others.
-	Size *int64 `json:"size",optional`
+	Size *int64 `json:"size,omitempty"`
 	// Mode is the file mode bits.
-	Mode string `json:"mode",optional`
+	Mode string `json:"mode,omitempty"`
 	// ModTime is the file last modified time
-	ModTime time.Time `json:"modTime",optional`
+	ModTime time.Time `json:"modTime,omitempty"`
 	// IsDir is true if the file is a directory.
-	IsDir *bool `json:"isDir",optional`
+	IsDir *bool `json:"isDir,omitempty"`
 	// Error is the String representation of the error returned obtaining the information.
-	Error string `json:"error",optional`
+	Error string `json:"error,omitempty"`
 }
 
 // Cgroup contains the Cgroup value for a given setting.
@@ -72,23 +72,23 @@ type Cgroup struct {
 	// Name is the full path name of the cgroup.
 	Name string `json:"name"`
 	// Value is the integer files in the cgroup file.
-	Value *int `json:"value",optional`
+	Value *int `json:"value,omitempty"`
 	// ReadOnly is true if the cgroup was not writable.
-	ReadOnly *bool `json:"readOnly",optional`
+	ReadOnly *bool `json:"readOnly,omitempty"`
 	// Error is the String representation of the error returned obtaining the information.
-	Error string `json:"error",optional`
+	Error string `json:"error,omitempty"`
 }
 
 // Mount contains information about a given mount.
 type Mount struct {
 	// Device is the device that is mounted
-	Device string `json:"device",optional`
+	Device string `json:"device,omitempty"`
 	// Path is the location where the volume is mounted
-	Path string `json:"path",optional`
+	Path string `json:"path,omitempty"`
 	// Type is the filesystem type (i.e. sysfs, proc, tmpfs, ext4, overlay, etc.)
-	Type string `json:"type",optional`
+	Type string `json:"type,omitempty"`
 	// Options is the mount options set (i.e. rw, nosuid, relatime, etc.)
-	Options []string `json:"options",optional`
+	Options []string `json:"options,omitempty"`
 	// Error is the String representation of the error returned obtaining the information.
-	Error string `json:"error",optional`
+	Error string `json:"error,omitempty"`
 }


### PR DESCRIPTION
This adds a conformance test to validate the SHOULD clause for sysctls
in the runtime contract. This ensures that sysctls mounted in the
container are read-only. It does this by looking at the mount options
for the filesystem in /proc/mounts. This change also breaks out the
runtime image handler to prevent it from becoming too large.

Fixes #2975 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->