### PR TITLE
Update pkg and test-infra deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,7 +450,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:e02673e5f75fc39a4ec48f5dbf8d70290634fba92237f729f66c774867a3faee"
+  digest = "1:96668306757feff41921a310fd40dc87106cb803a5ab3297870e3837e4e8108f"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -500,11 +500,11 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "374dc8c6cea59ddf9d54046d4623ea14d21ef53d"
+  revision = "2a8c1b0e5ad2719b00e20fef8594d63fa202640f"
 
 [[projects]]
   branch = "master"
-  digest = "1:d3bd98febae5cf04f4289ad7f00f1c8a41d2e3c884658b0ddf58cbfb314f6c50"
+  digest = "1:1c4f385aed37e1ab32b4d6eaa8e8401e7b4f80c73c8ab9e3774754fe996c4269"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -522,7 +522,7 @@
     "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "9ce9ec3c75dc8489b3e153b92dce0f465ba77ab9"
+  revision = "b74ea40f39551d3c868e43d967670e6da582d4ea"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,8 +28,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-02-22
-  revision = "374dc8c6cea59ddf9d54046d4623ea14d21ef53d"
+  # HEAD as of 2019-02-27
+  revision = "2a8c1b0e5ad2719b00e20fef8594d63fa202640f"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -94,8 +94,7 @@ func TestHelloWorldFromShell(t *testing.T) {
 		t.Fatalf("Failed to close new manifest file: %v", err)
 	}
 
-	t.Logf("Manifest file is %q", newYamlFilename)
-	t.Log("Deploying using kubectl")
+	t.Logf("Deploying using kubectl and using manifest file %q", newYamlFilename)
 
 	// Deploy using kubectl
 	if output, err := exec.Command("kubectl", "apply", "-f", newYamlFilename).CombinedOutput(); err != nil {

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/test"
 )
 
