### PR TITLE
[WIP] Add a K8s Job to configure a default domain.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,7 +450,7 @@
   revision = "06e9787157505a649b07677e77d26202ac91431c"
 
 [[projects]]
-  digest = "1:96668306757feff41921a310fd40dc87106cb803a5ab3297870e3837e4e8108f"
+  digest = "1:859db0b308a91086f43938573d9b7ab4865ebb699ee9c09a0a346a9dfc8b132e"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -492,6 +492,7 @@
     "test",
     "test/helpers",
     "test/logging",
+    "test/monitoring",
     "test/spoof",
     "test/zipkin",
     "tracker",
@@ -500,7 +501,8 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "2a8c1b0e5ad2719b00e20fef8594d63fa202640f"
+  revision = "e3954f08206bc00f7b1dd80f0492ce592b0171b8"
+  source = "github.com/mattmoor/pkg-1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,8 +28,9 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-02-27
-  revision = "2a8c1b0e5ad2719b00e20fef8594d63fa202640f"
+  # HEAD as of 2019-03-06
+  source = "github.com/mattmoor/pkg-1"
+  revision = "e3954f08206bc00f7b1dd80f0492ce592b0171b8"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/test/config/300-defaultdomain.yaml
+++ b/test/config/300-defaultdomain.yaml
@@ -1,0 +1,40 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: defaultdomain
+  namespace: knative-serving
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      # Piggyback on the controller's service account.
+      serviceAccountName: controller
+      containers:
+      - name: defaultdomain
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: github.com/knative/serving/test/defaultdomain
+        args: ["-magic-dns=xip.io"]
+        env:
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      restartPolicy: Never
+  backoffLimit: 10

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -100,6 +100,14 @@ func validateDomains(
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
 	// In order for tests to succeed reliably, we need to make sure that all domains succeed.
+	for _, resp := range baseExpected {
+		// Check for each of the responses we expect from the base domain.
+		resp := resp
+		g.Go(func() error {
+			t.Logf("Waiting for route to update domain: %s", baseDomain)
+			return waitForExpectedResponse(t, clients, baseDomain, resp)
+		})
+	}
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {

--- a/test/defaultdomain/main.go
+++ b/test/defaultdomain/main.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// Uncomment the following line to load the gcp plugin (only required
+	// to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/system"
+	cicfg "github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/config"
+	routecfg "github.com/knative/serving/pkg/reconciler/v1alpha1/route/config"
+)
+
+var (
+	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	magicDNS   = flag.String("magic-dns", "", "The hostname for the magic DNS service, e.g. xip.io or nip.io")
+)
+
+func main() {
+	flag.Parse()
+	logger := logging.FromContext(context.TODO()).Named("defaultdomain")
+
+	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+	if err != nil {
+		logger.Fatalw("Error building kubeconfig", zap.Error(err))
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		logger.Fatalw("Error building kube clientset", zap.Error(err))
+	}
+
+	// Fetch and parse the domain ConfigMap from the system namespace.
+	domainCM, err := kubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(
+		routecfg.DomainConfigName, metav1.GetOptions{})
+	if err != nil {
+		logger.Fatalw("Error getting ConfigMap", zap.Error(err))
+	}
+	domainConfig, err := routecfg.NewDomainFromConfigMap(domainCM)
+	if err != nil {
+		logger.Fatalw("Error parsing ConfigMap", zap.Error(err))
+	}
+	// If there is a catch-all domain configured, then bail out (successfully) here.
+	defaultDomain := domainConfig.LookupDomainForLabels(map[string]string{})
+	if defaultDomain != routecfg.DefaultDomain {
+		logger.Infof("Domain is configured as: %v", defaultDomain)
+		return
+	}
+
+	// Fetch and parse the Istio-ClusterIngress ConfigMap from the system namespace.
+	istioCM, err := kubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(
+		cicfg.IstioConfigName, metav1.GetOptions{})
+	if err != nil {
+		logger.Fatalw("Error getting ConfigMap", zap.Error(err))
+	}
+	istioConfig, err := cicfg.NewIstioFromConfigMap(istioCM)
+	if err != nil {
+		logger.Fatalw("Error parsing ConfigMap", zap.Error(err))
+	}
+
+	// Parse the service name to determine which Kubernetes Service resource to fetch.
+	serviceURL := istioConfig.IngressGateways[0].ServiceURL
+	parts := strings.SplitN(serviceURL, ".", 3)
+	if len(parts) != 3 {
+		logger.Fatalf("Unexpected service URL form: %v", serviceURL)
+	}
+
+	// Use the first two name parts to lookup the Kubernetes Service resource.
+	name, ns := parts[0], parts[1]
+	gwSvc, err := kubeClient.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		logger.Fatalw("Error getting ConfigMap", zap.Error(err))
+	}
+
+	// Walk the list of Ingress entries in the Service's LoadBalancer status
+	// and find the first with an assigned IP address.
+	ip := ""
+	for _, ing := range gwSvc.Status.LoadBalancer.Ingress {
+		if ing.IP == "" {
+			continue
+		}
+		ip = ing.IP
+		break
+	}
+	if ip == "" {
+		logger.Fatal("Istio gateway does not have an assigned external IP.")
+	}
+
+	// Use the IP (assumes IPv4) to set up a magic DNS name under a top-level Magic
+	// DNS service like xip.io or nip.io, where:
+	//     1.2.3.4.xip.io  ===(magically resolves to)===> 1.2.3.4
+	// Add this magic DNS name without a label selector to the ConfigMap,
+	// and send it back to the API server.
+	domain := fmt.Sprintf("%s.%s", ip, *magicDNS)
+	domainCM.Data[domain] = ""
+	_, err = kubeClient.CoreV1().ConfigMaps(system.Namespace()).Update(domainCM)
+	if err != nil {
+		logger.Fatalw("Error updating ConfigMap", zap.Error(err))
+	}
+
+	logger.Infof("Updated default domain to: %s", domain)
+}

