### PR TITLE
Update deployments to be on apps/v1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   revision = "3fc06fd3c9880a9ebb5c401f4b20cf6666cc7bc0"
 
 [[projects]]
-  digest = "1:6243ebb8894d4bcd54dc2dfdb2fbeeb3e49c7742ec9dfe9a8118ab642e98aac7"
+  digest = "1:b63240baa17619ca01a86c507c63416b679d934d1c63d0ecea2fd34d6ead1c7f"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -487,7 +487,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "0f749ef7d5e65aba4e8a76aa34b4744685981a91"
+  revision = "671c872a772b25ca519c211b9ca0a0ad274b0918"
 
 [[projects]]
   branch = "master"
@@ -1367,7 +1367,6 @@
     "k8s.io/api/authentication/v1",
     "k8s.io/api/autoscaling/v1",
     "k8s.io/api/core/v1",
-    "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,8 +24,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-03-26
-  revision = "0f749ef7d5e65aba4e8a76aa34b4744685981a91"
+  # HEAD as of 2019-03-27
+  revision = "671c872a772b25ca519c211b9ca0a0ad274b0918"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -28,7 +28,7 @@ import (
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/pkg/errors"
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -205,6 +205,6 @@ func GetConfigMap(client *pkgTest.KubeClient) k8styped.ConfigMapInterface {
 }
 
 // DeploymentScaledToZeroFunc returns a func that evaluates if a deployment has scaled to 0 pods.
-func DeploymentScaledToZeroFunc(d *apiv1beta1.Deployment) (bool, error) {
+func DeploymentScaledToZeroFunc(d *appsv1.Deployment) (bool, error) {
 	return d.Status.ReadyReplicas == 0, nil
 }

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/knative/serving/test"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,8 +41,8 @@ const (
 	autoscaleExpectedOutput = "399989"
 )
 
-func isDeploymentScaledUp() func(d *v1beta1.Deployment) (bool, error) {
-	return func(d *v1beta1.Deployment) (bool, error) {
+func isDeploymentScaledUp() func(d *appsv1.Deployment) (bool, error) {
+	return func(d *appsv1.Deployment) (bool, error) {
 		return d.Status.ReadyReplicas > 1, nil
 	}
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
@@ -60,7 +60,7 @@ func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clien
 	return pkgTest.WaitForDeploymentState(
 		clients.KubeClient,
 		deploymentName,
-		func(d *v1beta1.Deployment) (bool, error) {
+		func(d *appsv1.Deployment) (bool, error) {
 			t.Logf("Deployment %q has %d replicas", deploymentName, d.Status.ReadyReplicas)
 			return d.Status.ReadyReplicas == 0, nil
 		},

--- a/vendor/github.com/knative/pkg/apis/field_error.go
+++ b/vendor/github.com/knative/pkg/apis/field_error.go
@@ -91,7 +91,7 @@ func (fe *FieldError) ViaFieldIndex(field string, index int) *FieldError {
 
 // ViaKey is used to attach a key to the next ViaField provided.
 // For example, if a type recursively validates a parameter that has a collection:
-//  for k, v := range spec.Bag. {
+//  for k, v := range spec.Bag {
 //    if err := doValidation(v); err != nil {
 //      return err.ViaKey(k).ViaField("bag")
 //    }

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/knative/pkg/test/logging"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -43,8 +43,8 @@ const (
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForDeploymentState(client *KubeClient, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string, namespace string, timeout time.Duration) error {
-	d := client.Kube.ExtensionsV1beta1().Deployments(namespace)
+func WaitForDeploymentState(client *KubeClient, name string, inState func(d *appsv1.Deployment) (bool, error), desc string, namespace string, timeout time.Duration) error {
+	d := client.Kube.AppsV1().Deployments(namespace)
 	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc))
 	defer span.End()
 
@@ -81,8 +81,8 @@ func GetConfigMap(client *KubeClient, namespace string) k8styped.ConfigMapInterf
 }
 
 // DeploymentScaledToZeroFunc returns a func that evaluates if a deployment has scaled to 0 pods
-func DeploymentScaledToZeroFunc() func(d *apiv1beta1.Deployment) (bool, error) {
-	return func(d *apiv1beta1.Deployment) (bool, error) {
+func DeploymentScaledToZeroFunc() func(d *appsv1.Deployment) (bool, error) {
+	return func(d *appsv1.Deployment) (bool, error) {
 		return d.Status.ReadyReplicas == 0, nil
 	}
 }

--- a/vendor/github.com/knative/pkg/test/spoof/error_checks.go
+++ b/vendor/github.com/knative/pkg/test/spoof/error_checks.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// spoof contains logic to make polling HTTP requests against an endpoint with optional host spoofing.
+
+package spoof
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+func isTCPTimeout(e error) bool {
+	err, ok := e.(net.Error)
+	return err != nil && ok && err.Timeout()
+}
+
+func isDNSError(err error) bool {
+	if err, ok := err.(*url.Error); err != nil && ok {
+		if err, ok := err.Err.(*net.OpError); err != nil && ok {
+			if err, ok := err.Err.(*net.DNSError); err != nil && ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isTCPConnectRefuse(err error) bool {
+	// The alternative for the string check is:
+	// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)
+	// if errNo == syscall.Errno(0x6f) {...}
+	// But with assertions, of course.
+	if err != nil && strings.Contains(err.Error(), "connect: connection refused") {
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/knative/pkg/webhook/webhook.go
+++ b/vendor/github.com/knative/pkg/webhook/webhook.go
@@ -42,9 +42,9 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,7 +60,7 @@ const (
 )
 
 var (
-	deploymentKind      = v1beta1.SchemeGroupVersion.WithKind("Deployment")
+	deploymentKind      = appsv1.SchemeGroupVersion.WithKind("Deployment")
 	errMissingNewObject = errors.New("the new object may not be nil")
 )
 
@@ -398,7 +398,7 @@ func (ac *AdmissionController) register(
 	}
 
 	// Set the owner to our deployment.
-	deployment, err := ac.Client.ExtensionsV1beta1().Deployments(ac.Options.Namespace).Get(ac.Options.DeploymentName, metav1.GetOptions{})
+	deployment, err := ac.Client.Apps().Deployments(ac.Options.Namespace).Get(ac.Options.DeploymentName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to fetch our deployment: %v", err)
 	}


### PR DESCRIPTION
Move Deployments from extensions/v1beta to apps/v1.
It was this way in tests only.

Fixes # 3556
We don't have other types but Ingress but Ingress is still beta in 1.14 and we're on 1.12.
Thus I chose to ignore it for now.

/cc @dgerd @mattmoor 