### PR TITLE
Revert defaulting of local-gateway settings.

### DIFF
--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -48,3 +48,6 @@ data:
     # do have a service mesh setup, this isn't required.
     local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
 
+    # In case users just want to expose Services and Routes through the
+    # service mesh, use local-gateway.mesh = "mesh" like the following.
+    local-gateway.mesh: "mesh"

--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -45,11 +45,5 @@ data:
 
     # A cluster local gateway to allow pods outside of the mesh to access
     # Services and Routes not exposing through an ingress.  If the users
-    # do have a service mesh setup, this isn't required.  Instead, use
-    # the local-gateway.mesh = "mesh" the example following this one.
+    # do have a service mesh setup, this isn't required and can be removed.
     local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
-
-    # In case users just want to expose Services and Routes through the
-    # service mesh, use local-gateway.mesh = "mesh" like the following,
-    # in place of any local-gateway.xxx-gateway setting.
-    local-gateway.mesh: "mesh"

--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -46,4 +46,9 @@ data:
     # A cluster local gateway to allow pods outside of the mesh to access
     # Services and Routes not exposing through an ingress.  If the users
     # do have a service mesh setup, this isn't required and can be removed.
+    #
+    # An example use case is when users want to use Istio without any
+    # sidecar injection (like Knative's istio-lean.yaml).  Since every pod
+    # is outside of the service mesh in that case, a cluster-local  service
+    # will need to be exposed to a cluster-local gateway to be accessible.
     local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"

--- a/config/config-istio.yaml
+++ b/config/config-istio.yaml
@@ -45,9 +45,11 @@ data:
 
     # A cluster local gateway to allow pods outside of the mesh to access
     # Services and Routes not exposing through an ingress.  If the users
-    # do have a service mesh setup, this isn't required.
+    # do have a service mesh setup, this isn't required.  Instead, use
+    # the local-gateway.mesh = "mesh" the example following this one.
     local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
 
     # In case users just want to expose Services and Routes through the
-    # service mesh, use local-gateway.mesh = "mesh" like the following.
+    # service mesh, use local-gateway.mesh = "mesh" like the following,
+    # in place of any local-gateway.xxx-gateway setting.
     local-gateway.mesh: "mesh"

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -37,19 +36,12 @@ const (
 
 	// LocalGatewayKeyPrefix is the prefix of all keys to configure Istio gateways for public & private ClusterIngresses.
 	LocalGatewayKeyPrefix = "local-gateway."
-
-	// MeshGateway is the special case where local ClusterIngresses are only exposed to service mesh.
-	MeshGateway = "mesh"
 )
 
 var (
 	defaultGateway = Gateway{
 		GatewayName: "knative-ingress-gateway",
 		ServiceURL:  fmt.Sprintf("istio-ingressgateway.istio-system.svc.%s", utils.GetClusterDomainName()),
-	}
-	defaultLocalGateway = Gateway{
-		GatewayName: "cluster-local-gateway",
-		ServiceURL:  fmt.Sprintf("cluster-local-gateway.istio-system.svc.%s", utils.GetClusterDomainName()),
 	}
 )
 
@@ -77,9 +69,6 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 			continue
 		}
 		gatewayName, serviceURL := k[len(prefix):], v
-		if gatewayName == MeshGateway && serviceURL != MeshGateway {
-			return nil, errors.New("local-gateway.mesh can only be set to 'mesh'")
-		}
 		if errs := validation.IsDNS1123Subdomain(serviceURL); len(errs) > 0 {
 			return nil, fmt.Errorf("invalid gateway format: %v", errs)
 		}
@@ -97,16 +86,6 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 	return gateways, nil
 }
 
-func ignoreMeshGateway(gateways []Gateway) []Gateway {
-	results := []Gateway{}
-	for _, gw := range gateways {
-		if gw.GatewayName != MeshGateway {
-			results = append(results, gw)
-		}
-	}
-	return results
-}
-
 // NewIstioFromConfigMap creates an Istio config from the supplied ConfigMap
 func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 	gateways, err := parseGateways(configMap, GatewayKeyPrefix)
