### PR TITLE
Add URL to TrafficTarget Status

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -92,6 +92,7 @@ status:
   - revisionName: ...  # latestReadyRevisionName from a configurationName in spec
     name: ...
     percent: ...  # percentages add to 100. 0 is a valid list value
+    url: ... # present when name is set. URL of the named traffic target
   - ...
 
   conditions:  # See also the [error conditions documentation](errors.md)
@@ -385,6 +386,7 @@ status:
   - revisionName: ...  # latestReadyRevisionName from a configurationName in spec
     name: ...
     percent: ...  # percentages add to 100. 0 is a valid list value
+    url: ... # present when name is set. URL of the named traffic target
   - ...
 
   conditions:  # See also the documentation in errors.md

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -81,6 +81,10 @@ type TrafficTarget struct {
 	// Percent specifies percent of the traffic to this Revision or Configuration.
 	// This defaults to zero if unspecified.
 	Percent int `json:"percent"`
+
+	// URL displays the URL for accessing named traffic targets. URL is displayed in
+	// status. URL is disallowed on spec.
+	URL string `json:"url,omitempty"`
 }
 
 // RouteSpec holds the desired state of the Route (from the client).

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -83,7 +83,8 @@ type TrafficTarget struct {
 	Percent int `json:"percent"`
 
 	// URL displays the URL for accessing named traffic targets. URL is displayed in
-	// status. URL is disallowed on spec.
+	// status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+	// a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
 	URL string `json:"url,omitempty"`
 }
 

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -108,5 +108,8 @@ func (tt *TrafficTarget) Validate(ctx context.Context) *apis.FieldError {
 	if tt.Percent < 0 || tt.Percent > 100 {
 		errs = errs.Also(apis.ErrOutOfBoundsValue(strconv.Itoa(tt.Percent), "0", "100", "percent"))
 	}
+	if tt.URL != "" {
+		errs = errs.Also(apis.ErrDisallowedFields("url"))
+	}
 	return errs
 }

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -366,6 +366,14 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:      101,
 		},
 		want: apis.ErrOutOfBoundsValue("101", "0", "100", "percent"),
