### PR TITLE
Disallow unknown fields (again)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   revision = "3fc06fd3c9880a9ebb5c401f4b20cf6666cc7bc0"
 
 [[projects]]
-  digest = "1:27737fdaa86b6cab24d4cea8cce898fb66c9a9a887d91098fd387e95ece90036"
+  digest = "1:b7ccc2a66d28cfacf4cdd97fcb90662c7ce4feb9a68944975c6b06bbdfc8757e"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -487,7 +487,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "fe25685384ea3e4f267355f5940960d62e2b7b93"
+  revision = "04154dda9a1b8ef17939d30a628272b201330ddb"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@ required = [
 [[override]]
   name = "github.com/knative/pkg"
   # HEAD as of 2019-03-25
-  revision = "fe25685384ea3e4f267355f5940960d62e2b7b93"
+  revision = "04154dda9a1b8ef17939d30a628272b201330ddb"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -108,7 +108,8 @@ func main() {
 			net.SchemeGroupVersion.WithKind("ClusterIngress"):     &net.ClusterIngress{},
 			net.SchemeGroupVersion.WithKind("ServerlessService"):  &net.ServerlessService{},
 		},
-		Logger: logger,
+		Logger:                logger,
+		DisallowUnknownFields: true,
 	}
 	if err = controller.Run(stopCh); err != nil {
 		logger.Fatalw("Failed to start the admission controller", zap.Error(err))

--- a/vendor/github.com/knative/pkg/webhook/webhook.go
+++ b/vendor/github.com/knative/pkg/webhook/webhook.go
@@ -120,6 +120,8 @@ type AdmissionController struct {
 	Options  ControllerOptions
 	Handlers map[schema.GroupVersionKind]GenericCRD
 	Logger   *zap.SugaredLogger
+
+	DisallowUnknownFields bool
 }
 
 // GenericCRD is the interface definition that allows us to perform the generic
@@ -527,6 +529,9 @@ func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1
 	if len(newBytes) != 0 {
 		newObj = handler.DeepCopyObject().(GenericCRD)
 		newDecoder := json.NewDecoder(bytes.NewBuffer(newBytes))
+		if ac.DisallowUnknownFields {
+			newDecoder.DisallowUnknownFields()
+		}
 		if err := newDecoder.Decode(&newObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming new object: %v", err)
 		}
@@ -534,6 +539,9 @@ func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1
 	if len(oldBytes) != 0 {
 		oldObj = handler.DeepCopyObject().(GenericCRD)
 		oldDecoder := json.NewDecoder(bytes.NewBuffer(oldBytes))
+		if ac.DisallowUnknownFields {
+			oldDecoder.DisallowUnknownFields()
+		}
 		if err := oldDecoder.Decode(&oldObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming old object: %v", err)
 		}


### PR DESCRIPTION
This adds back the logic in the webhook that disallows unknown fields.

We had disabled this because of versioning, but the idea of silently accepting unknown fields is an undesireable failure mode.

We also can't currently detect / reject typos and such because of this, which continues to be a real hit to usability.

Fixes: https://github.com/knative/serving/issues/3309