### PR TITLE
Connect closeCh to the reconciler in route test.

### DIFF
--- a/pkg/reconciler/v1alpha1/route/reconcile_resources_test.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources_test.go
@@ -33,7 +33,10 @@ import (
 )
 
 func TestReconcileClusterIngress_Insert(t *testing.T) {
-	_, servingClient, c, _, _, _ := newTestReconciler(t)
+	closeCh := make(chan struct{})
+	defer close(closeCh)
+
+	_, servingClient, c, _, _, _ := newTestReconciler(t, closeCh)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -51,7 +54,10 @@ func TestReconcileClusterIngress_Insert(t *testing.T) {
 }
 
 func TestReconcileClusterIngress_Update(t *testing.T) {
-	_, servingClient, c, _, servingInformer, _ := newTestReconciler(t)
+	closeCh := make(chan struct{})
+	defer close(closeCh)
+
+	_, servingClient, c, _, servingInformer, _ := newTestReconciler(t, closeCh)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -83,7 +89,10 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 }
 
 func TestReconcileTargetRevisions(t *testing.T) {
-	_, _, c, _, _, _ := newTestReconciler(t)
+	closeCh := make(chan struct{})
+	defer close(closeCh)
+
+	_, _, c, _, _, _ := newTestReconciler(t, closeCh)
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This aims to resolve a data race I noticed which I think executes the hook even after the test is finished. See https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_serving/3259/pull-knative-serving-unit-tests/1097916945212116993/

(Note how there's a goroutine running from a different test).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
