### PR TITLE
Show `configurationName` in route’s status alongside `revisionName`

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/route_lifecycle.go
@@ -74,6 +74,12 @@ func (rs *RouteStatus) MarkConfigurationFailed(name string) {
 		"Configuration %q does not have any ready Revision.", name)
 }
 
+func (rs *RouteStatus) MarkConfigurationRevisionMismatch(configName, revName string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
+		"Mismatch",
+		"Configuration %q does not own Revision %q.", configName, revName)
+}
+
 func (rs *RouteStatus) MarkRevisionNotReady(name string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned,
 		"RevisionMissing",

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -91,20 +91,23 @@ func (rs *RouteSpec) Validate(ctx context.Context) *apis.FieldError {
 // Validate verifies that TrafficTarget is properly configured.
 func (tt *TrafficTarget) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-	switch {
-	case tt.RevisionName != "" && tt.ConfigurationName != "":
-		errs = apis.ErrMultipleOneOf("revisionName", "configurationName")
-	case tt.RevisionName != "":
-		if verrs := validation.IsQualifiedName(tt.RevisionName); len(verrs) > 0 {
-			errs = apis.ErrInvalidKeyName(tt.RevisionName, "revisionName", verrs...)
-		}
-	case tt.ConfigurationName != "":
-		if verrs := validation.IsQualifiedName(tt.ConfigurationName); len(verrs) > 0 {
-			errs = apis.ErrInvalidKeyName(tt.ConfigurationName, "configurationName", verrs...)
-		}
-	default:
+
+	if tt.RevisionName == "" && tt.ConfigurationName == "" {
 		errs = apis.ErrMissingOneOf("revisionName", "configurationName")
 	}
+
+	if tt.ConfigurationName != "" {
+		if verrs := validation.IsQualifiedName(tt.ConfigurationName); len(verrs) > 0 {
+			errs = errs.Also(apis.ErrInvalidKeyName(tt.ConfigurationName, "configurationName", verrs...))
+		}
+	}
+
+	if tt.RevisionName != "" {
+		if verrs := validation.IsQualifiedName(tt.RevisionName); len(verrs) > 0 {
+			errs = errs.Also(apis.ErrInvalidKeyName(tt.RevisionName, "revisionName", verrs...))
+		}
+	}
+
 	if tt.Percent < 0 || tt.Percent > 100 {
 		errs = errs.Also(apis.ErrOutOfBoundsValue(strconv.Itoa(tt.Percent), "0", "100", "percent"))
 	}

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -333,15 +333,12 @@ func TestTrafficTargetValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "invalid with both",
+		name: "valid with both",
 		tt: &TrafficTarget{
 			RevisionName:      "foo",
 			ConfigurationName: "bar",
 		},
-		want: &apis.FieldError{
-			Message: "expected exactly one, got both",
-			Paths:   []string{"revisionName", "configurationName"},
-		},
+		want: nil,
 	}, {
 		name: "invalid with neither",
 		tt: &TrafficTarget{

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -129,6 +129,7 @@ func getTestRevisionForConfig(config *v1alpha1.Configuration) *v1alpha1.Revision
 			Labels: map[string]string{
 				serving.ConfigurationLabelKey: config.Name,
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: config.Name}},
 		},
 		Spec: *config.Spec.RevisionTemplate.Spec.DeepCopy(),
 		Status: v1alpha1.RevisionStatus{
@@ -274,7 +275,6 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	route := getTestRouteWithTrafficTargets(
 		[]v1alpha1.TrafficTarget{{
 			RevisionName:      "test-rev",
-			ConfigurationName: "test-config",
 			Percent:           100,
 		}},
 	)
@@ -440,7 +440,6 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			Percent:           90,
 		}, {
 			RevisionName:      rev.Name,
-			ConfigurationName: "test-config",
 			Percent:           10,
 		}},
 	)

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -141,6 +141,7 @@ func TestReconcile(t *testing.T) {
 				// Populated by reconciliation when all traffic has been assigned.
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
+					ConfigurationName: "config",
 					RevisionName: "config-00001",
 					Percent:      100,
 				})),
@@ -187,6 +188,7 @@ func TestReconcile(t *testing.T) {
 				// Populated by reconciliation when all traffic has been assigned.
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
+					ConfigurationName: "config",
 					RevisionName: "config-00001",
 					Percent:      100,
 				})),
