### PR TITLE
Couple cleanups related to our imperative use of conditions.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
@@ -346,14 +346,6 @@ func TestTypicalFlowWithBuild(t *testing.T) {
 	if !r.Status.IsReady() {
 		t.Error("IsReady() = false, want true")
 	}
-
-	// Verify that this doesn't reset our conditions.
-	r.Status.InitializeConditions()
-	checkConditionSucceededRevision(r.Status, RevisionConditionBuildSucceeded, t)
-	checkConditionSucceededRevision(r.Status, RevisionConditionActive, t)
-	checkConditionSucceededRevision(r.Status, RevisionConditionResourcesAvailable, t)
-	checkConditionSucceededRevision(r.Status, RevisionConditionContainerHealthy, t)
-	checkConditionSucceededRevision(r.Status, RevisionConditionReady, t)
 }
 
 func TestTypicalFlowWithBuildFailure(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/route_lifecycle_test.go
@@ -176,12 +176,6 @@ func TestTypicalRouteFlow(t *testing.T) {
 	checkConditionSucceededRoute(r.Status, RouteConditionAllTrafficAssigned, t)
 	checkConditionSucceededRoute(r.Status, RouteConditionIngressReady, t)
 	checkConditionSucceededRoute(r.Status, RouteConditionReady, t)
-
-	// Verify that this doesn't reset our conditions.
-	r.Status.InitializeConditions()
-	checkConditionSucceededRoute(r.Status, RouteConditionAllTrafficAssigned, t)
-	checkConditionSucceededRoute(r.Status, RouteConditionIngressReady, t)
-	checkConditionSucceededRoute(r.Status, RouteConditionReady, t)
 }
 
 func TestTrafficNotAssignedFlow(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -330,6 +330,7 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 	if rev.GetDeletionTimestamp() != nil {
 		return nil
 	}
+	readyBeforeReconcile := rev.Status.IsReady()
 
 	// We may be reading a version of the object that was stored at an older version
 	// and may not have had all of the assumed defaults specified.  This won't result
@@ -339,8 +340,6 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 
 	rev.Status.InitializeConditions()
 	c.updateRevisionLoggingURL(ctx, rev)
-
-	readyBeforeReconcile := rev.Status.IsReady()
 
 	if err := c.reconcileBuild(ctx, rev); err != nil {
 		return err


### PR DESCRIPTION
1. In the Revision controller, we send an event when we become ready, but
  the input state was setup after InitializeConditions was called.  So move it.
1. Remove our tests that InitializeConditions doesn't reset things.

Related to: https://github.com/knative/pkg/issues/357