+	}, {
+		name: "disallowed url set",
+		tt: &TrafficTarget{
+			ConfigurationName: "foo",
+			Percent:           100,
+			URL:               "ShouldNotBeSet",
+		},
+		want: apis.ErrDisallowedFields("url"),
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -65,7 +65,7 @@ func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.Config, ingressCla
 }
 
 func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string]traffic.RevisionTargets) v1alpha1.IngressSpec {
-	// Domain and should have been specified in route status
+	// Domain should have been specified in route status
 	// before calling this func.
 	names := make([]string, 0, len(targets))
 	for name := range targets {
@@ -95,7 +95,7 @@ func routeDomains(targetName string, r *servingv1alpha1.Route) []string {
 	domains := []string{traffic.SubrouteDomain(targetName, r.Status.Domain)}
 
 	if targetName == traffic.DefaultTarget {
-		// The default target is also referred to by it's internal K8s
+		// The default target is also referred to by its internal K8s
 		// generated domain name.
 		internalHost := names.K8sServiceFullname(r)
 		if internalHost != "" && domains[0] != internalHost {

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -17,13 +17,11 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/pkg/system"
 	"github.com/knative/serving/pkg/activator"
@@ -93,17 +91,20 @@ func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string]traffic
 }
 
 func routeDomains(targetName string, r *servingv1alpha1.Route) []string {
+
+	domains := []string{traffic.SubrouteDomain(targetName, r.Status.Domain)}
+
 	if targetName == traffic.DefaultTarget {
-		// Nameless traffic targets correspond to many domains: the
-		// Route.Status.Domain.
-		domains := []string{
-			r.Status.Domain,
-			names.K8sServiceFullname(r),
+		// The default target is also referred to by it's internal K8s
+		// generated domain name.
+		internalHost := r.Status.Address.Hostname
+		if internalHost != "" && domains[0] != internalHost {
+			domains = append(domains, internalHost)
 		}
-		return dedup(domains)
 	}
 
-	return []string{fmt.Sprintf("%s.%s", targetName, r.Status.Domain)}
+	return domains
+
 }
 
 func makeClusterIngressRule(domains []string, ns string, targets traffic.RevisionTargets) *v1alpha1.ClusterIngressRule {
@@ -160,16 +161,4 @@ func addInactive(r *v1alpha1.HTTPClusterIngressPath, ns string, inactive traffic
 		activator.RevisionHeaderNamespace: ns,
 	}
 	return r
-}
-
-func dedup(strs []string) []string {
-	existed := sets.NewString()
-	unique := []string{}
-	for _, s := range strs {
-		if !existed.Has(s) {
-			existed.Insert(s)
-			unique = append(unique, s)
-		}
-	}
-	return unique
 }

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress.go
@@ -65,7 +65,7 @@ func MakeClusterIngress(r *servingv1alpha1.Route, tc *traffic.Config, ingressCla
 }
 
 func makeClusterIngressSpec(r *servingv1alpha1.Route, targets map[string]traffic.RevisionTargets) v1alpha1.IngressSpec {
-	// Domain should have been specified in route status
+	// Domain and should have been specified in route status
 	// before calling this func.
 	names := make([]string, 0, len(targets))
 	for name := range targets {
@@ -97,7 +97,7 @@ func routeDomains(targetName string, r *servingv1alpha1.Route) []string {
 	if targetName == traffic.DefaultTarget {
 		// The default target is also referred to by it's internal K8s
 		// generated domain name.
-		internalHost := r.Status.Address.Hostname
+		internalHost := names.K8sServiceFullname(r)
 		if internalHost != "" && domains[0] != internalHost {
 			domains = append(domains, internalHost)
 		}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/pkg/apis/networking"
@@ -43,8 +42,7 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain:  "domain.com",
-				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
+				Domain: "domain.com",
 			},
 		},
 	}
@@ -90,8 +88,7 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain:  "domain.com",
-				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
+				Domain: "domain.com",
 			},
 		},
 	}
@@ -143,8 +140,7 @@ func TestMakeClusterIngressSpec_CorrectVisibility(t *testing.T) {
 		route: v1alpha1.Route{
 			Status: v1alpha1.RouteStatus{
 				RouteStatusFields: v1alpha1.RouteStatusFields{
-					Domain:  "domain.com",
-					Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
+					Domain: "domain.com",
 				},
 			},
 		},
@@ -154,8 +150,7 @@ func TestMakeClusterIngressSpec_CorrectVisibility(t *testing.T) {
 		route: v1alpha1.Route{
 			Status: v1alpha1.RouteStatus{
 				RouteStatusFields: v1alpha1.RouteStatusFields{
-					Domain:  "local-route.default.svc.cluster.local",
-					Address: &duckv1alpha1.Addressable{Hostname: "local-route.default.svc.cluster.local"},
+					Domain: "local-route.default.svc.cluster.local",
 				},
 			},
 		},
@@ -180,8 +175,7 @@ func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain:  base,
-				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
+				Domain: base,
 			},
 		},
 	}
@@ -203,8 +197,7 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain:  base,
-				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
+				Domain: base,
 			},
 		},
 	}
@@ -230,8 +223,7 @@ func TestGetRouteDomains_NamedTarget(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain:  base,
-				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
+				Domain: base,
 			},
 		},
 	}

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/pkg/apis/networking"
@@ -42,7 +43,8 @@ func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain: "domain.com",
+				Domain:  "domain.com",
+				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
 			},
 		},
 	}
@@ -88,7 +90,8 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain: "domain.com",
+				Domain:  "domain.com",
+				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
 			},
 		},
 	}
@@ -140,7 +143,8 @@ func TestMakeClusterIngressSpec_CorrectVisibility(t *testing.T) {
 		route: v1alpha1.Route{
 			Status: v1alpha1.RouteStatus{
 				RouteStatusFields: v1alpha1.RouteStatusFields{
-					Domain: "domain.com",
+					Domain:  "domain.com",
+					Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
 				},
 			},
 		},
@@ -150,7 +154,8 @@ func TestMakeClusterIngressSpec_CorrectVisibility(t *testing.T) {
 		route: v1alpha1.Route{
 			Status: v1alpha1.RouteStatus{
 				RouteStatusFields: v1alpha1.RouteStatusFields{
-					Domain: "local-route.default.svc.cluster.local",
+					Domain:  "local-route.default.svc.cluster.local",
+					Address: &duckv1alpha1.Addressable{Hostname: "local-route.default.svc.cluster.local"},
 				},
 			},
 		},
@@ -175,7 +180,8 @@ func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain: base,
+				Domain:  base,
+				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
 			},
 		},
 	}
