### PR TITLE
Add @vagababov to serving approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,6 +4,7 @@ aliases:
   - grantr
   - mattmoor
   - tcnghia
+  - vagababov
   serving-api-reviewers:
   - dgerd
   - dprotaso


### PR DESCRIPTION
From ROLES.md:

Reviewer of the codebase for at least 3 months or 50% of project lifetime, whichever is shorter

Total project lifetime: 413 days (2018-01-30 to 2019-02-14)
50% of project lifetime: 206.5 days

Earliest review: 2018-12-03, 106 days ago

Primary reviewer for at least 10 substantial PRs to the codebase

Reviewed 47 L, 15 XL and 9 XXL PRs
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+-author%3Avagababov+reviewed-by%3Avagababov+label%3Asize%2FL+
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+-author%3Avagababov+reviewed-by%3Avagababov+label%3Asize%2FXL+
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+-author%3Avagababov+reviewed-by%3Avagababov+label%3Asize%2FXXL+

Reviewed or merged at least 30 PRs to the codebase

Reviewed 130 or merged 73 PRs
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Avagababov+-author%3Avagababov+is%3Aclosed+
https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Avagababov+is%3Aclosed+

Nominated by an area lead with no objections from other leads

Current API Core lead is @mattmoor.

/cc @evankanderson @mattmoor @vaikas-google
/assign @mattmoor 

