### PR TITLE
Default to using 1 pod for cluster-local-gateway.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -146,7 +146,6 @@ function install_knative_serving_standard() {
   # We should revisit this when Istio API exposes a Status that we can rely on.
   # TODO(tcnghia): remove this when https://github.com/istio/istio/issues/882 is fixed.
   echo ">> Patching Istio"
-
   # There are reports of Envoy failing (503) when istio-pilot is overloaded.
   # We generously add more pilot instances here to verify if we can reduce flakes.
   if kubectl get hpa -n istio-system istio-pilot 2>/dev/null; then
@@ -157,7 +156,7 @@ function install_knative_serving_standard() {
       `# Ignore error messages to avoid causing red herrings in the tests` \
       2>/dev/null
   else
-    # Some versions of Istio doesn't provide an HPA for pilot.
+    # Some versions of Istio don't provide an HPA for pilot.
     kubectl autoscale -n istio-system deploy istio-pilot --min=3 --max=10 --cpu-percent=60 || return 1
   fi
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -146,13 +146,6 @@ function install_knative_serving_standard() {
   # We should revisit this when Istio API exposes a Status that we can rely on.
   # TODO(tcnghia): remove this when https://github.com/istio/istio/issues/882 is fixed.
   echo ">> Patching Istio"
-  for gateway in istio-ingressgateway cluster-local-gateway; do
-    if kubectl get svc -n istio-system ${gateway} > /dev/null 2>&1 ; then
-      kubectl patch hpa -n istio-system ${gateway} --patch '{"spec": {"maxReplicas": 1}}'
-      kubectl set resources deploy -n istio-system ${gateway} \
-        -c=istio-proxy --requests=cpu=50m 2> /dev/null
-    fi
-  done
 
   # There are reports of Envoy failing (503) when istio-pilot is overloaded.
   # We generously add more pilot instances here to verify if we can reduce flakes.

--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -47,7 +47,7 @@ helm template --namespace=istio-system \
   install/kubernetes/helm/istio > ../istio.yaml
 cat cluster-local-gateway.yaml >> ../istio.yaml
 
-# A liter template, with no sidecar injection.  We could probably remove
+# A lighter template, with no sidecar injection.  We could probably remove
 # more from this template.
 helm template --namespace=istio-system \
   --set sidecarInjectorWebhook.enabled=false \

--- a/third_party/istio-1.0.2/download-istio.sh
+++ b/third_party/istio-1.0.2/download-istio.sh
@@ -14,6 +14,8 @@ cp install/kubernetes/helm/istio/templates/crds.yaml ../istio-crds.yaml
 
 # Create a custom cluster local gateway, based on the Istio custom-gateway template.
 helm template --namespace=istio-system \
+  --set gateways.custom-gateway.autoscaleMin=1 \
+  --set gateways.custom-gateway.autoscaleMax=1 \
   --set gateways.custom-gateway.cpu.targetAverageUtilization=60 \
   --set gateways.custom-gateway.labels.app='cluster-local-gateway' \
   --set gateways.custom-gateway.labels.istio='cluster-local-gateway' \

--- a/third_party/istio-1.0.2/istio-lean.yaml
+++ b/third_party/istio-1.0.2/istio-lean.yaml
@@ -4073,7 +4073,7 @@ metadata:
     name: cluster-local-gateway
     namespace: istio-system
 spec:
-    maxReplicas: 5
+    maxReplicas: 1
     minReplicas: 1
     scaleTargetRef:
       apiVersion: apps/v1beta1

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -4451,7 +4451,7 @@ metadata:
     name: cluster-local-gateway
     namespace: istio-system
 spec:
-    maxReplicas: 5
+    maxReplicas: 1
     minReplicas: 1
     scaleTargetRef:
       apiVersion: apps/v1beta1


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is very similar to #3102 but also removes seemingly unused code in the `e2e-common.sh` file, since we ship those values with our installation of Istio now.

## Proposed Changes

* Default to using 1 pod for `cluster-local-gateway` to sidestep Istio gateway readiness / eventual consistency problems.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
