### PR TITLE
Make created objects more obvious in the KPA.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -168,10 +168,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// Reconcile this copy of the pa and then write back any status
 	// updates regardless of whether the reconciliation errored out.
 	err = c.reconcile(ctx, pa)
-	if err != nil {
-		logger.Errorw("Error while reconciling", zap.Error(err))
-		c.Recorder.Event(pa, corev1.EventTypeWarning, "InternalError", err.Error())
-	}
 	if equality.Semantic.DeepEqual(original.Status, pa.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
@@ -182,6 +178,9 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for PA %q: %v", pa.Name, err)
 		return err
+	}
+	if err != nil {
+		c.Recorder.Event(pa, corev1.EventTypeWarning, "InternalError", err.Error())
 	}
 	return err
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/names"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"
+	perrors "github.com/pkg/errors"
 	"go.uber.org/atomic"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -681,7 +682,7 @@ func TestControllerCreateError(t *testing.T) {
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
 
-	got := ctl.Reconciler.Reconcile(context.Background(), key)
+	got := perrors.Cause(ctl.Reconciler.Reconcile(context.Background(), key))
 	if got != want {
 		t.Errorf("Reconcile() = %v, wanted %v", got, want)
 	}
@@ -723,7 +724,7 @@ func TestControllerUpdateError(t *testing.T) {
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
 
-	got := ctl.Reconciler.Reconcile(context.Background(), key)
+	got := perrors.Cause(ctl.Reconciler.Reconcile(context.Background(), key))
 	if got != want {
 		t.Errorf("Reconcile() = %v, wanted %v", got, want)
 	}
@@ -764,7 +765,7 @@ func TestControllerGetError(t *testing.T) {
 	servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 	servingInformer.Autoscaling().V1alpha1().PodAutoscalers().Informer().GetIndexer().Add(kpa)
 
-	got := ctl.Reconciler.Reconcile(context.Background(), key)
+	got := perrors.Cause(ctl.Reconciler.Reconcile(context.Background(), key))
 	if got != want {
 		t.Errorf("Reconcile() = %v, wanted %v", got, want)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

I missed this in the review of #3537. The reconciliation of the Decider should not be buried into a general `desiredScale` function. It makes the flow less obvious, especially when adding more created entities to it.

- Factor out `reconcileDecider`.
- Refactor error logging in that file to be more consistent.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
