### PR TITLE
Add a guard to the throttler against exceeding MaxConcurrency.

### DIFF
--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -99,7 +99,7 @@ func (t *Throttler) updateCapacity(revision *v1alpha1.Revision, breaker *queue.B
 	cc := int32(revision.Spec.ContainerConcurrency)
 
 	targetCapacity := cc * size
-	if targetCapacity == 0 {
+	if targetCapacity == 0 || targetCapacity > t.breakerParams.MaxConcurrency {
 		// The concurrency is unlimited, thus hand out as many tokens as we can in this breaker.
 		targetCapacity = t.breakerParams.MaxConcurrency
 	}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -99,7 +99,7 @@ func (t *Throttler) updateCapacity(revision *v1alpha1.Revision, breaker *queue.B
 	cc := int32(revision.Spec.ContainerConcurrency)
 
 	targetCapacity := cc * size
-	if targetCapacity == 0 || targetCapacity > t.breakerParams.MaxConcurrency {
+	if cc == 0 || targetCapacity > t.breakerParams.MaxConcurrency {
 		// The concurrency is unlimited, thus hand out as many tokens as we can in this breaker.
 		targetCapacity = t.breakerParams.MaxConcurrency
 	}

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -86,6 +86,12 @@ func TestThrottler_UpdateCapacity(t *testing.T) {
 		maxConcurrency:  defaultMaxConcurrency,
 		want:            int32(0),
 		wantError:       sampleError,
+	}, {
+		label:           "exceeds maxConcurrency",
+		revisionGetter:  existingRevisionGetter(10),
+		endpointsGetter: existingEndpointsGetter,
+		maxConcurrency:  int32(5),
+		want:            int32(5),
 	}}
 	for _, s := range samples {
 		t.Run(s.label, func(t *testing.T) {

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -44,6 +44,7 @@ var (
 	nonExistingRevisionGetter = func(RevisionID) (*v1alpha12.Revision, error) {
 		return nil, errors.New(sampleError)
 	}
+
 	existingEndpointsGetter = func(RevisionID) (int32, error) {
 		return initCapacity, nil
 	}
@@ -221,6 +222,10 @@ func TestUpdateEndpoints(t *testing.T) {
 		endpointsAfter: 1,
 		wantCapacity:   1 * revisionConcurrency,
 		initCapacity:   10,
+	}, {
+		label:          "exceed max concurrency",
+		endpointsAfter: 101 * revisionConcurrency,
+		wantCapacity:   int(defaultMaxConcurrency),
 	}}
 
 	for _, s := range samples {

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -217,16 +217,19 @@ func TestUpdateEndpoints(t *testing.T) {
 		label:          "add single endpoint",
 		endpointsAfter: 1,
 		wantCapacity:   1 * revisionConcurrency,
-		initCapacity:   0,
 	}, {
 		label:          "add several endpoints",
 		endpointsAfter: 2,
 		wantCapacity:   2 * revisionConcurrency,
-		initCapacity:   0,
 	}, {
 		label:          "do nothing",
 		endpointsAfter: 1,
 		wantCapacity:   1 * revisionConcurrency,
+		initCapacity:   10,
+	}, {
+		label:          "reduce endpoints",
+		endpointsAfter: 0,
+		wantCapacity:   0,
 		initCapacity:   10,
 	}, {
 		label:          "exceed max concurrency",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The Throttler blindly updates the breaker's capacity without checking if it would exceed it. Given our default value of MaxConcurrency = 1000 and ContainerConcurrency = 100 this condition can be met quite quickly.

This guards against that and instead defaults to MaxConcurrency whenever we try to exceed it.

/assign @vvraskin 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
