### PR TITLE
Retry '503: no healthy upstream' on route creation.

### DIFF
--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -121,7 +121,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		greenDomain,
-		test.RetryingRouteCreation(pkgTest.MatchesAny),
+		test.RetryingRouteConsistency(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", greenDomain, err)

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -121,7 +121,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		greenDomain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", greenDomain, err)

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"net/http"
 	"testing"
 
 	_ "github.com/knative/pkg/system/testing"
@@ -122,7 +121,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		greenDomain,
-		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", greenDomain, err)

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -56,13 +56,13 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.Domain,
-		pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}
 
 			return true, errors.New(string(resp.Body))
-		}, http.StatusNotFound),
+		}),
 		"RuntimeInfo",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
@@ -127,13 +127,13 @@ func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, options *
 		clients.KubeClient,
 		t.Logf,
 		url,
-		pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}
 
 			return true, errors.New(string(resp.Body))
-		}, http.StatusNotFound),
+		}),
 		"EnvVarsServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -56,7 +56,7 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.Domain,
-		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}
@@ -127,7 +127,7 @@ func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, options *
 		clients.KubeClient,
 		t.Logf,
 		url,
-		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -56,7 +56,7 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.Domain,
-		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}
@@ -127,7 +127,7 @@ func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, options *
 		clients.KubeClient,
 		t.Logf,
 		url,
-		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -70,16 +70,13 @@ func (pt *protocolsTest) makeRequest(domain string) *spoof.Response {
 
 	resp, err := pkgTest.WaitForEndpointState(
 		pt.clients.KubeClient, pt.t.Logf, domain,
-		pkgTest.Retrying(
-			func(resp *spoof.Response) (bool, error) {
-				if resp.StatusCode == http.StatusOK {
-					return true, nil
-				}
+		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
+			if resp.StatusCode == http.StatusOK {
+				return true, nil
+			}
 
-				return true, fmt.Errorf("unexpected status: %d", resp.StatusCode)
-			},
-			http.StatusNotFound,
-		),
+			return true, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+		}),
 		pt.t.Name(), test.ServingFlags.ResolvableDomain,
 	)
 	if err != nil {

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -70,7 +70,7 @@ func (pt *protocolsTest) makeRequest(domain string) *spoof.Response {
 
 	resp, err := pkgTest.WaitForEndpointState(
 		pt.clients.KubeClient, pt.t.Logf, domain,
-		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}

--- a/test/conformance/protocol_test.go
+++ b/test/conformance/protocol_test.go
@@ -70,7 +70,7 @@ func (pt *protocolsTest) makeRequest(domain string) *spoof.Response {
 
 	resp, err := pkgTest.WaitForEndpointState(
 		pt.clients.KubeClient, pt.t.Logf, domain,
-		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
 			if resp.StatusCode == http.StatusOK {
 				return true, nil
 			}

--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -64,7 +64,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(want))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(want))),
 		"ResourceTestServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -64,7 +64,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(want)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(want))),
 		"ResourceTestServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/resources_test.go
+++ b/test/conformance/resources_test.go
@@ -64,7 +64,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(want))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(want))),
 		"ResourceTestServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -186,7 +186,7 @@ func TestRevisionTimeout(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		rev5sDomain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -186,7 +186,7 @@ func TestRevisionTimeout(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		rev5sDomain,
-		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -186,7 +186,7 @@ func TestRevisionTimeout(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		rev5sDomain,
-		test.RetryingRouteCreation(pkgTest.MatchesAny),
+		test.RetryingRouteConsistency(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -39,7 +39,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -39,7 +39,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/route_test.go
+++ b/test/conformance/route_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package conformance
 
 import (
-	"net/http"
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
@@ -40,7 +39,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -88,7 +88,7 @@ func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.
 		clients.KubeClient,
 		t.Logf,
 		names.Domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -88,7 +88,7 @@ func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.
 		clients.KubeClient,
 		t.Logf,
 		names.Domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -20,7 +20,6 @@ package conformance
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 	"testing"
 
@@ -89,7 +88,7 @@ func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.
 		clients.KubeClient,
 		t.Logf,
 		names.Domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -86,7 +86,7 @@ func TestSingleConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAny),
+		test.RetryingRouteConsistency(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -86,7 +86,7 @@ func TestSingleConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)

--- a/test/conformance/single_threaded_test.go
+++ b/test/conformance/single_threaded_test.go
@@ -86,7 +86,7 @@ func TestSingleConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -168,7 +168,7 @@ func setup(t *testing.T) *testContext {
 		domain,
 		// Istio doesn't expose a status for us here: https://github.com/istio/istio/issues/6082
 		// TODO(tcnghia): Remove this when https://github.com/istio/istio/issues/882 is fixed.
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput))),
 		"CheckingEndpointAfterUpdating",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -168,7 +168,7 @@ func setup(t *testing.T) *testContext {
 		domain,
 		// Istio doesn't expose a status for us here: https://github.com/istio/istio/issues/6082
 		// TODO(tcnghia): Remove this when https://github.com/istio/istio/issues/882 is fixed.
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput))),
 		"CheckingEndpointAfterUpdating",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -168,7 +168,7 @@ func setup(t *testing.T) *testContext {
 		domain,
 		// Istio doesn't expose a status for us here: https://github.com/istio/istio/issues/6082
 		// TODO(tcnghia): Remove this when https://github.com/istio/istio/issues/882 is fixed.
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput))),
 		"CheckingEndpointAfterUpdating",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -186,7 +186,7 @@ func TestPipeline(t *testing.T) {
 			}
 			domain := route.Status.Domain
 
