### PR TITLE
Add conformance test to validate stdin

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -155,8 +155,8 @@ or platform providers MAY use hooks to implement their own lifecycle controls.
 
 #### File descriptors
 
-The `stdin` file descriptor on the container SHOULD be redirected to
-`/dev/null`. The `stdout` and `stderr` file descriptors on the container SHOULD
+A read from the `stdin` file descriptor on the container SHOULD always result in
+`EOF`. The `stdout` and `stderr` file descriptors on the container SHOULD
 be collected and retained in a developer-accessible logging repository. (See
 also operability contract being specified in
 https://github.com/knative/serving/pull/727).

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -157,9 +157,8 @@ or platform providers MAY use hooks to implement their own lifecycle controls.
 
 A read from the `stdin` file descriptor on the container SHOULD always result in
 `EOF`. The `stdout` and `stderr` file descriptors on the container SHOULD
-be collected and retained in a developer-accessible logging repository. (See
-also operability contract being specified in
-https://github.com/knative/serving/pull/727).
+be collected and retained in a developer-accessible logging repository.
+(TODO:[docs#902](https://github.com/knative/docs/issues/902)).
 
 Within the container, pipes and file descriptors may be used to communicate
 between processes running in the same container.

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -122,6 +122,9 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 	userContainer.Ports = buildContainerPorts(userPort)
 	userContainer.Env = append(userContainer.Env, buildUserPortEnv(userPortStr))
 	userContainer.Env = append(userContainer.Env, getKnativeEnvVar(rev)...)
+	// Explicitly disable stdin and tty allocation
+	userContainer.Stdin = false
+	userContainer.TTY = false
 
 	// Prefer imageDigest from revision if available
 	if rev.Status.ImageDigest != "" {

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -49,6 +49,8 @@ var (
 		VolumeMounts:             []corev1.VolumeMount{varLogVolumeMount},
 		Lifecycle:                userLifecycle,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Stdin:                    false,
+		TTY:                      false,
 		Env: []corev1.EnvVar{{
 			Name:  "PORT",
 			Value: "8080",

--- a/test/conformance/file_descriptor_test.go
+++ b/test/conformance/file_descriptor_test.go
@@ -1,0 +1,48 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/serving/test"
+)
+
+// TestMustHaveCgroupConfigured verifies using the runtime test container that reading from the
+// stdin file descriptor results in EOF.
+func TestShouldHaveStdinEOF(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	clients := setup(t)
+
+	ri, err := fetchRuntimeInfo(clients, logger, &test.Options{})
+	if err != nil {
+		t.Fatalf("Error fetching runtime info: %v", err)
+	}
+
+	stdin := ri.Host.Stdin
+
+	if stdin.Error != "" {
+		t.Fatalf("Error reading stdin: %v", stdin.Error)
+	}
+
+	if got, want := *stdin.EOF, true; got != want {
+		t.Errorf("Stdin.EOF = %t, expected: %t", got, want)
+	}
+}

--- a/test/conformance/file_descriptor_test.go
+++ b/test/conformance/file_descriptor_test.go
@@ -21,17 +21,15 @@ package conformance
 import (
 	"testing"
 
-	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/test"
 )
 
 // TestMustHaveCgroupConfigured verifies using the runtime test container that reading from the
 // stdin file descriptor results in EOF.
 func TestShouldHaveStdinEOF(t *testing.T) {
-	logger := logging.GetContextLogger(t.Name())
 	clients := setup(t)
 
-	ri, err := fetchRuntimeInfo(clients, logger, &test.Options{})
+	ri, err := fetchRuntimeInfo(t, clients, &test.Options{})
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}

--- a/test/test_images/runtime/handlers/proc.go
+++ b/test/test_images/runtime/handlers/proc.go
@@ -19,19 +19,13 @@ package handlers
 import (
 	"io"
 	"os"
-	"strconv"
 
 	"github.com/knative/serving/test/types"
 )
 
 // stdin attempts to read bytes from the stdin file descriptor and returns the result.
 func stdin() *types.Stdin {
-	file, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/fd/0")
-	if err != nil {
-		return &types.Stdin{Error: err.Error()}
-	}
-
-	_, err = file.Read(make([]byte, 1))
+	_, err := os.Stdin.Read(make([]byte, 1))
 	if err == io.EOF {
 		return &types.Stdin{EOF: &yes}
 	}

--- a/test/test_images/runtime/handlers/proc.go
+++ b/test/test_images/runtime/handlers/proc.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/knative/serving/test/types"
+)
+
+// stdin attempts to read bytes from the stdin file descriptor and returns the result.
+func stdin() *types.Stdin {
+	file, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/fd/0")
+	if err != nil {
+		return &types.Stdin{Error: err.Error()}
+	}
+
+	_, err = file.Read(make([]byte, 1))
+	if err == io.EOF {
+		return &types.Stdin{EOF: &yes}
+	}
+	if err != nil {
+		return &types.Stdin{Error: err.Error()}
+	}
+
+	return &types.Stdin{EOF: &no}
+}

--- a/test/test_images/runtime/handlers/runtime.go
+++ b/test/test_images/runtime/handlers/runtime.go
@@ -30,6 +30,7 @@ func runtimeHandler(w http.ResponseWriter, r *http.Request) {
 			Files:   fileInfo(filePaths...),
 			Cgroups: cgroups(cgroupPaths...),
 			Mounts:  mounts(),
+			Stdin:   stdin(),
 		},
 	}
 

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -50,6 +50,15 @@ type HostInfo struct {
 	Cgroups []*Cgroup `json:"cgroups"`
 	// Mounts is a list of mounted volume information, or error.
 	Mounts []*Mount `json:"mounts"`
+	Stdin  *Stdin   `json:"stdin"`
+}
+
+// Stdin contains information about the Stdin file descriptor for the container.
+type Stdin struct {
+	// EOF is true if the first byte read from stdin results in EOF.
+	EOF *bool `json"eof,omitempty"`
+	// Error is the String representation of an error probing sdtin.
+	Error string `json:"error,omitempty"`
 }
 
 // FileInfo contains the metadata for a given file.


### PR DESCRIPTION
This change validates that stdin is not available for containers ran with
Knative. It also updates the runtime contract to reflect the behavior
defined by Kubernetes, and explicitly opts to disable stdin and tty
allocation when making the PodSpec.

Fixes #2971

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

```release-note
* Updates File Descriptors section of Runtime Contract
* Adds conformance test for File Descriptor behavior
```
