### PR TITLE
Fixes #3201. Improves the speed of ./test/upload-test-images.sh

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -18,19 +18,16 @@ set -o errexit
 
 function upload_test_images() {
   echo ">> Publishing test images"
-  local image_dirs="$(find $(dirname $0)/test_images -mindepth 1 -maxdepth 1 -type d)"
+  local image_dir="$(dirname $0)/test_images"
   local docker_tag=$1
   local tag_option=""
   if [ -n "${docker_tag}" ]; then
     tag_option="--tags $docker_tag,latest"
   fi
 
-  for image_dir in ${image_dirs}; do
-      local image_name="$(basename ${image_dir})"
-      local image="github.com/knative/serving/test/test_images/${image_name}"
-
-      ko publish -B ${tag_option} "${image}"
-  done
+  # ko resolve is being used for the side-effect of publishing images,
+  # so the resulting yaml produced is ignored.
+  ko resolve ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
 : ${DOCKER_REPO_OVERRIDE:?"You must set 'DOCKER_REPO_OVERRIDE', see DEVELOPMENT.md"}


### PR DESCRIPTION
Replaces the serial runs of `ko publish` with a single run of `ko
resolve`. This in turn causes the ./test/upload-test-images.sh script to run much faster.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3201 

## Proposed Changes

* Change ./test/upload-test-images.sh shell script to use `ko resolve` instead of `ko publish`.
