### PR TITLE
[WIP] [POC] proof that retries are the cause of our grpc streaming-activation issue

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -80,6 +80,8 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *ActivationHandler) proxyRequest(w http.ResponseWriter, r *http.Request, target *url.URL) (int, int) {
+	time.Sleep(5 * time.Second)
+
 	capture := &statusCapture{
 		ResponseWriter: w,
 		statusCode:     http.StatusOK,

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -200,6 +200,6 @@ func TestGRPC(t *testing.T) {
 	t.Run("unary ping after scale-to-zero", unaryTest)
 
 	// TODO(#3239): Fix gRPC streaming after cold start
-	// waitForScaleToZero()
-	// t.Run("streaming ping after scale-to-zero", streamTest)
+	waitForScaleToZero()
+	t.Run("streaming ping after scale-to-zero", streamTest)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Add sleep 5s before activator forward request.
*  Reenable gRPC stream-activation test.

/cc @tanzeeb 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