@@ -120,12 +99,6 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(localGateways) == 0 {
-		localGateways = append(localGateways, defaultLocalGateway)
-	}
-	// MeshGateway specification is a workaround of defaulting empty list
-	// of gateways, so we remove it after defaulting.
-	localGateways = ignoreMeshGateway(localGateways)
 	return &Istio{
 		IngressGateways: gateways,
 		LocalGateways:   localGateways,

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
@@ -49,7 +49,7 @@ func TestGatewayConfiguration(t *testing.T) {
 		name: "gateway configuration with no network input",
 		wantIstio: &Istio{
 			IngressGateways: []Gateway{defaultGateway},
-			LocalGateways:   []Gateway{defaultLocalGateway},
+			LocalGateways:   []Gateway{},
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -78,7 +78,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				GatewayName: "knative-ingress-freeway",
 				ServiceURL:  "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
-			LocalGateways: []Gateway{defaultLocalGateway},
+			LocalGateways: []Gateway{},
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -106,35 +106,6 @@ func TestGatewayConfiguration(t *testing.T) {
 			},
 			Data: map[string]string{
 				"local-gateway.knative-ingress-backroad": "istio-ingressbackroad.istio-system.svc.cluster.local",
-			},
-		},
-	}, {
-		name:    "mesh-only gateway configuration",
-		wantErr: false,
-		wantIstio: &Istio{
-			IngressGateways: []Gateway{defaultGateway},
-			LocalGateways:   []Gateway{},
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      IstioConfigName,
-			},
-			Data: map[string]string{
-				"local-gateway.mesh": "mesh",
-			},
-		},
-	}, {
-		name:      "mesh-only gateway invalid configuration",
-		wantErr:   true,
-		wantIstio: (*Istio)(nil),
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      IstioConfigName,
-			},
-			Data: map[string]string{
-				"local-gateway.mesh": "mess",
 			},
 		},
 	}}

--- a/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/config/istio_test.go
@@ -108,6 +108,35 @@ func TestGatewayConfiguration(t *testing.T) {
 				"local-gateway.knative-ingress-backroad": "istio-ingressbackroad.istio-system.svc.cluster.local",
 			},
 		},
+	}, {
+		name:    "mesh-only gateway configuration",
+		wantErr: false,
+		wantIstio: &Istio{
+			IngressGateways: []Gateway{defaultGateway},
+			LocalGateways:   []Gateway{},
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"local-gateway.mesh": "mesh",
+			},
+		},
+	}, {
+		name:      "mesh-only gateway invalid configuration",
+		wantErr:   true,
+		wantIstio: (*Istio)(nil),
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"local-gateway.mesh": "mess",
+			},
+		},
 	}}
 
 	for _, tt := range gatewayConfigTests {

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"sort"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -32,6 +33,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/resources/names"
+	"github.com/knative/serving/pkg/utils"
 )
 
 // MakeVirtualService creates an Istio VirtualService as network programming.
@@ -93,7 +95,7 @@ func makePortSelector(ios intstr.IntOrString) v1alpha3.PortSelector {
 
 func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPath) *v1alpha3.HTTPRoute {
 	matches := []v1alpha3.HTTPMatchRequest{}
-	for _, host := range hosts {
+	for _, host := range expandedHosts(hosts) {
 		matches = append(matches, makeMatch(host, http.Path))
 	}
 	weights := []v1alpha3.DestinationWeight{}
@@ -120,6 +122,38 @@ func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPa
 	}
 }
 
