### PR TITLE
Add a label knative.dev/crd-install to CRDs to allow installing CRDs in a separate pass.

### DIFF
--- a/config/300-certificate.yaml
+++ b/config/300-certificate.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
   version: v1alpha1

--- a/config/300-clusteringress.yaml
+++ b/config/300-clusteringress.yaml
@@ -18,6 +18,7 @@ metadata:
   name: clusteringresses.networking.internal.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
   version: v1alpha1

--- a/config/300-configuration.yaml
+++ b/config/300-configuration.yaml
@@ -18,6 +18,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-kpa.yaml
+++ b/config/300-kpa.yaml
@@ -18,6 +18,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
   version: v1alpha1

--- a/config/300-revision.yaml
+++ b/config/300-revision.yaml
@@ -18,6 +18,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-route.yaml
+++ b/config/300-route.yaml
@@ -18,6 +18,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-service.yaml
+++ b/config/300-service.yaml
@@ -18,6 +18,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
   version: v1alpha1

--- a/config/300-sks.yaml
+++ b/config/300-sks.yaml
@@ -18,6 +18,7 @@ metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
   version: v1alpha1


### PR DESCRIPTION
## Proposed Changes

- Label CRDs so that they can be installed first with `kubectl -l knative.dev/crd-install=true YAML_FILE`

**Release Note**

```release-note
- CRDs are now labelled with knative.dev/crd-install=true to allow installing without race conditions or kubectl errors.
```
