### PR TITLE
Enable throttler in activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -160,6 +160,7 @@ func main() {
 	endpointInformer := kubeInformerFactory.Core().V1().Endpoints()
 	revisionInformer := servingInformerFactory.Serving().V1alpha1().Revisions()
 
+	// Run informers instead of starting them from the factory to prevent the sync hanging because of empty handler.
 	go revisionInformer.Informer().Run(stopCh)
 	go endpointInformer.Informer().Run(stopCh)
 

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -191,6 +191,7 @@ func main() {
 	handler := cache.ResourceEventHandlerFuncs{
 		AddFunc:    activator.UpdateEndpoints(throttler),
 		UpdateFunc: controller.PassNew(activator.UpdateEndpoints(throttler)),
+		DeleteFunc: activator.DeleteBreaker(throttler),
 	}
 
 	filter := func(obj interface{}) bool {
@@ -205,11 +206,6 @@ func main() {
 	endpointInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: filter,
 		Handler:    handler,
-	})
-
-	// Remove the breaker if the revision was deleted.
-	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: activator.DeleteBreaker(throttler),
 	})
 
 	kubeInformerFactory.Start(stopCh)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -70,6 +70,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, activator.ErrActivatorOverload.Error(), http.StatusServiceUnavailable)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
+			a.Logger.Errorw("Error processing request in the activator", zap.Error(err))
 		}
 	}
 }

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"strconv"
 	"time"
-
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/activator/util"
 	pkghttp "github.com/knative/serving/pkg/http"
@@ -34,19 +33,36 @@ type ActivationHandler struct {
 	Logger    *zap.SugaredLogger
 	Transport http.RoundTripper
 	Reporter  activator.StatsReporter
+	Throttler *activator.Throttler
 }
 
 func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	namespace := pkghttp.LastHeaderValue(r.Header, activator.RevisionHeaderNamespace)
 	name := pkghttp.LastHeaderValue(r.Header, activator.RevisionHeaderName)
-
 	start := time.Now()
