### PR TITLE
Fix some stuff around the tests

### DIFF
--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -346,11 +346,13 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	logger.Info("Service traffic should go to the first revision and be available on two names traffic targets: 'current' and 'latest'")
-	validateDomains(t, logger, clients,
+	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
-		[]string{expectedFirstRev, expectedFirstRev})
+		[]string{expectedFirstRev, expectedFirstRev}); err != nil {
+		t.Fatal(err)
+	}
 
 	// One Revision Specified, current != latest.
 	logger.Info("Updating the Service Spec with a new image")
@@ -365,11 +367,13 @@ func TestReleaseService(t *testing.T) {
 	revisions = append(revisions, names.Revision)
 
 	logger.Info("Since the Service is using release the Route will not be updated, but new revision will be available at 'latest'")
-	validateDomains(t, logger, clients,
+	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
-		[]string{expectedSecondRev, expectedFirstRev})
+		[]string{expectedSecondRev, expectedFirstRev}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Two Revisions Specified, 50% rollout, candidate == latest.
 	logger.Info("Updating Service to split traffic between two revisions using Release mode")
@@ -378,11 +382,13 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	logger.Info("Traffic should be split between the two revisions and available on three named traffic targets, 'current', 'candidate', and 'latest'")
-	validateDomains(t, logger, clients,
+	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"candidate", "latest", "current"},
-		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev})
+		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Two Revisions Specified, 50% rollout, candidate != latest.
 	logger.Info("Updating the Service Spec with a new image")
@@ -391,11 +397,13 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	logger.Info("Traffic should remain between the two images, and the new revision should be available on the named traffic target 'latest'")
-	validateDomains(t, logger, clients,
+	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"latest", "candidate", "current"},
-		[]string{expectedThirdRev, expectedSecondRev, expectedFirstRev})
+		[]string{expectedThirdRev, expectedSecondRev, expectedFirstRev}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TODO(jonjohnsonjr): Examples of deploying from source.

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -32,6 +32,7 @@ import (
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	// Mysteriously required to support GCP auth (required by k8s libs). Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
@@ -101,14 +102,21 @@ func validateDomains(
 		subdomains = append(subdomains, fmt.Sprintf("%s.%s", target, baseDomain))
 	}
 
+	g, _ := errgroup.WithContext(context.Background())
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
-	logger.Infof("Waiting for route to update domain: %s", subdomains[0])
-	if err := waitForExpectedResponse(logger, clients, subdomains[0], targetsExpected[0]); err != nil {
-		t.Fatalf("Error waiting for route to update %s: %s", subdomains[0], targetsExpected[0])
+	// In order for tests to succeed reliably, we need to make sure that all domains succeed.
+	for i, s := range subdomains {
+		i, s := i, s
+		g.Go(func() error {
+			logger.Infof("Waiting for route to update domain: %s", s)
+			return waitForExpectedResponse(logger, clients, s, targetsExpected[i])
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Wrap(err, "error with initial domain probing")
 	}
 
-	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		var minBasePercentage float64
 		if len(baseExpected) == 1 {
@@ -127,8 +135,9 @@ func validateDomains(
 		})
 	}
 	if err := g.Wait(); err != nil {
-		t.Fatalf("Error sending requests: %v", err)
+		return errors.Wrap(err, "error checking routing distribution")
 	}
+	return nil
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -118,11 +118,9 @@ func validateDomains(
 	}
 
 	g.Go(func() error {
-		var minBasePercentage float64
+		minBasePercentage := minSplitPercentage
 		if len(baseExpected) == 1 {
 			minBasePercentage = minDirectPercentage
-		} else {
-			minBasePercentage = minSplitPercentage
 		}
 		min := int(math.Floor(concurrentRequests * minBasePercentage))
 		return checkDistribution(logger, clients, baseDomain, concurrentRequests, min, baseExpected)

--- a/test/util.go
+++ b/test/util.go
@@ -31,7 +31,7 @@ const (
 
 // LogResourceObject logs the resource object with the resource name and value
 func LogResourceObject(logger *logging.BaseLogger, value ResourceObjects) {
-	logger.Infof("resource %s", spew.Sdump(value))
+	logger.Debugf("resource %s", spew.Sdump(value))
 }
 
 // ImagePath is a helper function to prefix image name with repo and suffix with tag

--- a/vendor/github.com/knative/pkg/test/logging/logging.go
+++ b/vendor/github.com/knative/pkg/test/logging/logging.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/logging"
 	"go.opencensus.io/stats/view"
@@ -58,9 +59,9 @@ type BaseLogger struct {
 // ExportView will emit the view data vd (i.e. the stats that have been
 // recorded) to the zap logger.
 func (e *zapMetricExporter) ExportView(vd *view.Data) {
-	// We are not curretnly consuming these metrics, so for now we'll juse
+	// We are not currently consuming these metrics, so for now we'll juse
 	// dump the view.Data object as is.
-	e.logger.Info(vd)
+	e.logger.Debug(spew.Sdump(vd))
 }
 
 // ExportSpan will emit the trace data to the zap logger.

--- a/vendor/github.com/knative/pkg/test/logging/logging.go
+++ b/vendor/github.com/knative/pkg/test/logging/logging.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/logging"
 	"go.opencensus.io/stats/view"
@@ -59,9 +58,9 @@ type BaseLogger struct {
 // ExportView will emit the view data vd (i.e. the stats that have been
 // recorded) to the zap logger.
 func (e *zapMetricExporter) ExportView(vd *view.Data) {
-	// We are not currently consuming these metrics, so for now we'll juse
+	// We are not curretnly consuming these metrics, so for now we'll juse
 	// dump the view.Data object as is.
-	e.logger.Debug(spew.Sdump(vd))
+	e.logger.Info(vd)
 }
 
 // ExportSpan will emit the trace data to the zap logger.


### PR DESCRIPTION
/lint
## Proposed Changes

* remove extremely annoying logging from Prometheus worker.go (I downgraded it to Debug, so it won't show in the test output and made it print in a more sensible way)
* downgraded util logging as well. Still possible to see by passing logLevel flag.
* make `validateDomains` return error and fatal in the test instead. 
* make `validateDomains` do much more stuff in parallel. My test runs are consistently down from 210s to ~160s. A minute a run, sounds like fun.
* this also incorporates the change I did in different PR, where **all** domains are probed to be ready, since we've seen many a second gateway propagation delays
* some error changes here and there

/cc @mattmoor @dgerd 

