### PR TITLE
Use a fake recorder in the SyncHandler tests

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/queueing_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
@@ -127,6 +128,7 @@ func newTestController(t *testing.T, stopCh chan struct{}) (
 			ConfigMapWatcher: configMapWatcher,
 			Logger:           TestLogger(t),
 			StopChannel:      stopCh,
+			Recorder:         record.NewFakeRecorder(1000),
 		},
 		servingInformer.Serving().V1alpha1().Configurations(),
 		servingInformer.Serving().V1alpha1().Revisions(),

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	fakecachingclientset "github.com/knative/caching/pkg/client/clientset/versioned/fake"
 	cachinginformers "github.com/knative/caching/pkg/client/informers/externalversions"
@@ -42,9 +40,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
@@ -163,6 +163,7 @@ func newTestController(t *testing.T, stopCh <-chan struct{}) (
 		Logger:           TestLogger(t),
 		ResyncPeriod:     0,
 		StopChannel:      stopCh,
+		Recorder:         record.NewFakeRecorder(1000),
 	}
 	buildInformerFactory = KResourceTypedInformerFactory(opt)
 

--- a/pkg/reconciler/v1alpha1/route/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/route/queueing_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 )
@@ -99,6 +100,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,
 			Logger:           TestLogger(t),
+			Recorder:         record.NewFakeRecorder(1000),
 		},
 		servingInformer.Serving().V1alpha1().Routes(),
 		servingInformer.Serving().V1alpha1().Configurations(),


### PR DESCRIPTION
We are seeing a large number of test flakes complaining about `t.Log` being called after the test has completed, and the callstack shows that this is coming through the event broadcaster stuff, which is passed a reference to the logger.

The default event broadcaster stuff is bypassed if passed a recorder in the reconciler options, so pass in a fake instead to try and reduce flakes.

Fixes: https://github.com/knative/serving/issues/3209
