### PR TITLE
Revisions should wait for minScale replicas to report ready

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -455,7 +455,7 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 		ret = !pa.Status.IsInactive() // Any state but inactive should change SKS.
 		pa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")
 
-	case got >= 0 && got < minReady && want > 0:
+	case got < minReady && want > 0:
 		ret = pa.Status.IsInactive() // If we were inactive and became activating.
 		pa.Status.MarkActivating(
 			"Queued", "Requests to the target are being buffered as resources are provisioned.")

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -310,6 +310,7 @@ func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAut
 	} else if err != nil {
 		return nil, perrors.Wrap(err, "error fetching decider")
 	}
+
 	// Ignore status when reconciling
 	desiredDecider.Status = decider.Status
 	if !equality.Semantic.DeepEqual(desiredDecider, decider) {

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -19,6 +19,7 @@ package kpa
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -545,27 +546,27 @@ func TestReconcile(t *testing.T) {
 		Name: "kpa does not become ready without minScale endpoints",
 		Key:  key,
 		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, WithMinScale(2)),
+			kpa(testNamespace, testRevision, withMinScale(2)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision, markActivating, WithMinScale(2), WithPAStatusService(testRevision)),
+			Object: kpa(testNamespace, testRevision, markActivating, withMinScale(2), WithPAStatusService(testRevision)),
 		}},
 	}, {
 		Name: "kpa becomes ready with minScale endpoints",
 		Key:  key,
 		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, markActivating, WithMinScale(2), WithPAStatusService(testRevision)),
+			kpa(testNamespace, testRevision, markActivating, withMinScale(2), WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(2, testNamespace, testRevision),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision, markActive, WithMinScale(2), WithPAStatusService(testRevision)),
+			Object: kpa(testNamespace, testRevision, markActive, withMinScale(2), WithPAStatusService(testRevision)),
 		}},
 	}, {
 		Name: "sks does not exist",
@@ -1540,13 +1541,21 @@ func makeSKSPrivateEndpoints(num int, ns, n string) *corev1.Endpoints {
 func addEndpoint(ep *corev1.Endpoints) *corev1.Endpoints {
 	if ep.Subsets == nil {
 		ep.Subsets = []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{IP: "127.0.0.1"}},
+			Addresses: []corev1.EndpointAddress{},
 		}}
-		return ep
 	}
 
 	ep.Subsets[0].Addresses = append(ep.Subsets[0].Addresses, corev1.EndpointAddress{IP: "127.0.0.1"})
 	return ep
+}
+
+func withMinScale(minScale int) PodAutoscalerOption {
+	return func(pa *asv1a1.PodAutoscaler) {
+		if pa.Annotations == nil {
+			pa.Annotations = make(map[string]string)
+		}
+		pa.Annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(minScale)
+	}
 }
 
 type testConfigStore struct {

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/kpa/resources"
 	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
 	revisionresources "github.com/knative/serving/pkg/reconciler/revision/resources"
+	presources "github.com/knative/serving/pkg/resources"
 	perrors "github.com/pkg/errors"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 
@@ -1551,10 +1552,10 @@ func addEndpoint(ep *corev1.Endpoints) *corev1.Endpoints {
 
 func withMinScale(minScale int) PodAutoscalerOption {
 	return func(pa *asv1a1.PodAutoscaler) {
-		if pa.Annotations == nil {
-			pa.Annotations = make(map[string]string)
-		}
-		pa.Annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(minScale)
+		pa.Annotations = presources.UnionMaps(
+			pa.Annotations,
+			map[string]string{autoscaling.MinScaleAnnotationKey: strconv.Itoa(minScale)},
+		)
 	}
 }
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -229,7 +229,6 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desir
 	}
 
 	min, max := pa.ScaleBounds()
-
 	if newScale := applyBounds(min, max, desiredScale); newScale != desiredScale {
 		logger.Debugf("Adjusting desiredScale to meet the min and max bounds before applying: %d -> %d", desiredScale, newScale)
 		desiredScale = newScale
@@ -240,6 +239,7 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desir
 		logger.Errorw(fmt.Sprintf("Resource %q not found", pa.Name), zap.Error(err))
 		return desiredScale, err
 	}
+
 	currentScale := int32(1)
 	if ps.Spec.Replicas != nil {
 		currentScale = *ps.Spec.Replicas

--- a/pkg/reconciler/testing/functional.go
+++ b/pkg/reconciler/testing/functional.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/knative/pkg/apis"
@@ -997,15 +996,6 @@ func WithTraffic(pa *autoscalingv1alpha1.PodAutoscaler) {
 func WithPAStatusService(svc string) PodAutoscalerOption {
 	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.ServiceName = svc
-	}
-}
-
-func WithMinScale(minScale int) PodAutoscalerOption {
-	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
-		if pa.Annotations == nil {
-			pa.Annotations = make(map[string]string)
-		}
-		pa.Annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(minScale)
 	}
 }
 

--- a/pkg/reconciler/testing/functional.go
+++ b/pkg/reconciler/testing/functional.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/knative/pkg/apis"
@@ -996,6 +997,15 @@ func WithTraffic(pa *autoscalingv1alpha1.PodAutoscaler) {
 func WithPAStatusService(svc string) PodAutoscalerOption {
 	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.ServiceName = svc
+	}
+}
+
+func WithMinScale(minScale int) PodAutoscalerOption {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
+		if pa.Annotations == nil {
+			pa.Annotations = make(map[string]string)
+		}
+		pa.Annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(minScale)
 	}
 }
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -57,7 +57,6 @@ func TestMinScale(t *testing.T) {
 		t.Fatalf("The Configuration %q does not have a LatestCreatedRevisionName: %v", names.Config, err)
 	}
 
