### PR TITLE
Add arbitrarily large timeout while cleaning up serving-tests namespace

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -239,5 +239,5 @@ function test_teardown() {
   ko delete --ignore-not-found=true --now -f test/config/
   echo ">> Removing test namespace"
   kubectl delete all --all --ignore-not-found --now --timeout 60s -n serving-tests
-  kubectl delete --ignore-not-found --now --timeout 600s namespace serving-tests
+  kubectl delete --ignore-not-found --now --timeout 60s namespace serving-tests
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -238,6 +238,6 @@ function test_teardown() {
   echo ">> Removing test resources (test/config/)"
   ko delete --ignore-not-found=true --now -f test/config/
   echo ">> Removing test namespace"
-  kubectl delete all --all --ignore-not-found --now -n serving-tests
-  kubectl delete --ignore-not-found --now namespace serving-tests
+  kubectl delete all --all --ignore-not-found --now --timeout 60s -n serving-tests
+  kubectl delete --ignore-not-found --now --timeout 600s namespace serving-tests
 }


### PR DESCRIPTION
upgrade tests sometimes hang during `kubectl delete namespace`, which could be unlocked by running `kubectl delete all` again in a separate process. 

By default `kubectl delete` determines timeout based on object size, which might leave resources not completely deleted, and makes `kubectl delete namespace` hang. This PR sets explicit timeout to help with deletion, as well as guard against hanging

Part of: https://github.com/knative/test-infra/issues/676
