### PR TITLE
Remove an imperative use of Conditions.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/helpers.go
+++ b/pkg/reconciler/v1alpha1/revision/helpers.go
@@ -17,10 +17,7 @@ limitations under the License.
 package revision
 
 import (
-	"time"
-
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -43,14 +40,6 @@ func isServiceReady(e *corev1.Endpoints) bool {
 		}
 	}
 	return false
-}
-
-func getRevisionLastTransitionTime(r *v1alpha1.Revision) time.Time {
-	ready := r.Status.GetCondition(v1alpha1.RevisionConditionReady)
-	if ready == nil {
-		return r.CreationTimestamp.Time
-	}
-	return ready.LastTransitionTime.Inner.Time
 }
 
 func hasDeploymentTimedOut(deployment *appsv1.Deployment) bool {

--- a/pkg/reconciler/v1alpha1/revision/helpers_test.go
+++ b/pkg/reconciler/v1alpha1/revision/helpers_test.go
@@ -18,15 +18,11 @@ package revision
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetBuildDoneCondition(t *testing.T) {
@@ -131,47 +127,6 @@ func TestGetIsServiceReady(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetRevisionLastTransitionTime(t *testing.T) {
-	expectedTime := time.Now()
-	tests := []struct {
-		description string
-		rev         *v1alpha1.Revision
-	}{{
-		description: "creation time",
-		rev: &v1alpha1.Revision{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.NewTime(expectedTime),
-			},
-		},
-	}, {
-		description: "last condition time",
-		rev: &v1alpha1.Revision{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.NewTime(expectedTime.Add(-20 * time.Minute)),
-			},
-			Status: v1alpha1.RevisionStatus{
-				Status: duckv1alpha1.Status{
-					Conditions: duckv1alpha1.Conditions{{
-						Type:               v1alpha1.RevisionConditionReady,
-						Status:             corev1.ConditionTrue,
-						LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(expectedTime)},
-					}},
-				},
-			},
-		},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			ltt := getRevisionLastTransitionTime(test.rev)
-			if ltt != expectedTime {
-				t.Errorf("getRevisionLastTransitionTime(%v) = %v, want %v", test.rev, ltt, expectedTime)
-			}
-		})
-	}
-
 }
 
 func TestGetDeploymentProgressCondition(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -229,7 +229,7 @@ func (c *Reconciler) reconcileService(ctx context.Context, rev *v1alpha1.Revisio
 		// If the endpoints resource is NOT ready, then check whether it is taking unreasonably
 		// long to become ready and if so mark our revision as having timed out waiting
 		// for the Service to become ready.
-		revisionAge := time.Since(getRevisionLastTransitionTime(rev))
+		revisionAge := time.Since(endpoints.CreationTimestamp.Time)
 		if revisionAge >= serviceTimeoutDuration {
 			rev.Status.MarkServiceTimeout()
 			// TODO(mattmoor): How to ensure this only fires once?

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/serving/pkg/apis/autoscaling"
@@ -742,19 +741,6 @@ func WithFailedBuild(reason, message string) RevisionOption {
 			}},
 		})
 	}
-}
-
-// WithEmptyLTTs clears the LastTransitionTime fields on all of the conditions of the
-// provided Revision.
-func WithEmptyLTTs(r *v1alpha1.Revision) {
-	conds := r.Status.Conditions
-	for i, c := range conds {
-		// The LTT defaults and is long enough ago that we expire waiting
-		// on the Endpoints to become ready.
-		c.LastTransitionTime = apis.VolatileTime{}
-		conds[i] = c
-	}
-	r.Status.Conditions = conds
 }
 
 // WithLastPinned updates the "last pinned" annotation to the provided timestamp.


### PR DESCRIPTION
Today we key off of a strange mix of CreationTimestamp and LastTransitionTime
on Ready as a "clock" for deployment progress.  I believe that this is a
throwback to a world where Ready changes based on the active state.

During deployment, this clock is unreliable because the conditions vary a fair
amount.  Once Ready, we shouldn't see this particular condition again.

This also switches to using the CreationTimestamp on the Endpoints instead of
the Revision, since the Endpoints no longer come/go.

Related: https://github.com/knative/pkg/issues/357