### PR TITLE
Format markdown

### DIFF
--- a/docs/scaling/README.md
+++ b/docs/scaling/README.md
@@ -22,8 +22,8 @@ autoscaling.knative.dev/maxScale: "10"
 
 You can also use these annotations directly on `kpa` objects.
 
-**NOTE**: These annotations apply for the full lifetime of a `revision`.
-Even when a `revision` is not referenced by any `route`, the minimal pod count
+**NOTE**: These annotations apply for the full lifetime of a `revision`. Even
+when a `revision` is not referenced by any `route`, the minimal pod count
 specified by `autoscaling.knative.dev/minScale` will still be provided. Keep in
 mind that non-routeable `revisions` may be garbage collected, which enables
 Knative to reclaim the resources. **These annotations are specific to Autoscaler


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`