### PR TITLE
Only default to MaxConcurrency if there are endpoints available.

### DIFF
--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -100,7 +100,7 @@ func (t *Throttler) updateCapacity(revision *v1alpha1.Revision, breaker *queue.B
 	cc := int32(revision.Spec.ContainerConcurrency)
 
 	targetCapacity := cc * size
-	if cc == 0 || targetCapacity > t.breakerParams.MaxConcurrency {
+	if size > 0 && (cc == 0 || targetCapacity > t.breakerParams.MaxConcurrency) {
 		// The concurrency is unlimited, thus hand out as many tokens as we can in this breaker.
 		targetCapacity = t.breakerParams.MaxConcurrency
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

@greghaynes found weird behavior using his pod tracing PR. When not specifying a containerConcurrency, we always defaulted the capacity to the maximum available capacity, even if there are no endpoints available yet.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
