### PR TITLE
Update knative/pkg dependency to catch the new Gateway

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   revision = "babf400eeec07acdd0d6864ad28709c2bcee0c82"
 
 [[projects]]
-  digest = "1:0b2007a4488cc86e71524f17a536568ce753ab1dba56cd2329422437161ac8f8"
+  digest = "1:8357b8c7cec3c476032bf6eea23fa4b2f2f6bf0b8b6475b3ad1e6c33c4d35e3a"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -488,7 +488,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "281cda84ceb316a70c2eafc5b3250a4b72c2d468"
+  revision = "ff46edef0ae5fa1a1f12dbe1d3b8095d2d23501f"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,8 +24,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-04-02
-  revision = "281cda84ceb316a70c2eafc5b3250a4b72c2d468"
+  # HEAD as of 2019-04-03
+  revision = "ff46edef0ae5fa1a1f12dbe1d3b8095d2d23501f"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/vendor/github.com/knative/pkg/apis/istio/v1alpha3/gateway_types.go
+++ b/vendor/github.com/knative/pkg/apis/istio/v1alpha3/gateway_types.go
@@ -259,6 +259,24 @@ type TLSOptions struct {
 	// client side certificate.
 	CaCertificates string `json:"caCertificates"`
 
+	// The credentialName stands for a unique identifier that can be used
+	// to identify the serverCertificate and the privateKey. The
+	// credentialName appended with suffix "-cacert" is used to identify
+	// the CaCertificates associated with this server. Gateway workloads
+	// capable of fetching credentials from a remote credential store such
+	// as Kubernetes secrets, will be configured to retrieve the
+	// serverCertificate and the privateKey using credentialName, instead
+	// of using the file system paths specified above. If using mutual TLS,
+	// gateway workload instances will retrieve the CaCertificates using
+	// credentialName-cacert. The semantics of the name are platform
+	// dependent.  In Kubernetes, the default Istio supplied credential
+	// server expects the credentialName to match the name of the
+	// Kubernetes secret that holds the server certificate, the private
+	// key, and the CA certificate (if using mutual TLS). Set the
+	// `ISTIO_META_USER_SDS` metadata variable in the gateway's proxy to
+	// enable the dynamic credential fetching feature.
+	CredentialName string `json:"credentialName,omitempty"`
+
 	// A list of alternate names to verify the subject identity in the
 	// certificate presented by the client.
 	SubjectAltNames []string `json:"subjectAltNames"`


### PR DESCRIPTION


## Proposed Changes

* Update knative/pkg dependency to catch the new Gateway which has the `CredentialName`



