### PR TITLE
Cleanup some of the breaker/semaphore code.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -259,7 +259,7 @@ func main() {
 		if queueDepth < 10 {
 			queueDepth = 10
 		}
-		params := queue.BreakerParams{QueueDepth: int32(queueDepth), MaxConcurrency: int32(containerConcurrency), InitialCapacity: int32(containerConcurrency), Logger: logger}
+		params := queue.BreakerParams{QueueDepth: int32(queueDepth), MaxConcurrency: int32(containerConcurrency), InitialCapacity: int32(containerConcurrency)}
 		breaker = queue.NewBreaker(params)
 		logger.Infof("Queue container is starting with %#v", params)
 	}

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -152,7 +152,7 @@ func (s *semaphore) Release() error {
 	case s.queue <- struct{}{}:
 		return nil
 	default:
-		// This should never happen.
+		// This only happens if Release is called more often than Acquire.
 		return ErrRelease
 	}
 }

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -63,7 +63,7 @@ func NewBreaker(params BreakerParams) *Breaker {
 	if params.InitialCapacity < 0 || params.InitialCapacity > params.MaxConcurrency {
 		panic(fmt.Sprintf("Initial capacity must be between 0 and max concurrency. Got %v.", params.InitialCapacity))
 	}
-	sem := NewSemaphore(params.MaxConcurrency, params.InitialCapacity)
+	sem := newSemaphore(params.MaxConcurrency, params.InitialCapacity)
 	return &Breaker{
 		pendingRequests: make(chan token, params.QueueDepth+params.MaxConcurrency),
 		sem:             sem,
@@ -109,11 +109,11 @@ func (b *Breaker) Capacity() int32 {
 	return b.sem.Capacity()
 }
 
-// NewSemaphore creates a semaphore with the desired maximal and initial capacity.
+// newSemaphore creates a semaphore with the desired maximal and initial capacity.
 // Maximal capacity is the size of the buffered channel, it defines maximum number of tokens
 // in the rotation. Attempting to add more capacity then the max will result in error.
 // Initial capacity is the initial number of free tokens.
-func NewSemaphore(maxCapacity, initialCapacity int32) *semaphore {
+func newSemaphore(maxCapacity, initialCapacity int32) *semaphore {
 	if initialCapacity < 0 || initialCapacity > maxCapacity {
 		panic(fmt.Sprintf("Initial capacity must be between 0 and maximal capacity. Got %v.", initialCapacity))
 	}

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -36,14 +36,12 @@ type BreakerParams struct {
 	InitialCapacity int32
 }
 
-type token struct{}
-
 // Breaker is a component that enforces a concurrency limit on the
 // execution of a function. It also maintains a queue of function
 // executions in excess of the concurrency limit. Function call attempts
 // beyond the limit of the queue are failed immediately.
 type Breaker struct {
-	pendingRequests chan token
+	pendingRequests chan struct{}
 	sem             *semaphore
 }
 
@@ -61,7 +59,7 @@ func NewBreaker(params BreakerParams) *Breaker {
 	}
 	sem := newSemaphore(params.MaxConcurrency, params.InitialCapacity)
 	return &Breaker{
-		pendingRequests: make(chan token, params.QueueDepth+params.MaxConcurrency),
+		pendingRequests: make(chan struct{}, params.QueueDepth+params.MaxConcurrency),
 		sem:             sem,
 	}
 }
@@ -71,12 +69,11 @@ func NewBreaker(params BreakerParams) *Breaker {
 // already consumed, Maybe returns immediately without calling thunk. If
 // the thunk was executed, Maybe returns true, else false.
 func (b *Breaker) Maybe(thunk func()) bool {
-	var t token
 	select {
 	default:
 		// Pending request queue is full.  Report failure.
 		return false
-	case b.pendingRequests <- t:
+	case b.pendingRequests <- struct{}{}:
 		// Pending request has capacity.
 		// Wait for capacity in the active queue.
 		b.sem.Acquire()
@@ -113,7 +110,7 @@ func newSemaphore(maxCapacity, initialCapacity int32) *semaphore {
 	if initialCapacity < 0 || initialCapacity > maxCapacity {
 		panic(fmt.Sprintf("Initial capacity must be between 0 and maximal capacity. Got %v.", initialCapacity))
 	}
-	queue := make(chan token, maxCapacity)
+	queue := make(chan struct{}, maxCapacity)
 	sem := semaphore{queue: queue}
 	if initialCapacity > 0 {
 		sem.UpdateCapacity(initialCapacity)
@@ -126,8 +123,7 @@ func newSemaphore(maxCapacity, initialCapacity int32) *semaphore {
 // Hence the max number of tokens to hand out equals to the size of the channel.
 // `capacity` defines the current number of tokens in the rotation.
 type semaphore struct {
-	queue    chan token
-	token    token
+	queue    chan struct{}
 	reducers int32
 	capacity int32
 	mux      sync.Mutex
@@ -153,7 +149,7 @@ func (s *semaphore) Release() error {
 
 	// We want to make sure releasing a token is always non-blocking.
 	select {
-	case s.queue <- s.token:
+	case s.queue <- struct{}{}:
 		return nil
 	default:
 		// This should never happen.
@@ -182,7 +178,7 @@ func (s *semaphore) UpdateCapacity(size int32) error {
 			s.reducers--
 		} else {
 			select {
-			case s.queue <- s.token:
+			case s.queue <- struct{}{}:
 				s.capacity++
 			default:
 				// This indicates that we're operating close to

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -339,7 +339,7 @@ func (b *Breaker) concurrentRequests(n int) []request {
 	return requests
 }
 
-func waitForQueue(queue chan token, size int) {
+func waitForQueue(queue chan struct{}, size int) {
 	err := wait.PollImmediate(1*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
 		return len(queue) == size, nil
 	})

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -182,7 +182,7 @@ func TestBreaker_UpdateConcurrency_Overlow(t *testing.T) {
 func TestSemaphore_Acquire_HasNoCapacity(t *testing.T) {
 	gotChan := make(chan struct{}, 1)
 
-	sem := NewSemaphore(1, 0)
+	sem := newSemaphore(1, 0)
 	tryAcquire(sem, gotChan)
 
 	select {
@@ -197,7 +197,7 @@ func TestSemaphore_Acquire_HasNoCapacity(t *testing.T) {
 func TestSemaphore_Acquire_HasCapacity(t *testing.T) {
 	gotChan := make(chan struct{}, 1)
 
-	sem := NewSemaphore(1, 0)
+	sem := newSemaphore(1, 0)
 	tryAcquire(sem, gotChan)
 	sem.Release() // Allows 1 acquire
 
@@ -205,7 +205,7 @@ func TestSemaphore_Acquire_HasCapacity(t *testing.T) {
 }
 
 func TestSemaphore_Release(t *testing.T) {
-	sem := NewSemaphore(1, 1)
+	sem := newSemaphore(1, 1)
 	sem.Acquire()
 	err := sem.Release()
 	assertEqual(nil, err, t)
@@ -216,7 +216,7 @@ func TestSemaphore_Release(t *testing.T) {
 func TestSemaphore_ReleasesSeveralReducers(t *testing.T) {
 	wantAfterFirstRelease := int32(1)
 	wantAfterSecondRelease := int32(0)
-	sem := NewSemaphore(2, 2)
+	sem := newSemaphore(2, 2)
 	sem.Acquire()
 	sem.Acquire()
 	sem.UpdateCapacity(int32(0))
@@ -230,7 +230,7 @@ func TestSemaphore_ReleasesSeveralReducers(t *testing.T) {
 
 func TestSemaphore_UpdateCapacity(t *testing.T) {
 	initialCapacity := int32(1)
-	sem := NewSemaphore(3, initialCapacity)
+	sem := newSemaphore(3, initialCapacity)
 	assertEqual(int32(1), sem.Capacity(), t)
 	sem.Acquire()
 	sem.UpdateCapacity(initialCapacity + 2)
@@ -240,7 +240,7 @@ func TestSemaphore_UpdateCapacity(t *testing.T) {
 // Test the case when we add more capacity then the number of waiting reducers
 func TestSemaphore_UpdateCapacity_LessThenReducers(t *testing.T) {
 	initialCapacity := int32(2)
-	sem := NewSemaphore(2, initialCapacity)
+	sem := newSemaphore(2, initialCapacity)
 	sem.Acquire()
 	sem.Acquire()
 	sem.UpdateCapacity(initialCapacity - 2)
@@ -253,7 +253,7 @@ func TestSemaphore_UpdateCapacity_LessThenReducers(t *testing.T) {
 
 func TestSemaphore_UpdateCapacity_ConsumingReducers(t *testing.T) {
 	initialCapacity := int32(2)
-	sem := NewSemaphore(2, initialCapacity)
+	sem := newSemaphore(2, initialCapacity)
 	sem.Acquire()
 	sem.Acquire()
 	sem.UpdateCapacity(initialCapacity - 2)
@@ -264,27 +264,27 @@ func TestSemaphore_UpdateCapacity_ConsumingReducers(t *testing.T) {
 }
 
 func TestSemaphore_UpdateCapacity_Overflow(t *testing.T) {
-	sem := NewSemaphore(2, 0)
+	sem := newSemaphore(2, 0)
 	err := sem.UpdateCapacity(int32(3))
 	assertEqual(err, ErrUpdateCapacity, t)
 }
 
 func TestSemaphore_UpdateCapacity_OutOfBound(t *testing.T) {
-	sem := NewSemaphore(1, 1)
+	sem := newSemaphore(1, 1)
 	sem.Acquire()
 	err := sem.UpdateCapacity(-1)
 	assertEqual(err, ErrUpdateCapacity, t)
 }
 
 func TestSemaphore_UpdateCapacity_BrokenState(t *testing.T) {
-	sem := NewSemaphore(1, 0)
+	sem := newSemaphore(1, 0)
 	sem.Release() // This Release is not paired with an Acquire
 	err := sem.UpdateCapacity(1)
 	assertEqual(err, ErrUpdateCapacity, t)
 }
 
 func TestSemaphore_UpdateCapacity_DoNothing(t *testing.T) {
-	sem := NewSemaphore(1, 1)
+	sem := newSemaphore(1, 1)
 	err := sem.UpdateCapacity(1)
 	assertEqual(err, nil, t)
 }
@@ -295,7 +295,7 @@ func TestSemaphore_WrongInitialCapacity(t *testing.T) {
 			t.Error("The code did not panic")
 		}
 	}()
-	_ = NewSemaphore(1, 2)
+	_ = newSemaphore(1, 2)
 }
 
 // Attempts to perform a concurrent request against the specified breaker.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Makes semaphore completely private.
* Removes the logger from the breaker.
* Removes `token` type.
* Removes assert functions from tests (These make the tests hard to debug because the error messages do not carry helpful line numbers so you end up having to compare expected return values to reach the correct line where the test failed)

This is some groundwork to a breaker change I'm planning to do next.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