--- a/test/defaultdomain/main.go
+++ b/test/defaultdomain/main.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	// Uncomment the following line to load the gcp plugin (only required
+	// The following line is to load the gcp plugin (only required
 	// to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
@@ -89,7 +89,7 @@ func main() {
 	serviceURL := istioConfig.IngressGateways[0].ServiceURL
 	parts := strings.SplitN(serviceURL, ".", 3)
 	if len(parts) != 3 {
-		logger.Fatalf("Unexpected service URL form: %v", serviceURL)
+		logger.Fatalf("Unexpected service URL form: %s", serviceURL)
 	}
 
 	// Use the first two name parts to lookup the Kubernetes Service resource.

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -104,6 +104,7 @@ func TestActivatorOverload(t *testing.T) {
 			res, err := client.Do(req)
 			if err != nil {
 				t.Errorf("unexpected error sending a request, %v", err)
+				return
 			}
 
 			if res.StatusCode != http.StatusOK {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -115,6 +115,11 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	// As a final check (since we know they are both up), check that we cannot send a request directly to the helloworld app.
 	response, err = sendRequest(t, clients, test.ServingFlags.ResolvableDomain, helloworldDomain)
 	if err != nil {
+		if test.ServingFlags.ResolvableDomain {
+			// When we're testing with resolvable domains, we might fail earlier trying
+			// to resolve the shorter domain(s) off-cluster.
+			return
+		}
 		t.Fatalf("Unexpected error when sending request to helloworld: %v", err)
 	}
 

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -48,8 +48,8 @@ type ServingEnvironmentFlags struct {
 func initializeServingFlags() *ServingEnvironmentFlags {
 	var f ServingEnvironmentFlags
 
-	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
-		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
+	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", true,
+		"Set this flag to false if you do not have a properly configured domain for your Route controller.")
 
 	flag.StringVar(&f.DockerRepo, "dockerrepo", os.Getenv("KO_DOCKER_REPO"),
 		"Provide the uri of the docker repo you have uploaded the test image to using `upload-test-images.sh`. Defaults to $KO_DOCKER_REPO")

--- a/vendor/github.com/knative/pkg/apis/istio/v1alpha3/virtualservice_types.go
+++ b/vendor/github.com/knative/pkg/apis/istio/v1alpha3/virtualservice_types.go
@@ -283,6 +283,22 @@ type HTTPMatchRequest struct {
 	//
 	// **Note:** The keys `uri`, `scheme`, `method`, and `authority` will be ignored.
 	Headers map[string]v1alpha1.StringMatch `json:"headers,omitempty"`
+
+	// Specifies the ports on the host that is being addressed. Many services
+	// only expose a single port or label ports with the protocols they support,
+	// in these cases it is not required to explicitly select the port.
+	Port uint32 `json:"port,omitempty"`
+
+	// One or more labels that constrain the applicability of a rule to
+	// workloads with the given labels. If the VirtualService has a list of
+	// gateways specified at the top, it should include the reserved gateway
+	// `mesh` in order for this field to be applicable.
+	SourceLabels map[string]string `json:"sourceLabels,omitempty"`
+
+	// Names of gateways where the rule should be applied to. Gateway names
+	// at the top of the VirtualService (if any) are overridden. The gateway match is
+	// independent of sourceLabels.
+	Gateways []string `json:"gateways,omitempty"`
 }
 
 type DestinationWeight struct {

--- a/vendor/github.com/knative/pkg/apis/istio/v1alpha3/zz_generated.deepcopy.go
+++ b/vendor/github.com/knative/pkg/apis/istio/v1alpha3/zz_generated.deepcopy.go
@@ -392,6 +392,18 @@ func (in *HTTPMatchRequest) DeepCopyInto(out *HTTPMatchRequest) {
 			(*out)[key] = val
 		}
 	}
+	if in.SourceLabels != nil {
+		in, out := &in.SourceLabels, &out.SourceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Gateways != nil {
+		in, out := &in.Gateways, &out.Gateways
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/vendor/github.com/knative/pkg/logging/config.go
+++ b/vendor/github.com/knative/pkg/logging/config.go
@@ -173,7 +173,7 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 	return func(configMap *corev1.ConfigMap) {
 		loggingConfig, err := NewConfigFromConfigMap(configMap, components...)
 		if err != nil {
-			logger.Error("Failed to parse the logging configmap. Previous config map will be used.", zap.Error(err))
+			logger.Errorw("Failed to parse the logging configmap. Previous config map will be used.", zap.Error(err))
 			return
 		}
 

--- a/vendor/github.com/knative/pkg/metrics/config.go
+++ b/vendor/github.com/knative/pkg/metrics/config.go
@@ -127,9 +127,9 @@ func UpdateExporterFromConfigMap(domain string, component string, logger *zap.Su
 		if err != nil {
 			if ce := getCurMetricsExporter(); ce == nil {
 				// Fail the process if there doesn't exist an exporter.
-				logger.Error("Failed to get a valid metrics config", zap.Error(err))
+				logger.Errorw("Failed to get a valid metrics config", zap.Error(err))
 			} else {
-				logger.Error("Failed to get a valid metrics config; Skip updating the metrics exporter", zap.Error(err))
+				logger.Errorw("Failed to get a valid metrics config; Skip updating the metrics exporter", zap.Error(err))
 			}
 			return
 		}

--- a/vendor/github.com/knative/pkg/metrics/prometheus_exporter.go
+++ b/vendor/github.com/knative/pkg/metrics/prometheus_exporter.go
@@ -30,7 +30,7 @@ var (
 func newPrometheusExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, error) {
 	e, err := prometheus.NewExporter(prometheus.Options{Namespace: config.component})
 	if err != nil {
-		logger.Error("Failed to create the Prometheus exporter.", zap.Error(err))
+		logger.Errorw("Failed to create the Prometheus exporter.", zap.Error(err))
 		return nil, err
 	}
 	logger.Infof("Created Opencensus Prometheus exporter with config: %v. Start the server for Prometheus exporter.", config)

--- a/vendor/github.com/knative/pkg/metrics/stackdriver_exporter.go
+++ b/vendor/github.com/knative/pkg/metrics/stackdriver_exporter.go
@@ -53,7 +53,7 @@ func newStackdriverExporter(config *metricsConfig, logger *zap.SugaredLogger) (v
 		DefaultMonitoringLabels: &stackdriver.Labels{},
 	})
 	if err != nil {
-		logger.Error("Failed to create the Stackdriver exporter: ", zap.Error(err))
+		logger.Errorw("Failed to create the Stackdriver exporter: ", zap.Error(err))
 		return nil, err
 	}
 	logger.Infof("Created Opencensus Stackdriver exporter with config %v", config)

--- a/vendor/github.com/knative/pkg/test/monitoring/doc.go
+++ b/vendor/github.com/knative/pkg/test/monitoring/doc.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package monitoring provides common methods for all the monitoring components used in the tests
+
+This package exposes following methods:
+
+	CheckPortAvailability(port int) error
+		Checks if the given port is available
+	GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error)
+		Gets the list of pods that satisfy the lable selector app=<app>
+	Cleanup(pid int) error
+		Kill the current port forwarding process running in the background
+	PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int) (int, error)
+		Create a background process that will port forward the first pod from the local to remote port
+		It returns the process id for the background process created.
+*/
+package monitoring

--- a/vendor/github.com/knative/pkg/test/monitoring/monitoring.go
+++ b/vendor/github.com/knative/pkg/test/monitoring/monitoring.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/knative/pkg/test/logging"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	namespace = "istio-system"
+)
+
+// CheckPortAvailability checks to see if the port is available on the machine.
+func CheckPortAvailability(port int) error {
+	server, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		// Port is likely taken
+		return err
+	}
+	server.Close()
+
+	return nil
+}
+
+// GetPods retrieves the current existing podlist for the app in monitoring namespace
+// This uses app=<app> as labelselector for selecting pods
+func GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error) {
+	pods, err := kubeClientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", app)})
+	if err == nil && len(pods.Items) == 0 {
+		err = fmt.Errorf("No %s Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup", app)
+	}
+
+	return pods, err
+}
+
+// Cleanup will clean the background process used for port forwarding
+func Cleanup(pid int) error {
+	ps := os.Process{Pid: pid}
+	return ps.Kill()
+}
+
+// PortForward sets up local port forward to the pod specified by the "app" label in the given namespace
+func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int) (int, error) {
+	podName := podList.Items[0].Name
+	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %d:%d -n %s", podName, localPort, remotePort, namespace)
+	portFwdProcess, err := executeCmdBackground(logf, portFwdCmd)
+
+	if err != nil {
+		return 0, fmt.Errorf("Failed to port forward: %v", err)
+	}
+
+	logf("running %s port-forward in background, pid = %d", podName, portFwdProcess.Pid)
+	return portFwdProcess.Pid, nil
+}
+
+// RunBackground starts a background process and returns the Process if succeed
+func executeCmdBackground(logf logging.FormatLogger, format string, args ...interface{}) (*os.Process, error) {
+	cmd := fmt.Sprintf(format, args...)
+	logf("Executing command: %s", cmd)
+	parts := strings.Split(cmd, " ")
+	c := exec.Command(parts[0], parts[1:]...) // #nosec
+	if err := c.Start(); err != nil {
+		return nil, fmt.Errorf("%s command failed: %v", cmd, err)
+	}
+	return c.Process, nil
+}

--- a/vendor/github.com/knative/pkg/test/request.go
+++ b/vendor/github.com/knative/pkg/test/request.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -119,8 +120,8 @@ func MatchesAllOf(checkers ...spoof.ResponseChecker) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, domain string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
-	return WaitForEndpointStateWithTimeout(kubeClient, logf, domain, inState, desc, resolvable, spoof.RequestTimeout)
+func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, theURL string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
+	return WaitForEndpointStateWithTimeout(kubeClient, logf, theURL, inState, desc, resolvable, spoof.RequestTimeout)
 }
 
 // WaitForEndpointStateWithTimeout will poll an endpoint until inState indicates the state is achieved
@@ -130,16 +131,25 @@ func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, dom
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
 func WaitForEndpointStateWithTimeout(
-	kubeClient *KubeClient, logf logging.FormatLogger, domain string, inState spoof.ResponseChecker,
+	kubeClient *KubeClient, logf logging.FormatLogger, theURL string, inState spoof.ResponseChecker,
 	desc string, resolvable bool, timeout time.Duration) (*spoof.Response, error) {
 	defer logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForEndpointState/%s", desc)).End()
 
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+	// Try parsing the "theURL" with and without a scheme.
+	asURL, err := url.Parse(fmt.Sprintf("http://%s", theURL))
+	if err != nil {
+		asURL, err = url.Parse(theURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, asURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := NewSpoofingClient(kubeClient, logf, domain, resolvable)
+	client, err := NewSpoofingClient(kubeClient, logf, asURL.Hostname(), resolvable)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/knative/pkg/test/zipkin/doc.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/doc.go
@@ -37,5 +37,5 @@ A general flow for a Test Suite to use Zipkin Tracing support is as follows:
 		2. Use SpoofingClient to make HTTP requests.
 		3. Call CleanupZipkinTracingSetup on cleanup after tests are executed.
 
- */
+*/
 package zipkin

--- a/vendor/github.com/knative/pkg/test/zipkin/util.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/util.go
@@ -19,14 +19,11 @@ limitations under the License.
 package zipkin
 
 import (
-	"fmt"
-	"net"
-	"os"
-	"os/exec"
 	"sync"
 
+	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/monitoring"
 	"go.opencensus.io/trace"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -34,16 +31,16 @@ const (
 	//ZipkinTraceIDHeader HTTP response header key to be used to store Zipkin Trace ID.
 	ZipkinTraceIDHeader = "ZIPKIN_TRACE_ID"
 
-	// ZipkinPort port exposed by the Zipkin Pod
+	// ZipkinPort is port exposed by the Zipkin Pod
 	// https://github.com/knative/serving/blob/master/config/monitoring/200-common/100-zipkin.yaml#L25 configures the Zipkin Port on the cluster.
 	ZipkinPort = 9411
 
 	// ZipkinTraceEndpoint port-forwarded zipkin endpoint
 	ZipkinTraceEndpoint = "http://localhost:9411/api/v2/trace/"
 
-	// ZipkinNamespace namespace where zipkin pod runs.
-	// https://github.com/knative/serving/blob/master/config/monitoring/200-common/100-zipkin.yaml#L19 configures the namespace for zipkin.
-	ZipkinNamespace = "istio-system"
+	// App is the name of this component.
+	// This will be used as a label selector
+	app = "zipkin"
 )
 
 var (
@@ -63,30 +60,25 @@ var (
 // 1. Setting up port-forwarding from localhost to zipkin pod on the cluster
 //    (pid of the process doing Port-Forward is stored in a global variable).
 // 2. Enable AlwaysSample config for tracing.
-func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf func(template string, args ...interface{})) {
+func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.FormatLogger) {
 	setupOnce.Do(func() {
-		if err := CheckZipkinPortAvailability(); err != nil {
+		if err := monitoring.CheckPortAvailability(ZipkinPort); err != nil {
 			logf("Zipkin port not available on the machine: %v", err)
 			return
 		}
 
-		zipkinPods, err := kubeClientset.CoreV1().Pods(ZipkinNamespace).List(metav1.ListOptions{LabelSelector: "app=zipkin"})
+		zipkinPods, err := monitoring.GetPods(kubeClientset, app)
 		if err != nil {
 			logf("Error retrieving Zipkin pod details: %v", err)
 			return
 		}
 
-		if len(zipkinPods.Items) == 0 {
-			logf("No Zipkin Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup")
-			return
-		}
-
-		portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace="+ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
-		if err = portForwardCmd.Start(); err != nil {
+		zipkinPortForwardPID, err = monitoring.PortForward(logf, zipkinPods, ZipkinPort, ZipkinPort)
+		if err != nil {
 			logf("Error starting kubectl port-forward command: %v", err)
 			return
 		}
-		zipkinPortForwardPID = portForwardCmd.Process.Pid
+
 		logf("Zipkin port-forward process started with PID: %d", zipkinPortForwardPID)
 
 		// Applying AlwaysSample config to ensure we propagate zipkin header for every request made by this client.
@@ -97,19 +89,17 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf func(template 
 }
 
 // CleanupZipkinTracingSetup cleans up the Zipkin tracing setup on the machine. This involves killing the process performing port-forward.
-func CleanupZipkinTracingSetup(logf func(template string, args ...interface{})) {
+func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 	teardownOnce.Do(func() {
 		if !ZipkinTracingEnabled {
 			return
 		}
 
-		ps := os.Process{Pid: zipkinPortForwardPID}
-		if err := ps.Kill(); err != nil {
+		if err := monitoring.Cleanup(zipkinPortForwardPID); err != nil {
 			logf("Encountered error killing port-forward process in CleanupZipkingTracingSetup() : %v", err)
 			return
 		}
 
-		logf("Successfully killed Zipkin port-forward process")
 		ZipkinTracingEnabled = false
 	})
 }
@@ -117,12 +107,5 @@ func CleanupZipkinTracingSetup(logf func(template string, args ...interface{})) 
 // CheckZipkinPortAvailability checks to see if Zipkin Port is available on the machine.
 // returns error if the port is not available.
 func CheckZipkinPortAvailability() error {
-	server, err := net.Listen("tcp", fmt.Sprintf(":%d", ZipkinPort))
-	if err != nil {
-		// Port is likely taken
-		return err
-	}
-	server.Close()
-
-	return nil
+	return monitoring.CheckPortAvailability(ZipkinPort)
 }

--- a/vendor/github.com/knative/pkg/webhook/certs.go
+++ b/vendor/github.com/knative/pkg/webhook/certs.go
@@ -110,19 +110,19 @@ func createCA(ctx context.Context, name, namespace string) (*rsa.PrivateKey, *x5
 	logger := logging.FromContext(ctx)
 	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		logger.Error("error generating random key", zap.Error(err))
+		logger.Errorw("error generating random key", zap.Error(err))
 		return nil, nil, nil, err
 	}
 
 	rootCertTmpl, err := createCACertTemplate(name, namespace)
 	if err != nil {
-		logger.Error("error generating CA cert", zap.Error(err))
+		logger.Errorw("error generating CA cert", zap.Error(err))
 		return nil, nil, nil, err
 	}
 
 	rootCert, rootCertPEM, err := createCert(rootCertTmpl, rootCertTmpl, &rootKey.PublicKey, rootKey)
 	if err != nil {
-		logger.Error("error signing the CA cert", zap.Error(err))
+		logger.Errorw("error signing the CA cert", zap.Error(err))
 		return nil, nil, nil, err
 	}
 	return rootKey, rootCert, rootCertPEM, nil
@@ -143,19 +143,19 @@ func CreateCerts(ctx context.Context, name, namespace string) (serverKey, server
 	// Then create the private key for the serving cert
 	servKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		logger.Error("error generating random key", zap.Error(err))
+		logger.Errorw("error generating random key", zap.Error(err))
 		return nil, nil, nil, err
 	}
 	servCertTemplate, err := createServerCertTemplate(name, namespace)
 	if err != nil {
-		logger.Error("failed to create the server certificate template", zap.Error(err))
+		logger.Errorw("failed to create the server certificate template", zap.Error(err))
 		return nil, nil, nil, err
 	}
 
 	// create a certificate which wraps the server's public key, sign it with the CA private key
 	_, servCertPEM, err := createCert(servCertTemplate, caCertificate, &servKey.PublicKey, caKey)
 	if err != nil {
-		logger.Error("error signing server certificate template", zap.Error(err))
+		logger.Errorw("error signing server certificate template", zap.Error(err))
 		return nil, nil, nil, err
 	}
 	servKeyPEM := pem.EncodeToMemory(&pem.Block{


### PR DESCRIPTION
This adds a simple Kubernetes Job that runs when we `ko apply -f test/config` to set up a default DNS entry based on `xip.io` with the IP address of the Istio Ingress Gateway.

Related to: https://github.com/knative/serving/issues/2968

At this point, I kind of just want to see if this works properly with out e2e testing infrastructure, so please ignore this until I remove the WIP.