### PR TITLE
Make all 'CallSyncHandler' tests work the same.

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/queueing_test.go
@@ -168,7 +168,7 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 	})
 
 	if _, err := servingClient.ServingV1alpha1().Configurations(config.Namespace).Create(config); err != nil {
-		t.Fatalf("Unexpected error creating revision: %v", err)
+		t.Fatalf("Unexpected error creating configuration: %v", err)
 	}
 
 	if err := h.WaitForHooks(time.Second * 3); err != nil {

--- a/pkg/reconciler/v1alpha1/configuration/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/queueing_test.go
@@ -90,7 +90,7 @@ func getTestConfiguration() *v1alpha1.Configuration {
 	}
 }
 
-func newTestController(t *testing.T, servingObjects ...runtime.Object) (
+func newTestController(t *testing.T, stopCh chan struct{}) (
 	kubeClient *fakekubeclientset.Clientset,
 	sharedClient *fakesharedclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
@@ -112,7 +112,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 	// The ability to insert objects here is intended to work around the problem
 	// with watches not firing in client-go 1.9. When we update to client-go 1.10
 	// this can probably be removed.
-	servingClient = fakeclientset.NewSimpleClientset(servingObjects...)
+	servingClient = fakeclientset.NewSimpleClientset()
 
 	// Create informer factories with fake clients. The second parameter sets the
 	// resync period to zero, disabling it.
@@ -126,6 +126,7 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,
 			Logger:           TestLogger(t),
+			StopChannel:      stopCh,
 		},
 		servingInformer.Serving().V1alpha1().Configurations(),
 		servingInformer.Serving().V1alpha1().Revisions(),
@@ -136,11 +137,8 @@ func newTestController(t *testing.T, servingObjects ...runtime.Object) (
 
 func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 	config := getTestConfiguration()
-	// TODO(grantr): inserting the configuration at client creation is necessary
-	// because ObjectTracker doesn't fire watches in the 1.9 client. When we
-	// upgrade to 1.10 we can remove the config argument here and instead use the
-	// Create() method.
-	_, _, servingClient, controller, kubeInformer, servingInformer := newTestController(t, config)
+	stopCh := make(chan struct{})
+	_, _, servingClient, controller, kubeInformer, servingInformer := newTestController(t, stopCh)
 
 	h := NewHooks()
 
@@ -152,7 +150,6 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 		return HookComplete
 	})
 
-	stopCh := make(chan struct{})
 	eg := errgroup.Group{}
 	defer func() {
 		close(stopCh)
@@ -163,9 +160,16 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 	kubeInformer.Start(stopCh)
 	servingInformer.Start(stopCh)
 
+	kubeInformer.WaitForCacheSync(stopCh)
+	servingInformer.WaitForCacheSync(stopCh)
+
 	eg.Go(func() error {
 		return controller.Run(2, stopCh)
 	})
+
+	if _, err := servingClient.ServingV1alpha1().Configurations(config.Namespace).Create(config); err != nil {
+		t.Fatalf("Unexpected error creating revision: %v", err)
+	}
 
 	if err := h.WaitForHooks(time.Second * 3); err != nil {
 		t.Error(err)

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -36,7 +36,7 @@ import (
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/network"
-	rclr "github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/config"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
@@ -134,7 +134,7 @@ func getTestControllerConfigMap() *corev1.ConfigMap {
 	}
 }
 
-func newTestController(t *testing.T, stopCh <-chan struct{}, servingObjects ...runtime.Object) (
+func newTestController(t *testing.T, stopCh <-chan struct{}) (
 	kubeClient *fakekubeclientset.Clientset,
 	servingClient *fakeclientset.Clientset,
 	cachingClient *fakecachingclientset.Clientset,
@@ -148,13 +148,13 @@ func newTestController(t *testing.T, stopCh <-chan struct{}, servingObjects ...r
 
 	// Create fake clients
 	kubeClient = fakekubeclientset.NewSimpleClientset()
-	servingClient = fakeclientset.NewSimpleClientset(servingObjects...)
+	servingClient = fakeclientset.NewSimpleClientset()
 	cachingClient = fakecachingclientset.NewSimpleClientset()
 	dynamicClient = fakedynamicclientset.NewSimpleDynamicClient(runtime.NewScheme())
 
 	configMapWatcher = &configmap.ManualWatcher{Namespace: system.Namespace()}
 
-	opt := rclr.Options{
+	opt := reconciler.Options{
 		KubeClientSet:    kubeClient,
 		ServingClientSet: servingClient,
 		DynamicClientSet: dynamicClient,
@@ -235,13 +235,7 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	stopCh := make(chan struct{})
 
 	rev := getTestRevision()
-	// TODO(grantr): inserting the route at client creation is necessary
-	// because ObjectTracker doesn't fire watches in the 1.9 client. When we
-	// upgrade to 1.10 we can remove the config argument here and instead use the
-	// Create() method.
-	kubeClient, _, _, _, controller, kubeInformer,
-		servingInformer, _, servingSystemInformer, _ :=
-		newTestController(t, stopCh, rev)
+	kubeClient, servingClient, _, _, controller, kubeInformer, servingInformer, _, configMapWatcher, _ := newTestController(t, stopCh)
 
 	h := NewHooks()
 
@@ -263,11 +257,18 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 
 	kubeInformer.Start(stopCh)
 	servingInformer.Start(stopCh)
-	servingSystemInformer.Start(stopCh)
+	configMapWatcher.Start(stopCh)
+
+	kubeInformer.WaitForCacheSync(stopCh)
+	servingInformer.WaitForCacheSync(stopCh)
 
 	eg.Go(func() error {
 		return controller.Run(2, stopCh)
 	})
+
+	if _, err := servingClient.ServingV1alpha1().Revisions(rev.Namespace).Create(rev); err != nil {
+		t.Fatalf("Unexpected error creating revision: %v", err)
+	}
 
 	if err := h.WaitForHooks(time.Second * 3); err != nil {
 		t.Error(err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3258 

## Proposed Changes

* Removes specialized behavior which was once needed because we used older clients.
* Passes the stopCh to all reconcilers.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
