### PR TITLE
Clear conditions on initialization across most of Serving.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -97,6 +97,9 @@ func (rs *PodAutoscalerStatus) GetCondition(t apis.ConditionType) *apis.Conditio
 }
 
 func (rs *PodAutoscalerStatus) InitializeConditions() {
+	// TODO(mattmoor): Uncomment once CanScaleToZero (below) isn't
+	// based on LastTransitionTimestamp.
+	// rs.Conditions = nil
 	podCondSet.Manage((*duckv1beta1.Status)(rs)).InitializeConditions()
 }
 

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
@@ -23,6 +23,7 @@ import (
 
 // InitializeConditions initializes the certificate conditions.
 func (cs *CertificateStatus) InitializeConditions() {
+	cs.Conditions = nil
 	certificateCondSet.Manage(cs).InitializeConditions()
 }
 

--- a/pkg/apis/networking/v1alpha1/clusteringress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_lifecycle.go
@@ -42,6 +42,7 @@ func (cis *IngressStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 }
 
 func (cis *IngressStatus) InitializeConditions() {
+	cis.Conditions = nil
 	clusterIngressCondSet.Manage(cis).InitializeConditions()
 }
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -37,6 +37,7 @@ func (sss *ServerlessServiceStatus) GetCondition(t apis.ConditionType) *apis.Con
 
 // InitializeConditions initializes the conditions.
 func (sss *ServerlessServiceStatus) InitializeConditions() {
+	sss.Conditions = nil
 	serverlessServiceCondSet.Manage(sss).InitializeConditions()
 }
 

--- a/pkg/apis/serving/v1alpha1/configuration_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/configuration_lifecycle.go
@@ -45,6 +45,7 @@ func (cs *ConfigurationStatus) GetCondition(t apis.ConditionType) *apis.Conditio
 }
 
 func (cs *ConfigurationStatus) InitializeConditions() {
+	cs.Conditions = nil
 	confCondSet.Manage(cs).InitializeConditions()
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -130,6 +130,9 @@ func (rs *RevisionStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 }
 
 func (rs *RevisionStatus) InitializeConditions() {
+	// TODO(mattmoor): Uncomment this once we can cleanly build up a Revision's
+	// status without imperatively depending on the prior state.
+	// rs.Conditions = nil
 	revCondSet.Manage(rs).InitializeConditions()
 }
 

--- a/pkg/apis/serving/v1alpha1/route_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/route_lifecycle.go
@@ -44,6 +44,7 @@ func (rs *RouteStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 }
 
 func (rs *RouteStatus) InitializeConditions() {
+	rs.Conditions = nil
 	routeCondSet.Manage(rs).InitializeConditions()
 }
 

--- a/pkg/apis/serving/v1alpha1/service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/service_lifecycle.go
@@ -50,6 +50,7 @@ func (ss *ServiceStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 
 // InitializeConditions sets the initial values to the conditions.
 func (ss *ServiceStatus) InitializeConditions() {
+	ss.Conditions = nil
 	serviceCondSet.Manage(ss).InitializeConditions()
 }
 

--- a/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/hpa/hpa.go
@@ -159,7 +159,7 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 	} else if !metav1.IsControlledBy(hpa, pa) {
 		// Surface an error in the PodAutoscaler's status, and return an error.
 		pa.Status.MarkResourceNotOwned("HorizontalPodAutoscaler", desiredHpa.Name)
-		return fmt.Errorf("PodAutoscaler: %q does not own HPA: %q", pa.Name, desiredHpa.Name)
+		return nil
 	} else {
 		if !equality.Semantic.DeepEqual(desiredHpa.Spec, hpa.Spec) {
 			logger.Infof("Updating HPA %q", desiredHpa.Name)

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -319,7 +319,7 @@ func (c *Reconciler) reconcileMetricsService(ctx context.Context, pa *pav1alpha1
 		return err
 	} else if !metav1.IsControlledBy(svc, pa) {
 		pa.Status.MarkResourceNotOwned("Service", sn)
-		return fmt.Errorf("KPA: %q does not own Service: %q", pa.Name, sn)
+		return nil
 	} else {
 		tmpl := resources.MakeMetricsService(pa, selector)
 		want := svc.DeepCopy()

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -220,7 +220,6 @@ func TestMetricsSvcIsReconciled(t *testing.T) {
 			s.OwnerReferences[0].UID = types.UID("1984")
 			return s
 		}(),
-		wantErr:      "does not own Service",
 		hookShouldTO: true,
 	}}
 	for _, test := range tests {

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress.go
@@ -19,7 +19,6 @@ package clusteringress
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -318,7 +317,7 @@ func (c *Reconciler) reconcileVirtualService(ctx context.Context, ci *v1alpha1.C
 	} else if !metav1.IsControlledBy(vs, ci) {
 		// Surface an error in the ClusterIngress's status, and return an error.
 		ci.Status.MarkResourceNotOwned("VirtualService", name)
-		return fmt.Errorf("ClusterIngress: %q does not own VirtualService: %q", ci.Name, name)
+		return nil
 	} else if !equality.Semantic.DeepEqual(vs.Spec, desired.Spec) {
 		// Don't modify the informers copy
 		existing := vs.DeepCopy()

--- a/pkg/reconciler/v1alpha1/route/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/route/reconcile_resources.go
@@ -152,7 +152,7 @@ func (c *Reconciler) reconcilePlaceholderService(ctx context.Context, route *v1a
 	} else if !metav1.IsControlledBy(service, route) {
 		// Surface an error in the route's status, and return an error.
 		route.Status.MarkServiceNotOwned(name)
-		return fmt.Errorf("Route: %q does not own Service: %q", route.Name, name)
+		return nil
 	} else {
 		// Make sure that the service has the proper specification.
 		if !equality.Semantic.DeepEqual(service.Spec, desiredService.Spec) {

--- a/pkg/reconciler/v1alpha1/service/service.go
+++ b/pkg/reconciler/v1alpha1/service/service.go
@@ -182,7 +182,7 @@ func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) e
 	} else if !metav1.IsControlledBy(config, service) {
 		// Surface an error in the service's status,and return an error.
 		service.Status.MarkConfigurationNotOwned(configName)
-		return fmt.Errorf("Service: %q does not own Configuration: %q", service.Name, configName)
+		return nil
 	} else if config, err = c.reconcileConfiguration(ctx, service, config); err != nil {
 		logger.Errorw(
 			fmt.Sprintf("Failed to reconcile Service: %q failed to reconcile Configuration: %q",
@@ -209,7 +209,7 @@ func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) e
 	} else if !metav1.IsControlledBy(route, service) {
 		// Surface an error in the service's status, and return an error.
 		service.Status.MarkRouteNotOwned(routeName)
-		return fmt.Errorf("Service: %q does not own Route: %q", service.Name, routeName)
+		return nil
 	} else if route, err = c.reconcileRoute(ctx, service, route); err != nil {
 		logger.Errorf("Failed to reconcile Service: %q failed to reconcile Route: %q", service.Name, routeName)
 		return err

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -865,8 +865,7 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "route-fails"),
 		},
 	}, {
-		Name:    "runLatest - not owned config exists",
-		WantErr: true,
+		Name: "runLatest - not owned config exists",
 		Objects: []runtime.Object{
 			Service("run-latest", "foo", WithRunLatestRollout),
 			config("run-latest", "foo", WithRunLatestRollout, WithConfigOwnersRemoved),
@@ -878,11 +877,10 @@ func TestReconcile(t *testing.T) {
 				WithInitSvcConditions, MarkConfigurationNotOwned),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", `Service: "run-latest" does not own Configuration: "run-latest"`),
+			Eventf(corev1.EventTypeNormal, "Updated", `Updated Service "run-latest"`),
 		},
 	}, {
-		Name:    "runLatest - not owned route exists",
-		WantErr: true,
+		Name: "runLatest - not owned route exists",
 		Objects: []runtime.Object{
 			Service("run-latest", "foo", WithRunLatestRollout),
 			config("run-latest", "foo", WithRunLatestRollout),
@@ -895,7 +893,7 @@ func TestReconcile(t *testing.T) {
 				WithInitSvcConditions, MarkRouteNotOwned),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", `Service: "run-latest" does not own Route: "run-latest"`),
+			Eventf(corev1.EventTypeNormal, "Updated", `Updated Service "run-latest"`),
 		},
 	}, {
 		Name: "runLatest - correct not owned by adding owner refs",

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -808,13 +808,18 @@ func MarkContainerExiting(exitCode int32, message string) RevisionOption {
 	}
 }
 
+// MarkRevisionHealthy calls the necessary helpers to make the Revision healthy.
+func MarkRevisionHealthy(r *v1alpha1.Revision) {
+	r.Status.MarkResourcesAvailable()
+	r.Status.MarkContainerHealthy()
+}
+
 // MarkRevisionReady calls the necessary helpers to make the Revision Ready=True.
 func MarkRevisionReady(r *v1alpha1.Revision) {
 	WithInitRevConditions(r)
 	WithNoBuild(r)
 	MarkActive(r)
-	r.Status.MarkResourcesAvailable()
-	r.Status.MarkContainerHealthy()
+	MarkRevisionHealthy(r)
 }
 
 type PodAutoscalerOption func(*autoscalingv1alpha1.PodAutoscaler)


### PR DESCRIPTION
This makes virtually all of the `InitializeConditions` methods in Serving
clear the conditions prior to calling the shared `InitializeConditions` method
on the condition set.  The goal of this is to make our reconcilers less
imperative about how they update conditions.

The only type that does NOT reset the conditions list at the beginning of
reconciliation is the PodAutoscaler, which still relies on LastTransitionTime
to perform its 30 second sleep (which we hope to eliminate in 0.6).

Additional changes:
 - Don't treat `NotOwned` as a `Reconcile()` failure.  Generally when `Reconcile()`
  returns an error, it represents a system error to be retried (think: 5xx).  In
  this case, the system isn't going to fix itself and this is likely the result of
  a user error (think: 4xx).

 - Rework the way build events are surfaced, which is somewhat fundamentally
  imperative..

 - Make the Revision controller bail out of its phase loop upon encountering a
  `Ready: False` condition (this is newly possible due to the reset, which would
  otherwise have needed to run everything to get a crack at correcting things).

Related: https://github.com/knative/pkg/issues/357
