### PR TITLE
Add support for using Jaeger as backend tracing solution

### DIFF
--- a/config/monitoring/README.md
+++ b/config/monitoring/README.md
@@ -2,6 +2,13 @@
 
 This folder contains deployment files for monitoring and logging components.
 
+## Tracing
+
+Deployment files are available for a range of distributed tracing solutions. However, only one solution can be deployed at a time. Refer to the following links to find out more information on capabilities and benefits of each solution.
+
+* [Zipkin](https://zipkin.io/)
+* [Jaeger](https://www.jaegertracing.io/)
+
 ## Notes for Contributors
 
 `kubectl -R -f` installs the files within a folder in alphabetical order. In

--- a/config/monitoring/tracing/jaeger/100-jaegertracing_v1_jaeger_crd.yaml
+++ b/config/monitoring/tracing/jaeger/100-jaegertracing_v1_jaeger_crd.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jaegers.jaegertracing.io
+spec:
+  group: jaegertracing.io
+  names:
+    kind: Jaeger
+    listKind: JaegerList
+    plural: jaegers
+    singular: jaeger
+  scope: Namespaced
+  version: v1

--- a/config/monitoring/tracing/jaeger/101-service_account.yaml
+++ b/config/monitoring/tracing/jaeger/101-service_account.yaml
@@ -1,0 +1,19 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jaeger-operator
+  namespace: istio-system

--- a/config/monitoring/tracing/jaeger/102-role.yaml
+++ b/config/monitoring/tracing/jaeger/102-role.yaml
@@ -1,0 +1,87 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: jaeger-operator
+  namespace: istio-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - io.jaegertracing
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - "*"
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - "*"
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - '*'
+- apiGroups:
+  - jaegertracing.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/config/monitoring/tracing/jaeger/103-role_binding.yaml
+++ b/config/monitoring/tracing/jaeger/103-role_binding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jaeger-operator
+  namespace: istio-system
+subjects:
+- kind: ServiceAccount
+  name: jaeger-operator
+  namespace: istio-system
+roleRef:
+  kind: ClusterRole
+  name: jaeger-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/config/monitoring/tracing/jaeger/104-operator.yaml
+++ b/config/monitoring/tracing/jaeger/104-operator.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger-operator
-  # istio assumes that tracing is installed in istio-system namespace - 
+  # istio assumes that tracing is installed in istio-system namespace -
   # we have to install to istio-system until istio allows overriding this behavior.
   namespace: istio-system
   labels:

--- a/config/monitoring/tracing/jaeger/104-operator.yaml
+++ b/config/monitoring/tracing/jaeger/104-operator.yaml
@@ -1,0 +1,51 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger-operator
+  # istio assumes that tracing is installed in istio-system namespace - 
+  # we have to install to istio-system until istio allows overriding this behavior.
+  namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: jaeger-operator
+  template:
+    metadata:
+      labels:
+        name: jaeger-operator
+    spec:
+      serviceAccountName: jaeger-operator
+      containers:
+        - name: jaeger-operator
+          image: jaegertracing/jaeger-operator:1.11
+          ports:
+          - containerPort: 8383
+            name: metrics
+          args: ["start"]
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "jaeger-operator"

--- a/config/monitoring/tracing/jaeger/105-zipkin-service.yaml
+++ b/config/monitoring/tracing/jaeger/105-zipkin-service.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  # istio assumes that tracing is installed in istio-system namespace - 
+  # we have to install to istio-system until istio allows overriding this behavior.
+  namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  ports:
+  - name: http
+    port: 9411
+  selector:
+    app: jaeger
+---

--- a/config/monitoring/tracing/jaeger/105-zipkin-service.yaml
+++ b/config/monitoring/tracing/jaeger/105-zipkin-service.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: zipkin
-  # istio assumes that tracing is installed in istio-system namespace - 
+  # istio assumes that tracing is installed in istio-system namespace -
   # we have to install to istio-system until istio allows overriding this behavior.
   namespace: istio-system
   labels:

--- a/config/monitoring/tracing/jaeger/elasticsearch/110-jaeger.yaml
+++ b/config/monitoring/tracing/jaeger/elasticsearch/110-jaeger.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger
+  # istio assumes that tracing is installed in istio-system namespace - 
+  # we have to install to istio-system until istio allows overriding this behavior.
+  namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  strategy: production
+  storage:
+    type: elasticsearch
+    options:
+      es:
+        server-urls: http://elasticsearch-logging.knative-monitoring.svc.cluster.local:9200

--- a/config/monitoring/tracing/jaeger/elasticsearch/110-jaeger.yaml
+++ b/config/monitoring/tracing/jaeger/elasticsearch/110-jaeger.yaml
@@ -16,7 +16,7 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: jaeger
-  # istio assumes that tracing is installed in istio-system namespace - 
+  # istio assumes that tracing is installed in istio-system namespace -
   # we have to install to istio-system until istio allows overriding this behavior.
   namespace: istio-system
   labels:

--- a/config/monitoring/tracing/jaeger/memory/110-jaeger.yaml
+++ b/config/monitoring/tracing/jaeger/memory/110-jaeger.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger
+  # istio assumes that tracing is installed in istio-system namespace - 
+  # we have to install to istio-system until istio allows overriding this behavior.
+  namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel

--- a/config/monitoring/tracing/jaeger/memory/110-jaeger.yaml
+++ b/config/monitoring/tracing/jaeger/memory/110-jaeger.yaml
@@ -16,7 +16,7 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: jaeger
-  # istio assumes that tracing is installed in istio-system namespace - 
+  # istio assumes that tracing is installed in istio-system namespace -
   # we have to install to istio-system until istio allows overriding this behavior.
   namespace: istio-system
   labels:

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -59,6 +59,8 @@ readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
 readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
 readonly MONITORING_TRACE_ZIPKIN_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin.yaml
 readonly MONITORING_TRACE_ZIPKIN_IN_MEM_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin-in-mem.yaml
+readonly MONITORING_TRACE_JAEGER_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-jaeger.yaml
+readonly MONITORING_TRACE_JAEGER_IN_MEM_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-jaeger-in-mem.yaml
 readonly MONITORING_LOG_ELASTICSEARCH_YAML=${YAML_OUTPUT_DIR}/monitoring-logs-elasticsearch.yaml
 
 # Flags for all ko commands
@@ -102,6 +104,12 @@ ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/zipkin | "${LABEL_YA
 
 # Traces via Zipkin in Memory when ElasticSearch is not installed
 ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/zipkin-in-mem | "${LABEL_YAML_CMD[@]}" > "${MONITORING_TRACE_ZIPKIN_IN_MEM_YAML}"
+
+# Traces via Jaeger when ElasticSearch is installed
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/jaeger -f config/monitoring/tracing/jaeger/elasticsearch | "${LABEL_YAML_CMD[@]}" > "${MONITORING_TRACE_JAEGER_YAML}"
+
+# Traces via Jaeger in Memory when ElasticSearch is not installed
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/jaeger -f config/monitoring/tracing/jaeger/memory | "${LABEL_YAML_CMD[@]}" > "${MONITORING_TRACE_JAEGER_IN_MEM_YAML}"
 
 echo "All manifests generated"
 


### PR DESCRIPTION
# Proposed Changes

* Added deployment files for Jaeger using the jaeger-operator, with custom resources for an in-memory option and a production/elasticsearch option.
* Generating yaml files for the two configurations.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The release includes support for Jaeger as an alternative tracing backend solution.
```
