### PR TITLE
Bucketize autoscaling metrics by timeframe not by pod name.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -67,7 +67,7 @@ type StatMessage struct {
 	Stat Stat
 }
 
-// StatsBucket keep all the stats that fall into the defined bucket.
+// StatsBucket keeps all the stats that fall into a defined bucket.
 type StatsBucket struct {
 	stats map[string][]Stat
 }
@@ -216,8 +216,8 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	target := a.targetConcurrency()
 	// Desired pod count is observed concurrency of revision over desired (stable) concurrency per pod.
 	// The scaling up rate limited to within MaxScaleUpRate.
-	desiredStablePodCount := a.podCountLimited(observedStableConcurrency/target, readyPods)
-	desiredPanicPodCount := a.podCountLimited(observedPanicConcurrency/target, readyPods)
+	desiredStablePodCount := math.Ceil(a.podCountLimited(observedStableConcurrency/target, readyPods))
+	desiredPanicPodCount := math.Ceil(a.podCountLimited(observedPanicConcurrency/target, readyPods))
 
 	a.reporter.ReportStableRequestConcurrency(observedStableConcurrency)
 	a.reporter.ReportPanicRequestConcurrency(observedPanicConcurrency)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -68,18 +68,17 @@ type StatMessage struct {
 
 // statsBucket keeps all the stats that fall into a defined bucket.
 type statsBucket struct {
-	stats map[string][]Stat
+	stats map[string][]*Stat
 }
 
 // add adds a Stat to the bucket. Stats from the same pod will be
 // collapsed.
-func (b *statsBucket) add(stat Stat) {
+func (b *statsBucket) add(stat *Stat) {
 	podStats, ok := b.stats[stat.PodName]
 	if !ok {
-		podStats = []Stat{}
+		podStats = []*Stat{}
 	}
-	podStats = append(podStats, stat)
-	b.stats[stat.PodName] = podStats
+	b.stats[stat.PodName] = append(podStats, stat)
 }
 
 // concurrency calculates the overall concurrency as measured by this
@@ -165,10 +164,10 @@ func (a *Autoscaler) Record(ctx context.Context, stat Stat) {
 	bucketKey := stat.Time.Truncate(bucketSize)
 	bucket, ok := a.bucketed[bucketKey]
 	if !ok {
-		bucket = &statsBucket{stats: make(map[string][]Stat)}
+		bucket = &statsBucket{stats: make(map[string][]*Stat)}
 		a.bucketed[bucketKey] = bucket
 	}
-	bucket.add(stat)
+	bucket.add(&stat)
 }
 
 // Scale calculates the desired scale based on current statistics given the current time.

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -249,11 +249,11 @@ func (a *Autoscaler) aggregateData(now time.Time, stableWindow, panicWindow time
 	var panicTotal float64
 
 	for bucketTime, bucket := range a.bucketed {
-		if bucketTime.Add(panicWindow).After(now) {
+		if !bucketTime.Add(panicWindow).Before(now) {
 			panicBuckets++
 			panicTotal += bucket.concurrency()
 		}
-		if bucketTime.Add(stableWindow).After(now) {
+		if !bucketTime.Add(stableWindow).Before(now) {
 			stableBuckets++
 			stableTotal += bucket.concurrency()
 		} else {

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -156,7 +156,7 @@ func (a *Autoscaler) Record(ctx context.Context, stat Stat) {
 	a.statsMutex.Lock()
 	defer a.statsMutex.Unlock()
 
-	bucketKey := stat.Time.Round(bucketSize)
+	bucketKey := stat.Time.Truncate(bucketSize)
 	bucket, ok := a.bucketed[bucketKey]
 	if !ok {
 		bucket = &StatsBucket{stats: make(map[string][]Stat)}

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"math"
-	"strings"
 	"sync"
 	"time"
 
@@ -288,9 +287,4 @@ func (a *Autoscaler) readyPods() (float64, error) {
 
 	// Use 1 as minimum for multiplication and division.
 	return math.Max(1, float64(readyPods)), nil
-}
-
-func isActivator(podName string) bool {
-	// TODO(#2282): This can cause naming collisions.
-	return strings.HasPrefix(podName, ActivatorPodName)
 }

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -77,7 +77,7 @@ func (b statsBucket) add(stat *Stat) {
 
 // concurrency calculates the overall concurrency as measured by this
 // bucket. All stats that belong to the same pod will be averaged.
-// The overall concurrency is the sum the measured concurrency of all
+// The overall concurrency is the sum of the measured concurrency of all
 // pods (including activator metrics).
 func (b statsBucket) concurrency() float64 {
 	var total float64

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -245,15 +245,16 @@ func (a *Autoscaler) aggregateData(now time.Time, stableWindow, panicWindow time
 	a.statsMutex.Lock()
 	defer a.statsMutex.Unlock()
 
-	var stableBuckets float64
-	var stableTotal float64
+	var (
+		stableBuckets float64
+		stableTotal   float64
 
-	var panicBuckets float64
-	var panicTotal float64
+		panicBuckets float64
+		panicTotal   float64
 
-	var lastBucketTime time.Time
-	var lastBucket *statsBucket
-
+		lastBucketTime time.Time
+		lastBucket     *statsBucket
+	)
 	for bucketTime, bucket := range a.bucketed {
 		if !bucketTime.Add(panicWindow).Before(now) {
 			panicBuckets++

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -52,14 +52,14 @@ func TestNew_ErrorWhenGivenEmptyInterface(t *testing.T) {
 
 func TestAutoscaler_NoData_NoAutoscale(t *testing.T) {
 	a := newTestAutoscaler(10.0)
-	a.expectScale(t, time.Now(), 0, false)
+	a.expectScale(t, roundedNow(), 0, false)
 }
 
 func TestAutoscaler_NoDataAtZero_NoAutoscale(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 0,
 			endConcurrency:   0,
@@ -76,7 +76,7 @@ func TestAutoscaler_StableMode_NoChange(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -90,7 +90,7 @@ func TestAutoscaler_StableMode_SlowIncrease(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   20,
@@ -104,7 +104,7 @@ func TestAutoscaler_StableMode_SlowDecrease(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 20,
 			endConcurrency:   10,
@@ -118,7 +118,7 @@ func TestAutoscaler_StableModeLowPodCount_NoChange(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -132,7 +132,7 @@ func TestAutoscaler_StableModeNoTraffic_ScaleToZero(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   1,
@@ -147,7 +147,7 @@ func TestAutoscaler_StableModeNoTraffic_ScaleToZero(t *testing.T) {
 		linearSeries{
 			startConcurrency: 0,
 			endConcurrency:   0,
-			duration:         stableWindow,
+			duration:         stableWindow + bucketSize,
 			podCount:         1,
 		})
 	a.expectScale(t, now, 0, true)
@@ -162,7 +162,7 @@ func TestAutoscaler_StableModeLowTraffic_NoChange(t *testing.T) {
 
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   1,
@@ -177,7 +177,7 @@ func TestAutoscaler_StableModeLowTraffic_NoChange(t *testing.T) {
 		linearSeries{
 			startConcurrency: 0,
 			endConcurrency:   0,
-			duration:         stableWindow - time.Second,
+			duration:         stableWindow - bucketSize,
 			podCount:         1,
 		})
 	a.expectScale(t, now, 1, true)
@@ -187,7 +187,7 @@ func TestAutoscaler_PanicMode_DoublePodCount(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -213,7 +213,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 	a := newTestAutoscaler(1.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 1,
 			endConcurrency:   10,
@@ -267,7 +267,7 @@ func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -311,7 +311,7 @@ func TestAutoscaler_PodsAreWeightedBasedOnLatestStatTime(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -320,7 +320,7 @@ func TestAutoscaler_PodsAreWeightedBasedOnLatestStatTime(t *testing.T) {
 		})
 	now = a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 0,
 			endConcurrency:   0,
@@ -333,7 +333,7 @@ func TestAutoscaler_PodsAreWeightedBasedOnLatestStatTime(t *testing.T) {
 func TestAutoscaler_Activator_CausesInstantScale(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 
-	now := time.Now()
+	now := roundedNow()
 	now = a.recordMetric(t, Stat{
 		Time:                      &now,
 		PodName:                   ActivatorPodName,
@@ -347,7 +347,7 @@ func TestAutoscaler_Activator_CausesInstantScale(t *testing.T) {
 func TestAutoscaler_Activator_MultipleInstancesAreAggregated(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 
-	now := time.Now()
+	now := roundedNow()
 	now = a.recordMetric(t, Stat{
 		Time:                      &now,
 		PodName:                   ActivatorPodName + "-0",
@@ -369,7 +369,7 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -378,7 +378,7 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 		})
 	a.expectScale(t, now, 1, true)
 	if len(a.bucketed) != 30 {
-		t.Errorf("Unexpected stat count. Expected 60. Got %v.", len(a.bucketed))
+		t.Errorf("Unexpected stat count. Expected 30. Got %v.", len(a.bucketed))
 	}
 	now = now.Add(time.Minute)
 	a.expectScale(t, now, 0, false)
@@ -400,7 +400,7 @@ func TestAutoscaler_Stats_DenyNoTime(t *testing.T) {
 	if len(a.bucketed) != 0 {
 		t.Errorf("Unexpected stat count. Expected 0. Got %v.", len(a.bucketed))
 	}
-	a.expectScale(t, time.Now(), 0, false)
+	a.expectScale(t, roundedNow(), 0, false)
 }
 
 func TestAutoscaler_RateLimit_ScaleUp(t *testing.T) {
@@ -408,7 +408,7 @@ func TestAutoscaler_RateLimit_ScaleUp(t *testing.T) {
 
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 1000,
 			endConcurrency:   1000,
@@ -437,7 +437,7 @@ func TestAutoscaler_UseOnePodAsMinimunIfEndpointsNotFound(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 1000,
 			endConcurrency:   1000,
@@ -471,7 +471,7 @@ func TestAutoscaler_UpdateTarget(t *testing.T) {
 	a := newTestAutoscaler(10.0)
 	now := a.recordLinearSeries(
 		t,
-		time.Now(),
+		roundedNow(),
 		linearSeries{
 			startConcurrency: 10,
 			endConcurrency:   10,
@@ -627,4 +627,8 @@ func addIps(ep *corev1.Endpoints, ipCount int) *corev1.Endpoints {
 func createEndpoints(ep *corev1.Endpoints) {
 	kubeClient.CoreV1().Endpoints(testNamespace).Create(ep)
 	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Add(ep)
+}
+
+func roundedNow() time.Time {
+	return time.Now().Truncate(bucketSize)
 }

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -220,7 +220,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			duration:         panicWindow,
 			podCount:         1,
 		})
-	a.expectScale(t, now, 8, true)
+	a.expectScale(t, now, 6, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -228,9 +228,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   10,
 			duration:         panicWindow,
-			podCount:         8,
+			podCount:         6,
 		})
-	a.expectScale(t, now, 60, true)
+	a.expectScale(t, now, 36, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -238,9 +238,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   10,
 			duration:         panicWindow,
-			podCount:         60,
+			podCount:         36,
 		})
-	a.expectScale(t, now, 450, true)
+	a.expectScale(t, now, 216, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -248,9 +248,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   10,
 			duration:         panicWindow,
-			podCount:         450,
+			podCount:         216,
 		})
-	a.expectScale(t, now, 3375, true)
+	a.expectScale(t, now, 1296, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -258,9 +258,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   1, // achieved desired concurrency
 			duration:         panicWindow,
-			podCount:         3375,
+			podCount:         1296,
 		})
-	a.expectScale(t, now, 3375, true)
+	a.expectScale(t, now, 1296, true)
 }
 
 func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
@@ -377,8 +377,8 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 			podCount:         1,
 		})
 	a.expectScale(t, now, 1, true)
-	if len(a.bucketed) != 29 {
-		t.Errorf("Unexpected stat count. Expected 29. Got %v.", len(a.bucketed))
+	if len(a.bucketed) != 30 {
+		t.Errorf("Unexpected stat count. Expected 30. Got %v.", len(a.bucketed))
 	}
 	now = now.Add(time.Minute)
 	a.expectScale(t, now, 0, false)

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -220,7 +220,7 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			duration:         panicWindow,
 			podCount:         1,
 		})
-	a.expectScale(t, now, 6, true)
+	a.expectScale(t, now, 8, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -228,9 +228,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   10,
 			duration:         panicWindow,
-			podCount:         6,
+			podCount:         8,
 		})
-	a.expectScale(t, now, 36, true)
+	a.expectScale(t, now, 60, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -238,9 +238,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   10,
 			duration:         panicWindow,
-			podCount:         36,
+			podCount:         60,
 		})
-	a.expectScale(t, now, 216, true)
+	a.expectScale(t, now, 450, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -248,9 +248,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   10,
 			duration:         panicWindow,
-			podCount:         216,
+			podCount:         450,
 		})
-	a.expectScale(t, now, 1296, true)
+	a.expectScale(t, now, 3375, true)
 	now = a.recordLinearSeries(
 		t,
 		now,
@@ -258,9 +258,9 @@ func TestAutoscaler_PanicModeExponential_TrackAndStablize(t *testing.T) {
 			startConcurrency: 1,
 			endConcurrency:   1, // achieved desired concurrency
 			duration:         panicWindow,
-			podCount:         1296,
+			podCount:         3375,
 		})
-	a.expectScale(t, now, 1296, true)
+	a.expectScale(t, now, 3375, true)
 }
 
 func TestAutoscaler_PanicThenUnPanic_ScaleDown(t *testing.T) {
@@ -377,8 +377,8 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 			podCount:         1,
 		})
 	a.expectScale(t, now, 1, true)
-	if len(a.bucketed) != 30 {
-		t.Errorf("Unexpected stat count. Expected 30. Got %v.", len(a.bucketed))
+	if len(a.bucketed) != 29 {
+		t.Errorf("Unexpected stat count. Expected 29. Got %v.", len(a.bucketed))
 	}
 	now = now.Add(time.Minute)
 	a.expectScale(t, now, 0, false)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -261,7 +261,7 @@ func assertNumberOfPods(ctx *testContext, numReplicasMin int32, numReplicasMax i
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get deployment %q", deployment)
 	}
-	gotReplicas := deployment.Status.Replicas
+	gotReplicas := deployment.Status.ReadyReplicas
 	mes := fmt.Sprintf("got %d replicas, expected between [%d, %d] replicas for deployment %s", gotReplicas, numReplicasMin, numReplicasMax, ctx.deploymentName)
 	ctx.t.Log(mes)
 	if gotReplicas < numReplicasMin || gotReplicas > numReplicasMax {
@@ -281,7 +281,7 @@ func assertAutoscaleUpToNumPods(ctx *testContext, numPods int32) {
 	defer close(stopChan)
 
 	go func() {
-		if err := generateTraffic(ctx, int(numPods*10), 30*time.Second, stopChan); err != nil {
+		if err := generateTraffic(ctx, int(numPods*10), 60*time.Second, stopChan); err != nil {
 			errChan <- err
 		}
 	}()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2977
Fixes #2379

## Proposed Changes

Stats are averaged in each specific timeframe vs. averaged over the whole window. See the linked issue for more in-depth information

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
TBD
```
