### PR TITLE
Construct a better resolver transport

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resolve.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve.go
@@ -63,7 +63,7 @@ func newResolverTransport(path string) (*http.Transport, error) {
 	// Copied from https://github.com/golang/go/blob/release-branch.go1.12/src/net/http/transport.go#L42-L53
 	// We want to use the DefaultTransport but change its TLSClientConfig. There
 	// isn't a clean way to do this yet: https://github.com/golang/go/issues/26013
-	resolverTransport := &http.Transport{
+	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -75,13 +75,11 @@ func newResolverTransport(path string) (*http.Transport, error) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-	}
-
-	resolverTransport.TLSClientConfig = &tls.Config{
-		RootCAs: pool,
-	}
-
-	return resolverTransport, nil
+		// Use the cert pool with k8s cert bundle appended.
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}, nil
 }
 
 // Resolve resolves the image references that use tags to digests.

--- a/pkg/reconciler/v1alpha1/revision/resolve.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve.go
@@ -73,6 +73,7 @@ func newResolverTransport(path string) (*http.Transport, error) {
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 

--- a/pkg/reconciler/v1alpha1/revision/resolve.go
+++ b/pkg/reconciler/v1alpha1/revision/resolve.go
@@ -22,13 +22,14 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
-
-	"k8s.io/apimachinery/pkg/util/sets"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -59,11 +60,27 @@ func newResolverTransport(path string) (*http.Transport, error) {
 		return nil, errors.New("Failed to append k8s cert bundle to cert pool.")
 	}
 
-	return &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs: pool,
-		},
-	}, nil
+	// Copied from https://github.com/golang/go/blob/release-branch.go1.12/src/net/http/transport.go#L42-L53
+	// We want to use the DefaultTransport but change its TLSClientConfig. There
+	// isn't a clean way to do this yet: https://github.com/golang/go/issues/26013
+	resolverTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	resolverTransport.TLSClientConfig = &tls.Config{
+		RootCAs: pool,
+	}
+
+	return resolverTransport, nil
 }
 
 // Resolve resolves the image references that use tags to digests.


### PR DESCRIPTION
This replicates the settings from http.DefaultTransport. Notably, we
were missing ProxyFromEnvironment, causing HTTPS_PROXY env variables not
to work.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3392

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
