### PR TITLE
Update receiver name to be consistent with previous receiver name

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -372,13 +372,13 @@ func validateProbe(p *corev1.Probe) *apis.FieldError {
 }
 
 // CheckImmutableFields checks the immutable fields are not modified.
-func (current *Revision) CheckImmutableFields(ctx context.Context, og apis.Immutable) *apis.FieldError {
+func (rt *Revision) CheckImmutableFields(ctx context.Context, og apis.Immutable) *apis.FieldError {
 	original, ok := og.(*Revision)
 	if !ok {
 		return &apis.FieldError{Message: "The provided original was not a Revision"}
 	}
 
-	if diff, err := kmp.SafeDiff(original.Spec, current.Spec); err != nil {
+	if diff, err := kmp.SafeDiff(original.Spec, rt.Spec); err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff Revision",
 			Paths:   []string{"spec"},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes  lint error of inconsistent receiver name


## Proposed Changes

* internal refactor, no breaking change

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
