### PR TITLE
Add test for same service name in different namespace

### DIFF
--- a/pkg/reconciler/v1alpha1/testing/service.go
+++ b/pkg/reconciler/v1alpha1/testing/service.go
@@ -37,3 +37,17 @@ func Service(name, namespace string, so ...ServiceOption) *v1alpha1.Service {
 	s.SetDefaults(context.Background())
 	return s
 }
+
+// ServiceWithoutNamespace creates a service with ServiceOptions but without a specific namespace
+func ServiceWithoutNamespace(name string, so ...ServiceOption) *v1alpha1.Service {
+	s := &v1alpha1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+		},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	s.SetDefaults(context.Background())
+	return s
+}

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -42,7 +42,7 @@ type Options struct {
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by names.Image.
 func CreateConfiguration(t *testing.T, clients *Clients, names ResourceNames, options *Options, fopt ...rtesting.ConfigOption) (*v1alpha1.Configuration, error) {
-	config := Configuration(ServingNamespace, names, options, fopt...)
+	config := Configuration(names, options, fopt...)
 	LogResourceObject(t, ResourceObjects{Config: config})
 	return clients.ServingClient.Configs.Create(config)
 }

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -38,7 +38,7 @@ import (
 // createLatestService creates a service in namespace with the name names.Service
 // that uses the image specified by names.Image
 func createLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) (*v1alpha1.Service, error) {
-	service := test.LatestService(test.ServingNamespace, names, &test.Options{}, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
+	service := test.LatestService(names, &test.Options{}, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
 	test.LogResourceObject(t, test.ResourceObjects{Service: service})
 	svc, err := clients.ServingClient.Services.Create(service)
 	return svc, err

--- a/test/crd.go
+++ b/test/crd.go
@@ -61,10 +61,9 @@ type ResourceObjects struct {
 
 // Route returns a Route object in namespace using the route and configuration
 // names in names.
-func Route(namespace string, names ResourceNames, fopt ...v1alpha1testing.RouteOption) *v1alpha1.Route {
+func Route(names ResourceNames, fopt ...v1alpha1testing.RouteOption) *v1alpha1.Route {
 	route := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
 			Name:      names.Route,
 		},
 		Spec: v1alpha1.RouteSpec{
@@ -85,10 +84,9 @@ func Route(namespace string, names ResourceNames, fopt ...v1alpha1testing.RouteO
 
 // BlueGreenRoute returns a Route object in namespace using the route and configuration
 // names in names. Traffic is split evenly between blue and green.
-func BlueGreenRoute(namespace string, names, blue, green ResourceNames) *v1alpha1.Route {
+func BlueGreenRoute(names, blue, green ResourceNames) *v1alpha1.Route {
 	return &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
 			Name:      names.Route,
 		},
 		Spec: v1alpha1.RouteSpec{
@@ -144,10 +142,9 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 
 // Configuration returns a Configuration object in namespace with the name names.Config
 // that uses the image specified by names.Image
-func Configuration(namespace string, names ResourceNames, options *Options, fopt ...v1alpha1testing.ConfigOption) *v1alpha1.Configuration {
+func Configuration(names ResourceNames, options *Options, fopt ...v1alpha1testing.ConfigOption) *v1alpha1.Configuration {
 	config := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
 			Name:      names.Config,
 		},
 		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image), options),
@@ -166,10 +163,9 @@ func Configuration(namespace string, names ResourceNames, options *Options, fopt
 // ConfigurationWithBuild returns a Configuration object in the `namespace`
 // with the name `names.Config` that uses the provided Build spec `build`
 // and image specified by `names.Image`.
-func ConfigurationWithBuild(namespace string, names ResourceNames, build *v1alpha1.RawExtension) *v1alpha1.Configuration {
+func ConfigurationWithBuild(names ResourceNames, build *v1alpha1.RawExtension) *v1alpha1.Configuration {
 	return &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
 			Name:      names.Config,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
@@ -187,21 +183,21 @@ func ConfigurationWithBuild(namespace string, names ResourceNames, build *v1alph
 
 // LatestService returns a RunLatest Service object in namespace with the name names.Service
 // that uses the image specified by names.Image.
-func LatestService(namespace string, names ResourceNames, options *Options, fopt ...v1alpha1testing.ServiceOption) *v1alpha1.Service {
+func LatestService(names ResourceNames, options *Options, fopt ...v1alpha1testing.ServiceOption) *v1alpha1.Service {
 	a := append([]v1alpha1testing.ServiceOption{
 		v1alpha1testing.WithRunLatestConfigSpec(*ConfigurationSpec(ptest.ImagePath(names.Image), options)),
 	}, fopt...)
-	return v1alpha1testing.Service(names.Service, namespace, a...)
+	return v1alpha1testing.ServiceWithoutNamespace(names.Service, a...)
 
 }
 
 // ReleaseLatestService returns a Release Service object in namespace with the name names.Service
 // that uses the image specified by names.Image and `@latest` as the only revision.
-func ReleaseLatestService(namespace string, names ResourceNames, options *Options, fopt ...v1alpha1testing.ServiceOption) *v1alpha1.Service {
+func ReleaseLatestService(names ResourceNames, options *Options, fopt ...v1alpha1testing.ServiceOption) *v1alpha1.Service {
 	a := append([]v1alpha1testing.ServiceOption{
 		v1alpha1testing.WithReleaseRolloutConfigSpec(*ConfigurationSpec(ptest.ImagePath(names.Image), options),
 			[]string{v1alpha1.ReleaseLatestRevisionKeyword}...)}, fopt...)
-	return v1alpha1testing.Service(names.Service, namespace, a...)
+	return v1alpha1testing.ServiceWithoutNamespace(names.Service, a...)
 }
 
 // ReleaseService returns a Release Service object in namespace with the name names.Service that uses

--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -204,10 +204,10 @@ func TestPipeline(t *testing.T) {
 			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 			defer test.TearDown(clients, names)
 
-			if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.ServingNamespace, names, tc.rawExtension)); err != nil {
+			if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(names, tc.rawExtension)); err != nil {
 				t.Fatalf("Failed to create Configuration: %v", err)
 			}
-			if _, err := clients.ServingClient.Routes.Create(test.Route(test.ServingNamespace, names)); err != nil {
+			if _, err := clients.ServingClient.Routes.Create(test.Route(names)); err != nil {
 				t.Fatalf("Failed to create Route: %v", err)
 			}
 

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -62,10 +62,10 @@ func TestBuildSpecAndServe(t *testing.T) {
 		},
 	}
 
-	if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.ServingNamespace, names, build)); err != nil {
+	if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(names, build)); err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
-	if _, err := clients.ServingClient.Routes.Create(test.Route(test.ServingNamespace, names)); err != nil {
+	if _, err := clients.ServingClient.Routes.Create(test.Route(names)); err != nil {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
@@ -164,10 +164,10 @@ func TestBuildAndServe(t *testing.T) {
 		},
 	}
 
-	if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.ServingNamespace, names, build)); err != nil {
+	if _, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(names, build)); err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
-	if _, err := clients.ServingClient.Routes.Create(test.Route(test.ServingNamespace, names)); err != nil {
+	if _, err := clients.ServingClient.Routes.Create(test.Route(names)); err != nil {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
@@ -287,7 +287,7 @@ func TestBuildFailure(t *testing.T) {
 		},
 	}
 
-	config, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(test.ServingNamespace, names, build))
+	config, err := clients.ServingClient.Configs.Create(test.ConfigurationWithBuild(names, build))
 	if err != nil {
 		t.Fatalf("Failed to create Configuration with failing build: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -23,10 +23,15 @@ const (
 
 // Setup creates the client objects needed in the e2e tests.
 func Setup(t *testing.T) *test.Clients {
+	return SetupWithNamespace(t, test.ServingNamespace)
+}
+
+// SetupWithNamespace creates the client objects needed in the e2e tests under the specified namespace.
+func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
 	clients, err := test.NewClients(
 		pkgTest.Flags.Kubeconfig,
 		pkgTest.Flags.Cluster,
-		test.ServingNamespace)
+		namespace)
 	if err != nil {
 		t.Fatalf("Couldn't initialize clients: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -18,6 +18,11 @@ import (
 )
 
 const (
+	pizzaPlanet1 = "pizzaplanetv1"
+	pizzaPlanet2 = "pizzaplanetv2"
+
+	pizzaPlanetText1 = "What a spaceport!"
+	pizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
 	helloWorldExpectedOutput = "Hello World! How about some tasty noodles?"
 )
 

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -1,0 +1,83 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/serving/test"
+)
+
+func checkResponse(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedText string) error {
+	_, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		names.Domain,
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
+		"WaitForEndpointToServeText",
+		test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, names.Domain, expectedText, err)
+	}
+
+	return nil
+}
+
+func TestMultipleNamespace(t *testing.T) {
+	t.Parallel()
+
+	altServiceNamespace := fmt.Sprintf("%s-%s", test.ServingNamespace, test.ObjectNameForTest(t))
+	serviceName := test.ObjectNameForTest(t)
+
+	defaultClients := Setup(t) // This one uses the default namespace `test.ServingNamespace`
+	altClients := SetupWithNamespace(t, altServiceNamespace)
+
+	defer test.DeleteNamespace(altClients, altServiceNamespace)
+	err := test.CreateNamespace(altClients, altServiceNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultResources := test.ResourceNames{
+		Service: serviceName,
+		Image:   pizzaPlanet1,
+	}
+	defer test.TearDown(defaultClients, defaultResources)
+	if _, err := test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources, &test.Options{}); err != nil {
+		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
+	}
+
+	altResources := test.ResourceNames{
+		Service: serviceName,
+		Image:   pizzaPlanet2,
+	}
+	defer test.TearDown(altClients, altResources)
+	if _, err := test.CreateRunLatestServiceReady(t, altClients, &altResources, &test.Options{}); err != nil {
+		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, altServiceNamespace, err)
+	}
+
+	if err := checkResponse(t, defaultClients, defaultResources, pizzaPlanetText1); err != nil {
+		t.Error(err)
+	}
+
+	if err := checkResponse(t, altClients, altResources, pizzaPlanetText2); err != nil {
+		t.Error(err)
+	}
+}

--- a/test/namespace.go
+++ b/test/namespace.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// namespace.go provides methods to create and delete namespaces.
+
+package test
+
+import (
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateNamespace creates and returns the namespace that was successfully created otherwise error
+func CreateNamespace(clients *Clients, name string) error {
+	namespaceSpec := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	_, err := clients.KubeClient.Kube.CoreV1().Namespaces().Create(namespaceSpec)
+	return err
+}
+
+// DeleteNamespace deletes the namespace specified otherwise error
+func DeleteNamespace(clients *Clients, name string) error {
+	return clients.KubeClient.Kube.CoreV1().Namespaces().Delete(name, &metav1.DeleteOptions{})
+}

--- a/test/route.go
+++ b/test/route.go
@@ -32,7 +32,7 @@ import (
 
 // CreateRoute creates a route in the given namespace using the route name in names
 func CreateRoute(t *testing.T, clients *Clients, names ResourceNames, fopt ...rtesting.RouteOption) (*v1alpha1.Route, error) {
-	route := Route(ServingNamespace, names, fopt...)
+	route := Route(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Route: route})
 	return clients.ServingClient.Routes.Create(route)
 }
@@ -40,7 +40,7 @@ func CreateRoute(t *testing.T, clients *Clients, names ResourceNames, fopt ...rt
 // CreateBlueGreenRoute creates a route in the given namespace using the route name in names.
 // Traffic is evenly split between the two routes specified by blue and green.
 func CreateBlueGreenRoute(t *testing.T, clients *Clients, names, blue, green ResourceNames) error {
-	route := BlueGreenRoute(ServingNamespace, names, blue, green)
+	route := BlueGreenRoute(names, blue, green)
 	LogResourceObject(t, ResourceObjects{Route: route})
 	_, err := clients.ServingClient.Routes.Create(route)
 	return err
@@ -52,7 +52,7 @@ func UpdateBlueGreenRoute(t *testing.T, clients *Clients, names, blue, green Res
 	if err != nil {
 		return nil, err
 	}
-	newRoute := BlueGreenRoute(ServingNamespace, names, blue, green)
+	newRoute := BlueGreenRoute(names, blue, green)
 	newRoute.ObjectMeta = route.ObjectMeta
 	LogResourceObject(t, ResourceObjects{Route: newRoute})
 	patchBytes, err := createPatch(route, newRoute)

--- a/test/service.go
+++ b/test/service.go
@@ -184,14 +184,14 @@ func CreateRunLatestServiceReady(t *testing.T, clients *Clients, names *Resource
 // CreateReleaseService creates a service in namespace with the name names.Service and names.Image,
 // configured with `@latest` revision.
 func CreateReleaseService(t *testing.T, clients *Clients, names ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
-	service := ReleaseLatestService(ServingNamespace, names, options, fopt...)
+	service := ReleaseLatestService(names, options, fopt...)
 	LogResourceObject(t, ResourceObjects{Service: service})
 	return clients.ServingClient.Services.Create(service)
 }
 
 // CreateLatestService creates a service in namespace with the name names.Service and names.Image
 func CreateLatestService(t *testing.T, clients *Clients, names ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
-	service := LatestService(ServingNamespace, names, options, fopt...)
+	service := LatestService(names, options, fopt...)
 	LogResourceObject(t, ResourceObjects{Service: service})
 	svc, err := clients.ServingClient.Services.Create(service)
 	return svc, err


### PR DESCRIPTION
Fixes #3230 

Add a new conformance test where the same service name exists in different namespaces. The expectation is that it routes correctly.

I've added it to conformance instead of just e2e as this seems like a behaviour we want to ensure for all versions rather than just latest.