### PR TITLE
Add new field test to revision validation

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -1060,6 +1060,31 @@ func TestImmutableFields(t *testing.T) {
 `,
 		},
 	}, {
+		name: "bad (new field added)",
+		new: &Revision{
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Image: "helloworld",
+				},
+				DeprecatedConcurrencyModel: "Multi",
+			},
+		},
+		old: &Revision{
+			Spec: RevisionSpec{
+				Container: corev1.Container{
+					Image: "helloworld",
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1alpha1.RevisionSpec}.DeprecatedConcurrencyModel:
+	-: v1alpha1.RevisionRequestConcurrencyModelType("")
+	+: v1alpha1.RevisionRequestConcurrencyModelType("Multi")
+`,
+		},
+	}, {
 		name: "bad (multiple changes)",
 		new: &Revision{
 			Spec: RevisionSpec{


### PR DESCRIPTION
This test validates output of incorrectly adding a new field to the revision.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Addresses #3554

## Proposed Changes

* New test

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
