### PR TITLE
Generic sks helpers for pa

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/resources/doc.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resources contains methods for manipulating K8s resources
+// shared between different PA implementations.
+package resources

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/names/doc.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/names/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package names contains methods for manipulating K8s resources' names
+// shared between different PA implementations.
+package names

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/names/names.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package names contains name generating functions for the pod autoscalers.
 package names
 
-// SKSreturns the name of the SKS resource that backs this PA.
+// SKS returns the name of the SKS resource that backs this PA.
 func SKS(paName string) string {
 	return paName
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/names/names.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package names contains name generating functions for the pod autoscalers.
 package names
 
-// SKSName returns the name of the SKS resource that backs this PA.
-func SKSName(paName string) string {
+// SKSreturns the name of the SKS resource that backs this PA.
+func SKS(paName string) string {
 	return paName
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/names/names.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/names/names.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package names contains name generating functions for the pod autoscalers.
+package names
+
+// SKSName returns the name of the SKS resource that backs this PA.
+func SKSName(paName string) string {
+	return paName
+}

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/names/names_test.go
@@ -18,8 +18,8 @@ package names
 
 import "testing"
 
-func TestSKSName(t *testing.T) {
-	if got, want := SKSName("ristretto"), "ristretto"; got != want {
+func TestSKS(t *testing.T) {
+	if got, want := SKS("ristretto"), "ristretto"; got != want {
 		t.Errorf("SKSName = %q, want: %q", got, want)
 	}
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/names/names_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/names/names_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import "testing"
+
+func TestSKSName(t *testing.T) {
+	if got, want := SKSName("ristretto"), "ristretto"; got != want {
+		t.Errorf("SKSName = %q, want: %q", got, want)
+	}
+}

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/sks.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/sks.go
@@ -21,7 +21,7 @@ import (
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/names"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling/resources/names"
 	"github.com/knative/serving/pkg/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/sks.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/sks.go
@@ -30,7 +30,7 @@ import (
 func MakeSKS(pa *pav1alpha1.PodAutoscaler, selector map[string]string, mode nv1a1.ServerlessServiceOperationMode) *nv1a1.ServerlessService {
 	return &nv1a1.ServerlessService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.SKSName(pa.Name),
+			Name:      names.SKS(pa.Name),
 			Namespace: pa.Namespace,
 			Labels:    resources.CopyMap(pa.GetLabels()),
 			Annotations: resources.FilterMap(pa.GetAnnotations(), func(s string) bool {

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/sks.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/sks.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/names"
+	"github.com/knative/serving/pkg/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MakeSKS makes an SKS resource from the PA, selector and operation mode.
+func MakeSKS(pa *pav1alpha1.PodAutoscaler, selector map[string]string, mode nv1a1.ServerlessServiceOperationMode) *nv1a1.ServerlessService {
+	return &nv1a1.ServerlessService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.SKSName(pa.Name),
+			Namespace: pa.Namespace,
+			Labels:    resources.CopyMap(pa.GetLabels()),
+			Annotations: resources.FilterMap(pa.GetAnnotations(), func(s string) bool {
+				return s == autoscaling.MetricAnnotationKey
+
+			}),
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pa)},
+		},
+		Spec: nv1a1.ServerlessServiceSpec{
+			Selector:     selector,
+			Mode:         mode,
+			ProtocolType: pa.Spec.ProtocolType,
+		},
+	}
+}

--- a/pkg/reconciler/v1alpha1/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/resources/sks_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pav1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking"
+	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var boolTrue = true
+
+// MakeSKS makes an SKS resource from the PA, selector and operation mode.
+func TestMakeSKS(t *testing.T) {
+	pa := &pav1a1.PodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "here",
+			Name:      "with-you",
+			UID:       "2006",
+			// Those labels are propagated from the Revision->KPA.
+			Labels: map[string]string{
+				serving.RevisionLabelKey: "with-you",
+				serving.RevisionUID:      "2009",
+			},
+			Annotations: map[string]string{
+				"a": "b",
+			},
+		},
+		Spec: pav1a1.PodAutoscalerSpec{
+			ProtocolType: networking.ProtocolHTTP1,
+		},
+	}
+
+	selector := map[string]string{"cant": "stop"}
+	const mode = nv1a1.SKSOperationModeServe
+
+	want := &nv1a1.ServerlessService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "here",
+			Name:      "with-you",
+			// Those labels are propagated from the Revision->KPA.
+			Labels: map[string]string{
+				serving.RevisionLabelKey: "with-you",
+				serving.RevisionUID:      "2009",
+			},
+			Annotations: map[string]string{
+				"a": "b",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         pav1a1.SchemeGroupVersion.String(),
+				Kind:               "PodAutoscaler",
+				Name:               "with-you",
+				UID:                "2006",
+				Controller:         &boolTrue,
+				BlockOwnerDeletion: &boolTrue,
+			}},
+		},
+		Spec: nv1a1.ServerlessServiceSpec{
+			ProtocolType: networking.ProtocolHTTP1,
+			Mode:         nv1a1.SKSOperationModeServe,
+			Selector:     selector,
+		},
+	}
+	if got, want := MakeSKS(pa, selector, mode), want; !cmp.Equal(got, want) {
+		t.Errorf("MakeSKS = %#v, want: %#v, diff: %s", got, want, cmp.Diff(got, want))
+	}
+}


### PR DESCRIPTION
For #1997 
Add the helpers for the PA implementations to reconcile SKS resources: creation, naming, etc.
In future other shared things can go there.

/cc @mattmoor 