### PR TITLE
Fail at compile time on unsupported go version

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	"github.com/knative/serving/pkg/goversion"
 	"github.com/knative/serving/pkg/http/h2c"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/metrics"
@@ -57,6 +58,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
+
+// Fail if using unsupported go version
+var _ = goversion.IsSupported()
 
 const (
 	maxUploadBytes = 32e6 // 32MB - same as app engine

--- a/pkg/goversion/go12.go
+++ b/pkg/goversion/go12.go
@@ -1,0 +1,21 @@
+// +build go1.12
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goversion
+
+const requiresGo1dot12 = true

--- a/pkg/goversion/goversion.go
+++ b/pkg/goversion/goversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goversion
+
+// IsSupported should fail to compile due to missing const references on
+// unsupported go versions, otherwise return true.
+func IsSupported() bool {
+	return requiresGo1dot12
+}


### PR DESCRIPTION
We currently succeed in a build and fail at runtime with an obscure
error when using go < 1.12.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
