### PR TITLE
Make our ReverseProxies unbuffered and flushable.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -245,8 +245,10 @@ func main() {
 	}
 
 	httpProxy = httputil.NewSingleHostReverseProxy(target)
+	httpProxy.FlushInterval = -1
 	h2cProxy = httputil.NewSingleHostReverseProxy(target)
 	h2cProxy.Transport = h2c.DefaultTransport
+	h2cProxy.FlushInterval = -1
 
 	activatorutil.SetupHeaderPruning(httpProxy)
 	activatorutil.SetupHeaderPruning(h2cProxy)

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -122,7 +122,13 @@ type timeoutWriter struct {
 	wroteOnce bool
 }
 
+var _ http.Flusher = (*timeoutWriter)(nil)
+
 var _ http.ResponseWriter = (*timeoutWriter)(nil)
+
+func (tw *timeoutWriter) Flush() {
+	tw.w.(http.Flusher).Flush()
+}
 
 // Hijack calls Hijack() on the wrapped http.ResponseWriter if it implements
 // http.Hijacker interface, which is required for net/http/httputil/reverseproxy

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -108,7 +108,7 @@ func TestGRPC(t *testing.T) {
 			},
 			"DeploymentIsScaledDown",
 			test.ServingNamespace,
-			2*time.Minute,
+			3*time.Minute,
 		)
 		if err != nil {
 			t.Fatalf("Could not scale to zero: %v", err)
@@ -166,8 +166,7 @@ func TestGRPC(t *testing.T) {
 		for i := 0; i < count; i++ {
 			logger.Infof("Sending stream %d of %d", i+1, count)
 
-			// TODO(#3188): Responses less than 4KB are buffered indefinitely
-			want := payload(4096)
+			want := payload(10)
 
 			err = stream.Send(&ping.Request{Msg: want})
 			if err != nil {
@@ -198,10 +197,9 @@ func TestGRPC(t *testing.T) {
 	t.Run("streaming ping", streamTest)
 
 	waitForScaleToZero()
-
 	t.Run("unary ping after scale-to-zero", unaryTest)
 
 	// TODO(#3239): Fix gRPC streaming after cold start
-	//waitForScaleToZero()
-	//t.Run("streaming ping after scale-to-zero", streamTest)
+	// waitForScaleToZero()
+	// t.Run("streaming ping after scale-to-zero", streamTest)
 }


### PR DESCRIPTION
In Go 1.12 setting `FlushInterval` to -1 makes it `Flush()` the ResponseWriter on each `Write()` (thanks @bradfitz).

We also need the `ResponseWriter` wrappers we have to implement `http.Flusher` for this to work.

Fixes: #3188
