### PR TITLE
Remove endpoint `/quitquitquit` from admin server

### DIFF
--- a/pkg/queue/constants.go
+++ b/pkg/queue/constants.go
@@ -17,15 +17,14 @@ limitations under the License.
 package queue
 
 const (
-	// RequestQueueQuitPath specifies the path to send quit request to
-	// queue-proxy. This is used for preStop hook of queue-proxy. It:
-	// - marks the service as not ready, so that requests will no longer
-	//   be routed to it,
-	// - adds a small delay, so that the container doesn't get killed at
-	//   the same time the pod is marked for removal.
-	RequestQueueQuitPath = "/quitquitquit"
-
 	// RequestQueueHealthPath specifies the path for health checks for
 	// queue-proxy.
 	RequestQueueHealthPath = "/health"
+
+	// RequestQueueDrainPath specifies the path to wait until the proxy
+	// server is shut down. Any subsequent calls to this endpoint after
+	// the server has finished shutting down it will return immediately.
+	// Main usage is to delay the termination of user-container until all
+	// accepted requests have been processed.
+	RequestQueueDrainPath = "/wait-for-drain"
 )

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 const (
@@ -123,7 +124,7 @@ func TestHealthStateHealthHandler(t *testing.T) {
 	}
 }
 
-func TestHealthStateQuitHandler(t *testing.T) {
+func TestHealthStateDrainHandler(t *testing.T) {
 	state := &State{}
 	state.setAlive()
 
@@ -134,22 +135,48 @@ func TestHealthStateQuitHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 
-	calledCh := make(chan struct{}, 1)
-	handler := http.HandlerFunc(state.QuitHandler(func() {
-		close(calledCh)
-	}))
-	handler.ServeHTTP(rr, req)
+	completedCh := make(chan struct{}, 1)
+	handler := http.HandlerFunc(state.DrainHandler())
+	go func(handler http.Handler, recorder *httptest.ResponseRecorder) {
+		handler.ServeHTTP(recorder, req)
+		close(completedCh)
+	}(handler, rr)
 
-	// The channel should be closed as the cleaner is called.
-	<-calledCh
+	state.drainFinished()
+	<-completedCh
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			rr.Code, http.StatusOK)
 	}
+}
 
-	if rr.Body.String() != notAliveBody {
-		t.Errorf("handler returned unexpected body: got %v want %v",
-			rr.Body.String(), notAliveBody)
+func TestHealthStateShutdown(t *testing.T) {
+	state := &State{}
+	state.setAlive()
+	state.drainCh = make(chan struct{})
+
+	calledCh := make(chan struct{}, 1)
+	state.Shutdown(func() {
+		close(calledCh)
+	})
+
+	// The channel should be closed as the cleaner is called.
+	select {
+	case <-calledCh:
+	case <-time.After(2 * time.Second):
+		t.Errorf("drain function not called when shutting down")
+	}
+
+	if !state.drainCompleted {
+		t.Error("shutdown did not complete draining")
+	}
+
+	if !state.shuttingDown {
+		t.Errorf("wrong shutdown state: got %v want %v", state.shuttingDown, true)
+	}
+
+	if state.alive {
+		t.Errorf("wrong alive state: got %v want %v", state.alive, false)
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -63,7 +63,7 @@ var (
 		PreStop: &corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port: intstr.FromInt(v1alpha1.RequestQueueAdminPort),
-				Path: queue.RequestQueueQuitPath,
+				Path: queue.RequestQueueDrainPath,
 			},
 		},
 	}

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -70,7 +70,6 @@ var (
 		Name:           QueueContainerName,
 		Resources:      queueResources,
 		Ports:          queuePorts,
-		Lifecycle:      queueLifecycle,
 		ReadinessProbe: queueReadinessProbe,
 		Env: []corev1.EnvVar{{
 			Name:  "SERVING_NAMESPACE",

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"strconv"
 
 	"github.com/knative/pkg/logging"
@@ -27,7 +28,6 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var (
@@ -47,16 +47,7 @@ var (
 		Name:          v1alpha1.RequestQueueMetricsPortName,
 		ContainerPort: int32(v1alpha1.RequestQueueMetricsPort),
 	}}
-	// This handler (1) marks the service as not ready and (2)
-	// adds a small delay before the container is killed.
-	queueLifecycle = &corev1.Lifecycle{
-		PreStop: &corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port: intstr.FromInt(v1alpha1.RequestQueueAdminPort),
-				Path: queue.RequestQueueQuitPath,
-			},
-		},
-	}
+
 	queueReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -97,7 +88,6 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, a
 		Image:          controllerConfig.QueueSidecarImage,
 		Resources:      queueResources,
 		Ports:          queuePorts,
-		Lifecycle:      queueLifecycle,
 		ReadinessProbe: queueReadinessProbe,
 		Env: []corev1.EnvVar{{
 			Name:  "SERVING_NAMESPACE",

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -70,7 +70,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
-			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env: []corev1.EnvVar{{
@@ -140,7 +139,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
-			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -216,7 +214,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
-			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env: []corev1.EnvVar{{
@@ -289,7 +286,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
-			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env: []corev1.EnvVar{{
@@ -357,7 +353,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			Name:           QueueContainerName,
 			Resources:      queueResources,
 			Ports:          queuePorts,
-			Lifecycle:      queueLifecycle,
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env: []corev1.EnvVar{{


### PR DESCRIPTION
In this PR the goal is to avoid exposing the admin port to all other pods while maintaining liveness and readiness probing.
- Port 8022 is no longer exposed through deployment
- Admin server is now only bound to localhost
- Liveness and Readiness probes are now executing the queue application to hit its own endpoints.
  * This was done to avoid either updating the base image to have something like `curl` or creating another binary whose sole purpose is to query the admin endpoints.
  * To query health or quit it's now `/ko-app/queue exec health` and `/ko-app/queue exec quit`

Fixes #3279

/lint
/wip
/hold

Open questions:
- Should the executable path be configurable through a `ConfigMap`? Separate PR?
