### PR TITLE
Drop replicas from the activator.

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -20,7 +20,6 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: activator


### PR DESCRIPTION
"No `replicas:`" defaults to 1, and this enables us to apply a new activator yaml to a manually scaled activator deployment without shrinking it back to 1.

Fixes: https://github.com/knative/serving/issues/3152