### PR TITLE
Append routeFinalizer into route.Finalizers to keep the finalizer order

### DIFF
--- a/pkg/reconciler/v1alpha1/route/route.go
+++ b/pkg/reconciler/v1alpha1/route/route.go
@@ -388,11 +388,9 @@ func (c *Reconciler) ensureFinalizer(route *v1alpha1.Route) error {
 	if finalizers.Has(routeFinalizer) {
 		return nil
 	}
-	finalizers.Insert(routeFinalizer)
-
 	mergePatch := map[string]interface{}{
 		"metadata": map[string]interface{}{
-			"finalizers":      finalizers.List(),
+			"finalizers":      append(route.Finalizers, routeFinalizer),
 			"resourceVersion": route.ResourceVersion,
 		},
 	}


### PR DESCRIPTION

## Proposed Changes
Instead of using `Sets(x).List()`, we append routeFinalizer into route.Finalizers slice to keep the finalizer order.

