### PR TITLE
Speed up TestAutoscaleUpDownUp

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -147,7 +147,8 @@ func setup(t *testing.T) *testContext {
 
 	logger.Info("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, "autoscale", &test.Options{
-		ContainerConcurrency: 10,
+		ContainerConcurrency:   10,
+		RevisionTimeoutSeconds: 10,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Set RevisionTimeoutSeconds to 10 in TestAutoscaleUpDownUp

Without this change this test spends a lot of time just waiting for the autoscale container to terminate (default timeout is 5 minutes):
```
--- PASS: TestAutoscaleUpDownUp (469.45s)
```

With this change:
```
--- PASS: TestAutoscaleUpDownUp (188.14s)
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
