### PR TITLE
This modifies the service-to-service test to test cluster-local services.

### DIFF
--- a/test/configuration.go
+++ b/test/configuration.go
@@ -23,6 +23,8 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
 
 // Options are test setup parameters.
@@ -37,8 +39,8 @@ type Options struct {
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by names.Image.
-func CreateConfiguration(logger *logging.BaseLogger, clients *Clients, names ResourceNames, options *Options) (*v1alpha1.Configuration, error) {
-	config := Configuration(ServingNamespace, names, options)
+func CreateConfiguration(logger *logging.BaseLogger, clients *Clients, names ResourceNames, options *Options, fopt ...testing.ConfigOption) (*v1alpha1.Configuration, error) {
+	config := Configuration(ServingNamespace, names, options, fopt...)
 	LogResourceObject(logger, ResourceObjects{Config: config})
 	return clients.ServingClient.Configs.Create(config)
 }

--- a/test/crd.go
+++ b/test/crd.go
@@ -52,8 +52,8 @@ type ResourceObjects struct {
 
 // Route returns a Route object in namespace using the route and configuration
 // names in names.
-func Route(namespace string, names ResourceNames) *v1alpha1.Route {
-	return &v1alpha1.Route{
+func Route(namespace string, names ResourceNames, fopt ...testing.RouteOption) *v1alpha1.Route {
+	route := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      names.Route,
@@ -66,6 +66,12 @@ func Route(namespace string, names ResourceNames) *v1alpha1.Route {
 			}},
 		},
 	}
+
+	for _, opt := range fopt {
+		opt(route)
+	}
+
+	return route
 }
 
 // BlueGreenRoute returns a Route object in namespace using the route and configuration
@@ -119,7 +125,7 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 
 // Configuration returns a Configuration object in namespace with the name names.Config
 // that uses the image specified by names.Image
-func Configuration(namespace string, names ResourceNames, options *Options) *v1alpha1.Configuration {
+func Configuration(namespace string, names ResourceNames, options *Options, fopt ...testing.ConfigOption) *v1alpha1.Configuration {
 	config := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -130,6 +136,11 @@ func Configuration(namespace string, names ResourceNames, options *Options) *v1a
 	if options.ContainerPorts != nil && len(options.ContainerPorts) > 0 {
 		config.Spec.RevisionTemplate.Spec.Container.Ports = options.ContainerPorts
 	}
+
+	for _, opt := range fopt {
+		opt(config)
+	}
+
 	return config
 }
 
@@ -187,7 +198,7 @@ func ReleaseLatestService(namespace string, names ResourceNames, options *Option
 		},
 		Spec: v1alpha1.ServiceSpec{
 			Release: &v1alpha1.ReleaseType{
-				Revisions: []string{v1alpha1.ReleaseLatestRevisionKeyword},
+				Revisions:     []string{v1alpha1.ReleaseLatestRevisionKeyword},
 				Configuration: *ConfigurationSpec(ImagePath(names.Image), options),
 			},
 		},

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -30,6 +30,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	routeconfig "github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
+	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
 
 var (
@@ -47,14 +50,20 @@ func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
 	if err != nil {
 		t.Fatalf("Failed to get Route of helloworld app: %v", err)
 	}
-	if helloWorldRoute.Status.Address == nil {
-		t.Fatalf("Route is missing .Status.Address: %v", helloWorldRoute.Status)
+	if helloWorldRoute.Status.Domain == "" {
+		t.Fatalf("Route is missing .Status.Domain: %#v", helloWorldRoute.Status)
 	}
-	internalDomain := helloWorldRoute.Status.Address.Hostname
-	logger.Infof("helloworld internal domain is %v.", internalDomain)
+	if helloWorldRoute.Status.Address == nil {
+		t.Fatalf("Route is missing .Status.Address: %#v", helloWorldRoute.Status)
+	}
+	// Check that the target Route's Domain matches its cluster local address.
+	if want, got := helloWorldRoute.Status.Address.Hostname, helloWorldRoute.Status.Domain; got != want {
+		t.Errorf("Route.Domain = %v, wanted %v", got, want)
+	}
+	logger.Infof("helloworld internal domain is %v.", helloWorldRoute.Status.Domain)
 	return []corev1.EnvVar{{
 		Name:  targetHostEnv,
-		Value: internalDomain,
+		Value: helloWorldRoute.Status.Domain,
 	}}
 }
 
@@ -84,15 +93,34 @@ func TestServiceToServiceCall(t *testing.T) {
 
 	// Set up helloworld app.
 	logger.Info("Creating a Route and Configuration for helloworld test app.")
-	helloWorldNames, err := CreateRouteAndConfig(clients, logger, "helloworld", &test.Options{})
 
-	if err != nil {
-		t.Fatalf("Failed to create Route and Configuration: %v", err)
+	helloWorldNames := test.ResourceNames{
+		Config: test.AppendRandomString(configName, logger),
+		Route:  test.AppendRandomString(routeName, logger),
+		Image:  "helloworld",
 	}
+
+	if _, err := test.CreateConfiguration(logger, clients, helloWorldNames, &test.Options{}); err != nil {
+		t.Fatalf("Failed to create Configuration: %v", err)
+	}
+
+	withInternalVisibility := WithRouteLabel(
+		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
+
+	if _, err := test.CreateRoute(logger, clients, helloWorldNames, withInternalVisibility); err != nil {
+		t.Fatalf("Failed to create Route: %v", err)
+	}
+
 	test.CleanupOnInterrupt(func() { TearDown(clients, helloWorldNames, logger) }, logger)
 	defer TearDown(clients, helloWorldNames, logger)
+
 	if err := test.WaitForRouteState(clients.ServingClient, helloWorldNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", helloWorldNames.Route, err)
+	}
+
+	helloWorldRoute, err := clients.ServingClient.Routes.Get(helloWorldNames.Route, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Route %q of helloworld app: %v", helloWorldNames.Route, err)
 	}
 
 	// Set up httpproxy app.
@@ -132,5 +160,16 @@ func TestServiceToServiceCall(t *testing.T) {
 	// We expect the response from httpproxy is equal to the response from htlloworld
 	if helloworldResponse != strings.TrimSpace(string(response.Body)) {
 		t.Fatalf("The httpproxy response '%s' is not equal to helloworld response '%s'.", string(response.Body), helloworldResponse)
+	}
+
+	// As a final check (since we know they are both up), check that we cannot
+	// send a request directly to the helloWorldRoute.
+	response, err = sendRequest(test.ServingFlags.ResolvableDomain, helloWorldRoute.Status.Domain)
+	if err != nil {
+		t.Fatalf("Failed to send request to helloworld: %v", err)
+	}
+
+	if got, want := response.StatusCode, http.StatusNotFound; got != want {
+		t.Errorf("Unexpected helloworld response status code = %v, wanted %v", got, want)
 	}
 }

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -58,9 +58,9 @@ func createTargetHostEnvVars(routeName string, t *testing.T) []corev1.EnvVar {
 	}
 	// Check that the target Route's Domain matches its cluster local address.
 	if want, got := helloWorldRoute.Status.Address.Hostname, helloWorldRoute.Status.Domain; got != want {
-		t.Errorf("Route.Domain = %v, wanted %v", got, want)
+		t.Errorf("Route.Domain = %v, want %v", got, want)
 	}
-	logger.Infof("helloworld internal domain is %v.", helloWorldRoute.Status.Domain)
+	logger.Infof("helloworld internal domain is %s.", helloWorldRoute.Status.Domain)
 	return []corev1.EnvVar{{
 		Name:  targetHostEnv,
 		Value: helloWorldRoute.Status.Domain,
@@ -170,6 +170,6 @@ func TestServiceToServiceCall(t *testing.T) {
 	}
 
 	if got, want := response.StatusCode, http.StatusNotFound; got != want {
-		t.Errorf("Unexpected helloworld response status code = %v, wanted %v", got, want)
+		t.Errorf("helloworld response StatusCode = %v, want %v", got, want)
 	}
 }

--- a/test/route.go
+++ b/test/route.go
@@ -23,11 +23,13 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
 
 // CreateRoute creates a route in the given namespace using the route name in names
-func CreateRoute(logger *logging.BaseLogger, clients *Clients, names ResourceNames) (*v1alpha1.Route, error) {
-	route := Route(ServingNamespace, names)
+func CreateRoute(logger *logging.BaseLogger, clients *Clients, names ResourceNames, fopt ...testing.RouteOption) (*v1alpha1.Route, error) {
+	route := Route(ServingNamespace, names, fopt...)
 	LogResourceObject(logger, ResourceObjects{Route: route})
 	return clients.ServingClient.Routes.Create(route)
 }


### PR DESCRIPTION
We were already using the cluster-internal domain to talk from the `httpproxy` to `helloworld` service, but this makes the `helloworld` service use our visibility label to force cluster-locality so that the `.status.domain` matches the `.status.address.hostname` we use.

The additional checks are added:
1. `.status.domain` matches `.status.address.hostname`
1. It we use the "spoofing client" to try and reach `.status.domain` we get a 404 (verifies that the `.svc.cluster.local` domain isn't exposed on the gateway).

Fixes: https://github.com/knative/serving/issues/2784
