### PR TITLE
Format markdown

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -226,10 +226,11 @@ full set of HTTP headers is constantly evolving, it is RECOMMENDED that
 platforms which strip headers define a common prefix which covers all headers
 removed by the platform.
 
-In addition, the following base set of HTTP/1.1 headers MUST be set on the request:
+In addition, the following base set of HTTP/1.1 headers MUST be set on the
+request:
 
-- `Host` - As specified by [RFC 7230 Section
-  5.4](https://tools.ietf.org/html/rfc7230#section-5.4)
+- `Host` - As specified by
+  [RFC 7230 Section 5.4](https://tools.ietf.org/html/rfc7230#section-5.4)
 
 Also, the following proxy-specific request headers MUST be set:
 

--- a/test/test_images/failing/README.md
+++ b/test/test_images/failing/README.md
@@ -2,8 +2,8 @@
 
 This directory contains the test image used to simulate a crashing image.
 
-The image runs for 10 seconds and then exits. It is useful for testing
-readiness probes.
+The image runs for 10 seconds and then exits. It is useful for testing readiness
+probes.
 
 ## Trying out
 

--- a/test/test_images/protocols/README.md
+++ b/test/test_images/protocols/README.md
@@ -1,11 +1,11 @@
 # Protocols test image
 
-This directory contains the test image used to test the [supported
-network protocols](/docs/runtime-contract.md#protocols-and-ports).
+This directory contains the test image used to test the
+[supported network protocols](/docs/runtime-contract.md#protocols-and-ports).
 
 The image contains a simple server that will serve HTTP/1.1 and HTTP/2.0
-requests from the same port. The response will be a JSON with the
-following format:
+requests from the same port. The response will be a JSON with the following
+format:
 
 ```
 {
@@ -13,7 +13,6 @@ following format:
   'protoMinor': 1 # 0 if HTTP/2
 }
 ```
-
 
 ## Building
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`