### PR TITLE
Import the webhook contexts and use them.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   revision = "babf400eeec07acdd0d6864ad28709c2bcee0c82"
 
 [[projects]]
-  digest = "1:9782bcc7c948c967ffa4d7dd2cddd1a7fb8918d6b8200ccd450549546bc5635f"
+  digest = "1:828517719ba14c379e1c2ef0bc31e4f42bbf34f5bff38d21535628ff66671f39"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -489,7 +489,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "21372d06ff77b1a728ec6a0decd41af895531f87"
+  revision = "2b574edcd712e848556c69cc95a2622145284882"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,8 +24,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-04-05
-  revision = "21372d06ff77b1a728ec6a0decd41af895531f87"
+  # HEAD as of 2019-04-08
+  revision = "2b574edcd712e848556c69cc95a2622145284882"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -52,7 +52,6 @@ var (
 	// Check that PodAutoscaler can be validated, can be defaulted, and has immutable fields.
 	_ apis.Validatable = (*PodAutoscaler)(nil)
 	_ apis.Defaultable = (*PodAutoscaler)(nil)
-	_ apis.Immutable   = (*PodAutoscaler)(nil)
 
 	// Check that we can create OwnerReferences to a PodAutoscaler.
 	_ kmeta.OwnerRefable = (*PodAutoscaler)(nil)

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -31,10 +31,43 @@ import (
 )
 
 func (pa *PodAutoscaler) Validate(ctx context.Context) *apis.FieldError {
-	return serving.ValidateObjectMetadata(pa.GetObjectMeta()).
+	errs := serving.ValidateObjectMetadata(pa.GetObjectMeta()).
 		ViaField("metadata").
 		Also(pa.Spec.Validate(ctx).ViaField("spec")).
 		Also(pa.validateMetric())
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*PodAutoscaler)
+
+		errs = errs.Also(pa.checkImmutableFields(ctx, original))
+	}
+
+	return errs
+}
+
+func (current *PodAutoscaler) checkImmutableFields(ctx context.Context, original *PodAutoscaler) *apis.FieldError {
+	if diff, err := compareSpec(original, current); err != nil {
+		return &apis.FieldError{
+			Message: "Failed to diff PodAutoscaler",
+			Paths:   []string{"spec"},
+			Details: err.Error(),
+		}
+	} else if diff != "" {
+		return &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: diff,
+		}
+	}
+	// Verify the PA class does not change.
+	// For backward compatibility, we allow a new class where there was none before.
+	if oldClass, newClass, annotationChanged := classAnnotationChanged(original, current); annotationChanged {
+		return &apis.FieldError{
+			Message: fmt.Sprintf("Immutable class annotation changed (-%q +%q)", oldClass, newClass),
+			Paths:   []string{"annotations[autoscaling.knative.dev/class]"},
+		}
+	}
+	return nil
 }
 
 // Validate validates PodAutoscaler Spec.
@@ -102,37 +135,6 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 			Message: fmt.Sprintf("Unsupported metric %q for PodAutoscaler class %q",
 				metric, pa.Class()),
 			Paths: []string{"annotations[autoscaling.knative.dev/metric]"},
