### PR TITLE
ScaleRevisionByLoadTest

### DIFF
--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/knative/pkg/controller"
 	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
-	"github.com/knative/pkg/test/spoof"
 	testingv1alpha1 "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
 	"github.com/knative/serving/pkg/resources"
 	"github.com/knative/serving/test"
@@ -112,7 +111,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 		clients.KubeClient,
 		t.Logf,
 		domain+"/?timeout=10", // To generate any kind of a valid response.
-		test.RetryingRouteInconsistency(IsStatusOK),
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
@@ -199,8 +198,4 @@ func errorsPercentage(resp *loadgenerator.GeneratorResults) float64 {
 		}
 	}
 	return float64(errors*100) / float64(errors+successes)
-}
-
-func IsStatusOK(resp *spoof.Response) (bool, error) {
-	return resp.StatusCode == http.StatusOK, nil
 }

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -1,0 +1,218 @@
+// +build performance
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package performance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	pkgTest "github.com/knative/pkg/test"
+	ingress "github.com/knative/pkg/test/ingress"
+	"github.com/knative/pkg/test/spoof"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+	"github.com/knative/test-infra/shared/junit"
+	"github.com/knative/test-infra/shared/loadgenerator"
+	"github.com/knative/test-infra/shared/testgrid"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	qpsPerClient         = 10               // frequencies of requests per client
+	iterationDuration    = 60 * time.Second // iteration duration for a single scale
+	processingTimeMillis = 100              // delay of each request on "server" side
+	containerConcurrency = 10
+)
+
+// number of concurrent clients in each iteration
+var tests = []int{10, 20, 40, 80, 160, 320}
+
+type scaleEvent struct {
+	oldScale  int
+	newScale  int
+	timestamp time.Time
+}
+
+// TestScaleRevisionByLoad performs several iterations with increasing number of clients
+// while measuring response times, error rates, and time to scale up.
+func TestScaleRevisionByLoad(t *testing.T) {
+	tc := make([]junit.TestCase, 0)
+	for _, numClients := range tests {
+		t.Run(fmt.Sprintf("clients-%02d", numClients), func(t *testing.T) {
+			tc = scaleRevisionByLoad(t, numClients, tc)
+		})
+	}
+	if err := testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
+		t.Fatalf("Cannot create output xml: %v", err)
+	}
+}
+
+func scaleRevisionByLoad(t *testing.T, numClients int, tc []junit.TestCase) []junit.TestCase {
+	perfClients, err := Setup(t.Logf, true)
+	if err != nil {
+		t.Fatalf("Cannot initialize performance client: %v", err)
+	}
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "observed-concurrency",
+	}
+	clients := perfClients.E2EClients
+
+	defer TearDown(perfClients, names, t.Logf)
+	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
+
+	t.Log("Creating a new Service")
+	objs, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{
+		ContainerResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		}},
+		func(service *v1alpha1.Service) {
+			service.Spec.RunLatest.Configuration.RevisionTemplate.Annotations = map[string]string{"autoscaling.knative.dev/target": fmt.Sprintf("%d", containerConcurrency)}
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+
+	domain := objs.Route.Status.Domain
+	endpoint, err := ingress.GetIngressEndpoint(clients.KubeClient.Kube)
+	if err != nil {
+		t.Fatalf("Cannot get service endpoint: %v", err)
+	}
+
+	// Make sure we are ready to serve.
+	st := time.Now()
+	t.Log("Starting to probe the endpoint at", st)
+	_, err = pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		domain+"/?timeout=10", // To generate any kind of a valid response.
+		test.RetryingRouteInconsistency(func(resp *spoof.Response) (bool, error) {
+			_, _, err := parseResponse(string(resp.Body))
+			return err == nil, nil
+		}),
+		"WaitForEndpointToServeText",
+		test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		t.Fatalf("The endpoint at domain %s didn't serve the expected response: %v", domain, err)
+	}
+	t.Logf("Took %v for the endpoint to start serving", time.Since(st))
+
+	scaleChannel := make(chan *scaleEvent)
+	endMonitoring := make(chan bool)
+	eg := errgroup.Group{}
+
+	eg.Go(func() error {
+		t.Logf("Scale Monitoring Started")
+		defer close(scaleChannel)
+		previousNumEndpoints := 1 //we start with 1 pod running
+		for {
+			select {
+			case <-endMonitoring:
+				t.Logf("Scale Monitoring Finished")
+				return nil
+			default:
+				currentNumEndpoints, err := test.NumEndpoints(clients, test.ServingNamespace, names.Service)
+				if err != nil {
+					t.Logf("Unable to get pod count: %s", err.Error())
+				}
+				if currentNumEndpoints != previousNumEndpoints {
+					event := &scaleEvent{
+						oldScale:  previousNumEndpoints,
+						newScale:  currentNumEndpoints,
+						timestamp: time.Now(),
+					}
+					scaleChannel <- event
+					previousNumEndpoints = currentNumEndpoints
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	})
+
+	events := make([]*scaleEvent, 0)
+	eg.Go(func() error {
+		for scaleEvent := range scaleChannel {
+			events = append(events, scaleEvent)
+		}
+		return nil
+	})
+
+	opts := loadgenerator.GeneratorOptions{
+		Duration:       iterationDuration,
+		NumThreads:     numClients,
+		NumConnections: numClients,
+		Domain:         domain,
+		QPS:            qpsPerClient * float64(numClients),
+		URL:            fmt.Sprintf("http://%s/?timeout=%d", *endpoint, processingTimeMillis),
+	}
+
+	t.Logf("Starting test with %d clients at %s", numClients, time.Now())
+	resp, err := opts.RunLoadTest(false)
+	if err != nil {
+		t.Fatalf("Generating traffic via fortio failed: %v", err)
+	}
+
+	endMonitoring <- true
+
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("Failed to collect Pod counts: %v", err)
+	}
+
+	// Save the json result for benchmarking
+	resp.SaveJSON(strings.Replace(t.Name(), "/", "_", -1))
+
+	tc = append(tc, CreatePerfTestCase(float32(resp.Result.DurationHistogram.Count), "requestCount", t.Name()))
+	tc = append(tc, CreatePerfTestCase(float32(qpsPerClient*numClients), "requestedQPS", t.Name()))
+	tc = append(tc, CreatePerfTestCase(float32(resp.Result.ActualQPS), "actualQPS", t.Name()))
+	tc = append(tc, CreatePerfTestCase(float32(errorsPercentage(resp)), "errorsPercentage", t.Name()))
+
+	for _, ev := range events {
+		t.Logf("Scaled: %d -> %d in %v", ev.oldScale, ev.newScale, ev.timestamp.Sub(resp.Result.StartTime))
+		tc = append(tc, CreatePerfTestCase(float32(ev.timestamp.Sub(resp.Result.StartTime)/time.Second), fmt.Sprintf("scale-from-%02d-to-%02d(seconds)", ev.oldScale, ev.newScale), t.Name()))
+	}
+
+	for _, p := range resp.Result.DurationHistogram.Percentiles {
+		val := float32(p.Value) * 1000
+		name := fmt.Sprintf("p%d(ms)", int(p.Percentile))
+		tc = append(tc, CreatePerfTestCase(val, name, t.Name()))
+	}
+
+	return tc
+}
+
+func errorsPercentage(resp *loadgenerator.GeneratorResults) float64 {
+	var successes, errors int64
+	for retCode, count := range resp.Result.RetCodes {
+		if retCode == 200 {
+			successes = successes + count
+		} else {
+			errors = errors + count
+		}
+	}
+	return float64(errors*100) / float64(errors+successes)
+}

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -67,7 +67,7 @@ func TestScaleRevisionByLoad(t *testing.T) {
 }
 
 func scaleRevisionByLoad(t *testing.T, numClients int, tc []junit.TestCase) {
-	perfClients, err := Setup(t.Logf, true)
+	perfClients, err := Setup(t)
 	if err != nil {
 		t.Fatalf("Cannot initialize performance client: %v", err)
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -15,16 +15,13 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/knative/pkg/signals"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // HelloVolumePath is the path to the test volume.
@@ -59,19 +56,4 @@ func ListenAndServeGracefullyWithPattern(addr string, handlers map[string]func(w
 
 	<-signals.SetupSignalHandler()
 	server.Shutdown(context.Background())
-}
-
-// NumEndpoints returns the number of endpoints for the given service. Returns error
-// if the endpoints cannot be listed
-func NumEndpoints(clients *Clients, namespace string, serviceName string) (int, error) {
-	endpointList, _ := clients.KubeClient.Kube.CoreV1().Endpoints(namespace).List(metav1.ListOptions{})
-	for _, endpoints := range endpointList.Items {
-		if strings.Contains(endpoints.Name, serviceName) {
-			if len(endpoints.Subsets) != 1 {
-				return 0, fmt.Errorf("Endpoint addresses for service %s unavailable", serviceName)
-			}
-			return len(endpoints.Subsets[0].Addresses), nil
-		}
-	}
-	return 0, fmt.Errorf("Unable to find endpoints for given service %s", serviceName)
 }

--- a/test/util.go
+++ b/test/util.go
@@ -15,13 +15,16 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/knative/pkg/signals"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // HelloVolumePath is the path to the test volume.
@@ -56,4 +59,19 @@ func ListenAndServeGracefullyWithPattern(addr string, handlers map[string]func(w
 
 	<-signals.SetupSignalHandler()
 	server.Shutdown(context.Background())
+}
+
+// NumEndpoints returns the number of endpoints for the given service. Returns error
+// if the endpoints cannot be listed
+func NumEndpoints(clients *Clients, namespace string, serviceName string) (int, error) {
+	endpointList, _ := clients.KubeClient.Kube.CoreV1().Endpoints(namespace).List(metav1.ListOptions{})
+	for _, endpoints := range endpointList.Items {
+		if strings.Contains(endpoints.Name, serviceName) {
+			if len(endpoints.Subsets) != 1 {
+				return 0, fmt.Errorf("Endpoint addresses for service %s unavailable", serviceName)
+			}
+			return len(endpoints.Subsets[0].Addresses), nil
+		}
+	}
+	return 0, fmt.Errorf("Unable to find endpoints for given service %s", serviceName)
 }


### PR DESCRIPTION
* increase the number of clients in iterations
* for each iteration measure time-to-scale, errors percentage, request count, requested and actual QPS (queries per second)

## Proposed Changes

* Create a load test with concurrency bigger than 1 (as is in the ObservedConcurrencyTest) and measure various statistics while increasing the number of clients
* Each iteration starts with a new Revision with scale==1. My original idea was to use only a single revision for all iterations and increase the number of clients (preventing scaling down at all). However, spinning up more then 100 threads takes quite long and it can happen that the revision scales down before the new clients start sending requests, which affects the test results. Hence each iteration starts from 1.
* An example XML report from that test looks like  this: https://gist.github.com/mgencur/ddcdc753be55b2b08f1db694b7cbb55b  (this is only for a single iteration)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
