### PR TITLE
golang format tools

### DIFF
--- a/pkg/activator/testing/utils.go
+++ b/pkg/activator/testing/utils.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testing
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // GetTestEndpointsSubset generates the subsets of endpoints used for testing.

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -19,8 +19,9 @@ package reconciler
 import (
 	"fmt"
 
-	"github.com/knative/serving/pkg/utils"
 	"strings"
+
+	"github.com/knative/serving/pkg/utils"
 )
 
 const suffix = "-service"

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio.go
@@ -21,9 +21,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/knative/serving/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
-        "github.com/knative/serving/pkg/utils"
 )
 
 const (
@@ -92,7 +92,7 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 
 // NewIstioFromConfigMap creates an Istio config from the supplied ConfigMap
 func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
-        
+
 	gateways, err := parseGateways(configMap, GatewayKeyPrefix)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/v1alpha1/revision/config/controller.go
+++ b/pkg/reconciler/v1alpha1/revision/config/controller.go
@@ -43,8 +43,8 @@ func NewControllerConfigFromMap(configMap map[string]string) (*Controller, error
 	if registries, ok := configMap[registriesSkippingTagResolving]; !ok {
 		// It is ok if registries are missing
 		nc.RegistriesSkippingTagResolving = map[string]struct{}{
-			"ko.local":  struct{}{},
-			"dev.local": struct{}{},
+			"ko.local":  {},
+			"dev.local": {},
 		}
 	} else {
 		nc.RegistriesSkippingTagResolving = toStringSet(registries, ",")

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -341,7 +341,6 @@ func withOwnerReference(name string) revisionOption {
 	}
 }
 
-
 func TestMakePodSpec(t *testing.T) {
 	tests := []struct {
 		name string
@@ -383,8 +382,8 @@ func TestMakePodSpec(t *testing.T) {
 			withContainerConcurrency(1),
 			func(revision *v1alpha1.Revision) {
 				revision.Spec.Container.Ports = []corev1.ContainerPort{{
-                                        ContainerPort: 8888,
-                                }}
+					ContainerPort: 8888,
+				}}
 				revision.Spec.Container.VolumeMounts = []corev1.VolumeMount{{
 					Name:      "asdf",
 					MountPath: "/asdf",

--- a/test/crd.go
+++ b/test/crd.go
@@ -187,7 +187,7 @@ func ReleaseLatestService(namespace string, names ResourceNames, options *Option
 		},
 		Spec: v1alpha1.ServiceSpec{
 			Release: &v1alpha1.ReleaseType{
-				Revisions: []string{v1alpha1.ReleaseLatestRevisionKeyword},
+				Revisions:     []string{v1alpha1.ReleaseLatestRevisionKeyword},
 				Configuration: *ConfigurationSpec(ImagePath(names.Image), options),
 			},
 		},

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -210,5 +210,5 @@ func GetConfigMap(client *pkgTest.KubeClient) k8styped.ConfigMapInterface {
 
 // DeploymentScaledToZeroFunc returns a func that evaluates if a deployment has scaled to 0 pods.
 func DeploymentScaledToZeroFunc(d *apiv1beta1.Deployment) (bool, error) {
-		return d.Status.ReadyReplicas == 0, nil
+	return d.Status.ReadyReplicas == 0, nil
 }

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
+	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/loadgenerator"
 	"github.com/knative/test-infra/shared/testgrid"
-	"github.com/knative/test-infra/shared/junit"
 )
 
 func TestTimeToServeLatency(t *testing.T) {
@@ -87,7 +87,7 @@ func TestTimeToServeLatency(t *testing.T) {
 	}
 
 	ts := junit.TestSuites{}
-	ts.AddTestSuite( &junit.TestSuite{Name:"TestPerformanceLatency", TestCases:tc} )
+	ts.AddTestSuite(&junit.TestSuite{Name: "TestPerformanceLatency", TestCases: tc})
 
 	if err = testgrid.CreateXMLOutput(&ts, testName); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -201,7 +201,7 @@ func TestObservedConcurrency(t *testing.T) {
 	}
 	// TODO: For future, recreate the CreateTestgridXML function so we don't want to repeat the code shown in next 2 lines
 	ts := junit.TestSuites{}
-	ts.AddTestSuite( &junit.TestSuite{Name:"TestPerformanceLatency", TestCases:tc} )
+	ts.AddTestSuite(&junit.TestSuite{Name: "TestPerformanceLatency", TestCases: tc})
 
 	if err = testgrid.CreateXMLOutput(&ts, tName); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -147,7 +147,7 @@ func testGrid(s *stats, tName string) error {
 	val := float32(s.avg.Seconds() / 1000)
 	tc = append(tc, CreatePerfTestCase(val, "Average", tName))
 	ts := junit.TestSuites{}
-	ts.AddTestSuite( &junit.TestSuite{Name:"TestPerformanceLatency", TestCases:tc} )
+	ts.AddTestSuite(&junit.TestSuite{Name: "TestPerformanceLatency", TestCases: tc})
 	return testgrid.CreateXMLOutput(&ts, tName)
 }
 

--- a/test/performance/scale_test.go
+++ b/test/performance/scale_test.go
@@ -163,7 +163,7 @@ func TestScaleToN(t *testing.T) {
 
 	// We do this once here because it doesn't like table test names (with '/')
 	ts := junit.TestSuites{}
-	ts.AddTestSuite( &junit.TestSuite{Name:t.Name(), TestCases:results} )
+	ts.AddTestSuite(&junit.TestSuite{Name: t.Name(), TestCases: results})
 
 	if err := testgrid.CreateXMLOutput(&ts, t.Name()); err != nil {
 		t.Errorf("Cannot create output xml: %v", err)


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