-		}
-	}
-	return nil
-}
-
-// CheckImmutableFields checks the immutability of the PodAutoscaler.
-func (pa *PodAutoscaler) CheckImmutableFields(ctx context.Context, og apis.Immutable) *apis.FieldError {
-	original, ok := og.(*PodAutoscaler)
-	if !ok {
-		return &apis.FieldError{Message: "The provided original was not a PodAutoscaler"}
-	}
-
-	if diff, err := compareSpec(original, pa); err != nil {
-		return &apis.FieldError{
-			Message: "Failed to diff PodAutoscaler",
-			Paths:   []string{"spec"},
-			Details: err.Error(),
-		}
-	} else if diff != "" {
-		return &apis.FieldError{
-			Message: "Immutable fields changed (-old +new)",
-			Paths:   []string{"spec"},
-			Details: diff,
-		}
-	}
-	// Verify the PA class does not change.
-	// For backward compatibility, we allow a new class where there was none before.
-	if oldClass, newClass, annotationChanged := classAnnotationChanged(original, pa); annotationChanged {
-		return &apis.FieldError{
-			Message: fmt.Sprintf("Immutable class annotation changed (-%q +%q)", oldClass, newClass),
-			Paths:   []string{"annotations[autoscaling.knative.dev/class]"},
 		}
 	}
 	return nil

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -64,4 +64,11 @@ const (
 	// BuildHashLabelKey is the label key attached to a Build indicating the
 	// hash of the spec from which they were created.
 	BuildHashLabelKey = GroupName + "/buildHash"
+
+	// CreatorAnnotation is the annotation key to describe the user that
+	// created the resource.
+	CreatorAnnotation = GroupName + "/creator"
+	// UpdaterAnnotation is the annotation key to describe the user that
+	// last updated the resource.
+	UpdaterAnnotation = GroupName + "/lastModifier"
 )

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -52,7 +52,6 @@ var (
 	// Check that Revision can be validated, can be defaulted, and has immutable fields.
 	_ apis.Validatable = (*Revision)(nil)
 	_ apis.Defaultable = (*Revision)(nil)
-	_ apis.Immutable   = (*Revision)(nil)
 
 	// Check that we can create OwnerReferences to a Revision.
 	_ kmeta.OwnerRefable = (*Revision)(nil)

--- a/pkg/apis/serving/v1alpha1/service_defaults.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults.go
@@ -16,10 +16,36 @@ limitations under the License.
 
 package v1alpha1
 
-import "context"
+import (
+	"context"
+
+	"github.com/knative/pkg/apis"
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"github.com/knative/serving/pkg/apis/serving"
+)
 
 func (s *Service) SetDefaults(ctx context.Context) {
 	s.Spec.SetDefaults(ctx)
+
+	if ui := apis.GetUserInfo(ctx); ui != nil {
+		ans := s.GetAnnotations()
+		if ans == nil {
+			ans = map[string]string{}
+			defer s.SetAnnotations(ans)
+		}
+
+		if apis.IsInUpdate(ctx) {
+			old := apis.GetBaseline(ctx).(*Service)
+			if equality.Semantic.DeepEqual(old.Spec, s.Spec) {
+				return
+			}
+			ans[serving.UpdaterAnnotation] = ui.Username
+		} else {
+			ans[serving.CreatorAnnotation] = ui.Username
+			ans[serving.UpdaterAnnotation] = ui.Username
+		}
+	}
 }
 
 func (ss *ServiceSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/serving/v1alpha1/service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/service_lifecycle.go
@@ -17,15 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
-	authv1 "k8s.io/api/authentication/v1"
 )
 
 var serviceCondSet = apis.NewLivingConditionSet(
@@ -145,40 +142,4 @@ func (ss *ServiceStatus) SetManualStatus() {
 	newStatus.DeprecatedDomainInternal = ss.DeprecatedDomainInternal
 
 	*ss = *newStatus
-}
-
-const (
-	// CreatorAnnotation is the annotation key to describe the user that
-	// created the resource.
-	CreatorAnnotation = "serving.knative.dev/creator"
-	// UpdaterAnnotation is the annotation key to describe the user that
-	// last updated the resource.
-	UpdaterAnnotation = "serving.knative.dev/lastModifier"
-)
-
-// AnnotateUserInfo satisfay the apis.Annotatable interface, and set the proper annotations
-// on the Service resource about the user that performed the action.
-func (s *Service) AnnotateUserInfo(ctx context.Context, prev apis.Annotatable, ui *authv1.UserInfo) {
-	ans := s.GetAnnotations()
-	if ans == nil {
-		ans = map[string]string{}
-		defer s.SetAnnotations(ans)
-	}
-
-	// WebHook makes sure we get the proper type here.
-	ps, _ := prev.(*Service)
-
-	// Creation.
-	if ps == nil {
-		ans[CreatorAnnotation] = ui.Username
-		ans[UpdaterAnnotation] = ui.Username
-		return
-	}
-
-	// Compare the Spec's, we update the `lastModifier` key iff
-	// there's a change in the spec.
-	if equality.Semantic.DeepEqual(ps.Spec, s.Spec) {
-		return
-	}
-	ans[UpdaterAnnotation] = ui.Username
 }

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	corev1 "k8s.io/api/core/v1"
@@ -141,7 +142,7 @@ func validateAnnotations(objs *test.ResourceObjects) error {
 	// List of issues listing annotations that we check: #1642.
 
 	anns := objs.Service.GetAnnotations()
-	for _, a := range []string{v1alpha1.CreatorAnnotation, v1alpha1.UpdaterAnnotation} {
+	for _, a := range []string{serving.CreatorAnnotation, serving.UpdaterAnnotation} {
 		if got := anns[a]; got == "" {
 			return fmt.Errorf("Expected %s annotation to be set, but was empty", a)
 		}

--- a/vendor/github.com/knative/pkg/apis/contexts.go
+++ b/vendor/github.com/knative/pkg/apis/contexts.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"context"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+// This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being created.
+type inCreateKey struct{}
+
+// WithinCreate is used to note that the webhook is calling within
+// the context of a Create operation.
+func WithinCreate(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inCreateKey{}, struct{}{})
+}
+
+// IsInCreate checks whether the context is a Create.
+func IsInCreate(ctx context.Context) bool {
+	return ctx.Value(inCreateKey{}) != nil
+}
+
+// This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being updated.
+type inUpdateKey struct{}
+
+// WithinUpdate is used to note that the webhook is calling within
+// the context of a Update operation.
+func WithinUpdate(ctx context.Context, base interface{}) context.Context {
+	return context.WithValue(ctx, inUpdateKey{}, base)
+}
+
+// IsInUpdate checks whether the context is an Update.
+func IsInUpdate(ctx context.Context) bool {
+	return ctx.Value(inUpdateKey{}) != nil
+}
+
+// GetBaseline returns the baseline of the update, or nil when we
+// are not within an update context.
+func GetBaseline(ctx context.Context) interface{} {
+	return ctx.Value(inUpdateKey{})
+}
+
+// This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being created.
+type userInfoKey struct{}
+
+// WithUserInfo is used to note that the webhook is calling within
+// the context of a Create operation.
+func WithUserInfo(ctx context.Context, ui *authenticationv1.UserInfo) context.Context {
+	return context.WithValue(ctx, userInfoKey{}, ui)
+}
+
+// GetUserInfo accesses the UserInfo attached to the webhook context.
+func GetUserInfo(ctx context.Context) *authenticationv1.UserInfo {
+	if ui, ok := ctx.Value(userInfoKey{}).(*authenticationv1.UserInfo); ok {
+		return ui
+	}
+	return nil
+}

--- a/vendor/github.com/knative/pkg/apis/interfaces.go
+++ b/vendor/github.com/knative/pkg/apis/interfaces.go
@@ -19,7 +19,6 @@ package apis
 import (
 	"context"
 
-	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -35,8 +34,19 @@ type Validatable interface {
 	Validate(context.Context) *FieldError
 }
 
+// Convertible indicates that a particular type supports conversions to/from
+// "higher" versions of the same type.
+type Convertible interface {
+	// ConvertUp up-converts the receiver into `to`.
+	ConvertUp(to Convertible) error
+
+	// ConvertDown down-converts from `from` into the receiver.
+	ConvertDown(from Convertible) error
+}
+
 // Immutable indicates that a particular type has fields that should
 // not change after creation.
+// DEPRECATED: Use WithinUpdate / GetBaseline from within Validatable instead.
 type Immutable interface {
 	// CheckImmutableFields checks that the current instance's immutable
 	// fields haven't changed from the provided original.
@@ -52,6 +62,7 @@ type Listable interface {
 }
 
 // Annotatable indicates that a particular type applies various annotations.
-type Annotatable interface {
-	AnnotateUserInfo(ctx context.Context, previous Annotatable, ui *authenticationv1.UserInfo)
-}
+// DEPRECATED: Use WithUserInfo / GetUserInfo from within SetDefaults instead.
+// The webhook functionality for this has been turned down, which is why this
+// interface is empty.
+type Annotatable interface{}

--- a/vendor/github.com/knative/pkg/apis/testing/conditions.go
+++ b/vendor/github.com/knative/pkg/apis/testing/conditions.go
@@ -40,7 +40,7 @@ func CheckCondition(s *duckv1b1.Status, c apis.ConditionType, cs corev1.Conditio
 func CheckConditionOngoing(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionUnknown); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -48,7 +48,7 @@ func CheckConditionOngoing(s *duckv1b1.Status, c apis.ConditionType, t *testing.
 func CheckConditionFailed(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionFalse); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -56,6 +56,6 @@ func CheckConditionFailed(s *duckv1b1.Status, c apis.ConditionType, t *testing.T
 func CheckConditionSucceeded(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionTrue); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
This imports the new webhook context decorators that enable
`apis.Validatable` and `apis.Defaultable` to subsume both
`apis.Immutable` and `apis.Annotatable`.

See: https://github.com/knative/pkg/pull/368

WIP until https://github.com/knative/pkg/pull/368 merges.