### PR TITLE
Remove Lameduck field from Stat

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -53,10 +53,6 @@ type Stat struct {
 
 	// Number of requests received since last Stat (approximately QPS).
 	RequestCount int32
-
-	// Lameduck indicates this Pod has received a shutdown signal.
-	// Deprecated and no longer used by newly created Pods.
-	LameDuck bool
 }
 
 // StatMessage wraps a Stat with identifying information so it can be routed

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -558,7 +558,7 @@ func (a *Autoscaler) recordLinearSeries(test *testing.T, now time.Time, s linear
 			a.Record(TestContextWithLogger(test), stat)
 		}
 	}
-	// Change the IP count according to podCount and lameduck
+	// Change the IP count according to podCount
 	createEndpoints(addIps(makeEndpoints(), s.podCount))
 	return now
 }


### PR DESCRIPTION
Starting 0.4 release, queue-proxy no longer sends metrics to autoscaler if the pods are terminating. Now `Lameduck` field of `Stat` is no longer used anywhere. This PR removes it.