### PR TITLE
Add conformance test for request headers

### DIFF
--- a/test/conformance/header_test.go
+++ b/test/conformance/header_test.go
@@ -61,7 +61,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 
 		// Trace Headers
 		// See https://github.com/openzipkin/b3-propagation#overall-process
-		// We use the multiple header varient for tracing. We do not validate the single header varient.
+		// We use the multiple header variant for tracing. We do not validate the single header variant.
 		// We expect the value to be a 64-bit hex string
 		"x-b3-spanid": regexp.MustCompile("[0-9a-f]{16}"),
 		// We expect the value to be a 64-bit or 128-bit hex string

--- a/test/conformance/header_test.go
+++ b/test/conformance/header_test.go
@@ -65,7 +65,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 		// Trace Headers
 		// See https://github.com/openzipkin/b3-propagation#overall-process
 		// We use the multiple header variant for tracing. We do not validate the single header variant.
-		// We expect the value to be a 64-bit hex stringgg
+		// We expect the value to be a 64-bit hex string
 		"x-b3-spanid": regexp.MustCompile("[0-9a-f]{16}"),
 		// We expect the value to be a 64-bit or 128-bit hex string
 		"x-b3-traceid": regexp.MustCompile("[0-9a-f]{16}|[0-9a-f]{32}"),

--- a/test/conformance/header_test.go
+++ b/test/conformance/header_test.go
@@ -95,8 +95,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 		if header == "x-forwarded-for" {
 			ips := strings.Split(hv, ",")
 			for _, ip := range ips {
-				ok := net.ParseIP(strings.TrimSpace(ip))
-				if ok == nil {
+				if net.ParseIP(strings.TrimSpace(ip)) == nil {
 					t.Errorf("Header %s has invalid IP: %s", header, ip)
 				}
 			}

--- a/test/conformance/header_test.go
+++ b/test/conformance/header_test.go
@@ -1,0 +1,91 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/test"
+)
+
+// TestMustHaveHeadersSet verified that all headers declared as "MUST" in the runtime
+// contract are present from the point of view of the user container.
+func TestMustHaveHeadersSet(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	clients := setup(t)
+
+	ri, err := fetchRuntimeInfo(clients, logger, &test.Options{})
+	if err != nil {
+		t.Fatalf("Error fetching runtime info: %v", err)
+	}
+
+	// For incoming requests, the Host header is promoted to the
+	// Request.Host field and removed from the Header map. Therefore we
+	// check against the Host field instead of the map.
+	if ri.Request.Host == "" {
+		// We just check that the host header exists and is non-empty as the request
+		// may be made internally or externally which will result in a different host.
+		t.Error("Header host was not present on request")
+	}
+}
+
+// TestMustHaveHeadersSet verified that all headers declared as "SHOULD" in the runtime
+// contract are present from the point of view of the user container.
+func TestShouldHaveHeadersSet(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	clients := setup(t)
+
+	expectedHeaders := map[string]*regexp.Regexp{
+		// We expect the protocol to be http for our test image.
+		"x-forwarded-proto": regexp.MustCompile("http"),
+		// We expect the value to be a list of at least one comma separated IP addresses.
+		"x-forwarded-for": regexp.MustCompile("(\\d{1,3}\\.){3}\\d{1,3}(, (\\d{1,3}\\.){3}\\d{1,3})*"),
+
+		// Trace Headers
+		// See https://github.com/openzipkin/b3-propagation#overall-process
+		// We use the multiple header varient for tracing. We do not validate the single header varient.
+		// We expect the value to be a 64-bit hex string
+		"x-b3-spanid": regexp.MustCompile("[0-9a-f]{16}"),
+		// We expect the value to be a 64-bit or 128-bit hex string
+		"x-b3-traceid": regexp.MustCompile("[0-9a-f]{16}|[0-9a-f]{32}"),
+
+		// "x-b3-parentspanid" and "x-b3-sampled" are often present for tracing, but are not
+		// required for tracing so we do not validate them.
+	}
+
+	ri, err := fetchRuntimeInfo(clients, logger, &test.Options{})
+	if err != nil {
+		t.Fatalf("Error fetching runtime info: %v", err)
+	}
+
+	headers := ri.Request.Headers
+
+	for header, regex := range expectedHeaders {
+		hv, ok := headers[header]
+		if !ok {
+			t.Errorf("Header %s was not present on request", header)
+			continue
+		}
+		if !regex.MatchString(hv) {
+			t.Errorf("%s = %s; want: %s", header, hv, regex.String())
+		}
+	}
+}

--- a/test/conformance/header_test.go
+++ b/test/conformance/header_test.go
@@ -85,12 +85,12 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 
 	for header, regex := range expectedHeaders {
 		hvl, ok := headers[http.CanonicalHeaderKey(header)]
+		if !ok {
+			t.Errorf("Header %s was not present on request", header)
+			continue
+		}
 		// Check against each value for the header key
 		for _, hv := range hvl {
-			if !ok {
-				t.Errorf("Header %s was not present on request", header)
-				continue
-			}
 
 			switch {
 			case strings.EqualFold(header, "x-forwarded-for"):

--- a/test/test_images/runtime/handlers/request.go
+++ b/test/test_images/runtime/handlers/request.go
@@ -14,28 +14,11 @@ limitations under the License.
 package handlers
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/knative/serving/test/types"
 )
-
-func headers(r *http.Request) map[string]string {
-	headerMap := map[string]string{}
-	for name, headers := range r.Header {
-		name = strings.ToLower(name)
-		for i, h := range headers {
-			if len(headers) > 1 {
-				headerMap[fmt.Sprintf("%s[%d]", name, i)] = h
-			} else {
-				headerMap[fmt.Sprintf("%s", name)] = h
-			}
-		}
-	}
-	return headerMap
-}
 
 func requestInfo(r *http.Request) *types.RequestInfo {
 	return &types.RequestInfo{
@@ -43,6 +26,6 @@ func requestInfo(r *http.Request) *types.RequestInfo {
 		URI:     r.RequestURI,
 		Host:    r.Host,
 		Method:  r.Method,
-		Headers: headers(r),
+		Headers: r.Header,
 	}
 }

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -14,6 +14,7 @@ limitations under the License.
 package types
 
 import (
+	"net/http"
 	"time"
 )
 
@@ -36,7 +37,7 @@ type RequestInfo struct {
 	// Method is the method used for the request.
 	Method string `json:"method"`
 	// Headers is a Map of all headers set.
-	Headers map[string][]string `json:"headers"`
+	Headers http.Header `json:"headers"`
 }
 
 // HostInfo contains information about the host environment.

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -36,7 +36,7 @@ type RequestInfo struct {
 	// Method is the method used for the request.
 	Method string `json:"method"`
 	// Headers is a Map of all headers set.
-	Headers map[string]string `json:"headers"`
+	Headers map[string][]string `json:"headers"`
 }
 
 // HostInfo contains information about the host environment.


### PR DESCRIPTION
This change adds conformance testing for the MUST and SHOULD
headers defined in the the runtime contract.

https://github.com/knative/serving/blob/master/docs/runtime-contract.md#headers

Fixes #2267