### PR TITLE
Change the breaker's way of updating capacity.

### DIFF
--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -136,10 +136,7 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 	if err != nil {
 		return err
 	}
-	if err := t.updateCapacity(revision, breaker, size); err != nil {
-		return err
-	}
-	return nil
+	return t.updateCapacity(revision, breaker, size)
 }
 
 // UpdateEndpoints is a handler function to be used by the Endpoints informer.
@@ -151,12 +148,7 @@ func UpdateEndpoints(throttler *Throttler) func(_, newObj interface{}) {
 		endpoints := newObj.(*corev1.Endpoints)
 		addresses := EndpointsAddressCount(endpoints.Subsets)
 		revID := RevisionID{endpoints.Namespace, reconciler.GetServingRevisionNameForK8sService(endpoints.Name)}
-		_, err := throttler.getRevision(revID)
-		if err != nil {
-			throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
-			return
-		}
-		if err = throttler.UpdateCapacity(revID, int32(addresses)); err != nil {
+		if err := throttler.UpdateCapacity(revID, int32(addresses)); err != nil {
 			throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
 		}
 	}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -143,6 +143,8 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 // It updates the endpoints in the Throttler if the number of hosts changed and
 // the revision already exists (we don't want to create/update throttlers for the endpoints
 // that do not belong to any revision).
+//
+// This function must not be called in parallel to not induce a wrong order of events.
 func UpdateEndpoints(throttler *Throttler) func(_, newObj interface{}) {
 	return func(_, newObj interface{}) {
 		endpoints := newObj.(*corev1.Endpoints)

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	capacityUpdateFailure = "updating capacity failed"
 	// OverloadMessage indicates that throttler has no free slots to buffer the request.
 	OverloadMessage = "activator overload"
 )
@@ -151,7 +150,7 @@ func UpdateEndpoints(throttler *Throttler) func(_, newObj interface{}) {
 		addresses := EndpointsAddressCount(endpoints.Subsets)
 		revID := RevisionID{endpoints.Namespace, reconciler.GetServingRevisionNameForK8sService(endpoints.Name)}
 		if err := throttler.UpdateCapacity(revID, int32(addresses)); err != nil {
-			throttler.logger.Errorw(capacityUpdateFailure, zap.Error(err))
+			throttler.logger.Errorw("updating capacity failed", zap.Error(err))
 		}
 	}
 }

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -107,10 +107,7 @@ func (t *Throttler) updateCapacity(revision *v1alpha1.Revision, breaker *queue.B
 		targetCapacity = t.breakerParams.MaxConcurrency
 	}
 
-	if err := breaker.UpdateConcurrency(targetCapacity); err != nil {
-		return err
-	}
-	return nil
+	return breaker.UpdateConcurrency(targetCapacity)
 }
 
 // getOrCreateBreaker retrieves existing breaker or creates a new one.
@@ -139,7 +136,7 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 	if err != nil {
 		return err
 	}
-	if err = t.updateCapacity(revision, breaker, size); err != nil {
+	if err := t.updateCapacity(revision, breaker, size); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -162,10 +162,10 @@ func TestBreaker_UpdateConcurrency(t *testing.T) {
 	params := BreakerParams{QueueDepth: 1, MaxConcurrency: 1, InitialCapacity: 0}
 	b := NewBreaker(params)
 	b.UpdateConcurrency(int32(1))
-	assertEqual(int32(1), b.sem.capacity, t)
+	assertEqual(int32(1), b.Capacity(), t)
 
 	b.UpdateConcurrency(int32(0))
-	assertEqual(int32(0), b.sem.capacity, t)
+	assertEqual(int32(0), b.Capacity(), t)
 
 	err := b.UpdateConcurrency(int32(-2))
 	assertEqual(ErrReduceCapacity, err, t)
@@ -236,20 +236,20 @@ func TestSemaphore_ReleasesSeveralReducers(t *testing.T) {
 	sem.Acquire()
 	sem.UpdateCapacity(int32(0))
 	sem.Release()
-	assertEqual(wantAfterFirstRelease, sem.capacity, t)
+	assertEqual(wantAfterSecondRelease, sem.Capacity(), t)
 	assertEqual(wantAfterFirstRelease, sem.reducers, t)
 	sem.Release()
-	assertEqual(wantAfterSecondRelease, sem.capacity, t)
+	assertEqual(wantAfterSecondRelease, sem.Capacity(), t)
 	assertEqual(wantAfterSecondRelease, sem.reducers, t)
 }
 
 func TestSemaphore_AddCapacity(t *testing.T) {
 	initialCapacity := int32(1)
 	sem := NewSemaphore(3, initialCapacity)
-	assertEqual(int32(1), sem.capacity, t)
+	assertEqual(int32(1), sem.Capacity(), t)
 	sem.Acquire()
 	sem.UpdateCapacity(initialCapacity + 2)
-	assertEqual(int32(3), sem.capacity, t)
+	assertEqual(int32(3), sem.Capacity(), t)
 }
 
 // Test the case when we add more capacity then the number of waiting reducers

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -168,14 +168,14 @@ func TestBreaker_UpdateConcurrency(t *testing.T) {
 	assertEqual(int32(0), b.Capacity(), t)
 
 	err := b.UpdateConcurrency(int32(-2))
-	assertEqual(ErrReduceCapacity, err, t)
+	assertEqual(ErrUpdateCapacity, err, t)
 }
 
 func TestBreaker_UpdateConcurrency_Overlow(t *testing.T) {
 	params := BreakerParams{QueueDepth: 1, MaxConcurrency: 1, InitialCapacity: 0}
 	b := NewBreaker(params)
 	err := b.UpdateConcurrency(int32(2))
-	assertEqual(ErrAddCapacity, err, t)
+	assertEqual(ErrUpdateCapacity, err, t)
 }
 
 // Test empty semaphore, token cannot be acquired
@@ -265,22 +265,22 @@ func TestSemaphore_UpdateCapacity_ConsumingReducers(t *testing.T) {
 
 func TestSemaphore_UpdateCapacity_Overflow(t *testing.T) {
 	sem := NewSemaphore(2, 0)
-	response := sem.UpdateCapacity(int32(3))
-	assertEqual(ErrAddCapacity, response, t)
+	err := sem.UpdateCapacity(int32(3))
+	assertEqual(err, ErrUpdateCapacity, t)
 }
 
 func TestSemaphore_UpdateCapacity_OutOfBound(t *testing.T) {
 	sem := NewSemaphore(1, 1)
 	sem.Acquire()
 	err := sem.UpdateCapacity(-1)
-	assertEqual(err, ErrReduceCapacity, t)
+	assertEqual(err, ErrUpdateCapacity, t)
 }
 
 func TestSemaphore_UpdateCapacity_BrokenState(t *testing.T) {
 	sem := NewSemaphore(1, 0)
 	sem.Release() // This Release is not paired with an Acquire
 	err := sem.UpdateCapacity(1)
-	assertEqual(err, ErrAddCapacity, t)
+	assertEqual(err, ErrUpdateCapacity, t)
 }
 
 func TestSemaphore_UpdateCapacity_DoNothing(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The recently added throttler updates the capacity of the underlying breaker by calculating diffs based on the capacity it asks for. However, asking for a locked value from the outside and calculating diffs based on that will be prone to concurrent updates and slight bookkeeping bugs.

This moves this all the way inside the semaphore itself and instead only surfaces a `UpdateCapacity` method. The bookkeeping is all internal and thus should be consistent.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
