### PR TITLE
Add a new stat metric in queue to prevent double counting

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -150,11 +150,7 @@ func probeUserContainer() bool {
 }
 
 // Make handler a closure for testing.
-func handler(rc chan queue.ReqEvent, b *queue.Breaker, h1, h2 *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
-	reqChan := rc
-	breaker := b
-	httpProxy := h1
-	h2cProxy := h2
+func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, httpProxy, h2cProxy *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		proxy := httpProxy
 		if r.ProtoMajor == 2 {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/cmd/util"
+	"github.com/knative/serving/pkg/activator"
 	activatorutil "github.com/knative/serving/pkg/activator/util"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
@@ -111,18 +112,10 @@ func initEnv() {
 func reportStats(statChan chan *autoscaler.Stat) {
 	for {
 		s := <-statChan
-		if err := reporter.Report(float64(s.RequestCount), s.AverageConcurrentRequests); err != nil {
+		if err := reporter.Report(s); err != nil {
 			logger.Errorw("Error while sending stat", zap.Error(err))
 		}
 	}
-}
-
-func proxyForRequest(req *http.Request) *httputil.ReverseProxy {
-	if req.ProtoMajor == 2 {
-		return h2cProxy
-	}
-
-	return httpProxy
 }
 
 func knativeProbeHeader(r *http.Request) string {
@@ -133,6 +126,10 @@ func isKubeletProbe(r *http.Request) bool {
 	// Since K8s 1.8, prober requests have
 	//   User-Agent = "kube-probe/{major-version}.{minor-version}".
 	return strings.HasPrefix(r.Header.Get("User-Agent"), "kube-probe/")
+}
+
+func knativeProxyHeader(r *http.Request) string {
+	return r.Header.Get(network.ProxyHeaderName)
 }
 
 func probeUserContainer() bool {
@@ -152,47 +149,61 @@ func probeUserContainer() bool {
 	return err == nil
 }
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	proxy := proxyForRequest(r)
+// Make handler a closure for testing.
+func handler(rc chan queue.ReqEvent, b *queue.Breaker, h1, h2 *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
+	reqChan := rc
+	breaker := b
+	httpProxy := h1
+	h2cProxy := h2
+	return func(w http.ResponseWriter, r *http.Request) {
+		proxy := httpProxy
+		if r.ProtoMajor == 2 {
+			proxy = h2cProxy
+		}
 
-	ph := knativeProbeHeader(r)
-	switch {
-	case ph != "":
-		if ph != queue.Name {
-			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusServiceUnavailable)
+		ph := knativeProbeHeader(r)
+		switch {
+		case ph != "":
+			if ph != queue.Name {
+				http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusServiceUnavailable)
+				return
+			}
+			if probeUserContainer() {
+				// Respond with the name of the component handling the request.
+				w.Write([]byte(queue.Name))
+			} else {
+				http.Error(w, "container not ready", http.StatusServiceUnavailable)
+			}
+			return
+		case isKubeletProbe(r):
+			// Do not count health checks for concurrency metrics
+			proxy.ServeHTTP(w, r)
 			return
 		}
-		if probeUserContainer() {
-			// Respond with the name of the component handling the request.
-			w.Write([]byte(queue.Name))
+
+		// Metrics for autoscaling
+		h := knativeProxyHeader(r)
+		in, out := queue.ReqIn, queue.ReqOut
+		if activator.Name == h {
+			in, out = queue.ProxiedIn, queue.ProxiedOut
+		}
+		reqChan <- queue.ReqEvent{Time: time.Now(), EventType: in}
+		defer func() {
+			reqChan <- queue.ReqEvent{Time: time.Now(), EventType: out}
+		}()
+
+		// Enforce queuing and concurrency limits
+		if breaker != nil {
+			ok := breaker.Maybe(func() {
+				proxy.ServeHTTP(w, r)
+			})
+			if !ok {
+				http.Error(w, "overload", http.StatusServiceUnavailable)
+			}
 		} else {
-			http.Error(w, "container not ready", http.StatusServiceUnavailable)
-		}
-		return
-	case isKubeletProbe(r):
-		// Do not count health checks for concurrency metrics
-		proxy.ServeHTTP(w, r)
-		return
-	}
-
-	// Metrics for autoscaling
-	reqChan <- queue.ReqEvent{Time: time.Now(), EventType: queue.ReqIn}
-	defer func() {
-		reqChan <- queue.ReqEvent{Time: time.Now(), EventType: queue.ReqOut}
-	}()
-
-	// Enforce queuing and concurrency limits
-	if breaker != nil {
-		ok := breaker.Maybe(func() {
 			proxy.ServeHTTP(w, r)
-		})
-		if !ok {
-			http.Error(w, "overload", http.StatusServiceUnavailable)
 		}
-	} else {
-		proxy.ServeHTTP(w, r)
 	}
-
 }
 
 // Sets up /health and /wait-for-drain endpoints.
@@ -274,7 +285,7 @@ func main() {
 
 	server = h2c.NewServer(
 		fmt.Sprintf(":%d", v1alpha1.RequestQueuePort),
-		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler),
+		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler(reqChan, breaker, httpProxy, h2cProxy)),
 			time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
 
 	errChan := make(chan error, 2)

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -65,6 +65,6 @@ func TestHandler_ReqEvent(t *testing.T) {
 			t.Errorf("Want: %v, got: %v\n", queue.ReqIn, e.EventType)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatalf("Timed out waiting for an event to be intercepted")
+		t.Fatal("Timed out waiting for an event to be intercepted")
 	}
 }

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/knative/serving/pkg/activator"
+	"github.com/knative/serving/pkg/network"
+
+	"github.com/knative/serving/pkg/queue"
+)
+
+func TestHandler_ReqEvent(t *testing.T) {
+	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(activator.RevisionHeaderName) != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if r.Header.Get(activator.RevisionHeaderNamespace) != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+
+	server := httptest.NewServer(httpHandler)
+	serverURL, _ := url.Parse(server.URL)
+
+	defer server.Close()
+	proxy := httputil.NewSingleHostReverseProxy(serverURL)
+
+	params := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+	breaker := queue.NewBreaker(params)
+	reqChan := make(chan queue.ReqEvent, 10)
+	h := handler(reqChan, breaker, proxy, proxy)
+
+	writer := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.Header.Set(network.ProxyHeaderName, activator.Name)
+	h(writer, req)
+	e := <-reqChan
+	if e.EventType != queue.ProxiedIn {
+		t.Errorf("Want: %v, got: %v\n", queue.ReqIn, e.EventType)
+	}
+}

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -180,6 +180,8 @@ func (a *ActivationHandler) proxyRequest(w http.ResponseWriter, r *http.Request,
 	proxy.Transport = a.Transport
 	proxy.FlushInterval = -1
 
+	r.Header.Set(network.ProxyHeaderName, activator.Name)
+
 	util.SetupHeaderPruning(proxy)
 
 	proxy.ServeHTTP(capture, r)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -427,7 +427,6 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
 	namespace, revName := testNamespace, testRevName
 
-	act := newStubActivator(namespace, revName)
 	interceptCh := make(chan *http.Request, 1)
 	rt := util.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		interceptCh <- r
@@ -437,11 +436,12 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 	throttler := getThrottler(breakerParams, t)
 
 	handler := ActivationHandler{
-		Activator: act,
-		Transport: rt,
-		Logger:    TestLogger(t),
-		Reporter:  &fakeReporter{},
-		Throttler: throttler,
+		Transport:   rt,
+		Logger:      TestLogger(t),
+		Reporter:    &fakeReporter{},
+		Throttler:   throttler,
+		GetRevision: stubRevisionGetter,
+		GetService:  stubServiceGetter,
 	}
 
 	writer := httptest.NewRecorder()

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -423,6 +423,39 @@ func TestActivationHandler_OverflowSeveralRevisions(t *testing.T) {
 	assertResponses(wantedSuccess, wantedFailure, overallRequests, lockerCh, respCh, t)
 }
 
+func TestActivationHandler_ProxyHeader(t *testing.T) {
+	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+	namespace, revName := testNamespace, testRevName
+
+	act := newStubActivator(namespace, revName)
+	interceptCh := make(chan *http.Request, 1)
+	rt := util.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		interceptCh <- r
+		fake := httptest.NewRecorder()
+		return fake.Result(), nil
+	})
+	throttler := getThrottler(breakerParams, t)
+
+	handler := ActivationHandler{
+		Activator: act,
+		Transport: rt,
+		Logger:    TestLogger(t),
+		Reporter:  &fakeReporter{},
+		Throttler: throttler,
+	}
+
+	writer := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.Header.Set(activator.RevisionHeaderNamespace, namespace)
+	req.Header.Set(activator.RevisionHeaderName, revName)
+	handler.ServeHTTP(writer, req)
+
+	httpReq := <-interceptCh
+	if got := httpReq.Header.Get(network.ProxyHeaderName); got != activator.Name {
+		t.Errorf("Header '%s' does not have the expected value. Want = '%s', got = '%s'.", network.ProxyHeaderName, activator.Name, got)
+	}
+}
+
 // sendRequests sends `count` concurrent requests via the given handler and writes
 // the recorded responses to the `respCh`.
 func sendRequests(count int, namespace, revName string, respCh chan *httptest.ResponseRecorder, handler ActivationHandler) {

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -456,7 +456,7 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 			t.Errorf("Header '%s' does not have the expected value. Want = '%s', got = '%s'.", network.ProxyHeaderName, activator.Name, got)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatalf("Timed out waiting for a request to be intercepted")
+		t.Fatal("Timed out waiting for a request to be intercepted")
 	}
 }
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -450,9 +450,13 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 	req.Header.Set(activator.RevisionHeaderName, revName)
 	handler.ServeHTTP(writer, req)
 
-	httpReq := <-interceptCh
-	if got := httpReq.Header.Get(network.ProxyHeaderName); got != activator.Name {
-		t.Errorf("Header '%s' does not have the expected value. Want = '%s', got = '%s'.", network.ProxyHeaderName, activator.Name, got)
+	select {
+	case httpReq := <-interceptCh:
+		if got := httpReq.Header.Get(network.ProxyHeaderName); got != activator.Name {
+			t.Errorf("Header '%s' does not have the expected value. Want = '%s', got = '%s'.", network.ProxyHeaderName, activator.Name, got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timed out waiting for a request to be intercepted")
 	}
 }
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -86,6 +86,8 @@ func (b statsBucket) concurrency() float64 {
 	for _, podStats := range b {
 		var subtotal float64
 		for _, stat := range podStats {
+			// Proxied requests have been counted at the activator. Subtract
+			// AverageProxiedConcurrentRequests to avoid double counting.
 			subtotal += stat.AverageConcurrentRequests - stat.AverageProxiedConcurrentRequests
 		}
 		total += subtotal / float64(len(podStats))

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -51,14 +51,14 @@ type Stat struct {
 	// Average number of requests currently being handled by this pod.
 	AverageConcurrentRequests float64
 
-	// Similar to AverageConcurrentRequests, but for requests going through a proxy.
-	AverageProxiedConcurrency float64
+	// Part of AverageConcurrentRequests, for requests going through a proxy.
+	AverageProxiedConcurrentRequests float64
 
 	// Number of requests received since last Stat (approximately QPS).
 	RequestCount int32
 
-	// Number of requests received through a proxy since last Stat.
-	ProxiedCount int32
+	// Part of RequestCount, for requests going through a proxy.
+	ProxiedRequestCount int32
 }
 
 // StatMessage wraps a Stat with identifying information so it can be routed
@@ -86,7 +86,7 @@ func (b statsBucket) concurrency() float64 {
 	for _, podStats := range b {
 		var subtotal float64
 		for _, stat := range podStats {
-			subtotal += stat.AverageConcurrentRequests - stat.AverageProxiedConcurrency
+			subtotal += stat.AverageConcurrentRequests - stat.AverageProxiedConcurrentRequests
 		}
 		total += subtotal / float64(len(podStats))
 	}

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -474,12 +474,12 @@ func TestAutoScaler_Concurrency(t *testing.T) {
 	}
 	a.Record(TestContextWithLogger(t), stat)
 	stat = Stat{
-		Time:                      &now,
-		PodName:                   "pod1",
-		AverageConcurrentRequests: 1,
-		AverageProxiedConcurrency: 1,
-		RequestCount:              1,
-		ProxiedCount:              1,
+		Time:                             &now,
+		PodName:                          "pod1",
+		AverageConcurrentRequests:        1,
+		AverageProxiedConcurrentRequests: 1,
+		RequestCount:                     1,
+		ProxiedRequestCount:              1,
 	}
 	a.Record(TestContextWithLogger(t), stat)
 	a.expectScale(t, now, 1, true)

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -144,12 +144,12 @@ func (s *ServiceScraper) Scrape(ctx context.Context, statsCh chan<- *StatMessage
 	// scraperPodName so in autoscaler all stats are either from activator or
 	// scraper.
 	newStat := Stat{
-		Time:                      stat.Time,
-		PodName:                   scraperPodName,
-		AverageConcurrentRequests: stat.AverageConcurrentRequests * float64(readyPodsCount),
-		AverageProxiedConcurrency: stat.AverageProxiedConcurrency * float64(readyPodsCount),
-		RequestCount:              stat.RequestCount * int32(readyPodsCount),
-		ProxiedCount:              stat.ProxiedCount * int32(readyPodsCount),
+		Time:                             stat.Time,
+		PodName:                          scraperPodName,
+		AverageConcurrentRequests:        stat.AverageConcurrentRequests * float64(readyPodsCount),
+		AverageProxiedConcurrentRequests: stat.AverageProxiedConcurrentRequests * float64(readyPodsCount),
+		RequestCount:                     stat.RequestCount * int32(readyPodsCount),
+		ProxiedRequestCount:              stat.ProxiedRequestCount * int32(readyPodsCount),
 	}
 
 	s.sendStatMessage(newStat, statsCh)
@@ -190,10 +190,10 @@ func extractData(body io.Reader) (*Stat, error) {
 		return nil, errors.New("could not find value for queue_average_concurrent_requests in response")
 	}
 
-	if pMetric := getPrometheusMetric(metricFamilies, "queue_average_proxied_concurrency"); pMetric != nil {
-		stat.AverageProxiedConcurrency = *pMetric.Gauge.Value
+	if pMetric := getPrometheusMetric(metricFamilies, "queue_average_proxied_concurrent_requests"); pMetric != nil {
+		stat.AverageProxiedConcurrentRequests = *pMetric.Gauge.Value
 	} else {
-		return nil, errors.New("could not find value for queue_average_proxied_concurrency in response")
+		return nil, errors.New("could not find value for queue_average_proxied_concurrent_requests in response")
 	}
 
 	if pMetric := getPrometheusMetric(metricFamilies, "queue_operations_per_second"); pMetric != nil {
@@ -203,7 +203,7 @@ func extractData(body io.Reader) (*Stat, error) {
 	}
 
 	if pMetric := getPrometheusMetric(metricFamilies, "queue_proxied_operations_per_second"); pMetric != nil {
-		stat.ProxiedCount = int32(*pMetric.Gauge.Value)
+		stat.ProxiedRequestCount = int32(*pMetric.Gauge.Value)
 	} else {
 		return nil, errors.New("could not find value for queue_proxied_operations_per_second in response")
 	}

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -45,9 +45,9 @@ queue_average_concurrent_requests{destination_namespace="test-namespace",destina
 # TYPE queue_operations_per_second gauge
 queue_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 5
 `
-	testAverageProxiedConcurrenyContext = `# HELP queue_average_proxied_concurrency Number of proxied requests currently being handled by this pod
-# TYPE queue_average_proxied_concurrency gauge
-queue_average_proxied_concurrency{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 2.0
+	testAverageProxiedConcurrenyContext = `# HELP queue_average_proxied_concurrent_requests Number of proxied requests currently being handled by this pod
+# TYPE queue_average_proxied_concurrent_requests gauge
+queue_average_proxied_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 2.0
 `
 	testProxiedQPSContext = `# HELP queue_proxied_operations_per_second Number of proxied requests received since last Stat
 # TYPE queue_proxied_operations_per_second gauge
@@ -146,11 +146,11 @@ func TestScrapeViaURL_HappyCase(t *testing.T) {
 	if stat.RequestCount != 5 {
 		t.Errorf("stat.RequestCount=%v, want 5", stat.RequestCount)
 	}
-	if stat.AverageProxiedConcurrency != 2.0 {
-		t.Errorf("stat.AverageProxiedConcurrency=%v, want 2.0", stat.AverageProxiedConcurrency)
+	if stat.AverageProxiedConcurrentRequests != 2.0 {
+		t.Errorf("stat.AverageProxiedConcurrency=%v, want 2.0", stat.AverageProxiedConcurrentRequests)
 	}
-	if stat.ProxiedCount != 4 {
-		t.Errorf("stat.ProxiedCount=%v, want 4", stat.ProxiedCount)
+	if stat.ProxiedRequestCount != 4 {
+		t.Errorf("stat.ProxiedCount=%v, want 4", stat.ProxiedRequestCount)
 	}
 }
 
@@ -189,7 +189,7 @@ func TestScrapeViaURL_ErrorCases(t *testing.T) {
 		name:            "Missing average proxied concurrency",
 		responseCode:    http.StatusOK,
 		responseContext: testAverageConcurrencyContext + testQPSContext + testProxiedQPSContext,
-		expectedErr:     "could not find value for queue_average_proxied_concurrency in response",
+		expectedErr:     "could not find value for queue_average_proxied_concurrent_requests in response",
 	}, {
 		name:            "Missing proxied QPS",
 		responseCode:    http.StatusOK,
@@ -248,13 +248,13 @@ func TestScrape_HappyCase(t *testing.T) {
 		t.Errorf("StatMessage.Stat.RequestCount=%v, want %v", got.Stat.RequestCount, 10)
 	}
 	// 2 pods times 2.0
-	if got.Stat.AverageProxiedConcurrency != 4.0 {
+	if got.Stat.AverageProxiedConcurrentRequests != 4.0 {
 		t.Errorf("StatMessage.Stat.AverageProxiedConcurrency=%v, want %v",
-			got.Stat.AverageProxiedConcurrency, 4.0)
+			got.Stat.AverageProxiedConcurrentRequests, 4.0)
 	}
 	// 2 pods times 4
-	if got.Stat.ProxiedCount != 8 {
-		t.Errorf("StatMessage.Stat.ProxiedCount=%v, want %v", got.Stat.ProxiedCount, 8)
+	if got.Stat.ProxiedRequestCount != 8 {
+		t.Errorf("StatMessage.Stat.ProxiedCount=%v, want %v", got.Stat.ProxiedRequestCount, 8)
 	}
 }
 

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -37,14 +37,23 @@ const (
 	testKPAKey    = "test-namespace/test-revision"
 	testURL       = "http://test-revision-service.test-namespace:9090/metrics"
 
-	testAverageConcurrenyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
+	testAverageConcurrencyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
 # TYPE queue_average_concurrent_requests gauge
-queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 2.0
+queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 3.0
 `
 	testQPSContext = `# HELP queue_operations_per_second Number of requests received since last Stat
 # TYPE queue_operations_per_second gauge
-queue_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 1
+queue_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 5
 `
+	testAverageProxiedConcurrenyContext = `# HELP queue_average_proxied_concurrency Number of proxied requests currently being handled by this pod
+# TYPE queue_average_proxied_concurrency gauge
+queue_average_proxied_concurrency{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 2.0
+`
+	testProxiedQPSContext = `# HELP queue_proxied_operations_per_second Number of proxied requests received since last Stat
+# TYPE queue_proxied_operations_per_second gauge
+queue_proxied_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 4
+`
+	testFullContext = testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext
 )
 
 func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
@@ -122,7 +131,7 @@ func TestNewServiceScraperWithClient_ErrorCases(t *testing.T) {
 }
 
 func TestScrapeViaURL_HappyCase(t *testing.T) {
-	client := newTestClient(getHTTPResponse(http.StatusOK, testAverageConcurrenyContext+testQPSContext), nil)
+	client := newTestClient(getHTTPResponse(http.StatusOK, testFullContext), nil)
 	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("newServiceScraperWithClient=%v, want no error", err)
@@ -131,11 +140,17 @@ func TestScrapeViaURL_HappyCase(t *testing.T) {
 	if err != nil {
 		t.Errorf("scrapeViaURL=%v, want no error", err)
 	}
-	if stat.AverageConcurrentRequests != 2.0 {
-		t.Errorf("stat.AverageConcurrentRequests=%v, want 2.0", stat.AverageConcurrentRequests)
+	if stat.AverageConcurrentRequests != 3.0 {
+		t.Errorf("stat.AverageConcurrentRequests=%v, want 3.0", stat.AverageConcurrentRequests)
 	}
-	if stat.RequestCount != 1 {
-		t.Errorf("stat.RequestCount=%v, want 1", stat.RequestCount)
+	if stat.RequestCount != 5 {
+		t.Errorf("stat.RequestCount=%v, want 5", stat.RequestCount)
+	}
+	if stat.AverageProxiedConcurrency != 2.0 {
+		t.Errorf("stat.AverageProxiedConcurrency=%v, want 2.0", stat.AverageProxiedConcurrency)
+	}
+	if stat.ProxiedCount != 4 {
+		t.Errorf("stat.ProxiedCount=%v, want 4", stat.ProxiedCount)
 	}
 }
 
@@ -163,13 +178,23 @@ func TestScrapeViaURL_ErrorCases(t *testing.T) {
 	}, {
 		name:            "Missing average concurrency",
 		responseCode:    http.StatusOK,
-		responseContext: testQPSContext,
+		responseContext: testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext,
 		expectedErr:     "could not find value for queue_average_concurrent_requests in response",
 	}, {
 		name:            "Missing QPS",
 		responseCode:    http.StatusOK,
-		responseContext: testAverageConcurrenyContext,
+		responseContext: testAverageConcurrencyContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext,
 		expectedErr:     "could not find value for queue_operations_per_second in response",
+	}, {
+		name:            "Missing average proxied concurrency",
+		responseCode:    http.StatusOK,
+		responseContext: testAverageConcurrencyContext + testQPSContext + testProxiedQPSContext,
+		expectedErr:     "could not find value for queue_average_proxied_concurrency in response",
+	}, {
+		name:            "Missing proxied QPS",
+		responseCode:    http.StatusOK,
+		responseContext: testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext,
+		expectedErr:     "could not find value for queue_proxied_operations_per_second in response",
 	}}
 
 	for _, test := range testCases {
@@ -189,7 +214,7 @@ func TestScrapeViaURL_ErrorCases(t *testing.T) {
 }
 
 func TestScrape_HappyCase(t *testing.T) {
-	client := newTestClient(getHTTPResponse(http.StatusOK, testAverageConcurrenyContext+testQPSContext), nil)
+	client := newTestClient(getHTTPResponse(http.StatusOK, testFullContext), nil)
 	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("newServiceScraperWithClient=%v, want no error", err)
@@ -213,19 +238,28 @@ func TestScrape_HappyCase(t *testing.T) {
 	if got.Stat.PodName != scraperPodName {
 		t.Errorf("StatMessage.Stat.PodName=%v, want %v", got.Stat.PodName, scraperPodName)
 	}
-	// 2 pods times 2.0
-	if got.Stat.AverageConcurrentRequests != 4.0 {
+	// 2 pods times 3.0
+	if got.Stat.AverageConcurrentRequests != 6.0 {
 		t.Errorf("StatMessage.Stat.AverageConcurrentRequests=%v, want %v",
-			got.Stat.AverageConcurrentRequests, 4.0)
+			got.Stat.AverageConcurrentRequests, 6.0)
 	}
-	// 2 pods times 1
-	if got.Stat.RequestCount != 2 {
-		t.Errorf("StatMessage.Stat.RequestCount=%v, want %v", got.Stat.RequestCount, 2)
+	// 2 pods times 5
+	if got.Stat.RequestCount != 10 {
+		t.Errorf("StatMessage.Stat.RequestCount=%v, want %v", got.Stat.RequestCount, 10)
+	}
+	// 2 pods times 2.0
+	if got.Stat.AverageProxiedConcurrency != 4.0 {
+		t.Errorf("StatMessage.Stat.AverageProxiedConcurrency=%v, want %v",
+			got.Stat.AverageProxiedConcurrency, 4.0)
+	}
+	// 2 pods times 4
+	if got.Stat.ProxiedCount != 8 {
+		t.Errorf("StatMessage.Stat.ProxiedCount=%v, want %v", got.Stat.ProxiedCount, 8)
 	}
 }
 
 func TestScrape_DoNotScrapeIfNoPodsFound(t *testing.T) {
-	client := newTestClient(getHTTPResponse(200, testAverageConcurrenyContext+testQPSContext), nil)
+	client := newTestClient(getHTTPResponse(200, testFullContext), nil)
 	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("newServiceScraperWithClient=%v, want no error", err)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -30,6 +30,10 @@ const (
 	// included in request metrics.
 	ProbeHeaderName = "k-network-probe"
 
+	// ProxyHeaderName is the name of an internal header that activator
+	// uses to mark requests going through it.
+	ProxyHeaderName = "k-proxy-request"
+
 	// ConfigName is the name of the configmap containing all
 	// customizations for networking features.
 	ConfigName = "config-network"

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -133,12 +133,12 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 				}
 
 				stat := &autoscaler.Stat{
-					Time:                      &now,
-					PodName:                   s.podName,
-					AverageConcurrentRequests: avg,
-					AverageProxiedConcurrency: avgp,
-					RequestCount:              requestCount,
-					ProxiedCount:              proxiedCount,
+					Time:                             &now,
+					PodName:                          s.podName,
+					AverageConcurrentRequests:        avg,
+					AverageProxiedConcurrentRequests: avgp,
+					RequestCount:                     requestCount,
+					ProxiedRequestCount:              proxiedCount,
 				}
 				// Send the stat to another goroutine to transmit
 				// so we can continue bucketing stats.

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -36,6 +36,10 @@ const (
 	ReqIn ReqEventType = iota
 	// ReqOut represents a finished request
 	ReqOut
+	// ProxiedIn represents an incoming request through a proxy.
+	ProxiedIn
+	// ProxiedOut represents a finished proxied request.
+	ProxiedOut
 )
 
 // Channels is a structure for holding the channels for driving Stats.
@@ -63,11 +67,16 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 	}
 
 	go func() {
-		var requestCount int32
-		var concurrency int32
+		var (
+			requestCount       int32
+			proxiedCount       int32
+			concurrency        int32
+			proxiedConcurrency int32
+		)
 
 		lastChange := startedAt
 		timeOnConcurrency := make(map[int32]time.Duration)
+		timeOnProxiedConcurrency := make(map[int32]time.Duration)
 
 		// Updates the lastChanged/timeOnConcurrency state
 		// Note: Due to nature of the channels used below, the ReportChan
@@ -78,6 +87,7 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 			if time.After(lastChange) {
 				durationSinceChange := time.Sub(lastChange)
 				timeOnConcurrency[concurrency] += durationSinceChange
+				timeOnProxiedConcurrency[proxiedConcurrency] += durationSinceChange
 				lastChange = time
 			}
 		}
@@ -88,11 +98,18 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 				updateState(event.Time)
 
 				switch event.EventType {
+				case ProxiedIn:
+					proxiedConcurrency++
+					proxiedCount++
+					fallthrough
 				case ReqIn:
-					requestCount = requestCount + 1
-					concurrency = concurrency + 1
+					requestCount++
+					concurrency++
+				case ProxiedOut:
+					proxiedConcurrency--
+					fallthrough
 				case ReqOut:
-					concurrency = concurrency - 1
+					concurrency--
 				}
 			case now := <-s.ch.ReportChan:
 				updateState(now)
@@ -102,19 +119,26 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 					totalTimeUsed += val
 				}
 
-				var avg float64
+				var avg, avgp float64
 				if totalTimeUsed > 0 {
-					for c, val := range timeOnConcurrency {
-						ratio := float64(val) / float64(totalTimeUsed)
-						avg += float64(c) * ratio
+					f := func(times map[int32]time.Duration) float64 {
+						a := 0.0
+						for c, val := range times {
+							ratio := float64(val) / float64(totalTimeUsed)
+							a += float64(c) * ratio
+						}
+						return a
 					}
+					avg, avgp = f(timeOnConcurrency), f(timeOnProxiedConcurrency)
 				}
 
 				stat := &autoscaler.Stat{
 					Time:                      &now,
 					PodName:                   s.podName,
 					AverageConcurrentRequests: avg,
+					AverageProxiedConcurrency: avgp,
 					RequestCount:              requestCount,
+					ProxiedCount:              proxiedCount,
 				}
 				// Send the stat to another goroutine to transmit
 				// so we can continue bucketing stats.
@@ -122,7 +146,9 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 
 				// Reset the stat counts which have been reported.
 				timeOnConcurrency = make(map[int32]time.Duration)
+				timeOnProxiedConcurrency = make(map[int32]time.Duration)
 				requestCount = 0
+				proxiedCount = 0
 			}
 		}
 	}()

--- a/pkg/queue/stats_reporter_test.go
+++ b/pkg/queue/stats_reporter_test.go
@@ -118,7 +118,7 @@ func testReportWithProxiedRequests(t *testing.T, stat *autoscaler.Stat, reqCount
 	checkData(t, operationsPerSecondN, reqCount, testTagKeyValueMap)
 	checkData(t, averageConcurrentRequestsN, concurrency, testTagKeyValueMap)
 	checkData(t, proxiedOperationsPerSecondN, proxiedCount, testTagKeyValueMap)
-	checkData(t, averageProxiedConcurrencyN, proxiedConcurrency, testTagKeyValueMap)
+	checkData(t, averageProxiedConcurrentRequestsN, proxiedConcurrency, testTagKeyValueMap)
 	if err := reporter.UnregisterViews(); err != nil {
 		t.Errorf("Error with unregistering views, %v", err)
 	}
@@ -135,7 +135,7 @@ func TestReporter_ReportNoProxied(t *testing.T) {
 }
 
 func TestReporter_Report(t *testing.T) {
-	testReportWithProxiedRequests(t, &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedCount: 15, AverageProxiedConcurrency: 2}, 39, 3, 15, 2)
+	testReportWithProxiedRequests(t, &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2}, 39, 3, 15, 2)
 }
 
 func checkData(t *testing.T, measurementName string, wanted float64, wantedTagKeyValueMap map[tag.Key]string) {

--- a/pkg/queue/stats_test.go
+++ b/pkg/queue/stats_test.go
@@ -202,12 +202,12 @@ func TestOneProxiedRequest(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                      &now,
-		PodName:                   podName,
-		AverageConcurrentRequests: 1.0,
-		AverageProxiedConcurrency: 1.0,
-		RequestCount:              1,
-		ProxiedCount:              1,
+		Time:                             &now,
+		PodName:                          podName,
+		AverageConcurrentRequests:        1.0,
+		AverageProxiedConcurrentRequests: 1.0,
+		RequestCount:                     1,
+		ProxiedRequestCount:              1,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Unexpected stat (-want +got): %v", diff)
@@ -223,12 +223,12 @@ func TestOneEndedProxiedRequest(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                      &now,
-		PodName:                   podName,
-		AverageConcurrentRequests: 0.5,
-		AverageProxiedConcurrency: 0.5,
-		RequestCount:              1,
-		ProxiedCount:              1,
+		Time:                             &now,
+		PodName:                          podName,
+		AverageConcurrentRequests:        0.5,
+		AverageProxiedConcurrentRequests: 0.5,
+		RequestCount:                     1,
+		ProxiedRequestCount:              1,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Unexpected stat (-want +got): %v", diff)
@@ -245,12 +245,12 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                      &now,
-		PodName:                   podName,
-		AverageConcurrentRequests: 1.0,
-		AverageProxiedConcurrency: 0.5,
-		RequestCount:              2,
-		ProxiedCount:              1,
+		Time:                             &now,
+		PodName:                          podName,
+		AverageConcurrentRequests:        1.0,
+		AverageProxiedConcurrentRequests: 0.5,
+		RequestCount:                     2,
+		ProxiedRequestCount:              1,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Unexpected stat (-want +got): %v", diff)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
Currently a request pending in both the activator and queue proxy is counted twice, once in the activator, and one in the queue proxy.  This change fixes it by letting queue report a concurrency metric for proxied requests and letting the autoscaler discount such concurrency when it calculates the total concurrency for scaling decision.

Fixes #3301 

## Proposed Changes

* Add a new Knative header for tracking where a request goes through.  And let the activator use it to mark proxied requests.
* Let queue report a new metric for the average concurrency of requests proxied through activator.
* Autoscaler discount the average proxied concurrency from the average concurrency from queue when it calculate the total concurrency for scaling decision.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
