### PR TITLE
Separate / Simplify image cache creation.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/cruds.go
+++ b/pkg/reconciler/v1alpha1/revision/cruds.go
@@ -101,11 +101,8 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 	return d, nil
 }
 
-func (c *Reconciler) createImageCache(ctx context.Context, rev *v1alpha1.Revision, deploy *appsv1.Deployment) (*caching.Image, error) {
-	image, err := resources.MakeImageCache(rev, deploy)
-	if err != nil {
-		return nil, err
-	}
+func (c *Reconciler) createImageCache(ctx context.Context, rev *v1alpha1.Revision) (*caching.Image, error) {
+	image := resources.MakeImageCache(rev)
 
 	return c.CachingClientSet.CachingV1alpha1().Images(image.Namespace).Create(image)
 }

--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -100,12 +100,17 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 			"Revision %s not ready due to Deployment timeout", rev.Name)
 	}
 
-	// We do this here so that we can construct the Image resource based on the
-	// resulting Deployment resource (e.g. including resolved digest).
+	return nil
+}
+
+func (c *Reconciler) reconcileImageCache(ctx context.Context, rev *v1alpha1.Revision) error {
+	logger := logging.FromContext(ctx)
+
+	ns := rev.Namespace
 	imageName := resourcenames.ImageCache(rev)
 	_, getImageCacheErr := c.imageLister.Images(ns).Get(imageName)
 	if apierrs.IsNotFound(getImageCacheErr) {
-		_, err := c.createImageCache(ctx, rev, deployment)
+		_, err := c.createImageCache(ctx, rev)
 		if err != nil {
 			logger.Errorf("Error creating image cache %q: %v", imageName, err)
 			return err

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -360,6 +360,9 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 			name: "user deployment",
 			f:    c.reconcileDeployment,
 		}, {
+			name: "image cache",
+			f:    c.reconcileImageCache,
+		}, {
 			name: "user k8s service",
 			f:    c.reconcileService,
 		}, {

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -966,17 +966,7 @@ func image(namespace, name string, co ...configOption) *caching.Image {
 		opt(config)
 	}
 
-	rev := rev(namespace, name)
-	// Do this here instead of in `rev` itself to ensure that we populate defaults
-	// before calling MakeDeployment within Reconcile.
-	rev.SetDefaults(context.Background())
-	deploy := resources.MakeDeployment(rev, config.Logging, config.Network, config.Observability,
-		config.Autoscaler, config.Controller)
-	img, err := resources.MakeImageCache(rev, deploy)
-	if err != nil {
-		panic(err.Error())
-	}
-	return img
+	return resources.MakeImageCache(rev(namespace, name))
 }
 
 func fluentdConfigMap(namespace, name string, co ...configOption) *corev1.ConfigMap {


### PR DESCRIPTION
With a separate `.status.imageDigest` this no longer needs the coupling with Deployment.

