### PR TITLE
Drop functional dependency on 'configurationMetadataGeneration' label

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -234,8 +234,7 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 func (c *Reconciler) latestCreatedRevision(config *v1alpha1.Configuration) (*v1alpha1.Revision, error) {
 	lister := c.revisionLister.Revisions(config.Namespace)
 
-	// TODO(#643) - in serving 0.5 switch to serving.ConfigurationGenerationLabelKey
-	generationKey := serving.DeprecatedConfigurationMetadataGenerationLabelKey
+	generationKey := serving.ConfigurationGenerationLabelKey
 
 	list, err := lister.List(labels.SelectorFromSet(map[string]string{
 		generationKey:                 resources.RevisionLabelValueForKey(generationKey, config),

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -25,6 +25,7 @@ import (
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/gc"
 	"github.com/knative/serving/pkg/reconciler"
@@ -189,6 +190,16 @@ func TestReconcile(t *testing.T) {
 			cfg("matching-revision-done-idempotent", "foo", 5566,
 				WithObservedGen, WithLatestCreated("matching-revision"), WithLatestReady("matching-revision")),
 			rev("matching-revision-done-idempotent", "foo", 5566,
+				WithCreationTimestamp(now), MarkRevisionReady, WithRevName("matching-revision")),
+		},
+		Key: "foo/matching-revision-done-idempotent",
+	}, {
+		Name: "reconcile revision matching generation (ready: true, idempotent, no deprecated generation label)",
+		Objects: []runtime.Object{
+			cfg("matching-revision-done-idempotent", "foo", 5566,
+				WithObservedGen, WithLatestCreated("matching-revision"), WithLatestReady("matching-revision")),
+			rev("matching-revision-done-idempotent", "foo", 5566,
+				WithoutConfigMetadataGenerationLabel,
 				WithCreationTimestamp(now), MarkRevisionReady, WithRevName("matching-revision")),
 		},
 		Key: "foo/matching-revision-done-idempotent",
@@ -653,4 +664,8 @@ func TestIsRevisionStale(t *testing.T) {
 			}
 		})
 	}
+}
+
+func WithoutConfigMetadataGenerationLabel(rev *v1alpha1.Revision) {
+	delete(rev.Labels, serving.DeprecatedConfigurationMetadataGenerationLabelKey)
 }


### PR DESCRIPTION
Addresses #643

In 0.4, Revisions have both `/configurationMetadataGeneration` and
`/configurationGeneration` labels have a value equal to the
Configuration's metadata.generation

This commit has the Configuration's reconciler use
`/configurationGeneration` when looking up the latest created
revision

We should be able to drop the use of `/configurationMetadataGeneration`
in 0.6

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
