### PR TITLE
Conformance Tests for Protocols

### DIFF
--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -1,7 +1,7 @@
 // +build e2e
 
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -1,0 +1,196 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/spoof"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
+	"github.com/knative/serving/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type protocolsTest struct {
+	t       *testing.T
+	logger  *logging.BaseLogger
+	clients *test.Clients
+	names   test.ResourceNames
+}
+
+func (pt *protocolsTest) setup(t *testing.T) {
+	pt.t = t
+
+	pt.clients = setup(t)
+	pt.logger = logging.GetContextLogger(t.Name())
+	pt.names = test.ResourceNames{
+		Service: test.AppendRandomString("protocols", pt.logger),
+		Image:   protocols,
+	}
+
+	test.CleanupOnInterrupt(func() { pt.teardown() }, pt.logger)
+}
+
+func (pt *protocolsTest) teardown() {
+	tearDown(pt.clients, pt.names)
+}
+
+func (pt *protocolsTest) getProtocol(resp *spoof.Response) protocol {
+	var got protocol
+
+	err := json.Unmarshal(resp.Body, &got)
+	if err != nil {
+		pt.t.Fatalf("Can't unmarshal response %s: %v", resp.Body, err)
+	}
+
+	pt.logger.Infof("Parsed version: %q", got.String())
+
+	return got
+}
+
+func (pt *protocolsTest) makeRequest(domain string) *spoof.Response {
+	pt.logger.Infof("Making request to %q", domain)
+
+	resp, err := pkgTest.WaitForEndpointState(
+		pt.clients.KubeClient, pt.logger, domain,
+		pkgTest.Retrying(
+			func(resp *spoof.Response) (bool, error) {
+				if resp.StatusCode == http.StatusOK {
+					return true, nil
+				}
+
+				return true, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+			},
+			http.StatusNotFound,
+		),
+		pt.t.Name(), test.ServingFlags.ResolvableDomain,
+	)
+	if err != nil {
+		pt.t.Fatalf("Failed to get a successful request from %s: %v", domain, err)
+	}
+
+	pt.logger.Infof("Got response: %s", resp.Body)
+
+	return resp
+}
+
+func (pt *protocolsTest) createService(options *test.Options) *v1alpha1.Service {
+	pt.logger.Infof("Creating service %q with options: %#v", pt.names.Service, options)
+
+	service := test.LatestService(test.ServingNamespace, pt.names, options)
+
+	svc, err := pt.clients.ServingClient.Services.Create(service)
+	if err != nil {
+		pt.t.Fatalf("Error creating service: %s", err.Error())
+	}
+
+	if err := test.WaitForServiceState(pt.clients.ServingClient, pt.names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		pt.t.Fatalf("Service %s not marked Ready: %v", pt.names.Service, err)
+	}
+
+	pt.logger.Infof("Service %q created", pt.names.Service)
+
+	return svc
+}
+
+func (pt *protocolsTest) getDomain(service *v1alpha1.Service) string {
+	pt.names.Route = serviceresourcenames.Route(service)
+
+	pt.logger.Infof("Fetching domain from route %q", pt.names.Route)
+
+	if err := test.WaitForRouteState(pt.clients.ServingClient, pt.names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
+		pt.t.Fatalf("Route %s not marked Ready: %v", pt.names.Route, err)
+	}
+
+	route, err := pt.clients.ServingClient.Routes.Get(pt.names.Route, metav1.GetOptions{})
+	if err != nil {
+		pt.t.Fatalf("Error fetching Route %s: %v", pt.names.Route, err)
+	}
+
+	pt.logger.Infof("Got domain %q", route.Status.Domain)
+
+	return route.Status.Domain
+}
+
+type protocol struct {
+	Major int `json:"protoMajor"`
+	Minor int `json:"protoMinor"`
+}
+
+func (p *protocol) String() string {
+	return fmt.Sprintf("HTTP/%d.%d", p.Major, p.Minor)
+}
+
+func portOption(portname string) *test.Options {
+	options := &test.Options{}
+
+	if portname != "" {
+		options.ContainerPorts = []corev1.ContainerPort{{Name: portname, ContainerPort: 8080}}
+	}
+
+	return options
+}
+
+func TestProtocols(t *testing.T) {
+	tests := []struct {
+		Name     string
+		PortName string
+		Want     protocol
+	}{{
+		Name:     "HTTP/2.0",
+		PortName: "h2c",
+		Want:     protocol{Major: 2, Minor: 0},
+	}, {
+		Name:     "HTTP/1.1",
+		PortName: "http1",
+		Want:     protocol{Major: 1, Minor: 1},
+	}, {
+		Name:     "Default",
+		PortName: "",
+		Want:     protocol{Major: 1, Minor: 1},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			var pt protocolsTest
+
+			pt.setup(t)
+			defer pt.teardown()
+
+			options := portOption(tt.PortName)
+
+			service := pt.createService(options)
+			domain := pt.getDomain(service)
+
+			response := pt.makeRequest(domain)
+			got := pt.getProtocol(response)
+
+			if got != tt.Want {
+				t.Errorf("Want %s, got %s", tt.Want.String(), got.String())
+			}
+		})
+	}
+}

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -49,6 +49,7 @@ const (
 	timeout             = "timeout"
 	printport           = "printport"
 	runtime             = "runtime"
+	protocols           = "protocols"
 
 	concurrentRequests = 50
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.

--- a/test/crd.go
+++ b/test/crd.go
@@ -119,6 +119,7 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 					Image:          imagePath,
 					Resources:      options.ContainerResources,
 					ReadinessProbe: options.ReadinessProbe,
+					Ports:          options.ContainerPorts,
 				},
 				ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
 			},

