### PR TITLE
Share TearDown methods across e2e/conformance

### DIFF
--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -22,19 +22,27 @@ package test
 import (
 	"os"
 	"os/signal"
-
-	"github.com/knative/pkg/test/logging"
 )
 
 // CleanupOnInterrupt will execute the function cleanup if an interrupt signal is caught
-func CleanupOnInterrupt(cleanup func(), logger *logging.BaseLogger) {
+func CleanupOnInterrupt(cleanup func()) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		for range c {
-			logger.Info("Test interrupted, cleaning up.")
 			cleanup()
 			os.Exit(1)
 		}
 	}()
+}
+
+// TearDown will delete created names using clients.
+func TearDown(clients *Clients, names ResourceNames) {
+	if clients != nil && clients.ServingClient != nil {
+		clients.ServingClient.Delete(
+			[]string{names.Route},
+			[]string{names.Config},
+			[]string{names.Service},
+		)
+	}
 }

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -46,7 +46,7 @@ func CreateConfiguration(logger *logging.BaseLogger, clients *Clients, names Res
 }
 
 // PatchConfigImage patches the existing config passed in with a new imagePath. Returns the latest Configuration object
-func PatchConfigImage(logger *logging.BaseLogger, clients *Clients, cfg *v1alpha1.Configuration, imagePath string) (*v1alpha1.Configuration, error) {
+func PatchConfigImage(clients *Clients, cfg *v1alpha1.Configuration, imagePath string) (*v1alpha1.Configuration, error) {
 	newCfg := cfg.DeepCopy()
 	newCfg.Spec.RevisionTemplate.Spec.Container.Image = imagePath
 	patchBytes, err := createPatch(cfg, newCfg)

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -63,8 +63,8 @@ func TestBlueGreenRoute(t *testing.T) {
 	blue.TrafficTarget = "blue"
 	green.TrafficTarget = "green"
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
-	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	// Setup Initial Service
 	logger.Info("Creating a new Service in runLatest")
@@ -84,7 +84,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	objects.Service = svc
 
 	logger.Info("Updating the Configuration to use a different image")
-	cfg, err := test.PatchConfigImage(logger, clients, objects.Config, imagePaths[1])
+	cfg, err := test.PatchConfigImage(clients, objects.Config, imagePaths[1])
 	if err != nil {
 		t.Fatalf("Patch update for Configuration %s with new image %s failed: %v", names.Config, imagePaths[1], err)
 	}

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -38,8 +38,8 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  pizzaPlanet1,
 	}
 
-	defer tearDown(clients, names)
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	logger.Infof("Creating new configuration %s", names.Config)
 	if _, err := test.CreateConfiguration(logger, clients, names, &test.Options{}); err != nil {

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -44,8 +44,8 @@ func fetchRuntimeInfo(clients *test.Clients, logger *logging.BaseLogger, options
 		Image:   runtime,
 	}
 
-	defer tearDown(clients, names)
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, options)
 	if err != nil {
@@ -90,8 +90,8 @@ func fetchEnvInfo(clients *test.Clients, logger *logging.BaseLogger, urlPath str
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
-	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	var revisionName string
 	logger.Info("The Service will be updated with the name of the Revision once it is created")

--- a/test/conformance/errorcondition_test.go
+++ b/test/conformance/errorcondition_test.go
@@ -57,8 +57,8 @@ func TestContainerErrorMsg(t *testing.T) {
 	if _, err := test.CreateConfiguration(logger, clients, names, &test.Options{}); err != nil {
 		t.Fatalf("Failed to create configuration %s", names.Config)
 	}
-	defer tearDown(clients, names)
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	manifestUnknown := string(transport.ManifestUnknownErrorCode)
 	logger.Info("When the imagepath is invalid, the Configuration should have error status.")
@@ -148,8 +148,8 @@ func TestContainerExitingMsg(t *testing.T) {
 	if _, err := test.CreateConfiguration(logger, clients, names, &test.Options{ReadinessProbe: probe}); err != nil {
 		t.Fatalf("Failed to create configuration %s: %v", names.Config, err)
 	}
-	defer tearDown(clients, names)
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	logger.Info("When the containers keep crashing, the Configuration should have error status.")
 

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -48,11 +48,11 @@ func (pt *protocolsTest) setup(t *testing.T) {
 		Image:   protocols,
 	}
 
-	test.CleanupOnInterrupt(func() { pt.teardown() }, pt.logger)
+	test.CleanupOnInterrupt(func() { pt.teardown() })
 }
 
 func (pt *protocolsTest) teardown() {
-	tearDown(pt.clients, pt.names)
+	test.TearDown(pt.clients, pt.names)
 }
 
 func (pt *protocolsTest) getProtocol(resp *spoof.Response) protocol {

--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -53,8 +53,8 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   "bloatingcow",
 	}
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
-	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{ContainerResources: resources})
 	if err != nil {

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -109,8 +109,8 @@ func TestRevisionTimeout(t *testing.T) {
 		Image:   timeout,
 	}
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
-	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("Creating a new Service in runLatest")
 	svc, err := createLatestService(logger, clients, names, 2)

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -108,8 +108,8 @@ func TestRouteCreation(t *testing.T) {
 		Image:         pizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
-	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("Creating a new Route and Configuration")
 	config, err := test.CreateConfiguration(logger, clients, names, &test.Options{})
@@ -143,7 +143,7 @@ func TestRouteCreation(t *testing.T) {
 	defer test.AssertProberDefault(t, prober)
 
 	logger.Info("Updating the Configuration to use a different image")
-	objects.Config, err = test.PatchConfigImage(logger, clients, objects.Config, test.ImagePath(pizzaPlanet2))
+	objects.Config, err = test.PatchConfigImage(clients, objects.Config, test.ImagePath(pizzaPlanet2))
 	if err != nil {
 		t.Fatalf("Patch update for Configuration %s with new image %s failed: %v", names.Config, pizzaPlanet2, err)
 	}

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -183,8 +183,8 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer tearDown(clients, names)
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup initial Service
 	objects, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{})
@@ -359,8 +359,8 @@ func TestReleaseService(t *testing.T) {
 		Service: test.AppendRandomString("test-release-service-"),
 		Image:   pizzaPlanet1,
 	}
-	defer tearDown(clients, names)
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Expected Text for different revisions.
 	const (

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -47,8 +47,8 @@ func TestSingleConcurrency(t *testing.T) {
 		Image:  singleThreadedImage,
 	}
 
-	test.CleanupOnInterrupt(func() { tearDown(clients, names) }, logger)
-	defer tearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	configOptions := test.Options{
 		ContainerConcurrency: 1,

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -76,12 +76,6 @@ func setup(t *testing.T) *test.Clients {
 	return clients
 }
 
-func tearDown(clients *test.Clients, names test.ResourceNames) {
-	if clients != nil && clients.ServingClient != nil {
-		clients.ServingClient.Delete([]string{names.Route}, []string{names.Config}, []string{names.Service})
-	}
-}
-
 func waitForExpectedResponse(logger *logging.BaseLogger, clients *test.Clients, domain, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, logger, domain, test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/volumes_test.go
+++ b/test/conformance/volumes_test.go
@@ -58,7 +58,7 @@ func TestConfigMapVolume(t *testing.T) {
 	logger.Info("Successfully created configMap: %v", configMap)
 
 	cleanup := func() {
-		tearDown(clients, names)
+		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -66,7 +66,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	defer cleanup()
-	test.CleanupOnInterrupt(cleanup, logger)
+	test.CleanupOnInterrupt(cleanup)
 
 	addVolume := func(svc *v1alpha1.Service) {
 		rt := &svc.Spec.RunLatest.Configuration.RevisionTemplate.Spec
@@ -133,7 +133,7 @@ func TestSecretVolume(t *testing.T) {
 	logger.Info("Successfully created secret: %v", secret)
 
 	cleanup := func() {
-		tearDown(clients, names)
+		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -141,7 +141,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	defer cleanup()
-	test.CleanupOnInterrupt(cleanup, logger)
+	test.CleanupOnInterrupt(cleanup)
 
 	addVolume := func(svc *v1alpha1.Service) {
 		rt := &svc.Spec.RunLatest.Configuration.RevisionTemplate.Spec

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -49,7 +49,7 @@ func isDeploymentScaledUp() func(d *v1beta1.Deployment) (bool, error) {
 }
 
 func tearDown(ctx *testContext) {
-	TearDown(ctx.clients, ctx.names, ctx.logger)
+	test.TearDown(ctx.clients, ctx.names)
 }
 
 func generateTraffic(ctx *testContext, concurrency int, duration time.Duration, stopChan chan struct{}) error {
@@ -141,7 +141,7 @@ func setup(t *testing.T) *testContext {
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	logger.Info("When the Revision can have traffic routed to it, the Route is marked as Ready.")
 	err = test.WaitForRouteState(
@@ -255,7 +255,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	ctx := setup(t)
 	stopChan := DiagnoseMeEvery(15*time.Second, ctx.clients, ctx.logger)
 	defer close(stopChan)
-	defer tearDown(ctx)
+	defer test.TearDown(ctx.clients, ctx.names)
 
 	assertScaleUp(ctx)
 	assertScaleDown(ctx)
@@ -320,7 +320,7 @@ func assertAutoscaleUpToNumPods(ctx *testContext, numPods int32) {
 
 func TestAutoscaleUpCountPods(t *testing.T) {
 	ctx := setup(t)
-	defer tearDown(ctx)
+	defer test.TearDown(ctx.clients, ctx.names)
 
 	ctx.logger.Info("The autoscaler spins up additional replicas when traffic increases.")
 	// note: without the warm-up / gradual increase of load the test is retrieving a 503 (overload) from the envoy

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -162,8 +162,8 @@ func TestBuildPipelineAndServe(t *testing.T) {
 				tc.preFn(t, clients, logger)
 			}
 
-			test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-			defer TearDown(clients, names, logger)
+			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			defer test.TearDown(clients, names)
 
 			if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.ServingNamespace, names, tc.rawExtension)); err != nil {
 				t.Fatalf("Failed to create Configuration: %v", err)

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -71,8 +71,8 @@ func TestBuildSpecAndServe(t *testing.T) {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-	defer TearDown(clients, names, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("When the Revision can have traffic routed to it, the Route is marked as Ready.")
 	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
@@ -174,8 +174,8 @@ func TestBuildAndServe(t *testing.T) {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-	defer TearDown(clients, names, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("When the Revision can have traffic routed to it, the Route is marked as Ready.")
 	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
@@ -297,8 +297,8 @@ func TestBuildFailure(t *testing.T) {
 		t.Fatalf("Failed to create Configuration with failing build: %v", err)
 	}
 
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-	defer TearDown(clients, names, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	// Wait for the Config have a LatestCreatedRevisionName
 	if err := test.WaitForConfigurationState(clients.ServingClient, names.Config, test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision"); err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -51,8 +51,8 @@ func TestDestroyPodInflight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-	defer TearDown(clients, names, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("When the Revision can have traffic routed to it, the Route is marked as Ready")
 	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -31,13 +31,6 @@ func Setup(t *testing.T) *test.Clients {
 	return clients
 }
 
-// TearDown will delete created names using clients.
-func TearDown(clients *test.Clients, names test.ResourceNames, logger *logging.BaseLogger) {
-	if clients != nil && clients.ServingClient != nil {
-		clients.ServingClient.Delete([]string{names.Route}, []string{names.Config}, []string{names.Service})
-	}
-}
-
 // CreateRouteAndConfig will create Route and Config objects using clients.
 // The Config object will serve requests to a container started from the image at imagePath.
 func CreateRouteAndConfig(clients *test.Clients, logger *logging.BaseLogger, image string, options *test.Options) (test.ResourceNames, error) {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -54,8 +54,8 @@ func TestGRPC(t *testing.T) {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}
 
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-	defer TearDown(clients, names, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("Waiting for route to be ready")
 

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -49,7 +49,7 @@ func noStderrShell(name string, arg ...string) string {
 	return string(out)
 }
 
-func cleanup(yamlFilename string, logger *logging.BaseLogger) {
+func cleanup(yamlFilename string) {
 	exec.Command("kubectl", "delete", "-f", yamlFilename).Run()
 	os.Remove(yamlFilename)
 }
@@ -76,8 +76,8 @@ func TestHelloWorldFromShell(t *testing.T) {
 		t.Fatalf("Failed to create temporary manifest: %v", err)
 	}
 	newYamlFilename := newYaml.Name()
-	defer cleanup(newYamlFilename, logger)
-	test.CleanupOnInterrupt(func() { cleanup(newYamlFilename, logger) }, logger)
+	defer cleanup(newYamlFilename)
+	test.CleanupOnInterrupt(func() { cleanup(newYamlFilename) })
 
 	// Populate manifets file with the real path to the container
 	yamlBytes, err := ioutil.ReadFile(appYaml)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -40,8 +40,8 @@ func TestHelloWorld(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-	defer TearDown(clients, names, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
 	logger.Info("When the Revision can have traffic routed to it, the Route is marked as Ready.")
 	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -185,8 +185,8 @@ func ScaleToWithin(t *testing.T, logger *logging.BaseLogger, scale int, duration
 		select {
 		case names := <-cleanupCh:
 			logger.Infof("Added %v to cleanup routine.", names)
-			test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
-			defer TearDown(clients, names, logger)
+			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			defer test.TearDown(clients, names)
 
 		case err := <-doneCh:
 			if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -106,8 +106,8 @@ func TestServiceToServiceCall(t *testing.T) {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
-	test.CleanupOnInterrupt(func() { TearDown(clients, helloWorldNames, logger) }, logger)
-	defer TearDown(clients, helloWorldNames, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, helloWorldNames) })
+	defer test.TearDown(clients, helloWorldNames)
 
 	if err := test.WaitForRouteState(clients.ServingClient, helloWorldNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", helloWorldNames.Route, err)
@@ -128,8 +128,8 @@ func TestServiceToServiceCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Route and Configuration: %v", err)
 	}
-	test.CleanupOnInterrupt(func() { TearDown(clients, httpProxyNames, logger) }, logger)
-	defer TearDown(clients, httpProxyNames, logger)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, httpProxyNames) })
+	defer test.TearDown(clients, httpProxyNames)
 	if err := test.WaitForRouteState(clients.ServingClient, httpProxyNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", httpProxyNames.Route, err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -136,8 +136,8 @@ func TestWebSocket(t *testing.T) {
 	}
 
 	// Clean up in both abnormal and normal exits.
-	defer TearDown(clients, names, logger)
-	test.CleanupOnInterrupt(func() { TearDown(clients, names, logger) }, logger)
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup a WebSocket server.
 	if _, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{}); err != nil {

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -49,7 +49,7 @@ func TestTimeToServeLatency(t *testing.T) {
 	clients := perfClients.E2EClients
 
 	defer TearDown(perfClients, logger, names)
-	test.CleanupOnInterrupt(func() { TearDown(perfClients, logger, names) }, logger)
+	test.CleanupOnInterrupt(func() { TearDown(perfClients, logger, names) })
 
 	logger.Info("Creating a new Service")
 	objs, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{})

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -137,7 +137,7 @@ func TestObservedConcurrency(t *testing.T) {
 	clients := perfClients.E2EClients
 
 	defer TearDown(perfClients, logger, names)
-	test.CleanupOnInterrupt(func() { TearDown(perfClients, logger, names) }, logger)
+	test.CleanupOnInterrupt(func() { TearDown(perfClients, logger, names) })
 
 	logger.Info("Creating a new Service")
 	objs, err := test.CreateRunLatestServiceReady(logger, clients, &names, &test.Options{ContainerConcurrency: 1})

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -64,9 +64,7 @@ func Setup(ctx context.Context, logger *logging.BaseLogger, promReqd bool) (*Cli
 
 // TearDown cleans up resources used
 func TearDown(client *Client, logger *logging.BaseLogger, names test.ResourceNames) {
-	if client.E2EClients != nil && client.E2EClients.ServingClient != nil {
-		client.E2EClients.ServingClient.Delete([]string{names.Route}, []string{names.Config}, []string{names.Service})
-	}
+	test.TearDown(client.E2EClients, names)
 
 	if client.PromClient != nil {
 		client.PromClient.Teardown(logger)

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -104,7 +104,7 @@ func parallelScaleFromZero(logger *logging.BaseLogger, count int) ([]time.Durati
 		}
 	}
 	defer cleanupNames()
-	test.CleanupOnInterrupt(cleanupNames, logger)
+	test.CleanupOnInterrupt(cleanupNames)
 
 	g, _ := errgroup.WithContext(ctx)
 	for i := 0; i < count; i++ {


### PR DESCRIPTION
Drop the logger argument from the shared TearDown and CleanupOnInterrupt.

WIP until https://github.com/knative/serving/pull/3265 merges.