### PR TITLE
Installing monitoring components in perf test scripts (#3446)

### DIFF
--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -22,7 +22,7 @@ source $(dirname $0)/e2e-common.sh
 # Build Knative, but don't install the default "no monitoring" version
 function knative_setup() {
   build_knative_from_source
-  install_knative_serving "${ISTIO_CRD_YAML}" "${ISTIO_YAML}" "${SERVING_YAML}"
+  install_knative_serving "${ISTIO_CRD_YAML}" "${ISTIO_YAML}" "${SERVING_YAML}" "${MONITORING_YAML}"
 }
 
 initialize $@


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Changes: 

* Add optional flag "--install-monitoring" to install monitoring component for e2e test. This change is based from https://github.com/dushyanthsc/serving/commit/14af0096d71585adf9f19e18a9b5a36f7ef0d4e9. 
* Install monitoring components in perf test scripts 

Fixes #3446 

**Release Note**

NONE 