### PR TITLE
Removed the liveness check from deployment probe in the runtime contract

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -285,10 +285,10 @@ container startup time (aka cold start time).
 On the initial deployment, platform providers SHOULD start an instance of the
 container to validate that the container is valid and will become ready. This
 startup SHOULD occur even if the container would not serve any user requests. If
-a container cannot satisfy the `livenessProbe` and `readinessProbe` during
-deployment startup, the deployment SHOULD be marked as failed.
+a container cannot satisfy the `readinessProbe` during deployment startup, the
+Revision SHOULD be marked as failed.
 
-Initial readiness and liveness probes allow the platform to avoid attempting to
+Initial readiness probes allow the platform to avoid attempting to
 later provision or scale deployments (Revisions) which cannot become healthy,
 and act as a backstop to developer testing (via CI/CD or otherwise) which has
 been performed on the supplied container. Common causes of these failures can


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Removed the liveness check from the deployment probe runtime contract. 

Fixes #2972 
