### PR TITLE
Temporarily switch to a different zone to avoid us-west1.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -20,6 +20,9 @@
 E2E_MIN_CLUSTER_NODES=4
 E2E_MAX_CLUSTER_NODES=4
 
+# Temporarily switch to a different region to avoid GCE out of stock.
+E2E_CLUSTER_REGION=us-central1
+
 # This script provides helper methods to perform cluster actions.
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Run e2e tests in `us-central1` instead of `us-west1` to avoid GCE resource exhaustion issue.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