@@ -237,6 +239,7 @@ func TestReconcile(t *testing.T) {
 				WithLocalDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
+					ConfigurationName: "config",
 					RevisionName: "config-00001",
 					Percent:      100,
 				})),
@@ -282,6 +285,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -329,6 +333,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -379,6 +384,7 @@ func TestReconcile(t *testing.T) {
 				// the cluster ingress.
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
+					ConfigurationName: "config",
 					RevisionName: "config-00001",
 					Percent:      100,
 				})),
@@ -398,6 +404,7 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -465,6 +472,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					}),
@@ -485,6 +493,7 @@ func TestReconcile(t *testing.T) {
 				WithAnotherDomain, WithDomainInternal, WithAddress,
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(v1alpha1.TrafficTarget{
+					ConfigurationName: "config",
 					RevisionName: "config-00001",
 					Percent:      100,
 				}), WithRouteLabel("app", "prod")),
@@ -520,6 +529,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -592,6 +602,7 @@ func TestReconcile(t *testing.T) {
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
 							TrafficTarget: v1alpha1.TrafficTarget{
+								ConfigurationName: "config",
 								// This is the new config we're making become ready.
 								RevisionName: "config-00002",
 								Percent:      100,
@@ -607,6 +618,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00002",
 						Percent:      100,
 					})),
@@ -675,6 +687,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00002",
 						Percent:      100,
 					})),
@@ -691,6 +704,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -734,6 +748,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -778,6 +793,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -817,6 +833,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -855,6 +872,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -962,6 +980,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "newconfig",
 						RevisionName: "newconfig-00001",
 						Percent:      100,
 					})),
@@ -1104,9 +1123,11 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "blue",
 						RevisionName: "blue-00001",
 						Percent:      50,
 					}, v1alpha1.TrafficTarget{
+						ConfigurationName: "green",
 						RevisionName: "green-00001",
 						Percent:      50,
 					})),
@@ -1191,6 +1212,7 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						Name:         "gray",
+						ConfigurationName: "gray",
 						RevisionName: "gray-00001",
 						Percent:      50,
 					}, v1alpha1.TrafficTarget{
@@ -1264,6 +1286,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "green",
 						RevisionName: "green-00001",
 						Percent:      100,
 					}), WithRouteFinalizer),
@@ -1341,6 +1364,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),
@@ -1380,6 +1404,7 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
+						ConfigurationName: "config",
 						RevisionName: "config-00001",
 						Percent:      100,
 					})),

--- a/pkg/reconciler/v1alpha1/route/traffic/errors.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/errors.go
@@ -108,6 +108,33 @@ func (e *unreadyRevisionError) IsFailure() bool {
 	return e.isFailure
 }
 
+type revisionOwnerMismatchError struct {
+	revisionName string // Name of the revision
+	configName   string // Name of the configuration
+}
+
+func (e *revisionOwnerMismatchError) Error() string {
+	return fmt.Sprintf("Configuration %q is not the owner of revision %q", e.revisionName, e.revisionName)
+}
+
+func (e *revisionOwnerMismatchError) MarkBadTrafficTarget(rs *v1alpha1.RouteStatus) {
+	rs.MarkConfigurationRevisionMismatch(e.configName, e.revisionName)
+}
+
+// IsFailure returns whether a TargetError is a true failure, e.g.
+// a Configuration fails to become ready.
+func (e *revisionOwnerMismatchError) IsFailure() bool {
+	return true
+}
+
+// errRevisionOwnerMismatch returns an error for a mismatched.
+func errRevisionOwnerMismatch(configName, revName string) TargetError {
+	return &revisionOwnerMismatchError{
+		configName:   configName,
+		revisionName: revName,
+	}
+}
+
 // errUnreadyConfiguration returns a TargetError for a Configuration that is not ready.
 func errUnreadyConfiguration(config *v1alpha1.Configuration) TargetError {
 	status := corev1.ConditionUnknown


### PR DESCRIPTION
/area API
/area networking

* User can now specify both `configurationName` and `revisionName` at the same time.
* When both `configurationName` and `revisionName` is specified in `route.spec.traffic[*]`, we validate the specified revision came from the specified configuration.
* `route.status.traffic` shows both `configurationName` and `revisionName` iff `route.spec.traffic[*]` specifies `configurationName`.


Fixes #3420 