### PR TITLE
Stop the probing manager before fatally exiting test.

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -183,6 +183,9 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 
 		case err := <-doneCh:
 			if err != nil {
+				// If we don't do this first, then we'll see tons of 503s from the ongoing probes
+				// as we tear down the things they are probing.
+				defer pm.Stop()
 				t.Fatalf("Unexpected error: %v", err)
 			}
 

--- a/test/prober.go
+++ b/test/prober.go
@@ -186,6 +186,8 @@ func (m *manager) Spawn(domain string) Prober {
 		// to ultimately establish the SLI and compare to the SLO.
 		_, err = client.Poll(req, p.handleResponse)
 		if err != nil {
+			// SLO violations are not reflected as errors. They are
+			// captured and calculated internally.
 			m.t.Logf("Poll() = %v", err)
 			p.errCh <- err
 			return
@@ -230,6 +232,7 @@ func (m *manager) Foreach(f func(domain string, p Prober)) {
 	}
 }
 
+// NewProberManager creates a new manager for probes.
 func NewProberManager(t *testing.T, clients *Clients, minProbes int64) ProberManager {
 	return &manager{
 		t:         t,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

As per the inline comment, we need to stop the probes before actually exiting the test and executing the cleanup logic.

Also:
- Add a comment in the prober on how the error channel is used to clarify the behavior if requests fail.
- Fix linter warning regarding exported but uncommented function.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
