### PR TITLE
Fix the test that had a potential deadlock and other beautifications.

### DIFF
--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -64,9 +64,7 @@ func generateTraffic(client *spoof.SpoofingClient, url string, concurrency int, 
 					if err != nil {
 						logger.Infof("Error sending request: %v", err)
 					}
-					if resChannel != nil {
-						resChannel <- res
-					}
+					resChannel <- res
 				}
 			}
 		})
@@ -157,21 +155,21 @@ func TestObservedConcurrency(t *testing.T) {
 
 	// Make sure we are ready to serve.
 	st := time.Now()
-	logger.Info("Starting to probe the endpoint at ", st)
-	_, err = pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		logger,
-		domain+"/?timeout=10", // To generate any kind of a valid response.
-		pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
-			_, _, err := parseResponse(string(resp.Body))
-			return err == nil, nil
-		}, http.StatusNotFound),
-		"WaitForEndpointToServeText",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
-		t.Fatalf("The endpoint at domain %s didn't serve the expected response: %v", domain, err)
-	}
-	logger.Infof("Took %v for the endpoint to start serving", time.Now().Sub(st))
+		logger.Info("Starting to probe the endpoint at ", st)
+		_, err = pkgTest.WaitForEndpointState(
+			clients.KubeClient,
+			logger,
+			domain+"/?timeout=10", // To generate any kind of a valid response.
+			pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
+				_, _, err := parseResponse(string(resp.Body))
+				return err == nil, nil
+			}, http.StatusNotFound),
+			"WaitForEndpointToServeText",
+			test.ServingFlags.ResolvableDomain)
+		if err != nil {
+			t.Fatalf("The endpoint at domain %s didn't serve the expected response: %v", domain, err)
+		}
+	logger.Infof("Took %v for the endpoint to start serving", time.Since(st))
 
 	// This just helps with preallocation.
 	const presumedSize = 1000

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -72,7 +72,6 @@ func generateTraffic(client *spoof.SpoofingClient, url string, concurrency int, 
 		})
 	}
 
-	// Requests is no longer touched by the parallel go routines, so it's safe to read it as is.
 	if err := group.Wait(); err != nil {
 		return fmt.Errorf("error making requests for scale up: %v", err)
 	}
@@ -149,12 +148,8 @@ func TestObservedConcurrency(t *testing.T) {
 	}
 
 	domain := objs.Route.Status.Domain
-	endpoint, err := spoof.GetServiceEndpoint(clients.KubeClient.Kube)
-	if err != nil {
-		t.Fatalf("Cannot get service endpoint: %v", err)
-	}
 
-	url := fmt.Sprintf("http://%s/?timeout=1000", *endpoint)
+	url := fmt.Sprintf("http://%s/?timeout=1000", domain)
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -62,7 +62,7 @@ func generateTraffic(client *spoof.SpoofingClient, url string, concurrency int, 
 				default:
 					res, err := client.Do(req)
 					if err != nil {
-						logger.Errorf("Error sending request: %v", err)
+						logger.Infof("Error sending request: %v", err)
 					}
 					if resChannel != nil {
 						resChannel <- res

--- a/test/test_images/observed-concurrency/observed_concurrency.go
+++ b/test/test_images/observed-concurrency/observed_concurrency.go
@@ -29,7 +29,7 @@ import (
 func handler(w http.ResponseWriter, r *http.Request) {
 	timeout, _ := strconv.Atoi(r.URL.Query().Get("timeout"))
 	start := time.Now().UnixNano()
-	time.Sleep(timeout * time.Millisecond)
+	time.Sleep(time.Duration(timeout) * time.Millisecond)
 	end := time.Now().UnixNano()
 	fmt.Fprintf(w, "%d,%d\n", start, end)
 }

--- a/test/test_images/observed-concurrency/observed_concurrency.go
+++ b/test/test_images/observed-concurrency/observed_concurrency.go
@@ -29,7 +29,7 @@ import (
 func handler(w http.ResponseWriter, r *http.Request) {
 	timeout, _ := strconv.Atoi(r.URL.Query().Get("timeout"))
 	start := time.Now().UnixNano()
-	time.Sleep(time.Duration(timeout) * time.Millisecond)
+	time.Sleep(timeout * time.Millisecond)
 	end := time.Now().UnixNano()
 	fmt.Fprintf(w, "%d,%d\n", start, end)
 }


### PR DESCRIPTION
Clean up the observed_concurency_test to be nice and steady.


## Proposed Changes
- Removed a deadlock, wherein the generator threads were writing to
  a fixed size channel, and if they generated more requests than the
  channel would permit, the test would deadlock. So run the consumer
  queue in parallel.
- The test, as written (may be intentionally was not waiting for the
  image to start serving (I guess that's scale to 1?), but instead
  generated over 3K requests that resulted in 404. So I've added probing
  before the real test would start. I am not sure about this change and
  I can roll it back (or we can use that as a benchmark for scale to 1)?

/lint
