### PR TITLE
Move the ProtocolType from serving to networking.

### DIFF
--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -19,7 +19,7 @@ package activator
 import (
 	"fmt"
 
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 )
 
 const (
@@ -48,12 +48,11 @@ func (rev RevisionID) String() string {
 	return fmt.Sprintf("%s/%s", rev.Namespace, rev.Name)
 }
 
-// ServicePort returns the activator service port for the given Revision protocol.
+// ServicePort returns the activator service port for the given app level protocol.
 // Default is `ServicePortHTTP1`.
-func ServicePort(protocol v1alpha1.RevisionProtocolType) int32 {
-	if protocol == v1alpha1.RevisionProtocolH2C {
+func ServicePort(protocol v1alpha1.ProtocolType) int32 {
+	if protocol == v1alpha1.ProtocolH2C {
 		return ServicePortH2C
 	}
-
 	return ServicePortHTTP1
 }

--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -19,7 +19,7 @@ package activator
 import (
 	"fmt"
 
-	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking"
 )
 
 const (
@@ -50,8 +50,8 @@ func (rev RevisionID) String() string {
 
 // ServicePort returns the activator service port for the given app level protocol.
 // Default is `ServicePortHTTP1`.
-func ServicePort(protocol v1alpha1.ProtocolType) int32 {
-	if protocol == v1alpha1.ProtocolH2C {
+func ServicePort(protocol networking.ProtocolType) int32 {
+	if protocol == networking.ProtocolH2C {
 		return ServicePortH2C
 	}
 	return ServicePortHTTP1

--- a/pkg/activator/activator_test.go
+++ b/pkg/activator/activator_test.go
@@ -18,21 +18,21 @@ package activator
 import (
 	"testing"
 
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 )
 
 func TestServicePort(t *testing.T) {
 	tests := []struct {
 		name     string
-		protocol netv1a1.ProtocolType
+		protocol net.ProtocolType
 		port     int32
 	}{{
 		name:     "h2c",
-		protocol: netv1a1.ProtocolH2C,
+		protocol: net.ProtocolH2C,
 		port:     ServicePortH2C,
 	}, {
 		name:     "http1",
-		protocol: netv1a1.ProtocolHTTP1,
+		protocol: net.ProtocolHTTP1,
 		port:     ServicePortHTTP1,
 	}}
 

--- a/pkg/activator/activator_test.go
+++ b/pkg/activator/activator_test.go
@@ -18,21 +18,21 @@ package activator
 import (
 	"testing"
 
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 )
 
 func TestServicePort(t *testing.T) {
 	tests := []struct {
 		name     string
-		protocol v1alpha1.RevisionProtocolType
+		protocol netv1a1.ProtocolType
 		port     int32
 	}{{
 		name:     "h2c",
-		protocol: v1alpha1.RevisionProtocolH2C,
+		protocol: netv1a1.ProtocolH2C,
 		port:     ServicePortH2C,
 	}, {
 		name:     "http1",
-		protocol: v1alpha1.RevisionProtocolHTTP1,
+		protocol: netv1a1.ProtocolHTTP1,
 		port:     ServicePortHTTP1,
 	}}
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
-	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,10 +94,7 @@ type PodAutoscalerSpec struct {
 	ServiceName string `json:"serviceName"`
 
 	// The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.
-	ProtocolType netv1alpha1.ProtocolType
-
-	// Selector is the pod selector for this revision.
-	Selector map[string]string
+	ProtocolType net.ProtocolType
 }
 
 const (

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,8 +93,11 @@ type PodAutoscalerSpec struct {
 	// load balances over the pods referenced by the ScaleTargetRef.
 	ServiceName string `json:"serviceName"`
 
-	// The application-layer protocol. Matches `RevisionProtocolType` set on the owning revision.
-	ProtocolType servingv1alpha1.RevisionProtocolType
+	// The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.
+	ProtocolType netv1alpha1.ProtocolType
+
+	// Selector is the pod selector for this revision.
+	Selector map[string]string
 }
 
 const (

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
-	servingv1a1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
 
@@ -182,7 +182,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 					Kind:       "Deployment",
 					Name:       "bar",
 				},
-				ProtocolType: servingv1a1.RevisionProtocolHTTP1,
+				ProtocolType: netv1a1.ProtocolHTTP1,
 			},
 		},
 		want: nil,
@@ -223,7 +223,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 					Kind:       "Deployment",
 					Name:       "bar",
 				},
-				ProtocolType: servingv1a1.RevisionProtocolType("WebSocket"),
+				ProtocolType: netv1a1.ProtocolType("WebSocket"),
 			},
 		},
 		want: apis.ErrInvalidValue("WebSocket", "spec.protocolType"),
@@ -335,7 +335,7 @@ func TestImmutableFields(t *testing.T) {
 					Kind:       "Deployment",
 					Name:       "bar",
 				},
-				ProtocolType: servingv1a1.RevisionProtocolHTTP1,
+				ProtocolType: netv1a1.ProtocolHTTP1,
 			},
 		},
 		old: &PodAutoscaler{

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
 
@@ -182,7 +182,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 					Kind:       "Deployment",
 					Name:       "bar",
 				},
-				ProtocolType: netv1a1.ProtocolHTTP1,
+				ProtocolType: net.ProtocolHTTP1,
 			},
 		},
 		want: nil,
@@ -223,7 +223,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 					Kind:       "Deployment",
 					Name:       "bar",
 				},
-				ProtocolType: netv1a1.ProtocolType("WebSocket"),
+				ProtocolType: net.ProtocolType("WebSocket"),
 			},
 		},
 		want: apis.ErrInvalidValue("WebSocket", "spec.protocolType"),
