### PR TITLE
Reject revision template spec name

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -51,7 +51,11 @@ func (rt *Revision) Validate() *apis.FieldError {
 
 // Validate ensures RevisionTemplateSpec is properly configured.
 func (rt *RevisionTemplateSpec) Validate() *apis.FieldError {
-	return rt.Spec.Validate().ViaField("spec")
+	var errs *apis.FieldError
+	if rt.GetName() != "" {
+		errs = errs.Also(apis.ErrDisallowedFields(apis.CurrentField).ViaField("metadata", "name"))
+	}
+	return errs.Also(rt.Spec.Validate().ViaField("spec"))
 }
 
 // Validate ensures RevisionSpec is properly configured.

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -810,6 +810,20 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.container.name"),
+	}, {
+		name: "has revision template name",
+		rts: &RevisionTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Image: "helloworld",
+				},
+				DeprecatedConcurrencyModel: "Multi",
+			},
+		},
+		want: apis.ErrDisallowedFields("metadata.name"),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

If config revision template has a name set, service creation passes, but following update operation fails with a very confusing k8s response:
```
Revision creation failed with message: The POST operation against Revision.serving.knative.dev could not be completed at this time, please try again..
```
This PR adds webhook validation for revision template metadata.

## Proposed Changes

* admission webhook throws an error if the revision template metadata has a `name` field set:
```
2019/03/20 16:33:28 Creating service: Internal error occurred: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: must not set the field(s): spec.runLatest.configuration.revisionTemplate.metadata.name
```

**Release Note**

```release-note
NONE
```
