### PR TITLE
Add an example of domainTemplate to the config map's comments

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -83,3 +83,19 @@ data:
     # update this value during the setup of Knative, to avoid getting
     # undefined behavior.
     clusteringress.class: "istio.ingress.networking.knative.dev"
+
+    # domainTemplate specifies the golang text template string to use
+    # when constructing the Knative service's DNS name. The default
+    # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}". And those three
+    # values (Name, Namespace, Domain) are the only variables defined.
+    #
+    # Changing this value might be necessary when the extra levels in
+    # the domain name generated is problematic for wildcard certificates
+    # that only support a single level of domain name added to the
+    # certificate's domain. In those cases you might consider using a value
+    # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+    # entirely from the template. When choosing a new value be thoughtful
+    # of the potential for conflicts - for example, when users choose to use
+    # characters such as `-` in their service, or namespace, names.
+    #
+    domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"


### PR DESCRIPTION
Just more docs...

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint

**Release Note**

```release-note
NONE
```

Closes #3651 