@@ -335,7 +335,7 @@ func TestImmutableFields(t *testing.T) {
 					Kind:       "Deployment",
 					Name:       "bar",
 				},
-				ProtocolType: netv1a1.ProtocolHTTP1,
+				ProtocolType: net.ProtocolHTTP1,
 			},
 		},
 		old: &PodAutoscaler{

--- a/pkg/apis/networking/generic_types.go
+++ b/pkg/apis/networking/generic_types.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import "github.com/knative/pkg/apis"
+
+// This files contains the versionless types and enums that are strongly
+// unlikely to change from version to version.
+
+// ProtocolType is an enumeration of the supported application-layer protocols
+// See also: https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports
+type ProtocolType string
+
+const (
+	// ProtocolHTTP1 maps to HTTP/1.1.
+	ProtocolHTTP1 ProtocolType = "http1"
+	// ProtocolH2C maps to HTTP/2 with Prior Knowledge.
+	ProtocolH2C ProtocolType = "h2c"
+)
+
+// Validate validates that ProtocolType has a correct enum value.
+func (p ProtocolType) Validate() *apis.FieldError {
+	switch p {
+	case ProtocolH2C, ProtocolHTTP1:
+		return nil
+	}
+	return apis.ErrInvalidValue(string(p), apis.CurrentField)
+}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -98,8 +98,19 @@ type ServerlessServiceSpec struct {
 
 	// The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
 	// serving imports networking, so just use string.
-	ProtocolType string
+	ProtocolType ProtocolType
 }
+
+// ProtocolType is an enumeration of the supported application-layer protocols
+// See also: https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports
+type ProtocolType string
+
+const (
+	// ProtocolHTTP1 maps to HTTP/1.1.
+	ProtocolHTTP1 ProtocolType = "http1"
+	// ProtocolH2C maps to HTTP/2 with Prior Knowledge.
+	ProtocolH2C ProtocolType = "h2c"
+)
 
 // ServerlessServiceStatus describes the current state of the ServerlessService.
 type ServerlessServiceStatus struct {

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
+	networking "github.com/knative/serving/pkg/apis/networking"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -98,19 +99,8 @@ type ServerlessServiceSpec struct {
 
 	// The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
 	// serving imports networking, so just use string.
-	ProtocolType ProtocolType
+	ProtocolType networking.ProtocolType
 }
-
-// ProtocolType is an enumeration of the supported application-layer protocols
-// See also: https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports
-type ProtocolType string
-
-const (
-	// ProtocolHTTP1 maps to HTTP/1.1.
-	ProtocolHTTP1 ProtocolType = "http1"
-	// ProtocolH2C maps to HTTP/2 with Prior Knowledge.
-	ProtocolH2C ProtocolType = "h2c"
-)
 
 // ServerlessServiceStatus describes the current state of the ServerlessService.
 type ServerlessServiceStatus struct {

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -57,11 +57,14 @@ func (spec *ServerlessServiceSpec) Validate(ctx context.Context) *apis.FieldErro
 		}
 	}
 
-	switch spec.ProtocolType {
-	// revision_types.go for values.
-	case "http1", "h2c":
-	default:
-		all = all.Also(apis.ErrInvalidValue(spec.ProtocolType, "protocolType"))
+	return all.Also(spec.ProtocolType.Validate().ViaField("protocolType"))
+}
+
+// Validate validates that ProtocolType has a correct enum value.
+func (p ProtocolType) Validate() *apis.FieldError {
+	switch p {
+	case ProtocolH2C, ProtocolHTTP1:
+		return nil
 	}
-	return all
+	return apis.ErrInvalidValue(string(p), apis.CurrentField)
 }

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -59,12 +59,3 @@ func (spec *ServerlessServiceSpec) Validate(ctx context.Context) *apis.FieldErro
 
 	return all.Also(spec.ProtocolType.Validate().ViaField("protocolType"))
 }
