### PR TITLE
Add reconciliation for the protocol type.

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
+++ b/pkg/reconciler/v1alpha1/revision/reconcile_resources.go
@@ -151,9 +151,9 @@ func (c *Reconciler) reconcileKPA(ctx context.Context, rev *v1alpha1.Revision) e
 	// TODO(vagababov): required for #1997. Should be removed in 0.7,
 	// to fix the protocol type when it's unset.
 	tmpl := resources.MakeKPA(rev)
-	want := kpa.DeepCopy()
-	want.Spec = tmpl.Spec
-	if !equality.Semantic.DeepEqual(want, kpa) {
+	if !equality.Semantic.DeepEqual(tmpl.Spec, kpa.Spec) {
+		want := kpa.DeepCopy()
+		want.Spec = tmpl.Spec
 		logger.Infof("KPA %s needs reconciliation", kpa.Name)
 		if _, err := c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(kpa.Namespace).Update(want); err != nil {
 			return err

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -819,6 +819,13 @@ func MarkRevisionReady(r *v1alpha1.Revision) {
 
 type PodAutoscalerOption func(*autoscalingv1alpha1.PodAutoscaler)
 
+// WithProtocolType sets the protocol type on the PodAutoscaler.
+func WithProtocolType(pt networking.ProtocolType) PodAutoscalerOption {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
+		pa.Spec.ProtocolType = pt
+	}
+}
+
 // WithPodAutoscalerOwnersRemoved clears the owner references of this PodAutoscaler.
 func WithPodAutoscalerOwnersRemoved(r *autoscalingv1alpha1.PodAutoscaler) {
 	r.OwnerReferences = nil


### PR DESCRIPTION
Currently we have lots of KPA resources with PT unset, and this upsets
the downstream KPA/SKS code, since the defaulting is done in the revision
code. And we do not want to propagate that logic to the downstream
objects (otherwise we could just avoided the field in the first place).

So this adds temporary reconciliation for the time being, and in 0,7 it
can be removed.

/cc @mattmoor @markusthoemmes 
