### PR TITLE
Move all target calculation into MakeMetric

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -52,15 +51,6 @@ type Config struct {
 	TickInterval   time.Duration
 
 	ScaleToZeroGracePeriod time.Duration
-}
-
-// TargetConcurrency calculates the target concurrency for a given container-concurrency
-// taking the container-concurrency-target-percentage into account.
-func (c *Config) TargetConcurrency(concurrency v1alpha1.RevisionContainerConcurrencyType) float64 {
-	if concurrency == 0 {
-		return c.ContainerConcurrencyTargetDefault
-	}
-	return float64(concurrency) * c.ContainerConcurrencyTargetPercentage
 }
 
 // NewConfigFromMap creates a Config from the supplied map

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -23,44 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-
 	. "github.com/knative/serving/pkg/reconciler/testing"
 )
-
-func TestTargetConcurrency(t *testing.T) {
-	c := &Config{
-		ContainerConcurrencyTargetPercentage: 0.5,
-		ContainerConcurrencyTargetDefault:    10.0,
-	}
-
-	tests := []struct {
-		name                 string
-		containerConcurrency int
-		want                 float64
-	}{{
-		name:                 "default",
-		containerConcurrency: 0,
-		want:                 10.0,
-	}, {
-		name:                 "single",
-		containerConcurrency: 1,
-		want:                 0.5,
-	}, {
-		name:                 "multi",
-		containerConcurrency: 10,
-		want:                 5.0,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := c.TargetConcurrency(v1alpha1.RevisionContainerConcurrencyType(test.containerConcurrency))
-			if got != test.want {
-				t.Errorf("TargetConcurrency() = %v, want %v", got, test.want)
-			}
-		})
-	}
-}
 
 func TestNewConfig(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--
/lint
-->

## Proposed Changes

* Consolidate all concurrency target calculations into the MakeMetric method.
* Delete TargetConcurrency.

**Release Note**

```release-note
NONE
```
