### PR TITLE
Refactor the pool to resolve race condition.

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -23,7 +23,6 @@ import (
 type impl struct {
 	wg     sync.WaitGroup
 	workCh chan func() error
-	errCh  chan error
 	doneCh chan interface{}
 
 	// Ensure that we Wait exactly once and memoize


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The worker pool in `pkg/pool` had a [data race](https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-serving-continuous/1093359232851382272). It is not allowed to call `Wait` and `Add`from different goroutines for the `SyncGroup`.

To solve that I've thrown away the goroutines in the `Wait` function altogether and removed the need for an `errCh`. Since we need only the very first error anyway, we can just set that in a `Once` block.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
/cc @vagababov 

(@vagababov we had so much fun discussing concurrency on the Websocket connection, let's continue our journey here? 🙂 )