### PR TITLE
Use UpdateExporter instead of UpdateExporterFromConfigMap

### DIFF
--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -30,5 +30,11 @@ const (
 // UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
 // when a config map is updated
 func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
-	return metrics.UpdateExporterFromConfigMap(metricsDomain, component, logger)
+	return func(configMap *corev1.ConfigMap) {
+		metrics.UpdateExporter(metrics.ExporterOptions{
+			Domain:    metricsDomain,
+			Component: component,
+			ConfigMap: configMap.Data,
+		}, logger)
+	}
 }


### PR DESCRIPTION
`UpdateExporterFromConfigMap` from knative/pkg/metircs is deprecated.