### PR TITLE
fix output error for table test

### DIFF
--- a/pkg/reconciler/testing/table.go
+++ b/pkg/reconciler/testing/table.go
@@ -153,7 +153,7 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 				continue
 			}
 			t.Errorf("Missing update for %s (-want, +prevState): %s", key,
-				cmp.Diff(oldObj, wo, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
+				cmp.Diff(wo, oldObj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
 			continue
 		}
 
@@ -188,7 +188,7 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 				continue
 			}
 			t.Errorf("Missing status update for %s (-want, +prevState): %s", key,
-				cmp.Diff(oldObj, wo, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
+				cmp.Diff(wo, oldObj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
 			continue
 		}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes a small bug with the table tests.

Previously, when an update was missing from a table test, the diff would list the (-want, +prevState) backwards.

Given the test:
```
{
		Name: "diff order test",
		Objects: []runtime.Object{
			rev("foo", "diff-test",
				WithK8sServiceName, WithLogURL, AllUnknownConditions),
			kpa("foo", "diff-test"),
			deploy("foo", "diff-test"),
			svc("foo", "diff-test"),
			image("foo", "diff-test"),
		},
		WantUpdates: []clientgotesting.UpdateActionImpl{{
			Object: rev("foo", "diff-test", WithBadServiceName, WithLogURL, AllUnknownConditions),
		}},
		Key: "foo/diff-test",
}
```
along with:
```
func WithBadServiceName(r *v1alpha1.Revision) {
	r.Status.ServiceName = "wanted-service-name"
}
```

Output before the change:
```
--- FAIL: TestReconcile/diff_order_test (0.00s)
        table.go:155: Missing update for *v1alpha1.Revision/foo/diff-test (-want, +prevState): {*v1alpha1.Revision}.Status.ServiceName:
                -: "diff-test-service"
                +: "wanted-service-name"
```

Output after the change:
```
--- FAIL: TestReconcile/diff_order_test (0.00s)
        table.go:155: Missing update for *v1alpha1.Revision/foo/diff-test (-want, +prevState): {*v1alpha1.Revision}.Status.ServiceName:
                -: "wanted-service-name"
                +: "diff-test-service"
```

## Proposed Changes

* Reverse order of inputs to have `-want` and `+prevState` align with outputs
