### PR TITLE
Remove extra f-calls wherein no formatting is performed

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
@@ -127,7 +127,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(pa, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -168,7 +168,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(pa, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -159,7 +159,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		c.Recorder.Eventf(ci, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(ci, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }

--- a/pkg/reconciler/v1alpha1/configuration/configuration.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration.go
@@ -144,7 +144,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		c.Recorder.Eventf(config, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(config, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }
@@ -170,8 +170,8 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 		if err != nil {
 			errMsg := fmt.Sprintf("Failed to create Revision for Configuration %q: %v", config.Name, err)
 
-			logger.Errorf(errMsg)
-			c.Recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", errMsg)
+			logger.Error(errMsg)
+			c.Recorder.Event(config, corev1.EventTypeWarning, "CreationFailed", errMsg)
 
 			// Mark the Configuration as not-Ready since creating
 			// its latest revision failed.
@@ -295,7 +295,7 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1alpha1.Config
 		return nil, err
 	}
 	c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Revision %q", rev.Name)
-	logger.Infof("Created Revision:\n%+v", created)
+	logger.Infof("Created Revision: %+v", created)
 
 	return created, nil
 }

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -277,7 +277,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		c.Recorder.Eventf(rev, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(rev, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }
@@ -411,7 +411,7 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 
 	readyAfterReconcile := rev.Status.IsReady()
 	if !readyBeforeReconcile && readyAfterReconcile {
-		c.Recorder.Eventf(rev, corev1.EventTypeNormal, "RevisionReady",
+		c.Recorder.Event(rev, corev1.EventTypeNormal, "RevisionReady",
 			"Revision becomes ready upon all resources being ready")
 	}
 

--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -236,7 +236,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		c.Recorder.Eventf(route, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(route, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -156,7 +156,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		c.Recorder.Eventf(service, corev1.EventTypeNormal, "Updated", "Updated Service %q", service.GetName())
 	}
 	if err != nil {
-		c.Recorder.Eventf(service, corev1.EventTypeWarning, "InternalError", err.Error())
+		c.Recorder.Event(service, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -39,6 +39,6 @@ func main() {
 		Handler: mux,
 	}
 
-	log.Printf("Server starting on port %s\n", port)
+	log.Printf("Server starting on port %s", port)
 	log.Fatal(server.ListenAndServe())
 }


### PR DESCRIPTION
/lint

## Proposed Changes

* there were some eventf calls where no formatting was present, so remove `f`.
* also log statements terminated with \n, which is redundant.
*

/assign @mattmoor 