### PR TITLE
Probe user-containers using an HTTP OPTIONS request.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -144,7 +144,7 @@ func probeUserContainer() bool {
 		logger.Debug("Probing the user-container.")
 		err = health.HTTPProbe(userTargetAddress, 100*time.Millisecond)
 		if err != nil {
-			logger.Debug("Probe failed")
+			logger.Debugw("Probe failed", zap.Error(err))
 			return false, nil
 		}
 		return true, nil

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -141,18 +141,21 @@ func isKubeletProbe(r *http.Request) bool {
 func probeUserContainer() bool {
 	var err error
 	wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (bool, error) {
-		logger.Debug("TCP probing the user-container.")
-		err = health.TCPProbe(userTargetAddress, 100*time.Millisecond)
-		return err == nil, nil
+		logger.Debug("Probing the user-container.")
+		err = health.HTTPProbe(userTargetAddress, 100*time.Millisecond)
+		if err != nil {
+			logger.Debug("Probe failed")
+			return false, nil
+		}
+		return true, nil
 	})
 
-	if err == nil {
-		logger.Info("User-container successfully probed.")
-	} else {
+	if err != nil {
 		logger.Errorw("User-container could not be probed successfully.", zap.Error(err))
+		return false
 	}
-
-	return err == nil
+	logger.Info("User-container successfully probed.")
+	return true
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -17,7 +17,9 @@ limitations under the License.
 package health
 
 import (
+	"fmt"
 	"net"
+	"net/http"
 	"time"
 )
 
@@ -30,5 +32,29 @@ func TCPProbe(addr string, socketTimeout time.Duration) error {
 		return err
 	}
 	conn.Close()
+	return nil
+}
+
+// HTTPProbe checks that an OPTIONS http call is answered correctly with
+// a '200'.
+func HTTPProbe(addr string, timeout time.Duration) error {
+	req, err := http.NewRequest(http.MethodOptions, "http://"+addr, nil)
+	if err != nil {
+		return err
+	}
+
+	client := http.Client{
+		Timeout: timeout,
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code %v", res.StatusCode)
+	}
+
 	return nil
 }

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -42,6 +42,7 @@ func HTTPProbe(addr string, timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
+	req.URL.Path = "*"
 
 	client := http.Client{
 		Timeout: timeout,

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-func TestTcpProbe(t *testing.T) {
+func TestTCPProbe(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -38,6 +38,25 @@ func TestTcpProbe(t *testing.T) {
 	// Close the server so probing fails afterwards
 	server.Close()
 	if err := TCPProbe(serverAddr, 1*time.Second); err == nil {
+		t.Error("Expected probe to fail but it didn't")
+	}
+}
+
+func TestHTTPProbe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	serverAddr := server.Listener.Addr().String()
+
+	// Connecting to the server should work
+	if err := HTTPProbe(serverAddr, 1*time.Second); err != nil {
+		t.Errorf("Expected probe to succeed but it failed with %v", err)
+	}
+
+	// Close the server so probing fails afterwards
+	server.Close()
+	if err := HTTPProbe(serverAddr, 1*time.Second); err == nil {
 		t.Error("Expected probe to fail but it didn't")
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is to verify whether or not our current TCP probe is actually effective. I have a feeling that the occasional 500s we're seeing in tests might be related to the probe not being accurate enough.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
