### PR TITLE
Fix t.Error/t.Fatal calls in goroutines throughout our tests.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -357,7 +357,7 @@ func TestNoEndpoints(t *testing.T) {
 	})
 
 	// Wait for the Reconcile to complete.
-	_ = <-createdCh
+	<-createdCh
 	if err := reconcileGrp.Wait(); err != nil {
 		t.Errorf("Reconcile() = %v", err)
 	}
@@ -418,7 +418,7 @@ func TestEmptyEndpoints(t *testing.T) {
 	})
 
 	// Wait for the Reconcile to complete.
-	_ = <-createdCh
+	<-createdCh
 	if err := reconcileGrp.Wait(); err != nil {
 		t.Errorf("Reconcile() = %v", err)
 	}

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/knative/serving/pkg/system"
 	_ "github.com/knative/serving/pkg/system/testing"
 	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,14 +116,11 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	kpa := revisionresources.MakeKPA(rev)
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	reconcileDone := make(chan struct{})
-	go func() {
-		defer close(reconcileDone)
-		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err != nil {
-			t.Errorf("Reconcile() = %v", err)
-		}
-	}()
+
+	reconcileGrp := errgroup.Group{}
+	reconcileGrp.Go(func() error {
+		return ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
+	})
 
 	// Ensure revision creation has been seen before deleting it.
 	select {
@@ -132,7 +130,9 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	}
 
 	// Wait for the Reconcile to complete.
-	_ = <-reconcileDone
+	if err := reconcileGrp.Wait(); err != nil {
+		t.Errorf("Reconcile() = %v", err)
+	}
 
 	if count := fakeMetrics.createCallCount.Load(); count != 1 {
 		t.Fatalf("Create called %d times instead of once", count)
@@ -151,8 +151,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	servingInformer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Delete(rev)
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Delete(testRevision, nil)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Delete(kpa)
-	err = ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-	if err != nil {
+	if err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision); err != nil {
 		t.Errorf("Reconcile() = %v", err)
 	}
 
@@ -203,14 +202,11 @@ func TestUpdate(t *testing.T) {
 	kpa := revisionresources.MakeKPA(rev)
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	reconcileDone := make(chan struct{})
-	go func() {
-		defer close(reconcileDone)
-		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err != nil {
-			t.Errorf("Reconcile() = %v", err)
-		}
-	}()
+
+	reconcileGrp := errgroup.Group{}
+	reconcileGrp.Go(func() error {
+		return ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
+	})
 
 	// Ensure revision creation has been seen before updating it.
 	select {
@@ -220,7 +216,9 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Wait for the Reconcile to complete.
-	_ = <-reconcileDone
+	if err := reconcileGrp.Wait(); err != nil {
+		t.Errorf("Reconcile() = %v", err)
+	}
 
 	if count := fakeMetrics.createCallCount.Load(); count != 1 {
 		t.Fatalf("Create called %d times instead of once", count)
@@ -240,15 +238,9 @@ func TestUpdate(t *testing.T) {
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Update(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Update(kpa)
 
-	reconcileDone = make(chan struct{})
-	go func() {
-		defer close(reconcileDone)
-		err = ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err != nil {
-			t.Errorf("Reconcile() = %v", err)
-		}
-	}()
-	_ = <-reconcileDone
+	if err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision); err != nil {
+		t.Errorf("Reconcile() = %v", err)
+	}
 
 	if fakeMetrics.updateCallCount.Load() == 0 {
 		t.Fatal("Update was not called")
@@ -294,18 +286,21 @@ func TestNonKpaClass(t *testing.T) {
 	kpa := revisionresources.MakeKPA(rev)
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	reconcileDone := make(chan struct{})
+
+	reconcileCh := make(chan error)
 	go func() {
-		defer close(reconcileDone)
-		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err != nil {
-			t.Errorf("Reconcile() = %v", err)
+		defer close(reconcileCh)
+		if err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision); err != nil {
+			reconcileCh <- err
 		}
 	}()
 
 	// Wait for reconcile to finish
 	select {
-	case <-reconcileDone:
+	case err, ok := <-reconcileCh:
+		if ok && err != nil {
+			t.Errorf("Reconcile() = %v", err)
+		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("Reconciliation timed out")
 	}
@@ -355,18 +350,17 @@ func TestNoEndpoints(t *testing.T) {
 	kpa := revisionresources.MakeKPA(rev)
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	reconcileDone := make(chan struct{})
-	go func() {
-		defer close(reconcileDone)
-		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err != nil {
-			t.Errorf("Reconcile() = %v", err)
-		}
-	}()
+
+	reconcileGrp := errgroup.Group{}
+	reconcileGrp.Go(func() error {
+		return ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
+	})
 
 	// Wait for the Reconcile to complete.
 	_ = <-createdCh
-	_ = <-reconcileDone
+	if err := reconcileGrp.Wait(); err != nil {
+		t.Errorf("Reconcile() = %v", err)
+	}
 
 	newKPA, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(kpa.Namespace).Get(
 		kpa.Name, metav1.GetOptions{})
@@ -417,18 +411,17 @@ func TestEmptyEndpoints(t *testing.T) {
 	kpa := revisionresources.MakeKPA(rev)
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	reconcileDone := make(chan struct{})
-	go func() {
-		defer close(reconcileDone)
-		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err != nil {
-			t.Errorf("Reconcile() = %v", err)
-		}
-	}()
+
+	reconcileGrp := errgroup.Group{}
+	reconcileGrp.Go(func() error {
+		return ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
+	})
 
 	// Wait for the Reconcile to complete.
 	_ = <-createdCh
-	_ = <-reconcileDone
+	if err := reconcileGrp.Wait(); err != nil {
+		t.Errorf("Reconcile() = %v", err)
+	}
 
 	newKPA, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(kpa.Namespace).Get(
 		kpa.Name, metav1.GetOptions{})
@@ -589,18 +582,21 @@ func TestScaleFailure(t *testing.T) {
 	rev := newTestRevision(testNamespace, testRevision)
 	kpa := revisionresources.MakeKPA(rev)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
-	go func() {
-		err := ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
-		if err == nil {
-			t.Error("Reconcile() = nil, wanted error")
-		}
-	}()
+
+	reconcileGrp := errgroup.Group{}
+	reconcileGrp.Go(func() error {
+		return ctl.Reconciler.Reconcile(context.TODO(), testNamespace+"/"+testRevision)
+	})
 
 	// Ensure revision creation has been seen before deleting it.
 	select {
 	case <-createdCh:
 	case <-time.After(3 * time.Second):
 		t.Fatal("Revision creation notification timed out")
+	}
+
+	if err := reconcileGrp.Wait(); err == nil {
+		t.Error("Reconcile() = nil, wanted error")
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

As per title. This has been noted to be buggy in #3113.

Also includes a fix for `scale.go` from our e2e tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
