### PR TITLE
merge latest test-infra, ignores broken lint links

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -501,7 +501,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bb4a0cc53257bd07bb82b201d3afcf61c6c5ae51e91b2011a7484a91a9bb163a"
+  digest = "1:e10292ca31f337970056e5c3900ccc664385053baddff7fddc5f77b96c4114c5"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -514,7 +514,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "bf7e4dd5a226f5758e0eedd7370b99d33d464910"
+  revision = "425d36b7c2477efe7c8981dbdf76d2eb10c1d4e1"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"
@@ -1276,6 +1276,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/davecgh/go-spew/spew",
     "github.com/ghodss/yaml",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",

--- a/vendor/github.com/knative/test-infra/scripts/markdown-link-check-config.json
+++ b/vendor/github.com/knative/test-infra/scripts/markdown-link-check-config.json
@@ -2,6 +2,9 @@
     "ignorePatterns": [
         {
             "pattern": "^https?://localhost($|[:/].*)"
+        },
+        {
+            "pattern": "^(\\.|\\.\\.)?/.*"
         }
     ]
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Merge latest test-infra commit, which fixes [an issue](https://github.com/knative/test-infra/issues/445) where lint was falsely reporting errors by ignoring the link types that were failing.
* Also includes [this commit](https://github.com/knative/test-infra/commit/3509acd2a6c72b9730a3bdfdb715dcbea19de319)
*
