### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,8 +30,7 @@ You must install these tools:
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
 1. [`dep`](https://github.com/golang/dep): For managing external Go
    dependencies.
-1. [`ko`](https://github.com/google/ko):
-   For development.
+1. [`ko`](https://github.com/google/ko): For development.
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    managing development environments.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The Knative Serving project provides middleware primitives that enable:
 - Point-in-time snapshots of deployed code and configurations
 
 For documentation on using Knative Serving, see the
-[serving](https://github.com/knative/docs/tree/master/docs/serving) folder of the
-[Knative Docs](https://github.com/knative/docs) repository.
+[serving](https://github.com/knative/docs/tree/master/docs/serving) folder of
+the [Knative Docs](https://github.com/knative/docs) repository.
 
 For documentation on the Knative Serving specification, see the
 [docs](https://github.com/knative/serving/tree/master/docs) folder of this

--- a/docs/scaling/DEVELOPMENT.md
+++ b/docs/scaling/DEVELOPMENT.md
@@ -180,10 +180,10 @@ evaluating the 60-second windows again.
 #### Deactivation
 
 When the Autoscaler has observed an average concurrency per pod of 0.0 for some
-time ([#305](https://github.com/knative/serving/issues/305)), it will
-transition the Revision into the Reserve state. This scales the Deployment to
-0, stops any single tenant Autoscaler associated with the Revision, and routes
-all traffic for the Revision to the Activator.
+time ([#305](https://github.com/knative/serving/issues/305)), it will transition
+the Revision into the Reserve state. This scales the Deployment to 0, stops any
+single tenant Autoscaler associated with the Revision, and routes all traffic
+for the Revision to the Activator.
 
 ### Activator
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`