### PR TITLE
Remove 'knative.dev/type' from the specification.

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -138,8 +138,6 @@ spec:
 
   revisionTemplate:  # template for building Revision
     metadata: ...
-      labels:
-        knative.dev/type: "function"  # One of "function" or "app"
     spec:  # knative.RevisionTemplateSpec. Copied to a new revision
 
       # +optional. DEPRECATED, use buildRef
@@ -297,8 +295,6 @@ kind: Service
 metadata:
   name: myservice
   namespace: default
-  labels:
-    knative.dev/type: "function"  # convention, one of "function" or "app"
   # system generated meta
   uid: ...
   resourceVersion: ...  # used for optimistic concurrency control

--- a/test/test_images/helloworld/helloworld.yaml
+++ b/test/test_images/helloworld/helloworld.yaml
@@ -19,9 +19,6 @@ metadata:
   namespace: default
 spec:
   revisionTemplate:
-    metadata:
-      labels:
-        knative.dev/type: app
     spec:
       container:
         # This is the Go import path for the binary to containerize


### PR DESCRIPTION
This has confused people a couple of times as it seems like as if this has an effect on the behavior of Knative Serving, which it hasn't.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This has confused people a couple of times as it seems like as if this has an effect on the behavior of Knative Serving, which it hasn't.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @sixolet 
/assign @evankanderson 
