### PR TITLE
Use test name in e2e test resources, so we can tell which resources belong to which test.

### DIFF
--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -237,11 +237,14 @@ For example to create a `Configuration` object that uses a certain docker image
 with a randomized name:
 
 ```go
-var names test.ResourceNames
-names.Config := test.AppendRandomString('hotdog', logger)
-_, err := clients.ServingClient.Create(test.Configuration(namespaceName, names, imagePath))
-if err != nil {
-    return err
+func TestSomeAwesomeFeature(t *testing.T) {
+  var names test.ResourceNames
+  names.Config := test.ObjectNameForTest(t)
+  _, err := clients.ServingClient.Create(test.Configuration(namespaceName, names, imagePath))
+  if err != nil {
+      // handle error case
+  }
+  // more testing
 }
 ```
 

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -52,7 +52,7 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	var names, blue, green test.ResourceNames
 	// Set Service and Image for names to create the initial service
-	names.Service = test.AppendRandomString("test-blue-green-route-")
+	names.Service = test.ObjectNameForTest(t)
 	names.Image = pizzaPlanet1
 
 	// Set names for traffic targets to make them directly routable.

--- a/test/conformance/configuration_test.go
+++ b/test/conformance/configuration_test.go
@@ -31,7 +31,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 	clients := setup(t)
 
 	names := test.ResourceNames{
-		Config: test.AppendRandomString("test-update-configuration-meta-"),
+		Config: test.ObjectNameForTest(t),
 		Image:  pizzaPlanet1,
 	}
 

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -40,7 +40,7 @@ import (
 // RuntimeInfo object.
 func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options) (*types.RuntimeInfo, error) {
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("runtime-test-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   runtime,
 	}
 
@@ -81,7 +81,7 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, options *test.Options) ([]byte, *test.ResourceNames, error) {
 	t.Log("Creating a new Service")
 	var names test.ResourceNames
-	names.Service = test.AppendRandomString("yashiki")
+	names.Service = test.ObjectNameForTest(t)
 	names.Image = "environment"
 	svc, err := test.CreateLatestService(t, clients, names, options)
 	if err != nil {

--- a/test/conformance/container_test.go
+++ b/test/conformance/container_test.go
@@ -32,7 +32,7 @@ import (
 func TestShouldNotHaveHooks(t *testing.T) {
 	clients := setup(t)
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("test-should-not-have-hooks-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   pizzaPlanet1,
 	}
 

--- a/test/conformance/errorcondition_test.go
+++ b/test/conformance/errorcondition_test.go
@@ -44,7 +44,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	clients := setup(t)
 
 	names := test.ResourceNames{
-		Config: test.AppendRandomString("test-container-error-msg"),
+		Config: test.ObjectNameForTest(t),
 		Image:  "invalidhelloworld",
 	}
 	// Specify an invalid image path
@@ -118,7 +118,7 @@ func TestContainerExitingMsg(t *testing.T) {
 	clients := setup(t)
 
 	names := test.ResourceNames{
-		Config: test.AppendRandomString("test-container-exiting-msg"),
+		Config: test.ObjectNameForTest(t),
 		Image:  "failing",
 	}
 

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -41,7 +41,7 @@ func (pt *protocolsTest) setup(t *testing.T) {
 
 	pt.clients = setup(t)
 	pt.names = test.ResourceNames{
-		Service: test.AppendRandomString("protocols"),
+		Service: test.ObjectNameForTest(t),
 		Image:   protocols,
 	}
 
@@ -127,15 +127,15 @@ func TestProtocols(t *testing.T) {
 		PortName string
 		Want     protocol
 	}{{
-		Name:     "HTTP/2.0",
+		Name:     "h2c",
 		PortName: "h2c",
 		Want:     protocol{Major: 2, Minor: 0},
 	}, {
-		Name:     "HTTP/1.1",
+		Name:     "http1",
 		PortName: "http1",
 		Want:     protocol{Major: 1, Minor: 1},
 	}, {
-		Name:     "Default",
+		Name:     "default",
 		PortName: "",
 		Want:     protocol{Major: 1, Minor: 1},
 	}}

--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -45,7 +45,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("test-resource-limits-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   "bloatingcow",
 	}
 

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -101,7 +101,7 @@ func TestRevisionTimeout(t *testing.T) {
 
 	var rev2s, rev5s test.ResourceNames
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("timeout"),
+		Service: test.ObjectNameForTest(t),
 		Image:   timeout,
 	}
 

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -97,10 +97,11 @@ func TestRouteCreation(t *testing.T) {
 	clients := setup(t)
 
 	var objects test.ResourceObjects
+	svcName := test.ObjectNameForTest(t)
 	names := test.ResourceNames{
-		Config:        test.AppendRandomString("test-route-creation-"),
-		Route:         test.AppendRandomString("test-route-creation-"),
-		TrafficTarget: test.AppendRandomString("test-route-creation-"),
+		Config:        svcName,
+		Route:         svcName,
+		TrafficTarget: svcName,
 		Image:         pizzaPlanet1,
 	}
 

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -174,7 +174,7 @@ func TestRunLatestService(t *testing.T) {
 	clients := setup(t)
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("test-run-latest-service-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   pizzaPlanet1,
 	}
 
@@ -351,7 +351,7 @@ func TestReleaseService(t *testing.T) {
 	releaseImagePath2 := test.ImagePath(pizzaPlanet2)
 	releaseImagePath3 := test.ImagePath(helloworld)
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("test-release-service-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   pizzaPlanet1,
 	}
 	defer test.TearDown(clients, names)

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -37,9 +37,10 @@ import (
 func TestSingleConcurrency(t *testing.T) {
 	clients := setup(t)
 
+	svcName := test.ObjectNameForTest(t)
 	names := test.ResourceNames{
-		Config: test.AppendRandomString("single-threaded-"),
-		Route:  test.AppendRandomString("single-threaded-"),
+		Config: svcName,
+		Route:  svcName,
 		Image:  singleThreadedImage,
 	}
 

--- a/test/conformance/volumes_test.go
+++ b/test/conformance/volumes_test.go
@@ -33,7 +33,7 @@ func TestConfigMapVolume(t *testing.T) {
 	clients := setup(t)
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("cm-volume-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   "hellovolume",
 	}
 
@@ -105,11 +105,11 @@ func TestSecretVolume(t *testing.T) {
 	clients := setup(t)
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("secret-volume-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   "hellovolume",
 	}
 
-	text := test.AppendRandomString("hello-volumes-")
+	text := test.ObjectNameForTest(t)
 
 	// Create the Secret with random text.
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -148,9 +148,10 @@ func TestBuildPipelineAndServe(t *testing.T) {
 			clients := Setup(t)
 
 			t.Log("Creating a new Route and Configuration with build")
+			svcName := test.ObjectNameForTest(t)
 			names := test.ResourceNames{
-				Config: test.AppendRandomString(configName),
-				Route:  test.AppendRandomString(routeName),
+				Config: svcName,
+				Route:  svcName,
 				Image:  "helloworld",
 			}
 

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -32,14 +32,14 @@ import (
 	"github.com/knative/serving/test"
 )
 
-func TestBuildPipelineAndServe(t *testing.T) {
+func TestPipeline(t *testing.T) {
 	testCases := []struct {
 		name         string
 		rawExtension *v1alpha1.RawExtension
 		preFn        func(*testing.T, *test.Clients)
 		validateFn   func(*testing.T, string, *test.Clients)
 	}{{
-		name: "taskrun",
+		name: "task run",
 		rawExtension: &v1alpha1.RawExtension{
 			Object: &pipelinev1alpha1.TaskRun{
 				TypeMeta: metav1.TypeMeta{
@@ -76,7 +76,7 @@ func TestBuildPipelineAndServe(t *testing.T) {
 			}
 		},
 	}, {
-		name: "pipelineRun",
+		name: "pipeline run",
 		rawExtension: &v1alpha1.RawExtension{
 			Object: &pipelinev1alpha1.PipelineRun{
 				TypeMeta: metav1.TypeMeta{
@@ -91,7 +91,7 @@ func TestBuildPipelineAndServe(t *testing.T) {
 						Type: pipelinev1alpha1.PipelineTriggerTypeManual,
 					},
 					PipelineRef: pipelinev1alpha1.PipelineRef{
-						Name: "hello-pipeline",
+						Name: "test-pipe",
 					},
 				},
 			},
@@ -101,7 +101,7 @@ func TestBuildPipelineAndServe(t *testing.T) {
 			if _, err := clients.PipelineClient.Task.Create(&pipelinev1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: test.ServingNamespace,
-					Name:      "hello-task",
+					Name:      "test-task",
 				},
 				Spec: pipelinev1alpha1.TaskSpec{
 					Steps: []corev1.Container{{
@@ -116,13 +116,13 @@ func TestBuildPipelineAndServe(t *testing.T) {
 			if _, err := clients.PipelineClient.Pipeline.Create(&pipelinev1alpha1.Pipeline{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: test.ServingNamespace,
-					Name:      "hello-pipeline",
+					Name:      "test-pipe",
 				},
 				Spec: pipelinev1alpha1.PipelineSpec{
 					Tasks: []pipelinev1alpha1.PipelineTask{{
-						Name: "hello-pipeline-hello-task",
+						Name: "test-pipe-test-task",
 						TaskRef: pipelinev1alpha1.TaskRef{
-							Name: "hello-task",
+							Name: "test-task",
 						},
 					}},
 				},

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -46,9 +46,10 @@ func TestBuildSpecAndServe(t *testing.T) {
 
 	t.Log("Creating a new Route and Configuration with build")
 
+	svcName := test.ObjectNameForTest(t)
 	names := test.ResourceNames{
-		Config: test.AppendRandomString(configName),
-		Route:  test.AppendRandomString(routeName),
+		Config: svcName,
+		Route:  svcName,
 		Image:  "helloworld",
 	}
 
@@ -146,9 +147,10 @@ func TestBuildAndServe(t *testing.T) {
 	clients := Setup(t)
 	t.Log("Creating a new Route and Configuration with build")
 
+	svcName := test.ObjectNameForTest(t)
 	names := test.ResourceNames{
-		Config: test.AppendRandomString(configName),
-		Route:  test.AppendRandomString(routeName),
+		Config: svcName,
+		Route:  svcName,
 		Image:  "helloworld",
 	}
 
@@ -263,7 +265,7 @@ func TestBuildFailure(t *testing.T) {
 
 	t.Log("Creating a new Configuration with failing build")
 	names := test.ResourceNames{
-		Config: test.AppendRandomString(configName),
+		Config: test.ObjectNameForTest(t),
 		Image:  "helloworld",
 	}
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -33,9 +33,10 @@ func Setup(t *testing.T) *test.Clients {
 // CreateRouteAndConfig will create Route and Config objects using clients.
 // The Config object will serve requests to a container started from the image at imagePath.
 func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, options *test.Options) (test.ResourceNames, error) {
+	svcName := test.ObjectNameForTest(t)
 	names := test.ResourceNames{
-		Config: test.AppendRandomString(configName),
-		Route:  test.AppendRandomString(routeName),
+		Config: svcName,
+		Route:  svcName,
 		Image:  image,
 	}
 

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -93,7 +93,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 
 		wg.Go(func() error {
 			names := test.ResourceNames{
-				Service: test.AppendRandomString(fmt.Sprintf("scale-%05d-%03d-", scale, i)),
+				Service: test.SubServiceNameForTest(t, fmt.Sprintf("%d", i)),
 				Image:   "helloworld",
 			}
 

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -87,9 +87,10 @@ func TestServiceToServiceCall(t *testing.T) {
 	// Set up helloworld app.
 	t.Log("Creating a Route and Configuration for helloworld test app.")
 
+	svcName := test.ObjectNameForTest(t)
 	helloWorldNames := test.ResourceNames{
-		Config: test.AppendRandomString(configName),
-		Route:  test.AppendRandomString(routeName),
+		Config: svcName,
+		Route:  svcName,
 		Image:  "helloworld",
 	}
 

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -129,7 +129,7 @@ func TestWebSocket(t *testing.T) {
 	clients := Setup(t)
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("websocket-server-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   "wsserver",
 	}
 

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -43,7 +43,7 @@ func TestTimeToServeLatency(t *testing.T) {
 	}
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("helloworld"),
+		Service: test.ObjectNameForTest(t),
 		Image:   "helloworld",
 	}
 	clients := perfClients.E2EClients

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -128,7 +128,7 @@ func TestObservedConcurrency(t *testing.T) {
 	}
 
 	names := test.ResourceNames{
-		Service: test.AppendRandomString("observed-concurrency-"),
+		Service: test.ObjectNameForTest(t),
 		Image:   "observed-concurrency",
 	}
 	clients := perfClients.E2EClients


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Use test name in e2e test resources, so we can tell which resources belong to which test.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
