### PR TITLE
Remove hardcoded NodePorts on istio-ingressgateway.

### DIFF
--- a/third_party/istio-1.0.6/download-istio.sh
+++ b/third_party/istio-1.0.6/download-istio.sh
@@ -41,7 +41,10 @@ helm template --namespace=istio-system \
   `# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
   --set gateways.istio-ingressgateway.autoscaleMin=1 \
   --set gateways.istio-ingressgateway.autoscaleMax=1 \
-  install/kubernetes/helm/istio > ../istio.yaml
+  install/kubernetes/helm/istio \
+  `# Remove all hardcoded NodePorts` \
+  | grep -v "^[[:space:]]*nodePort[[:space:]]*:[[:space:]]*[[:digit:]]\+$" \
+  > ../istio.yaml
 cat cluster-local-gateway.yaml >> ../istio.yaml
 
 # A lighter template, with no sidecar injection.  We could probably remove
@@ -57,7 +60,10 @@ helm template --namespace=istio-system \
   `# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
   --set gateways.istio-ingressgateway.autoscaleMin=1 \
   --set gateways.istio-ingressgateway.autoscaleMax=1 \
-  install/kubernetes/helm/istio > ../istio-lean.yaml
+  install/kubernetes/helm/istio \
+  `# Remove all hardcoded NodePorts` \
+  | grep -v "^[[:space:]]*nodePort[[:space:]]*:[[:space:]]*[[:digit:]]\+$" \
+  > ../istio-lean.yaml
 cat cluster-local-gateway.yaml >> ../istio-lean.yaml
 
 # Clean up.

--- a/third_party/istio-1.0.6/istio-lean.yaml
+++ b/third_party/istio-1.0.6/istio-lean.yaml
@@ -1988,16 +1988,13 @@ spec:
   ports:
     -
       name: http2
-      nodePort: 31380
       port: 80
       targetPort: 80
     -
       name: https
-      nodePort: 31390
       port: 443
     -
       name: tcp
-      nodePort: 31400
       port: 31400
     -
       name: tcp-pilot-grpc-tls

--- a/third_party/istio-1.0.6/istio.yaml
+++ b/third_party/istio-1.0.6/istio.yaml
@@ -2216,16 +2216,13 @@ spec:
   ports:
     -
       name: http2
-      nodePort: 31380
       port: 80
       targetPort: 80
     -
       name: https
-      nodePort: 31390
       port: 443
     -
       name: tcp
-      nodePort: 31400
       port: 31400
     -
       name: tcp-pilot-grpc-tls


### PR DESCRIPTION
These are usually ok for most installations, but for CI that
repeatedly install Istio we sometime run into installation flakes.

These are also customizable by editing `values.yaml` so this is
still a valid customization of Istio, not a patch.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3374

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
