### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -175,8 +175,8 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ConfigurationGenerationLabelKey:                   "100",
 					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
 					serving.ServiceLabelKey:                                   "",
-					"foo": "bar",
-					"baz": "blah",
+					"foo":                                                     "bar",
+					"baz":                                                     "blah",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
