### PR TITLE
The test loggers were not cleared, prohibiting `-count=X>1` execution

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -329,6 +329,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 }
 
 func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
+	defer ClearAllLoggers()
 	_, _, servingClient, controller, _, _, sharedInformer, servingInformer, watcher := newTestSetup(t)
 
 	stopCh := make(chan struct{})

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -857,6 +857,7 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 }
 
 func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
+	defer ClearAllLoggers()
 	// Test changes in domain config map. Routes should get updated appropriately.
 	// We're expecting exactly one route modification per config-map change.
 	tests := []struct {


### PR DESCRIPTION

Also:
go test ./pkg/reconciler/v1alpha1/route
-test.run=TestGlobalResyncOnUpdateDomainConfigMap -count=40 -race
PASS | github.com/knative/serving/pkg/reconciler/v1alpha1/route 83.233s
in relation to #3351.

/cc @mattmoor @dgerd 