### PR TITLE
Set istio trace sampling back to 100%

### DIFF
--- a/third_party/istio-1.0.6/download-istio.sh
+++ b/third_party/istio-1.0.6/download-istio.sh
@@ -37,6 +37,8 @@ helm template --namespace=istio-system \
   `# Set a generous number of pilot replicas to avoid Pilot being overloaded.` \
   --set pilot.autoscaleMin=3 \
   --set pilot.autoscaleMax=10 \
+  `# Set pilot trace sampling to 100%` \
+  --set pilot.traceSampling=100 \
   --set pilot.cpu.targetAverageUtilization=60 \
   `# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
   --set gateways.istio-ingressgateway.autoscaleMin=1 \
@@ -58,6 +60,8 @@ helm template --namespace=istio-system \
   `# Disable mixer policy check, since in our template we set no policy.` \
   --set global.disablePolicyChecks=true \
   `# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
+  `# Set pilot trace sampling to 100%` \
+  --set pilot.traceSampling=100 \
   --set gateways.istio-ingressgateway.autoscaleMin=1 \
   --set gateways.istio-ingressgateway.autoscaleMax=1 \
   install/kubernetes/helm/istio \

--- a/third_party/istio-1.0.6/istio-lean.yaml
+++ b/third_party/istio-1.0.6/istio-lean.yaml
@@ -2829,7 +2829,7 @@ spec:
           - name: PILOT_PUSH_THROTTLE_COUNT
             value: "100"
           - name: PILOT_TRACE_SAMPLING
-            value: "1"
+            value: "100"
           resources:
             requests:
               cpu: 500m

--- a/third_party/istio-1.0.6/istio.yaml
+++ b/third_party/istio-1.0.6/istio.yaml
@@ -3072,7 +3072,7 @@ spec:
           - name: PILOT_PUSH_THROTTLE_COUNT
             value: "100"
           - name: PILOT_TRACE_SAMPLING
-            value: "1"
+            value: "100"
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
We accidentally set this to the upstream production default of 1% when
switching to istio 1.0.6.



**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
