### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -299,7 +299,6 @@ const (
 	CandidateTrafficTarget = "candidate"
 )
 
-
 // MarkRouteNotYetReady marks the service `RouteReady` condition to the `Unknown` state.
 // See: #2430, for details.
 func (ss *ServiceStatus) MarkRouteNotYetReady() {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
