### PR TITLE
Take enable-scale-to-zero from configmap into account in KAP reconciler

### DIFF
--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -340,12 +340,6 @@ func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, scaleCha
 			return
 		}
 
-		// Don't scale to zero if scale to zero is disabled.
-		if desiredScale == 0 && !m.dynConfig.Current().EnableScaleToZero {
-			logger.Debug("Cannot scale: Desired scale == 0 && EnableScaleToZero == false.")
-			return
-		}
-
 		scaleChan <- desiredScale
 	}
 }

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -340,6 +340,12 @@ func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, scaleCha
 			return
 		}
 
+		// Don't scale to zero if scale to zero is disabled.
+		if desiredScale == 0 && !m.dynConfig.Current().EnableScaleToZero {
+			logger.Debug("Cannot scale: Desired scale == 0 && EnableScaleToZero == false.")
+			return
+		}
+
 		scaleChan <- desiredScale
 	}
 }

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -340,12 +340,6 @@ func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, scaleCha
 			return
 		}
 
-		// Don't scale to zero if scale to zero is disabled.
-		if desiredScale == 0 && !m.dynConfig.Current().EnableScaleToZero {
-			logger.Warn("Cannot scale: Desired scale == 0 && EnableScaleToZero == false.")
-			return
-		}
-
 		scaleChan <- desiredScale
 	}
 }

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -227,6 +227,52 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	}
 }
 
+func TestMultiScalerWithoutScaleToZero(t *testing.T) {
+	ctx := context.Background()
+	ms, stopCh, statCh, uniScaler := createMultiScaler(t, &Config{
+		TickInterval:      tickInterval,
+		EnableScaleToZero: false,
+	})
+	defer close(stopCh)
+	defer close(statCh)
+
+	decider := newDecider()
+	uniScaler.setScaleResult(0, true)
+
+	// Before it exists, we should get a NotFound.
+	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("Get() = (%v, %v), want not found error", m, err)
+	}
+
+	errCh := make(chan error)
+	defer close(errCh)
+	ms.Watch(func(key string) {
+		// Let the main process know when this is called.
+		errCh <- nil
+	})
+
+	_, err = ms.Create(ctx, decider)
+	if err != nil {
+		t.Errorf("Create() = %v", err)
+	}
+
+	// Verify that we get no "ticks", because the desired scale is zero
+	if err := verifyNoTick(errCh); err != nil {
+		t.Fatal(err)
+	}
+
+	err = ms.Delete(ctx, decider.Namespace, decider.Name)
+	if err != nil {
+		t.Errorf("Delete() = %v", err)
+	}
+
+	// Verify that we stop seeing "ticks"
+	if err := verifyNoTick(errCh); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 	ctx := context.Background()
 	ms, stopCh, statCh, uniScaler := createMultiScaler(t, &Config{

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -227,52 +227,6 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	}
 }
 
