### PR TITLE
golang format tools

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -254,7 +254,7 @@ func main() {
 		GetProbeCount: maxRetries,
 	}
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
-	ah = &activatorhandler.ProbeHandler{NextHandler:ah}
+	ah = &activatorhandler.ProbeHandler{NextHandler: ah}
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/system"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
