### PR TITLE
Further leverage aggregated ClusterRole to split off Istio RBAC.

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -51,6 +51,16 @@ rules:
   - apiGroups: ["networking.internal.knative.dev"]
     resources: ["clusteringresses", "clusteringresses/status", "serverlessservices", "serverlessservices/status"]
     verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # These are the permissions needed by the Istio ClusterIngress implementation.
+  name: knative-serving-istio
+  labels:
+    serving.knative.dev/release: devel
+    serving.knative.dev/controller: "true"
+rules:
   - apiGroups: ["networking.istio.io"]
     resources: ["virtualservices", "gateways"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]


### PR DESCRIPTION
This further separates our RBAC permissions so that the bit granting access to Istio resouces is separate.

