### PR TITLE
Convert TestSingleConcurrency to use Service.

### DIFF
--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -47,6 +47,9 @@ func TestSingleConcurrency(t *testing.T) {
 	objects, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{
 		ContainerConcurrency: 1,
 	})
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
 	domain := objects.Service.Status.Domain
 
 	// Ready does not actually mean Ready for a Route just yet.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Convert  TestSingleConcurrency to use Service.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
