### PR TITLE
development.md: show override PROJECT_ID

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -170,7 +170,7 @@ Next, run:
 
 ```shell
 ko apply -f config/
-./hack/dev-patch-config-gke.sh my-k8s-cluster-name  # optional
+PROJECT_ID="my-gcp-project-id" ./hack/dev-patch-config-gke.sh my-k8s-cluster-name  # optional
 ```
 
 The above step is equivalent to applying the `serving.yaml` for released


### PR DESCRIPTION
I assume most people are not on the knative-environments project.
So showing how to override the default in the build/deploy doc.