### PR TITLE
Add dgerd to list of serving-api-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,6 @@
 aliases:
   serving-api-approvers:
+  - dgerd
   - grantr
   - mattmoor
   - tcnghia


### PR DESCRIPTION
From [ROLES.md](https://github.com/knative/docs/blob/1b52510c44168a99efe6179c523cd68bdac1e07b/community/ROLES.md):

> Reviewer of the codebase for at least 3 months or 50% of project lifetime, whichever is shorter

Total project lifetime: 380 days (2018-01-30 to 2019-02-14)
50% of project lifetime: 190 days

**Earliest review: 2018-10-16, 121 days ago**
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Adgerd+sort%3Acreated-asc+

> Primary reviewer for at least 10 substantial PRs to the codebase

**Reviewed 21 L, XL, or XXL PRs**
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+-author%3Adgerd+reviewed-by%3Adgerd+label%3Asize%2FL+
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+-author%3Adgerd+reviewed-by%3Adgerd+label%3Asize%2FXL+

10 substantial examples:

1. https://github.com/knative/serving/pull/2190
2. https://github.com/knative/serving/pull/2044
3. https://github.com/knative/serving/pull/2493
4. https://github.com/knative/serving/pull/2733
5. https://github.com/knative/serving/pull/2898
6. https://github.com/knative/serving/pull/2948
7. https://github.com/knative/serving/pull/3019
8. https://github.com/knative/serving/pull/3070
9. https://github.com/knative/serving/pull/3099
10. https://github.com/knative/serving/pull/3104

> Reviewed or merged at least 30 PRs to the codebase

**Reviewed or merged 51 PRs**
https://github.com/knative/serving/pulls?q=is%3Apr+reviewed-by%3Adgerd+is%3Aclosed
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+-reviewed-by%3Adgerd+is%3Aclosed+author%3Adgerd

> Nominated by an area lead with no objections from other leads

[Current API Core lead is @mattmoor](https://github.com/knative/docs/blob/1b52510c44168a99efe6179c523cd68bdac1e07b/community/WORKING-GROUPS.md#api-core).

/cc @evankanderson @mattmoor @vaikas-google @mdemirhan @tcnghia @ImJasonH @josephburnett 

/cc @grantr : Thank you for the template! 👍 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
