### PR TITLE
Move Scraper from Scaler to Collector.

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"context"
 	"sync"
+	"time"
 
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"go.uber.org/zap"
@@ -40,22 +41,30 @@ type MetricSpec struct{}
 // MetricStatus reflects the status of metric collection for this specific entity.
 type MetricStatus struct{}
 
-// NewMetricCollector creates a new metric collector.
-func NewMetricCollector(logger *zap.SugaredLogger) *MetricCollector {
-	collector := &MetricCollector{
-		logger:      logger,
-		collections: make(map[string]*collection),
-	}
-
-	return collector
-}
+// StatsScraperFactory creates a StatsScraper for a given Metric.
+type StatsScraperFactory func(*Metric) (StatsScraper, error)
 
 // MetricCollector manages collection of metrics for many entities.
 type MetricCollector struct {
 	logger *zap.SugaredLogger
 
+	statsScraperFactory StatsScraperFactory
+	statsCh             chan *StatMessage
+
 	collections      map[string]*collection
 	collectionsMutex sync.RWMutex
+}
+
+// NewMetricCollector creates a new metric collector.
+func NewMetricCollector(statsScraperFactory StatsScraperFactory, statsCh chan *StatMessage, logger *zap.SugaredLogger) *MetricCollector {
+	collector := &MetricCollector{
+		logger:              logger,
+		collections:         make(map[string]*collection),
+		statsScraperFactory: statsScraperFactory,
+		statsCh:             statsCh,
+	}
+
+	return collector
 }
 
 // Get gets a Metric's state from the collector.
