### PR TITLE
[WIP] [PoC] Add a flag to allow ignoring build/build-pipeline tests.

### DIFF
--- a/test/e2e/build_pipeline_test.go
+++ b/test/e2e/build_pipeline_test.go
@@ -34,6 +34,9 @@ import (
 )
 
 func TestPipeline(t *testing.T) {
+	if test.ServingFlags.ServingOnly {
+		t.Skip()
+	}
 	t.Parallel()
 	pipelineName := test.ObjectNameForTest(t)
 

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -41,6 +41,9 @@ import (
 var buildCondSet = duckv1alpha1.NewBatchConditionSet()
 
 func TestBuildSpecAndServe(t *testing.T) {
+	if test.ServingFlags.ServingOnly {
+		t.Skip()
+	}
 	t.Parallel()
 	clients := Setup(t)
 
@@ -144,6 +147,9 @@ func TestBuildSpecAndServe(t *testing.T) {
 }
 
 func TestBuildAndServe(t *testing.T) {
+	if test.ServingFlags.ServingOnly {
+		t.Skip()
+	}
 	t.Parallel()
 	clients := Setup(t)
 	t.Log("Creating a new Route and Configuration with build")
@@ -262,6 +268,9 @@ func TestBuildAndServe(t *testing.T) {
 }
 
 func TestBuildFailure(t *testing.T) {
+	if test.ServingFlags.ServingOnly {
+		t.Skip()
+	}
 	t.Parallel()
 	clients := Setup(t)
 

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -40,6 +40,7 @@ var ServingFlags = initializeServingFlags()
 // ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
 type ServingEnvironmentFlags struct {
 	ResolvableDomain bool // Resolve Route controller's `domainSuffix`
+	ServingOnly      bool // Whether to skip tests that touch build and build pipeline.
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -47,6 +48,8 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
 		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
+	flag.BoolVar(&f.ServingOnly, "servingOnly", false,
+		"Set this flag to true if you only want to exclude that have dependencies on other knative/ projects like build.")
 
 	flag.Parse()
 	flag.Set("alsologtostderr", "true")


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Add a test flag to allow ignoring tests that depends on another `knative/` project like build or build pipeline.  I don't know if this would be the right way to do things, so mainly to poll your thoughts @adrcunha @srinivashegde86 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
