### PR TITLE
Temporarily remove the fixed NodePort in istio.yaml during test run.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -125,7 +125,11 @@ function install_knative_serving_standard() {
 
   echo ">> Bringing up Istio"
   kubectl apply -f "${INSTALL_ISTIO_CRD_YAML}" || return 1
-  kubectl apply -f "${INSTALL_ISTIO_YAML}" || return 1
+  # Temporarily remove the fixed NodePort in istio.yaml, until
+  # we pick up either 0.5.0 (#3386) or 0.4.2 (#3520) in upgrade
+  # testing.
+  grep -v "^[[:space:]]*nodePort[[:space:]]*:[[:space:]]*[[:digit:]]\+$"  "${INSTALL_ISTIO_YAML}" \
+    | kubectl apply -f - || return 1
 
   echo ">> Installing Build"
   # TODO: should this use a released copy of Build?

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -128,7 +128,11 @@ function install_knative_serving_standard() {
   # Temporarily remove the fixed NodePort in istio.yaml, until
   # we pick up either 0.5.0 (#3386) or 0.4.2 (#3520) in upgrade
   # testing.
-  curl -L "${INSTALL_ISTIO_YAML}" \
+  ISTIO_YAML_URL="${INSTALL_ISTIO_YAML}"
+  if [[ $ISTIO_YAML_URL != *":"* ]]; then
+    ISTIO_YAML_URL="file://${INSTALL_ISTIO_YAML}"
+  fi
+  curl -L $ISTIO_YAML_URL \
     | grep -v "^[[:space:]]*nodePort[[:space:]]*:[[:space:]]*[[:digit:]]\+$" \
     | kubectl apply -f - || return 1
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -128,7 +128,8 @@ function install_knative_serving_standard() {
   # Temporarily remove the fixed NodePort in istio.yaml, until
   # we pick up either 0.5.0 (#3386) or 0.4.2 (#3520) in upgrade
   # testing.
-  grep -v "^[[:space:]]*nodePort[[:space:]]*:[[:space:]]*[[:digit:]]\+$"  "${INSTALL_ISTIO_YAML}" \
+  curl -L "${INSTALL_ISTIO_YAML}" \
+    | grep -v "^[[:space:]]*nodePort[[:space:]]*:[[:space:]]*[[:digit:]]\+$" \
     | kubectl apply -f - || return 1
 
   echo ">> Installing Build"


### PR DESCRIPTION
Until we pick up either 0.5.0 (#3386) or 0.4.2 (#3520) in upgrade testing.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Temporarily remove the fixed NodePort in istio.yaml during test run.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
