### PR TITLE
Hoist RevisionReady event to only fire when we're really ready.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -221,9 +221,6 @@ func (c *Reconciler) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 	if getIsServiceReady(endpoints) {
 		rev.Status.MarkResourcesAvailable()
 		rev.Status.MarkContainerHealthy()
-		// TODO(mattmoor): How to ensure this only fires once?
-		c.Recorder.Eventf(rev, corev1.EventTypeNormal, "RevisionReady",
-			"Revision becomes ready upon endpoint %q becoming ready", serviceName)
 	} else if !rev.Status.IsActivationRequired() {
 		// If the endpoints is NOT ready, then check whether it is taking unreasonably
 		// long to become ready and if so mark our revision as having timed out waiting

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -366,6 +366,8 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 	rev.Status.InitializeConditions()
 	c.updateRevisionLoggingURL(ctx, rev)
 
+	readyBeforeReconcile := rev.Status.IsReady()
+
 	if err := c.reconcileBuild(ctx, rev); err != nil {
 		return err
 	}
@@ -401,6 +403,12 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 				return err
 			}
 		}
+	}
+
+	readyAfterReconcile := rev.Status.IsReady()
+	if !readyBeforeReconcile && readyAfterReconcile {
+		c.Recorder.Eventf(rev, corev1.EventTypeNormal, "RevisionReady",
+			"Revision becomes ready upon all resources being ready")
 	}
 
 	rev.Status.ObservedGeneration = rev.Generation

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -450,7 +450,7 @@ func TestMarkRevReadyUponEndpointBecomesReady(t *testing.T) {
 	h := NewHooks()
 	// Look for the revision ready event. Events are delivered asynchronously so
 	// we need to use hooks here.
-	expectedMessage := "Revision becomes ready upon endpoint \"test-rev-service\" becoming ready"
+	expectedMessage := "Revision becomes ready upon all resources being ready"
 	h.OnCreate(&kubeClient.Fake, "events", ExpectNormalEventDelivery(t, expectedMessage))
 
 	deployingRev := createRevision(t, kubeClient, kubeInformer, servingClient, servingInformer, cachingClient, cachingInformer, controller, rev)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2900

## Proposed Changes

* Only fire the RevisionReady event if we've not been ready before the reconcile, but are ready after a full reconcile.
* The event is now only dependent on the overall status of the Revision.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a condition where the "RevisionReady" event could be fired prematurely.
```