+func dedup(hosts []string) []string {
+	set := sets.NewString()
+	unique := []string{}
+	for _, h := range hosts {
+		if !set.Has(h) {
+			set.Insert(h)
+			unique = append(unique, h)
+		}
+	}
+	// Sort the names to give a deterministic ordering.
+	sort.Strings(unique)
+	return unique
+}
+
+func expandedHosts(hosts []string) []string {
+	expanded := []string{}
+	allowedSuffixes := []string{
+		"",
+		"." + utils.GetClusterDomainName(),
+		".svc." + utils.GetClusterDomainName(),
+		".default.svc." + utils.GetClusterDomainName(),
+	}
+	for _, h := range hosts {
+		for _, suffix := range allowedSuffixes {
+			if strings.HasSuffix(h, suffix) {
+				expanded = append(expanded, strings.TrimSuffix(h, suffix))
+			}
+		}
+	}
+	return dedup(expanded)
+}
+
 func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 	match := v1alpha3.HTTPMatchRequest{
 		Authority: &istiov1alpha1.StringMatch{
@@ -137,17 +171,11 @@ func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 }
 
 func getHosts(ci *v1alpha1.ClusterIngress) []string {
-	hosts := sets.NewString()
-	unique := []string{}
+	hosts := []string{}
 	for _, rule := range ci.Spec.Rules {
 		for _, h := range rule.Hosts {
-			if !hosts.Has(h) {
-				hosts.Insert(h)
-				unique = append(unique, h)
-			}
+			hosts = append(hosts, h)
 		}
 	}
-	// Sort the names to give a deterministic ordering.
-	sort.Strings(unique)
-	return unique
+	return dedup(hosts)
 }

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,17 +122,7 @@ func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPa
 }
 
 func dedup(hosts []string) []string {
-	set := sets.NewString()
-	unique := []string{}
-	for _, h := range hosts {
-		if !set.Has(h) {
-			set.Insert(h)
-			unique = append(unique, h)
-		}
-	}
-	// Sort the names to give a deterministic ordering.
-	sort.Strings(unique)
-	return unique
+	return sets.NewString(hosts...).List()
 }
 
 func expandedHosts(hosts []string) []string {
@@ -142,7 +131,6 @@ func expandedHosts(hosts []string) []string {
 		"",
 		"." + utils.GetClusterDomainName(),
 		".svc." + utils.GetClusterDomainName(),
-		".default.svc." + utils.GetClusterDomainName(),
 	}
 	for _, h := range hosts {
 		for _, suffix := range allowedSuffixes {

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -143,13 +143,13 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Authority: &istiov1alpha1.StringMatch{Exact: "domain.com"},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc.cluster.local"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns"},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
 			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc"},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns"},
+			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc.cluster.local"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -314,5 +314,70 @@ func TestGetHosts_Duplicate(t *testing.T) {
 	}
 	if diff := cmp.Diff(expected, hosts); diff != "" {
 		t.Errorf("Unexpected hosts  (-want +got): %v", diff)
+	}
+}
+
+func TestGetExpandedHosts(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		hosts []string
+		want  []string
+	}{{
+		name: "cluster local service in non-default namespace",
+		hosts: []string{
+			"service.namespace.svc.cluster.local",
+		},
+		want: []string{
+			"service.namespace",
+			"service.namespace.svc",
+			"service.namespace.svc.cluster.local",
+		},
+	}, {
+		name: "cluster local default service in default namespace",
+		hosts: []string{
+			"service.default.svc.cluster.local",
+		},
+		want: []string{
+			"service",
+			"service.default",
+			"service.default.svc",
+			"service.default.svc.cluster.local",
+		},
+	}, {
+		name: "example.com service",
+		hosts: []string{
+			"foo.bar.example.com",
+		},
+		want: []string{
+			"foo.bar.example.com",
+		},
+	}, {
+		name: "default.example.com service",
+		hosts: []string{
+			"foo.default.example.com",
+		},
+		want: []string{
+			"foo.default.example.com",
+		},
+	}, {
+		name: "mix",
+		hosts: []string{
+			"foo.default.example.com",
+			"foo.default.svc.cluster.local",
+		},
+		want: []string{
+			"foo",
+			"foo.default",
+			"foo.default.example.com",
+			"foo.default.svc",
+			"foo.default.svc.cluster.local",
+		},
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			got := expandedHosts(test.hosts)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("Unexpected (-want +got): %v", diff)
+			}
+		})
 	}
 }

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -333,17 +333,6 @@ func TestGetExpandedHosts(t *testing.T) {
 			"service.namespace.svc.cluster.local",
 		},
 	}, {
-		name: "cluster local default service in default namespace",
-		hosts: []string{
-			"service.default.svc.cluster.local",
-		},
-		want: []string{
-			"service",
-			"service.default",
-			"service.default.svc",
-			"service.default.svc.cluster.local",
-		},
-	}, {
 		name: "example.com service",
 		hosts: []string{
 			"foo.bar.example.com",
@@ -366,7 +355,6 @@ func TestGetExpandedHosts(t *testing.T) {
 			"foo.default.svc.cluster.local",
 		},
 		want: []string{
-			"foo",
 			"foo.default",
 			"foo.default.example.com",
 			"foo.default.svc",

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -95,13 +95,10 @@ func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string]traffic
 func routeDomains(targetName string, r *servingv1alpha1.Route) []string {
 	if targetName == traffic.DefaultTarget {
 		// Nameless traffic targets correspond to many domains: the
-		// Route.Status.Domain, and also various names of the Route's
-		// headless Service.
+		// Route.Status.Domain.
 		domains := []string{
 			r.Status.Domain,
 			names.K8sServiceFullname(r),
-			fmt.Sprintf("%s.%s.svc", r.Name, r.Namespace),
-			fmt.Sprintf("%s.%s", r.Name, r.Namespace),
 		}
 		return dedup(domains)
 	}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -88,8 +88,6 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 		Hosts: []string{
 			"domain.com",
 			"test-route.test-ns.svc.cluster.local",
-			"test-route.test-ns.svc",
-			"test-route.test-ns",
 		},
 		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -177,7 +175,6 @@ func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
 	expected := []string{
 		base,
 		"test-route.test-ns.svc.cluster.local",
-		"test-route.test-ns.svc",
 	}
 	domains := routeDomains("", r)
 	if diff := cmp.Diff(expected, domains); diff != "" {
@@ -198,8 +195,6 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 	expected := []string{
 		base,
 		"test-route.test-ns.svc.cluster.local",
-		"test-route.test-ns.svc",
-		"test-route.test-ns",
 	}
 	domains := routeDomains("", r)
 	if diff := cmp.Diff(expected, domains); diff != "" {

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -316,8 +316,6 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 			Hosts: []string{
 				domain,
 				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
-				"test-route.test",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -405,8 +403,6 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 			Hosts: []string{
 				domain,
 				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
-				"test-route.test",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -486,8 +482,6 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			Hosts: []string{
 				domain,
 				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
-				"test-route.test",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -586,8 +580,6 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			Hosts: []string{
 				domain,
 				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
-				"test-route.test",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -706,8 +698,6 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			Hosts: []string{
 				domain,
 				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
-				"test-route.test",
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Previously empty list of local gateway would mean all KService and Route are mesh-local, until we empty out our ConfigMap and slightly change the defaulting.  This PR brings such behavior back. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
