### PR TITLE
Semaphore is the internal implementation detail of the breaker.

### DIFF
--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -374,7 +374,7 @@ func assertEqual(want, got interface{}, t *testing.T) {
 	}
 }
 
-func tryAcquire(sem *Semaphore, gotChan chan struct{}) {
+func tryAcquire(sem *semaphore, gotChan chan struct{}) {
 	go func() {
 		// blocking until someone puts the token into the semaphore
 		sem.Acquire()


### PR DESCRIPTION
Hence there is no reason for it to be public.

/cc @markusthoemmes @mattmoor 