### PR TITLE
Drop the 'ActivatorPodName' constant.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -257,6 +257,6 @@ func newTestStats(clock system.Clock) (*testStats, *ConcurrencyReporter) {
 		statChan:     make(chan *autoscaler.StatMessage, 20),
 		reportBiChan: reportBiChan,
 	}
-	cr := NewConcurrencyReporterWithClock(autoscaler.ActivatorPodName, t.reqChan, t.reportChan, t.statChan, clock)
+	cr := NewConcurrencyReporterWithClock("activator", t.reqChan, t.reportChan, t.statChan, clock)
 	return t, cr
 }

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -31,10 +31,6 @@ import (
 )
 
 const (
-	// ActivatorPodName defines the pod name of the activator
-	// as defined in the metrics it sends.
-	ActivatorPodName string = "activator"
-
 	// bucketSize is the size of the buckets of stats we create.
 	bucketSize time.Duration = 2 * time.Second
 )

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	stableWindow = 60 * time.Second
-	panicWindow  = 6 * time.Second
+	stableWindow     = 60 * time.Second
+	panicWindow      = 6 * time.Second
+	activatorPodName = "activator"
 )
 
 var (
@@ -314,7 +315,7 @@ func TestAutoscaler_Activator_CausesInstantScale(t *testing.T) {
 	now := roundedNow()
 	now = a.recordMetric(t, Stat{
 		Time:                      &now,
-		PodName:                   ActivatorPodName,
+		PodName:                   activatorPodName,
 		RequestCount:              0,
 		AverageConcurrentRequests: 100.0,
 	})
@@ -328,13 +329,13 @@ func TestAutoscaler_Activator_MultipleInstancesAreAggregated(t *testing.T) {
 	now := roundedNow()
 	now = a.recordMetric(t, Stat{
 		Time:                      &now,
-		PodName:                   ActivatorPodName + "-0",
+		PodName:                   activatorPodName + "-0",
 		RequestCount:              0,
 		AverageConcurrentRequests: 50.0,
 	})
 	now = a.recordMetric(t, Stat{
 		Time:                      &now,
-		PodName:                   ActivatorPodName + "-1",
+		PodName:                   activatorPodName + "-1",
 		RequestCount:              0,
 		AverageConcurrentRequests: 50.0,
 	})


### PR DESCRIPTION
This is used nowhere besides tests and thus should be removed to avoid confusion.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

A quick flyby fix while working on the pluggable autoscaler.

This is used nowhere besides tests and thus should be removed to avoid confusion.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
