### PR TITLE
Rename Reporter to AutoscalingStatsReporter for queue proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -83,7 +83,7 @@ var (
 
 	server      *http.Server
 	healthState = &health.State{}
-	reporter    *queue.Reporter // Prometheus stats reporter.
+	reporter    *queue.AutoscalingStatsReporter // Prometheus stats reporter.
 )
 
 func initEnv() {
@@ -101,7 +101,7 @@ func initEnv() {
 
 	// TODO(mattmoor): Move this key to be in terms of the KPA.
 	servingRevisionKey = autoscaler.NewMetricKey(servingNamespace, servingRevision)
-	_reporter, err := queue.NewStatsReporter(servingNamespace, servingConfig, servingRevision, podName)
+	_reporter, err := queue.NewAutoscalingStatsReporter(servingNamespace, servingConfig, servingRevision, podName)
 	if err != nil {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}

--- a/pkg/queue/autoscaling_stats_reporter.go
+++ b/pkg/queue/autoscaling_stats_reporter.go
@@ -60,8 +60,9 @@ var (
 	}
 )
 
-// Reporter structure represents a prometheus exporter.
-type Reporter struct {
+// AutoscalingStatsReporter structure represents a prometheus exporter for
+// autoscaling stats.
+type AutoscalingStatsReporter struct {
 	Initialized     bool
 	ctx             context.Context
 	configTagKey    tag.Key
@@ -70,8 +71,8 @@ type Reporter struct {
 	podTagKey       tag.Key
 }
 
-// NewStatsReporter creates a reporter that collects and reports queue metrics.
-func NewStatsReporter(namespace string, config string, revision string, pod string) (*Reporter, error) {
+// NewAutoscalingStatsReporter creates a reporter that collects and reports queue metrics.
+func NewAutoscalingStatsReporter(namespace string, config string, revision string, pod string) (*AutoscalingStatsReporter, error) {
 	if len(namespace) < 1 {
 		return nil, errors.New("namespace must not be empty")
 	}
@@ -134,7 +135,7 @@ func NewStatsReporter(namespace string, config string, revision string, pod stri
 	if err != nil {
 		return nil, err
 	}
-	return &Reporter{
+	return &AutoscalingStatsReporter{
 		Initialized: true,
 
 		ctx:             ctx,
@@ -146,7 +147,7 @@ func NewStatsReporter(namespace string, config string, revision string, pod stri
 }
 
 // Report captures request metrics.
-func (r *Reporter) Report(operationsPerSecond float64, averageConcurrentRequests float64) error {
+func (r *AutoscalingStatsReporter) Report(operationsPerSecond float64, averageConcurrentRequests float64) error {
 	if !r.Initialized {
 		return errors.New("statsReporter is not Initialized yet")
 	}
@@ -156,7 +157,7 @@ func (r *Reporter) Report(operationsPerSecond float64, averageConcurrentRequests
 }
 
 // UnregisterViews Unregister views.
-func (r *Reporter) UnregisterViews() error {
+func (r *AutoscalingStatsReporter) UnregisterViews() error {
 	if !r.Initialized {
 		return errors.New("reporter is not initialized")
 	}

--- a/pkg/queue/autoscaling_stats_reporter_test.go
+++ b/pkg/queue/autoscaling_stats_reporter_test.go
@@ -31,7 +31,7 @@ const (
 	pod       = "helloworld-go-00001-deployment-8ff587cc9-7g9gc"
 )
 
-func TestNewStatsReporter_negative(t *testing.T) {
+func TestNewAutoscalingStatsReporter_negative(t *testing.T) {
 	tests := []struct {
 		name      string
 		errorMsg  string
@@ -81,19 +81,19 @@ func TestNewStatsReporter_negative(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := NewStatsReporter(test.namespace, test.config, test.revision, test.pod); err.Error() != test.result.Error() {
+			if _, err := NewAutoscalingStatsReporter(test.namespace, test.config, test.revision, test.pod); err.Error() != test.result.Error() {
 				t.Errorf("%+v, got: '%+v'", test.errorMsg, err)
 			}
 		})
 	}
 }
 
-func TestNewStatsReporter_doubledeclare(t *testing.T) {
-	reporter, err := NewStatsReporter(namespace, config, revision, pod)
+func TestNewAutoscalingStatsReporter_doubledeclare(t *testing.T) {
+	reporter, err := NewAutoscalingStatsReporter(namespace, config, revision, pod)
 	if err != nil {
 		t.Error("Something went wrong with creating a reporter.")
 	}
-	if _, err := NewStatsReporter(namespace, config, revision, pod); err == nil {
+	if _, err := NewAutoscalingStatsReporter(namespace, config, revision, pod); err == nil {
 		t.Error("Something went wrong with double declaration of reporter.")
 	}
 	reporter.UnregisterViews()
@@ -107,7 +107,7 @@ func TestReporter_Report(t *testing.T) {
 	if err != nil {
 		t.Errorf("Something went wrong with creating tag, '%v'.", err)
 	}
-	reporter, err := NewStatsReporter(namespace, config, revision, pod)
+	reporter, err := NewAutoscalingStatsReporter(namespace, config, revision, pod)
 	if err != nil {
 		t.Errorf("Something went wrong with creating a reporter, '%v'.", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Rename `serving/pkg/queue/stats_reporter.go` to `serving/pkg/queue/autoscaling_stats_reporter.go`.
* Rename `Reporter` for autoscaling stats to `AutoscalingStatsReporter`.

This is because `stats_reporter.go` in other components is used to report metrics to the configured metrics backend for general purpose. The `Reporter` in the original `stats_reporter.go` for queue-proxy always reports metrics to `9090/metrics` in Prometheus format for autoscaling purpose. This PR is to reduce confusion and pave the road to introduce stats reporter for general purpose.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
