### PR TITLE
Expose the private k8s svc name on the status of the sks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1383,7 +1383,6 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
-    "k8s.io/apimachinery/pkg/api/validation",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/labels",

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -44,6 +44,26 @@ const (
 	// SKSLabelKey is the label key that SKS Controller attaches to the
 	// underlying resources it controls.
 	SKSLabelKey = GroupName + "/serverlessservice"
+
+	// ServiceTypeKey is the label key attached to a service specifying the type of service.
+	// e.g. Public, Metrics
+	ServiceTypeKey = GroupName + "/serviceType"
+)
+
+// ServiceType is the enumeration type for the Kubernetes services
+// that we have in our system, classified by usage purpose.
+type ServiceType string
+
+const (
+	// ServiceTypePrivate is the label value for internal only services
+	// for user applications.
+	ServiceTypePrivate ServiceType = "Private"
+	// ServiceTypePublic is the label value for externally reachable
+	// services for user applications.
+	ServiceTypePublic ServiceType = "Public"
+	// ServiceTypeMetrics is the label value for Metrics services. Such services
+	// are used for meric scraping.
+	ServiceTypeMetrics ServiceType = "Metrics"
 )
 
 // Pseudo-constants

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -110,6 +110,11 @@ type ServerlessServiceStatus struct {
 	// load balances over the pods backing this Revision (activator or revision).
 	// +optional
 	ServiceName string `json:"serviceName,omitempty"`
+
+	// PrivateServiceName holds the name of a core K8s Service resource that
+	// load balances over the user service pods backing this Revision.
+	// +optional
+	PrivateServiceName string `json:"privateServiceName,omitempty"`
 }
 
 // ConditionType represents a ServerlessService condition value

