### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/route/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/route/queueing_test.go
@@ -51,7 +51,7 @@ import (
 */
 
 func TestNewRouteCallsSyncHandler(t *testing.T) {
-	defer  ClearAllLoggers()
+	defer ClearAllLoggers()
 	// A standalone revision
 	rev := getTestRevision("test-rev")
 	// A route targeting the revision


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
