### PR TITLE
Fix typo about the default value of `ServerCertificate` of `ClusterIngress`

### DIFF
--- a/pkg/apis/networking/v1alpha1/clusteringress_types.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_types.go
@@ -142,7 +142,7 @@ type ClusterIngressTLS struct {
 	SecretNamespace string `json:"secretNamespace,omitempty"`
 
 	// ServerCertificate identifies the certificate filename in the secret.
-	// Defaults to `tls.cert`.
+	// Defaults to `tls.crt`.
 	// +optional
 	ServerCertificate string `json:"serverCertificate,omitempty"`
 


### PR DESCRIPTION


## Proposed Changes

* Fix typo about the default value of `ServerCertificate` of `ClusterIngress`


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->


