### PR TITLE
Fix activator test flakes (again).

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -235,7 +235,7 @@ func TestActivationHandler(t *testing.T) {
 					fake.Header().Add(activator.RequestCountHTTPHeader, e.attempts)
 				}
 
-				fake.WriteHeader(200)
+				fake.WriteHeader(http.StatusOK)
 				fake.WriteString(wantBody)
 				return fake.Result(), nil
 			})
@@ -365,7 +365,7 @@ func getHandler(throttler *activator.Throttler, act activator.Activator, lockerC
 		lockerCh <- struct{}{}
 
 		fake := httptest.NewRecorder()
-		fake.WriteHeader(200)
+		fake.WriteHeader(http.StatusOK)
 		fake.WriteString(wantBody)
 
 		return fake.Result(), nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3194

## Proposed Changes

* Waiting for failed responses first since those are not blocked by the `lockChan` makes the test deterministic. The problem was that there were situations where we unlocked requests before all requests had made their way into the Throttler.
* Removes the need of a test server from the tests. This was one of the first flake causes to kill because of the i/o issues I saw. Turned out to be a red herring but good to have nonetheless.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @dprotaso 