### PR TITLE
add test for websocket connection through activator

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -52,8 +52,8 @@ func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, opt
 	return names, err
 }
 
-// WaitForScaleToZero will wait for the deployment specified by names to scale
-// to 0 replicas. Will wait up to 3 minutes before failing.
+// WaitForScaleToZero will wait for the deployment specified by names to scale to
+// 0 replicas. Will wait up to 6 times the configured ScaleToZeroGracePeriod before failing.
 func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clients) error {
 	t.Helper()
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -68,26 +68,24 @@ func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clien
 		},
 		"DeploymentIsScaledDown",
 		test.ServingNamespace,
-		scaleToZeroGracePeriod(t, clients.KubeClient),
+		scaleToZeroGracePeriod(t, clients.KubeClient)*6,
 	)
 }
 
 func scaleToZeroGracePeriod(t *testing.T, client *pkgTest.KubeClient) time.Duration {
-	const gracePeriodMultiplier = 6
-
 	t.Helper()
 
 	autoscalerCM, err := client.Kube.CoreV1().ConfigMaps("knative-serving").Get("config-autoscaler", metav1.GetOptions{})
 	if err != nil {
 		t.Logf("Failed to Get autoscaler configmap = %v, falling back to DefaultScaleToZeroGracePeriod", err)
-		return autoscaler.DefaultScaleToZeroGracePeriod * gracePeriodMultiplier
+		return autoscaler.DefaultScaleToZeroGracePeriod
 	}
 
 	config, err := autoscaler.NewConfigFromConfigMap(autoscalerCM)
 	if err != nil {
 		t.Log("Failed to build autoscaler config, falling back to DefaultScaleToZeroGracePeriod")
-		return autoscaler.DefaultScaleToZeroGracePeriod * gracePeriodMultiplier
+		return autoscaler.DefaultScaleToZeroGracePeriod
 	}
 
-	return config.ScaleToZeroGracePeriod * gracePeriodMultiplier
+	return config.ScaleToZeroGracePeriod
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -73,19 +73,21 @@ func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clien
 }
 
 func scaleToZeroGracePeriod(t *testing.T, client *pkgTest.KubeClient) time.Duration {
+	const gracePeriodMultiplier = 6
+
 	t.Helper()
 
 	autoscalerCM, err := client.Kube.CoreV1().ConfigMaps("knative-serving").Get("config-autoscaler", metav1.GetOptions{})
 	if err != nil {
-		t.Log("failed to Get autoscaler configmap, falling back to DefaultScaleToZeroGracePeriod")
-		return autoscaler.DefaultScaleToZeroGracePeriod * 6
+		t.Logf("Failed to Get autoscaler configmap = %v, falling back to DefaultScaleToZeroGracePeriod", err)
+		return autoscaler.DefaultScaleToZeroGracePeriod * gracePeriodMultiplier
 	}
 
 	config, err := autoscaler.NewConfigFromConfigMap(autoscalerCM)
 	if err != nil {
-		t.Log("failed to build autoscaler config, falling back to DefaultScaleToZeroGracePeriod")
-		return autoscaler.DefaultScaleToZeroGracePeriod * 6
+		t.Log("Failed to build autoscaler config, falling back to DefaultScaleToZeroGracePeriod")
+		return autoscaler.DefaultScaleToZeroGracePeriod * gracePeriodMultiplier
 	}
 
-	return config.ScaleToZeroGracePeriod * 6
+	return config.ScaleToZeroGracePeriod * gracePeriodMultiplier
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -52,8 +52,8 @@ func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, opt
 	return names, err
 }
 
