### PR TITLE
Feature flag unbuffered HTTP proxy

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -45,7 +45,6 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
-	"github.com/knative/serving/pkg/goversion"
 	"github.com/knative/serving/pkg/http/h2c"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/metrics"
@@ -58,9 +57,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
-
-// Fail if using unsupported go version
-var _ = goversion.IsSupported()
 
 const (
 	maxUploadBytes = 32e6 // 32MB - same as app engine

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/knative/pkg/websocket"
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/activator/util"
+	"github.com/knative/serving/pkg/goversion"
 	pkghttp "github.com/knative/serving/pkg/http"
 	"github.com/knative/serving/pkg/network"
 	"go.uber.org/zap"
@@ -140,7 +141,10 @@ func (a *ActivationHandler) proxyRequest(w http.ResponseWriter, r *http.Request,
 	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = a.Transport
-	proxy.FlushInterval = -1
+
+	if goversion.SupportsUnbufferedHTTPProxy {
+		proxy.FlushInterval = -1
+	}
 
 	attempts := int(1) // one attempt is always needed
 	proxy.ModifyResponse = func(r *http.Response) error {

--- a/pkg/goversion/go12.go
+++ b/pkg/goversion/go12.go
@@ -18,4 +18,5 @@ limitations under the License.
 
 package goversion
 
-const requiresGo1dot12 = true
+// SupportsUnbufferedHTTPProxy is set to true if Go supports -1 (unbuffered) HTTP FlushInterval
+const SupportsUnbufferedHTTPProxy = true

--- a/pkg/goversion/notgo12.go
+++ b/pkg/goversion/notgo12.go
@@ -1,3 +1,5 @@
+// +build !go1.12
+
 /*
 Copyright 2019 The Knative Authors
 
@@ -16,8 +18,5 @@ limitations under the License.
 
 package goversion
 
-// IsSupported should fail to compile due to missing const references on
-// unsupported go versions, otherwise return true.
-func IsSupported() bool {
-	return requiresGo1dot12
-}
+// SupportsUnbufferedHTTPProxy is set to false if Go does not support -1 (unbuffered) HTTP FlushInterval
+const SupportsUnbufferedHTTPProxy = false

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -1,4 +1,6 @@
 // +build e2e
+// We need unbuffered HTTP reverse proxying for this to work
+// +build go1.12
 
 /*
 Copyright 2019 The Knative Authors


### PR DESCRIPTION
We were hard depending on Go 1.12 in order to set our HTTP proxy
FlushInterval to -1. Create a flag which lets us continue working in old
go versions by not setting this value.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fall back to old streaming behavior (rather than failing) on Go <1.12.
```
