### PR TITLE
extending revision spec to support image registry authentication

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -229,6 +229,12 @@ type RevisionSpec struct {
 	// +optional
 	Container corev1.Container `json:"container,omitempty"`
 
+	// ImagePullSecrets defines a list of secrets which can be used to authenticate
+	// against a private secure registry. Secret(s) must exist in the same namespace
+	// as a revision's pod.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
 	// Volumes defines a set of Kubernetes volumes to be mounted into the
 	// specified Container.  Currently only ConfigMap and Secret volumes are
 	// supported.

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -305,6 +305,11 @@ func (in *RevisionSpec) DeepCopyInto(out *RevisionSpec) {
 		}
 	}
 	in.Container.DeepCopyInto(&out.Container)
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy.go
@@ -147,6 +147,10 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 		ServiceAccountName:            rev.Spec.ServiceAccountName,
 		TerminationGracePeriodSeconds: &revisionTimeout,
 	}
+	// In case secret(s) for accessing image registry is provided, adding it to the POD spec.
+	if rev.Spec.ImagePullSecrets != nil {
+		podSpec.ImagePullSecrets = rev.Spec.ImagePullSecrets
+	}
 
 	// Add Fluentd sidecar and its config map volume if var log collection is enabled.
 	if observabilityConfig.EnableVarLogCollection {

--- a/pkg/reconciler/v1alpha1/revision/resources/imagecache.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/imagecache.go
@@ -47,10 +47,11 @@ func MakeImageCache(rev *v1alpha1.Revision, deploy *appsv1.Deployment) (*caching
 				// Key off of the Deployment for the resolved image digest.
 				Image:              container.Image,
 				ServiceAccountName: deploy.Spec.Template.Spec.ServiceAccountName,
-				// We don't support ImagePullSecrets today.
 			},
 		}
-
+		if rev.Spec.ImagePullSecrets != nil {
+			img.Spec.ImagePullSecrets = rev.Spec.ImagePullSecrets
+		}
 		return img, nil
 	}
 	return nil, fmt.Errorf("user container %q not found: %v", UserContainerName, deploy)

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -346,9 +346,15 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 	opt := k8schain.Options{
 		Namespace:          rev.Namespace,
 		ServiceAccountName: rev.Spec.ServiceAccountName,
-		// ImagePullSecrets: Not possible via RevisionSpec, since we
-		// don't expose such a field.
 	}
+	var secrets []string
+	if rev.Spec.ImagePullSecrets != nil {
+		secrets = make([]string, len(rev.Spec.ImagePullSecrets))
+		for _, s := range rev.Spec.ImagePullSecrets {
+			secrets = append(secrets, s.Name)
+		}
+	}
+	opt.ImagePullSecrets = secrets
 	digest, err := c.resolver.Resolve(rev.Spec.Container.Image, opt, cfgs.Controller.RegistriesSkippingTagResolving)
 	if err != nil {
 		rev.Status.MarkContainerMissing(v1alpha1.RevisionContainerMissingMessage(rev.Spec.Container.Image, err.Error()))


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently image used for revision is defined in a revision spec, in case a private image registry used, there is no way to provide credentials to use to pull the image. 
## Proposed Changes
Extend RevisionSpec to include a slice of Local Object References which points to kubernetes secret object(s) that should be used to pull an image for the revision, 

```release-note
None
```
