### PR TITLE
Add test flags to choose Istio version and mesh option

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -44,8 +44,6 @@ function install_latest_release() {
   local url="https://github.com/knative/serving/releases/download/v${LATEST_SERVING_RELEASE_VERSION}"
   # TODO: should this test install istio and build at all, or only serving?
   install_knative_serving \
-    "${ISTIO_CRD_YAML}" \
-    "${ISTIO_YAML}" \
     "${url}/serving.yaml" \
     || fail_test "Knative latest release installation failed"
 }

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -22,7 +22,7 @@ source $(dirname $0)/e2e-common.sh
 # Build Knative, but don't install the default "no monitoring" version
 function knative_setup() {
   build_knative_from_source
-  install_knative_serving "${ISTIO_CRD_YAML}" "${ISTIO_YAML}" "${SERVING_YAML}" "${MONITORING_YAML}"
+  install_knative_serving "${SERVING_YAML}" "${MONITORING_YAML}"
 }
 
 initialize $@


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

*  Extract out easy way to choose an Istio configuration for e2e

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
