### PR TITLE
Remove unnecessary sleep in e2e/autoscale_test

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -236,8 +236,6 @@ func assertScaleDown(ctx *testContext) {
 		ctx.t.Fatalf("Waiting for Pod.List to have no non-Evicted pods of %q: %v", ctx.deploymentName, err)
 	}
 
-	ctx.t.Log("Sleeping 10 seconds.")
-	time.Sleep(10 * time.Second)
 	ctx.t.Log("The Revision should remain ready after scaling to zero.")
 	if err := test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, test.IsRevisionReady); err != nil {
 		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zero: %v", ctx.names.Revision, err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The sleep is not necessary any more.

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

