### PR TITLE
Fail stdin conformance test gracefully

### DIFF
--- a/test/conformance/file_descriptor_test.go
+++ b/test/conformance/file_descriptor_test.go
@@ -34,7 +34,13 @@ func TestShouldHaveStdinEOF(t *testing.T) {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}
 
+	if ri.Host == nil {
+		t.Fatal("Missing host information from runtime info.")
+	}
 	stdin := ri.Host.Stdin
+	if stdin == nil {
+		t.Fatal("Missing stdin information from host info.")
+	}
 
 	if stdin.Error != "" {
 		t.Fatalf("Error reading stdin: %v", stdin.Error)


### PR DESCRIPTION
If the runtime image is not updated the Stdin information will not be
returned. Previously this resulted in a nil pointer error that was
difficult to understand what is going on. Update the test logic to check
for nil and report a more user friendly message.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->