### PR TITLE
Remove ServiceEntry with one-word host name.

### DIFF
--- a/config/monitoring/metrics/stackdriver/100-stackdriver-serviceentry.yaml
+++ b/config/monitoring/metrics/stackdriver/100-stackdriver-serviceentry.yaml
@@ -31,28 +31,6 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: metadata-server-gke
-  namespace: knative-monitoring
-  labels:
-    serving.knative.dev/release: devel
-spec:
-  hosts:
-  - metadata
-  ports:
-  - number: 80
-    name: http
-    protocol: HTTP
-  - number: 443
-    name: https
-    protocol: HTTPS
-  location: MESH_EXTERNAL
-  resolution: DNS
-  endpoints:
-  - address: 169.254.169.254
----
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
   name: metadata-server
   namespace: knative-monitoring
   labels:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3389

## Proposed Changes

* Remove `metadata` ServiceEntry.  One-word host is now disallowed in Istio 1.0.x.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
