### PR TITLE
Fix activator watching metrics endpoint

### DIFF
--- a/pkg/reconciler/filter.go
+++ b/pkg/reconciler/filter.go
@@ -46,3 +46,30 @@ func LabelExistsFilterFunc(label string) func(obj interface{}) bool {
 		return false
 	}
 }
+
+// LabelFilterFunc creates a FilterFunc only accepting objects where a label is set to a specific value.
+func LabelFilterFunc(label string, value string, allowUnset bool) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		if mo, ok := obj.(metav1.Object); ok {
+			labels := mo.GetLabels()
+			val, ok := labels[label]
+			if !ok {
+				return allowUnset
+			}
+			return val == value
+		}
+		return false
+	}
+}
+
+// ChainFilterFuncs creates a FilterFunc which performs an AND of the passed FilterFuncs.
+func ChainFilterFuncs(funcs ...func(interface{}) bool) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		for _, f := range funcs {
+			if !f(obj) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/service.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	sv1a1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/names"
@@ -31,11 +32,15 @@ const kpaLabelKey = autoscaling.GroupName + "/kpa"
 
 // MakeMetricsService constructs a service that can be scraped for metrics.
 func MakeMetricsService(pa *pav1alpha1.PodAutoscaler, selector map[string]string) *corev1.Service {
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            names.MetricsServiceName(pa.Name),
-			Namespace:       pa.Namespace,
-			Labels:          resources.UnionMaps(pa.GetLabels(), map[string]string{kpaLabelKey: pa.Name}),
+			Name:      names.MetricsServiceName(pa.Name),
+			Namespace: pa.Namespace,
+			Labels: resources.UnionMaps(pa.GetLabels(), map[string]string{
+				kpaLabelKey:               pa.Name,
+				networking.ServiceTypeKey: string(networking.ServiceTypeMetrics),
+			}),
 			Annotations:     resources.CopyMap(pa.GetAnnotations()),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pa)},
 		},

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/service_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	pav1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
@@ -59,9 +60,10 @@ func TestMakeService(t *testing.T) {
 			Name:      "with-you-metrics",
 			Labels: map[string]string{
 				// Those should be propagated.
-				serving.RevisionLabelKey: "with-you",
-				serving.RevisionUID:      "2009",
-				kpaLabelKey:              "with-you",
+				serving.RevisionLabelKey:  "with-you",
+				serving.RevisionUID:       "2009",
+				kpaLabelKey:               "with-you",
+				networking.ServiceTypeKey: string(networking.ServiceTypeMetrics),
 			},
 			Annotations: map[string]string{
 				"a": "b",

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/apis/networking"
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -34,6 +35,7 @@ import (
 // serving.RevisionLabelKey label. Traffic is routed to queue-proxy port.
 func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 	labels := makeLabels(rev)
+	labels[networking.ServiceTypeKey] = string(networking.ServiceTypePublic)
 	// Set KPALabelKey label if KPA is used for this Revision. If ClassAnnotationKey
 	// is empty, default to KPA class for backward compatibility.
 	if pa, ok := rev.Annotations[autoscaling.ClassAnnotationKey]; !ok || pa == autoscaling.KPA {

--- a/pkg/reconciler/v1alpha1/revision/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
@@ -48,10 +49,11 @@ func TestMakeK8sService(t *testing.T) {
 				Namespace: "foo",
 				Name:      "bar-service",
 				Labels: map[string]string{
-					autoscaling.KPALabelKey:  "bar",
-					serving.RevisionLabelKey: "bar",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
+					autoscaling.KPALabelKey:   "bar",
+					serving.RevisionLabelKey:  "bar",
+					serving.RevisionUID:       "1234",
+					AppLabelKey:               "bar",
+					networking.ServiceTypeKey: string(networking.ServiceTypePublic),
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
@@ -99,10 +101,11 @@ func TestMakeK8sService(t *testing.T) {
 				Namespace: "blah",
 				Name:      "baz-service",
 				Labels: map[string]string{
-					autoscaling.KPALabelKey:  "baz",
-					serving.RevisionLabelKey: "baz",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "baz",
+					autoscaling.KPALabelKey:   "baz",
+					serving.RevisionLabelKey:  "baz",
+					serving.RevisionUID:       "1234",
+					AppLabelKey:               "baz",
+					networking.ServiceTypeKey: string(networking.ServiceTypePublic),
 				},
 				Annotations: map[string]string{
 					autoscaling.ClassAnnotationKey: autoscaling.KPA,
@@ -145,9 +148,10 @@ func TestMakeK8sService(t *testing.T) {
 				Namespace: "foo",
 				Name:      "bar-service",
 				Labels: map[string]string{
-					serving.RevisionLabelKey: "bar",
-					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
+					serving.RevisionLabelKey:  "bar",
+					serving.RevisionUID:       "1234",
+					AppLabelKey:               "bar",
+					networking.ServiceTypeKey: string(networking.ServiceTypePublic),
 				},
 				Annotations: map[string]string{
 					autoscaling.ClassAnnotationKey: autoscaling.HPA,


### PR DESCRIPTION
In #3580 we added a new metrics service which is indistinguishable from
our main svc which activator watches for when an endpoint is available.
This causes activator to repeatedly error due to not being able to find
a revision matching our metrics service.

Fixes: #3660

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