-// WaitForScaleToZero will wait for the deployment specified by names to scale to
-// 0 replicas. Will wait up to 6 times the configured ScaleToZeroGracePeriod before failing.
+// WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
+// Will wait up to 6 times the configured ScaleToZeroGracePeriod before failing.
 func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clients) error {
 	t.Helper()
 

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -26,7 +26,6 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/spoof"
-	rnames "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
 	"github.com/knative/serving/test"
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	"google.golang.org/grpc"
@@ -191,12 +190,7 @@ func TestGRPCStreamingPing(t *testing.T) {
 
 func TestGRPCUnaryPingFromZero(t *testing.T) {
 	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		rev, err := clients.ServingClient.Revisions.Get(names.Revision, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Error fetching Revision %s: %v", names.Revision, err)
-		}
-
-		deploymentName := rnames.Deployment(rev)
+		deploymentName := names.Revision + "-deployment"
 
 		if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
 			t.Fatalf("Could not scale to zero: %v", err)
@@ -208,12 +202,7 @@ func TestGRPCUnaryPingFromZero(t *testing.T) {
 
 func TestGRPCStreamingPingFromZero(t *testing.T) {
 	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		rev, err := clients.ServingClient.Revisions.Get(names.Revision, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Error fetching Revision %s: %v", names.Revision, err)
-		}
-
-		deploymentName := rnames.Deployment(rev)
+		deploymentName := names.Revision + "-deployment"
 
 		if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
 			t.Fatalf("Could not scale to zero: %v", err)

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -190,14 +190,24 @@ func TestGRPCStreamingPing(t *testing.T) {
 
 func TestGRPCUnaryPingFromZero(t *testing.T) {
 	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		WaitForScaleToZero(t, names, clients)
+		rev, err := clients.ServingClient.Revisions.Get(names.Revision, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Error fetching Revision %s: %v", names.Revision, err)
+		}
+
+		WaitForScaleToZero(t, rev, clients)
 		unaryTest(t, names, clients, host, domain)
 	})
 }
 
 func TestGRPCStreamingPingFromZero(t *testing.T) {
 	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		WaitForScaleToZero(t, names, clients)
+		rev, err := clients.ServingClient.Revisions.Get(names.Revision, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Error fetching Revision %s: %v", names.Revision, err)
+		}
+
+		WaitForScaleToZero(t, rev, clients)
 		streamTest(t, names, clients, host, domain)
 	})
 }

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -26,6 +26,7 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/spoof"
+	rnames "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
 	"github.com/knative/serving/test"
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	"google.golang.org/grpc"
@@ -195,7 +196,9 @@ func TestGRPCUnaryPingFromZero(t *testing.T) {
 			t.Fatalf("Error fetching Revision %s: %v", names.Revision, err)
 		}
 
-		WaitForScaleToZero(t, rev, clients)
+		deploymentName := rnames.Deployment(rev)
+
+		WaitForScaleToZero(t, deploymentName, clients)
 		unaryTest(t, names, clients, host, domain)
 	})
 }
@@ -207,7 +210,9 @@ func TestGRPCStreamingPingFromZero(t *testing.T) {
 			t.Fatalf("Error fetching Revision %s: %v", names.Revision, err)
 		}
 
-		WaitForScaleToZero(t, rev, clients)
+		deploymentName := rnames.Deployment(rev)
+
+		WaitForScaleToZero(t, deploymentName, clients)
 		streamTest(t, names, clients, host, domain)
 	})
 }

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -30,7 +30,6 @@ import (
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -119,26 +118,6 @@ func streamTest(t *testing.T, names test.ResourceNames, clients *test.Clients, h
 	}
 }
 
