### PR TITLE
Verify revision identity before scale-up E2E test

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -209,7 +209,6 @@ func assertScaleUp(ctx *testContext) {
 	if err != nil {
 		ctx.t.Fatalf("Unable to observe the Deployment named %s scaling up. %s", ctx.deploymentName, err)
 	}
-
 }
 
 func assertScaleDown(ctx *testContext) {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -210,7 +210,7 @@ func assertScaleUp(ctx *testContext) {
 	}
 
 	// verify scale-up has happened
-	if dep.Status.ReadyReplicas <= 0 {
+	if dep.Status.ReadyReplicas == 0 {
 		ctx.t.Fatalf("Deployment %s failed to scale up", ctx.deploymentName)
 	}
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -177,6 +177,12 @@ func setup(t *testing.T) *testContext {
 	}
 
 	t.Logf("Revision under test: %s", names.Revision)
+
+	// verify that revision is consistent and is ready
+	if err := test.CheckRevisionState(clients.ServingClient, names.Revision, test.IsRevisionReady); err != nil {
+		t.Fatalf("The Revision %s is not in ready state: %v", names.Revision, err)
+	}
+
 	return &testContext{
 		t:              t,
 		clients:        clients,
@@ -202,16 +208,6 @@ func assertScaleUp(ctx *testContext) {
 		2*time.Minute)
 	if err != nil {
 		ctx.t.Fatalf("Unable to observe the Deployment named %s scaling up. %s", ctx.deploymentName, err)
-	}
-
-	dep, err := ctx.clients.KubeClient.Kube.AppsV1().Deployments(test.ServingNamespace).Get(ctx.deploymentName, metav1.GetOptions{})
-	if err != nil {
-		ctx.t.Fatalf("Could not get deployment %v", ctx.deploymentName)
-	}
-
-	// verify scale-up has happened
-	if dep.Status.ReadyReplicas == 0 {
-		ctx.t.Fatalf("Deployment %s failed to scale up", ctx.deploymentName)
 	}
 
 }
@@ -250,7 +246,7 @@ func assertScaleDown(ctx *testContext) {
 
 	ctx.t.Log("The Revision should remain ready after scaling to zero.")
 	if err := test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, test.IsRevisionReady); err != nil {
-		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zero: %v", ctx.names.Revision, err)
+		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zerozero: %v", ctx.names.Revision, err)
 	}
 
 	ctx.t.Log("Scaled down.")

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -246,7 +246,7 @@ func assertScaleDown(ctx *testContext) {
 
 	ctx.t.Log("The Revision should remain ready after scaling to zero.")
 	if err := test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, test.IsRevisionReady); err != nil {
-		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zerozero: %v", ctx.names.Revision, err)
+		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zero: %v", ctx.names.Revision, err)
 	}
 
 	ctx.t.Log("Scaled down.")

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -198,7 +198,7 @@ func assertScaleUp(ctx *testContext) {
 	if err != nil {
 		ctx.t.Fatalf("Error during initial scale up: %v", err)
 	}
-	ctx.t.Logf("Waiting for scale up revsion %s", ctx.names.Revision)
+	ctx.t.Logf("Waiting for scale up revision %s", ctx.names.Revision)
 	err = pkgTest.WaitForDeploymentState(
 		ctx.clients.KubeClient,
 		ctx.deploymentName,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2318

## Proposed Changes

* Log revision under test in scale up test.
* Verify that revision is consistent in setup().

NB: random string is injected to revision by #3268
 https://github.com/knative/serving/blob/5424ed3359eae4b4b0efb09882e7723fe5e7bb32/test/crd.go#L272

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