+	revID := activator.RevisionID{namespace, name}
+
+	// ActiveEndpoint() will block until the first endpoint is available.
+	ar := a.Activator.ActiveEndpoint(namespace, name)
+
+	err := a.Throttler.Try(revID, func() {
+		a.sendRequest(w, r, namespace, name, start, ar)
+	})
+	if err != nil {
+		if err == activator.OverloadMessage {
+			http.Error(w, activator.OverloadMessage.Error(), http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+func (a *ActivationHandler) sendRequest(w http.ResponseWriter, r *http.Request, namespace, name string, start time.Time, ar activator.ActivationResult) {
 	capture := &statusCapture{
 		ResponseWriter: w,
 		statusCode:     http.StatusOK,
 	}
 
-	ar := a.Activator.ActiveEndpoint(namespace, name)
 	if ar.Error != nil {
 		msg := fmt.Sprintf("Error getting active endpoint: %v", ar.Error)
 		a.Logger.Error(msg)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -433,7 +433,7 @@ func assertResponses(wantedSuccess, wantedFailure, overallRequests int, respCh c
 	t.Helper()
 	var succeeded int
 	var failed int
-	wantedOverflowMessage := activator.OverloadMessage.Error() + "\n"
+	wantedOverflowMessage := activator.ErrActivatorOverload.Error() + "\n"
 	for i := 0; i < overallRequests; i++ {
 		resp := <-respCh
 		switch resp.Code {

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -297,7 +297,7 @@ func TestActivationHandler(t *testing.T) {
 
 			gotBody, _ := ioutil.ReadAll(resp.Body)
 			if string(gotBody) != e.wantBody {
-				t.Errorf("Unexpected response body. Want %q, got %q", e.wantBody, gotBody)
+				t.Errorf("Unexpected response body. Response body %q, want %q", gotBody, e.wantBody)
 			}
 
 			if diff := cmp.Diff(e.reporterCalls, reporter.calls, ignoreDurationOption); diff != "" {
@@ -416,6 +416,9 @@ func getHandler(throttler *activator.Throttler, t *testing.T, act activator.Acti
 		if err != nil {
 			return resp, err
 		}
+		// Simulate a real request round trip to avoid race condition.
+		// If sending N requests that equals to the number of slots, we need to make sure that
+		// N+1 won't get a slot that is freed up by one of the "speedy" responses.
 		time.Sleep(50 * time.Millisecond)
 		return resp, nil
 	})

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -310,9 +310,11 @@ func TestActivationHandler(t *testing.T) {
 
 // Make sure we return http internal server error when the Breaker is overflowed
 func TestActivationHandler_Overflow(t *testing.T) {
-	wantedSuccess := 20
-	wantedFailure := 1
-	requests := 21
+	const (
+		wantedSuccess = 20
+		wantedFailure = 1
+		requests      = 21
+	)
 	respCh := make(chan *httptest.ResponseRecorder, requests)
 	// overall max 20 requests in the Breaker
 	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
@@ -333,10 +335,13 @@ func TestActivationHandler_Overflow(t *testing.T) {
 
 // Make sure if one breaker is overflowed, the requests to other revisions are still served
 func TestActivationHandler_OverflowSeveralRevisions(t *testing.T) {
-	wantedSuccess := 40
-	wantedFailure := 2
-	overallRequests := 42
-	revisions := 2
+	const (
+		wantedSuccess   = 40
+		wantedFailure   = 2
+		overallRequests = 42
+		revisions       = 2
+	)
+
 	respCh := make(chan *httptest.ResponseRecorder, overallRequests)
 
 	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +30,20 @@ import (
 	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/activator/util"
+	v1alpha12 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/queue"
 )
+
+const (
+	wantBody    = "everything good!"
+	successCode = http.StatusOK
+	failureCode = http.StatusServiceUnavailable
+)
+
+var stubRevisionGetter = func(activator.RevisionID) (*v1alpha12.Revision, error) {
+	revision := &v1alpha12.Revision{Spec: v1alpha12.RevisionSpec{ContainerConcurrency: 1}}
+	return revision, nil
+}
 
 type stubActivator struct {
 	endpoint  activator.Endpoint
@@ -68,6 +82,12 @@ func (fa *stubActivator) Shutdown() {
 }
 
 func TestActivationHandler(t *testing.T) {
+	goodEndpointsGetter := func(activator.RevisionID) (int32, error) {
+		return 1000, nil
+	}
+	brokenEndpointGetter := func(activator.RevisionID) (int32, error) {
+		return 0, errors.New("some error")
+	}
 	errMsg := func(msg string) string {
 		return fmt.Sprintf("Error getting active endpoint: %v\n", msg)
 	}
@@ -82,23 +102,25 @@ func TestActivationHandler(t *testing.T) {
 	act := newStubActivator("real-namespace", "real-name", server)
 
 	examples := []struct {
-		label         string
-		namespace     string
-		name          string
-		wantBody      string
-		wantCode      int
-		wantErr       error
-		attempts      string
-		reporterCalls []reporterCall
+		label           string
+		namespace       string
+		name            string
+		wantBody        string
+		wantCode        int
+		wantErr         error
+		attempts        string
+		endpointsGetter func(activator.RevisionID) (int32, error)
+		reporterCalls   []reporterCall
 	}{
 		{
-			label:     "active endpoint",
-			namespace: "real-namespace",
-			name:      "real-name",
-			wantBody:  "everything good!",
-			wantCode:  http.StatusOK,
-			wantErr:   nil,
-			attempts:  "123",
+			label:           "active endpoint",
+			namespace:       "real-namespace",
+			name:            "real-name",
+			wantBody:        "everything good!",
+			wantCode:        http.StatusOK,
+			wantErr:         nil,
+			attempts:        "123",
+			endpointsGetter: goodEndpointsGetter,
 			reporterCalls: []reporterCall{
 				{
 					Op:         "ReportRequestCount",
@@ -121,12 +143,13 @@ func TestActivationHandler(t *testing.T) {
 			},
 		},
 		{
-			label:     "active endpoint with missing count header",
-			namespace: "real-namespace",
-			name:      "real-name",
-			wantBody:  "everything good!",
-			wantCode:  http.StatusOK,
-			wantErr:   nil,
+			label:           "active endpoint with missing count header",
+			namespace:       "real-namespace",
+			name:            "real-name",
+			wantBody:        "everything good!",
+			wantCode:        http.StatusOK,
+			wantErr:         nil,
+			endpointsGetter: goodEndpointsGetter,
 			reporterCalls: []reporterCall{
 				{
 					Op:         "ReportRequestCount",
@@ -149,21 +172,23 @@ func TestActivationHandler(t *testing.T) {
 			},
 		},
 		{
-			label:         "no active endpoint",
-			namespace:     "fake-namespace",
-			name:          "fake-name",
-			wantBody:      errMsg("not found"),
-			wantCode:      http.StatusNotFound,
-			wantErr:       nil,
-			reporterCalls: nil,
+			label:           "no active endpoint",
+			namespace:       "fake-namespace",
+			name:            "fake-name",
+			wantBody:        errMsg("not found"),
+			wantCode:        http.StatusNotFound,
+			wantErr:         nil,
+			endpointsGetter: goodEndpointsGetter,
+			reporterCalls:   nil,
 		},
 		{
-			label:     "request error",
-			namespace: "real-namespace",
-			name:      "real-name",
-			wantBody:  "",
-			wantCode:  http.StatusBadGateway,
-			wantErr:   errors.New("request error"),
+			label:           "request error",
+			namespace:       "real-namespace",
+			name:            "real-name",
+			wantBody:        "",
+			wantCode:        http.StatusBadGateway,
+			wantErr:         errors.New("request error"),
+			endpointsGetter: goodEndpointsGetter,
 			reporterCalls: []reporterCall{
 				{
 					Op:         "ReportRequestCount",
@@ -186,13 +211,14 @@ func TestActivationHandler(t *testing.T) {
 			},
 		},
 		{
-			label:     "invalid number of attempts",
-			namespace: "real-namespace",
-			name:      "real-name",
-			wantBody:  "everything good!",
-			wantCode:  http.StatusOK,
-			wantErr:   nil,
-			attempts:  "hi there",
+			label:           "invalid number of attempts",
+			namespace:       "real-namespace",
+			name:            "real-name",
+			wantBody:        "everything good!",
+			wantCode:        http.StatusOK,
+			wantErr:         nil,
+			attempts:        "hi there",
+			endpointsGetter: goodEndpointsGetter,
 			reporterCalls: []reporterCall{
 				{
 					Op:         "ReportRequestCount",
@@ -213,6 +239,17 @@ func TestActivationHandler(t *testing.T) {
 					StatusCode: http.StatusOK,
 				},
 			},
+		},
+		{
+			label:           "broken GetEndpoints",
+			namespace:       "real-namespace",
+			name:            "real-name",
+			wantBody:        "",
+			wantCode:        http.StatusInternalServerError,
+			wantErr:         nil,
+			attempts:        "hi there",
+			endpointsGetter: brokenEndpointGetter,
+			reporterCalls:   nil,
 		},
 	}
 
@@ -233,11 +270,14 @@ func TestActivationHandler(t *testing.T) {
 			})
 
 			reporter := &fakeReporter{}
+			params := queue.BreakerParams{QueueDepth: 1000, MaxConcurrency: 1000, InitialCapacity: 0}
+			throttlerParams := activator.ThrottlerParams{BreakerParams: params, Logger: TestLogger(t), GetRevision: stubRevisionGetter, GetEndpoints: e.endpointsGetter}
 			handler := ActivationHandler{
 				Activator: act,
 				Transport: rt,
 				Logger:    TestLogger(t),
 				Reporter:  reporter,
+				Throttler: activator.NewThrottler(throttlerParams),
 			}
 
 			resp := httptest.NewRecorder()
@@ -268,6 +308,159 @@ func TestActivationHandler(t *testing.T) {
 
 }
 
+// Make sure we return http internal server error when the Breaker is overflowed
+func TestActivationHandler_Overflow(t *testing.T) {
+	wantedSuccess := 20
+	wantedFailure := 1
+	requests := 21
+	respCh := make(chan *httptest.ResponseRecorder, requests)
+	// overall max 20 requests in the Breaker
+	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+
+	conf := Config{
+		namespace:   "real-namespace",
+		revName:     "real-name",
+		serviceName: "real-name-service",
+		wantBody:    wantBody,
+		requests:    requests,
+		respCh:      respCh,
+	}
+	throttler := getThrottler(breakerParams, t)
+	run(conf, throttler, t)
+
+	assertResponses(wantedSuccess, wantedFailure, requests, respCh, t)
+}
+
+// Make sure if one breaker is overflowed, the requests to other revisions are still served
+func TestActivationHandler_OverflowSeveralRevisions(t *testing.T) {
+	wantedSuccess := 40
+	wantedFailure := 2
+	overallRequests := 42
+	revisions := 2
+	respCh := make(chan *httptest.ResponseRecorder, overallRequests)
+
+	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+
+	throttler := getThrottler(breakerParams, t)
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, wantBody)
+		}),
+	)
+
+	for rev := 0; rev < revisions; rev++ {
+		config := Config{
+			namespace:   fmt.Sprintf("real-namespace-%d", rev),
+			revName:     "real-name",
+			serviceName: "real-name-service",
+			wantBody:    wantBody,
+			requests:    21,
+			respCh:      respCh,
+			revisions:   revisions,
+		}
+		act := newStubActivator(config.namespace, config.revName, server)
+		handler := getHandler(throttler, t, act)
+		sendRequests(config, handler)
+	}
+	assertResponses(wantedSuccess, wantedFailure, overallRequests, respCh, t)
+}
+
+type Config struct {
+	namespace     string
+	revName       string
+	serviceName   string
+	requests      int
+	respCh        chan *httptest.ResponseRecorder
+	wantBody      string
+	breakerParams queue.BreakerParams
+	revisions     int
+}
+
+func sendRequests(config Config, handler ActivationHandler) {
+	for i := 0; i < config.requests; i++ {
+		go func() {
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "http://example.com", nil)
+			req.Header.Set(activator.RevisionHeaderNamespace, config.namespace)
+			req.Header.Set(activator.RevisionHeaderName, config.revName)
+			handler.ServeHTTP(resp, req)
+			config.respCh <- resp
+		}()
+	}
+}
+
+func getThrottler(breakerParams queue.BreakerParams, t *testing.T) *activator.Throttler {
+	endpointsGetter := func(activator.RevisionID) (int32, error) {
+		return breakerParams.InitialCapacity, nil
+	}
+	throttlerParams := activator.ThrottlerParams{BreakerParams: breakerParams, Logger: TestLogger(t), GetRevision: stubRevisionGetter, GetEndpoints: endpointsGetter}
+	throttler := activator.NewThrottler(throttlerParams)
+	return throttler
+}
+
+func run(conf Config, throttler *activator.Throttler, t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, conf.wantBody)
+		}),
+	)
+	act := newStubActivator(conf.namespace, conf.revName, server)
+	handler := getHandler(throttler, t, act)
+	sendRequests(conf, handler)
+}
+
+func getHandler(throttler *activator.Throttler, t *testing.T, act activator.Activator) ActivationHandler {
+	rt := util.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		resp, err := http.DefaultTransport.RoundTrip(r)
+		if err != nil {
+			return resp, err
+		}
+		time.Sleep(50 * time.Millisecond)
+		return resp, nil
+	})
+	handler := ActivationHandler{
+		Activator: act,
+		Transport: rt,
+		Logger:    TestLogger(t),
+		Reporter:  &fakeReporter{},
+		Throttler: throttler,
+	}
+	return handler
+}
+
+func assertResponses(wantedSuccess, wantedFailure, overallRequests int, respCh chan *httptest.ResponseRecorder, t *testing.T) {
+	t.Helper()
+	var succeeded int
+	var failed int
+	wantedOverflowMessage := activator.OverloadMessage.Error() + "\n"
+	for i := 0; i < overallRequests; i++ {
+		resp := <-respCh
+		switch resp.Code {
+		case successCode:
+			gotBody, _ := ioutil.ReadAll(resp.Body)
+			if string(gotBody) != wantBody {
+				t.Errorf("Unexpected response body. Want %q, got %q", wantBody, gotBody)
+			}
+			succeeded++
+		case failureCode:
+			if wantedOverflowMessage != resp.Body.String() {
+				t.Errorf("Unexpected error message. Want %s, got %s", wantedOverflowMessage, resp.Body)
+			}
+			failed++
+		default:
+			t.Errorf("Unknown http response code was received. Want either %d|%d, got %d", successCode, failureCode, resp.Code)
+		}
+	}
+	if wantedFailure != failed {
+		t.Errorf("Unexpected number of failed requests. Want %d, got %d", wantedFailure, failed)
+	}
+	if succeeded != wantedSuccess {
+		t.Errorf("Unexpected number of succeeded requests. Want %d, got %d", wantedSuccess, succeeded)
+	}
+
+}
+
 var ignoreDurationOption = cmpopts.IgnoreFields(reporterCall{}, "Duration")
 
 type reporterCall struct {
@@ -284,9 +477,12 @@ type reporterCall struct {
 
 type fakeReporter struct {
 	calls []reporterCall
+	mux   sync.Mutex
 }
 
 func (f *fakeReporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v int64) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
 	f.calls = append(f.calls, reporterCall{
 		Op:         "ReportRequestCount",
 		Namespace:  ns,
@@ -302,6 +498,8 @@ func (f *fakeReporter) ReportRequestCount(ns, service, config, rev string, respo
 }
 
 func (f *fakeReporter) ReportResponseTime(ns, service, config, rev string, responseCode int, d time.Duration) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
 	f.calls = append(f.calls, reporterCall{
 		Op:         "ReportResponseTime",
 		Namespace:  ns,

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -157,8 +157,9 @@ func UpdateEndpoints(throttler *Throttler) func(newObj interface{}) {
 // It removes the Breaker from the Throttler bookkeeping.
 func DeleteBreaker(throttler *Throttler) func(obj interface{}) {
 	return func(obj interface{}) {
-		rev := obj.(*v1alpha1.Revision)
-		revID := RevisionID{rev.Namespace, rev.Name}
+		ep := obj.(*corev1.Endpoints)
+		name := reconciler.GetServingRevisionNameForK8sService(ep.Name)
+		revID := RevisionID{ep.Namespace, name}
 		throttler.Remove(revID)
 	}
 }

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -142,8 +142,8 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 // that do not belong to any revision).
 //
 // This function must not be called in parallel to not induce a wrong order of events.
-func UpdateEndpoints(throttler *Throttler) func(_, newObj interface{}) {
-	return func(_, newObj interface{}) {
+func UpdateEndpoints(throttler *Throttler) func(newObj interface{}) {
+	return func(newObj interface{}) {
 		endpoints := newObj.(*corev1.Endpoints)
 		addresses := EndpointsAddressCount(endpoints.Subsets)
 		revID := RevisionID{endpoints.Namespace, reconciler.GetServingRevisionNameForK8sService(endpoints.Name)}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -27,8 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// OverloadMessage indicates that throttler has no free slots to buffer the request.
-var OverloadMessage = errors.New("activator overload")
+// ErrActivatorOverload indicates that throttler has no free slots to buffer the request.
+var ErrActivatorOverload = errors.New("activator overload")
 
 // ThrottlerParams defines the parameters of the Throttler.
 type ThrottlerParams struct {
@@ -89,7 +89,7 @@ func (t *Throttler) Try(rev RevisionID, function func()) error {
 		}
 	}
 	if !breaker.Maybe(function) {
-		return OverloadMessage
+		return ErrActivatorOverload
 	}
 	return nil
 }

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -27,10 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	// OverloadMessage indicates that throttler has no free slots to buffer the request.
-	OverloadMessage = "activator overload"
-)
+// OverloadMessage indicates that throttler has no free slots to buffer the request.
+var OverloadMessage = errors.New("activator overload")
 
 // ThrottlerParams defines the parameters of the Throttler.
 type ThrottlerParams struct {
@@ -91,7 +89,7 @@ func (t *Throttler) Try(rev RevisionID, function func()) error {
 		}
 	}
 	if !breaker.Maybe(function) {
-		return errors.New(OverloadMessage)
+		return OverloadMessage
 	}
 	return nil
 }

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -241,10 +241,8 @@ func TestUpdateEndpoints(t *testing.T) {
 		throttler := getThrottler(s.concurrency, existingRevisionGetter(10), existingEndpointsGetter, TestLogger(t), s.initCapacity)
 		throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
 		updater := UpdateEndpoints(throttler)
-
-		endpointsBefore := corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointBefore, 1)}
-		endpointsAfter := corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointsAfter, 1)}
-		updater(&endpointsBefore, &endpointsAfter)
+		endpointsAfter := corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: revID.Name + "-service", Namespace: revID.Namespace}, Subsets: testinghelper.GetTestEndpointsSubset(s.endpointsAfter-s.endpointBefore, 1)}
+		updater(&endpointsAfter)
 
 		breaker, _ := throttler.breakers[revID]
 		got := breaker.Capacity()

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -268,7 +268,7 @@ func TestThrottler_Remove(t *testing.T) {
 
 func TestHelper_DeleteBreaker(t *testing.T) {
 	throttler := getThrottler(int32(20), existingRevisionGetter(10), existingEndpointsGetter, TestLogger(t), initCapacity)
-	revision := &v1alpha1.Revision{
+	endpoints := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      revID.Name,
 			Namespace: revID.Namespace,
@@ -279,7 +279,7 @@ func TestHelper_DeleteBreaker(t *testing.T) {
 	if got := len(throttler.breakers); got != 1 {
 		t.Errorf("Breaker map size got %d, want: 1", got)
 	}
-	DeleteBreaker(throttler)(revision)
+	DeleteBreaker(throttler)(endpoints)
 	if len(throttler.breakers) != 0 {
 		t.Error("Breaker map is not empty")
 	}

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -190,8 +190,8 @@ func TestThrottler_TryOverload(t *testing.T) {
 	})
 	// `err` must be non-nil here, since `t.Fatal()` above would ensure we
 	// don't reach here on success.
-	if got := err; got != OverloadMessage {
-		t.Errorf("Error message = %q, want: %q", got, OverloadMessage.Error())
+	if got := err; got != ErrActivatorOverload {
+		t.Errorf("Error message = %q, want: %q", got, ErrActivatorOverload.Error())
 	}
 	close(done)
 	if err := g.Wait(); err != nil {

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -191,7 +191,7 @@ func TestThrottler_TryOverload(t *testing.T) {
 	// `err` must be non-nil here, since `t.Fatal()` above would ensure we
 	// don't reach here on success.
 	if got := err; got != ErrActivatorOverload {
-		t.Errorf("Error message = %q, want: %q", got, ErrActivatorOverload.Error())
+		t.Errorf("Error message = %v, want: %v", got, ErrActivatorOverload)
 	}
 	close(done)
 	if err := g.Wait(); err != nil {

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -168,7 +168,7 @@ func TestThrottler_Try(t *testing.T) {
 
 func TestThrottler_TryOverload(t *testing.T) {
 	th := getThrottler(
-		1 /*maxConcurrency*/, existingRevisionGetter(10), existingEndpointsGetter, TestLogger(t),
+		1 /*maxConcurrency*/ , existingRevisionGetter(10), existingEndpointsGetter, TestLogger(t),
 		1 /*initial capacity*/)
 	done := make(chan struct{})
 
@@ -190,8 +190,8 @@ func TestThrottler_TryOverload(t *testing.T) {
 	})
 	// `err` must be non-nil here, since `t.Fatal()` above would ensure we
 	// don't reach here on success.
-	if got := err.Error(); got != OverloadMessage {
-		t.Errorf("Error message = %q, want: %q", got, OverloadMessage)
+	if got := err; got != OverloadMessage {
+		t.Errorf("Error message = %q, want: %q", got, OverloadMessage.Error())
 	}
 	close(done)
 	if err := g.Wait(); err != nil {

--- a/pkg/reconciler/filter.go
+++ b/pkg/reconciler/filter.go
@@ -18,7 +18,6 @@ package reconciler
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // AnnotationFilterFunc creates a FilterFunc only accepting objects with given annotation key and value
@@ -39,8 +38,11 @@ func AnnotationFilterFunc(key string, value string, allowUnset bool) func(interf
 // LabelExistsFilterFunc creates a FilterFunc only accepting objects which have a given label.
 func LabelExistsFilterFunc(label string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
-		endpoints := obj.(*corev1.Endpoints)
-		_, ok := endpoints.Labels[label]
-		return ok
+		if mo, ok := obj.(metav1.Object); ok {
+			labels := mo.GetLabels()
+			_, ok := labels[label]
+			return ok
+		}
+		return false
 	}
 }

--- a/pkg/reconciler/filter.go
+++ b/pkg/reconciler/filter.go
@@ -18,6 +18,7 @@ package reconciler
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // AnnotationFilterFunc creates a FilterFunc only accepting objects with given annotation key and value
@@ -32,5 +33,14 @@ func AnnotationFilterFunc(key string, value string, allowUnset bool) func(interf
 			return annoVal == value
 		}
 		return false
+	}
+}
+
+// LabelExistsFilterFunc creates a FilterFunc only accepting objects which have a given label.
+func LabelExistsFilterFunc(label string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		endpoints := obj.(*corev1.Endpoints)
+		_, ok := endpoints.Labels[label]
+		return ok
 	}
 }

--- a/pkg/reconciler/filter_test.go
+++ b/pkg/reconciler/filter_test.go
@@ -29,56 +29,60 @@ var (
 	valueToFilter = "testVal"
 )
 
-func config(annos map[string]string) *v1alpha1.Configuration {
+func config(annos, labels map[string]string) *v1alpha1.Configuration {
 	return &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   "testSpace",
 			Name:        "testName",
 			Annotations: annos,
+			Labels:      labels,
 		},
 	}
 }
 
+type params struct {
+	name       string
+	allowUnset bool
+	in         interface{}
+	want       bool
+}
+
 func TestAnnotationFilter(t *testing.T) {
-	tests := []struct {
-		name       string
-		allowUnset bool
-		in         interface{}
-		want       bool
-	}{{
-		name: "non kubernetes object",
+	tests := []params{{
+		name:
+		"non kubernetes object",
 		in:   struct{}{},
 		want: false,
 	}, {
 		name: "empty annotations",
-		in:   config(nil),
+		in:   config(nil, nil),
 		want: false,
 	}, {
 		name:       "empty annotations, allow unset",
 		allowUnset: true,
-		in:         config(nil),
+		in:         config(nil, nil),
 		want:       true,
 	}, {
 		name: "other annotations",
-		in:   config(map[string]string{"anotherKey": "anotherValue"}),
+		in:   config(map[string]string{"anotherKey": "anotherValue"}, nil),
 		want: false,
 	}, {
 		name:       "other annotations, allow unset",
 		allowUnset: true,
-		in:         config(map[string]string{"anotherKey": "anotherValue"}),
+		in:         config(map[string]string{"anotherKey": "anotherValue"}, nil),
 		want:       true,
 	}, {
 		name: "matching key, value mismatch",
-		in:   config(map[string]string{keyToFilter: "testVal2"}),
+		in:   config(map[string]string{keyToFilter: "testVal2"}, nil),
 		want: false,
 	}, {
 		name:       "matching key, value mismatch, allow unset",
 		allowUnset: true,
-		in:         config(map[string]string{keyToFilter: "testVal2"}),
+		in:         config(map[string]string{keyToFilter: "testVal2"}, nil),
 		want:       false,
 	}, {
 		name: "match",
-		in:   config(map[string]string{keyToFilter: valueToFilter}),
+		in:   config(map[string]string{keyToFilter: valueToFilter}, nil),
 		want: true,
 	}}
 
@@ -88,6 +92,36 @@ func TestAnnotationFilter(t *testing.T) {
 			got := filter(test.in)
 			if got != test.want {
 				t.Errorf("AnnotationFilterFunc did not return the expected result, got: %v", got)
+			}
+		})
+	}
+}
+
+func TestLabelExistsFilterFunc(t *testing.T) {
+	ti := []params{{
+		name: "label exists",
+		in:   config(nil, map[string]string{keyToFilter: valueToFilter}),
+		want: true,
+	}, {
+		name: "empty labels",
+		in:   config(nil, map[string]string{}),
+		want: false,
+	}, {
+		name: "non-emtpy map, the required label doesn't exist",
+		in:   config(nil, map[string]string{"randomLabel": ""}),
+		want: false,
+	}, {
+		name: "non kubernetes object",
+		in:   struct{}{},
+		want: false,
+	}}
+
+	for _, test := range ti {
+		t.Run(test.name, func(t *testing.T) {
+			filter := LabelExistsFilterFunc(keyToFilter)
+			got := filter(test.in)
+			if got != test.want {
+				t.Errorf("LabelExistsFilterFunc did not return the expected result, got: %v", got)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2381

## Proposed Changes

* Enable throttler in `activator/main.go` and in `pkg/activator/handler/handler.go`.
* Define endpoint observer and revision observers in the main method.
* Return 503 in case of throttler overflow (should not happen unless the BreakersQueueDepth is reached), and 502 in case if the revision is not found (should not happen)
* See the reduction of previously observed 503s - https://github.com/knative/serving/issues/1846#issuecomment-459338147
* Extend existing unit tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
Throttle requests in activator in case of overflow.
```
