### PR TITLE
Eliminate global test variables.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,7 +450,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:5da3c33700a4253bf74a2190510255887ff1e1db8c8779f787012b13e95e83ec"
+  digest = "1:f348f2d44656cc013143c3c7f557fbd8cd9e15fc7d3ebbd081aec4ed91ac8591"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -490,6 +490,7 @@
     "system",
     "system/testing",
     "test",
+    "test/helpers",
     "test/logging",
     "test/spoof",
     "test/zipkin",
@@ -1282,6 +1283,7 @@
   input-imports = [
     "github.com/davecgh/go-spew/spew",
     "github.com/ghodss/yaml",
+    "github.com/golang/protobuf/proto",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/go-containerregistry/pkg/authn/k8schain",
@@ -1325,6 +1327,7 @@
     "github.com/knative/pkg/system",
     "github.com/knative/pkg/system/testing",
     "github.com/knative/pkg/test",
+    "github.com/knative/pkg/test/helpers",
     "github.com/knative/pkg/test/logging",
     "github.com/knative/pkg/test/spoof",
     "github.com/knative/pkg/tracker",
@@ -1349,9 +1352,11 @@
     "go.uber.org/atomic",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
+    "golang.org/x/net/context",
     "golang.org/x/net/http2",
     "golang.org/x/net/http2/h2c",
     "golang.org/x/sync/errgroup",
+    "google.golang.org/grpc",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authentication/v1",
     "k8s.io/api/autoscaling/v1",

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -29,6 +29,10 @@ import (
 const (
 	// ConfigName is the name of the config map of the autoscaler.
 	ConfigName = "config-autoscaler"
+
+	// Default values for several key autoscaler settings.
+	DefaultStableWindow           = 60 * time.Second
+	DefaultScaleToZeroGracePeriod = 30 * time.Second
 )
 
 // Config defines the tunable autoscaler parameters
@@ -118,7 +122,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}{{
 		key:          "stable-window",
 		field:        &lc.StableWindow,
-		defaultValue: 60 * time.Second,
+		defaultValue: DefaultStableWindow,
 	}, {
 		key:          "panic-window",
 		field:        &lc.PanicWindow,
@@ -126,7 +130,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}, {
 		key:          "scale-to-zero-grace-period",
 		field:        &lc.ScaleToZeroGracePeriod,
-		defaultValue: 30 * time.Second,
+		defaultValue: DefaultScaleToZeroGracePeriod,
 	}, {
 		key:          "tick-interval",
 		field:        &lc.TickInterval,

--- a/test/crd.go
+++ b/test/crd.go
@@ -19,14 +19,11 @@ package test
 // crd contains functions that construct boilerplate CRD definitions.
 
 import (
-	"math/rand"
-	"sync"
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/knative/pkg/test/helpers"
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
@@ -259,41 +256,10 @@ func ManualService(svc *v1alpha1.Service) *v1alpha1.Service {
 	}
 }
 
-const (
-	letterBytes   = "abcdefghijklmnopqrstuvwxyz"
-	randSuffixLen = 8
-)
-
-// r is used by AppendRandomString to generate a random string. It is seeded with the time
-// at import so the strings will be different between test runs.
-var (
-	r        *rand.Rand
-	rndMutex *sync.Mutex
-)
-
-// once is used to initialize r
-var once sync.Once
-
-func initSeed(logger *logging.BaseLogger) func() {
-	return func() {
-		seed := time.Now().UTC().UnixNano()
-		logger.Infof("Seeding rand.Rand with %d", seed)
-		r = rand.New(rand.NewSource(seed))
-		rndMutex = &sync.Mutex{}
-	}
-}
-
 // AppendRandomString will generate a random string that begins with prefix. This is useful
 // if you want to make sure that your tests can run at the same time against the same
 // environment without conflicting. This method will seed rand with the current time when
 // called for the first time.
 func AppendRandomString(prefix string, logger *logging.BaseLogger) string {
-	once.Do(initSeed(logger))
-	suffix := make([]byte, randSuffixLen)
-	rndMutex.Lock()
-	defer rndMutex.Unlock()
-	for i := range suffix {
-		suffix[i] = letterBytes[r.Intn(len(letterBytes))]
-	}
-	return prefix + string(suffix)
+	return helpers.AppendRandomString(prefix)
 }

--- a/test/e2e/testdata/config-autoscaler.yaml
+++ b/test/e2e/testdata/config-autoscaler.yaml
@@ -1,1 +1,0 @@
-../../../config/config-autoscaler.yaml

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -127,8 +127,8 @@ func validateWebSocketConnection(logger *logging.BaseLogger, clients *test.Clien
 // (2) connects to the service using websocket, (3) sends a message, and
 // (4) verifies that we receive back the same message.
 func TestWebSocket(t *testing.T) {
-	logger = logging.GetContextLogger(t.Name())
-	clients = Setup(t)
+	logger := logging.GetContextLogger(t.Name())
+	clients := Setup(t)
 
 	names := test.ResourceNames{
 		Service: test.AppendRandomString("websocket-server-", logger),

--- a/vendor/github.com/knative/pkg/test/helpers/data.go
+++ b/vendor/github.com/knative/pkg/test/helpers/data.go
@@ -1,0 +1,40 @@
+package helpers
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	letterBytes   = "abcdefghijklmnopqrstuvwxyz"
+	randSuffixLen = 8
+	sep           = "-"
+)
+
+var (
+	r        *rand.Rand
+	rndMutex *sync.Mutex
+	once     sync.Once
+)
+
+func initSeed() {
+	seed := time.Now().UTC().UnixNano()
+	r = rand.New(rand.NewSource(seed))
+	rndMutex = &sync.Mutex{}
+}
+
+func AppendRandomString(prefix string) string {
+	once.Do(initSeed)
+	suffix := make([]byte, randSuffixLen)
+
+	rndMutex.Lock()
+	defer rndMutex.Unlock()
+
+	for i := range suffix {
+		suffix[i] = letterBytes[r.Intn(len(letterBytes))]
+	}
+
+	return strings.Join([]string{prefix, string(suffix)}, sep)
+}


### PR DESCRIPTION
This eliminates virtually all of the globals used in our e2e tests, which create potential races when we try to run tests in parallel.