-			endState := test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
+			endState := test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 			if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 				t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 			}

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package e2e
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -187,7 +186,7 @@ func TestPipeline(t *testing.T) {
 			}
 			domain := route.Status.Domain
 
-			endState := pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)), http.StatusNotFound)
+			endState := test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 			if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 				t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 			}

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -186,7 +186,7 @@ func TestPipeline(t *testing.T) {
 			}
 			domain := route.Status.Domain
 
-			endState := test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
+			endState := test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 			if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 				t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 			}

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -83,7 +83,7 @@ func TestBuildSpecAndServe(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	endState := test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
+	endState := test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 	if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
@@ -185,7 +185,7 @@ func TestBuildAndServe(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	endState := test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
+	endState := test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 	if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -19,7 +19,6 @@ package e2e
 
 import (
 	"encoding/json"
-	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -84,7 +83,7 @@ func TestBuildSpecAndServe(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	endState := pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)), http.StatusNotFound)
+	endState := test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 	if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
@@ -186,7 +185,7 @@ func TestBuildAndServe(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	endState := pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)), http.StatusNotFound)
+	endState := test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 	if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -83,7 +83,7 @@ func TestBuildSpecAndServe(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	endState := test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
+	endState := test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 	if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
@@ -185,7 +185,7 @@ func TestBuildAndServe(t *testing.T) {
 	}
 	domain := route.Status.Domain
 
-	endState := test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
+	endState := test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)))
 	if _, err := pkgTest.WaitForEndpointState(clients.KubeClient, t.Logf, domain, endState, "HelloWorldServesText", test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -77,7 +77,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(timeoutExpectedOutput))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(timeoutExpectedOutput))),
 		"TimeoutAppServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -77,7 +77,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(timeoutExpectedOutput)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(timeoutExpectedOutput))),
 		"TimeoutAppServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -77,7 +77,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(timeoutExpectedOutput))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(timeoutExpectedOutput))),
 		"TimeoutAppServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -78,7 +78,7 @@ func TestGRPC(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAny),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAny),
 		"gRPCPingReadyToServe",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"net/http"
 	"testing"
 	"time"
 
@@ -79,7 +78,7 @@ func TestGRPC(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAny),
 		"gRPCPingReadyToServe",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -78,7 +78,7 @@ func TestGRPC(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAny),
+		test.RetryingRouteConsistency(pkgTest.MatchesAny),
 		"gRPCPingReadyToServe",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -55,7 +55,7 @@ func TestHelloWorld(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"net/http"
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
@@ -56,7 +55,7 @@ func TestHelloWorld(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -55,7 +55,7 @@ func TestHelloWorld(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -148,7 +147,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				clients.KubeClient,
 				t.Logf,
 				domain,
-				pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput)), http.StatusNotFound),
+				test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput))),
 				"WaitForEndpointToServeText",
 				test.ServingFlags.ResolvableDomain)
 			if err != nil {

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -147,7 +147,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				clients.KubeClient,
 				t.Logf,
 				domain,
-				test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput))),
+				test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput))),
 				"WaitForEndpointToServeText",
 				test.ServingFlags.ResolvableDomain)
 			if err != nil {

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -147,7 +147,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				clients.KubeClient,
 				t.Logf,
 				domain,
-				test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput))),
+				test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput))),
 				"WaitForEndpointToServeText",
 				test.ServingFlags.ResolvableDomain)
 			if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -140,7 +140,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		httpProxyRoute.Status.Domain, test.RetryingRouteCreation(pkgTest.MatchesAny),
