### PR TITLE
Reclaim the use of the revision label `configurationGeneration`

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -53,13 +53,13 @@ const (
 	// which Service they are created.
 	ServiceLabelKey = GroupName + "/service"
 
-	// DeprecatedConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
-	// generation of the Configuration that created this revision
-	DeprecatedConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
-
-	// ConfigurationMetadataGenerationLabelKey is the label key attached to a Revision indicating the
+	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
 	// metadata generation of the Configuration that created this revision
-	ConfigurationMetadataGenerationLabelKey = GroupName + "/configurationMetadataGeneration"
+	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
+
+	// DeprecatedConfigurationMetadataGenerationLabelKey is the label key attached to a Revision indicating the
+	// metadata generation of the Configuration that created this revision
+	DeprecatedConfigurationMetadataGenerationLabelKey = GroupName + "/configurationMetadataGeneration"
 
 	// BuildHashLabelKey is the label key attached to a Build indicating the
 	// hash of the spec from which they were created.

--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -234,7 +234,8 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 func (c *Reconciler) latestCreatedRevision(config *v1alpha1.Configuration) (*v1alpha1.Revision, error) {
 	lister := c.revisionLister.Revisions(config.Namespace)
 
-	generationKey := serving.ConfigurationMetadataGenerationLabelKey
+	// TODO(#643) - in serving 0.5 switch to serving.ConfigurationGenerationLabelKey
+	generationKey := serving.DeprecatedConfigurationMetadataGenerationLabelKey
 
 	list, err := lister.List(labels.SelectorFromSet(map[string]string{
 		generationKey:                 resources.RevisionLabelValueForKey(generationKey, config),

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -25,7 +25,6 @@ import (
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
-	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/gc"
 	"github.com/knative/serving/pkg/reconciler"
@@ -654,13 +653,4 @@ func TestIsRevisionStale(t *testing.T) {
 			}
 		})
 	}
-}
-
-// WithoutConfigurationMetadataGenerationLabel clears the label from the revision
-func WithoutConfigurationMetadataGenerationLabel(rev *v1alpha1.Revision) {
-	if rev.Labels == nil {
-		return
-	}
-
-	delete(rev.Labels, serving.ConfigurationMetadataGenerationLabelKey)
 }

--- a/pkg/reconciler/v1alpha1/configuration/resources/build_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/build_test.go
@@ -60,7 +60,6 @@ func TestBuilds(t *testing.T) {
 				Name:      "build",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 31,
 				Build: &v1alpha1.RawExtension{BuildSpec: &buildv1alpha1.BuildSpec{
 					Steps: []corev1.Container{{
 						Image: "busybox",
@@ -116,7 +115,6 @@ func TestBuilds(t *testing.T) {
 				Name:      "build",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 31,
 				Build: &v1alpha1.RawExtension{
 					Object: &buildv1alpha1.Build{
 						TypeMeta: metav1.TypeMeta{
@@ -181,7 +179,6 @@ func TestBuilds(t *testing.T) {
 				Name:      "build-template",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 42,
 				Build: &v1alpha1.RawExtension{BuildSpec: &buildv1alpha1.BuildSpec{
 					Template: &buildv1alpha1.TemplateInstantiationSpec{
 						Name: "buildpacks",

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -61,8 +61,8 @@ func UpdateRevisionLabels(rev *v1alpha1.Revision, config *v1alpha1.Configuration
 	for _, key := range []string{
 		serving.ConfigurationLabelKey,
 		serving.ServiceLabelKey,
-		serving.DeprecatedConfigurationGenerationLabelKey,
-		serving.ConfigurationMetadataGenerationLabelKey,
+		serving.ConfigurationGenerationLabelKey,
+		serving.DeprecatedConfigurationMetadataGenerationLabelKey,
 	} {
 		rev.Labels[key] = RevisionLabelValueForKey(key, config)
 	}
@@ -75,9 +75,9 @@ func RevisionLabelValueForKey(key string, config *v1alpha1.Configuration) string
 		return config.Name
 	case serving.ServiceLabelKey:
 		return config.Labels[serving.ServiceLabelKey]
-	case serving.DeprecatedConfigurationGenerationLabelKey:
-		return fmt.Sprintf("%d", config.Spec.DeprecatedGeneration)
-	case serving.ConfigurationMetadataGenerationLabelKey:
+	case serving.ConfigurationGenerationLabelKey:
+		return fmt.Sprintf("%d", config.Generation)
+	case serving.DeprecatedConfigurationMetadataGenerationLabelKey:
 		return fmt.Sprintf("%d", config.Generation)
 	}
 

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -42,7 +42,6 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 10,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 12,
 				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
 						Container: corev1.Container{
@@ -65,10 +64,10 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                     "build",
-					serving.DeprecatedConfigurationGenerationLabelKey: "12",
-					serving.ConfigurationMetadataGenerationLabelKey:   "10",
-					serving.ServiceLabelKey:                           "",
+					serving.ConfigurationLabelKey:                             "build",
+					serving.ConfigurationGenerationLabelKey:                   "10",
+					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "10",
+					serving.ServiceLabelKey:                                   "",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -86,7 +85,6 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 99,
 				Build: &v1alpha1.RawExtension{BuildSpec: &buildv1alpha1.BuildSpec{
 					Steps: []corev1.Container{{
 						Image: "busybox",
@@ -119,10 +117,10 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                     "build",
-					serving.DeprecatedConfigurationGenerationLabelKey: "99",
-					serving.ConfigurationMetadataGenerationLabelKey:   "100",
-					serving.ServiceLabelKey:                           "",
+					serving.ConfigurationLabelKey:                             "build",
+					serving.ConfigurationGenerationLabelKey:                   "100",
+					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
+					serving.ServiceLabelKey:                                   "",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -145,7 +143,6 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 99,
 				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
@@ -174,12 +171,12 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                     "labels",
-					serving.DeprecatedConfigurationGenerationLabelKey: "99",
-					serving.ConfigurationMetadataGenerationLabelKey:   "100",
-					serving.ServiceLabelKey:                           "",
-					"foo":                                             "bar",
-					"baz":                                             "blah",
+					serving.ConfigurationLabelKey:                             "labels",
+					serving.ConfigurationGenerationLabelKey:                   "100",
+					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
+					serving.ServiceLabelKey:                                   "",
+					"foo":                                                     "bar",
+					"baz":                                                     "blah",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -197,7 +194,6 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedGeneration: 99,
 				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
@@ -225,10 +221,10 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: &boolTrue,
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                     "annotations",
-					serving.DeprecatedConfigurationGenerationLabelKey: "99",
-					serving.ConfigurationMetadataGenerationLabelKey:   "100",
-					serving.ServiceLabelKey:                           "",
+					serving.ConfigurationLabelKey:                             "annotations",
+					serving.ConfigurationGenerationLabelKey:                   "100",
+					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
+					serving.ServiceLabelKey:                                   "",
 				},
 				Annotations: map[string]string{
 					"foo": "bar",

--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -75,6 +75,12 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 	// Otherwise attempt an update (with ONLY the spec changes).
 	desiredDeployment := have.DeepCopy()
 	desiredDeployment.Spec = deployment.Spec
+
+	// carry over new labels
+	for k, v := range deployment.Labels {
+		desiredDeployment.Labels[k] = v
+	}
+
 	d, err := c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Update(desiredDeployment)
 	if err != nil {
 		return nil, Unchanged, err

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -461,6 +461,9 @@ func (c *Reconciler) updateStatus(desired *v1alpha1.Revision) (*v1alpha1.Revisio
 func (c *Reconciler) migrateConfigurationMetadata(rev *v1alpha1.Revision) (*v1alpha1.Revision, error) {
 	stale := false
 
+	// The /configurationGeneration label key used to be an annotation key
+	// This is not the case anymore so if the revision has that annotation
+	// we delete it since it used to point to a configuration's spec.generation
 	if rev.Annotations[serving.ConfigurationGenerationLabelKey] != "" {
 		delete(rev.Annotations, serving.ConfigurationGenerationLabelKey)
 		stale = true
@@ -472,6 +475,8 @@ func (c *Reconciler) migrateConfigurationMetadata(rev *v1alpha1.Revision) (*v1al
 	legacyValue, hasLegacy := rev.Labels[legacyKey]
 	targetValue, hasTarget := rev.Labels[targetKey]
 
+	// If the two keys are different then set /configurationGeneration
+	// to be the value of the label /configurationMetadataGeneration
 	if hasLegacy && targetValue != legacyValue {
 		stale = true
 		rev.Labels[targetKey] = legacyValue

--- a/test/states.go
+++ b/test/states.go
@@ -124,10 +124,9 @@ func IsConfigRevisionCreationFailed(c *v1alpha1.Configuration) (bool, error) {
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations
 // on the revision include an annotation for the generation and that the annotation is
 // set to the expected value.
-// TODO(dprotaso) Delete this assertion for the 0.4 release
 func IsRevisionAtExpectedGeneration(expectedGeneration string) func(r *v1alpha1.Revision) (bool, error) {
 	return func(r *v1alpha1.Revision) (bool, error) {
-		if a, ok := r.Labels[serving.DeprecatedConfigurationGenerationLabelKey]; ok {
+		if a, ok := r.Labels[serving.ConfigurationGenerationLabelKey]; ok {
 			if a != expectedGeneration {
 				return true, fmt.Errorf("Expected Revision %s to be labeled with generation %s but was %s instead", r.Name, expectedGeneration, a)
 			}


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
/hold
-->

Addresses  #643

- in 0.3 the value of this label was the configuration's `spec.generation`.
- now (0.4) the value of this label is set to the configuration's
  `metadata.generation`

We are not switching the latest created revision selection to key
off the `configurationGeneration` label key since there may be a
'race' while migration occurs

