### PR TITLE
dev.local and ko.local are both mentioned and can be confusing

### DIFF
--- a/docs/creating-a-kubernetes-cluster.md
+++ b/docs/creating-a-kubernetes-cluster.md
@@ -80,7 +80,7 @@ export KO_DOCKER_REPO="ko.local"
 ### Enabling Knative to Use Images in Minikube
 
 In order to have Knative access an image in Minikube's Docker daemon you should
-prefix your image name with the `dev.local` registry. This will cause Knative to
+prefix your image name with the `ko.local` registry. This will cause Knative to
 use the cached image. You must not tag your image as `latest` since this causes
 Kubernetes to
 [always attempt a pull](https://kubernetes.io/docs/concepts/containers/images/#updating-images).
@@ -90,7 +90,7 @@ For example:
 ```shell
 eval $(minikube docker-env)
 docker pull gcr.io/knative-samples/primer:latest
-docker tag gcr.io/knative-samples/primer:latest dev.local/knative-samples/primer:v1
+docker tag gcr.io/knative-samples/primer:latest ko.local/knative-samples/primer:v1
 ```
 
 ### Minikube with GCR


### PR DESCRIPTION
Both `dev.local` and `ko.local` are mentioned in the doc.  It can be confusing.   Most users simply cut and paste these commands to follow these steps.   As a result, their environments are not set up correctly and nothing works.   It may not be obviously to users that things do not work because local  repo name was messed up.


## Proposed Changes
To use `ko.local` consistently to avoid confusing and unexpected results.


**Release Note**


