### PR TITLE
Make panic propagation in timeout handler deterministic.

### DIFF
--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -73,7 +73,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 	// The recovery value of a panic is written to this channel to be
 	// propagated (panicked with) again.
-	panicChan := make(chan interface{}, 1)
+	panicChan := make(chan interface{})
 	defer close(panicChan)
 
 	tw := &timeoutWriter{w: w}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We had a few flakes of the panic propagation test of the TimeToFirstByteTimeoutHandler [recently](https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-serving-continuous/1099232864509104128). The root cause for that flake is the panic channel racing the done channel because the panic channel is buffered. Taking out the buffering makes the signals arrive in order deterministically.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
