### PR TITLE
Stop executing Hook actions after WaitForHooks has finished.

### DIFF
--- a/pkg/reconciler/testing/hooks.go
+++ b/pkg/reconciler/testing/hooks.go
@@ -82,6 +82,10 @@ type Hooks struct {
 	completionCh    chan int32
 	completionIndex int32
 
+	// Denotes whether or not the registered hooks should no longer be called
+	// because they have already been waited upon.
+	// This uses a Mutex over a channel to guarantee that after WaitForHooks
+	// returns no hooked functions will be called.
 	closed bool
 	mutex  sync.RWMutex
 }

--- a/pkg/reconciler/testing/hooks.go
+++ b/pkg/reconciler/testing/hooks.go
@@ -19,6 +19,7 @@ package testing
 
 import (
 	"errors"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -80,6 +81,9 @@ that all hooks complete in a timely manner.
 type Hooks struct {
 	completionCh    chan int32
 	completionIndex int32
+
+	closed bool
+	mutex  sync.RWMutex
 }
 
 // NewHooks returns a Hooks struct that can be used to attach hooks to one or
@@ -98,7 +102,10 @@ func (h *Hooks) OnCreate(fake *kubetesting.Fake, resource string, rf CreateHookF
 	index := atomic.AddInt32(&h.completionIndex, 1)
 	fake.PrependReactor("create", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
 		obj := a.(kubetesting.CreateActionImpl).Object
-		if rf(obj) == HookComplete {
+
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
+		if !h.closed && rf(obj) == HookComplete {
 			h.completionCh <- index
 		}
 		return false, nil, nil
@@ -111,7 +118,10 @@ func (h *Hooks) OnUpdate(fake *kubetesting.Fake, resource string, rf UpdateHookF
 	index := atomic.AddInt32(&h.completionIndex, 1)
 	fake.PrependReactor("update", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
 		obj := a.(kubetesting.UpdateActionImpl).Object
-		if rf(obj) == HookComplete {
+
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
+		if !h.closed && rf(obj) == HookComplete {
 			h.completionCh <- index
 		}
 		return false, nil, nil
@@ -124,7 +134,10 @@ func (h *Hooks) OnDelete(fake *kubetesting.Fake, resource string, rf DeleteHookF
 	index := atomic.AddInt32(&h.completionIndex, 1)
 	fake.PrependReactor("delete", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
 		name := a.(kubetesting.DeleteActionImpl).Name
-		if rf(name) == HookComplete {
+
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
+		if !h.closed && rf(name) == HookComplete {
 			h.completionCh <- index
 		}
 		return false, nil, nil
@@ -133,11 +146,20 @@ func (h *Hooks) OnDelete(fake *kubetesting.Fake, resource string, rf DeleteHookF
 
 // WaitForHooks waits until all attached hooks have returned true at least once.
 // If the given timeout expires before that happens, an error is returned.
+// The registered actions will no longer be executed after WaitForHooks has
+// returned.
 func (h *Hooks) WaitForHooks(timeout time.Duration) error {
+	defer func() {
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+		h.closed = true
+	}()
+
 	ci := int(atomic.LoadInt32(&h.completionIndex))
 	if ci == -1 {
 		return nil
 	}
+
 	// Convert index to count.
 	ci++
 	timer := time.After(timeout)

--- a/pkg/reconciler/testing/hooks_test.go
+++ b/pkg/reconciler/testing/hooks_test.go
@@ -170,3 +170,33 @@ func TestMultiUpdate(t *testing.T) {
 		t.Errorf("Unexpected number of Update events; want 2, got %d", updates)
 	}
 }
+
+func TestWaitNoExecutionAfterWait(t *testing.T) {
+	h := NewHooks()
+	f := fake.NewSimpleClientset()
+
+	createCalled := false
+	h.OnCreate(&f.Fake, "pods", func(obj runtime.Object) HookResult {
+		createCalled = true
+		return true
+	})
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
+	}
+	err := h.WaitForHooks(time.Millisecond)
+
+	f.CoreV1().Pods("test").Create(pod)
+
+	if err == nil {
+		t.Error("expected uncalled hook to cause a timeout error")
+	}
+	if createCalled == true {
+		t.Error("expected create hook not to be called")
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The hook actions generally capture variables that are part of the scope of the tests they are used in (most notably `t` itself). If a hook executes after a test has already finished and moved on that results in data races.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
