### PR TITLE
Use latest knative/pkg  to pickup websocket/hijack.go.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,7 +450,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:090e3e43588dacf324bf790db592f3527ebcbdbb153eb893baccebdc8d776404"
+  digest = "1:5da3c33700a4253bf74a2190510255887ff1e1db8c8779f787012b13e95e83ec"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -499,7 +499,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "0183bf9cdc7349e3c76c26e51f84689b411fccea"
+  revision = "717a172c9107c1800efc92e6e1aeef89c34099f7"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,8 +28,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-02-14 💖
-  revision = "0183bf9cdc7349e3c76c26e51f84689b411fccea"
+  # HEAD as of 2019-02-15
+  revision = "717a172c9107c1800efc92e6e1aeef89c34099f7"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/vendor/github.com/knative/pkg/test/request.go
+++ b/vendor/github.com/knative/pkg/test/request.go
@@ -50,6 +50,24 @@ func Retrying(rc spoof.ResponseChecker, codes ...int) spoof.ResponseChecker {
 	}
 }
 
+// IsOneOfStatusCodes checks that the response code is equal to the given one.
+func IsOneOfStatusCodes(codes ...int) spoof.ResponseChecker {
+	return func(resp *spoof.Response) (bool, error) {
+		for code := range codes {
+			if resp.StatusCode == code {
+				return true, nil
+			}
+		}
+
+		return true, fmt.Errorf("status = %d, want one of: %v, body = %s", resp.StatusCode, codes, string(resp.Body))
+	}
+}
+
+// IsStatusOK checks that the response code is a 200.
+func IsStatusOK() spoof.ResponseChecker {
+	return IsOneOfStatusCodes(http.StatusOK)
+}
+
 // MatchesBody checks that the *first* response body matches the "expected" body, otherwise failing.
 func MatchesBody(expected string) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {

--- a/vendor/github.com/knative/pkg/websocket/hijack.go
+++ b/vendor/github.com/knative/pkg/websocket/hijack.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// HijackIfPossible calls Hijack() on the given http.ResponseWriter if it implements
+// http.Hijacker interface, which is required for net/http/httputil/reverseproxy
+// to handle connection upgrade/switching protocol.  Otherwise returns an error.
+func HijackIfPossible(w http.ResponseWriter) (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("wrapped writer of type %T can't be hijacked", w)
+	}
+	return hj.Hijack()
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Use latest knative/pkg  to pickup websocket/hijack.go.

```release-note
NONE
```
