### PR TITLE
Add labels to our OWNERS files by area.

### DIFF
--- a/cmd/activator/OWNERS
+++ b/cmd/activator/OWNERS
@@ -1,9 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
 - networking-approvers
 
 reviewers:
-- autoscaling-reviewers
 - networking-reviewers
+
+labels:
+- area/networking

--- a/cmd/autoscaler/OWNERS
+++ b/cmd/autoscaler/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - autoscaling-reviewers
+
+labels:
+- area/autoscale

--- a/cmd/controller/OWNERS
+++ b/cmd/controller/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - serving-api-reviewers
+
+labels:
+- area/API

--- a/cmd/queue/OWNERS
+++ b/cmd/queue/OWNERS
@@ -1,9 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
 - networking-approvers
 
 reviewers:
-- autoscaling-reviewers
 - networking-reviewers
+
+labels:
+- area/networking

--- a/config/monitoring/OWNERS
+++ b/config/monitoring/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - monitoring-reviewers
+
+labels:
+- area/monitoring

--- a/docs/scaling/OWNERS
+++ b/docs/scaling/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - autoscaling-reviewers
+
+labels:
+- area/autoscale

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - productivity-reviewers
+
+labels:
+- area/test-and-release

--- a/pkg/activator/OWNERS
+++ b/pkg/activator/OWNERS
@@ -1,9 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
 - networking-approvers
 
 reviewers:
-- autoscaling-reviewers
 - networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -4,3 +4,6 @@ approvers:
 - evankanderson
 - mattmoor
 - vaikas-google
+
+labels:
+- area/API

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - autoscaling-reviewers
+
+labels:
+- area/autoscale

--- a/pkg/apis/networking/OWNERS
+++ b/pkg/apis/networking/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/autoscaler/OWNERS
+++ b/pkg/autoscaler/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - autoscaling-reviewers
+
+labels:
+- area/autoscale

--- a/pkg/http/h2c/OWNERS
+++ b/pkg/http/h2c/OWNERS
@@ -1,9 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
 - networking-approvers
 
 reviewers:
-- autoscaling-reviewers
 - networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/logging/OWNERS
+++ b/pkg/logging/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - monitoring-reviewers
+
+labels:
+- area/monitoring

--- a/pkg/metrics/OWNERS
+++ b/pkg/metrics/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - monitoring-reviewers
+
+labels:
+- area/monitoring

--- a/pkg/network/OWNERS
+++ b/pkg/network/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/pool/OWNERS
+++ b/pkg/pool/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - serving-api-reviewers
+
+labels:
+- area/API

--- a/pkg/queue/OWNERS
+++ b/pkg/queue/OWNERS
@@ -1,9 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
 - networking-approvers
 
 reviewers:
-- autoscaling-reviewers
 - networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/reconciler/OWNERS
+++ b/pkg/reconciler/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - serving-api-reviewers
+
+labels:
+- area/API

--- a/pkg/reconciler/v1alpha1/autoscaling/OWNERS
+++ b/pkg/reconciler/v1alpha1/autoscaling/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - autoscaling-reviewers
+
+labels:
+- area/autoscale

--- a/pkg/reconciler/v1alpha1/clusteringress/OWNERS
+++ b/pkg/reconciler/v1alpha1/clusteringress/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/reconciler/v1alpha1/route/OWNERS
+++ b/pkg/reconciler/v1alpha1/route/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - networking-reviewers
+
+labels:
+- area/networking

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - productivity-reviewers
+
+labels:
+- area/test-and-release

--- a/third_party/OWNERS
+++ b/third_party/OWNERS
@@ -7,8 +7,6 @@ approvers:
 - monitoring-approvers
 # knative/build
 - build-approvers
-# VPA
-- autoscaling-approvers
 
 
 reviewers:
@@ -18,5 +16,3 @@ reviewers:
 - monitoring-reviewers
 # knative/build
 - build-reviewers
-# VPA
-- autoscaling-reviewers

--- a/third_party/config/monitoring/OWNERS
+++ b/third_party/config/monitoring/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
 - monitoring-reviewers
+
+labels:
+- area/monitoring


### PR DESCRIPTION
This also cleans up a few ACLs (e.g. queue/activator -> networking, and no more VPA in third party).

Example in K8s: https://github.com/kubernetes/kubernetes/blob/ebea0377292677a8895ca632208833a0afbd33f3/staging/src/k8s.io/sample-controller/OWNERS#L11-L12