### PR TITLE
Probe with name

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -74,7 +74,6 @@ var (
 	userTargetAddress      string
 	containerConcurrency   int
 	revisionTimeoutSeconds int
-	statChan               = make(chan *autoscaler.Stat, statReportingQueueLength)
 	reqChan                = make(chan queue.ReqEvent, requestCountingQueueLength)
 	logger                 *zap.SugaredLogger
 	breaker                *queue.Breaker
@@ -109,7 +108,7 @@ func initEnv() {
 	reporter = _reporter
 }
 
-func reportStats() {
+func reportStats(statChan chan *autoscaler.Stat) {
 	for {
 		s := <-statChan
 		if err := reporter.Report(float64(s.RequestCount), s.AverageConcurrentRequests); err != nil {
@@ -126,8 +125,8 @@ func proxyForRequest(req *http.Request) *httputil.ReverseProxy {
 	return httpProxy
 }
 
-func isKnativeProbe(r *http.Request) bool {
-	return r.Header.Get(network.ProbeHeaderName) != ""
+func knativeProbeHeader(r *http.Request) string {
+	return r.Header.Get(network.ProbeHeaderName)
 }
 
 func isKubeletProbe(r *http.Request) bool {
@@ -156,8 +155,13 @@ func probeUserContainer() bool {
 func handler(w http.ResponseWriter, r *http.Request) {
 	proxy := proxyForRequest(r)
 
+	ph := knativeProbeHeader(r)
 	switch {
-	case isKnativeProbe(r):
+	case ph != "":
+		if ph != queue.Name {
+			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusNotFound)
+			return
+		}
 		if probeUserContainer() {
 			// Respond with the name of the component handling the request.
 			w.Write([]byte("queue"))
@@ -165,7 +169,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "container not ready", http.StatusServiceUnavailable)
 		}
 		return
-
 	case isKubeletProbe(r):
 		// Do not count health checks for concurrency metrics
 		proxy.ServeHTTP(w, r)
@@ -252,12 +255,15 @@ func main() {
 		http.ListenAndServe(fmt.Sprintf(":%d", v1alpha1.RequestQueueMetricsPort), mux)
 	}()
 
-	go reportStats()
+	statChan := make(chan *autoscaler.Stat, statReportingQueueLength)
+	defer close(statChan)
+	go reportStats(statChan)
 
-	reportTicker := time.NewTicker(queue.ReporterReportingPeriod).C
+	reportTicker := time.NewTicker(queue.ReporterReportingPeriod)
+	defer reportTicker.Stop()
 	queue.NewStats(podName, queue.Channels{
 		ReqChan:    reqChan,
-		ReportChan: reportTicker,
+		ReportChan: reportTicker.C,
 		StatChan:   statChan,
 	}, time.Now())
 
@@ -268,9 +274,11 @@ func main() {
 
 	server = h2c.NewServer(
 		fmt.Sprintf(":%d", v1alpha1.RequestQueuePort),
-		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler), time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
+		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler),
+			time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
 
 	errChan := make(chan error, 2)
+	defer close(errChan)
 	// Runs a server created by creator and sends fatal errors to the errChan.
 	// Does not act on the ErrServerClosed error since that indicates we're
 	// already shutting everything down.

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -159,7 +159,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case ph != "":
 		if ph != queue.Name {
-			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusNotFound)
+			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusServiceUnavailable)
 			return
 		}
 		if probeUserContainer() {

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -88,7 +88,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				ProtoMinor: r.ProtoMinor,
 				Host:       r.Host,
 				Header: map[string][]string{
-					http.CanonicalHeaderKey(network.ProbeHeaderName): {"true"},
+					http.CanonicalHeaderKey(network.ProbeHeaderName): {queue.Name},
 				},
 			}
 			settings := wait.Backoff{

--- a/pkg/activator/handler/probe_handler.go
+++ b/pkg/activator/handler/probe_handler.go
@@ -14,6 +14,7 @@ limitations under the License.
 package handler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/knative/serving/pkg/network"
@@ -27,8 +28,12 @@ type ProbeHandler struct {
 func (h *ProbeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If this header is set the request was sent by a Knative component
 	// probing the network, respond with a 200 and our component name.
-	if r.Header.Get(network.ProbeHeaderName) != "" {
-		w.Write([]byte("activator"))
+	if val := r.Header.Get(network.ProbeHeaderName); val != "" {
+		if val != activator.Name {
+			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", val), http.StatusNotFound)
+			return
+		}
+		w.Write([]byte(activator.Name))
 		return
 	}
 

--- a/pkg/activator/handler/probe_handler.go
+++ b/pkg/activator/handler/probe_handler.go
@@ -31,7 +31,7 @@ func (h *ProbeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// probing the network, respond with a 200 and our component name.
 	if val := r.Header.Get(network.ProbeHeaderName); val != "" {
 		if val != activator.Name {
-			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", val), http.StatusNotFound)
+			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", val), http.StatusServiceUnavailable)
 			return
 		}
 		w.Write([]byte(activator.Name))

--- a/pkg/activator/handler/probe_handler_test.go
+++ b/pkg/activator/handler/probe_handler_test.go
@@ -38,7 +38,7 @@ func TestProbeHandler(t *testing.T) {
 		label:          "filter a POST request containing probe header, even if probe is for a different target",
 		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: "not-empty"}),
 		passed:         false,
-		expectedStatus: http.StatusNotFound,
+		expectedStatus: http.StatusServiceUnavailable,
 		method:         http.MethodPost,
 	}, {
 		label:          "filter a POST request containing probe header",
@@ -56,7 +56,7 @@ func TestProbeHandler(t *testing.T) {
 		label:          "filter a GET request containing probe header, with wrong target system",
 		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: "not-empty"}),
 		passed:         false,
-		expectedStatus: http.StatusNotFound,
+		expectedStatus: http.StatusServiceUnavailable,
 		method:         http.MethodGet,
 	}, {
 		label:          "filter a GET request containing probe header",

--- a/pkg/activator/handler/probe_handler_test.go
+++ b/pkg/activator/handler/probe_handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/queue"
 )
 
 func TestProbeHandler(t *testing.T) {
@@ -36,7 +37,7 @@ func TestProbeHandler(t *testing.T) {
 		method:         http.MethodPost,
 	}, {
 		label:          "filter a POST request containing probe header, even if probe is for a different target",
-		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: "not-empty"}),
+		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: queue.Name}),
 		passed:         false,
 		expectedStatus: http.StatusServiceUnavailable,
 		method:         http.MethodPost,

--- a/pkg/activator/handler/probe_handler_test.go
+++ b/pkg/activator/handler/probe_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/network"
 )
 
@@ -34,8 +35,14 @@ func TestProbeHandler(t *testing.T) {
 		expectedStatus: http.StatusOK,
 		method:         http.MethodPost,
 	}, {
-		label:          "filter a POST request containing probe header",
+		label:          "filter a POST request containing probe header, even if probe is for a different target",
 		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: "not-empty"}),
+		passed:         false,
+		expectedStatus: http.StatusNotFound,
+		method:         http.MethodPost,
+	}, {
+		label:          "filter a POST request containing probe header",
+		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: activator.Name}),
 		passed:         false,
 		expectedStatus: http.StatusOK,
 		method:         http.MethodPost,
@@ -46,8 +53,14 @@ func TestProbeHandler(t *testing.T) {
 		expectedStatus: http.StatusOK,
 		method:         http.MethodGet,
 	}, {
-		label:          "filter a GET request containing probe header",
+		label:          "filter a GET request containing probe header, with wrong target system",
 		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: "not-empty"}),
+		passed:         false,
+		expectedStatus: http.StatusNotFound,
+		method:         http.MethodGet,
+	}, {
+		label:          "filter a GET request containing probe header",
+		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: activator.Name}),
 		passed:         false,
 		expectedStatus: http.StatusOK,
 		method:         http.MethodGet,

--- a/pkg/queue/constants.go
+++ b/pkg/queue/constants.go
@@ -17,6 +17,9 @@ limitations under the License.
 package queue
 
 const (
+	// Name is the name of the component.
+	Name = "queue"
+
 	// RequestQueueHealthPath specifies the path for health checks for
 	// queue-proxy.
 	RequestQueueHealthPath = "/health"


### PR DESCRIPTION
/lint

## Proposed Changes
* When sending the probe send the target system in the header name, rather than just `true`.
* Receiving system can fail the probe if it's not targeting itself.
* also flyby changes to queue/main.

As discussed with @mattmoor.

/cc @mattmoor @tcnghia 