### PR TITLE
Fix some log formats for SKS.

### DIFF
--- a/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice.go
@@ -218,7 +218,7 @@ func (r *reconciler) reconcilePublicService(ctx context.Context, sks *netv1alpha
 		return err
 	} else if !metav1.IsControlledBy(srv, sks) {
 		sks.Status.MarkEndpointsNotOwned("Service", sn)
-		return fmt.Errorf("SKS %q does not own Service %q", sks.Name, sn)
+		return fmt.Errorf("SKS: %q does not own Service: %q", sks.Name, sn)
 	} else {
 		tmpl := resources.MakePublicService(sks)
 		want := srv.DeepCopy()
@@ -269,7 +269,7 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 		return err
 	} else if !metav1.IsControlledBy(eps, sks) {
 		sks.Status.MarkEndpointsNotOwned("Endpoints", sn)
-		return fmt.Errorf("SKS %q does not own Endpoints %q", sks.Name, sn)
+		return fmt.Errorf("SKS: %q does not own Endpoints: %q", sks.Name, sn)
 	} else {
 		want := eps.DeepCopy()
 		want.Subsets = srcEps.Subsets
@@ -312,7 +312,7 @@ func (r *reconciler) reconcilePrivateService(ctx context.Context, sks *netv1alph
 		return err
 	} else if !metav1.IsControlledBy(svc, sks) {
 		sks.Status.MarkEndpointsNotOwned("Service", sn)
-		return fmt.Errorf("SKS %q does not own Service %q", sks.Name, sn)
+		return fmt.Errorf("SKS: %q does not own Service: %q", sks.Name, sn)
 	}
 	tmpl := resources.MakePrivateService(sks)
 	want := svc.DeepCopy()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Consistently use `%q` for entity names.
* Fixed lines around `presources.ReadyAddressCount` to actually work.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