@@ -84,7 +93,11 @@ func (c *MetricCollector) Create(ctx context.Context, metric *Metric) (*Metric, 
 	key := NewMetricKey(metric.Namespace, metric.Name)
 	coll, exists := c.collections[key]
 	if !exists {
-		coll = &collection{metric}
+		scraper, err := c.statsScraperFactory(metric)
+		if err != nil {
+			return nil, err
+		}
+		coll = newCollection(metric, scraper, c.statsCh, c.logger)
 		c.collections[key] = coll
 	}
 
@@ -113,7 +126,8 @@ func (c *MetricCollector) Delete(ctx context.Context, namespace, name string) er
 	c.logger.Debugf("Stopping metric collection of %s/%s", namespace, name)
 
 	key := NewMetricKey(namespace, name)
-	if _, ok := c.collections[key]; ok {
+	if collection, ok := c.collections[key]; ok {
+		collection.close()
 		delete(c.collections, key)
 	}
 	return nil
@@ -122,4 +136,42 @@ func (c *MetricCollector) Delete(ctx context.Context, namespace, name string) er
 // collection represents the collection of metrics for one specific entity.
 type collection struct {
 	metric *Metric
+
+	grp    sync.WaitGroup
+	stopCh chan struct{}
+}
+
+func newCollection(metric *Metric, scraper StatsScraper, statsCh chan *StatMessage, logger *zap.SugaredLogger) *collection {
+	c := &collection{
+		metric: metric,
+		stopCh: make(chan struct{}),
+	}
+
+	c.grp.Add(1)
+	go func() {
+		defer c.grp.Done()
+
+		scrapeTicker := time.NewTicker(scrapeTickInterval)
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case <-scrapeTicker.C:
+				message, err := scraper.Scrape()
+				if err != nil {
+					logger.Errorw("Failed to scrape metrics", zap.Error(err))
+				}
+				if message != nil {
+					statsCh <- message
+				}
+			}
+		}
+	}()
+
+	return c
+}
+
+func (c *collection) close() {
+	close(c.stopCh)
+	c.grp.Wait()
 }

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -27,6 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// scrapeTickInterval is the interval of time between scraping metrics across
+	// all pods of a revision.
+	// TODO(yanweiguo): tuning this value. To be based on pod population?
+	scrapeTickInterval = time.Second / 3
+)
+
 // Metric represents a resource to configure the metric collector with.
 // +k8s:deepcopy-gen=true
 type Metric struct {
@@ -155,6 +162,7 @@ func newCollection(metric *Metric, scraper StatsScraper, statsCh chan *StatMessa
 		for {
 			select {
 			case <-c.stopCh:
+				scrapeTicker.Stop()
 				return
 			case <-scrapeTicker.C:
 				message, err := scraper.Scrape()

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -40,6 +40,8 @@ var (
 )
 
 func TestMetricCollectorCrud(t *testing.T) {
+	defer ClearAll()
+
 	logger := TestLogger(t)
 	ctx := context.Background()
 
@@ -104,6 +106,8 @@ func TestMetricCollectorCrud(t *testing.T) {
 }
 
 func TestMetricCollectorScraper(t *testing.T) {
+	defer ClearAll()
+
 	logger := TestLogger(t)
 	ctx := context.Background()
 

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -35,11 +35,6 @@ const (
 	// seconds while an http request is taking the full timeout of 5
 	// second.
 	scaleBufferSize = 10
-
-	// scrapeTickInterval is the interval of time between scraping metrics across
-	// all pods of a revision.
-	// TODO(yanweiguo): tuning this value. To be based on pod population?
-	scrapeTickInterval = time.Second / 3
 )
 
 // Decider is a resource which observes the request load of a Revision and

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -407,12 +407,10 @@ func TestMultiScalerUpdate(t *testing.T) {
 func createMultiScaler(t *testing.T, config *Config) (*MultiScaler, chan<- struct{}, chan *StatMessage, *fakeUniScaler) {
 	logger := TestLogger(t)
 	uniscaler := &fakeUniScaler{}
-	statsScraper := &fakeStatsScraper{}
 
 	stopChan := make(chan struct{})
 	statChan := make(chan *StatMessage)
-	ms := NewMultiScaler(NewDynamicConfig(config, logger),
-		stopChan, statChan, uniscaler.fakeUniScalerFactory, statsScraper.fakeStatsScraperFactory, logger)
+	ms := NewMultiScaler(NewDynamicConfig(config, logger), stopChan, statChan, uniscaler.fakeUniScalerFactory, logger)
 
 	return ms, stopChan, statChan, uniscaler
 }
@@ -474,16 +472,4 @@ func newDecider() *Decider {
 		},
 		Status: DeciderStatus{},
 	}
-}
-
-type fakeStatsScraper struct {
-}
-
-func (s *fakeStatsScraper) fakeStatsScraperFactory(*Decider) (StatsScraper, error) {
-	return s, nil
-}
-
-// Scrape always sends the same test StatMessage.
-func (s *fakeStatsScraper) Scrape() (*StatMessage, error) {
-	return &testStatMessage, nil
 }

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -83,17 +83,6 @@ func verifyNoTick(errCh chan error) error {
 	}
 }
 
-// verifyTick verifies that we get a tick in a certain amount of time.
-func verifyStatMessageTick(statsCh chan *StatMessage) error {
-	select {
-	case <-statsCh:
-		// We got the StatMessage!
-		return nil
-	case <-time.After(2 * scrapeTickInterval):
-		return errors.New("Did not get expected StatMessage")
-	}
-}
-
 func TestMultiScalerScaling(t *testing.T) {
 	ctx := context.Background()
 	ms, stopCh, statCh, uniScaler := createMultiScaler(t, &Config{
@@ -128,10 +117,6 @@ func TestMultiScalerScaling(t *testing.T) {
 	// Verify that subsequent "ticks" don't trigger a callback, since
 	// the desired scale has not changed.
 	if err := verifyNoTick(errCh); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := verifyStatMessageTick(statCh); err != nil {
 		t.Fatal(err)
 	}
 
@@ -410,7 +395,7 @@ func createMultiScaler(t *testing.T, config *Config) (*MultiScaler, chan<- struc
 
 	stopChan := make(chan struct{})
 	statChan := make(chan *StatMessage)
-	ms := NewMultiScaler(NewDynamicConfig(config, logger), stopChan, statChan, uniscaler.fakeUniScalerFactory, logger)
+	ms := NewMultiScaler(NewDynamicConfig(config, logger), stopChan, uniscaler.fakeUniScalerFactory, logger)
 
 	return ms, stopChan, statChan, uniscaler
 }

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -73,17 +73,17 @@ type ServiceScraper struct {
 }
 
 // NewServiceScraper creates a new StatsScraper for the Revision which
-// the given Decider is responsible for.
-func NewServiceScraper(decider *Decider, endpointsLister corev1listers.EndpointsLister) (*ServiceScraper, error) {
-	return newServiceScraperWithClient(decider, endpointsLister, cacheDisabledClient)
+// the given Metric is responsible for.
+func NewServiceScraper(metric *Metric, endpointsLister corev1listers.EndpointsLister) (*ServiceScraper, error) {
+	return newServiceScraperWithClient(metric, endpointsLister, cacheDisabledClient)
 }
 
 func newServiceScraperWithClient(
-	decider *Decider,
+	metric *Metric,
 	endpointsLister corev1listers.EndpointsLister,
 	httpClient *http.Client) (*ServiceScraper, error) {
-	if decider == nil {
-		return nil, errors.New("decider must not be nil")
+	if metric == nil {
+		return nil, errors.New("metric must not be nil")
 	}
 	if endpointsLister == nil {
 		return nil, errors.New("endpoints lister must not be nil")
@@ -91,18 +91,18 @@ func newServiceScraperWithClient(
 	if httpClient == nil {
 		return nil, errors.New("HTTP client must not be nil")
 	}
-	revName := decider.Labels[serving.RevisionLabelKey]
+	revName := metric.Labels[serving.RevisionLabelKey]
 	if revName == "" {
-		return nil, fmt.Errorf("no Revision label found for Decider %s", decider.Name)
+		return nil, fmt.Errorf("no Revision label found for Metric %s", metric.Name)
 	}
 
 	serviceName := names.MetricsServiceName(revName)
 	return &ServiceScraper{
 		httpClient:          httpClient,
 		endpointsLister:     endpointsLister,
-		url:                 fmt.Sprintf("http://%s.%s:%d/metrics", serviceName, decider.Namespace, v1alpha1.RequestQueueMetricsPort),
-		metricKey:           NewMetricKey(decider.Namespace, decider.Name),
-		namespace:           decider.Namespace,
+		url:                 fmt.Sprintf("http://%s.%s:%d/metrics", serviceName, metric.Namespace, v1alpha1.RequestQueueMetricsPort),
+		metricKey:           NewMetricKey(metric.Namespace, metric.Name),
+		namespace:           metric.Namespace,
 		scrapeTargetService: serviceName,
 	}, nil
 }

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -70,14 +70,14 @@ func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
 }
 
 func TestNewServiceScraperWithClient_ErrorCases(t *testing.T) {
-	decider := getTestDecider()
-	invalidDecider := getTestDecider()
-	invalidDecider.Labels = map[string]string{}
+	metric := getTestMetric()
+	invalidMetric := getTestMetric()
+	invalidMetric.Labels = map[string]string{}
 	client := newTestClient(nil, nil)
 	lister := kubeInformer.Core().V1().Endpoints().Lister()
 	testCases := []struct {
 		name        string
-		decider     *Decider
+		metric      *Metric
 		client      *http.Client
 		lister      corev1listers.EndpointsLister
 		expectedErr string
@@ -85,27 +85,27 @@ func TestNewServiceScraperWithClient_ErrorCases(t *testing.T) {
 		name:        "Empty Decider",
 		client:      client,
 		lister:      lister,
-		expectedErr: "decider must not be nil",
+		expectedErr: "metric must not be nil",
 	}, {
 		name:        "Missing revision label in Decider",
-		decider:     &invalidDecider,
+		metric:      invalidMetric,
 		client:      client,
 		lister:      lister,
-		expectedErr: "no Revision label found for Decider test-revision",
+		expectedErr: "no Revision label found for Metric test-revision",
 	}, {
 		name:        "Empty HTTP client",
-		decider:     &decider,
+		metric:      metric,
 		lister:      lister,
 		expectedErr: "HTTP client must not be nil",
 	}, {
 		name:        "Empty lister",
-		decider:     &decider,
+		metric:      metric,
 		client:      client,
 		expectedErr: "endpoints lister must not be nil",
 	}}
 
 	for _, test := range testCases {
-		if _, err := newServiceScraperWithClient(test.decider, test.lister, test.client); err != nil {
+		if _, err := newServiceScraperWithClient(test.metric, test.lister, test.client); err != nil {
 			got := err.Error()
 			want := test.expectedErr
 			if got != want {
@@ -259,12 +259,12 @@ func TestScrape_DoNotScrapeIfNoPodsFound(t *testing.T) {
 }
 
 func serviceScraperForTest(httpClient *http.Client) (*ServiceScraper, error) {
-	decider := getTestDecider()
-	return newServiceScraperWithClient(&decider, kubeInformer.Core().V1().Endpoints().Lister(), httpClient)
+	metric := getTestMetric()
+	return newServiceScraperWithClient(metric, kubeInformer.Core().V1().Endpoints().Lister(), httpClient)
 }
 
-func getTestDecider() Decider {
-	return Decider{
+func getTestMetric() *Metric {
+	return &Metric{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testRevision,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Make the Scraper depend on a given Metric, not on a given Decider.
* Move creation of the Scraper out of the Scaler and into the Collector

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
