### PR TITLE
Improve error reporting of ScaleToN tests.

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -25,6 +25,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -112,7 +113,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 
 			if err != nil {
 				t.Errorf("CreateLatestService() = %v", err)
-				return nil
+				return errors.Wrap(err, "CreateLatestService() failed")
 			}
 			// Record the time it took to create the service.
 			latencies.Add("time-to-create", start)
@@ -133,7 +134,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 			}, "ServiceUpdatedWithDomain")
 			if err != nil {
 				t.Errorf("WaitForServiceState(w/ Domain) = %v", err)
-				return nil
+				return errors.Wrap(err, "WaitForServiceState(w/ Domain) failed")
 			}
 			// Record the time it took to become ready.
 			latencies.Add("time-to-ready", start)
@@ -142,12 +143,12 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				clients.KubeClient,
 				t.Logf,
 				domain,
-				test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(helloWorldExpectedOutput))),
+				test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(helloWorldExpectedOutput))),
 				"WaitForEndpointToServeText",
 				test.ServingFlags.ResolvableDomain)
 			if err != nil {
 				t.Errorf("WaitForEndpointState(expected text) = %v", err)
-				return nil
+				return errors.Wrap(err, "WaitForEndpointState(expected text) failed")
 			}
 			// Record the time it took to get back a 200 with the expected text.
 			latencies.Add("time-to-200", start)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

These tests produce a large amount of logs on failures and the errors produced by the service-creation goroutine are easily swallowed and overlooked in the flood of logs. This will report the very first of these errors at the end of the test output for much easier debugability.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
