### PR TITLE
Return 'BadRequest' if a probe request doesn't match.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -161,7 +161,7 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, httpProxy, h2c
 		switch {
 		case ph != "":
 			if ph != queue.Name {
-				http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusServiceUnavailable)
+				http.Error(w, fmt.Sprintf("unexpected probe header value: %q", ph), http.StatusBadRequest)
 				return
 			}
 			if probeUserContainer() {

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -123,7 +123,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				defer probeResp.Body.Close()
 				httpStatus = probeResp.StatusCode
-				if httpStatus == http.StatusServiceUnavailable {
+				if httpStatus != http.StatusOK {
 					logger.Warnf("Pod probe sent status: %d", httpStatus)
 					return false, nil
 				}

--- a/pkg/activator/handler/probe_handler.go
+++ b/pkg/activator/handler/probe_handler.go
@@ -31,7 +31,7 @@ func (h *ProbeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// probing the network, respond with a 200 and our component name.
 	if val := r.Header.Get(network.ProbeHeaderName); val != "" {
 		if val != activator.Name {
-			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", val), http.StatusServiceUnavailable)
+			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", val), http.StatusBadRequest)
 			return
 		}
 		w.Write([]byte(activator.Name))

--- a/pkg/activator/handler/probe_handler_test.go
+++ b/pkg/activator/handler/probe_handler_test.go
@@ -39,7 +39,7 @@ func TestProbeHandler(t *testing.T) {
 		label:          "filter a POST request containing probe header, even if probe is for a different target",
 		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: queue.Name}),
 		passed:         false,
-		expectedStatus: http.StatusServiceUnavailable,
+		expectedStatus: http.StatusBadRequest,
 		method:         http.MethodPost,
 	}, {
 		label:          "filter a POST request containing probe header",
@@ -57,7 +57,7 @@ func TestProbeHandler(t *testing.T) {
 		label:          "filter a GET request containing probe header, with wrong target system",
 		headers:        mapToHeader(map[string]string{network.ProbeHeaderName: "not-empty"}),
 		passed:         false,
-		expectedStatus: http.StatusServiceUnavailable,
+		expectedStatus: http.StatusBadRequest,
 		method:         http.MethodGet,
 	}, {
 		label:          "filter a GET request containing probe header",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Another little something @greghaynes noted in his tracing: The probe takes a long time to return if it reaches the activator first. It looks a lot like istio's retries are at play here (they can retry on 503).

## Proposed Changes

Arguably, returning 'ServiceUnavailable' if a probe response does not match the expected target isn't semantically the right error response. Rather, the request sent in doesn't match the expectation of the probe handler, thus 'BadRequest' makes more sense here.

This has the side effect of not triggering any istio-internal retries for these requests, making the retry-interval-policy entirely up to the prober.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