@@ -197,7 +203,8 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain: base,
+				Domain:  base,
+				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
 			},
 		},
 	}
@@ -223,7 +230,8 @@ func TestGetRouteDomains_NamedTarget(t *testing.T) {
 		},
 		Status: v1alpha1.RouteStatus{
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Domain: base,
+				Domain:  base,
+				Address: &duckv1alpha1.Addressable{Hostname: "test-route.test-ns.svc.cluster.local"},
 			},
 		},
 	}

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -64,7 +64,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "not-ready", 1, WithInitRevConditions, WithRevName("not-ready-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "first-reconcile", WithConfigTarget("not-ready"),
+			Object: route("default", "first-reconcile", WithConfigTarget("not-ready"), WithDomain,
 				// The first reconciliation initializes the conditions and reflects
 				// that the referenced configuration is not yet ready.
 				WithInitRouteConditions, MarkConfigurationNotReady("not-ready")),
@@ -81,7 +81,7 @@ func TestReconcile(t *testing.T) {
 				WithInitRevConditions, MarkContainerMissing),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "first-reconcile", WithConfigTarget("permanently-failed"),
+			Object: route("default", "first-reconcile", WithConfigTarget("permanently-failed"), WithDomain,
 				WithInitRouteConditions, MarkConfigurationFailed("permanently-failed")),
 		}},
 		Key: "default/first-reconcile",
@@ -97,7 +97,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "not-ready", 1, WithInitRevConditions, WithRevName("not-ready-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "first-reconcile", WithConfigTarget("not-ready"),
+			Object: route("default", "first-reconcile", WithConfigTarget("not-ready"), WithDomain,
 				WithInitRouteConditions, MarkConfigurationNotReady("not-ready")),
 		}},
 		WantEvents: []string{
@@ -973,7 +973,7 @@ func TestReconcile(t *testing.T) {
 			route("default", "config-missing", WithConfigTarget("not-found")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "config-missing", WithConfigTarget("not-found"),
+			Object: route("default", "config-missing", WithConfigTarget("not-found"), WithDomain,
 				WithInitRouteConditions, MarkMissingTrafficTarget("Configuration", "not-found")),
 		}},
 		Key: "default/config-missing",
@@ -985,7 +985,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "missing-revision-direct", WithRevTarget("not-found"),
+			Object: route("default", "missing-revision-direct", WithRevTarget("not-found"), WithDomain,
 				WithInitRouteConditions, MarkMissingTrafficTarget("Revision", "not-found")),
 		}},
 		Key: "default/missing-revision-direct",
@@ -997,7 +997,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "missing-revision-indirect", WithConfigTarget("config"),
+			Object: route("default", "missing-revision-indirect", WithConfigTarget("config"), WithDomain,
 				WithInitRouteConditions, MarkMissingTrafficTarget("Revision", "config-00001")),
 		}},
 		Key: "default/missing-revision-indirect",