+		httpProxyRoute.Status.Domain, test.RetryingRouteConsistency(pkgTest.MatchesAny),
 		"HttpProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -140,7 +140,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		httpProxyRoute.Status.Domain, pkgTest.Retrying(pkgTest.MatchesAny, http.StatusNotFound),
+		httpProxyRoute.Status.Domain, test.RetryingRouteCreation(pkgTest.MatchesAny),
 		"HttpProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -140,7 +140,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		httpProxyRoute.Status.Domain, test.RetryingRouteConsistency(pkgTest.MatchesAny),
+		httpProxyRoute.Status.Domain, test.RetryingRouteInconsistency(pkgTest.MatchesAny),
 		"HttpProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -157,7 +157,7 @@ func TestObservedConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain+"/?timeout=10", // To generate any kind of a valid response.
-		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
 			_, _, err := parseResponse(string(resp.Body))
 			return err == nil, nil
 		}),

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -157,7 +157,7 @@ func TestObservedConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain+"/?timeout=10", // To generate any kind of a valid response.
-		test.RetryingRouteConsistency(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
 			_, _, err := parseResponse(string(resp.Body))
 			return err == nil, nil
 		}),

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -157,10 +157,10 @@ func TestObservedConcurrency(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		domain+"/?timeout=10", // To generate any kind of a valid response.
-		pkgTest.Retrying(func(resp *spoof.Response) (bool, error) {
+		test.RetryingRouteCreation(func(resp *spoof.Response) (bool, error) {
 			_, _, err := parseResponse(string(resp.Body))
 			return err == nil, nil
-		}, http.StatusNotFound),
+		}),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *test.Res
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		m := fmt.Sprintf("%d: the endpoint for Route %q at domain %q didn't serve the expected text %q: %v", idx, ro.Route.Name, domain, helloWorldExpectedOutput, err)

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -69,7 +69,7 @@ func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *test.Res
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		m := fmt.Sprintf("%d: the endpoint for Route %q at domain %q didn't serve the expected text %q: %v", idx, ro.Route.Name, domain, helloWorldExpectedOutput, err)

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -69,7 +69,7 @@ func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *test.Res
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		m := fmt.Sprintf("%d: the endpoint for Route %q at domain %q didn't serve the expected text %q: %v", idx, ro.Route.Name, domain, helloWorldExpectedOutput, err)

--- a/test/route.go
+++ b/test/route.go
@@ -63,10 +63,10 @@ func UpdateBlueGreenRoute(t *testing.T, clients *Clients, names, blue, green Res
 	return clients.ServingClient.Routes.Patch(names.Route, types.JSONPatchType, patchBytes, "")
 }
 
-// RetryingRouteConsistency retries common requests seen when creating a new route
+// RetryingRouteInconsistency retries common requests seen when creating a new route
 // - 404 until the route is propagated to the proxy
 // - 503 "no healthy upstream" until the endpoints are propagated to the proxy
-func RetryingRouteConsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		if resp.StatusCode == http.StatusNotFound {
 			return false, nil

--- a/test/route.go
+++ b/test/route.go
@@ -63,11 +63,10 @@ func UpdateBlueGreenRoute(t *testing.T, clients *Clients, names, blue, green Res
 	return clients.ServingClient.Routes.Patch(names.Route, types.JSONPatchType, patchBytes, "")
 }
 
-// RetryingRouteCreation retries common requests seen when creating a new route
-//
+// RetryingRouteConsistency retries common requests seen when creating a new route
 // - 404 until the route is propagated to the proxy
 // - 503 "no healthy upstream" until the endpoints are propagated to the proxy
-func RetryingRouteCreation(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+func RetryingRouteConsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		if resp.StatusCode == http.StatusNotFound {
 			return false, nil

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -17,7 +17,6 @@ limitations under the License.
 package upgrade
 
 import (
-	"net/http"
 	"testing"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
@@ -44,7 +43,7 @@ func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names te
 		clients.KubeClient,
 		t.Logf,
 		routeDomain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText)), http.StatusNotFound),
+		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -43,7 +43,7 @@ func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names te
 		clients.KubeClient,
 		t.Logf,
 		routeDomain,
-		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -43,7 +43,7 @@ func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names te
 		clients.KubeClient,
 		t.Logf,
 		routeDomain,
-		test.RetryingRouteCreation(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
+		test.RetryingRouteConsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK(), pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is potentially only temporary but to reduce the enormous amount of test flakes we're seeing right now.

I know that this is potentially masking issues. I'd like to come up with an e2e test that specifically stresses 

## Proposed Changes

* Add a common helper to retry route creation responses.
* Retry 503: no healthy upstream
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
