### PR TITLE
Drop unnecessary interface.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -57,9 +57,6 @@ var _ apis.Validatable = (*PodAutoscaler)(nil)
 var _ apis.Defaultable = (*PodAutoscaler)(nil)
 var _ apis.Immutable = (*PodAutoscaler)(nil)
 
-// Check that ConfigurationStatus may have its conditions managed.
-var _ duckv1alpha1.ConditionsAccessor = (*PodAutoscalerStatus)(nil)
-
 // PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).
 type PodAutoscalerSpec struct {
 	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
@@ -251,16 +248,4 @@ func (rs *PodAutoscalerStatus) CanMarkInactive(idlePeriod time.Duration) bool {
 		}
 	}
 	return false
-}
-
-// GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (rs *PodAutoscalerStatus) GetConditions() duckv1alpha1.Conditions {
-	return rs.Conditions
-}
-
-// SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (rs *PodAutoscalerStatus) SetConditions(conditions duckv1alpha1.Conditions) {
-	rs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -54,9 +54,6 @@ var _ apis.Defaultable = (*Configuration)(nil)
 // Check that we can create OwnerReferences to a Configuration.
 var _ kmeta.OwnerRefable = (*Configuration)(nil)
 
-// Check that ConfigurationStatus may have its conditions managed.
-var _ duckv1alpha1.ConditionsAccessor = (*ConfigurationStatus)(nil)
-
 // ConfigurationSpec holds the desired state of the Configuration (from the client).
 type ConfigurationSpec struct {
 	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
@@ -185,16 +182,4 @@ func (cs *ConfigurationStatus) MarkLatestReadyDeleted() {
 		ConfigurationConditionReady,
 		"RevisionDeleted",
 		"Revision %q was deleted.", cs.LatestReadyRevisionName)
-}
-
-// GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (cs *ConfigurationStatus) GetConditions() duckv1alpha1.Conditions {
-	return cs.Conditions
-}
-
-// SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (cs *ConfigurationStatus) SetConditions(conditions duckv1alpha1.Conditions) {
-	cs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -58,9 +58,6 @@ var _ apis.Validatable = (*Revision)(nil)
 var _ apis.Defaultable = (*Revision)(nil)
 var _ apis.Immutable = (*Revision)(nil)
 
-// Check that RevisionStatus may have its conditions managed.
-var _ duckv1alpha1.ConditionsAccessor = (*RevisionStatus)(nil)
-
 // Check that we can create OwnerReferences to a Revision.
 var _ kmeta.OwnerRefable = (*Revision)(nil)
 
@@ -426,18 +423,6 @@ func (rs *RevisionStatus) MarkInactive(reason, message string) {
 
 func (rs *RevisionStatus) MarkContainerMissing(message string) {
 	revCondSet.Manage(rs).MarkFalse(RevisionConditionContainerHealthy, "ContainerMissing", message)
-}
-
-// GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (rs *RevisionStatus) GetConditions() duckv1alpha1.Conditions {
-	return rs.Conditions
-}
-
-// SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (rs *RevisionStatus) SetConditions(conditions duckv1alpha1.Conditions) {
-	rs.Conditions = conditions
 }
 
 // RevisionContainerMissingMessage constructs the status message if a given image

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -59,9 +59,6 @@ var _ apis.Defaultable = (*Route)(nil)
 // Check that we can create OwnerReferences to a Route.
 var _ kmeta.OwnerRefable = (*Route)(nil)
 
-// Check that RouteStatus may have its conditions managed.
-var _ duckv1alpha1.ConditionsAccessor = (*RouteStatus)(nil)
-
 // TrafficTarget holds a single entry of the routing table for a Route.
 type TrafficTarget struct {
 	// Name is optionally used to expose a dedicated hostname for referencing this
@@ -247,16 +244,4 @@ func (rs *RouteStatus) PropagateClusterIngressStatus(cs v1alpha1.IngressStatus) 
 	case cc.Status == corev1.ConditionFalse:
 		routeCondSet.Manage(rs).MarkFalse(RouteConditionIngressReady, cc.Reason, cc.Message)
 	}
-}
-
-// GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (rs *RouteStatus) GetConditions() duckv1alpha1.Conditions {
-	return rs.Conditions
-}
-
-// SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (rs *RouteStatus) SetConditions(conditions duckv1alpha1.Conditions) {
-	rs.Conditions = conditions
 }

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -62,9 +62,6 @@ var _ apis.Defaultable = (*Service)(nil)
 // Check that we can create OwnerReferences to a Service.
 var _ kmeta.OwnerRefable = (*Service)(nil)
 
-// Check that ServiceStatus may have its conditions managed.
-var _ duckv1alpha1.ConditionsAccessor = (*ServiceStatus)(nil)
-
 // ServiceSpec represents the configuration for the Service object. Exactly one
 // of its members (other than Generation) must be specified. Services can either
 // track the latest ready revision of a configuration or be pinned to a specific
@@ -346,18 +343,6 @@ func (ss *ServiceStatus) SetManualStatus() {
 	newStatus.DeprecatedDomainInternal = ss.DeprecatedDomainInternal
 
 	*ss = *newStatus
-}
-
-// GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (ss *ServiceStatus) GetConditions() duckv1alpha1.Conditions {
-	return ss.Conditions
-}
-
-// SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (ss *ServiceStatus) SetConditions(conditions duckv1alpha1.Conditions) {
-	ss.Conditions = conditions
 }
 
 const (

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -730,7 +730,7 @@ func WithEmptyLTTs(r *v1alpha1.Revision) {
 		c.LastTransitionTime = apis.VolatileTime{}
 		conds[i] = c
 	}
-	r.Status.SetConditions(conds)
+	r.Status.Conditions = conds
 }
 
 // WithLastPinned updates the "last pinned" annotation to the provided timestamp.


### PR DESCRIPTION
Scott added a reflection-based path (a while ago) that no longer requires this boilerplate,
so this simply removes it and changes the one call-site that we had to set the conditions
explicitly.
