### PR TITLE
Distinguish config-logging

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -258,7 +258,7 @@ func main() {
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
-	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
+	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	// Watch the observability config map and dynamically update metrics exporter.
 	configMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
 	if err = configMapWatcher.Start(stopCh); err != nil {

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -81,7 +81,7 @@ func main() {
 	// Set up watcher to watch for config changes.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClientSet, system.Namespace())
 	// Watch the logging config map and dynamically update logging levels.
-	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
+	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	// Watch the observability config map and dynamically update metrics exporter.
 	configMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
 	// Watch the autoscaler config map and dynamically update autoscaler config.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -198,7 +198,7 @@ func main() {
 	}
 
 	// Watch the logging config map and dynamically update logging levels.
-	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
+	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	// Watch the observability config map and dynamically update metrics exporter.
 	configMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
-	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
+	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	if err = configMapWatcher.Start(stopCh); err != nil {
 		logger.Fatalw("Failed to start the ConfigMap watcher", zap.Error(err))
 	}

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -69,6 +69,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: CONFIG_LOGGING_NAME
+            value: config-logging
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging
@@ -77,7 +79,7 @@ spec:
       volumes:
         - name: config-logging
           configMap:
-            name: serving-config-logging
+            name: config-logging
         - name: config-observability
           configMap:
             name: config-observability

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -77,7 +77,7 @@ spec:
       volumes:
         - name: config-logging
           configMap:
-            name: config-logging
+            name: serving-config-logging
         - name: config-observability
           configMap:
             name: config-observability

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -63,13 +63,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
       volumes:
         - name: config-autoscaler
           configMap:
             name: config-autoscaler
         - name: config-logging
           configMap:
-            name: serving-config-logging
+            name: config-logging
         - name: config-observability
           configMap:
             name: config-observability

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -69,7 +69,7 @@ spec:
             name: config-autoscaler
         - name: config-logging
           configMap:
-            name: config-logging
+            name: serving-config-logging
         - name: config-observability
           configMap:
             name: config-observability

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: serving-config-logging
+  name: config-logging
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: serving-config-logging
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -60,4 +60,4 @@ spec:
       volumes:
         - name: config-logging
           configMap:
-            name: config-logging
+            name: serving-config-logging

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -57,7 +57,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
       volumes:
         - name: config-logging
           configMap:
-            name: serving-config-logging
+            name: config-logging

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -56,7 +56,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
       volumes:
         - name: config-logging
           configMap:
-            name: serving-config-logging
+            name: config-logging

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -59,4 +59,4 @@ spec:
       volumes:
         - name: config-logging
           configMap:
-            name: config-logging
+            name: serving-config-logging

--- a/pkg/logging/config.go
+++ b/pkg/logging/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	ConfigName = "config-logging"
+	ConfigName = "serving-config-logging"
 )
 
 var components = []string{"controller", "queueproxy", "webhook", "activator", "autoscaler"}

--- a/pkg/logging/config.go
+++ b/pkg/logging/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package logging
 
 import (
-	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -62,17 +61,9 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 }
 
 func ConfigMapName() string {
-	if cm := os.Getenv(ConfigMapNameEnv); cm != "" {
-		return cm
+	cm := os.Getenv(ConfigMapNameEnv)
+	if cm == "" {
+		return "config-logging"
 	}
-
-	panic(fmt.Sprintf(`The environment variable %q is not set
-
-If this is a process running on Kubernetes, then it should be using the downward
-API to initialize this variable via:
-
-  env:
-  - name: CONFIG_LOGGING_NAME
-    value: config-logging
-`, ConfigMapNameEnv))
+	return cm
 }

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -120,7 +120,7 @@ func TestNewConfigNoEntry(t *testing.T) {
 	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "knative-something",
-			Name:      "serving-config-logging",
+			Name:      "config-logging",
 		},
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ func TestNewConfig(t *testing.T) {
 	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "serving-config-logging",
+			Name:      "config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   wantCfg,
@@ -159,7 +159,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestOurConfig(t *testing.T) {
-	cm, example := ConfigMapsFromTestFile(t, ConfigName)
+	cm, example := ConfigMapsFromTestFile(t, ConfigMapName())
 
 	if cfg, err := NewConfigFromConfigMap(cm); err != nil {
 		t.Errorf("Expected no errors. got: %v", err)
@@ -186,7 +186,7 @@ func TestEmptyLevel(t *testing.T) {
 	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "serving-config-logging",
+			Name:      "config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",
@@ -206,7 +206,7 @@ func TestInvalidLevel(t *testing.T) {
 	_, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "serving-config-logging",
+			Name:      "config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   wantCfg,
@@ -224,7 +224,7 @@ func getTestConfig() (*logging.Config, string, string) {
 	c, _ := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "serving-config-logging",
+			Name:      "config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   wantCfg,
@@ -244,7 +244,7 @@ func TestUpdateLevelFromConfigMap(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "serving-config-logging",
+			Name:      "config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   "",

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -120,7 +120,7 @@ func TestNewConfigNoEntry(t *testing.T) {
 	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "knative-something",
-			Name:      "config-logging",
+			Name:      "serving-config-logging",
 		},
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ func TestNewConfig(t *testing.T) {
 	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "config-logging",
+			Name:      "serving-config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   wantCfg,
@@ -186,7 +186,7 @@ func TestEmptyLevel(t *testing.T) {
 	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "config-logging",
+			Name:      "serving-config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",
@@ -206,7 +206,7 @@ func TestInvalidLevel(t *testing.T) {
 	_, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "config-logging",
+			Name:      "serving-config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   wantCfg,
@@ -224,7 +224,7 @@ func getTestConfig() (*logging.Config, string, string) {
 	c, _ := NewConfigFromConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "config-logging",
+			Name:      "serving-config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   wantCfg,
@@ -244,7 +244,7 @@ func TestUpdateLevelFromConfigMap(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "config-logging",
+			Name:      "serving-config-logging",
 		},
 		Data: map[string]string{
 			"zap-logger-config":   "",

--- a/pkg/reconciler/v1alpha1/revision/config/store.go
+++ b/pkg/reconciler/v1alpha1/revision/config/store.go
@@ -57,11 +57,11 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			"revision",
 			logger,
 			configmap.Constructors{
-				ControllerConfigName:    NewControllerConfigFromConfigMap,
-				network.ConfigName:      network.NewConfigFromConfigMap,
-				ObservabilityConfigName: NewObservabilityFromConfigMap,
-				autoscaler.ConfigName:   autoscaler.NewConfigFromConfigMap,
-				logging.ConfigName:      logging.NewConfigFromConfigMap,
+				ControllerConfigName:      NewControllerConfigFromConfigMap,
+				network.ConfigName:        network.NewConfigFromConfigMap,
+				ObservabilityConfigName:   NewObservabilityFromConfigMap,
+				autoscaler.ConfigName:     autoscaler.NewConfigFromConfigMap,
+				(logging.ConfigMapName()): logging.NewConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -79,7 +79,7 @@ func (s *Store) Load() *Config {
 		Controller:    s.UntypedLoad(ControllerConfigName).(*Controller).DeepCopy(),
 		Network:       s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
 		Observability: s.UntypedLoad(ObservabilityConfigName).(*Observability).DeepCopy(),
-		Logging:       s.UntypedLoad(logging.ConfigName).(*pkglogging.Config).DeepCopy(),
+		Logging:       s.UntypedLoad((logging.ConfigMapName())).(*pkglogging.Config).DeepCopy(),
 		Autoscaler:    s.UntypedLoad(autoscaler.ConfigName).(*autoscaler.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/config/store_test.go
+++ b/pkg/reconciler/v1alpha1/revision/config/store_test.go
@@ -36,7 +36,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	controllerConfig := ConfigMapFromTestFile(t, ControllerConfigName, queueSidecarImageKey)
 	networkConfig := ConfigMapFromTestFile(t, network.ConfigName)
 	observabilityConfig := ConfigMapFromTestFile(t, ObservabilityConfigName)
-	loggingConfig := ConfigMapFromTestFile(t, logging.ConfigName)
+	loggingConfig := ConfigMapFromTestFile(t, logging.ConfigMapName())
 	autoscalerConfig := ConfigMapFromTestFile(t, autoscaler.ConfigName)
 
 	store.OnConfigChanged(controllerConfig)
@@ -90,7 +90,7 @@ func TestStoreImmutableConfig(t *testing.T) {
 	store.OnConfigChanged(ConfigMapFromTestFile(t, ControllerConfigName, queueSidecarImageKey))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, network.ConfigName))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, ObservabilityConfigName))
-	store.OnConfigChanged(ConfigMapFromTestFile(t, logging.ConfigName))
+	store.OnConfigChanged(ConfigMapFromTestFile(t, logging.ConfigMapName()))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, autoscaler.ConfigName))
 
 	config := store.Load()

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -195,7 +195,7 @@ func newTestController(t *testing.T, stopCh <-chan struct{}) (
 			}}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),
-				Name:      logging.ConfigName,
+				Name:      logging.ConfigMapName(),
 			},
 			Data: map[string]string{
 				"zap-logger-config":   "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -185,7 +185,7 @@ func newTestControllerWithConfig(t *testing.T, controllerConfig *config.Controll
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      logging.ConfigName,
+			Name:      logging.ConfigMapName(),
 		},
 		Data: map[string]string{
 			"zap-logger-config":   "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/3321

## Proposed Changes

Just want use the unique `config-logging` name. So change the configmap `config-logging` to `serving-config-logging`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->


