### PR TITLE
Switch "latest", "candidate", and "current" to be named constants.

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -88,6 +88,17 @@ type TrafficTarget struct {
 	Percent int `json:"percent"`
 }
 
+const (
+	// LatestTrafficTarget is the named constant of the `latest` traffic target.
+	LatestTrafficTarget = "latest"
+
+	// CurrentTrafficTarget is the named constnat of the `current` traffic target.
+	CurrentTrafficTarget = "current"
+
+	// CandidateTrafficTarget is the named constnat of the `candidate` traffic target.
+	CandidateTrafficTarget = "candidate"
+)
+
 // RouteSpec holds the desired state of the Route (from the client).
 type RouteSpec struct {
 	// DeprecatedGeneration was used prior in Kubernetes versions <1.11

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -88,17 +88,6 @@ type TrafficTarget struct {
 	Percent int `json:"percent"`
 }
 
-const (
-	// LatestTrafficTarget is the named constant of the `latest` traffic target.
-	LatestTrafficTarget = "latest"
-
-	// CurrentTrafficTarget is the named constnat of the `current` traffic target.
-	CurrentTrafficTarget = "current"
-
-	// CandidateTrafficTarget is the named constnat of the `candidate` traffic target.
-	CandidateTrafficTarget = "candidate"
-)
-
 // RouteSpec holds the desired state of the Route (from the client).
 type RouteSpec struct {
 	// DeprecatedGeneration was used prior in Kubernetes versions <1.11

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -286,7 +286,17 @@ func (ss *ServiceStatus) PropagateConfigurationStatus(cs *ConfigurationStatus) {
 const (
 	trafficNotMigratedReason  = "TrafficNotMigrated"
 	trafficNotMigratedMessage = "Traffic is not yet migrated to the latest revision."
+
+	// LatestTrafficTarget is the named constant of the `latest` traffic target.
+	LatestTrafficTarget = "latest"
+
+	// CurrentTrafficTarget is the named constnat of the `current` traffic target.
+	CurrentTrafficTarget = "current"
+
+	// CandidateTrafficTarget is the named constnat of the `candidate` traffic target.
+	CandidateTrafficTarget = "candidate"
 )
+
 
 // MarkRouteNotYetReady marks the service `RouteReady` condition to the `Unknown` state.
 // See: #2430, for details.

--- a/pkg/reconciler/v1alpha1/service/resources/route.go
+++ b/pkg/reconciler/v1alpha1/service/resources/route.go
@@ -45,7 +45,7 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 
 		// Configure the 'current' route.
 		ttCurrent := v1alpha1.TrafficTarget{
-			Name:    "current",
+			Name:    v1alpha1.CurrentTrafficTarget,
 			Percent: 100 - rolloutPercent,
 		}
 		currentRevisionName := service.Spec.Release.Revisions[0]
@@ -64,7 +64,7 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 		// Configure the 'candidate' route.
 		if numRevisions == 2 {
 			ttCandidate := v1alpha1.TrafficTarget{
-				Name:    "candidate",
+				Name:    v1alpha1.CandidateTrafficTarget,
 				Percent: rolloutPercent,
 			}
 			candidateRevisionName := service.Spec.Release.Revisions[1]
@@ -78,7 +78,7 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 
 		// Configure the 'latest' route.
 		ttLatest := v1alpha1.TrafficTarget{
-			Name:              "latest",
+			Name:              v1alpha1.LatestTrafficTarget,
 			ConfigurationName: names.Configuration(service),
 			Percent:           0,
 		}

--- a/pkg/reconciler/v1alpha1/service/resources/route_test.go
+++ b/pkg/reconciler/v1alpha1/service/resources/route_test.go
@@ -126,7 +126,7 @@ func TestRouteReleaseSingleRevision(t *testing.T) {
 	if got, want := ttCurrent.Percent, currentPercent; got != want {
 		t.Errorf("Expected %d percent got %d", want, got)
 	}
-	if got, want := ttCurrent.Name, "current"; got != want {
+	if got, want := ttCurrent.Name, v1alpha1.CurrentTrafficTarget; got != want {
 		t.Errorf("Expected %q name got %q", want, got)
 	}
 	if got, want := ttCurrent.RevisionName, testRevisionName; got != want {
@@ -139,7 +139,7 @@ func TestRouteReleaseSingleRevision(t *testing.T) {
 	if got, want := ttLatest.Percent, 0; got != want {
 		t.Errorf("Expected %d percent got %d", want, got)
 	}
-	if got, want := ttLatest.Name, "latest"; got != want {
+	if got, want := ttLatest.Name, v1alpha1.LatestTrafficTarget; got != want {
 		t.Errorf("Expected %q name got %q", want, got)
 	}
 	if got, want := ttLatest.RevisionName, ""; got != want {
@@ -180,15 +180,15 @@ func TestRouteLatestRevisionSplit(t *testing.T) {
 		t.Errorf("Expected %q for service namespace got %q", want, got)
 	}
 	wantT := []v1alpha1.TrafficTarget{{
-		Name:              "current",
+		Name:              v1alpha1.CurrentTrafficTarget,
 		Percent:           currentPercent,
 		ConfigurationName: testConfigName,
 	}, {
-		Name:         "candidate",
+		Name:         v1alpha1.CandidateTrafficTarget,
 		Percent:      rolloutPercent,
 		RevisionName: "juicy-revision",
 	}, {
-		Name:              "latest",
+		Name:              v1alpha1.LatestTrafficTarget,
 		ConfigurationName: testConfigName,
 	}}
 	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
@@ -223,15 +223,15 @@ func TestRouteLatestRevisionSplitCandidate(t *testing.T) {
 		t.Errorf("Expected %q for service namespace got %q", want, got)
 	}
 	wantT := []v1alpha1.TrafficTarget{{
-		Name:         "current",
+		Name:         v1alpha1.CurrentTrafficTarget,
 		Percent:      currentPercent,
 		RevisionName: "squishy-revision",
 	}, {
-		Name:              "candidate",
+		Name:              v1alpha1.CandidateTrafficTarget,
 		Percent:           rolloutPercent,
 		ConfigurationName: testConfigName,
 	}, {
-		Name:              "latest",
+		Name:              v1alpha1.LatestTrafficTarget,
 		ConfigurationName: testConfigName,
 	}}
 	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
@@ -264,11 +264,11 @@ func TestRouteLatestRevisionNoSplit(t *testing.T) {
 	}
 	// Should have 2 named traffic targets (current, latest)
 	wantT := []v1alpha1.TrafficTarget{{
-		Name:              "current",
+		Name:              v1alpha1.CurrentTrafficTarget,
 		Percent:           100,
 		ConfigurationName: testConfigName,
 	}, {
-		Name:              "latest",
+		Name:              v1alpha1.LatestTrafficTarget,
 		ConfigurationName: testConfigName,
 	}}
 	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
@@ -309,7 +309,7 @@ func TestRouteReleaseTwoRevisions(t *testing.T) {
 	if got, want := ttCurrent.Percent, currentPercent; got != want {
 		t.Errorf("Expected %d percent got %d", want, got)
 	}
-	if got, want := ttCurrent.Name, "current"; got != want {
+	if got, want := ttCurrent.Name, v1alpha1.CurrentTrafficTarget; got != want {
 		t.Errorf("Expected %q name got %q", want, got)
 	}
 	if got, want := ttCurrent.RevisionName, testRevisionName; got != want {
@@ -322,7 +322,7 @@ func TestRouteReleaseTwoRevisions(t *testing.T) {
 	if got, want := ttCandidate.Percent, rolloutPercent; got != want {
 		t.Errorf("Expected %d percent got %d", want, got)
 	}
-	if got, want := ttCandidate.Name, "candidate"; got != want {
+	if got, want := ttCandidate.Name, v1alpha1.CandidateTrafficTarget; got != want {
 		t.Errorf("Expected %q name got %q", want, got)
 	}
 	if got, want := ttCandidate.RevisionName, testCandidateRevisionName; got != want {
@@ -335,7 +335,7 @@ func TestRouteReleaseTwoRevisions(t *testing.T) {
 	if got, want := ttLatest.Percent, 0; got != want {
 		t.Errorf("Expected %d percent got %d", want, got)
 	}
-	if got, want := ttLatest.Name, "latest"; got != want {
+	if got, want := ttLatest.Name, v1alpha1.LatestTrafficTarget; got != want {
 		t.Errorf("Expected %q name got %q", want, got)
 	}
 	if got, want := ttLatest.RevisionName, ""; got != want {

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -138,11 +138,11 @@ func TestReconcile(t *testing.T) {
 			route("pinned3", "foo", WithReleaseRollout("pinned3-00001"),
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				WithStatusTraffic(v1alpha1.TrafficTarget{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "pinned3-00001",
 					Percent:      100,
 				}, v1alpha1.TrafficTarget{
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "pinned3-00001",
 					Percent:      0,
 				}), MarkTrafficAssigned, MarkIngressReady),
@@ -159,11 +159,11 @@ func TestReconcile(t *testing.T) {
 				// The delta induced by route object.
 				WithReadyRoute, WithSvcStatusDomain, WithSvcStatusAddress,
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "pinned3-00001",
 					Percent:      100,
 				}, v1alpha1.TrafficTarget{
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "pinned3-00001",
 					Percent:      0,
 				})),
@@ -354,11 +354,11 @@ func TestReconcile(t *testing.T) {
 				WithReleaseRollout(v1alpha1.ReleaseLatestRevisionKeyword),
 				RouteReady, WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				WithStatusTraffic([]v1alpha1.TrafficTarget{{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "release-ready-lr-00001",
 					Percent:      100,
 				}, {
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "release-ready-lr-00001",
 				}}...), MarkTrafficAssigned, MarkIngressReady),
 			config("release-ready-lr", "foo", WithReleaseRollout("release-ready-lr"), WithGeneration(1),
@@ -375,11 +375,11 @@ func TestReconcile(t *testing.T) {
 				// The delta induced by route object.
 				WithReadyRoute, WithSvcStatusDomain, WithSvcStatusAddress,
 				WithSvcStatusTraffic([]v1alpha1.TrafficTarget{{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "release-ready-lr-00001",
 					Percent:      100,
 				}, {
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "release-ready-lr-00001",
 				}}...),
 			),
@@ -401,15 +401,15 @@ func TestReconcile(t *testing.T) {
 					42, "release-ready-lr-00001", v1alpha1.ReleaseLatestRevisionKeyword),
 				RouteReady, WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				WithStatusTraffic([]v1alpha1.TrafficTarget{{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "release-ready-lr-00001",
 					Percent:      58,
 				}, {
-					Name:         "candidate",
+					Name:         v1alpha1.CandidateTrafficTarget,
 					RevisionName: "release-ready-lr-00002",
 					Percent:      42,
 				}, {
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "release-ready-lr-00002",
 				}}...), MarkTrafficAssigned, MarkIngressReady),
 			config("release-ready-lr", "foo", WithReleaseRollout("release-ready-lr"), WithGeneration(2),
@@ -427,15 +427,15 @@ func TestReconcile(t *testing.T) {
 				// The delta induced by route object.
 				WithReadyRoute, WithSvcStatusDomain, WithSvcStatusAddress,
 				WithSvcStatusTraffic([]v1alpha1.TrafficTarget{{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "release-ready-lr-00001",
 					Percent:      58,
 				}, {
-					Name:         "candidate",
+					Name:         v1alpha1.CandidateTrafficTarget,
 					RevisionName: "release-ready-lr-00002",
 					Percent:      42,
 				}, {
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "release-ready-lr-00002",
 				}}...),
 			),
@@ -457,15 +457,15 @@ func TestReconcile(t *testing.T) {
 					"release-ready-00001", "release-ready-00002"),
 				RouteReady, WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				WithStatusTraffic(v1alpha1.TrafficTarget{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "release-ready-00001",
 					Percent:      42,
 				}, v1alpha1.TrafficTarget{
-					Name:         "candidate",
+					Name:         v1alpha1.CandidateTrafficTarget,
 					RevisionName: "release-ready-00002",
 					Percent:      58,
 				}, v1alpha1.TrafficTarget{
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "release-ready-00002",
 					Percent:      0,
 				}), MarkTrafficAssigned, MarkIngressReady),
@@ -483,15 +483,15 @@ func TestReconcile(t *testing.T) {
 				// The delta induced by route object.
 				WithReadyRoute, WithSvcStatusDomain, WithSvcStatusAddress,
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
-					Name:         "current",
+					Name:         v1alpha1.CurrentTrafficTarget,
 					RevisionName: "release-ready-00001",
 					Percent:      42,
 				}, v1alpha1.TrafficTarget{
-					Name:         "candidate",
+					Name:         v1alpha1.CandidateTrafficTarget,
 					RevisionName: "release-ready-00002",
 					Percent:      58,
 				}, v1alpha1.TrafficTarget{
-					Name:         "latest",
+					Name:         v1alpha1.LatestTrafficTarget,
 					RevisionName: "release-ready-00002",
 					Percent:      0,
 				},

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -369,13 +369,13 @@ func TestReleaseService(t *testing.T) {
 		t.Fatalf("Service %s was not updated to release: %v", names.Service, err)
 	}
 	desiredTrafficShape := map[string]v1alpha1.TrafficTarget{
-		"current": {
-			Name:         "current",
+		v1alpha1.CurrentTrafficTarget: {
+			Name:         v1alpha1.CurrentTrafficTarget,
 			RevisionName: objects.Config.Status.LatestReadyRevisionName,
 			Percent:      100,
 		},
-		"latest": {
-			Name:         "latest",
+		v1alpha1.LatestTrafficTarget: {
+			Name:         v1alpha1.LatestTrafficTarget,
 			RevisionName: objects.Config.Status.LatestReadyRevisionName,
 		},
 	}
@@ -388,7 +388,7 @@ func TestReleaseService(t *testing.T) {
 	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev},
-		[]string{"latest", "current"},
+		[]string{v1alpha1.LatestTrafficTarget, v1alpha1.CurrentTrafficTarget},
 		[]string{expectedFirstRev, expectedFirstRev}); err != nil {
 		t.Fatal(err)
 	}
@@ -406,8 +406,8 @@ func TestReleaseService(t *testing.T) {
 	revisions = append(revisions, names.Revision)
 
 	// Also verify traffic is in the correct shape.
-	desiredTrafficShape["latest"] = v1alpha1.TrafficTarget{
-		Name:         "latest",
+	desiredTrafficShape[v1alpha1.LatestTrafficTarget] = v1alpha1.TrafficTarget{
+		Name:         v1alpha1.LatestTrafficTarget,
 		RevisionName: names.Revision,
 	}
 	logger.Info("Waiting for Service to become ready with the new shape.")
@@ -419,7 +419,7 @@ func TestReleaseService(t *testing.T) {
 	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev},
-		[]string{"latest", "current"},
+		[]string{v1alpha1.LatestTrafficTarget, v1alpha1.CurrentTrafficTarget},
 		[]string{expectedSecondRev, expectedFirstRev}); err != nil {
 		t.Fatal(err)
 	}
@@ -431,18 +431,18 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	desiredTrafficShape = map[string]v1alpha1.TrafficTarget{
-		"current": {
-			Name:         "current",
+		v1alpha1.CurrentTrafficTarget: {
+			Name:         v1alpha1.CurrentTrafficTarget,
 			RevisionName: revisions[0],
 			Percent:      50,
 		},
-		"candidate": {
-			Name:         "candidate",
+		v1alpha1.CandidateTrafficTarget: {
+			Name:         v1alpha1.CandidateTrafficTarget,
 			RevisionName: revisions[1],
 			Percent:      50,
 		},
-		"latest": {
-			Name:         "latest",
+		v1alpha1.LatestTrafficTarget: {
+			Name:         v1alpha1.LatestTrafficTarget,
 			RevisionName: revisions[1],
 		},
 	}
@@ -455,7 +455,7 @@ func TestReleaseService(t *testing.T) {
 	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev, expectedSecondRev},
-		[]string{"candidate", "latest", "current"},
+		[]string{v1alpha1.CandidateTrafficTarget, v1alpha1.LatestTrafficTarget, v1alpha1.CurrentTrafficTarget},
 		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev}); err != nil {
 		t.Fatal(err)
 	}
@@ -470,8 +470,8 @@ func TestReleaseService(t *testing.T) {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
 
-	desiredTrafficShape["latest"] = v1alpha1.TrafficTarget{
-		Name:         "latest",
+	desiredTrafficShape[v1alpha1.LatestTrafficTarget] = v1alpha1.TrafficTarget{
+		Name:         v1alpha1.LatestTrafficTarget,
 		RevisionName: names.Revision,
 	}
 	logger.Info("Waiting for Service to become ready with the new shape.")
@@ -483,7 +483,7 @@ func TestReleaseService(t *testing.T) {
 	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev, expectedSecondRev},
-		[]string{"latest", "candidate", "current"},
+		[]string{v1alpha1.LatestTrafficTarget, v1alpha1.CandidateTrafficTarget, v1alpha1.CurrentTrafficTarget},
 		[]string{expectedThirdRev, expectedSecondRev, expectedFirstRev}); err != nil {
 		t.Fatal(err)
 	}
@@ -496,8 +496,8 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	// `candidate` now points to the latest.
-	desiredTrafficShape["candidate"] = v1alpha1.TrafficTarget{
-		Name:         "candidate",
+	desiredTrafficShape[v1alpha1.CandidateTrafficTarget] = v1alpha1.TrafficTarget{
+		Name:         v1alpha1.CandidateTrafficTarget,
 		RevisionName: names.Revision,
 		Percent:      50,
 	}
@@ -509,7 +509,7 @@ func TestReleaseService(t *testing.T) {
 	if err := validateDomains(logger, clients,
 		names.Domain,
 		[]string{expectedFirstRev, expectedThirdRev},
-		[]string{"latest", "candidate", "current"},
+		[]string{v1alpha1.LatestTrafficTarget, v1alpha1.CandidateTrafficTarget, v1alpha1.CurrentTrafficTarget},
 		[]string{expectedThirdRev, expectedThirdRev, expectedFirstRev}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Those are well known names, used throughout the system.
So name them.


/lint

## Proposed Changes

* name the well known traffic targets as constants.

/cc @dgerd 