-func waitForScaleToZero(t *testing.T, names test.ResourceNames, clients *test.Clients) {
-	t.Helper()
-	deploymentName := names.Revision + "-deployment"
-	t.Logf("Waiting for %q to scale to zero", deploymentName)
-	err := pkgTest.WaitForDeploymentState(
-		clients.KubeClient,
-		deploymentName,
-		func(d *v1beta1.Deployment) (bool, error) {
-			t.Logf("Deployment %q has %d replicas", deploymentName, d.Status.ReadyReplicas)
-			return d.Status.ReadyReplicas == 0, nil
-		},
-		"DeploymentIsScaledDown",
-		test.ServingNamespace,
-		3*time.Minute,
-	)
-	if err != nil {
-		t.Fatalf("Could not scale to zero: %v", err)
-	}
-}
-
 func testGRPC(t *testing.T, f grpcTest) {
 	t.Helper()
 	t.Parallel()
@@ -211,14 +190,14 @@ func TestGRPCStreamingPing(t *testing.T) {
 
 func TestGRPCUnaryPingFromZero(t *testing.T) {
 	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		waitForScaleToZero(t, names, clients)
+		WaitForScaleToZero(t, names, clients)
 		unaryTest(t, names, clients, host, domain)
 	})
 }
 
 func TestGRPCStreamingPingFromZero(t *testing.T) {
 	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		waitForScaleToZero(t, names, clients)
+		WaitForScaleToZero(t, names, clients)
 		streamTest(t, names, clients, host, domain)
 	})
 }

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -198,7 +198,10 @@ func TestGRPCUnaryPingFromZero(t *testing.T) {
 
 		deploymentName := rnames.Deployment(rev)
 
-		WaitForScaleToZero(t, deploymentName, clients)
+		if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
+			t.Fatalf("Could not scale to zero: %v", err)
+		}
+
 		unaryTest(t, names, clients, host, domain)
 	})
 }
@@ -212,7 +215,10 @@ func TestGRPCStreamingPingFromZero(t *testing.T) {
 
 		deploymentName := rnames.Deployment(rev)
 
-		WaitForScaleToZero(t, deploymentName, clients)
+		if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
+			t.Fatalf("Could not scale to zero: %v", err)
+		}
+
 		streamTest(t, names, clients, host, domain)
 	})
 }

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	connectRetryInterval = 1 * time.Second
-	connectTimeout       = 6 * time.Minute
+	connectRetryInterval  = 1 * time.Second
+	connectTimeout        = 6 * time.Minute
+	wsServerTestImageName = "wsserver"
 )
 
 // connect attempts to establish WebSocket connection with the Service.
@@ -130,7 +131,7 @@ func TestWebSocket(t *testing.T) {
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
-		Image:   "wsserver",
+		Image:   wsServerTestImageName,
 	}
 
 	// Clean up in both abnormal and normal exits.
@@ -143,6 +144,34 @@ func TestWebSocket(t *testing.T) {
 	}
 
 	// Validate the websocket connection.
+	if err := validateWebSocketConnection(t, clients, names); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestWebSocketFromZero (1) creates a service based on the `wsserver` image,
+// (2) waits for the service to be scaled down to zero replicas
+// (3) connects to the service using websocket, (4) sends a message, and
+// (5) verifies that we receive back the same message.
+func TestWebSocketFromZero(t *testing.T) {
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   wsServerTestImageName,
+	}
+
+	// Clean up in both abnormal and normal exits.
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+
+	// Setup a WebSocket server.
+	if _, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}); err != nil {
+		t.Fatalf("Failed to create WebSocket server: %v", err)
+	}
+
+	WaitForScaleToZero(t, names, clients)
+
 	if err := validateWebSocketConnection(t, clients, names); err != nil {
 		t.Error(err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	rnames "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
 	"github.com/knative/serving/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -172,7 +173,9 @@ func TestWebSocketFromZero(t *testing.T) {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
-	if err := WaitForScaleToZero(t, resources.Revision, clients); err != nil {
+	deploymentName := rnames.Deployment(resources.Revision)
+
+	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
 		t.Fatalf("Could not scale to zero: %v", err)
 	}
 

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -139,7 +139,6 @@ func TestWebSocket(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	// Setup a WebSocket server.
 	if _, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
@@ -166,9 +165,7 @@ func TestWebSocketFromZero(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	// Setup a WebSocket server.
 	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{})
-
 	if err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -166,11 +166,15 @@ func TestWebSocketFromZero(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup a WebSocket server.
-	if _, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}); err != nil {
+	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{})
+
+	if err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
-	WaitForScaleToZero(t, names, clients)
+	if err := WaitForScaleToZero(t, resources.Revision, clients); err != nil {
+		t.Fatalf("Could not scale to zero: %v", err)
+	}
 
 	if err := validateWebSocketConnection(t, clients, names); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Addresses #3254

Adds a test that stands up a service based on the wsserver
test image, polls it until it is scaled down to zero replicas,
then initiates a websocket connection.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

