### PR TITLE
Lower SLO for TestScaleToN.

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -73,11 +73,11 @@ func ScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, duration
 		},
 	}
 	// These are the local (per-probe) and global (all probes) targets for the scale test.
-	// 95 = 19/20, so allow a single failure with the minimum number of probes, but expect
-	// us to have 3.5 9s overall.
+	// 90 = 18/20, so allow a single failure with the minimum number of probes, but expect
+	// us to have 2.5 9s overall.
 	const (
-		localSLO  = 0.95
-		globalSLO = 0.9995
+		localSLO  = 0.90
+		globalSLO = 0.995
 		minProbes = 20
 	)
 	pm := test.NewProberManager(logger, clients, minProbes)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -73,8 +73,10 @@ func ScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, duration
 		},
 	}
 	// These are the local (per-probe) and global (all probes) targets for the scale test.
-	// 90 = 18/20, so allow a single failure with the minimum number of probes, but expect
+	// 90 = 18/20, so allow two failures with the minimum number of probes, but expect
 	// us to have 2.5 9s overall.
+	//
+	// TODO(#2850): After moving to Istio 1.1 we need to revisit these SLOs.
 	const (
 		localSLO  = 0.90
 		globalSLO = 0.995


### PR DESCRIPTION
Since Istio 1.1 will solve some of the scaling issues, I think we
should lower these SLOs for now.  We should revisit again after
migrating to Istio 1.1.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
