### PR TITLE
Default to using 1 pod for istio-ingressgateway.

### DIFF
--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -39,6 +39,9 @@ helm template --namespace=istio-system \
   --set pilot.autoscaleMin=3 \
   --set pilot.autoscaleMax=10 \
   --set pilot.cpu.targetAverageUtilization=60 \
+  `# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
+  --set gateways.istio-ingressgateway.autoscaleMin=1 \
+  --set gateways.istio-ingressgateway.autoscaleMax=1 \
   install/kubernetes/helm/istio > ../istio.yaml
 cat cluster-local-gateway.yaml >> ../istio.yaml
 
@@ -52,6 +55,9 @@ helm template --namespace=istio-system \
   --set prometheus.enabled=false \
   `# Disable mixer policy check, since in our template we set no policy.` \
   --set global.disablePolicyChecks=true \
+  `# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
+  --set gateways.istio-ingressgateway.autoscaleMin=1 \
+  --set gateways.istio-ingressgateway.autoscaleMax=1 \
   install/kubernetes/helm/istio > ../istio-lean.yaml
 cat cluster-local-gateway.yaml >> ../istio-lean.yaml
 

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -2982,7 +2982,7 @@ metadata:
     name: istio-ingressgateway
     namespace: istio-system
 spec:
-    maxReplicas: 5
+    maxReplicas: 1
     minReplicas: 1
     scaleTargetRef:
       apiVersion: apps/v1beta1

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -3330,7 +3330,7 @@ metadata:
     name: istio-ingressgateway
     namespace: istio-system
 spec:
-    maxReplicas: 5
+    maxReplicas: 1
     minReplicas: 1
     scaleTargetRef:
       apiVersion: apps/v1beta1


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

*  Default to using 1 pod for `istio-ingressgateway` to sidestep Istio gateway readiness / eventual consistency problems.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
