### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,18 +37,16 @@ You must install these tools:
 
 ### Create a cluster and a repo
 
-1. [Set up a kubernetes
-   cluster](https://github.com/knative/docs/blob/master/install/README.md#install-guides)
+1. [Set up a kubernetes cluster](https://github.com/knative/docs/blob/master/install/README.md#install-guides)
    - Follow an install guide up through "Creating a Kubernetes Cluster"
    - You do _not_ need to install Istio or Knative using the instructions in the
      guide. Simply create the cluster and come back here.
-   - If you _did_ install Istio/Knative following those instructions, that's fine too,
-     you'll just redeploy over them, below.
+   - If you _did_ install Istio/Knative following those instructions, that's
+     fine too, you'll just redeploy over them, below.
 1. Set up a docker repository for pushing images. You can use any container
    image registry by adjusting the authentication methods and repository paths
    mentioned in the sections below.
-   - [Google Container Registry
-     quickstart](https://cloud.google.com/container-registry/docs/pushing-and-pulling)
+   - [Google Container Registry quickstart](https://cloud.google.com/container-registry/docs/pushing-and-pulling)
    - [Docker Hub quickstart](https://docs.docker.com/docker-hub/repos/)
 
 ### Setup your environment
@@ -60,8 +58,8 @@ recommend adding them to your `.bashrc`):
    `export GOPATH=...`
 1. `$GOPATH/bin` on `PATH`: This is so that tooling installed via `go get` will
    work properly.
-1. `KO_DOCKER_REPO`: The docker repository to which
-   developer images should be pushed (e.g. `gcr.io/[gcloud-project]`).
+1. `KO_DOCKER_REPO`: The docker repository to which developer images should be
+   pushed (e.g. `gcr.io/[gcloud-project]`).
 
 - **Note**: if you are using docker hub to store your images your
   `KO_DOCKER_REPO` variable should be `docker.io/<username>`.
@@ -133,8 +131,7 @@ Your `$K8S_USER_OVERRIDE` must be a cluster admin to perform the setup needed
 for Knative.
 
 The value you use depends on
-[your cluster
-setup](https://github.com/knative/docs/blob/master/install/README.md#install-guides):
+[your cluster setup](https://github.com/knative/docs/blob/master/install/README.md#install-guides):
 
 ```shell
 # When using Minikube, the K8s user is your local user.

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -156,8 +156,8 @@ or platform providers MAY use hooks to implement their own lifecycle controls.
 #### File descriptors
 
 A read from the `stdin` file descriptor on the container SHOULD always result in
-`EOF`. The `stdout` and `stderr` file descriptors on the container SHOULD
-be collected and retained in a developer-accessible logging repository.
+`EOF`. The `stdout` and `stderr` file descriptors on the container SHOULD be
+collected and retained in a developer-accessible logging repository.
 (TODO:[docs#902](https://github.com/knative/docs/issues/902)).
 
 Within the container, pipes and file descriptors may be used to communicate

--- a/hack/environments.md
+++ b/hack/environments.md
@@ -22,7 +22,8 @@ gcloud container clusters get-credentials knative-demo --zone us-central1-a --pr
 
 This environment is recreated by a periodic Prow job every Saturday 1AM PST,
 using the latest nightly Knative Serving release. The latest nightly release is
-available at [gs://knative-nightly/serving/latest](https://console.cloud.google.com/storage/knative-nightly).
+available at
+[gs://knative-nightly/serving/latest](https://console.cloud.google.com/storage/knative-nightly).
 
 You can configure your access by running:
 

--- a/test/README.md
+++ b/test/README.md
@@ -211,7 +211,8 @@ Loadbalancer to a NodePort. The external address of such a NodePort is usually
 not easily obtained within the cluster automatically, but can be provided from
 the outside through the `--ingressendpoint` flag. For a minikube setup for
 example, you'd want to run tests against the default `ingressgateway` (port
-31380) running on the minikube node:
+
+31380. running on the minikube node:
 
 ```
 go test -v -tags=e2e -count=1 ./test/conformance --ingressendpoint "$(minikube ip):31380"

--- a/test/test_images/wsserver/README.md
+++ b/test/test_images/wsserver/README.md
@@ -2,8 +2,8 @@
 
 A simple WebSocket server adapted from
 https://github.com/gorilla/WebSocket/blob/master/examples/echo/server.go . The
-server simply echoes messages sent to it.  We use this server in testing that
-all our proxies on request path can handle WebSocket upgrades.
+server simply echoes messages sent to it. We use this server in testing that all
+our proxies on request path can handle WebSocket upgrades.
 
 ## Building
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`