### PR TITLE
Set autoscaler stat timestamp upon receive

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -37,7 +37,7 @@ const (
 
 // Stat defines a single measurement at a point in time
 type Stat struct {
-	// The time the data point was collected on the pod.
+	// The time the data point was received by autoscaler.
 	Time *time.Time
 
 	// The unique identity of this pod.  Used to count how many pods

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -154,6 +154,8 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error(err)
 			continue
 		}
+		now := time.Now()
+		sm.Stat.Time = &now
 
 		s.logger.Debugf("Received stat message: %+v", sm)
 		// TODO(yanweiguo): Remove this after version 0.5.

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -139,11 +139,9 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 }
 
 func newStatMessage(revKey string, podName string, averageConcurrentRequests float64, requestCount int32) *autoscaler.StatMessage {
-	now := time.Now()
 	return &autoscaler.StatMessage{
 		Key: revKey,
 		Stat: autoscaler.Stat{
-			Time:                      &now,
 			PodName:                   podName,
 			AverageConcurrentRequests: averageConcurrentRequests,
 			RequestCount:              requestCount,
@@ -157,6 +155,10 @@ func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, stat
 	if !ok {
 		t.Fatalf("statistic not received")
 	}
+	if recv.Stat.Time == nil {
+		t.Fatalf("Stat time is nil")
+	}
+	sm.Stat.Time = recv.Stat.Time
 	if !cmp.Equal(sm, recv) {
 		t.Fatalf("Expected and actual stats messages are not equal: %s", cmp.Diff(sm, recv))
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3601 

## Proposed Changes

* Set autoscaler stat timestamp upon receive
* remove set stat timestamp at send


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
