### PR TITLE
golang format tools

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -86,7 +86,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				ProtoMinor: r.ProtoMinor,
 				Host:       r.Host,
 				Header: map[string][]string{
-					http.CanonicalHeaderKey(network.ProbeHeaderName): []string{"true"},
+					http.CanonicalHeaderKey(network.ProbeHeaderName): {"true"},
 				},
 			}
 			settings := wait.Backoff{

--- a/test/apicoverage/image/common/common.go
+++ b/test/apicoverage/image/common/common.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	ResourceMap = map[schema.GroupVersionKind]pkgWebhook.GenericCRD {
+	ResourceMap = map[schema.GroupVersionKind]pkgWebhook.GenericCRD{
 		v1alpha1.SchemeGroupVersion.WithKind("Revision"):      &v1alpha1.Revision{},
 		v1alpha1.SchemeGroupVersion.WithKind("Configuration"): &v1alpha1.Configuration{},
 		v1alpha1.SchemeGroupVersion.WithKind("Route"):         &v1alpha1.Route{},

--- a/test/apicoverage/image/main.go
+++ b/test/apicoverage/image/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import(
+import (
 	"github.com/knative/serving/test/apicoverage/image/webhook"
 )
 

--- a/test/apicoverage/image/rules/coverage_rules.go
+++ b/test/apicoverage/image/rules/coverage_rules.go
@@ -35,12 +35,11 @@ func IgnoreLowerLevelMetaFields(node resourcetree.NodeInterface) bool {
 }
 
 // NodeRules contains all resourcetree.NodeRules specified for knative serving.
-var NodeRules = resourcetree.NodeRules {
-		Rules: []func(node resourcetree.NodeInterface) bool{
-			IgnoreLowerLevelMetaFields,
-		},
-	}
-
+var NodeRules = resourcetree.NodeRules{
+	Rules: []func(node resourcetree.NodeInterface) bool{
+		IgnoreLowerLevelMetaFields,
+	},
+}
 
 // IgnoreDeprecatedFields ignores fields that are prefixed with the word "deprecated"
 func IgnoreDeprecatedFields(fieldName string) bool {
@@ -49,7 +48,7 @@ func IgnoreDeprecatedFields(fieldName string) bool {
 
 // FieldRules represent all resourcetree.FieldRules specified for knativer serving.
 var FieldRules = resourcetree.FieldRules{
-		Rules : []func(fieldName string) bool {
-			IgnoreDeprecatedFields,
-		},
+	Rules: []func(fieldName string) bool{
+		IgnoreDeprecatedFields,
+	},
 }

--- a/test/apicoverage/image/rules/display_rules.go
+++ b/test/apicoverage/image/rules/display_rules.go
@@ -33,7 +33,7 @@ func PackageDisplayRule(packageName string) string {
 		if len(tokens) >= 2 {
 			// As package names are built using reflect.Type.PackagePath, they are long.
 			// For better readability displaying only last two words of the package path. e.g. serving.v1alpha1
-			return strings.Join(tokens[len(tokens) - 2:], "/")
+			return strings.Join(tokens[len(tokens)-2:], "/")
 		}
 	}
 	return packageName
@@ -56,9 +56,9 @@ func FieldDisplayRule(field *coveragecalculator.FieldCoverage) string {
 }
 
 // GetDisplayRules returns the view.DisplayRules for knative serving.
-func GetDisplayRules () view.DisplayRules {
+func GetDisplayRules() view.DisplayRules {
 	return view.DisplayRules{
 		PackageNameRule: PackageDisplayRule,
-		FieldRule: FieldDisplayRule,
+		FieldRule:       FieldDisplayRule,
 	}
 }

--- a/test/apicoverage/image/webhook/webhook_server.go
+++ b/test/apicoverage/image/webhook/webhook_server.go
@@ -18,13 +18,14 @@ package webhook
 
 import (
 	"container/list"
+	"log"
+	"net/http"
+
 	"github.com/knative/pkg/signals"
 	"github.com/knative/serving/test/apicoverage/image/common"
 	"github.com/knative/serving/test/apicoverage/image/rules"
 	"github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree"
 	"github.com/knative/test-infra/tools/webhook-apicoverage/webhook"
-	"log"
-	"net/http"
 )
 
 // SetupWebhookServer builds the necessary webhook configuration, HttpServer and starts the webhook.
@@ -34,17 +35,17 @@ func SetupWebhookServer() {
 		log.Fatal("Namespace value to used by the webhook is not set")
 	}
 
-	webhookConf := webhook.BuildWebhookConfiguration(common.CommonComponentName, common.CommonComponentName + ".knative.serving.dev", common.WebhookNamespace)
+	webhookConf := webhook.BuildWebhookConfiguration(common.CommonComponentName, common.CommonComponentName+".knative.serving.dev", common.WebhookNamespace)
 	ac := webhook.APICoverageRecorder{
 		Logger: webhookConf.Logger,
-		ResourceForest: resourcetree.ResourceForest {
-			Version: "v1alpha1",
+		ResourceForest: resourcetree.ResourceForest{
+			Version:        "v1alpha1",
 			ConnectedNodes: make(map[string]*list.List),
-			TopLevelTrees: make(map[string]resourcetree.ResourceTree),
+			TopLevelTrees:  make(map[string]resourcetree.ResourceTree),
 		},
-		ResourceMap: common.ResourceMap,
-		NodeRules: rules.NodeRules,
-		FieldRules: rules.FieldRules,
+		ResourceMap:  common.ResourceMap,
+		NodeRules:    rules.NodeRules,
+		FieldRules:   rules.FieldRules,
 		DisplayRules: rules.GetDisplayRules(),
 	}
 	ac.Init()

--- a/test/apicoverage/tool/main.go
+++ b/test/apicoverage/tool/main.go
@@ -32,8 +32,8 @@ import (
 func main() {
 	var (
 		kubeConfigPath string
-		serviceIP string
-		err error
+		serviceIP      string
+		err            error
 	)
 
 	// Ensure artifactsDir exist, in case not invoked from this script
@@ -52,8 +52,8 @@ func main() {
 		log.Fatalf("Error retrieving Service IP: %v", err)
 	}
 
-	for resource, _ := range common.ResourceMap {
-		err = tools.GetAndWriteResourceCoverage(serviceIP, resource.Kind, path.Join(artifactsDir, strings.ToLower(resource.Kind) + ".dat"), rules.GetDisplayRules())
+	for resource := range common.ResourceMap {
+		err = tools.GetAndWriteResourceCoverage(serviceIP, resource.Kind, path.Join(artifactsDir, strings.ToLower(resource.Kind)+".dat"), rules.GetDisplayRules())
 		if err != nil {
 			log.Println(fmt.Sprintf("resource coverage for resource: %s failed. %v ", resource.Kind, err))
 		}

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/knative/pkg/test/logging"
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/pkg/errors"
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
