### PR TITLE
Update TestTimeToServing metrics unit to be ms

### DIFF
--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -77,7 +77,7 @@ func TestTimeToServeLatency(t *testing.T) {
 	var tc []junit.TestCase
 	for _, p := range resp.Result.DurationHistogram.Percentiles {
 		val := float32(p.Value) * 1000
-		name := fmt.Sprintf("p%d(sec)", int(p.Percentile))
+		name := fmt.Sprintf("p%d(ms)", int(p.Percentile))
 		tc = append(tc, CreatePerfTestCase(val, name, t.Name()))
 	}
 


### PR DESCRIPTION
The unit should be ms and not sec. Update to reflect the correct unit