-func TestMultiScalerWithoutScaleToZero(t *testing.T) {
-	ctx := context.Background()
-	ms, stopCh, statCh, uniScaler := createMultiScaler(t, &Config{
-		TickInterval:      tickInterval,
-		EnableScaleToZero: false,
-	})
-	defer close(stopCh)
-	defer close(statCh)
-
-	decider := newDecider()
-	uniScaler.setScaleResult(0, true)
-
-	// Before it exists, we should get a NotFound.
-	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("Get() = (%v, %v), want not found error", m, err)
-	}
-
-	errCh := make(chan error)
-	defer close(errCh)
-	ms.Watch(func(key string) {
-		// Let the main process know when this is called.
-		errCh <- nil
-	})
-
-	_, err = ms.Create(ctx, decider)
-	if err != nil {
-		t.Errorf("Create() = %v", err)
-	}
-
-	// Verify that we get no "ticks", because the desired scale is zero
-	if err := verifyNoTick(errCh); err != nil {
-		t.Fatal(err)
-	}
-
-	err = ms.Delete(ctx, decider.Namespace, decider.Name)
-	if err != nil {
-		t.Errorf("Delete() = %v", err)
-	}
-
-	// Verify that we stop seeing "ticks"
-	if err := verifyNoTick(errCh); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 	ctx := context.Background()
 	ms, stopCh, statCh, uniScaler := createMultiScaler(t, &Config{

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler.go
@@ -136,11 +136,16 @@ func isPAOwnedByRevision(ctx context.Context, pa *pav1alpha1.PodAutoscaler) bool
 
 func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale int32) (int32, bool) {
 	if desiredScale == 0 {
-		// We should only scale to zero when both of the following conditions are true:
-		//   a) The PA has been active for atleast the stable window, after which it gets marked inactive
-		//   b) The PA has been inactive for atleast the grace period
+		// We should only scale to zero when three of the following conditions are true:
+		//   a) enable-scale-to-zero from configmap is true
+		//   b) The PA has been active for atleast the stable window, after which it gets marked inactive
+		//   c) The PA has been inactive for atleast the grace period
 
 		config := ks.getAutoscalerConfig()
+
+		if config.EnableScaleToZero == false {
+			return 1, true
+		}
 
 		if pa.Status.IsActivating() { // Active=Unknown
 			// Don't scale-to-zero during activation
@@ -151,18 +156,18 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 			// Only let a revision be scaled to 0 if it's been active for at
 			// least the stable window's time.
 			if pa.Status.CanMarkInactive(config.StableWindow) {
-				return desiredScale, true
+				return desiredScale, false
 			}
 			// Otherwise, scale down to 1 until the idle period elapses
 			desiredScale = 1
 		} else { // Active=False
 			// Don't scale-to-zero if the grace period hasn't elapsed
 			if !pa.Status.CanScaleToZero(config.ScaleToZeroGracePeriod) {
-				return desiredScale, true
+				return desiredScale, false
 			}
 		}
 	}
-	return desiredScale, false
+	return desiredScale, true
 }
 
 func (ks *scaler) applyScale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desiredScale int32, resource *schema.GroupResource, scl *autoscalingapi.Scale) (int32, error) {
@@ -204,14 +209,14 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desir
 	}
 	currentScale := scl.Spec.Replicas
 
-	min, max := ks.getScaleBounds(pa)
+	min, max := pa.ScaleBounds()
 	if newScale := applyBounds(min, max, desiredScale); newScale != desiredScale {
 		logger.Debugf("Adjusting desiredScale: %v -> %v", desiredScale, newScale)
 		desiredScale = newScale
 	}
 
-	desiredScale, skipApplyScale := ks.handleScaleToZero(pa, desiredScale)
-	if skipApplyScale {
+	desiredScale, shouldApplyScale := ks.handleScaleToZero(pa, desiredScale)
+	if !shouldApplyScale {
 		return desiredScale, nil
 	}
 
@@ -232,14 +237,4 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desir
 	logger.Infof("Scaling from %d to %d", currentScale, desiredScale)
 
 	return ks.applyScale(ctx, pa, desiredScale, resource, scl)
-}
-
-func (ks *scaler) getScaleBounds(pa *pav1alpha1.PodAutoscaler) (int32, int32) {
-	config := ks.getAutoscalerConfig()
-	min, max := pa.ScaleBounds()
-	// Don't scale to zero if scale to zero is disabled.
-	if config.EnableScaleToZero == false && min == 0 {
-		min = 1
-	}
-	return min, max
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
@@ -205,6 +205,11 @@ func TestEnableScaleToZero(t *testing.T) {
 		scaleTo:       0,
 		minScale:      2,
 		wantReplicas:  2,
+	}, {
+		label:         "EnableScaleToZero == false and desire pod is -1(initial value)",
+		startReplicas: 10,
+		scaleTo:       -1,
+		wantReplicas:  1,
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
@@ -151,11 +151,12 @@ func TestScaler(t *testing.T) {
 		wantReplicas:  10,
 		wantScaling:   true,
 	}, {
-		label:         "ignore negative scale",
+		label:         "negative scale is bounded to minScale",
 		startReplicas: 12,
 		scaleTo:       -1,
-		wantReplicas:  12,
-		wantScaling:   false,
+		minScale:      2,
+		wantReplicas:  2,
+		wantScaling:   true,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3629

## Proposed Changes

* Takes `enable-scale-to-zero` from configmap into account in KPA reconciler when doing scale. If `minScale` annotation is not set or set to 0 and `enable-scale-to-zero` is set to false, keep 1 pod as minimum.
* Removes checking `EnableScaleToZero` in multiscaler.go.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes the bug that setting `enable-scale-to-zero: "false"` in `config/config-autoscaler.yaml` has not effect.
```