@@ -1193,10 +1193,12 @@ func TestReconcile(t *testing.T) {
 						Name:         "gray",
 						RevisionName: "gray-00001",
 						Percent:      50,
+						URL:          "http://gray.same-revision-targets.default.example.com",
 					}, v1alpha1.TrafficTarget{
 						Name:         "also-gray",
 						RevisionName: "gray-00001",
 						Percent:      50,
+						URL:          "http://also-gray.same-revision-targets.default.example.com",
 					})),
 		}},
 		WantEvents: []string{

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -29,7 +29,7 @@ import (
 // DefaultTarget is the unnamed default target for the traffic.
 const DefaultTarget = ""
 
-const httpScheme string = "http"
+const HttpScheme string = "http"
 
 // A RevisionTarget adds the Active/Inactive state and the transport protocol of a
 // Revision to a flattened TrafficTarget.
@@ -101,7 +101,7 @@ func SubrouteDomain(name, domain string) string {
 
 // subrouteURL returns the URL of the subroute given the scheme, traffic target name, and base domain. Curently
 // the subroute is represented as a subdomain of the base domain.
-func subrouteURL(scheme, name, domain string) string {
+func SubrouteURL(scheme, name, domain string) string {
 	return fmt.Sprintf("%s://%s", scheme, SubrouteDomain(name, domain))
 }
 
@@ -114,7 +114,7 @@ func (t *Config) GetRevisionTrafficTargets(domain string) []v1alpha1.TrafficTarg
 		results[i] = v1alpha1.TrafficTarget{RevisionName: tt.RevisionName, Name: tt.Name, Percent: tt.Percent}
 		if tt.Name != "" && domain != "" {
 			// http is currently the only supported scheme
-			results[i].URL = subrouteURL(httpScheme, tt.Name, domain)
+			results[i].URL = SubrouteURL(HttpScheme, tt.Name, domain)
 		}
 	}
 	return results

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -29,9 +29,9 @@ import (
 // DefaultTarget is the unnamed default target for the traffic.
 const DefaultTarget = ""
 
-type Scheme string
+type scheme string
 
-const http Scheme = "http"
+const http scheme = "http"
 
 // A RevisionTarget adds the Active/Inactive state and the transport protocol of a
 // Revision to a flattened TrafficTarget.
@@ -103,7 +103,7 @@ func SubrouteDomain(name, domain string) string {
 
 // subrouteURL returns the URL of the subroute given the scheme, traffic target name, and base domain. Curently
 // the subroute is represented as a subdomain of the base domain.
-func subrouteURL(scheme Scheme, name, domain string) string {
+func subrouteURL(scheme scheme, name, domain string) string {
 	return fmt.Sprintf("%s://%s", scheme, SubrouteDomain(name, domain))
 }
 

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -96,7 +96,7 @@ func BuildTrafficConfiguration(configLister listers.ConfigurationLister, revList
 // SubrouteDomain returns the domain name of a traffic target given the traffic target name and the Route's base domain.
 func SubrouteDomain(name, domain string) string {
 	if name == DefaultTarget {
-		return fmt.Sprintf("%s", domain)
+		return domain
 	}
 	return fmt.Sprintf("%s.%s", name, domain)
 }

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -29,9 +29,7 @@ import (
 // DefaultTarget is the unnamed default target for the traffic.
 const DefaultTarget = ""
 
-type scheme string
-
-const http scheme = "http"
+const httpScheme string = "http"
 
 // A RevisionTarget adds the Active/Inactive state and the transport protocol of a
 // Revision to a flattened TrafficTarget.
@@ -103,7 +101,7 @@ func SubrouteDomain(name, domain string) string {
 
 // subrouteURL returns the URL of the subroute given the scheme, traffic target name, and base domain. Curently
 // the subroute is represented as a subdomain of the base domain.
-func subrouteURL(scheme scheme, name, domain string) string {
+func subrouteURL(scheme, name, domain string) string {
 	return fmt.Sprintf("%s://%s", scheme, SubrouteDomain(name, domain))
 }
 
@@ -116,7 +114,7 @@ func (t *Config) GetRevisionTrafficTargets(domain string) []v1alpha1.TrafficTarg
 		results[i] = v1alpha1.TrafficTarget{RevisionName: tt.RevisionName, Name: tt.Name, Percent: tt.Percent}
 		if tt.Name != "" && domain != "" {
 			// http is currently the only supported scheme
-			results[i].URL = subrouteURL(http, tt.Name, domain)
+			results[i].URL = subrouteURL(httpScheme, tt.Name, domain)
 		}
 	}
 	return results

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -904,11 +904,11 @@ func TestRoundTripping(t *testing.T) {
 	}, {
 		Name:         "beta",
 		RevisionName: goodNewRev.Name,
-		URL:          subrouteURL(http, "beta", domain),
+		URL:          subrouteURL(httpScheme, "beta", domain),
 	}, {
 		Name:         "alpha",
 		RevisionName: niceNewRev.Name,
-		URL:          subrouteURL(http, "alpha", domain),
+		URL:          subrouteURL(httpScheme, "alpha", domain),
 	}}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -937,7 +937,7 @@ func TestSubrouteURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.TestName, func(t *testing.T) {
-			if got, want := tt.Expected, subrouteURL(http, tt.Name, tt.Domain); got != want {
+			if got, want := tt.Expected, subrouteURL(httpScheme, tt.Name, tt.Domain); got != want {
 				t.Errorf("SubrouteDomain = %s, want: %s", got, want)
 			}
 		})

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -904,11 +904,11 @@ func TestRoundTripping(t *testing.T) {
 	}, {
 		Name:         "beta",
 		RevisionName: goodNewRev.Name,
-		URL:          subrouteURL(httpScheme, "beta", domain),
+		URL:          SubrouteURL(HttpScheme, "beta", domain),
 	}, {
 		Name:         "alpha",
 		RevisionName: niceNewRev.Name,
-		URL:          subrouteURL(httpScheme, "alpha", domain),
+		URL:          SubrouteURL(HttpScheme, "alpha", domain),
 	}}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -937,7 +937,7 @@ func TestSubrouteURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.TestName, func(t *testing.T) {
-			if got, want := tt.Expected, subrouteURL(httpScheme, tt.Name, tt.Domain); got != want {
+			if got, want := tt.Expected, SubrouteURL(HttpScheme, tt.Name, tt.Domain); got != want {
 				t.Errorf("SubrouteDomain = %s, want: %s", got, want)
 			}
 		})

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -887,6 +887,7 @@ func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 }
 
 func TestRoundTripping(t *testing.T) {
+	domain := "domain.com"
 	tts := []v1alpha1.TrafficTarget{{
 		RevisionName: goodOldRev.Name,
 		Percent:      100,
@@ -903,14 +904,71 @@ func TestRoundTripping(t *testing.T) {
 	}, {
 		Name:         "beta",
 		RevisionName: goodNewRev.Name,
+		URL:          subrouteURL(http, "beta", domain),
 	}, {
 		Name:         "alpha",
 		RevisionName: niceNewRev.Name,
+		URL:          subrouteURL(http, "alpha", domain),
 	}}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if got, want := expected, tc.GetRevisionTrafficTargets(); !cmp.Equal(got, want) {
+	} else if got, want := expected, tc.GetRevisionTrafficTargets(domain); !cmp.Equal(got, want) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want))
+	}
+}
+
+func TestSubrouteURL(t *testing.T) {
+	tests := []struct {
+		TestName string
+		Name     string
+		Domain   string
+		Expected string
+	}{{
+		TestName: "subdomain",
+		Name:     "current",
+		Domain:   "svc.local.com",
+		Expected: "http://current.svc.local.com",
+	}, {
+		TestName: "default target",
+		Name:     DefaultTarget,
+		Domain:   "default.com",
+		Expected: "http://default.com",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			if got, want := tt.Expected, subrouteURL(http, tt.Name, tt.Domain); got != want {
+				t.Errorf("SubrouteDomain = %s, want: %s", got, want)
+			}
+		})
+	}
+
+}
+
+func TestSubrouteDomain(t *testing.T) {
+	tests := []struct {
+		TestName string
+		Name     string
+		Domain   string
+		Expected string
+	}{{
+		TestName: "subdomain",
+		Name:     "current",
+		Domain:   "svc.local.com",
+		Expected: "current.svc.local.com",
+	}, {
+		TestName: "default target",
+		Name:     DefaultTarget,
+		Domain:   "default.com",
+		Expected: "default.com",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			if got, want := tt.Expected, SubrouteDomain(tt.Name, tt.Domain); got != want {
+				t.Errorf("SubrouteDomain = %s, want: %s", got, want)
+			}
+		})
 	}
 }
 

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/kmp"
 	"github.com/knative/pkg/logging"
@@ -228,7 +229,13 @@ func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) e
 				want[idx].ConfigurationName = ""
 			}
 		}
