### PR TITLE
Test container exiting message for tcp readiness probe

### DIFF
--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -49,6 +49,8 @@ const (
 	printport           = "printport"
 	runtime             = "runtime"
 	protocols           = "protocols"
+	failing             = "failing"
+	invalidhelloworld   = "invalidhelloworld"
 
 	concurrentRequests = 50
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Adding tcp method coverage for readiness probe. 

Part of #3486 
