### PR TITLE
Temporarily turning off xip.io resolvable domain.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -182,11 +182,7 @@ function install_knative_serving_standard() {
 # Check if we should use --resolvabledomain.  In case the ingress only has
 # hostname, we doesn't yet have a way to support resolvable domain in tests.
 function use_resolvable_domain() {
-  local ip=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-  if [[ -n "${ip}" ]]; then
-    echo "true"
-    return
-  fi
+  # Temporarily turning off xip.io tests, as DNS errors aren't always retried.
   echo "false"
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* Temporarily turning off xip.io resolvable domain to reduce flakes.  Will turn on again after patching the retry logic.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