--- a/test/test_images/protocols/README.md
+++ b/test/test_images/protocols/README.md
@@ -10,7 +10,7 @@ following format:
 ```
 {
   'protoMajor': 1 # 2 if HTTP/2
-  'protoMinor': 1 # 0 if HTTP/1
+  'protoMinor': 1 # 0 if HTTP/2
 }
 ```
 

--- a/test/test_images/protocols/README.md
+++ b/test/test_images/protocols/README.md
@@ -1,0 +1,21 @@
+# Protocols test image
+
+This directory contains the test image used to test the [supported
+network protocols](/docs/runtime-contract.md#protocols-and-ports).
+
+The image contains a simple server that will serve HTTP/1.1 and HTTP/2.0
+requests from the same port. The response will be a JSON with the
+following format:
+
+```
+{
+  'protoMajor': 1 # 2 if HTTP/2
+  'protoMinor': 1 # 0 if HTTP/1
+}
+```
+
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/protocols/protocols.go
+++ b/test/test_images/protocols/protocols.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/knative/serving/test"
+)
+
+type Response struct {
+	ProtoMajor int `json:"protoMajor"`
+	ProtoMinor int `json:"protoMinor"`
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	response := Response{ProtoMajor: r.ProtoMajor, ProtoMinor: r.ProtoMinor}
+
+	json, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(json)
+}
+
+func main() {
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/test/util.go
+++ b/test/util.go
@@ -21,6 +21,8 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/knative/pkg/signals"
 	"github.com/knative/pkg/test/logging"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 const (
@@ -56,7 +58,7 @@ func ListenAndServeGracefullyWithPattern(addr string, handlers map[string]func(w
 		m.HandleFunc(pattern, handler)
 	}
 
-	server := http.Server{Addr: addr, Handler: m}
+	server := http.Server{Addr: addr, Handler: h2c.NewHandler(m, &http2.Server{})}
 	go server.ListenAndServe()
 
 	<-signals.SetupSignalHandler()


### PR DESCRIPTION
Added conformance tests to validate protocol support as per the [runtime contract](https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports).

Setting the container port name to `h2c` will enable HTTP 2.0 with Prior Knowledge, and setting it to `http1` or leaving it blank will fall back to HTTP 1.1

Fixes #3008 