### PR TITLE
Make the Pool's concurrency assumptions more clear.

### DIFF
--- a/pkg/pool/interface.go
+++ b/pkg/pool/interface.go
@@ -23,7 +23,8 @@ import (
 // Interface defines an errgroup-compatible interface for interacting with
 // our threadpool.
 type Interface interface {
-	// Go queues a single unit of work for execution on this pool.
+	// Go queues a single unit of work for execution on this pool. All calls
+	// to Go must be finished before Wait is called.
 	Go(func() error)
 
 	// Wait blocks until all work is complete, returning the first

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -24,30 +24,6 @@ import (
 	"time"
 )
 
-func TestRacingClose(t *testing.T) {
-	p := NewWithCapacity(1, 5)
-	wg := &sync.WaitGroup{}
-	var cntExecuted int32
-	const n = 5
-	wg.Add(n)
-	go func() {
-		for i := 0; i < n; i++ {
-			p.Go(func() error {
-				atomic.AddInt32(&cntExecuted, 1)
-				return nil
-			})
-			// Introduce delay so that p.Wait() has time to execute.
-			time.Sleep(10 * time.Millisecond)
-			wg.Done()
-		}
-	}()
-	p.Wait()
-	wg.Wait()
-	if cntExecuted == n {
-		t.Error("Not all items were expected to execute")
-	}
-}
-
 func TestParallelismNoErrors(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The Pool is still prone to racy behavior, see: https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_serving/3259/pull-knative-serving-unit-tests/1097476542792994816/

## Proposed Changes

The Pool is based on a WaitGroup. In a WaitGroup, Add and Wait need not to be called concurrently. All Add calls should be completed before Wait is called. This transports this notion to the functions of the Pool.

- Remove false friend safety guard against panicking.
- Remove test which behaves exactly like we don't want to.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