--- a/pkg/reconciler/v1alpha1/serverlessservice/resources/services.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/resources/services.go
@@ -49,7 +49,8 @@ func MakePublicService(sks *v1alpha1.ServerlessService) *corev1.Service {
 			Namespace: sks.Namespace,
 			Labels: resources.UnionMaps(sks.GetLabels(), map[string]string{
 				// Add our own special key.
-				networking.SKSLabelKey: sks.Name,
+				networking.SKSLabelKey:    sks.Name,
+				networking.ServiceTypeKey: string(networking.ServiceTypePublic),
 			}),
 			Annotations:     resources.CopyMap(sks.GetAnnotations()),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
@@ -74,7 +75,8 @@ func MakePublicEndpoints(sks *v1alpha1.ServerlessService, src *corev1.Endpoints)
 			Namespace: sks.Namespace,
 			Labels: resources.UnionMaps(sks.GetLabels(), map[string]string{
 				// Add our own special key.
-				networking.SKSLabelKey: sks.Name,
+				networking.SKSLabelKey:    sks.Name,
+				networking.ServiceTypeKey: string(networking.ServiceTypePublic),
 			}),
 			Annotations:     resources.CopyMap(sks.GetAnnotations()),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
@@ -97,7 +99,8 @@ func MakePrivateService(sks *v1alpha1.ServerlessService) *corev1.Service {
 			Namespace: sks.Namespace,
 			Labels: resources.UnionMaps(sks.GetLabels(), map[string]string{
 				// Add our own special key.
-				networking.SKSLabelKey: sks.Name,
+				networking.SKSLabelKey:    sks.Name,
+				networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
 			}),
 			Annotations:     resources.CopyMap(sks.GetAnnotations()),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},

--- a/pkg/reconciler/v1alpha1/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/resources/services_test.go
@@ -68,9 +68,10 @@ func TestMakeService(t *testing.T) {
 				Name:      "collie-pub",
 				Labels: map[string]string{
 					// Those should be propagated.
-					serving.RevisionLabelKey: "collie",
-					serving.RevisionUID:      "1982",
-					networking.SKSLabelKey:   "collie", // <= This one we add.
+					serving.RevisionLabelKey:  "collie",
+					serving.RevisionUID:       "1982",
+					networking.SKSLabelKey:    "collie",
+					networking.ServiceTypeKey: "Public",
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
@@ -120,9 +121,10 @@ func TestMakeService(t *testing.T) {
 				Name:      "dream-pub",
 				Labels: map[string]string{
 					// Those should be propagated.
-					serving.RevisionLabelKey: "dream",
-					serving.RevisionUID:      "1988",
-					networking.SKSLabelKey:   "dream", // <= This one we add.
+					serving.RevisionLabelKey:  "dream",
+					serving.RevisionUID:       "1988",
+					networking.SKSLabelKey:    "dream",
+					networking.ServiceTypeKey: "Public",
 				},
 				Annotations: map[string]string{
 					"cherub": "rock",
@@ -156,6 +158,7 @@ func TestMakeService(t *testing.T) {
 			// Now let's patch selector.
 			test.want.Spec.Selector = test.sks.Spec.Selector
 			test.want.Name = names.PrivateService(test.sks)
+			test.want.Labels[networking.ServiceTypeKey] = "Private"
 
 			got = MakePrivateService(test.sks)
 			if diff := cmp.Diff(test.want, got); diff != "" {
@@ -200,9 +203,10 @@ func TestMakeEndpoints(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie-pub",
 				Labels: map[string]string{
-					serving.RevisionLabelKey: "collie",
-					serving.RevisionUID:      "1982",
-					networking.SKSLabelKey:   "collie", // <= This one we add.
+					serving.RevisionLabelKey:  "collie",
+					serving.RevisionUID:       "1982",
+					networking.SKSLabelKey:    "collie",
+					networking.ServiceTypeKey: "Public",
 				},
 				Annotations: map[string]string{
 					"cherub": "rock",
@@ -226,8 +230,9 @@ func TestMakeEndpoints(t *testing.T) {
 				UID:       "1982",
 				// Those labels are propagated from the Revision->KPA.
 				Labels: map[string]string{
-					serving.RevisionLabelKey: "collie",
-					serving.RevisionUID:      "1982",
+					serving.RevisionLabelKey:  "collie",
+					serving.RevisionUID:       "1982",
+					networking.ServiceTypeKey: "Public",
 				},
 				Annotations: map[string]string{
 					"cherub": "rock",
@@ -261,9 +266,10 @@ func TestMakeEndpoints(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie-pub",
 				Labels: map[string]string{
-					serving.RevisionLabelKey: "collie",
-					serving.RevisionUID:      "1982",
-					networking.SKSLabelKey:   "collie", // <= This one we add.
+					serving.RevisionLabelKey:  "collie",
+					serving.RevisionUID:       "1982",
+					networking.SKSLabelKey:    "collie",
+					networking.ServiceTypeKey: "Public",
 				},
 				Annotations: map[string]string{
 					"cherub": "rock",

--- a/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice.go
@@ -327,8 +327,8 @@ func (r *reconciler) reconcilePrivateService(ctx context.Context, sks *netv1alph
 	want.Spec.Ports = tmpl.Spec.Ports
 	want.Spec.Selector = tmpl.Spec.Selector
 
-	sks.Status.MarkEndpointsNotReady("UpdatingPrivateService")
 	if !equality.Semantic.DeepEqual(svc.Spec, want.Spec) {
+		sks.Status.MarkEndpointsNotReady("UpdatingPrivateService")
 		logger.Infof("Private K8s Service changed; reconciling: %s", sn)
 		if _, err = r.KubeClientSet.CoreV1().Services(sks.Namespace).Update(want); err != nil {
 			logger.Errorw(fmt.Sprintf("Error updating private K8s Service %s: ", sn), zap.Error(err))

--- a/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice_test.go
@@ -82,7 +82,7 @@ func TestReconcile(t *testing.T) {
 		Name: "steady state",
 		Key:  "steady/state",
 		Objects: []runtime.Object{
-			sks("steady", "state", markHappy, withPubService),
+			sks("steady", "state", markHappy, withPubService, withPrivService),
 			svcpub("steady", "state"),
 			svcpriv("steady", "state"),
 			endpointspub("steady", "state", WithSubsets),
@@ -92,7 +92,7 @@ func TestReconcile(t *testing.T) {
 		Name: "pod change",
 		Key:  "pod/change",
 		Objects: []runtime.Object{
-			sks("pod", "change", markHappy, withPubService),
+			sks("pod", "change", markHappy, withPubService, withPrivService),
 			svcpub("pod", "change"),
 			svcpriv("pod", "change"),
 			endpointspub("pod", "change", WithSubsets),
@@ -105,7 +105,7 @@ func TestReconcile(t *testing.T) {
 		Name: "user changes priv svc",
 		Key:  "private/svc-change",
 		Objects: []runtime.Object{
-			sks("private", "svc-change", markHappy, withPubService),
+			sks("private", "svc-change", markHappy, withPubService, withPrivService),
 			svcpub("private", "svc-change"),
 			svcpriv("private", "svc-change", withTimeSelector),
 			endpointspub("private", "svc-change", withOtherSubsets),
@@ -118,7 +118,7 @@ func TestReconcile(t *testing.T) {
 		Name: "user changes public svc",
 		Key:  "public/svc-change",
 		Objects: []runtime.Object{
-			sks("public", "svc-change", markHappy, withPubService),
+			sks("public", "svc-change", markHappy, withPubService, withPrivService),
 			svcpub("public", "svc-change", withTimeSelector),
 			svcpriv("public", "svc-change"),
 			endpointspub("public", "svc-change", WithSubsets),
@@ -141,7 +141,7 @@ func TestReconcile(t *testing.T) {
 			endpointspub("on", "cde", WithSubsets),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: sks("on", "cde", markHappy, withPubService),
+			Object: sks("on", "cde", markHappy, withPubService, withPrivService),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "on/cde"`),
@@ -159,7 +159,7 @@ func TestReconcile(t *testing.T) {
 			endpointspub("on", "cneps"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: sks("on", "cneps", markNoEndpoints, withPubService),
+			Object: sks("on", "cneps", markNoEndpoints, withPubService, withPrivService),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "on/cneps"`),
@@ -223,7 +223,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "update-sks/fail4",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("update-sks", "fail4", withPubService),
+			sks("update-sks", "fail4", withPubService, withPrivService),
 			svcpub("update-sks", "fail4"),
 			svcpriv("update-sks", "fail4"),
 			endpointspub("update-sks", "fail4", WithSubsets),
@@ -234,7 +234,7 @@ func TestReconcile(t *testing.T) {
 		},
 		// We still record update, but it fails.
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: sks("update-sks", "fail4", markHappy, withPubService),
+			Object: sks("update-sks", "fail4", markHappy, withPubService, withPrivService),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status: inducing failure for update serverlessservices"),
@@ -244,7 +244,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "ronin-pub-service/fail5",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("ronin-pub-service", "fail5", withPubService),
+			sks("ronin-pub-service", "fail5", withPubService, withPrivService),
 			svcpub("ronin-pub-service", "fail5", WithK8sSvcOwnersRemoved),
 			svcpriv("ronin-pub-service", "fail5"),
 			endpointspub("ronin-pub-service", "fail5", WithSubsets),
@@ -258,7 +258,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "ronin-priv-service/fail6",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("ronin-priv-service", "fail6", withPubService),
+			sks("ronin-priv-service", "fail6", withPubService, withPrivService),
 			svcpub("ronin-priv-service", "fail6"),
 			svcpriv("ronin-priv-service", "fail6", WithK8sSvcOwnersRemoved),
 			endpointspub("ronin-priv-service", "fail6", WithSubsets),
@@ -272,7 +272,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "ronin-pub-eps/fail7",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("ronin-pub-eps", "fail7", withPubService),
+			sks("ronin-pub-eps", "fail7", withPubService, withPrivService),
 			svcpub("ronin-pub-eps", "fail7"),
 			svcpriv("ronin-pub-eps", "fail7"),
 			endpointspub("ronin-pub-eps", "fail7", WithSubsets, WithEndpointsOwnersRemoved),
@@ -286,7 +286,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "update-svc/fail8",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("update-svc", "fail8", withPubService),
+			sks("update-svc", "fail8", withPubService, withPrivService),
 			svcpub("update-svc", "fail8", withTimeSelector),
 			svcpriv("update-svc", "fail8"),
 			endpointspub("update-svc", "fail8", WithSubsets),
@@ -307,7 +307,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "update-svc/fail9",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("update-svc", "fail9", withPubService),
+			sks("update-svc", "fail9", withPubService, withPrivService),
 			svcpub("update-svc", "fail9"),
 			svcpriv("update-svc", "fail9", withTimeSelector),
 			endpointspub("update-svc", "fail9"),
@@ -328,7 +328,7 @@ func TestReconcile(t *testing.T) {
 		Key:     "update-eps/failA",
 		WantErr: true,
 		Objects: []runtime.Object{
-			sks("update-eps", "failA", withPubService),
+			sks("update-eps", "failA", withPubService, withPrivService),
 			svcpub("update-eps", "failA"),
 			svcpriv("update-eps", "failA"),
 			endpointspub("update-eps", "failA"),
@@ -371,6 +371,10 @@ func withOtherSubsets(ep *corev1.Endpoints) {
 	ep.Subsets = []corev1.EndpointSubset{{
 		Addresses: []corev1.EndpointAddress{{IP: "127.0.0.2"}},
 	}}
+}
+
+func withPrivService(sks *nv1a1.ServerlessService) {
+	sks.Status.PrivateServiceName = names.PrivateService(sks)
 }
 
 func withPubService(sks *nv1a1.ServerlessService) {


### PR DESCRIPTION
This is required so it can be consumed by activator.
This also builds on pieces of work provided in the #3659, but applied to
the SKS, rather than existing metrics and revision created k8s services.

Part of #1997.


/lint

## Proposed Changes

* update the API to expose the private service name in the status
*  update tests
* integrate parts of #3659 so we have this in SKS from the get-go.

/assign @mattmoor 
