### PR TITLE
Simplify activator test, add body to failure output.

### DIFF
--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -84,10 +84,6 @@ func TestActivatorOverload(t *testing.T) {
 	client.RequestTimeout = timeout
 
 	url := fmt.Sprintf("http://%s/?timeout=%d", domain, serviceSleep)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatalf("error creating http request: %v", err)
-	}
 
 	t.Log("Starting to send out the requests")
 
@@ -97,6 +93,14 @@ func TestActivatorOverload(t *testing.T) {
 		group.Add(1)
 		go func() {
 			defer group.Done()
+
+			// We need to create a new request per HTTP request because
+			// the spoofing client mutates them.
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Errorf("error creating http request: %v", err)
+			}
+
 			res, err := client.Do(req)
 			if err != nil {
 				t.Errorf("unexpected error sending a request, %v", err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

It turns out that only `Fatal(f)` and `Skip(f)` need to be called from the same goroutine as the test itself. Others can be called concurrently. That enables simplifying the test by quite a bit. See https://golang.org/pkg/testing/#T.

The wanted change here is adding the body to failure output. It's needed to be able to tell where errors come from, for example in https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-serving-continuous/1102599979622469632.

## Proposed Changes

- Simplifies the test-routine of the activator overload test for improved maintainability.
- Adds the body to potential error output to be able to distinguish different error scenarios.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
