### PR TITLE
Remove redundant logging in SKS reconciliation.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -377,7 +377,7 @@ func (c *Reconciler) reconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutosca
 		}
 		logger.Infof("Created SKS: %q", sksName)
 	} else if err != nil {
-		return perrors.Wrapf(err, "error getting SKS %s", sksName)
+		return perrors.Wrapf(err, "error getting SKS %s/%s", pa.Namespace, sksName)
 	} else if !metav1.IsControlledBy(sks, pa) {
 		pa.Status.MarkResourceNotOwned("ServerlessService", sksName)
 		return fmt.Errorf("KPA: %q does not own SKS: %q", pa.Name, sksName)
@@ -388,7 +388,7 @@ func (c *Reconciler) reconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutosca
 		want.Spec = tmpl.Spec
 		logger.Infof("SKS changed; reconciling: %s", sksName)
 		if _, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
-			return perrors.Wrapf(err, "error updating SKS %s", sksName)
+			return perrors.Wrapf(err, "error updating SKS %s/%s", pa.Namespace, sksName)
 		}
 	}
 	logger.Debugf("Done reconciling SKS %s", sksName)

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -447,7 +447,8 @@ func TestReconcile(t *testing.T) {
 			sks(testNamespace, testRevision, WithSelector(usualSelector)),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "error reconciling SKS: inducing failure for create serverlessservices"),
+			Eventf(corev1.EventTypeWarning, "InternalError",
+				fmt.Sprintf("error reconciling SKS: error creating SKS %s/%s: inducing failure for create serverlessservices", testNamespace, testRevision)),
 		},
 	}, {
 		Name: "sks cannot be updated",
@@ -467,7 +468,8 @@ func TestReconcile(t *testing.T) {
 			Object: sks(testNamespace, testRevision, WithSelector(usualSelector)),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "error reconciling SKS: inducing failure for update serverlessservices"),
+			Eventf(corev1.EventTypeWarning, "InternalError",
+				fmt.Sprintf("error reconciling SKS: error updating SKS %s/%s: inducing failure for update serverlessservices", testNamespace, testRevision)),
 		},
 	}, {
 		Name: "sks is disowned",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

In line with some other cleanup I recently did to that file.

## Proposed Changes

* Logging an error before returning it in a reconciler is redundant. It's cleaner to enrich the errors with enough context to be logged just once.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