-	// Get Configuration's latest Revision's Build, and check that the Build failed.
 	config, err := clients.ServingClient.Configs.Get(names.Config, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Configuration after it was seen to be live: %v", err)

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 func TestMinScale(t *testing.T) {
+	const minScale = 4
+
 	clients := Setup(t)
-	minScale := 4
 
 	names := test.ResourceNames{
 		Config: test.ObjectNameForTest(t),
@@ -70,7 +71,7 @@ func TestMinScale(t *testing.T) {
 
 	deployment, err := clients.KubeClient.Kube.ExtensionsV1beta1().Deployments(test.ServingNamespace).Get(revName+"-deployment", metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to get Deployment for Revision %s, err: %v", revName, err)
+		t.Fatalf("Failed to get Deployment for Revision %s, err: %v", revName, err)
 	}
 
 	if deployment.Status.AvailableReplicas < int32(minScale) {

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -1,0 +1,79 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMinScale(t *testing.T) {
+	clients := Setup(t)
+	minScale := 4
+
+	names := test.ResourceNames{
+		Config: test.ObjectNameForTest(t),
+		Image:  "helloworld",
+	}
+
+	if _, err := test.CreateConfiguration(t, clients, names, &test.Options{}, func(cfg *v1alpha1.Configuration) {
+		if cfg.Spec.Template.Annotations == nil {
+			cfg.Spec.Template.Annotations = make(map[string]string)
+		}
+
+		cfg.Spec.Template.Annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(minScale)
+
+	}); err != nil {
+		t.Fatalf("Failed to create Configuration: %v", err)
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	// Wait for the Config have a LatestCreatedRevisionName
+	if err := test.WaitForConfigurationState(clients.ServingClient, names.Config, test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision"); err != nil {
+		t.Fatalf("The Configuration %q does not have a LatestCreatedRevisionName: %v", names.Config, err)
+	}
+
+	// Get Configuration's latest Revision's Build, and check that the Build failed.
+	config, err := clients.ServingClient.Configs.Get(names.Config, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Configuration after it was seen to be live: %v", err)
+	}
+
+	revName := config.Status.LatestCreatedRevisionName
+
+	if err = test.WaitForRevisionState(clients.ServingClient, revName, test.IsRevisionReady, "RevisionIsReady"); err != nil {
+		t.Fatal("Revision did not become ready.")
+	}
+
+	deployment, err := clients.KubeClient.Kube.ExtensionsV1beta1().Deployments(test.ServingNamespace).Get(revName+"-deployment", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get Deployment for Revision %s, err: %v", revName, err)
+	}
+
+	if deployment.Status.AvailableReplicas < int32(minScale) {
+		t.Fatalf("Reported ready with %d replicas when minScale was %d", deployment.Status.AvailableReplicas, minScale)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3077 

## Proposed Changes

* Revisions with a minScale annotation are only marked as "Ready" when they have at least `minScale` number of ready replicas
* Fixes a bug when repeated calls were made to the `addEndpoint` helper


<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
