### PR TITLE
[WIP] Pod tracing

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -227,6 +227,7 @@ func main() {
 		revisionInformer.Lister(),
 		serviceInformer.Lister(),
 		sksInformer.Lister(),
+		kubeClient,
 	)
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)

--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -49,3 +49,7 @@ data:
 
     # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
+
+    # Enable tracing of kubernetes resources where possible.
+    # NOTE: This can have significant performance impact
+    kube-resource-tracing: "false"

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -29,6 +29,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
+	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
 
 	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/activator"
@@ -43,6 +46,8 @@ import (
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/network/prober"
 	"github.com/knative/serving/pkg/queue"
+	"github.com/knative/serving/pkg/tracing"
+	tracingconfig "github.com/knative/serving/pkg/tracing/config"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -282,6 +287,7 @@ func TestActivationHandler(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.label, func(t *testing.T) {
 			rt := getRT(t, test.probeErr, test.probeCode, test.probeResp, test.wantErr, test.wantBody, "test-host", nil)
+
 			reporter := &fakeReporter{}
 			params := queue.BreakerParams{QueueDepth: 1000, MaxConcurrency: 1000, InitialCapacity: 0}
 			throttler := activator.NewThrottler(
@@ -479,17 +485,83 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 	}
 }
 
+func TestActivationHandler_TraceSpans(t *testing.T) {
+	// Setup transport
+	rt := getRT(t, nil, 200, []string{}, nil, "hello", "", nil)
+	prober.TransportFactory = func() http.RoundTripper {
+		return rt
+	}
+	defer func() {
+		prober.TransportFactory = network.NewAutoTransport
+	}()
+
+	// Create tracer with reporter recorder
+	reporter := reporterrecorder.NewReporter()
+	defer reporter.Close()
+	endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
+	oct := tracing.NewOpenCensusTracer(tracing.WithZipkinExporter(func(cfg *tracingconfig.Config) (zipkinreporter.Reporter, error) {
+		return reporter, nil
+	}, endpoint))
+	defer oct.Finish()
+
+	cfg := tracingconfig.Config{
+		Enable: true,
+		Debug:  true,
+	}
+	if err := oct.ApplyConfig(&cfg); err != nil {
+		t.Errorf("Failed to apply tracer config: %v", err)
+	}
+
+	namespace := testNamespace
+	revName := testRevName
+
+	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+	throttler := activator.NewThrottler(
+		breakerParams,
+		endpointsInformer(endpoints(namespace, revName, breakerParams.InitialCapacity)),
+		sksLister(sks(namespace, revName)),
+		revisionLister(revision(namespace, revName)),
+		TestLogger(t))
+
+	handler := activationHandler{
+		transport:      rt,
+		logger:         TestLogger(t),
+		reporter:       &fakeReporter{},
+		throttler:      throttler,
+		revisionLister: revisionLister(revision(testNamespace, testRevName)),
+		serviceLister:  serviceLister(service(testNamespace, testRevName, "http")),
+		sksLister:      sksLister(sks(testNamespace, testRevName)),
+	}
+
+	_ = sendRequest(namespace, revName, handler)
+
+	gotSpans := reporter.Flush()
+	if len(gotSpans) != 4 {
+		t.Errorf("Got %d spans, expected %d", len(gotSpans), 4)
+	}
+
+	for i, spanName := range []string{"capacity_wait", "probe", "/", "proxy"} {
+		if gotSpans[i].Name != spanName {
+			t.Errorf("Got span %d named %q, expected %q", i, gotSpans[i].Name, spanName)
+		}
+	}
+}
+
+func sendRequest(namespace, revName string, handler activationHandler) *httptest.ResponseRecorder {
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.Header.Set(activator.RevisionHeaderNamespace, namespace)
+	req.Header.Set(activator.RevisionHeaderName, revName)
+	handler.ServeHTTP(resp, req)
+	return resp
+}
+
 // sendRequests sends `count` concurrent requests via the given handler and writes
 // the recorded responses to the `respCh`.
 func sendRequests(count int, namespace, revName string, respCh chan *httptest.ResponseRecorder, handler activationHandler) {
 	for i := 0; i < count; i++ {
 		go func() {
-			resp := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
-			req.Header.Set(activator.RevisionHeaderNamespace, namespace)
-			req.Header.Set(activator.RevisionHeaderName, revName)
-			handler.ServeHTTP(resp, req)
-			respCh <- resp
+			respCh <- sendRequest(namespace, revName, handler)
 		}()
 	}
 }

--- a/pkg/tracing/config/tracing_test.go
+++ b/pkg/tracing/config/tracing_test.go
@@ -64,16 +64,18 @@ func TestNewConfigFromMap(t *testing.T) {
 	}, {
 		name: "Everything enabled",
 		input: map[string]string{
-			enableKey:         "true",
-			zipkinEndpointKey: "some-endpoint",
-			debugKey:          "true",
-			sampleRateKey:     "0.5",
+			enableKey:              "true",
+			zipkinEndpointKey:      "some-endpoint",
+			debugKey:               "true",
+			sampleRateKey:          "0.5",
+			kubeResourceTracingKey: "true",
 		},
 		output: Config{
-			Enable:         true,
-			Debug:          true,
-			ZipkinEndpoint: "some-endpoint",
-			SampleRate:     0.5,
+			Enable:              true,
+			Debug:               true,
+			ZipkinEndpoint:      "some-endpoint",
+			SampleRate:          0.5,
+			KubeResourceTracing: true,
 		},
 	}}
 

--- a/pkg/tracing/pod_tracer.go
+++ b/pkg/tracing/pod_tracer.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/trace"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	csWaiting = "Waiting"
+	csRunning = "Running"
+	csReady   = "Ready"
+)
+
+type containerState string
+
+type containerTrace struct {
+	span  *trace.Span
+	state containerState
+}
+
+// TracePodStartup creates spans detailing the startup process of the pod who's events arrive over eventCh
+func TracePodStartup(ctx context.Context, stopCh <-chan struct{}, eventCh <-chan watch.Event) (*trace.Span, error) {
+	var (
+		podCreating    *trace.Span
+		podCreatingCtx context.Context
+		podState       containerState
+	)
+	initContainerSpans := make(map[string]*containerTrace)
+	containerSpans := make(map[string]*containerTrace)
+
+	for {
+		select {
+		case ev := <-eventCh:
+			if pod, ok := ev.Object.(*corev1.Pod); ok {
+				if podState == "" {
+					podCreatingCtx, podCreating = trace.StartSpan(ctx, "pod_creating")
+					podState = csWaiting
+				}
+
+				// Set (init)containerSpans
+				for _, csCase := range []struct {
+					src           []corev1.ContainerStatus
+					dest          map[string]*containerTrace
+					initContainer bool
+				}{{
+					src:           pod.Status.InitContainerStatuses,
+					dest:          initContainerSpans,
+					initContainer: true,
+				}, {
+					src:           pod.Status.ContainerStatuses,
+					dest:          containerSpans,
+					initContainer: false,
+				}} {
+					for _, cs := range csCase.src {
+						ct, ok := csCase.dest[cs.Name]
+						if !ok {
+							_, span := trace.StartSpan(podCreatingCtx, fmt.Sprintf("container_startup_%s", cs.Name))
+							csCase.dest[cs.Name] = &containerTrace{
+								span:  span,
+								state: csWaiting,
+							}
+							ct = csCase.dest[cs.Name]
+						}
+						span := ct.span
+
+						if cs.State.Terminated != nil {
+							if !csCase.initContainer {
+								span.Annotate([]trace.Attribute{
+									trace.StringAttribute(fmt.Sprintf("tracepod.container-%s.error", cs.Name), "terminated"),
+								}, "ContainerTerminated")
+							}
+							span.End()
+						}
+
+						if cs.State.Running != nil && ct.state != csRunning {
+							span.Annotate([]trace.Attribute{
+								trace.StringAttribute(fmt.Sprintf("tracepod.container-%s.running", cs.Name), "running"),
+							}, "ContainerRunning")
+							ct.state = csRunning
+						}
+
+						if cs.Ready {
+							ct.state = csReady
+							span.End()
+						}
+					}
+				}
+
+				if pod.Status.Phase == corev1.PodRunning {
+					if podCreating != nil && podState == csWaiting {
+						podState = csRunning
+						podCreating.Annotate([]trace.Attribute{
+							trace.StringAttribute("tracepod.running", "running"),
+						}, "PodTrace")
+					}
+				}
+
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+						if podCreating != nil {
+							podState = csReady
+							podCreating.End()
+						}
+						return podCreating, nil
+					}
+				}
+			}
+		case <-stopCh:
+			if podCreating != nil {
+				podCreating.Annotate([]trace.Attribute{
+					trace.StringAttribute("tracepod.error", "trace exit"),
+				}, "PodTrace")
+				podCreating.End()
+			}
+			return podCreating, nil
+		}
+	}
+}