-
-// Validate validates that ProtocolType has a correct enum value.
-func (p ProtocolType) Validate() *apis.FieldError {
-	switch p {
-	case ProtocolH2C, ProtocolHTTP1:
-		return nil
-	}
-	return apis.ErrInvalidValue(string(p), apis.CurrentField)
-}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
@@ -36,7 +36,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"a": "b",
 			},
-			ProtocolType: "http1",
+			ProtocolType: ProtocolHTTP1,
 		},
 		want: nil,
 	}, {
@@ -46,7 +46,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-1982",
 			},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolH2C,
 		},
 		want: nil,
 	}, {
@@ -56,7 +56,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-1982",
 			},
-			ProtocolType: "gRPC",
+			ProtocolType: ProtocolType("gRPC"),
 		},
 		want: apis.ErrInvalidValue("gRPC", "protocolType"),
 	}, {
@@ -67,7 +67,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 				"revision.knative.dev": "rev-1982",
 				"activator.service":    "act-service-1988",
 			},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolH2C,
 		},
 		want: nil,
 	}, {
@@ -77,7 +77,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-2009",
 			},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolH2C,
 		},
 		want: apis.ErrInvalidValue("bombastic", "mode"),
 	}, {
@@ -87,14 +87,14 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-2009",
 			},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolHTTP1,
 		},
 		want: apis.ErrMissingField("mode"),
 	}, {
 		name: "no selector",
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolH2C,
 		},
 		want: apis.ErrMissingField("selector"),
 	}, {
@@ -102,7 +102,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
 			Selector:     map[string]string{},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolHTTP1,
 		},
 		want: apis.ErrMissingField("selector"),
 	}, {
@@ -110,7 +110,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
 			Selector:     map[string]string{"": "n'importe quoi"},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolH2C,
 		},
 		want: apis.ErrInvalidKeyName("", "selector", "empty key is not permitted"),
 	}, {
@@ -120,7 +120,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "",
 			},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolHTTP1,
 		},
 		want: apis.ErrInvalidValue("", apis.CurrentField).ViaKey("revision.knative.dev").ViaField("selector"),
 	}, {
@@ -129,7 +129,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "",
 			},
-			ProtocolType: "h2c",
+			ProtocolType: ProtocolH2C,
 		},
 		want: apis.ErrMissingField("mode").Also(apis.ErrInvalidValue("", apis.CurrentField).ViaKey("revision.knative.dev").ViaField("selector")),
 	}, {

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	networking "github.com/knative/serving/pkg/apis/networking"
 )
 
 func TestServerlessServiceSpecValidation(t *testing.T) {
@@ -36,7 +37,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"a": "b",
 			},