@@ -65,11 +64,9 @@ func ingressAddress(gateway string, addressType string) string {
 
 func TestHelloWorldFromShell(t *testing.T) {
 	t.Parallel()
-	//add test case specific name to its own logger
-	logger := logging.GetContextLogger(t.Name())
 	imagePath := test.ImagePath("helloworld")
 
-	logger.Info("Creating manifest")
+	t.Log("Creating manifest")
 
 	// Create manifest file.
 	newYaml, err := ioutil.TempFile("", "helloworld")
@@ -97,15 +94,15 @@ func TestHelloWorldFromShell(t *testing.T) {
 		t.Fatalf("Failed to close new manifest file: %v", err)
 	}
 
-	logger.Infof("Manifest file is %q", newYamlFilename)
-	logger.Info("Deploying using kubectl")
+	t.Logf("Manifest file is %q", newYamlFilename)
+	t.Log("Deploying using kubectl")
 
 	// Deploy using kubectl
 	if output, err := exec.Command("kubectl", "apply", "-f", newYamlFilename).CombinedOutput(); err != nil {
 		t.Fatalf("Error running kubectl: %v", strings.TrimSpace(string(output)))
 	}
 
-	logger.Info("Waiting for ingress to come up")
+	t.Log("Waiting for ingress to come up")
 	gateway := "istio-ingressgateway"
 	// Wait for ingress to come up
 	ingressAddr := ""
@@ -125,7 +122,7 @@ func TestHelloWorldFromShell(t *testing.T) {
 		// serviceHost or ingressAddr might contain a useful error, dump them.
 		t.Fatalf("Ingress not found (ingress='%s', host='%s')", ingressAddr, serviceHost)
 	}
-	logger.Infof("Curling %s/%s", ingressAddr, serviceHost)
+	t.Logf("Curling %s/%s", ingressAddr, serviceHost)
 
 	outputString := ""
 	timeout = servingTimeout
@@ -142,7 +139,7 @@ func TestHelloWorldFromShell(t *testing.T) {
 			errorString = err.Error()
 		}
 		outputString = strings.TrimSpace(string(output))
-		logger.Infof("App replied with '%s' (error: %s)", outputString, errorString)
+		t.Logf("App replied with '%s' (error: %s)", outputString, errorString)
 		timeout -= checkInterval
 		time.Sleep(checkInterval)
 	}
@@ -150,5 +147,5 @@ func TestHelloWorldFromShell(t *testing.T) {
 	if outputString != helloWorldExpectedOutput {
 		t.Fatal("Timeout waiting for app to start serving")
 	}
-	logger.Info("App is serving")
+	t.Log("App is serving")
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -30,6 +30,9 @@ import (
 const (
 	// ServingNamespace is the default namespace for serving e2e tests
 	ServingNamespace = "serving-tests"
+
+	// E2EMetricExporter is the name for the metrics exporter logger
+	E2EMetricExporter = "e2e-metrics"
 )
 
 // ServingFlags holds the flags or defaults for knative/serving settings in the user's environment.
@@ -59,7 +62,7 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	logging.InitializeLogger(test.Flags.LogVerbose)
 
 	if test.Flags.EmitMetrics {
-		logging.InitializeMetricExporter()
+		logging.InitializeMetricExporter(E2EMetricExporter)
 	}
 
 	return &f

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	pkgTest "github.com/knative/pkg/test"
-	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/test"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/prometheus"
@@ -58,7 +57,7 @@ func Setup(ctx context.Context, t *testing.T, promReqd bool) (*Client, error) {
 	if promReqd {
 		t.Log("Creating prometheus proxy client")
 		p = &prometheus.PromProxy{Namespace: monitoringNS}
-		p.Setup(ctx, logging.GetContextLogger(t.Name()))
+		p.Setup(ctx, t.Logf)
 	}
 	return &Client{E2EClients: clients, PromClient: p}, nil
 }

--- a/vendor/github.com/knative/pkg/test/cleanup.go
+++ b/vendor/github.com/knative/pkg/test/cleanup.go
@@ -27,12 +27,12 @@ import (
 )
 
 // CleanupOnInterrupt will execute the function cleanup if an interrupt signal is caught
-func CleanupOnInterrupt(cleanup func(), logger *logging.BaseLogger) {
+func CleanupOnInterrupt(cleanup func(), logf logging.FormatLogger) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		for range c {
-			logger.Info("Test interrupted, cleaning up.")
+			logf("Test interrupted, cleaning up.")
 			cleanup()
 			os.Exit(1)
 		}

--- a/vendor/github.com/knative/pkg/test/clients.go
+++ b/vendor/github.com/knative/pkg/test/clients.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -33,7 +34,7 @@ type KubeClient struct {
 }
 
 // NewSpoofingClient returns a spoofing client to make requests
-func NewSpoofingClient(client *KubeClient, logf spoof.FormatLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
+func NewSpoofingClient(client *KubeClient, logf logging.FormatLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
 	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint)
 }
 

--- a/vendor/github.com/knative/pkg/test/request.go
+++ b/vendor/github.com/knative/pkg/test/request.go
@@ -119,7 +119,7 @@ func MatchesAllOf(checkers ...spoof.ResponseChecker) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClient *KubeClient, logf spoof.FormatLogger, domain string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
+func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, domain string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
 	return WaitForEndpointStateWithTimeout(kubeClient, logf, domain, inState, desc, resolvable, spoof.RequestTimeout)
 }
 
@@ -130,7 +130,7 @@ func WaitForEndpointState(kubeClient *KubeClient, logf spoof.FormatLogger, domai
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
 func WaitForEndpointStateWithTimeout(
-	kubeClient *KubeClient, logf spoof.FormatLogger, domain string, inState spoof.ResponseChecker,
+	kubeClient *KubeClient, logf logging.FormatLogger, domain string, inState spoof.ResponseChecker,
 	desc string, resolvable bool, timeout time.Duration) (*spoof.Response, error) {
 	defer logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForEndpointState/%s", desc)).End()
 

--- a/vendor/github.com/knative/pkg/test/spoof/spoof.go
+++ b/vendor/github.com/knative/pkg/test/spoof/spoof.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package spoof
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -29,6 +28,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/zipkin"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +47,9 @@ const (
 	// TODO(tcnghia): These probably shouldn't be hard-coded here?
 	istioIngressNamespace = "istio-system"
 	istioIngressName      = "istio-ingressgateway"
+	// Name of the temporary HTTP header that is added to http.Request to indicate that
+	// it is a SpoofClient.Poll request. This header is removed before making call to backend.
+	pollReqHeader = "X-Kn-Poll-Request-Do-Not-Trace"
 )
 
 // Response is a stripped down subset of http.Response. The is primarily useful
@@ -75,9 +78,6 @@ var _ Interface = (*SpoofingClient)(nil)
 // https://github.com/kubernetes/apimachinery/blob/cf7ae2f57dabc02a3d215f15ca61ae1446f3be8f/pkg/util/wait/wait.go#L172
 type ResponseChecker func(resp *Response) (done bool, err error)
 
-// FormatLogger is a printf style function for logging in the Spoof client.
-type FormatLogger func(template string, args ...interface{})
-
 // SpoofingClient is a minimal HTTP client wrapper that spoofs the domain of requests
 // for non-resolvable domains.
 type SpoofingClient struct {
@@ -88,7 +88,7 @@ type SpoofingClient struct {
 	endpoint string
 	domain   string
 
-	logf FormatLogger
+	logf logging.FormatLogger
 }
 
 // New returns a SpoofingClient that rewrites requests if the target domain is not `resolveable`.
@@ -96,7 +96,7 @@ type SpoofingClient struct {
 // follow the ingress if it moves (or if there are multiple ingresses).
 //
 // If that's a problem, see test/request.go#WaitForEndpointState for oneshot spoofing.
-func New(kubeClientset *kubernetes.Clientset, logf FormatLogger, domain string, resolvable bool, endpointOverride string) (*SpoofingClient, error) {
+func New(kubeClientset *kubernetes.Clientset, logf logging.FormatLogger, domain string, resolvable bool, endpointOverride string) (*SpoofingClient, error) {
 	sc := SpoofingClient{
 		Client:          &http.Client{Transport: &ochttp.Transport{Propagation: &b3.HTTPFormat{}}}, // Using ochttp Transport required for zipkin-tracing
 		RequestInterval: requestInterval,
@@ -185,6 +185,12 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 	traceContext, span := trace.StartSpan(req.Context(), "SpoofingClient-Trace")
 	defer span.End()
 
+	// Check to see if the call to this method is coming from a Poll call.
+	logZipkinTrace := true
+	if req.Header.Get(pollReqHeader) != "" {
+		req.Header.Del(pollReqHeader)
+		logZipkinTrace = false
+	}
 	resp, err := sc.Client.Do(req.WithContext(traceContext))
 	if err != nil {
 		return nil, err
@@ -198,12 +204,18 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 		return nil, err
 	}
 
-	return &Response{
+	spoofResp := &Response{
 		Status:     resp.Status,
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
 		Body:       body,
-	}, nil
+	}
+
+	if logZipkinTrace {
+		sc.logZipkinTrace(spoofResp)
+	}
+
+	return spoofResp, nil
 }
 
 // Poll executes an http request until it satisfies the inState condition or encounters an error.
@@ -214,6 +226,10 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 	)
 
 	err = wait.PollImmediate(sc.RequestInterval, sc.RequestTimeout, func() (bool, error) {
+		// As we may do multiple Do calls as part of a single Poll we add this temporary header
+		// to the request to indicate to Do method not to log Zipkin trace, instead it is
+		// handled by this method itself.
+		req.Header.Add(pollReqHeader, "True")
 		resp, err = sc.Do(req)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
@@ -226,13 +242,24 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		return inState(resp)
 	})
 
+	if resp != nil {
+		sc.logZipkinTrace(resp)
+	}
+
 	return resp, err
 }
 
-// LogZipkinTrace provides support to log Zipkin Trace for param: traceID
-func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
+// logZipkinTrace provides support to log Zipkin Trace for param: spoofResponse
+// We only log Zipkin trace for HTTP server errors i.e for HTTP status codes between 500 to 600
+func (sc *SpoofingClient) logZipkinTrace(spoofResp *Response) {
+	if !zipkin.ZipkinTracingEnabled || spoofResp.StatusCode < http.StatusInternalServerError || spoofResp.StatusCode >= 600 {
+		return
+	}
+
+	traceID := spoofResp.Header.Get(zipkin.ZipkinTraceIDHeader)
 	if err := zipkin.CheckZipkinPortAvailability(); err == nil {
-		return errors.New("port-forwarding for Zipkin is not-setup. Failing Zipkin Trace retrieval")
+		sc.logf("port-forwarding for Zipkin is not-setup. Failing Zipkin Trace retrieval")
+		return
 	}
 
 	sc.logf("Logging Zipkin Trace: %s", traceID)
@@ -242,20 +269,21 @@ func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
 	time.Sleep(5 * time.Second)
 	resp, err := http.Get(zipkinTraceEndpoint)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Zipkin trace: %v", err)
+		sc.logf("Error retrieving Zipkin trace: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 
 	trace, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("Error reading Zipkin trace response: %v", err)
+		sc.logf("Error reading Zipkin trace response: %v", err)
+		return
 	}
 
 	var prettyJSON bytes.Buffer
 	if error := json.Indent(&prettyJSON, trace, "", "\t"); error != nil {
-		return fmt.Errorf("JSON Parser Error while trying for Pretty-Format: %v, Original Response: %s", error, string(trace))
+		sc.logf("JSON Parser Error while trying for Pretty-Format: %v, Original Response: %s", error, string(trace))
+		return
 	}
 	sc.logf("%s", prettyJSON.String())
-
-	return nil
 }

--- a/vendor/github.com/knative/pkg/test/zipkin/doc.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/doc.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package zipkin adds Zipkin tracing support that can be used in conjunction with
+SpoofingClient to log zipkin traces for requests that have encountered server errors
+i.e HTTP request that have HTTP status between 500 to 600.
+
+This package exposes following methods:
+
+	SetupZipkinTracing(*kubernetes.Clientset) error
+		SetupZipkinTracing sets up zipkin tracing by setting up port-forwarding from
+		localhost to zipkin pod on the cluster. On successful setup this method sets
+		an internal flag zipkinTracingEnabled to true.
+
+	CleanupZipkinTracingSetup() error
+		CleanupZipkinTracingSetup cleans up zipkin tracing setup by cleaning up the
+		port-forwarding setup by call to SetupZipkinTracing. This method also sets
+		zipkinTracingEnabled flag to false.
+
+A general flow for a Test Suite to use Zipkin Tracing support is as follows:
+
+		1. Call SetupZipkinTracing(*kubernetes.Clientset) in TestMain.
+		2. Use SpoofingClient to make HTTP requests.
+		3. Call CleanupZipkinTracingSetup on cleanup after tests are executed.
+
+ */
+package zipkin


### PR DESCRIPTION
This PR updates:

1. pkg - removes baselogger
1. test-infra - Update prometheus pkg to use formatlogger

Plus, few updates in test code to handle update. Also, updates a few locations where we used baselogger to use formatlogger

Fixes https://github.com/knative/test-infra/issues/530