### PR TITLE
Revert setting a timeout in the autoscale test.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -26,10 +26,10 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/knative/pkg/system/testing"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/autoscaler"
-	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/test"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -147,8 +147,7 @@ func setup(t *testing.T) *testContext {
 
 	logger.Info("Creating a new Route and Configuration")
 	names, err := CreateRouteAndConfig(clients, logger, "autoscale", &test.Options{
-		ContainerConcurrency:   10,
-		RevisionTimeoutSeconds: 10,
+		ContainerConcurrency: 10,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)


### PR DESCRIPTION
This timeout was set because the test used to take a loooong time to shutdown pods. TerminationGracePeriod is set to this timeout (which defaults to 5 minutes) so potentially this **can** lead to long wait times. However, this is also covering bugs with our shutdown duration.

/cc @bradhoekstra 

I reviewed a few test runs from a few days ago (before the change was merged) and the test was already < 200s there (as you noted in your PR). Can you please verify that this does not cause a regression in the test time on HEAD? Did you see the very long runtime on HEAD or on v0.3?

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
