### PR TITLE
Document how to use --ingressendpoint.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -177,7 +177,7 @@ these flags:
 - [All flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags)
 - [`--dockerrepo`](#overriding-docker-repo)
 - [`--tag`](#using-a-docker-tag)
-- [`--ingressendpoint`](#using-a-custom-ingressendpoint)
+- [`--ingressendpoint`](#using-a-custom-ingress-endpoint)
 - [`--resolvabledomain`](#using-a-resolvable-domain)
 
 ### Overridding docker repo
@@ -207,7 +207,7 @@ go test -v -tags=e2e -count=1 ./test/e2e --tag any-old-tag
 Of course, this implies that you tagged the images when you
 [uploaded them](#building-the-test-images).
 
-### Using a custom ingressendpoint
+### Using a custom ingress endpoint
 
 Some environments (like minikube) do not support a Loadbalancer to make Knative
 services externally available. These environments usually rely on rewriting the

--- a/test/README.md
+++ b/test/README.md
@@ -215,11 +215,11 @@ Loadbalancer to a NodePort. The external address of such a NodePort is usually
 not easily obtained within the cluster automatically, but can be provided from
 the outside through the `--ingressendpoint` flag. For a minikube setup for
 example, you'd want to run tests against the default `ingressgateway` (port
-31380) running on the minishift node:
+31380) running on the minikube node:
 
 ```
-go test -v -tags=e2e -count=1 ./test/conformance --ingressendpoint "$(minishift ip):31380"
-go test -v -tags=e2e -count=1 ./test/e2e --ingressendpoint "$(minishift ip):31380"
+go test -v -tags=e2e -count=1 ./test/conformance --ingressendpoint "$(minikube ip):31380"
+go test -v -tags=e2e -count=1 ./test/e2e --ingressendpoint "$(minikube ip):31380"
 ```
 
 ### Using a resolvable domain

--- a/test/README.md
+++ b/test/README.md
@@ -177,7 +177,7 @@ these flags:
 - [All flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags)
 - [`--dockerrepo`](#overriding-docker-repo)
 - [`--tag`](#using-a-docker-tag)
-- [`--ingressendpoint`](#using-a-specified-ingressendpoint)
+- [`--ingressendpoint`](#using-a-custom-ingressendpoint)
 - [`--resolvabledomain`](#using-a-resolvable-domain)
 
 ### Overridding docker repo
@@ -207,7 +207,7 @@ go test -v -tags=e2e -count=1 ./test/e2e --tag any-old-tag
 Of course, this implies that you tagged the images when you
 [uploaded them](#building-the-test-images).
 
-### Using a specified ingressendpoint
+### Using a custom ingressendpoint
 
 Some environments (like minikube) do not support a Loadbalancer to make Knative
 services externally available. These environments usually rely on rewriting the

--- a/test/README.md
+++ b/test/README.md
@@ -132,15 +132,6 @@ go test -v -tags=e2e -count=1 ./test/conformance --kubeconfig ~/special/kubeconf
 go test -v -tags=e2e -count=1 ./test/e2e --kubeconfig ~/special/kubeconfig --cluster myspecialcluster --dockerrepo myspecialdockerrepo
 ```
 
-If you are running against an environment with no loadbalancer for the ingress,
-at the moment your only option is to use a domain which will resolve to the IP
-of the running node (see [#609](https://github.com/knative/serving/issues/609)):
-
-```bash
-go test -v -tags=e2e -count=1 ./test/conformance --resolvabledomain
-go test -v -tags=e2e -count=1 ./test/e2e --resolvabledomain
-```
-
 ## Test images
 
 ### Building the test images
@@ -186,6 +177,7 @@ these flags:
 - [All flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags)
 - [`--dockerrepo`](#overriding-docker-repo)
 - [`--tag`](#using-a-docker-tag)
+- [`--ingressendpoint`](#using-a-specified-ingressendpoint)
 - [`--resolvabledomain`](#using-a-resolvable-domain)
 
 ### Overridding docker repo
@@ -214,6 +206,21 @@ go test -v -tags=e2e -count=1 ./test/e2e --tag any-old-tag
 
 Of course, this implies that you tagged the images when you
 [uploaded them](#building-the-test-images).
+
+### Using a specified ingressendpoint
+
+Some environments (like minikube) do not support a Loadbalancer to make Knative
+services externally available. These environments usually rely on rewriting the
+Loadbalancer to a NodePort. The external address of such a NodePort is usually
+not easily obtained within the cluster automatically, but can be provided from
+the outside through the `--ingressendpoint` flag. For a minikube setup for
+example, you'd want to run tests against the default `ingressgateway` (port
+31380) running on the minishift node:
+
+```
+go test -v -tags=e2e -count=1 ./test/conformance --ingressendpoint "$(minishift ip):31380"
+go test -v -tags=e2e -count=1 ./test/e2e --ingressendpoint "$(minishift ip):31380"
+```
 
 ### Using a resolvable domain
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2885

Document how to use the recently pulled in `--ingressendpoint` flag to be able to run e2e tests against a minikube environment easily.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
