### PR TITLE
Clarify container-concurrency-target-default works for hpa as well.

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -47,8 +47,11 @@ data:
     container-concurrency-target-percentage: "1.0"
 
     # The container concurrency target default is what the Autoscaler will
-    # try to maintain when the Revision specifies unlimited concurrency. A
-    # value of 100 is chosen because it's enough to allow vertical pod
+    # try to maintain when the Revision specifies unlimited concurrency.
+    # Even when specifying unlimited concurrency, the autoscaler will
+    # horizontally scale the application based on this target concurrency.
+    #
+    # A value of 100 is chosen because it's enough to allow vertical pod
     # autoscaling to tune resource requests. E.g. maintaining 1 concurrent
     # "hello world" request doesn't consume enough resources to allow VPA
     # to achieve efficient resource usage (VPA CPU minimum is 300m).


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
