### PR TITLE
Update test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -504,7 +504,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9d5a3c4c510d4d622f275e7ccd6efcee38c6aecb3f03d0fe5efadaec4313f4f2"
+  digest = "1:d3bd98febae5cf04f4289ad7f00f1c8a41d2e3c884658b0ddf58cbfb314f6c50"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -522,7 +522,7 @@
     "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "0600862ee70f8f2e826f1024faae8f707cc814c7"
+  revision = "9ce9ec3c75dc8489b3e153b92dce0f465ba77ab9"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,14 +28,6 @@
 source $(dirname $0)/e2e-common.sh
 
 # Helper functions.
-function dump_app_logs() {
-  echo ">>> Knative Serving $1 logs:"
-  for pod in $(get_app_pods "$1" knative-serving)
-  do
-    echo ">>> Pod: $pod"
-    kubectl -n knative-serving logs "$pod" -c "$1"
-  done
-}
 
 function dump_extra_cluster_state() {
   echo ">>> Routes:"
@@ -45,10 +37,9 @@ function dump_extra_cluster_state() {
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
 
-  dump_app_logs controller
-  dump_app_logs webhook
-  dump_app_logs autoscaler
-  dump_app_logs activator
+  for app in controller webhook autoscaler activator; do
+    dump_app_logs ${app} knative-serving
+  done
 }
 
 function knative_setup() {

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -203,6 +203,7 @@ function create_test_cluster() {
     gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
   fi
   local result="$(cat ${TEST_RESULT_FILE})"
+  echo "Artifacts were written to ${ARTIFACTS}"
   echo "Test result code is ${result}"
 
   exit ${result}

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -44,6 +44,11 @@ readonly IS_PROW
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 readonly REPO_NAME="$(basename ${REPO_ROOT_DIR})"
 
+# Set ARTIFACTS to an empty temp dir if unset
+if [[ -z "${ARTIFACTS:-}" ]]; then
+  export ARTIFACTS="$(mktemp -d)"
+fi
+
 # On a Prow job, redirect stderr to stdout so it's synchronously added to log
 (( IS_PROW )) && exec 2>&1
 
@@ -200,6 +205,29 @@ function get_app_pods() {
   kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[*].metadata.name}"
 }
 
+# Capitalize the first letter of each word.
+# Parameters: $1..$n - words to capitalize.
+function capitalize() {
+  local capitalized=()
+  for word in $@; do
+    local initial="$(echo ${word:0:1}| tr 'a-z' 'A-Z')"
+    capitalized+=("${initial}${word:1}")
+  done
+  echo "${capitalized[@]}"
+}
+
+# Dumps pod logs for the given app.
+# Parameters: $1 - app name.
+#             $2 - namespace.
+function dump_app_logs() {
+  echo ">>> ${REPO_NAME_FORMATTED} $1 logs:"
+  for pod in $(get_app_pods "$1" "$2")
+  do
+    echo ">>> Pod: $pod"
+    kubectl -n "$2" logs "$pod" -c "$1"
+  done
+}
+
 # Sets the given user as cluster admin.
 # Parameters: $1 - user
 #             $2 - cluster name
@@ -246,10 +274,6 @@ function report_go_test() {
   local args=" $@ "
   local go_test="go test -race -v ${args/ -v / }"
   # Just run regular go tests if not on Prow.
-  if (( ! IS_PROW )); then
-    ${go_test}
-    return
-  fi
   echo "Running tests with '${go_test}'"
   local report=$(mktemp)
   ${go_test} | tee ${report}
@@ -264,6 +288,13 @@ function report_go_test() {
       | sed -e "s#\"github.com/knative/${REPO_NAME}/#\"#g" \
       > ${xml}
   echo "XML report written to ${xml}"
+  if (( ! IS_PROW )); then
+    # Keep the suffix, so files are related.
+    local logfile=${xml/junit_/go_test_}
+    logfile=${logfile/.xml/.log}
+    cp ${report} ${logfile}
+    echo "Test log written to ${logfile}"
+  fi
   return ${failed}
 }
 
@@ -392,3 +423,4 @@ function get_canonical_path() {
 # These MUST come last.
 
 readonly _TEST_INFRA_SCRIPTS_DIR="$(dirname $(get_canonical_path ${BASH_SOURCE[0]}))"
+readonly REPO_NAME_FORMATTED="Knative $(capitalize ${REPO_NAME//-/})"

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -31,18 +31,6 @@ function banner() {
     make_banner "@" "$1"
 }
 
-# Capitalize the first letter of each word.
-# Parameters: $1..$n - words to capitalize.
-function capitalize() {
-  local words=("$1")
-  local capitalized=()
-  for word in $@; do
-    local initial="$(echo ${word:0:1}| tr 'a-z' 'A-Z')"
-    capitalized+=("${initial}${word:1}")
-  done
-  echo "${capitalized[@]}"
-}
-
 # Tag images in the yaml files if $TAG is not empty.
 # $KO_DOCKER_REPO is the registry containing the images to tag with $TAG.
 # Parameters: $1..$n - yaml files to parse for images.
@@ -407,7 +395,7 @@ function main() {
 # Parameters: $1..$n - YAML files to add to the release.
 function publish_to_github() {
   (( PUBLISH_TO_GITHUB )) || return 0
-  local title="Knative $(capitalize ${REPO_NAME//-/ }) release ${TAG}"
+  local title="${REPO_NAME_FORMATTED} release ${TAG}"
   local attachments=()
   local description="$(mktemp)"
   local attachments_dir="$(mktemp -d)"


### PR DESCRIPTION
Major changes:
* store E2E test logs when running locally
* use the shared `dump_app_logs` function in E2E tests

Fixes knative/test-infra#252.
Fixes knative/test-infra#527.

/cc @yanweiguo 
/cc @ericKlawitter 
/assign @mattmoor 
/assign @evankanderson 