### PR TITLE
Add conformance test for setting user

### DIFF
--- a/test/configuration.go
+++ b/test/configuration.go
@@ -36,6 +36,7 @@ type Options struct {
 	RevisionTimeoutSeconds int64
 	ContainerResources     corev1.ResourceRequirements
 	ReadinessProbe         *corev1.Probe
+	SecurityContext        *corev1.SecurityContext
 }
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config

--- a/test/conformance/user_test.go
+++ b/test/conformance/user_test.go
@@ -1,0 +1,64 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/knative/serving/test"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const userID = 2020
+
+// TestMustRunAsUser verifies that a supplied runAsUser through securityContext takes
+// effect as delared by "MUST" in the runtime-contract.
+func TestMustRunAsUser(t *testing.T) {
+	t.Parallel()
+	clients := setup(t)
+
+	runAsUser := int64(userID)
+	securityContext := &corev1.SecurityContext{
+		RunAsUser: &runAsUser,
+	}
+
+	ri, err := fetchRuntimeInfo(t, clients, &test.Options{SecurityContext: securityContext})
+	if err != nil {
+		t.Fatalf("Error fetching runtime info: %v", err)
+	}
+
+	if ri.Host == nil {
+		t.Fatal("Missing host information from runtime info.")
+	}
+
+	if ri.Host.User == nil {
+		t.Fatal("Missing user information from runtime info.")
+	}
+
+	if got, want := ri.Host.User.UID, userID; got != want {
+		t.Errorf("uid = %d, want: %d", got, want)
+	}
+
+	// We expect the effective userID to match the userID as we
+	// did not use setuid.
+	if got, want := ri.Host.User.EUID, userID; got != want {
+		t.Errorf("euid = %d, want: %d", got, want)
+	}
+}

--- a/test/crd.go
+++ b/test/crd.go
@@ -119,10 +119,11 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 		RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 			Spec: v1alpha1.RevisionSpec{
 				Container: corev1.Container{
-					Image:          imagePath,
-					Resources:      options.ContainerResources,
-					ReadinessProbe: options.ReadinessProbe,
-					Ports:          options.ContainerPorts,
+					Image:           imagePath,
+					Resources:       options.ContainerResources,
+					ReadinessProbe:  options.ReadinessProbe,
+					Ports:           options.ContainerPorts,
+					SecurityContext: options.SecurityContext,
 				},
 				ContainerConcurrency: v1alpha1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
 			},

--- a/test/test_images/runtime/handlers/runtime.go
+++ b/test/test_images/runtime/handlers/runtime.go
@@ -31,6 +31,7 @@ func runtimeHandler(w http.ResponseWriter, r *http.Request) {
 			Cgroups: cgroups(cgroupPaths...),
 			Mounts:  mounts(),
 			Stdin:   stdin(),
+			User:    userInfo(),
 		},
 	}
 

--- a/test/test_images/runtime/handlers/user.go
+++ b/test/test_images/runtime/handlers/user.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"os"
+
+	"github.com/knative/serving/test/types"
+)
+
+func userInfo() *types.UserInfo {
+	return &types.UserInfo{
+		UID:  os.Getuid(),
+		EUID: os.Geteuid(),
+		GID:  os.Getgid(),
+		EGID: os.Getegid()}
+}

--- a/test/test_images/runtime/service.yaml
+++ b/test/test_images/runtime/service.yaml
@@ -10,3 +10,5 @@ spec:
         spec:
           container:
             image: github.com/knative/serving/test/test_images/runtime
+            securityContext:
+              runAsUser: 2020

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -49,8 +49,9 @@ type HostInfo struct {
 	// Cgroups is a list of cgroup information.
 	Cgroups []*Cgroup `json:"cgroups"`
 	// Mounts is a list of mounted volume information, or error.
-	Mounts []*Mount `json:"mounts"`
-	Stdin  *Stdin   `json:"stdin"`
+	Mounts []*Mount  `json:"mounts"`
+	Stdin  *Stdin    `json:"stdin"`
+	User   *UserInfo `json:"user"`
 }
 
 // Stdin contains information about the Stdin file descriptor for the container.
@@ -59,6 +60,14 @@ type Stdin struct {
 	EOF *bool `json"eof,omitempty"`
 	// Error is the String representation of an error probing sdtin.
 	Error string `json:"error,omitempty"`
+}
+
+// UserInfo container information about the current user and group for the running process.
+type UserInfo struct {
+	UID  int `json:"uid"`
+	EUID int `json:"euid"`
+	GID  int `json:"gid"`
+	EGID int `json:"egid"`
 }
 
 // FileInfo contains the metadata for a given file.


### PR DESCRIPTION
This change adds a conformance test to validate that a user set in the
securityContext is reflected in the container. This change also adds the
group information to the runtime test image, but we do not validate this
as 1. it is not currently part of the runtime contract and 2. Setting
group is currently an alpha feature that does not work on many Kubernetes
clusters. See https://github.com/kubernetes/enhancements/issues/213

Related to: #3223

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->