### PR TITLE
[RELEASE 0.3] Unbreak the release-0.3 CI flow

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -68,7 +68,7 @@ function install_knative_serving() {
   fi
   # TODO: Should we install build from a nightly release?
   # The latest released Build is always at this location.
-  INSTALL_BUILD_YAML=https://storage.googleapis.com/knative-releases/build/latest/release.yaml
+  INSTALL_BUILD_YAML=https://storage.googleapis.com/knative-releases/build/latest/build.yaml
 
   echo ">> Installing Knative serving"
   echo "Istio CRD YAML: ${INSTALL_ISTIO_CRD_YAML}"


### PR DESCRIPTION
Two major issues are causing each run of the release-0.3 CI flow to fail:
1. E2E tests fail due to the renamed build manifest.
1. `TestGlobalResyncOnUpdateGatewayConfigMap` is the flakiest test.

Fixes #3317.