### PR TITLE
Set autoscaler stat timestamp upon receive

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -64,14 +64,12 @@ func TestStats(t *testing.T) {
 		expectedStats: []*autoscaler.StatMessage{{
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod2",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
@@ -90,14 +88,12 @@ func TestStats(t *testing.T) {
 		expectedStats: []*autoscaler.StatMessage{{
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 2,
 				RequestCount:              2,
 				PodName:                   "activator",
@@ -119,14 +115,12 @@ func TestStats(t *testing.T) {
 		expectedStats: []*autoscaler.StatMessage{{
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
@@ -153,49 +147,42 @@ func TestStats(t *testing.T) {
 		expectedStats: []*autoscaler.StatMessage{{
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod2",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod1",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod2",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod3",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod2",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              0,
 				PodName:                   "activator",
 			}}, {
 			Key: "pod3",
 			Stat: autoscaler.Stat{
-				Time:                      &time.Time{},
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   "activator",

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -37,7 +37,7 @@ const (
 
 // Stat defines a single measurement at a point in time
 type Stat struct {
-	// The time the data point was collected on the pod.
+	// The time the data point was received by autoscaler.
 	Time *time.Time
 
 	// The unique identity of this pod.  Used to count how many pods

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -154,6 +154,8 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error(err)
 			continue
 		}
+		now := time.Now()
+		sm.Stat.Time = &now
 
 		s.logger.Debugf("Received stat message: %+v", sm)
 		// TODO(yanweiguo): Remove this after version 0.5.

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -161,7 +161,7 @@ func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, stat
 	}
 	ignoreTimeField := cmpopts.IgnoreFields(autoscaler.StatMessage{}, "Stat.Time")
 	if !cmp.Equal(sm, recv, ignoreTimeField) {
-		t.Fatalf("Expected and actual stats messages are not equal: %s", cmp.Diff(sm, recv, ignoreTimeField))
+		t.Fatalf("StatMessage mismatch: diff (-got, +want) %s", cmp.Diff(recv, sm, ignoreTimeField))
 	}
 	return true
 }

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -139,11 +139,9 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 }
 
 func newStatMessage(revKey string, podName string, averageConcurrentRequests float64, requestCount int32) *autoscaler.StatMessage {
-	now := time.Now()
 	return &autoscaler.StatMessage{
 		Key: revKey,
 		Stat: autoscaler.Stat{
-			Time:                      &now,
 			PodName:                   podName,
 			AverageConcurrentRequests: averageConcurrentRequests,
 			RequestCount:              requestCount,
@@ -157,6 +155,10 @@ func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, stat
 	if !ok {
 		t.Fatalf("statistic not received")
 	}
+	if recv.Stat.Time == nil {
+		t.Fatalf("Stat time is nil")
+	}
+	sm.Stat.Time = recv.Stat.Time
 	if !cmp.Equal(sm, recv) {
 		t.Fatalf("Expected and actual stats messages are not equal: %s", cmp.Diff(sm, recv))
 	}

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gorilla/websocket"
 	"github.com/knative/serving/pkg/autoscaler"
 	stats "github.com/knative/serving/pkg/autoscaler/statserver"
@@ -158,9 +159,9 @@ func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, stat
 	if recv.Stat.Time == nil {
 		t.Fatalf("Stat time is nil")
 	}
-	sm.Stat.Time = recv.Stat.Time
-	if !cmp.Equal(sm, recv) {
-		t.Fatalf("Expected and actual stats messages are not equal: %s", cmp.Diff(sm, recv))
+	ignoreTimeField := cmpopts.IgnoreFields(autoscaler.StatMessage{}, "Stat.Time")
+	if !cmp.Equal(sm, recv, ignoreTimeField) {
+		t.Fatalf("Expected and actual stats messages are not equal: %s", cmp.Diff(sm, recv, ignoreTimeField))
 	}
 	return true
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3601 

## Proposed Changes

* Set autoscaler stat timestamp upon receive
* remove set stat timestamp at send


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
