### PR TITLE
Fix activator forwarding bug.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -160,7 +160,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	case isKnativeProbe(r):
 		if probeUserContainer() {
 			// Respond with the name of the component handling the request.
-			w.Write([]byte("queue"))
+			w.Write([]byte(queue.Name))
 		} else {
 			http.Error(w, "container not ready", http.StatusServiceUnavailable)
 		}

--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -19,6 +19,8 @@ package activator
 import "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 
 const (
+	// Name is the name of the component.
+	Name = "activator"
 	// K8sServiceName is the name of the activator service
 	K8sServiceName = "activator-service"
 	// RevisionHeaderName is the header key for revision name

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"bufio"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -27,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/activator/util"
 	pkghttp "github.com/knative/serving/pkg/http"
 	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/queue"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -101,9 +103,17 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					a.Logger.Warnw("Pod probe failed", zap.Error(err))
 					return false, nil
 				}
+				defer probeResp.Body.Close()
 				httpStatus = probeResp.StatusCode
 				if httpStatus == http.StatusServiceUnavailable {
 					a.Logger.Warnf("Pod probe sent status: %d", httpStatus)
+					return false, nil
+				}
+				if body, err := ioutil.ReadAll(probeResp.Body); err != nil {
+					a.Logger.Errorw("Pod probe returns an invalid response body", zap.Error(err))
+					return false, nil
+				} else if queue.Name != string(body) {
+					a.Logger.Infof("Pod probe did not reach the target queue proxy. Reached: %s", body)
 					return false, nil
 				}
 				return true, nil

--- a/pkg/activator/handler/probe_handler.go
+++ b/pkg/activator/handler/probe_handler.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/network"
 )
 
@@ -28,7 +29,7 @@ func (h *ProbeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If this header is set the request was sent by a Knative component
 	// probing the network, respond with a 200 and our component name.
 	if r.Header.Get(network.ProbeHeaderName) != "" {
-		w.Write([]byte("activator"))
+		w.Write([]byte(activator.Name))
 		return
 	}
 

--- a/pkg/queue/constants.go
+++ b/pkg/queue/constants.go
@@ -17,6 +17,8 @@ limitations under the License.
 package queue
 
 const (
+	// Name is the name of the component.
+	Name = "queue"
 	// RequestQueueHealthPath specifies the path for health checks for
 	// queue-proxy.
 	RequestQueueHealthPath = "/health"

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -16,8 +16,3 @@ limitations under the License.
 // Package queue provides components for the queue-proxy binary.
 
 package queue
-
-const (
-	// Name is the name of the component.
-	Name = "queue"
-)

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -16,3 +16,8 @@ limitations under the License.
 // Package queue provides components for the queue-proxy binary.
 
 package queue
+
+const (
+	// Name is the name of the component.
+	Name = "queue"
+)


### PR DESCRIPTION
Currently the activator probings succeed when they reach the activator,
resulting in a chain of forwarding (header "X-Forwarding-For" has value
like [<client IP>, "127.0.0.1", "127.0.0.1", "127.0.0.1"]), and attempts
count is always 2 for probing + proxying, regardless the number of
retries.

Fix is to have probings succeed only when they reach "queue".

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Activator considers probing succeeded only when it reaches the queue-proxy.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
