### PR TITLE
Update deps:test-infra - skip presubmit test for documentation only PR

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -503,7 +503,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b3caf507cc4f2254f7e9ba3b420a5e72d052dfa212374c18134094ffb303bf7a"
+  digest = "1:7e21ca2875c349660aac9983e652b17329109ae712390ac244e6524e7495ff4a"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -516,7 +516,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "31319e986ac00fd10c15ad0608131b35dafb62bb"
+  revision = "6972ae2803c107ef379a2e66c3efd33757f6ac0f"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -27,7 +27,7 @@ readonly KNATIVE_BASE_YAML_SOURCE=https://storage.googleapis.com/knative-nightly
 readonly KNATIVE_ISTIO_CRD_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio-crds.yaml
 readonly KNATIVE_ISTIO_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio.yaml
 readonly KNATIVE_SERVING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/serving}/serving.yaml
-readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/release.yaml
+readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/build.yaml
 readonly KNATIVE_EVENTING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/eventing}/release.yaml
 
 # Conveniently set GOPATH if unset
@@ -277,23 +277,15 @@ function start_latest_knative_serving() {
   kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
   wait_until_pods_running istio-system || return 1
   kubectl label namespace default istio-injection=enabled || return 1
-  subheader "Installing Knative Build"
-  echo "Installing Build from ${KNATIVE_BUILD_RELEASE}"
-  kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1
   subheader "Installing Knative Serving"
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
   kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
   wait_until_pods_running knative-serving || return 1
-  wait_until_pods_running knative-build || return 1
 }
 
 # Install the latest stable Knative/build in the current cluster.
 function start_latest_knative_build() {
   header "Starting Knative Build"
-  subheader "Installing Istio"
-  echo "Installing Istio from ${KNATIVE_ISTIO_YAML}"
-  kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
-  wait_until_pods_running istio-system || return 1
   subheader "Installing Knative Build"
   echo "Installing Build from ${KNATIVE_BUILD_RELEASE}"
   kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -139,6 +139,9 @@ function default_build_test_runner() {
   markdown_build_tests || failed=1
   # For documentation PRs, just check the md files
   (( IS_DOCUMENTATION_PR )) && return ${failed}
+  # Skip build test if there is no go code
+  local go_pkg_dirs="$(go list ./...)"
+  [[ -z "${go_pkg_dirs}" ]] && return ${failed}
   # Ensure all the code builds
   subheader "Checking that go code builds"
   go build -v ./... || failed=1
@@ -154,7 +157,7 @@ function default_build_test_runner() {
   fi
   # Check that we don't have any forbidden licenses in our images.
   subheader "Checking for forbidden licenses"
-  check_licenses $(go list ./...) || failed=1
+  check_licenses ${go_pkg_dirs} || failed=1
   return ${failed}
 }
 
@@ -308,6 +311,8 @@ function main() {
     if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
       abort "--run-test must be used alone"
     fi
+    # If this is a presubmit run, but a documentation-only PR, don't run the test
+    (( IS_PRESUBMIT && IS_DOCUMENTATION_PR )) && exit 0
     ${TEST_TO_RUN} || failed=1
   fi
 


### PR DESCRIPTION
Update deps for test-infra, including changes that skips running presubmit test for documentation only PR