### PR TITLE
Pick up factored out 'GetIngressEndpoint' logic.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -405,6 +405,7 @@
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[projects]]
+  branch = "master"
   digest = "1:0836bde83bdc49aae7710e22d04e2555d9bd25cd133fbb78508c492307081aea"
   name = "github.com/knative/build"
   packages = [
@@ -435,7 +436,8 @@
   revision = "3fc06fd3c9880a9ebb5c401f4b20cf6666cc7bc0"
 
 [[projects]]
-  digest = "1:46d45a87b2948fcd7acc2ab5d0c1fab9cae697c210e0cbd155a295861ffb92e0"
+  branch = "refactor-ingressendpoint"
+  digest = "1:503b39b982efb0d3db9def3c70151112d8c15eb4d60f583a055c81b69dc064a9"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -476,6 +478,7 @@
     "system/testing",
     "test",
     "test/helpers",
+    "test/ingress",
     "test/logging",
     "test/monitoring",
     "test/spoof",
@@ -486,7 +489,8 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "60fdcbcabd2faeb34328d8b2725dc76c59189453"
+  revision = "0b5dd0abf3b1cfa0ff5cced929e3b74ddb025ff8"
+  source = "https://github.com/markusthoemmes/knative-pkg.git"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -405,7 +405,6 @@
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[projects]]
-  branch = "master"
   digest = "1:0836bde83bdc49aae7710e22d04e2555d9bd25cd133fbb78508c492307081aea"
   name = "github.com/knative/build"
   packages = [
@@ -436,7 +435,6 @@
   revision = "3fc06fd3c9880a9ebb5c401f4b20cf6666cc7bc0"
 
 [[projects]]
-  branch = "refactor-ingressendpoint"
   digest = "1:503b39b982efb0d3db9def3c70151112d8c15eb4d60f583a055c81b69dc064a9"
   name = "github.com/knative/pkg"
   packages = [
@@ -489,8 +487,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "0b5dd0abf3b1cfa0ff5cced929e3b74ddb025ff8"
-  source = "https://github.com/markusthoemmes/knative-pkg.git"
+  revision = "6dbff198831064f3a82b7333582efc137575f42c"
 
 [[projects]]
   branch = "master"
@@ -1332,6 +1329,7 @@
     "github.com/knative/pkg/system/testing",
     "github.com/knative/pkg/test",
     "github.com/knative/pkg/test/helpers",
+    "github.com/knative/pkg/test/ingress",
     "github.com/knative/pkg/test/logging",
     "github.com/knative/pkg/test/spoof",
     "github.com/knative/pkg/tracker",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,8 +24,9 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-03-21
-  revision = "60fdcbcabd2faeb34328d8b2725dc76c59189453"
+  # HEAD as of 2019-03-22
+  source = "https://github.com/markusthoemmes/knative-pkg.git"
+  branch = "refactor-ingressendpoint"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,8 +25,7 @@ required = [
 [[override]]
   name = "github.com/knative/pkg"
   # HEAD as of 2019-03-22
-  source = "https://github.com/markusthoemmes/knative-pkg.git"
-  branch = "refactor-ingressendpoint"
+  revision = "6dbff198831064f3a82b7333582efc137575f42c"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	pkgTest "github.com/knative/pkg/test"
-	"github.com/knative/pkg/test/spoof"
+	ingress "github.com/knative/pkg/test/ingress"
 	"github.com/knative/serving/test"
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	"google.golang.org/grpc"
@@ -171,7 +171,7 @@ func testGRPC(t *testing.T, f grpcTest) {
 
 	host := &domain
 	if !test.ServingFlags.ResolvableDomain {
-		host, err = spoof.GetServiceEndpoint(clients.KubeClient.Kube)
+		host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)
 		if err != nil {
 			t.Fatalf("Could not get service endpoint: %v", err)
 		}

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -63,7 +63,7 @@ func TestTimeToServeLatency(t *testing.T) {
 		NumThreads:     1,
 		NumConnections: 5,
 		Domain:         domain,
-		URL:            fmt.Sprintf("http://%s", endpoint),
+		URL:            fmt.Sprintf("http://%s", *endpoint),
 	}
 	resp, err := opts.RunLoadTest(false)
 	if err != nil {

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/knative/pkg/test/spoof"
+	ingress "github.com/knative/pkg/test/ingress"
 	"github.com/knative/serving/test"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/loadgenerator"
@@ -53,7 +53,7 @@ func TestTimeToServeLatency(t *testing.T) {
 	}
 
 	domain := objs.Route.Status.Domain
-	endpoint, err := spoof.GetServiceEndpoint(clients.KubeClient.Kube)
+	endpoint, err := ingress.GetIngressEndpoint(clients.KubeClient.Kube)
 	if err != nil {
 		t.Fatalf("Cannot get service endpoint: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestTimeToServeLatency(t *testing.T) {
 		NumThreads:     1,
 		NumConnections: 5,
 		Domain:         domain,
-		URL:            fmt.Sprintf("http://%s", *endpoint),
+		URL:            fmt.Sprintf("http://%s", endpoint),
 	}
 	resp, err := opts.RunLoadTest(false)
 	if err != nil {

--- a/vendor/github.com/knative/pkg/test/ingress/ingress.go
+++ b/vendor/github.com/knative/pkg/test/ingress/ingress.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// TODO(tcnghia): These probably shouldn't be hard-coded here?
+	istioIngressNamespace = "istio-system"
+	istioIngressName      = "istio-ingressgateway"
+)
+
+// GetIngressEndpoint gets the endpoint IP or hostname to use for the service.
+func GetIngressEndpoint(kubeClientset *kubernetes.Clientset) (*string, error) {
+	ingressName := istioIngressName
+	if gatewayOverride := os.Getenv("GATEWAY_OVERRIDE"); gatewayOverride != "" {
+		ingressName = gatewayOverride
+	}
+	ingressNamespace := istioIngressNamespace
+	if gatewayNsOverride := os.Getenv("GATEWAY_NAMESPACE_OVERRIDE"); gatewayNsOverride != "" {
+		ingressNamespace = gatewayNsOverride
+	}
+
+	ingress, err := kubeClientset.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := EndpointFromService(ingress)
+	if err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
+}
+
+// EndpointFromService extracts the endpoint from the service's ingress.
+func EndpointFromService(svc *v1.Service) (string, error) {
+	ingresses := svc.Status.LoadBalancer.Ingress
+	if len(ingresses) != 1 {
+		return "", fmt.Errorf("Expected exactly one ingress load balancer, instead had %d: %v", len(ingresses), ingresses)
+	}
+	itu := ingresses[0]
+
+	switch {
+	case itu.IP != "":
+		return itu.IP, nil
+	case itu.Hostname != "":
+		return itu.Hostname, nil
+	default:
+		return "", fmt.Errorf("Expected ingress loadbalancer IP or hostname for %s to be set, instead was empty", svc.Name)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* As per title, this also fixes the Websocket test to not only run against loadbalancers backed by IPs but also against those backed by hostname.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
