### PR TITLE
Create variants of TestObservedConcurrency test

### DIFF
--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -128,7 +128,7 @@ func TestObservedConcurrency(t *testing.T) {
 			tc = append(tc, testConcurrencyN(t, clients)...)
 		})
 	}
-	if err = testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
+	if err := testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)
 	}
 }

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -121,15 +121,19 @@ func timeToScale(events []*event, start time.Time, desiredScale int) (time.Durat
 }
 
 func TestObservedConcurrency(t *testing.T) {
+	tc := make([]junit.TestCase, 0)
 	tests := []int{5, 10} //going beyond 10 currently causes "overload" responses
 	for _, clients := range tests {
 		t.Run(fmt.Sprintf("scale-%02d", clients), func(t *testing.T) {
-			testConcurrencyN(t, clients)
+			tc = append(tc, testConcurrencyN(t, clients)...)
 		})
+	}
+	if err = testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
+		t.Fatalf("Cannot create output xml: %v", err)
 	}
 }
 
-func testConcurrencyN(t *testing.T, concurrency int) {
+func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 	perfClients, err := Setup(t)
 	if err != nil {
 		t.Fatalf("Cannot initialize performance client: %v", err)
@@ -235,7 +239,5 @@ func testConcurrencyN(t *testing.T, concurrency int) {
 	}
 	tc = append(tc, CreatePerfTestCase(float32(failedRequests), "failed requests", t.Name()))
 
-	if err = testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
-		t.Fatalf("Cannot create output xml: %v", err)
-	}
+	return tc
 }

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/spoof"
@@ -36,8 +38,6 @@ import (
 	"github.com/knative/test-infra/shared/testgrid"
 	"golang.org/x/sync/errgroup"
 )
-
-const concurrency = 5
 
 // generateTraffic loads the given endpoint with the given concurrency for the given duration.
 // All responses are forwarded to a channel, if given.
@@ -121,6 +121,15 @@ func timeToScale(events []*event, start time.Time, desiredScale int) (time.Durat
 }
 
 func TestObservedConcurrency(t *testing.T) {
+	tests := []int{5, 10} //going beyond 10 currently causes "overload" responses
+	for _, clients := range tests {
+		t.Run(fmt.Sprintf("scale-%02d", clients), func(t *testing.T) {
+			testConcurrencyN(t, clients)
+		})
+	}
+}
+
+func testConcurrencyN(t *testing.T, concurrency int) {
 	perfClients, err := Setup(t)
 	if err != nil {
 		t.Fatalf("Cannot initialize performance client: %v", err)
@@ -136,7 +145,19 @@ func TestObservedConcurrency(t *testing.T) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{ContainerConcurrency: 1})
+	objs, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{
+		ContainerConcurrency: 1,
+		ContainerResources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		},
+	})
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -148,10 +148,6 @@ func testConcurrencyN(t *testing.T, concurrency int) {
 	objs, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{
 		ContainerConcurrency: 1,
 		ContainerResources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-			},
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("20Mi"),

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -121,7 +121,7 @@ func timeToScale(events []*event, start time.Time, desiredScale int) (time.Durat
 }
 
 func TestObservedConcurrency(t *testing.T) {
-	tc := make([]junit.TestCase, 0)
+	var tc []junit.TestCase
 	tests := []int{5, 10} //going beyond 10 currently causes "overload" responses
 	for _, clients := range tests {
 		t.Run(fmt.Sprintf("scale-%02d", clients), func(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/3518

## Proposed Changes

* Make it possible to run TestObservedConcurrency with different concurrency numbers

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
