### PR TITLE
Test suite improvements for environments with limited resources

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -78,6 +78,19 @@ To run one e2e test case, e.g. TestAutoscaleUpDownUp, use
 go test -v -tags=e2e -count=1 ./test/e2e -run ^TestAutoscaleUpDownUp$
 ```
 
+### Running tests in short mode
+
+Running tests in short mode excludes some large-scale E2E tests 
+and saves time/resources required for running the test suite. To run the tests in
+short mode, use [the `-short` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags)
+
+```bash
+go test -v -tags=e2e -count=1 -short ./test/e2e
+```
+
+To get a better idea where the flag is used, search for `testing.Short()` throughout the test
+source code.
+
 ### Environment requirements
 
 These tests require:

--- a/test/crd.go
+++ b/test/crd.go
@@ -24,12 +24,17 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
+
+// Default for user containers in e2e tests. This value is lower than the general
+// Knative's default so as to run more effectively in CI with limited resources.
+const defaultRequestCPU = "100m"
 
 // ResourceNames holds names of various resources.
 type ResourceNames struct {
@@ -118,6 +123,14 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 
 	if options.EnvVars != nil {
 		spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
+	}
+
+	if options.ContainerResources.Limits == nil && options.ContainerResources.Requests == nil {
+		spec.RevisionTemplate.Spec.Container.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse(defaultRequestCPU),
+			},
+		}
 	}
 
 	return spec

--- a/test/crd.go
+++ b/test/crd.go
@@ -104,6 +104,14 @@ func BlueGreenRoute(namespace string, names, blue, green ResourceNames) *v1alpha
 // ConfigurationSpec returns the spec of a configuration to be used throughout different
 // CRD helpers.
 func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.ConfigurationSpec {
+	if options.ContainerResources.Limits == nil && options.ContainerResources.Requests == nil {
+		options.ContainerResources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse(defaultRequestCPU),
+			},
+		}
+	}
+
 	spec := &v1alpha1.ConfigurationSpec{
 		RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 			Spec: v1alpha1.RevisionSpec{
@@ -123,14 +131,6 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 
 	if options.EnvVars != nil {
 		spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
-	}
-
-	if options.ContainerResources.Limits == nil && options.ContainerResources.Requests == nil {
-		spec.RevisionTemplate.Spec.Container.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse(defaultRequestCPU),
-			},
-		}
 	}
 
 	return spec

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -38,6 +38,9 @@ func (nl *nopLatencies) Add(metric string, start time.Time) {
 	nl.logger.Infof("%q took %v", metric, duration)
 }
 
+// Limit for scale in -short mode
+const shortModeMaxScale = 10
+
 // While redundant, we run two versions of this by default:
 // 1. TestScaleToN/size-10: a developer smoke test that's useful when changing this to assess whether
 //   things have gone horribly wrong.  This should take about 12-20 seconds total.
@@ -58,6 +61,9 @@ func TestScaleToN(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("scale-%d", test.size), func(t *testing.T) {
+			if testing.Short() && test.size > shortModeMaxScale {
+				t.Skip("Skipping test in short mode")
+			}
 			// Add test case specific name to its own logger
 			logger := logging.GetContextLogger(t.Name())
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

1) Fixes #2987 by adding utilizing `-short` flag in E2E tests

2) Minimizes default CPU request for test containers. Most of the time they don't need more than 100m (I used the autoscaling tests for measuring that). In limited environments it speeds up test suite execution and also prevents random failures.