--- a/pkg/tracing/pod_tracer_test.go
+++ b/pkg/tracing/pod_tracer_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/knative/serving/pkg/tracing/config"
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinmodel "github.com/openzipkin/zipkin-go/model"
+	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
+	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	containerWaiting    string = "ContainerWaiting"
+	containerRunning    string = "ContainerRunning"
+	containerTerminated string = "ContainerTerminated"
+)
+
+func containerStatus(name string, ready bool, state string) *corev1.ContainerStatus {
+	status := &corev1.ContainerStatus{
+		Name:  name,
+		Ready: ready,
+	}
+	switch state {
+	case containerWaiting:
+		status.State = corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{},
+		}
+	case containerRunning:
+		status.State = corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		}
+	case containerTerminated:
+		status.State = corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{},
+		}
+	}
+	return status
+}
+
+func podConditions(ready bool) []corev1.PodCondition {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+
+	return []corev1.PodCondition{
+		{
+			Type:   corev1.PodReady,
+			Status: status,
+		},
+	}
+}
+
+func withInitContainerStatus(pod *corev1.Pod, status *corev1.ContainerStatus) *corev1.Pod {
+	pod.Status.InitContainerStatuses = append(pod.Status.InitContainerStatuses, *status)
+	return pod
+}
+
+func withContainerStatus(pod *corev1.Pod, status *corev1.ContainerStatus) *corev1.Pod {
+	pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, *status)
+	return pod
+}
+
+func withConditions(pod *corev1.Pod, conditions []corev1.PodCondition) *corev1.Pod {
+	pod.Status.Conditions = conditions
+	return pod
+}
+
+func testPod(phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func TestTracePodStartup(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		events      []watch.Event
+		expectSpans []zipkinmodel.SpanModel
+		forceEnd    bool
+	}{{
+		name: "Simple pod start",
+		events: []watch.Event{{
+			Type:   watch.Added,
+			Object: withConditions(testPod(corev1.PodPending), podConditions(false)),
+		}, {
+			Type:   watch.Modified,
+			Object: withConditions(testPod(corev1.PodRunning), podConditions(true)),
+		}},
+		expectSpans: []zipkinmodel.SpanModel{
+			{},
+		},
+	}, {
+		name: "Missed pod add",
+		events: []watch.Event{{
+			Type:   watch.Modified,
+			Object: withConditions(testPod(corev1.PodRunning), podConditions(true)),
+		}},
+		expectSpans: []zipkinmodel.SpanModel{
+			{},
+		},
+	}, {
+		name: "Single container started",
+		events: []watch.Event{{
+			Type: watch.Added,
+			Object: withContainerStatus(
+				withConditions(testPod(corev1.PodPending), podConditions(false)),
+				containerStatus("test-container", false, containerWaiting)),
+		}, {
+			Type: watch.Modified,
+			Object: withContainerStatus(
+				withConditions(testPod(corev1.PodRunning), podConditions(true)),
+				containerStatus("test-container", true, containerRunning)),
+		}},
+		expectSpans: []zipkinmodel.SpanModel{
+			{},
+			{},
+		},
+	}, {
+		name: "Single init container started",
+		events: []watch.Event{{
+			Type: watch.Added,
+			Object: withInitContainerStatus(
+				withConditions(testPod(corev1.PodPending), podConditions(false)),
+				containerStatus("test-init-container", false, containerWaiting)),
+		}, {
+			Type: watch.Modified,
+			Object: withInitContainerStatus(
+				withConditions(testPod(corev1.PodPending), podConditions(true)),
+				containerStatus("test-init-container", true, containerRunning)),
+		}},
+		expectSpans: []zipkinmodel.SpanModel{
+			{},
+			{},
+		},
+	}, {
+		name: "Container terminated",
+		events: []watch.Event{{
+			Type: watch.Added,
+			Object: withContainerStatus(
+				withConditions(testPod(corev1.PodPending), podConditions(false)),
+				containerStatus("test-container", false, containerWaiting)),
+		}, {
+			Type: watch.Modified,
+			Object: withContainerStatus(
+				withConditions(testPod(corev1.PodPending), podConditions(false)),
+				containerStatus("test-container", false, containerTerminated)),
+		}},
+		expectSpans: []zipkinmodel.SpanModel{
+			{},
+			{},
+		},
+		forceEnd: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			reporter := reporterrecorder.NewReporter()
+			defer reporter.Close()
+
+			endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
+			oct := NewOpenCensusTracer(WithZipkinExporter(func(cfg *config.Config) (zipkinreporter.Reporter, error) {
+				return reporter, nil
+			}, endpoint))
+			oct.ApplyConfig(&config.Config{
+				Enable: true,
+				Debug:  true,
+			})
+			defer oct.Finish()
+
+			stopCh := make(chan struct{})
+			if !tc.forceEnd {
+				defer close(stopCh)
+			}
+
+			evCh := make(chan watch.Event)
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				TracePodStartup(context.TODO(), stopCh, evCh)
+				wg.Done()
+			}()
+
+			for _, ev := range tc.events {
+				evCh <- ev
+			}
+			if tc.forceEnd {
+				time.Sleep(20 * time.Millisecond)
+				close(stopCh)
+			}
+
+			wg.Wait()
+
+			gotSpans := reporter.Flush()
+			if len(gotSpans) != len(tc.expectSpans) {
+				t.Errorf("Expected %d spans, got %d.", len(tc.expectSpans), len(gotSpans))
+			}
+
+			// TODO(greghaynes) better asserting on spans
+		})
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
When performing cold start the majority of our time is spent waiting for
our pod to be created. Unfortunately, because we do not control anything
beyond talking to kube-api, we have to perform our own resource tracking
to create spans which tie in to our existing cold-start tracing.

This depends on #2726 and #3881

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
