### PR TITLE
Format markdown

### DIFF
--- a/docs/resources-overview.md
+++ b/docs/resources-overview.md
@@ -9,17 +9,18 @@ which they form.
 
 ## Dependencies
 
-Knative Serving depends on [Istio](https://istio.io/) in order to function. Istio is responsible for
-setting up the network routing both inside the cluster and ingress into the cluster.
+Knative Serving depends on [Istio](https://istio.io/) in order to function.
+Istio is responsible for setting up the network routing both inside the cluster
+and ingress into the cluster.
 
 ## Components
 
 There are four primary components to the Knative Serving system. The first is
-the _Controller_ which is responsible for updating the state of the cluster based on
-user input. The second is the _Webhook_ component which handles validation of the
-objects and actions performed. The third is an _Activator_ component which brings
-back scaled-to-zero pods and forwards requests. The fourth is the _Autoscaler_
-which scales pods are requests come in.
+the _Controller_ which is responsible for updating the state of the cluster
+based on user input. The second is the _Webhook_ component which handles
+validation of the objects and actions performed. The third is an _Activator_
+component which brings back scaled-to-zero pods and forwards requests. The
+fourth is the _Autoscaler_ which scales pods are requests come in.
 
 The controller processes a series of state changes in order to move the system
 from its current, actual state to the state desired by the user.
@@ -32,13 +33,13 @@ To see only objects of a specific type, for example to see the webhook and
 controller deployments inside Knative Serving, you can run
 `kubectl -n knative-serving get deployments`.
 
-The Knative Serving controller creates Kubernetes and Istio
-resources when Knative Serving resources are created and updated. It will also
-create Build resources when provided in the Configuration spec. These
-sub-resources will be created in the same namespace as their parent Knative
-Serving resource, _not_ the `knative-serving` namespace. For example, if you
-create a Knative Serivce in namespace 'foo' the cooresponding Istio resources
-will also be in namespace 'foo'.
+The Knative Serving controller creates Kubernetes and Istio resources when
+Knative Serving resources are created and updated. It will also create Build
+resources when provided in the Configuration spec. These sub-resources will be
+created in the same namespace as their parent Knative Serving resource, _not_
+the `knative-serving` namespace. For example, if you create a Knative Serivce in
+namespace 'foo' the cooresponding Istio resources will also be in namespace
+'foo'.
 
 ## Kubernetes Resource Configs
 
@@ -98,8 +99,9 @@ controller-699fb46bb5-xhlkg   1/1       Running   0          5d
 webhook-76b87b8459-tzj6r      1/1       Running   0          5d
 ```
 
-Similarly, you can run the same commands in the istio (`istio-system`) namespaces
-to view the running deployments. To view all namespaces, run `kubectl get namespaces`.
+Similarly, you can run the same commands in the istio (`istio-system`)
+namespaces to view the running deployments. To view all namespaces, run
+`kubectl get namespaces`.
 
 ### Service Accounts and RBAC policies
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -448,10 +448,10 @@ container: # v1.Container
   # the container.  Each of the volumes in the RevisionSpec must be mounted here
   # or it is an error.
   volumeMounts:
-  - name: ... # This must match a name from Volumes
-    mountPath: ... # Where to mount the named Volume.
-    readOnly: ... # Must be True, will default to True, so it may be omitted.
-    # All other fields are disallowed.
+    - name: ... # This must match a name from Volumes
+      mountPath: ... # Where to mount the named Volume.
+      readOnly: ... # Must be True, will default to True, so it may be omitted.
+      # All other fields are disallowed.
 
   livenessProbe: ... # Optional
   readinessProbe: ... # Optional

--- a/pkg/reconciler/v1alpha1/route/README.md
+++ b/pkg/reconciler/v1alpha1/route/README.md
@@ -32,14 +32,15 @@ the following objects:
 - A VirtualService to realize the routing from the Gateway
   `knative-ingress-gateway` to the traffic target referenced in the Route.
 - A Service with the same name as the Route, so that we can access the Route
-  using `<route-name>.<route-namespace>.svc.<cluster-domain-name>`. This Service has no
-  Pod, we use it solely to have a domain name and a cluster IP to be used in the
-  VirtualService. The value of `<cluster-domain-name>` depends on a domain name
-  specified during the installation of the cluster. If no custom domain name was specified, then
-  `cluster.local` should be used as in the following example:
-  
+  using `<route-name>.<route-namespace>.svc.<cluster-domain-name>`. This Service
+  has no Pod, we use it solely to have a domain name and a cluster IP to be used
+  in the VirtualService. The value of `<cluster-domain-name>` depends on a
+  domain name specified during the installation of the cluster. If no custom
+  domain name was specified, then `cluster.local` should be used as in the
+  following example:
+
   `<route-name>.<route-namespace>.svc.cluster.local`
-  
+
   otherwise cluster's custom domain name should be used:
 
   `<route-name>.<route-namespace>.svc.real-domain-name.com`


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`