-			ProtocolType: ProtocolHTTP1,
+			ProtocolType: networking.ProtocolHTTP1,
 		},
 		want: nil,
 	}, {
@@ -46,7 +47,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-1982",
 			},
-			ProtocolType: ProtocolH2C,
+			ProtocolType: networking.ProtocolH2C,
 		},
 		want: nil,
 	}, {
@@ -56,7 +57,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-1982",
 			},
-			ProtocolType: ProtocolType("gRPC"),
+			ProtocolType: networking.ProtocolType("gRPC"),
 		},
 		want: apis.ErrInvalidValue("gRPC", "protocolType"),
 	}, {
@@ -67,7 +68,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 				"revision.knative.dev": "rev-1982",
 				"activator.service":    "act-service-1988",
 			},
-			ProtocolType: ProtocolH2C,
+			ProtocolType: networking.ProtocolH2C,
 		},
 		want: nil,
 	}, {
@@ -77,7 +78,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-2009",
 			},
-			ProtocolType: ProtocolH2C,
+			ProtocolType: networking.ProtocolH2C,
 		},
 		want: apis.ErrInvalidValue("bombastic", "mode"),
 	}, {
@@ -87,14 +88,14 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "rev-2009",
 			},
-			ProtocolType: ProtocolHTTP1,
+			ProtocolType: networking.ProtocolHTTP1,
 		},
 		want: apis.ErrMissingField("mode"),
 	}, {
 		name: "no selector",
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
-			ProtocolType: ProtocolH2C,
+			ProtocolType: networking.ProtocolH2C,
 		},
 		want: apis.ErrMissingField("selector"),
 	}, {
@@ -102,7 +103,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
 			Selector:     map[string]string{},
-			ProtocolType: ProtocolHTTP1,
+			ProtocolType: networking.ProtocolHTTP1,
 		},
 		want: apis.ErrMissingField("selector"),
 	}, {
@@ -110,7 +111,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
 			Selector:     map[string]string{"": "n'importe quoi"},
-			ProtocolType: ProtocolH2C,
+			ProtocolType: networking.ProtocolH2C,
 		},
 		want: apis.ErrInvalidKeyName("", "selector", "empty key is not permitted"),
 	}, {
@@ -120,7 +121,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "",
 			},
