### PR TITLE
Refactor main autoscaler function.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -254,7 +254,7 @@ func main() {
 		GetProbeCount: maxRetries,
 	}
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
-	ah = &activatorhandler.ProbeHandler{ah}
+	ah = &activatorhandler.ProbeHandler{NextHandler:ah}
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())


### PR DESCRIPTION
Make it clear what components an autoscaler job runs by pushing all
temporary variables to helper functions and organizing the code into two
sections--first set up the components, then run the components.

Minor edit in activator to fix a go vet complaint.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Separate setup code from executing code in main().
* Push temporary variables to helper functions to make it clear what components are at the top level of an autoscaler.
* Minor: fix a go vet complaint in activator.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
