### PR TITLE
[release-0.4] Support both host and host:<any-port> as :authority header (#3398)

### DIFF
--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,7 +147,7 @@ func expandedHosts(hosts []string) []string {
 func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 	match := v1alpha3.HTTPMatchRequest{
 		Authority: &istiov1alpha1.StringMatch{
-			Exact: host,
+			Regex: hostRegExp(host),
 		},
 	}
 	// Empty pathRegExp is considered match all path. We only need to
@@ -156,6 +158,14 @@ func makeMatch(host string, pathRegExp string) v1alpha3.HTTPMatchRequest {
 		}
 	}
 	return match
+}
+
+// hostRegExp returns an ECMAScript regular expression to match either host or host:<any port>
+func hostRegExp(host string) string {
+	// Should only match 1..65535, but for simplicity it matches 0-99999
+	portMatch := `(?::\d{1,5})?`
+
+	return fmt.Sprintf("^%s%s$", regexp.QuoteMeta(host), portMatch)
 }
 
 func getHosts(ci *v1alpha1.ClusterIngress) []string {

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -140,16 +140,16 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	expected := []v1alpha3.HTTPRoute{{
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "domain.com"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^domain\.com(?::\d{1,5})?$`},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns(?::\d{1,5})?$`},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns\.svc(?::\d{1,5})?$`},
 		}, {
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "test-route.test-ns.svc.cluster.local"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns\.svc\.cluster\.local(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -167,7 +167,7 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	}, {
 		Match: []v1alpha3.HTTPMatchRequest{{
 			Uri:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
-			Authority: &istiov1alpha1.StringMatch{Exact: "v1.domain.com"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^v1\.domain\.com(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -212,9 +212,9 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath)
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Authority: &istiov1alpha1.StringMatch{Exact: "a.com"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^a\.com(?::\d{1,5})?$`},
 		}, {
-			Authority: &istiov1alpha1.StringMatch{Exact: "b.org"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^b\.org(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{
@@ -263,7 +263,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath)
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Authority: &istiov1alpha1.StringMatch{Exact: "test.org"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test\.org(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.DestinationWeight{{
 			Destination: v1alpha3.Destination{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -125,7 +125,7 @@ func TestGRPC(t *testing.T) {
 
 	conn, err := grpc.Dial(
 		*host+":80",
-		grpc.WithAuthority(domain),
+		grpc.WithAuthority(domain+":80"),
 		grpc.WithInsecure(),
 	)
 	if err != nil {


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Cherry-picking fix for #3370 .

## Proposed Changes

* Support both host and host:<any-port> as :authority header
* RegExp escape hostname when creating VirtualService

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* gRPC apps can be invoked without explicitly setting host header.
```
