### PR TITLE
Fix malformed Prometheus performance example

### DIFF
--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -42,7 +42,7 @@ promAPI, err := prometheus.PromAPI()
 if err != nil {
   logger.Error("Cannot setup prometheus API")
 }
-query := fmt.Sprintf("%s{namespace_name=%q, configuration_name=%q, revision_name=%q},metric, test.ServingNamespace, names.Config, names.Revision)
+query := fmt.Sprintf("%s{namespace_name=%q, configuration_name=%q, revision_name=%q}", metric, test.ServingNamespace, names.Config, names.Revision)
 val, err := prometheus.RunQuery(context.Background(), logger, promAPI, query)
 if err != nil {
   logger.Infof("Error querying metric %s: %v", metric, err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Prometheus metrics example for performance testing is missing a quote in a `Sprintf()` call.