-		if eq, err := kmp.SafeEqual(got, want); !eq || err != nil {
+		opt := cmp.FilterPath(
+			func(p cmp.Path) bool {
+				return p.String() == "URL"
+			},
+			cmp.Ignore(),
+		)
+		if eq, err := kmp.SafeEqual(got, want, opt); !eq || err != nil {
 			service.Status.MarkRouteNotYetReady()
 		}
 	}

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -229,13 +229,13 @@ func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) e
 				want[idx].ConfigurationName = ""
 			}
 		}
-		opt := cmp.FilterPath(
+		ignoreURLs := cmp.FilterPath(
 			func(p cmp.Path) bool {
 				return p.String() == "URL"
 			},
 			cmp.Ignore(),
 		)
-		if eq, err := kmp.SafeEqual(got, want, opt); !eq || err != nil {
+		if eq, err := kmp.SafeEqual(got, want, ignoreURLs); !eq || err != nil {
 			service.Status.MarkRouteNotYetReady()
 		}
 	}

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -29,6 +29,7 @@ import (
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	routenames "github.com/knative/serving/pkg/reconciler/v1alpha1/route/resources/names"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
 	servicenames "github.com/knative/serving/pkg/reconciler/v1alpha1/service/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -291,9 +292,18 @@ func WithSvcStatusAddress(s *v1alpha1.Service) {
 }
 
 // WithSvcStatusTraffic sets the Service's status traffic block to the specified traffic targets.
-func WithSvcStatusTraffic(traffic ...v1alpha1.TrafficTarget) ServiceOption {
+func WithSvcStatusTraffic(targets ...v1alpha1.TrafficTarget) ServiceOption {
 	return func(r *v1alpha1.Service) {
-		r.Status.Traffic = traffic
+		// Automatically inject URL into TrafficTarget status
+		for _, tt := range targets {
+			if tt.Name != "" {
+				tt.URL = traffic.SubrouteURL(traffic.HttpScheme,
+					tt.Name,
+					"example.com")
+			}
+		}
+		r.Status.Traffic = targets
+
 	}
 }
 

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -121,7 +121,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		}
 	}
 	if blueDomain == "" || greenDomain == "" {
-		t.Fatalf("Unable to fetch URLs from traffic targets: %v", route.Status.Traffic)
+		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", route.Status.Traffic)
 	}
 	tealDomain := route.Status.Domain
 

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -20,8 +20,8 @@ package conformance
 
 import (
 	"context"
-	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	_ "github.com/knative/pkg/system/testing"
@@ -107,9 +107,22 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
 
-	// TODO(tcnghia): Add a RouteStatus method to create this string.
-	blueDomain := fmt.Sprintf("%s.%s", blue.TrafficTarget, route.Status.Domain)
-	greenDomain := fmt.Sprintf("%s.%s", green.TrafficTarget, route.Status.Domain)
+	var blueDomain, greenDomain string
+	for _, tt := range route.Status.Traffic {
+		if tt.Name == blue.TrafficTarget {
+			// Strip prefix as WaitForEndPointState expects a domain
+			// without scheme.
+			blueDomain = strings.TrimPrefix(tt.URL, "http://")
+		}
+		if tt.Name == green.TrafficTarget {
+			// Strip prefix as WaitForEndPointState expects a domain
+			// without scheme.
+			greenDomain = strings.TrimPrefix(tt.URL, "http://")
+		}
+	}
+	if blueDomain == "" || greenDomain == "" {
+		t.Fatalf("Unable to fetch URLs from traffic targets: %v", route.Status.Traffic)
+	}
 	tealDomain := route.Status.Domain
 
 	// Istio network programming takes some time to be effective.  Currently Istio

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -327,13 +327,13 @@ func waitForDesiredTrafficShape(t *testing.T, sName string, want map[string]v1al
 			for _, tt := range s.Status.Traffic {
 				got[tt.Name] = tt
 			}
-			opt := cmp.FilterPath(
+			ignoreURLs := cmp.FilterPath(
 				func(p cmp.Path) bool {
 					return p.String() == "URL"
 				},
 				cmp.Ignore(),
 			)
-			if !cmp.Equal(got, want, opt) {
+			if !cmp.Equal(got, want, ignoreURLs) {
 				t.Logf("For service %s traffic shape mismatch: (-got, +want) %s", sName, cmp.Diff(got, want))
 				return false, nil
 			}

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -327,7 +327,13 @@ func waitForDesiredTrafficShape(t *testing.T, sName string, want map[string]v1al
 			for _, tt := range s.Status.Traffic {
 				got[tt.Name] = tt
 			}
-			if !cmp.Equal(got, want) {
+			opt := cmp.FilterPath(
+				func(p cmp.Path) bool {
+					return p.String() == "URL"
+				},
+				cmp.Ignore(),
+			)
+			if !cmp.Equal(got, want, opt) {
 				t.Logf("For service %s traffic shape mismatch: (-got, +want) %s", sName, cmp.Diff(got, want))
 				return false, nil
 			}


### PR DESCRIPTION
This change adds URL to the output of each named Traffic Target. The URL
is prefixed with a scheme. Currently we only support subdomains for
named traffic targets and 'http' as the scheme. However, this change enables
clients to grab the URL from the API rather than making assumptions on
scheme and URL format which paves the way for operator customization.

Fixes #3450

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
URL is now present on Status.Traffic entries that have "name" specified.
```
