### PR TITLE
Bump timeout of 'TestGlobalResyncOnConfigMapUpdate' to 3 seconds.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -782,7 +782,7 @@ func TestGlobalResyncOnConfigMapUpdate(t *testing.T) {
 
 			watcher.OnChange(&test.configMapToUpdate)
 
-			if err := h.WaitForHooks(time.Second); err != nil {
+			if err := h.WaitForHooks(3 * time.Second); err != nil {
 				t.Errorf("%s Global Resync Failed: %v", test.name, err)
 			}
 		})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3085 

As per title. There are a few tests that are similar to this but not failing constantly. The glaring difference is that the other tests all have a timeout of 3 seconds. This removes that difference and hopefully fixes the flakes (passed 50 times locally).

These tests take quite long so genuinely running into timeouts made sense to me while testing locally.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
