### PR TITLE
Support both host and host:<any-port> as :authority header

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,7 +146,7 @@ func expandedHosts(hosts []string) []string {
 func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 	match := v1alpha3.HTTPMatchRequest{
 		Authority: &istiov1alpha1.StringMatch{
-			Exact: host,
+			Regex: hostRegExp(host),
 		},
 	}
 	// Empty pathRegExp is considered match all path. We only need to
@@ -156,6 +157,14 @@ func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 		}
 	}
 	return match
+}
+
+// hostRegExp returns an ECMAScript regular expression to match either host or host:<any port>
+func hostRegExp(host string) string {
+	// Should only match 1..65535, but for simplicity it matches 0-99999
+	portMatch := "(?::\\d{1,5})?"
+
+	return fmt.Sprintf("^%s%s$", host, portMatch)
 }
 
 func getHosts(ci *v1alpha1.ClusterIngress) []string {

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -162,9 +163,9 @@ func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 // hostRegExp returns an ECMAScript regular expression to match either host or host:<any port>
 func hostRegExp(host string) string {
 	// Should only match 1..65535, but for simplicity it matches 0-99999
-	portMatch := "(?::\\d{1,5})?"
+	portMatch := `(?::\d{1,5})?`
 
-	return fmt.Sprintf("^%s%s$", host, portMatch)
+	return fmt.Sprintf("^%s%s$", regexp.QuoteMeta(host), portMatch)
 }
 
 func getHosts(ci *v1alpha1.ClusterIngress) []string {

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -140,16 +140,16 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	expected := []v1alpha3.HTTPRoute{{
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "domain.com"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^domain.com(?::\\d{1,5})?$"},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^test-route.test-ns(?::\\d{1,5})?$"},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^test-route.test-ns.svc(?::\\d{1,5})?$"},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc.cluster.local"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^test-route.test-ns.svc.cluster.local(?::\\d{1,5})?$"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -167,7 +167,7 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	}, {
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "v1.domain.com"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^v1.domain.com(?::\\d{1,5})?$"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -212,9 +212,9 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath)
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Authority: &istiov1alpha1.StringMatch{Exact: "a.com"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^a.com(?::\\d{1,5})?$"},
 		}, {
-			Authority: &istiov1alpha1.StringMatch{Exact: "b.org"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^b.org(?::\\d{1,5})?$"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -263,7 +263,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath)
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Authority: &istiov1alpha1.StringMatch{Exact: "test.org"},
+			Authority: &istiov1alpha1.StringMatch{Regex: "^test.org(?::\\d{1,5})?$"},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -140,16 +140,16 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	expected := []v1alpha3.HTTPRoute{{
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Regex: "^domain.com(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^domain\.com(?::\d{1,5})?$`},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Regex: "^test-route.test-ns(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns(?::\d{1,5})?$`},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Regex: "^test-route.test-ns.svc(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns\.svc(?::\d{1,5})?$`},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Regex: "^test-route.test-ns.svc.cluster.local(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns\.svc\.cluster\.local(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -167,7 +167,7 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	}, {
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Regex: "^v1.domain.com(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^v1\.domain\.com(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -212,9 +212,9 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath)
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Authority: &istiov1alpha1.StringMatch{Regex: "^a.com(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^a\.com(?::\d{1,5})?$`},
 		}, {
-			Authority: &istiov1alpha1.StringMatch{Regex: "^b.org(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^b\.org(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -263,7 +263,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath)
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Authority: &istiov1alpha1.StringMatch{Regex: "^test.org(?::\\d{1,5})?$"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test\.org(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -40,7 +40,7 @@ func unaryTest(t *testing.T, names test.ResourceNames, clients *test.Clients, ho
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	conn, err := grpc.Dial(
 		host+":80",
-		grpc.WithAuthority(domain),
+		grpc.WithAuthority(domain+":80"),
 		grpc.WithInsecure(),
 	)
 	if err != nil {
@@ -68,7 +68,7 @@ func streamTest(t *testing.T, names test.ResourceNames, clients *test.Clients, h
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	conn, err := grpc.Dial(
 		host+":80",
-		grpc.WithAuthority(domain),
+		grpc.WithAuthority(domain+":80"),
 		grpc.WithInsecure(),
 	)
 	if err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3370

## Proposed Changes

Currently, the `host` / `:authority` header for any request must only contain the hostname. 

This is a problem for gRPC requests, because by default, most clients specify `host:port` as the authority. To work around this, gRPC requests to Knative services must supply a separate authority header.

This change allows the header to be either `host` or `host:<any-port`. 

**Release Note**

```release-note
* gRPC clients no longer need to specify an authority separately
```
