### PR TITLE
Remove all usages of 'MatchesAny', normalized to 'IsStatusOK'.

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -121,7 +121,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		greenDomain,
-		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", greenDomain, err)

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -23,11 +23,9 @@ package conformance
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
-	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	"github.com/knative/serving/test"
@@ -56,13 +54,7 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.Domain,
-		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
-			if resp.StatusCode == http.StatusOK {
-				return true, nil
-			}
-
-			return true, errors.New(string(resp.Body))
-		}),
+		pkgTest.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"RuntimeInfo",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
@@ -127,13 +119,7 @@ func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, options *
 		clients.KubeClient,
 		t.Logf,
 		url,
-		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
-			if resp.StatusCode == http.StatusOK {
-				return true, nil
-			}
-
-			return true, errors.New(string(resp.Body))
-		}),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"EnvVarsServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -54,7 +54,7 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.Domain,
-		pkgTest.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"RuntimeInfo",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -21,7 +21,6 @@ package conformance
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
@@ -70,13 +69,7 @@ func (pt *protocolsTest) makeRequest(domain string) *spoof.Response {
 
 	resp, err := pkgTest.WaitForEndpointState(
 		pt.clients.KubeClient, pt.t.Logf, domain,
-		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
-			if resp.StatusCode == http.StatusOK {
-				return true, nil
-			}
-
-			return true, fmt.Errorf("unexpected status: %d", resp.StatusCode)
-		}),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		pt.t.Name(), test.ServingFlags.ResolvableDomain,
 	)
 	if err != nil {

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -186,7 +186,7 @@ func TestRevisionTimeout(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		rev5sDomain,
-		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -86,7 +86,7 @@ func TestSingleConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -78,7 +78,7 @@ func TestGRPC(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"gRPCPingReadyToServe",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -140,7 +140,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		httpProxyRoute.Status.Domain, test.RetryingRouteInconsistency(pkgTest.MatchesAny),
+		httpProxyRoute.Status.Domain, test.RetryingRouteInconsistency(pkgTest.IsStatusOK()),
 		"HttpProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Related: #3233 

## Proposed Changes

* Replace all occurrences of `MatchesAny` with `IsStatusOK`. `MatchesAny` lets any possible request pass, including 503s.
* Replace all occurrences of "manual" Status == OK checks with the `IsStatusOK` handler.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
