### PR TITLE
Update test-infra to latest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -501,7 +501,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c4f98ad943675d137b7829ab807de3a43a6de0e14c089d9076ad844a30a26462"
+  digest = "1:b3caf507cc4f2254f7e9ba3b420a5e72d052dfa212374c18134094ffb303bf7a"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -514,7 +514,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "036c35039cf88c9ca4e8609de5fe0592d4e8067a"
+  revision = "31319e986ac00fd10c15ad0608131b35dafb62bb"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -86,10 +86,7 @@ func TestTimeToServeLatency(t *testing.T) {
 		tc = append(tc, CreatePerfTestCase(val, name, testName))
 	}
 
-	ts := junit.TestSuites{}
-	ts.AddTestSuite(&junit.TestSuite{Name: "TestPerformanceLatency", TestCases: tc})
-
-	if err = testgrid.CreateXMLOutput(&ts, testName); err != nil {
+	if err = testgrid.CreateXMLOutput(tc, testName); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)
 	}
 }

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -212,11 +212,7 @@ func TestObservedConcurrency(t *testing.T) {
 	}
 	tc = append(tc, CreatePerfTestCase(failedRequests, "failed requests", t.Name()))
 
-	// TODO: For future, recreate the CreateTestgridXML function so we don't want to repeat the code shown in next 2 lines
-	ts := junit.TestSuites{}
-	ts.AddTestSuite(&junit.TestSuite{Name: t.Name(), TestCases: tc})
-
-	if err = testgrid.CreateXMLOutput(&ts, t.Name()); err != nil {
+	if err = testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)
 	}
 }

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -146,9 +146,7 @@ func testGrid(s *stats, tName string) error {
 	var tc []junit.TestCase
 	val := float32(s.avg.Seconds())
 	tc = append(tc, CreatePerfTestCase(val, "Average", tName))
-	ts := junit.TestSuites{}
-	ts.AddTestSuite(&junit.TestSuite{Name: tName, TestCases: tc})
-	return testgrid.CreateXMLOutput(&ts, tName)
+	return testgrid.CreateXMLOutput(tc, tName)
 }
 
 func testScaleFromZero(t *testing.T, count int) {

--- a/test/performance/scale_test.go
+++ b/test/performance/scale_test.go
@@ -161,11 +161,7 @@ func TestScaleToN(t *testing.T) {
 		})
 	}
 
-	// We do this once here because it doesn't like table test names (with '/')
-	ts := junit.TestSuites{}
-	ts.AddTestSuite(&junit.TestSuite{Name: t.Name(), TestCases: results})
-
-	if err := testgrid.CreateXMLOutput(&ts, t.Name()); err != nil {
+	if err := testgrid.CreateXMLOutput(results, t.Name()); err != nil {
 		t.Errorf("Cannot create output xml: %v", err)
 	}
 }

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -100,7 +100,7 @@ function run_build_tests() {
     fi
   fi
   # Don't run post-build tests if pre/build tests failed
-  if function_exists post_build_tests; then
+  if (( ! failed )) && function_exists post_build_tests; then
     post_build_tests || failed=1
   fi
   results_banner "Build" ${failed}
@@ -177,7 +177,7 @@ function run_unit_tests() {
     fi
   fi
   # Don't run post-unit tests if pre/unit tests failed
-  if function_exists post_unit_tests; then
+  if (( ! failed )) && function_exists post_unit_tests; then
     post_unit_tests || failed=1
   fi
   results_banner "Unit" ${failed}

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -142,8 +142,9 @@ function prepare_auto_release() {
   TAG_RELEASE=1
   PUBLISH_RELEASE=1
 
+  git fetch --all
   local tags="$(git tag | cut -d 'v' -f2 | cut -d '.' -f1-2 | sort | uniq)"
-  local branches="$( { (git branch -r | grep origin/release-) ; (git branch  | grep release-); } | cut -d '-' -f2 | sort | uniq)"
+  local branches="$( { (git branch -r | grep upstream/release-) ; (git branch | grep release-); } | cut -d '-' -f2 | sort | uniq)"
   RELEASE_VERSION=""
 
   [[ -n "${tags}" ]] || abort "cannot obtain release tags for the repository"

--- a/vendor/github.com/knative/test-infra/shared/loadgenerator/loadgenerator.go
+++ b/vendor/github.com/knative/test-infra/shared/loadgenerator/loadgenerator.go
@@ -31,10 +31,12 @@ import (
 )
 
 const (
-	p50     = 50.0
-	p90     = 90.0
-	p99     = 99.0
-	jsonExt = ".json"
+	p50      = 50.0
+	p90      = 90.0
+	p99      = 99.0
+	duration = 1 * time.Minute
+	qps 	 = 10
+	jsonExt  = ".json"
 )
 
 // GeneratorOptions provides knobs to run the perf test
@@ -46,6 +48,7 @@ type GeneratorOptions struct {
 	Domain         string
 	RequestTimeout time.Duration
 	QPS            float64
+	AllowInitialErrors bool
 }
 
 // GeneratorResults contains the results of running the per test
@@ -53,8 +56,20 @@ type GeneratorResults struct {
 	Result *fhttp.HTTPRunnerResults
 }
 
+// addDefaults adds default values to non mandatory params
+func (g *GeneratorOptions) addDefaults() {
+	if (g.RequestTimeout == 0) {
+		g.RequestTimeout = duration
+	}
+
+	if (g.QPS == 0) {
+		g.QPS = qps
+	}
+}
+
 // CreateRunnerOptions sets up the fortio client with the knobs needed to run the load test
 func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTTPRunnerOptions {
+	g.addDefaults()
 	o := fhttp.NewHTTPOptions(g.URL)
 
 	o.NumConnections = g.NumConnections
@@ -73,7 +88,7 @@ func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTT
 			QPS:         g.QPS,
 		},
 		HTTPOptions:        *o,
-		AllowInitialErrors: true,
+		AllowInitialErrors: g.AllowInitialErrors,
 	}
 }
 

--- a/vendor/github.com/knative/test-infra/shared/testgrid/testgrid.go
+++ b/vendor/github.com/knative/test-infra/shared/testgrid/testgrid.go
@@ -44,13 +44,16 @@ func createDir(dirPath string) error {
 }
 
 // CreateXMLOutput creates the junit xml file in the provided artifacts directory
-func CreateXMLOutput(testSuites *junit.TestSuites, testName string) error {
+func CreateXMLOutput(tc []junit.TestCase, testName string) error {
+	ts := junit.TestSuites{}
+	ts.AddTestSuite(&junit.TestSuite{Name: testName, TestCases: tc})
+
 	// ensure artifactsDir exist, in case not invoked from this script
 	artifactsDir := prow.GetLocalArtifactsDir()
 	if err := createDir(artifactsDir); nil != err {
 		return err
 	}
-	op, err := testSuites.ToBytes("", "  ")
+	op, err := ts.ToBytes("", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This update updates:
1. Loagdenerator lib adds defaults to qps and timeout.
1. Testgrid lib now accepts testcase[] instead of testsuite to create output xml

This PR also updates the serving files to get these new changes.

part of #3154

Addresses https://github.com/knative/test-infra/issues/368