-			ProtocolType: ProtocolHTTP1,
+			ProtocolType: networking.ProtocolHTTP1,
 		},
 		want: apis.ErrInvalidValue("", apis.CurrentField).ViaKey("revision.knative.dev").ViaField("selector"),
 	}, {
@@ -129,7 +130,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Selector: map[string]string{
 				"revision.knative.dev": "",
 			},
-			ProtocolType: ProtocolH2C,
+			ProtocolType: networking.ProtocolH2C,
 		},
 		want: apis.ErrMissingField("mode").Also(apis.ErrInvalidValue("", apis.CurrentField).ViaKey("revision.knative.dev").ViaField("selector")),
 	}, {

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -97,13 +97,13 @@ func (r *Revision) BuildRef() *corev1.ObjectReference {
 }
 
 // GetProtocol returns the app level network protocol.
-func (r *Revision) GetProtocol() netv1alpha1.ProtocolType {
+func (r *Revision) GetProtocol() net.ProtocolType {
 	ports := r.Spec.Container.Ports
-	if len(ports) > 0 && ports[0].Name == string(netv1alpha1.ProtocolH2C) {
-		return netv1alpha1.ProtocolH2C
+	if len(ports) > 0 && ports[0].Name == string(net.ProtocolH2C) {
+		return net.ProtocolH2C
 	}
 
-	return netv1alpha1.ProtocolHTTP1
+	return net.ProtocolHTTP1
 }
 
 // IsReady looks at the conditions and if the Status has a condition
@@ -112,6 +112,7 @@ func (rs *RevisionStatus) IsReady() bool {
 	return revCondSet.Manage(rs).IsHappy()
 }
 
+// IsActivationRequired returns true if activation is required.
 func (rs *RevisionStatus) IsActivationRequired() bool {
 	if c := revCondSet.Manage(rs).GetCondition(RevisionConditionActive); c != nil {
 		return c.Status != corev1.ConditionTrue

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -95,13 +96,14 @@ func (r *Revision) BuildRef() *corev1.ObjectReference {
 	return nil
 }
 
-func (r *Revision) GetProtocol() RevisionProtocolType {
+// GetProtocol returns the app level network protocol.
+func (r *Revision) GetProtocol() netv1alpha1.ProtocolType {
 	ports := r.Spec.Container.Ports
-	if len(ports) > 0 && ports[0].Name == "h2c" {
-		return RevisionProtocolH2C
+	if len(ports) > 0 && ports[0].Name == string(netv1alpha1.ProtocolH2C) {
+		return netv1alpha1.ProtocolH2C
 	}
 
-	return RevisionProtocolHTTP1
+	return netv1alpha1.ProtocolHTTP1
 }
 
 // IsReady looks at the conditions and if the Status has a condition

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -632,32 +632,32 @@ func TestRevisionGetProtocol(t *testing.T) {
 	tests := []struct {
 		name      string
 		container corev1.Container
-		protocol  netv1a1.ProtocolType
+		protocol  net.ProtocolType
 	}{
 		{
 			name:      "undefined",
 			container: corev1.Container{},
-			protocol:  netv1a1.ProtocolHTTP1,
+			protocol:  net.ProtocolHTTP1,
 		},
 		{
 			name:      "http1",
 			container: containerWithPortName("http1"),
-			protocol:  netv1a1.ProtocolHTTP1,
+			protocol:  net.ProtocolHTTP1,
 		},
 		{
 			name:      "h2c",
 			container: containerWithPortName("h2c"),
-			protocol:  netv1a1.ProtocolH2C,
+			protocol:  net.ProtocolH2C,
 		},
 		{
 			name:      "unknown",
 			container: containerWithPortName("whatever"),
-			protocol:  netv1a1.ProtocolHTTP1,
+			protocol:  net.ProtocolHTTP1,
 		},
 		{
 			name:      "empty",
 			container: containerWithPortName(""),
-			protocol:  netv1a1.ProtocolHTTP1,
+			protocol:  net.ProtocolHTTP1,
 		},
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -631,32 +632,32 @@ func TestRevisionGetProtocol(t *testing.T) {
 	tests := []struct {
 		name      string
 		container corev1.Container
-		protocol  RevisionProtocolType
+		protocol  netv1a1.ProtocolType
 	}{
 		{
 			name:      "undefined",
 			container: corev1.Container{},
-			protocol:  RevisionProtocolHTTP1,
+			protocol:  netv1a1.ProtocolHTTP1,
 		},
 		{
 			name:      "http1",
 			container: containerWithPortName("http1"),
-			protocol:  RevisionProtocolHTTP1,
+			protocol:  netv1a1.ProtocolHTTP1,
 		},
 		{
 			name:      "h2c",
 			container: containerWithPortName("h2c"),
-			protocol:  RevisionProtocolH2C,
+			protocol:  netv1a1.ProtocolH2C,
 		},
 		{
 			name:      "unknown",
 			container: containerWithPortName("whatever"),
-			protocol:  RevisionProtocolHTTP1,
+			protocol:  netv1a1.ProtocolHTTP1,
 		},
 		{
 			name:      "empty",
 			container: containerWithPortName(""),
-			protocol:  RevisionProtocolHTTP1,
+			protocol:  netv1a1.ProtocolHTTP1,
 		},
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -112,17 +112,6 @@ const (
 	RevisionContainerConcurrencyMax RevisionContainerConcurrencyType = 1000
 )
 
-// RevisionProtocolType is an enumeration of the supported application-layer protocols
-// See also: https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports
-type RevisionProtocolType string
-
-const (
-	// HTTP/1.1
-	RevisionProtocolHTTP1 RevisionProtocolType = "http1"
-	// HTTP/2 with Prior Knowledge
-	RevisionProtocolH2C RevisionProtocolType = "h2c"
-)
-
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
 	// DeprecatedGeneration was used prior in Kubernetes versions <1.11

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -353,16 +353,6 @@ func validateBuildRef(buildRef *corev1.ObjectReference) *apis.FieldError {
 	return nil
 }
 
-// Validate validates that RevisionProtocolType has a correct enum value.
-func (p RevisionProtocolType) Validate() *apis.FieldError {
-	switch p {
-	case RevisionProtocolH2C, RevisionProtocolHTTP1:
-		return nil
-	}
-	return apis.ErrInvalidValue(string(p), apis.CurrentField)
-
-}
-
 func validateProbe(p *corev1.Probe) *apis.FieldError {
 	if p == nil {
 		return nil

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1102,16 +1102,16 @@ func TestImmutableFields(t *testing.T) {
 
 func TestRevisionProtocolType(t *testing.T) {
 	tests := []struct {
-		p    netv1a1.ProtocolType
+		p    net.ProtocolType
 		want *apis.FieldError
 	}{{
-		netv1a1.ProtocolH2C, nil,
+		net.ProtocolH2C, nil,
 	}, {
-		netv1a1.ProtocolHTTP1, nil,
+		net.ProtocolHTTP1, nil,
 	}, {
-		netv1a1.ProtocolType(""), apis.ErrInvalidValue("", apis.CurrentField),
+		net.ProtocolType(""), apis.ErrInvalidValue("", apis.CurrentField),
 	}, {
-		netv1a1.ProtocolType("token-ring"), apis.ErrInvalidValue("token-ring", apis.CurrentField),
+		net.ProtocolType("token-ring"), apis.ErrInvalidValue("token-ring", apis.CurrentField),
 	}}
 	for _, test := range tests {
 		e := test.p.Validate()

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1101,16 +1102,16 @@ func TestImmutableFields(t *testing.T) {
 
 func TestRevisionProtocolType(t *testing.T) {
 	tests := []struct {
-		p    RevisionProtocolType
+		p    netv1a1.ProtocolType
 		want *apis.FieldError
 	}{{
-		RevisionProtocolH2C, nil,
+		netv1a1.ProtocolH2C, nil,
 	}, {
-		RevisionProtocolHTTP1, nil,
+		netv1a1.ProtocolHTTP1, nil,
 	}, {
-		RevisionProtocolType(""), apis.ErrInvalidValue("", apis.CurrentField),
+		netv1a1.ProtocolType(""), apis.ErrInvalidValue("", apis.CurrentField),
 	}, {
-		RevisionProtocolType("token-ring"), apis.ErrInvalidValue("token-ring", apis.CurrentField),
+		netv1a1.ProtocolType("token-ring"), apis.ErrInvalidValue("token-ring", apis.CurrentField),
 	}}
 	for _, test := range tests {
 		e := test.p.Validate()

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -19,7 +19,7 @@ package resources
 import (
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/autoscaling"
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
@@ -68,7 +68,7 @@ func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 
 // ServicePortName returns the port for the app level protocol.
 func ServicePortName(rev *v1alpha1.Revision) string {
-	if rev.GetProtocol() == netv1a1.ProtocolH2C {
+	if rev.GetProtocol() == net.ProtocolH2C {
 		return ServicePortNameH2C
 	}
 	return ServicePortNameHTTP1

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/autoscaling"
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
@@ -65,10 +66,10 @@ func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 	}
 }
 
+// ServicePortName returns the port for the app level protocol.
 func ServicePortName(rev *v1alpha1.Revision) string {
-	if rev.GetProtocol() == v1alpha1.RevisionProtocolH2C {
+	if rev.GetProtocol() == netv1a1.ProtocolH2C {
 		return ServicePortNameH2C
 	}
-
 	return ServicePortNameHTTP1
 }

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -19,6 +19,7 @@ package traffic
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
@@ -32,7 +33,7 @@ const DefaultTarget = ""
 type RevisionTarget struct {
 	v1alpha1.TrafficTarget
 	Active   bool
-	Protocol v1alpha1.RevisionProtocolType
+	Protocol netv1a1.ProtocolType
 }
 
 // RevisionTargets is a collection of revision targets.

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic.go
@@ -19,7 +19,7 @@ package traffic
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
@@ -33,7 +33,7 @@ const DefaultTarget = ""
 type RevisionTarget struct {
 	v1alpha1.TrafficTarget
 	Active   bool
-	Protocol netv1a1.ProtocolType
+	Protocol net.ProtocolType
 }
 
 // RevisionTargets is a collection of revision targets.

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
@@ -129,7 +129,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -139,7 +139,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
@@ -246,7 +246,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -256,7 +256,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
@@ -283,7 +283,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   false,
-				Protocol: netv1a1.ProtocolHTTP1,
+				Protocol: net.ProtocolHTTP1,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -293,7 +293,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   false,
-			Protocol: netv1a1.ProtocolHTTP1,
+			Protocol: net.ProtocolHTTP1,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{inactiveConfig.Name: inactiveConfig},
 		Revisions:      map[string]*v1alpha1.Revision{inactiveRev.Name: inactiveRev},
@@ -323,7 +323,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 					Percent:           90,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -331,7 +331,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 					Percent:           10,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -341,7 +341,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				Percent:           90,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -349,7 +349,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				Percent:           10,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig, niceConfig.Name: niceConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev, niceNewRev.Name: niceNewRev},
@@ -380,7 +380,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 					Percent:           90,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolHTTP1,
+				Protocol: net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -388,7 +388,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 					Percent:           10,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -398,7 +398,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				Percent:           90,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolHTTP1,
+			Protocol: net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -406,7 +406,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				Percent:           10,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodOldRev.Name: goodOldRev, goodNewRev.Name: goodNewRev},
@@ -444,7 +444,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           49,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolHTTP1,
+				Protocol: net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					Name:              "two",
@@ -453,7 +453,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           51,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 			"one": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -463,7 +463,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolHTTP1,
+				Protocol: net.ProtocolHTTP1,
 			}},
 			"two": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -473,7 +473,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 			"also-two": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -483,7 +483,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -494,7 +494,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Percent:           49,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolHTTP1,
+			Protocol: net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "two",
@@ -503,7 +503,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Percent:           50,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "also-two",
@@ -512,7 +512,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Percent:           1,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodOldRev.Name: goodOldRev, goodNewRev.Name: goodNewRev},
@@ -542,7 +542,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 					Percent:           90,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolHTTP1,
+				Protocol: net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -550,7 +550,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 					Percent:           10,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -560,7 +560,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				Percent:           90,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolHTTP1,
+			Protocol: net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -568,7 +568,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				Percent:           10,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev, goodOldRev.Name: goodOldRev},
@@ -598,7 +598,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 					Percent:           40,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: niceConfig.Name,
@@ -606,7 +606,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 					Percent:           60,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -616,7 +616,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				Percent:           40,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
@@ -624,7 +624,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				Percent:           60,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig, niceConfig.Name: niceConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev, niceNewRev.Name: niceNewRev},
@@ -657,7 +657,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolHTTP1,
+				Protocol: net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					Name:              "beta",
@@ -665,7 +665,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					RevisionName:      goodNewRev.Name,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					Name:              "alpha",
@@ -673,7 +673,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					RevisionName:      niceNewRev.Name,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 			"beta": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -683,7 +683,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 			"alpha": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -693,7 +693,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: netv1a1.ProtocolH2C,
+				Protocol: net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -703,7 +703,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolHTTP1,
+			Protocol: net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "beta",
@@ -711,7 +711,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				RevisionName:      goodNewRev.Name,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "alpha",
@@ -719,7 +719,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				RevisionName:      niceNewRev.Name,
 			},
 			Active:   true,
-			Protocol: netv1a1.ProtocolH2C,
+			Protocol: net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig, niceConfig.Name: niceConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodOldRev.Name: goodOldRev, goodNewRev.Name: goodNewRev, niceNewRev.Name: niceNewRev},

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	netv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
@@ -128,7 +129,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -138,7 +139,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
@@ -245,7 +246,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -255,7 +256,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
@@ -282,7 +283,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   false,
-				Protocol: v1alpha1.RevisionProtocolHTTP1,
+				Protocol: netv1a1.ProtocolHTTP1,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -292,7 +293,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   false,
-			Protocol: v1alpha1.RevisionProtocolHTTP1,
+			Protocol: netv1a1.ProtocolHTTP1,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{inactiveConfig.Name: inactiveConfig},
 		Revisions:      map[string]*v1alpha1.Revision{inactiveRev.Name: inactiveRev},
@@ -322,7 +323,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 					Percent:           90,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -330,7 +331,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 					Percent:           10,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -340,7 +341,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				Percent:           90,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -348,7 +349,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				Percent:           10,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig, niceConfig.Name: niceConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev, niceNewRev.Name: niceNewRev},
@@ -379,7 +380,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 					Percent:           90,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolHTTP1,
+				Protocol: netv1a1.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -387,7 +388,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 					Percent:           10,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -397,7 +398,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				Percent:           90,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolHTTP1,
+			Protocol: netv1a1.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -405,7 +406,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				Percent:           10,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodOldRev.Name: goodOldRev, goodNewRev.Name: goodNewRev},
@@ -443,7 +444,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           49,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolHTTP1,
+				Protocol: netv1a1.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					Name:              "two",
@@ -452,7 +453,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           51,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 			"one": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -462,7 +463,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolHTTP1,
+				Protocol: netv1a1.ProtocolHTTP1,
 			}},
 			"two": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -472,7 +473,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 			"also-two": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -482,7 +483,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -493,7 +494,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Percent:           49,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolHTTP1,
+			Protocol: netv1a1.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "two",
@@ -502,7 +503,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Percent:           50,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "also-two",
@@ -511,7 +512,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Percent:           1,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodOldRev.Name: goodOldRev, goodNewRev.Name: goodNewRev},
@@ -541,7 +542,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 					Percent:           90,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolHTTP1,
+				Protocol: netv1a1.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -549,7 +550,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 					Percent:           10,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -559,7 +560,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				Percent:           90,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolHTTP1,
+			Protocol: netv1a1.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -567,7 +568,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				Percent:           10,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev, goodOldRev.Name: goodOldRev},
@@ -597,7 +598,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 					Percent:           40,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					ConfigurationName: niceConfig.Name,
@@ -605,7 +606,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 					Percent:           60,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -615,7 +616,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				Percent:           40,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
@@ -623,7 +624,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				Percent:           60,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig, niceConfig.Name: niceConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev, niceNewRev.Name: niceNewRev},
@@ -656,7 +657,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolHTTP1,
+				Protocol: netv1a1.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					Name:              "beta",
@@ -664,7 +665,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					RevisionName:      goodNewRev.Name,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}, {
 				TrafficTarget: v1alpha1.TrafficTarget{
 					Name:              "alpha",
@@ -672,7 +673,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					RevisionName:      niceNewRev.Name,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 			"beta": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -682,7 +683,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 			"alpha": {{
 				TrafficTarget: v1alpha1.TrafficTarget{
@@ -692,7 +693,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Percent:           100,
 				},
 				Active:   true,
-				Protocol: v1alpha1.RevisionProtocolH2C,
+				Protocol: netv1a1.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -702,7 +703,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				Percent:           100,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolHTTP1,
+			Protocol: netv1a1.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "beta",
@@ -710,7 +711,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				RevisionName:      goodNewRev.Name,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}, {
 			TrafficTarget: v1alpha1.TrafficTarget{
 				Name:              "alpha",
@@ -718,7 +719,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				RevisionName:      niceNewRev.Name,
 			},
 			Active:   true,
-			Protocol: v1alpha1.RevisionProtocolH2C,
+			Protocol: netv1a1.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig, niceConfig.Name: niceConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodOldRev.Name: goodOldRev, goodNewRev.Name: goodNewRev, niceNewRev.Name: niceNewRev},


### PR DESCRIPTION
First, this is a networking protocol
Second, networking does not depend on other knative APIs (but others do
depend on it), so it's the natural place to be.
Third, this removed duplicate constant defintions.
Fourth, fix some public method comments.

Part of #1997 

/cc @mattmoor 

