### PR TITLE
Use a value for empty strings in stats reporter

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -52,7 +52,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	namespace := pkghttp.LastHeaderValue(r.Header, activator.RevisionHeaderNamespace)
 	name := pkghttp.LastHeaderValue(r.Header, activator.RevisionHeaderName)
 	start := time.Now()
-	revID := activator.RevisionID{namespace, name}
+	revID := activator.RevisionID{Namespace:namespace, Name:name}
 
 	// ActiveEndpoint() will block until the first endpoint is available.
 	ar := a.Activator.ActiveEndpoint(namespace, name)

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -117,16 +117,24 @@ func NewStatsReporter() (*Reporter, error) {
 	return r, nil
 }
 
+func valueOrUnknown(v string) string {
+	if v != "" {
+		return v
+	}
+	return metricskey.ValueUnknown
+}
+
 // ReportRequestCount captures request count metric with value v.
 func (r *Reporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v int64) error {
 	if !r.initialized {
 		return errors.New("StatsReporter is not initialized yet")
 	}
 
+	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		context.Background(),
 		tag.Insert(r.namespaceTagKey, ns),
-		tag.Insert(r.serviceTagKey, service),
+		tag.Insert(r.serviceTagKey, valueOrUnknown(service)),
 		tag.Insert(r.configTagKey, config),
 		tag.Insert(r.revisionTagKey, rev),
 		tag.Insert(r.responseCodeKey, strconv.Itoa(responseCode)),
@@ -146,10 +154,11 @@ func (r *Reporter) ReportResponseTime(ns, service, config, rev string, responseC
 		return errors.New("StatsReporter is not initialized yet")
 	}
 
+	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		context.Background(),
 		tag.Insert(r.namespaceTagKey, ns),
-		tag.Insert(r.serviceTagKey, service),
+		tag.Insert(r.serviceTagKey, valueOrUnknown(service)),
 		tag.Insert(r.configTagKey, config),
 		tag.Insert(r.revisionTagKey, rev),
 		tag.Insert(r.responseCodeKey, strconv.Itoa(responseCode)),

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -84,6 +84,44 @@ func TestActivatorReporter(t *testing.T) {
 	checkDistributionData(t, "request_latencies", wantTags3, 2, 1100.0, 9100.0)
 }
 
+func TestReportRequestCount_EmptyServiceName(t *testing.T) {
+	r, _ := NewStatsReporter()
+	defer unregister()
+
+	wantTags := map[string]string{
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       metricskey.ValueUnknown,
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+		"response_code":                   "200",
+		"response_code_class":             "2xx",
+		"num_tries":                       "6",
+	}
+	expectSuccess(t, func() error { return r.ReportRequestCount("testns", /*service=*/"", "testconfig", "testrev", 200, 6, 10) })
+	checkSumData(t, "request_count", wantTags, 10)
+}
+
+func TestReportResponseTime_EmptyServiceName(t *testing.T) {
+	r, _ := NewStatsReporter()
+	defer unregister()
+
+	wantTags := map[string]string{
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       metricskey.ValueUnknown,
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+		"response_code":                   "200",
+		"response_code_class":             "2xx",
+	}
+	expectSuccess(t, func() error {
+		return r.ReportResponseTime("testns", /*service=*/"", "testconfig", "testrev", 200, 7100*time.Millisecond)
+	})
+	expectSuccess(t, func() error {
+		return r.ReportResponseTime("testns", /*service=*/"", "testconfig", "testrev", 200, 5100*time.Millisecond)
+	})
+	checkDistributionData(t, "request_latencies", wantTags, 2, 5100.0, 7100.0)
+}
+
 func expectSuccess(t *testing.T, f func() error) {
 	t.Helper()
 	if err := f(); err != nil {

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -167,17 +167,25 @@ type Reporter struct {
 	initialized bool
 }
 
+func valueOrUnknown(v string) string {
+	if v != "" {
+		return v
+	}
+	return metricskey.ValueUnknown
+}
+
 // NewStatsReporter creates a reporter that collects and reports autoscaler metrics
 func NewStatsReporter(podNamespace string, service string, config string, revision string) (*Reporter, error) {
 
 	r := &Reporter{}
 
 	// Our tags are static. So, we can get away with creating a single context
-	// and reuse it for reporting all of our metrics.
+	// and reuse it for reporting all of our metrics. Note that service names
+	// can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		context.Background(),
 		tag.Insert(namespaceTagKey, podNamespace),
-		tag.Insert(serviceTagKey, service),
+		tag.Insert(serviceTagKey, valueOrUnknown(service)),
 		tag.Insert(configTagKey, config),
 		tag.Insert(revisionTagKey, revision))
 	if err != nil {

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -97,6 +97,19 @@ func TestReporter_Report(t *testing.T) {
 	checkData(t, "panic_mode", wantTags, 0)
 }
 
+func TestReporter_EmptyServiceName(t *testing.T) {
+	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
+	r, _ := NewStatsReporter("testns", /*service=*/"", "testconfig", "testrev")
+	wantTags := map[string]string{
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       metricskey.ValueUnknown,
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+	}
+	expectSuccess(t, "ReportDesiredPodCount", func() error { return r.ReportDesiredPodCount(10) })
+	checkData(t, "desired_pods", wantTags, 10)
+}
+
 func expectSuccess(t *testing.T, funcName string, f func() error) {
 	if err := f(); err != nil {
 		t.Errorf("Reporter.%v() expected success but got error %v", funcName, err)
@@ -107,10 +120,12 @@ func checkData(t *testing.T, name string, wantTags map[string]string, wantValue 
 	if d, err := view.RetrieveData(name); err != nil {
 		t.Errorf("Got unexpected error from view.RetrieveData error: %v", err)
 	} else {
-		if len(d) != 1 {
-			t.Errorf("Want 1 data row but got %d from view.RetrieveData", len(d))
+		if len(d) > 2 {
+			t.Errorf("Want at most 2 data rows but got %d from view.RetrieveData", len(d))
 		}
-		for _, got := range d[0].Tags {
+		// The last row has the latest data, which is from the current test case.
+		last := len(d) - 1
+		for _, got := range d[last].Tags {
 			if want, ok := wantTags[got.Key.Name()]; !ok {
 				t.Errorf("Got an extra tag from view.RetrieveData: (%v, %v)", got.Key.Name(), got.Value)
 			} else {
@@ -120,7 +135,7 @@ func checkData(t *testing.T, name string, wantTags map[string]string, wantValue 
 			}
 		}
 
-		if s, ok := d[0].Data.(*view.LastValueData); !ok {
+		if s, ok := d[last].Data.(*view.LastValueData); !ok {
 			t.Error("Expected a LastValueData type from view.RetrieveData")
 		} else {
 			if s.Value != wantValue {


### PR DESCRIPTION
Some apps do not define service names (i.e., service name is ""),
and stats reporter takes it as missing service names.  The error is
reported as "Failed to export to Prometheus: inconsistent label
cardinality" in autoscaler's log.

This fix uses a special value instead of "" so that stats reporter has
enough dimensions.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #2480 

## Proposed Changes

* Use "empty" for "" in stats reporter.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
