### PR TITLE
Since we're scraping metrics service now, remove the metric port

### DIFF
--- a/pkg/reconciler/v1alpha1/revision/resources/constants.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/constants.go
@@ -38,23 +38,18 @@ const (
 
 	autoscalerPort = 8080
 
-	// ServicePortName is the name of the external port of the service
+	// ServicePortNameHTTP1 is the name of the external port of the service for HTTP/1.1
 	ServicePortNameHTTP1 = "http"
-	ServicePortNameH2C   = "http2"
+	// ServicePortNameH2C is the name of the external port of the service for HTTP/2
+	ServicePortNameH2C = "http2"
 
 	// ServicePort is the external port of the service
 	ServicePort = int32(80)
-	// MetricsPortName is the name of the external port of the service for metrics
-	MetricsPortName = "metrics"
-	// MetricsPort is the external port of the service for metrics
-	MetricsPort = int32(9090)
 	AppLabelKey = "app"
 )
 
-var ProgressDeadlineSeconds int32 = 120
-
-// pseudo-constants
 var (
+	ProgressDeadlineSeconds int32 = 120
 	// See https://github.com/knative/serving/pull/1124#issuecomment-397120430
 	// for how CPU and memory values were calculated.
 	fluentdContainerCPU = resource.MustParse("25m")

--- a/pkg/reconciler/v1alpha1/revision/resources/service.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service.go
@@ -57,11 +57,6 @@ func MakeK8sService(rev *v1alpha1.Revision) *corev1.Service {
 				Protocol:   corev1.ProtocolTCP,
 				Port:       ServicePort,
 				TargetPort: intstr.FromString(v1alpha1.RequestQueuePortName),
-			}, {
-				Name:       MetricsPortName,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       MetricsPort,
-				TargetPort: intstr.FromString(v1alpha1.RequestQueueMetricsPortName),
 			}},
 			Selector: map[string]string{
 				serving.RevisionLabelKey: rev.Name,

--- a/pkg/reconciler/v1alpha1/revision/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service_test.go
@@ -69,11 +69,6 @@ func TestMakeK8sService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       ServicePort,
 					TargetPort: intstr.FromString(v1alpha1.RequestQueuePortName),
-				}, {
-					Name:       MetricsPortName,
-					Protocol:   corev1.ProtocolTCP,
-					Port:       MetricsPort,
-					TargetPort: intstr.FromString(v1alpha1.RequestQueueMetricsPortName),
 				}},
 				Selector: map[string]string{
 					serving.RevisionLabelKey: "bar",
@@ -127,11 +122,6 @@ func TestMakeK8sService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       ServicePort,
 					TargetPort: intstr.FromString(v1alpha1.RequestQueuePortName),
-				}, {
-					Name:       MetricsPortName,
-					Protocol:   corev1.ProtocolTCP,
-					Port:       MetricsPort,
-					TargetPort: intstr.FromString(v1alpha1.RequestQueueMetricsPortName),
 				}},
 				Selector: map[string]string{
 					serving.RevisionLabelKey: "baz",
@@ -177,11 +167,6 @@ func TestMakeK8sService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       ServicePort,
 					TargetPort: intstr.FromString(v1alpha1.RequestQueuePortName),
-				}, {
-					Name:       MetricsPortName,
-					Protocol:   corev1.ProtocolTCP,
-					Port:       MetricsPort,
-					TargetPort: intstr.FromString(v1alpha1.RequestQueueMetricsPortName),
 				}},
 				Selector: map[string]string{
 					serving.RevisionLabelKey: "bar",


### PR DESCRIPTION
... from the user service k8s service.
Also removing a few constants that seem not to be used anymore.

/lint
## Proposed Changes

* remove metrics port from the user service
* update the tests
* remove unused constants.

/cc @mattmoor 