### PR TITLE
Change a few fields to pointers and use accessors to fetch them.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   revision = "babf400eeec07acdd0d6864ad28709c2bcee0c82"
 
 [[projects]]
-  digest = "1:82a94a97ff437f6e762c5f469a73806cd2c7ee5a841085e31b59fa1adffee6fd"
+  digest = "1:01aa33b0dc26e650a7a18c0d2f0437094dc81513b213598f0a7ebe698307d78b"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -473,6 +473,7 @@
     "logging/testing",
     "metrics",
     "metrics/metricskey",
+    "ptr",
     "signals",
     "system",
     "system/testing",
@@ -489,7 +490,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "9eb762fd55fe32d255a70091d669adc0d6c62a39"
+  revision = "dd77be3b9f3c45b4690e45a8bff8925e375442d3"
 
 [[projects]]
   branch = "master"
@@ -1337,6 +1338,7 @@
     "github.com/knative/pkg/logging/testing",
     "github.com/knative/pkg/metrics",
     "github.com/knative/pkg/metrics/metricskey",
+    "github.com/knative/pkg/ptr",
     "github.com/knative/pkg/signals",
     "github.com/knative/pkg/system",
     "github.com/knative/pkg/system/testing",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,8 +24,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-04-09
-  revision = "9eb762fd55fe32d255a70091d669adc0d6c62a39"
+  # HEAD as of 2019-04-10
+  revision = "dd77be3b9f3c45b4690e45a8bff8925e375442d3"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -45,12 +46,24 @@ func TestConfigurationDefaulting(t *testing.T) {
 	}{{
 		name: "empty",
 		in:   &Configuration{},
+		want: &Configuration{},
+	}, {
+		name: "shell",
+		in: &Configuration{
+			Spec: ConfigurationSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						Container: &corev1.Container{},
+					},
+				},
+			},
+		},
 		want: &Configuration{
 			Spec: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						TimeoutSeconds: config.DefaultRevisionTimeoutSeconds,
-						Container: corev1.Container{
+						TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+						Container: &corev1.Container{
 							Resources: defaultResources,
 						},
 					},
@@ -61,11 +74,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		name: "no overwrite values",
 		in: &Configuration{
 			Spec: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
 						ContainerConcurrency: 1,
-						TimeoutSeconds:       99,
-						Container: corev1.Container{
+						TimeoutSeconds:       ptr.Int64(99),
+						Container: &corev1.Container{
 							Resources: defaultResources,
 						},
 					},
@@ -74,11 +87,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		},
 		want: &Configuration{
 			Spec: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
 						ContainerConcurrency: 1,
-						TimeoutSeconds:       99,
-						Container: corev1.Container{
+						TimeoutSeconds:       ptr.Int64(99),
+						Container: &corev1.Container{
 							Resources: defaultResources,
 						},
 					},

--- a/pkg/apis/serving/v1alpha1/configuration_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/configuration_lifecycle.go
@@ -27,6 +27,17 @@ func (r *Configuration) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Configuration")
 }
 
+// GetTemplate returns a pointer to the relevant RevisionTemplateSpec field.
+// It is never nil and should be exactly the specified template as guaranteed
+// by validation.
+func (cs *ConfigurationSpec) GetTemplate() *RevisionTemplateSpec {
+	if cs.RevisionTemplate != nil {
+		return cs.RevisionTemplate
+	}
+	// Should be unreachable post-validation, but here to ease testing.
+	return &RevisionTemplateSpec{}
+}
+
 // IsReady looks at the conditions to see if they are happy.
 func (cs *ConfigurationStatus) IsReady() bool {
 	return confCondSet.Manage(cs).IsHappy()

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -79,7 +79,7 @@ type ConfigurationSpec struct {
 	// RevisionTemplate's BuildName field will be populated with the name of
 	// the Build object created to produce the container for the Revision.
 	// +optional
-	RevisionTemplate RevisionTemplateSpec `json:"revisionTemplate"`
+	RevisionTemplate *RevisionTemplateSpec `json:"revisionTemplate,omitempty"`
 }
 
 const (

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -38,6 +38,13 @@ func (cs *ConfigurationSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(cs, &ConfigurationSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
+	var templateField string
+	if cs.RevisionTemplate != nil {
+		templateField = "revisionTemplate"
+	} else {
+		return apis.ErrMissingField("revisionTemplate")
+	}
+
 	var errs *apis.FieldError
 	// TODO(mattmoor): Check ObjectMeta for Name/Namespace/GenerateName
 
@@ -51,5 +58,5 @@ func (cs *ConfigurationSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(apis.ErrInvalidValue(err, "build"))
 	}
 
-	return errs.Also(cs.RevisionTemplate.Validate(ctx).ViaField("revisionTemplate"))
+	return errs.Also(cs.GetTemplate().Validate(ctx).ViaField(templateField))
 }

--- a/pkg/apis/serving/v1alpha1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation_test.go
@@ -37,9 +37,9 @@ func TestConfigurationSpecValidation(t *testing.T) {
 	}{{
 		name: "valid",
 		c: &ConfigurationSpec{
-			RevisionTemplate: RevisionTemplateSpec{
+			RevisionTemplate: &RevisionTemplateSpec{
 				Spec: RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "hellworld",
 					},
 				},
@@ -49,9 +49,9 @@ func TestConfigurationSpecValidation(t *testing.T) {
 	}, {
 		name: "propagate revision failures",
 		c: &ConfigurationSpec{
-			RevisionTemplate: RevisionTemplateSpec{
+			RevisionTemplate: &RevisionTemplateSpec{
 				Spec: RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Name:  "stuart",
 						Image: "hellworld",
 					},
@@ -69,9 +69,9 @@ func TestConfigurationSpecValidation(t *testing.T) {
 					}},
 				},
 			},
-			RevisionTemplate: RevisionTemplateSpec{
+			RevisionTemplate: &RevisionTemplateSpec{
 				Spec: RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "hellworld",
 					},
 				},
@@ -94,9 +94,9 @@ func TestConfigurationSpecValidation(t *testing.T) {
 					},
 				},
 			},
-			RevisionTemplate: RevisionTemplateSpec{
+			RevisionTemplate: &RevisionTemplateSpec{
 				Spec: RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "hellworld",
 					},
 				},
@@ -115,9 +115,9 @@ func TestConfigurationSpecValidation(t *testing.T) {
 					},
 				},
 			},
-			RevisionTemplate: RevisionTemplateSpec{
+			RevisionTemplate: &RevisionTemplateSpec{
 				Spec: RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "hellworld",
 					},
 				},
@@ -130,9 +130,9 @@ func TestConfigurationSpecValidation(t *testing.T) {
 			Build: &RawExtension{
 				Raw: []byte(`"foo"`),
 			},
-			RevisionTemplate: RevisionTemplateSpec{
+			RevisionTemplate: &RevisionTemplateSpec{
 				Spec: RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "hellworld",
 					},
 				},
@@ -163,9 +163,9 @@ func TestConfigurationValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "hellworld",
 						},
 					},
@@ -180,9 +180,9 @@ func TestConfigurationValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Name:  "stuart",
 							Image: "hellworld",
 						},

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -37,18 +37,20 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 		rs.ContainerConcurrency = 1
 	}
 
-	if rs.TimeoutSeconds == 0 {
-		rs.TimeoutSeconds = cfg.Defaults.RevisionTimeoutSeconds
+	if rs.TimeoutSeconds == nil {
+		ts := cfg.Defaults.RevisionTimeoutSeconds
+		rs.TimeoutSeconds = &ts
 	}
 
-	if rs.Container.Resources.Requests == nil {
-		rs.Container.Resources.Requests = corev1.ResourceList{}
+	c := rs.GetContainer()
+	if c.Resources.Requests == nil {
+		c.Resources.Requests = corev1.ResourceList{}
 	}
-	if _, ok := rs.Container.Resources.Requests[corev1.ResourceCPU]; !ok {
-		rs.Container.Resources.Requests[corev1.ResourceCPU] = cfg.Defaults.RevisionCPURequest
+	if _, ok := c.Resources.Requests[corev1.ResourceCPU]; !ok {
+		c.Resources.Requests[corev1.ResourceCPU] = cfg.Defaults.RevisionCPURequest
 	}
 
-	vms := rs.Container.VolumeMounts
+	vms := c.VolumeMounts
 	for i := range vms {
 		vms[i].ReadOnly = true
 	}

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -80,6 +80,17 @@ func (r *Revision) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Revision")
 }
 
+// GetContainer returns a pointer to the relevant corev1.Container field.
+// It is never nil and should be exactly the specified container as guaranteed
+// by validation.
+func (rs *RevisionSpec) GetContainer() *corev1.Container {
+	if rs.Container != nil {
+		return rs.Container
+	}
+	// Should be unreachable post-validation, but here to ease testing.
+	return &corev1.Container{}
+}
+
 func (r *Revision) BuildRef() *corev1.ObjectReference {
 	if r.Spec.BuildRef != nil {
 		buildRef := r.Spec.BuildRef.DeepCopy()
@@ -103,7 +114,7 @@ func (r *Revision) BuildRef() *corev1.ObjectReference {
 
 // GetProtocol returns the app level network protocol.
 func (r *Revision) GetProtocol() net.ProtocolType {
-	ports := r.Spec.Container.Ports
+	ports := r.Spec.GetContainer().Ports
 	if len(ports) > 0 && ports[0].Name == string(net.ProtocolH2C) {
 		return net.ProtocolH2C
 	}

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
@@ -622,37 +622,35 @@ func TestRevisionGetProtocol(t *testing.T) {
 		name      string
 		container corev1.Container
 		protocol  net.ProtocolType
-	}{
-		{
-			name:      "undefined",
-			container: corev1.Container{},
-			protocol:  net.ProtocolHTTP1,
-		},
-		{
-			name:      "http1",
-			container: containerWithPortName("http1"),
-			protocol:  net.ProtocolHTTP1,
-		},
-		{
-			name:      "h2c",
-			container: containerWithPortName("h2c"),
-			protocol:  net.ProtocolH2C,
-		},
-		{
-			name:      "unknown",
-			container: containerWithPortName("whatever"),
-			protocol:  net.ProtocolHTTP1,
-		},
-		{
-			name:      "empty",
-			container: containerWithPortName(""),
-			protocol:  net.ProtocolHTTP1,
-		},
-	}
+	}{{
+		name:      "undefined",
+		container: corev1.Container{},
+		protocol:  net.ProtocolHTTP1,
+	}, {
+		name:      "http1",
+		container: containerWithPortName("http1"),
+		protocol:  net.ProtocolHTTP1,
+	}, {
+		name:      "h2c",
+		container: containerWithPortName("h2c"),
+		protocol:  net.ProtocolH2C,
+	}, {
+		name:      "unknown",
+		container: containerWithPortName("whatever"),
+		protocol:  net.ProtocolHTTP1,
+	}, {
+		name:      "empty",
+		container: containerWithPortName(""),
+		protocol:  net.ProtocolHTTP1,
+	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &Revision{Spec: RevisionSpec{Container: tt.container}}
+			r := &Revision{
+				Spec: RevisionSpec{
+					Container: &tt.container,
+				},
+			}
 
 			got := r.GetProtocol()
 			want := tt.protocol

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -174,16 +174,17 @@ type RevisionSpec struct {
 	// environment:
 	// https://github.com/knative/serving/blob/master/docs/runtime-contract.md
 	// +optional
-	Container corev1.Container `json:"container,omitempty"`
+	Container *corev1.Container `json:"container,omitempty"`
 
 	// Volumes defines a set of Kubernetes volumes to be mounted into the
 	// specified Container.  Currently only ConfigMap and Secret volumes are
 	// supported.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
-	// TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
+	// TimeoutSeconds holds the max duration the instance is allowed for
+	// responding to a request.
 	// +optional
-	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 const (

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -103,7 +103,12 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 		volumes.Insert(volume.Name)
 	}
 
-	errs = errs.Also(validateContainer(rs.Container, volumes).ViaField("container"))
+	if rs.Container != nil {
+		errs = errs.Also(validateContainer(*rs.Container, volumes).
+			ViaField("container"))
+	} else {
+		return apis.ErrMissingField("container")
+	}
 	errs = errs.Also(validateBuildRef(rs.BuildRef).ViaField("buildRef"))
 
 	if err := rs.DeprecatedConcurrencyModel.Validate(ctx).ViaField("concurrencyModel"); err != nil {
@@ -113,7 +118,10 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 			rs.ContainerConcurrency, rs.DeprecatedConcurrencyModel))
 	}
 
-	return errs.Also(validateTimeoutSeconds(rs.TimeoutSeconds))
+	if rs.TimeoutSeconds != nil {
+		errs = errs.Also(validateTimeoutSeconds(*rs.TimeoutSeconds))
+	}
+	return errs
 }
 
 func validateTimeoutSeconds(timeoutSeconds int64) *apis.FieldError {

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	net "github.com/knative/serving/pkg/apis/networking"
 	corev1 "k8s.io/api/core/v1"
@@ -659,7 +660,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}{{
 		name: "valid",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 			},
 			DeprecatedConcurrencyModel: "Multi",
@@ -668,7 +669,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "with volume (ok)",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 				VolumeMounts: []corev1.VolumeMount{{
 					MountPath: "/mount/path",
@@ -690,7 +691,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "with volume name collision",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 				VolumeMounts: []corev1.VolumeMount{{
 					MountPath: "/mount/path",
@@ -720,7 +721,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "has bad build ref",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 			},
 			BuildRef: &corev1.ObjectReference{},
@@ -729,7 +730,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "bad concurrency model",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 			},
 			DeprecatedConcurrencyModel: "bogus",
@@ -738,7 +739,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "bad container spec",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Name:  "steve",
 				Image: "helloworld",
 			},
@@ -747,10 +748,10 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "exceed max timeout",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 			},
-			TimeoutSeconds: 6000,
+			TimeoutSeconds: ptr.Int64(6000),
 		},
 		want: apis.ErrOutOfBoundsValue(6000, 0,
 			net.DefaultTimeout.Seconds(),
@@ -758,10 +759,10 @@ func TestRevisionSpecValidation(t *testing.T) {
 	}, {
 		name: "negative timeout",
 		rs: &RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "helloworld",
 			},
-			TimeoutSeconds: -30,
+			TimeoutSeconds: ptr.Int64(-30),
 		},
 		want: apis.ErrOutOfBoundsValue(-30, 0,
 			net.DefaultTimeout.Seconds(),
@@ -787,7 +788,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		name: "valid",
 		rts: &RevisionTemplateSpec{
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -802,7 +803,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		name: "nested spec error",
 		rts: &RevisionTemplateSpec{
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Name:  "kevin",
 					Image: "helloworld",
 				},
@@ -817,7 +818,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -848,7 +849,7 @@ func TestRevisionValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -870,7 +871,7 @@ func TestRevisionValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Name:  "kevin",
 					Image: "helloworld",
 				},
@@ -885,7 +886,7 @@ func TestRevisionValidation(t *testing.T) {
 				Name: "a" + strings.Repeat(".", 62) + "a",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -906,7 +907,7 @@ func TestRevisionValidation(t *testing.T) {
 				},
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -941,7 +942,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -952,7 +953,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -966,7 +967,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -982,7 +983,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -1008,7 +1009,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -1019,7 +1020,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -1040,7 +1041,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -1051,7 +1052,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Single",
@@ -1072,7 +1073,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -1083,7 +1084,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 			},
@@ -1103,7 +1104,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "helloworld",
 				},
 				DeprecatedConcurrencyModel: "Multi",
@@ -1114,7 +1115,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 				DeprecatedConcurrencyModel: "Single",

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/knative/serving/pkg/apis/config"
@@ -53,17 +54,25 @@ func TestServiceDefaulting(t *testing.T) {
 		name: "run latest",
 		in: &Service{
 			Spec: ServiceSpec{
-				RunLatest: &RunLatestType{},
+				RunLatest: &RunLatestType{
+					Configuration: ConfigurationSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
+							Spec: RevisionSpec{
+								Container: &corev1.Container{},
+							},
+						},
+					},
+				},
 			},
 		},
 		want: &Service{
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: config.DefaultRevisionTimeoutSeconds,
-								Container: corev1.Container{
+								TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+								Container: &corev1.Container{
 									Resources: defaultResources,
 								},
 							},
@@ -78,10 +87,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       config.DefaultRevisionTimeoutSeconds,
+								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+								Container:  &corev1.Container{},
 							},
 						},
 					},
@@ -92,11 +102,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       config.DefaultRevisionTimeoutSeconds,
-								Container: corev1.Container{
+								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+								Container: &corev1.Container{
 									Resources: defaultResources,
 								},
 							},
@@ -109,17 +119,25 @@ func TestServiceDefaulting(t *testing.T) {
 		name: "pinned",
 		in: &Service{
 			Spec: ServiceSpec{
-				DeprecatedPinned: &PinnedType{},
+				DeprecatedPinned: &PinnedType{
+					Configuration: ConfigurationSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
+							Spec: RevisionSpec{
+								Container: &corev1.Container{},
+							},
+						},
+					},
+				},
 			},
 		},
 		want: &Service{
 			Spec: ServiceSpec{
 				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: config.DefaultRevisionTimeoutSeconds,
-								Container: corev1.Container{
+								TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+								Container: &corev1.Container{
 									Resources: defaultResources,
 								},
 							},
@@ -134,10 +152,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       99,
+								TimeoutSeconds:       ptr.Int64(99),
+								Container:  &corev1.Container{},
 							},
 						},
 					},
@@ -148,11 +167,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       99,
-								Container: corev1.Container{
+								TimeoutSeconds:       ptr.Int64(99),
+								Container: &corev1.Container{
 									Resources: defaultResources,
 								},
 							},
@@ -165,17 +184,25 @@ func TestServiceDefaulting(t *testing.T) {
 		name: "release",
 		in: &Service{
 			Spec: ServiceSpec{
-				Release: &ReleaseType{},
+				Release: &ReleaseType{
+					Configuration: ConfigurationSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
+							Spec: RevisionSpec{
+								Container: &corev1.Container{},
+							},
+						},
+					},
+				},
 			},
 		},
 		want: &Service{
 			Spec: ServiceSpec{
 				Release: &ReleaseType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								TimeoutSeconds: config.DefaultRevisionTimeoutSeconds,
-								Container: corev1.Container{
+								TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+								Container: &corev1.Container{
 									Resources: defaultResources,
 								},
 							},
@@ -190,10 +217,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				Release: &ReleaseType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       99,
+								TimeoutSeconds:       ptr.Int64(99),
+								Container:  &corev1.Container{},
 							},
 						},
 					},
@@ -204,11 +232,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				Release: &ReleaseType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
-								TimeoutSeconds:       99,
-								Container: corev1.Container{
+								TimeoutSeconds:       ptr.Int64(99),
+								Container: &corev1.Container{
 									Resources: defaultResources,
 								},
 							},

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -44,9 +44,9 @@ func TestServiceValidation(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -66,9 +66,9 @@ func TestServiceValidation(t *testing.T) {
 				DeprecatedPinned: &PinnedType{
 					RevisionName: "asdf",
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -88,9 +88,9 @@ func TestServiceValidation(t *testing.T) {
 				Release: &ReleaseType{
 					Revisions: []string{"asdf"},
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -111,9 +111,9 @@ func TestServiceValidation(t *testing.T) {
 					Revisions:      []string{"asdf", "fdsa"},
 					RolloutPercent: 42,
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -143,9 +143,9 @@ func TestServiceValidation(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -155,9 +155,9 @@ func TestServiceValidation(t *testing.T) {
 				DeprecatedPinned: &PinnedType{
 					RevisionName: "asdf",
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -190,9 +190,9 @@ func TestServiceValidation(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Name:  "foo",
 									Image: "hellworld",
 								},
@@ -213,9 +213,9 @@ func TestServiceValidation(t *testing.T) {
 				DeprecatedPinned: &PinnedType{
 					RevisionName: "asdf",
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Name:  "foo",
 									Image: "hellworld",
 								},
@@ -235,9 +235,9 @@ func TestServiceValidation(t *testing.T) {
 			Spec: ServiceSpec{
 				Release: &ReleaseType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -257,9 +257,9 @@ func TestServiceValidation(t *testing.T) {
 				Release: &ReleaseType{
 					Revisions: []string{strings.Repeat("a", 64)},
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -279,9 +279,9 @@ func TestServiceValidation(t *testing.T) {
 				Release: &ReleaseType{
 					Revisions: []string{".negative"},
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -301,9 +301,9 @@ func TestServiceValidation(t *testing.T) {
 				Release: &ReleaseType{
 					Revisions: []string{"s-1-00001", ReleaseLatestRevisionKeyword},
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -323,9 +323,9 @@ func TestServiceValidation(t *testing.T) {
 				Release: &ReleaseType{
 					Revisions: []string{},
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -345,9 +345,9 @@ func TestServiceValidation(t *testing.T) {
 				Release: &ReleaseType{
 					Revisions: []string{"asdf", "fdsa", "abcde"},
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -368,9 +368,9 @@ func TestServiceValidation(t *testing.T) {
 					Revisions:      []string{"asdf", "fdsa"},
 					RolloutPercent: 100,
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -391,9 +391,9 @@ func TestServiceValidation(t *testing.T) {
 					Revisions:      []string{"asdf", "fdsa"},
 					RolloutPercent: -50,
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -414,9 +414,9 @@ func TestServiceValidation(t *testing.T) {
 					Revisions:      []string{"asdf"},
 					RolloutPercent: 10,
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -435,9 +435,9 @@ func TestServiceValidation(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -459,9 +459,9 @@ func TestServiceValidation(t *testing.T) {
 			Spec: ServiceSpec{
 				RunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
-						RevisionTemplate: RevisionTemplateSpec{
+						RevisionTemplate: &RevisionTemplateSpec{
 							Spec: RevisionSpec{
-								Container: corev1.Container{
+								Container: &corev1.Container{
 									Image: "hellworld",
 								},
 							},
@@ -495,9 +495,9 @@ func TestRunLatestTypeValidation(t *testing.T) {
 		name: "valid",
 		rlt: &RunLatestType{
 			Configuration: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "hellworld",
 						},
 					},
@@ -509,9 +509,9 @@ func TestRunLatestTypeValidation(t *testing.T) {
 		name: "propagate revision failures",
 		rlt: &RunLatestType{
 			Configuration: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Name:  "stuart",
 							Image: "hellworld",
 						},
@@ -542,9 +542,9 @@ func TestPinnedTypeValidation(t *testing.T) {
 		pt: &PinnedType{
 			RevisionName: "foo",
 			Configuration: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "hellworld",
 						},
 					},
@@ -556,9 +556,9 @@ func TestPinnedTypeValidation(t *testing.T) {
 		name: "missing revision name",
 		pt: &PinnedType{
 			Configuration: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "hellworld",
 						},
 					},
@@ -571,9 +571,9 @@ func TestPinnedTypeValidation(t *testing.T) {
 		pt: &PinnedType{
 			RevisionName: "foo",
 			Configuration: ConfigurationSpec{
-				RevisionTemplate: RevisionTemplateSpec{
+				RevisionTemplate: &RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Name:  "stuart",
 							Image: "hellworld",
 						},

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -96,7 +96,11 @@ func (in *ConfigurationSpec) DeepCopyInto(out *ConfigurationSpec) {
 		*out = new(RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	in.RevisionTemplate.DeepCopyInto(&out.RevisionTemplate)
+	if in.RevisionTemplate != nil {
+		in, out := &in.RevisionTemplate, &out.RevisionTemplate
+		*out = new(RevisionTemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -297,13 +301,22 @@ func (in *RevisionSpec) DeepCopyInto(out *RevisionSpec) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
-	in.Container.DeepCopyInto(&out.Container)
+	if in.Container != nil {
+		in, out := &in.Container, &out.Container
+		*out = new(v1.Container)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.TimeoutSeconds != nil {
+		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -991,7 +991,7 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image:      "gcr.io/repo/image",
 				Command:    []string{"echo"},
 				Args:       []string{"hello", "world"},

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -25,6 +25,7 @@ import (
 	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/gc"
@@ -42,10 +43,10 @@ import (
 )
 
 var revisionSpec = v1alpha1.RevisionSpec{
-	Container: corev1.Container{
+	Container: &corev1.Container{
 		Image: "busybox",
 	},
-	TimeoutSeconds: 60,
+	TimeoutSeconds: ptr.Int64(60),
 }
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
@@ -532,7 +533,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			DeprecatedGeneration: generation,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 				Spec: revisionSpec,
 			},
 		},

--- a/pkg/reconciler/v1alpha1/configuration/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/queueing_test.go
@@ -62,13 +62,13 @@ func getTestConfiguration() *v1alpha1.Configuration {
 		Spec: v1alpha1.ConfigurationSpec{
 			// TODO(grantr): This is a workaround for generation initialization
 			DeprecatedGeneration: 1,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					ServiceAccountName: "test-account",
 					// corev1.Container has a lot of setting.  We try to pass many
 					// of them here to verify that we pass through the settings to
 					// the derived Revisions.
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image:      "gcr.io/repo/image",
 						Command:    []string{"echo"},
 						Args:       []string{"hello", "world"},

--- a/pkg/reconciler/v1alpha1/configuration/resources/build_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/build_test.go
@@ -41,9 +41,9 @@ func TestBuilds(t *testing.T) {
 				Name:      "build",
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -64,9 +64,9 @@ func TestBuilds(t *testing.T) {
 						Image: "busybox",
 					}},
 				}},
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -130,9 +130,9 @@ func TestBuilds(t *testing.T) {
 							}},
 						},
 					}},
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -187,9 +187,9 @@ func TestBuilds(t *testing.T) {
 						}},
 					},
 				}},
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision.go
@@ -29,8 +29,8 @@ import (
 func MakeRevision(config *v1alpha1.Configuration, buildRef *corev1.ObjectReference) *v1alpha1.Revision {
 	// Start from the ObjectMeta/Spec inlined in the Configuration resources.
 	rev := &v1alpha1.Revision{
-		ObjectMeta: config.Spec.RevisionTemplate.ObjectMeta,
-		Spec:       config.Spec.RevisionTemplate.Spec,
+		ObjectMeta: config.Spec.GetTemplate().ObjectMeta,
+		Spec:       config.Spec.GetTemplate().Spec,
 	}
 	// Populate the Namespace and Name.
 	rev.Namespace = config.Namespace

--- a/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/resources/revision_test.go
@@ -42,9 +42,9 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 10,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -71,7 +71,7 @@ func TestMakeRevisions(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 			},
@@ -90,9 +90,9 @@ func TestMakeRevisions(t *testing.T) {
 						Image: "busybox",
 					}},
 				}},
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -129,7 +129,7 @@ func TestMakeRevisions(t *testing.T) {
 					Kind:       "Build",
 					Name:       "build-00099",
 				},
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 			},
@@ -143,7 +143,7 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"foo": "bar",
@@ -151,7 +151,7 @@ func TestMakeRevisions(t *testing.T) {
 						},
 					},
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -180,7 +180,7 @@ func TestMakeRevisions(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 			},
@@ -194,7 +194,7 @@ func TestMakeRevisions(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: v1alpha1.ConfigurationSpec{
-				RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+				RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"foo": "bar",
@@ -202,7 +202,7 @@ func TestMakeRevisions(t *testing.T) {
 						},
 					},
 					Spec: v1alpha1.RevisionSpec{
-						Container: corev1.Container{
+						Container: &corev1.Container{
 							Image: "busybox",
 						},
 					},
@@ -232,7 +232,7 @@ func TestMakeRevisions(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 			},

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/configmap"
 	ctrl "github.com/knative/pkg/controller"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/pkg/system"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -87,7 +88,7 @@ func getTestRevision() *v1alpha1.Revision {
 			// corev1.Container has a lot of setting.  We try to pass many
 			// of them here to verify that we pass through the settings to
 			// derived objects.
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image:      "gcr.io/repo/image",
 				Command:    []string{"echo"},
 				Args:       []string{"hello", "world"},
@@ -110,7 +111,7 @@ func getTestRevision() *v1alpha1.Revision {
 				TerminationMessagePath: "/dev/null",
 			},
 			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
-			TimeoutSeconds:             60,
+			TimeoutSeconds:             ptr.Int64(60),
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/deploy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -212,10 +213,10 @@ var (
 			},
 		},
 		Spec: v1alpha1.RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "busybox",
 			},
-			TimeoutSeconds: 45,
+			TimeoutSeconds: ptr.Int64(45),
 		},
 	}
 )
@@ -368,7 +369,7 @@ func TestMakePodSpec(t *testing.T) {
 		rev: revision(
 			withContainerConcurrency(1),
 			func(revision *v1alpha1.Revision) {
-				revision.Spec.Container.Ports = []corev1.ContainerPort{{
+				revision.Spec.GetContainer().Ports = []corev1.ContainerPort{{
 					ContainerPort: 8888,
 				}}
 			},
@@ -394,10 +395,10 @@ func TestMakePodSpec(t *testing.T) {
 		rev: revision(
 			withContainerConcurrency(1),
 			func(revision *v1alpha1.Revision) {
-				revision.Spec.Container.Ports = []corev1.ContainerPort{{
+				revision.Spec.GetContainer().Ports = []corev1.ContainerPort{{
 					ContainerPort: 8888,
 				}}
-				revision.Spec.Container.VolumeMounts = []corev1.VolumeMount{{
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
 					Name:      "asdf",
 					MountPath: "/asdf",
 				}}
@@ -493,7 +494,7 @@ func TestMakePodSpec(t *testing.T) {
 	}, {
 		name: "simple concurrency=multi http readiness probe",
 		rev: revision(func(revision *v1alpha1.Revision) {
-			container(&revision.Spec.Container,
+			container(revision.Spec.GetContainer(),
 				withHTTPReadinessProbe(v1alpha1.DefaultUserPort),
 			)
 		}),
@@ -512,7 +513,7 @@ func TestMakePodSpec(t *testing.T) {
 	}, {
 		name: "concurrency=multi, readinessprobe=shell",
 		rev: revision(func(revision *v1alpha1.Revision) {
-			container(&revision.Spec.Container,
+			container(revision.Spec.GetContainer(),
 				withExecReadinessProbe(
 					[]string{"echo", "hello"},
 				),
@@ -535,7 +536,7 @@ func TestMakePodSpec(t *testing.T) {
 	}, {
 		name: "concurrency=multi, readinessprobe=http",
 		rev: revision(func(revision *v1alpha1.Revision) {
-			container(&revision.Spec.Container,
+			container(revision.Spec.GetContainer(),
 				withReadinessProbe(corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
@@ -558,7 +559,7 @@ func TestMakePodSpec(t *testing.T) {
 	}, {
 		name: "concurrency=multi, livenessprobe=tcp",
 		rev: revision(func(revision *v1alpha1.Revision) {
-			container(&revision.Spec.Container,
+			container(revision.Spec.GetContainer(),
 				withLivenessProbe(corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{},
 				}),
@@ -617,13 +618,13 @@ func TestMakePodSpec(t *testing.T) {
 			withContainerConcurrency(1),
 			func(revision *v1alpha1.Revision) {
 				revision.ObjectMeta.Labels = map[string]string{}
-				revision.Spec.Container.Command = []string{"/bin/bash"}
-				revision.Spec.Container.Args = []string{"-c", "echo Hello world"}
-				container(&revision.Spec.Container,
+				revision.Spec.GetContainer().Command = []string{"/bin/bash"}
+				revision.Spec.GetContainer().Args = []string{"-c", "echo Hello world"}
+				container(revision.Spec.GetContainer(),
 					withEnvVar("FOO", "bar"),
 					withEnvVar("BAZ", "blah"),
 				)
-				revision.Spec.Container.Resources = corev1.ResourceRequirements{
+				revision.Spec.GetContainer().Resources = corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("666Mi"),
 						corev1.ResourceCPU:    resource.MustParse("666m"),
@@ -633,7 +634,7 @@ func TestMakePodSpec(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("888m"),
 					},
 				}
-				revision.Spec.Container.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+				revision.Spec.GetContainer().TerminationMessagePolicy = corev1.TerminationMessageReadFile
 			},
 		),
 		lc: &logging.Config{},

--- a/pkg/reconciler/v1alpha1/revision/resources/imagecache.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/imagecache.go
@@ -31,7 +31,7 @@ import (
 func MakeImageCache(rev *v1alpha1.Revision) *caching.Image {
 	image := rev.Status.ImageDigest
 	if image == "" {
-		image = rev.Spec.Container.Image
+		image = rev.Spec.GetContainer().Image
 	}
 
 	img := &caching.Image{

--- a/pkg/reconciler/v1alpha1/revision/resources/imagecache_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/imagecache_test.go
@@ -47,7 +47,7 @@ func TestMakeImageCache(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 			},
@@ -91,7 +91,7 @@ func TestMakeImageCache(t *testing.T) {
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
 				ServiceAccountName:   "privilegeless",
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image: "busybox",
 				},
 			},

--- a/pkg/reconciler/v1alpha1/revision/resources/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/kpa_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -95,8 +95,8 @@ func TestMakeKPA(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				Container: v1.Container{
-					Ports: []v1.ContainerPort{{
+				Container: &corev1.Container{
+					Ports: []corev1.ContainerPort{{
 						Name:     "h2c",
 						HostPort: int32(443),
 					}},

--- a/pkg/reconciler/v1alpha1/revision/resources/queue.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue.go
@@ -86,6 +86,11 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 		loggingLevel = ll.String()
 	}
 
+	ts := int64(0)
+	if rev.Spec.TimeoutSeconds != nil {
+		ts = *rev.Spec.TimeoutSeconds
+	}
+
 	return &corev1.Container{
 		Name:           QueueContainerName,
 		Image:          controllerConfig.QueueSidecarImage,
@@ -115,7 +120,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 			Value: strconv.Itoa(int(rev.Spec.ContainerConcurrency)),
 		}, {
 			Name:  "REVISION_TIMEOUT_SECONDS",
-			Value: strconv.Itoa(int(rev.Spec.TimeoutSeconds)),
+			Value: strconv.Itoa(int(ts)),
 		}, {
 			Name: "SERVING_POD",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/queue_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -57,7 +58,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -139,7 +140,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -227,7 +228,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 1,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -318,7 +319,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -400,7 +401,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{
@@ -487,7 +488,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 10,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -569,7 +570,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -651,7 +652,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			},
 			Spec: v1alpha1.RevisionSpec{
 				ContainerConcurrency: 0,
-				TimeoutSeconds:       45,
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},

--- a/pkg/reconciler/v1alpha1/revision/resources/service_test.go
+++ b/pkg/reconciler/v1alpha1/revision/resources/service_test.go
@@ -89,7 +89,7 @@ func TestMakeK8sService(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Ports: []corev1.ContainerPort{
 						{Name: "h2c"},
 					},

--- a/pkg/reconciler/v1alpha1/revision/revision.go
+++ b/pkg/reconciler/v1alpha1/revision/revision.go
@@ -314,9 +314,12 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 		// ImagePullSecrets: Not possible via RevisionSpec, since we
 		// don't expose such a field.
 	}
-	digest, err := c.resolver.Resolve(rev.Spec.Container.Image, opt, cfgs.Controller.RegistriesSkippingTagResolving)
+	digest, err := c.resolver.Resolve(rev.Spec.GetContainer().Image,
+		opt, cfgs.Controller.RegistriesSkippingTagResolving)
 	if err != nil {
-		rev.Status.MarkContainerMissing(v1alpha1.RevisionContainerMissingMessage(rev.Spec.Container.Image, err.Error()))
+		rev.Status.MarkContainerMissing(
+			v1alpha1.RevisionContainerMissingMessage(
+				rev.Spec.GetContainer().Image, err.Error()))
 		return err
 	}
 

--- a/pkg/reconciler/v1alpha1/revision/revision_test.go
+++ b/pkg/reconciler/v1alpha1/revision/revision_test.go
@@ -346,10 +346,11 @@ func TestResolutionFailed(t *testing.T) {
 	for _, ct := range []apis.ConditionType{"ContainerHealthy", "Ready"} {
 		got := rev.Status.GetCondition(ct)
 		want := &apis.Condition{
-			Type:               ct,
-			Status:             corev1.ConditionFalse,
-			Reason:             "ContainerMissing",
-			Message:            v1alpha1.RevisionContainerMissingMessage(rev.Spec.Container.Image, errorMessage),
+			Type:   ct,
+			Status: corev1.ConditionFalse,
+			Reason: "ContainerMissing",
+			Message: v1alpha1.RevisionContainerMissingMessage(
+				rev.Spec.GetContainer().Image, errorMessage),
 			LastTransitionTime: got.LastTransitionTime,
 			Severity:           apis.ConditionSeverityError,
 		}

--- a/pkg/reconciler/v1alpha1/revision/table_test.go
+++ b/pkg/reconciler/v1alpha1/revision/table_test.go
@@ -962,7 +962,9 @@ func rev(namespace, name string, ro ...RevisionOption) *v1alpha1.Revision {
 			UID:       "test-uid",
 		},
 		Spec: v1alpha1.RevisionSpec{
-			Container: corev1.Container{Image: "busybox"},
+			Container: &corev1.Container{
+				Image: "busybox",
+			},
 		},
 	}
 

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -87,7 +87,7 @@ func getTestRevisionWithCondition(name string, cond apis.Condition) *v1alpha1.Re
 			Namespace: testNamespace,
 		},
 		Spec: v1alpha1.RevisionSpec{
-			Container: corev1.Container{
+			Container: &corev1.Container{
 				Image: "test-image",
 			},
 		},
@@ -110,9 +110,9 @@ func getTestConfiguration() *v1alpha1.Configuration {
 		Spec: v1alpha1.ConfigurationSpec{
 			// This is a workaround for generation initialization
 			DeprecatedGeneration: 1,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "test-image",
 					},
 				},
@@ -131,7 +131,7 @@ func getTestRevisionForConfig(config *v1alpha1.Configuration) *v1alpha1.Revision
 				serving.ConfigurationLabelKey: config.Name,
 			},
 		},
-		Spec: *config.Spec.RevisionTemplate.Spec.DeepCopy(),
+		Spec: *config.Spec.GetTemplate().Spec.DeepCopy(),
 		Status: v1alpha1.RevisionStatus{
 			ServiceName: "p-deadbeef-service",
 		},

--- a/pkg/reconciler/v1alpha1/route/table_test.go
+++ b/pkg/reconciler/v1alpha1/route/table_test.go
@@ -1515,9 +1515,9 @@ func cfg(namespace, name string, co ...ConfigOption) *v1alpha1.Configuration {
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			DeprecatedGeneration: 1,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "busybox",
 					},
 				},

--- a/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
+++ b/pkg/reconciler/v1alpha1/route/traffic/traffic_test.go
@@ -1148,9 +1148,9 @@ func testConfig(name string) *v1alpha1.Configuration {
 		Spec: v1alpha1.ConfigurationSpec{
 			// This is a workaround for generation initialization.
 			DeprecatedGeneration: 1,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: "test-image",
 					},
 				},
@@ -1168,7 +1168,7 @@ func testRevForConfig(config *v1alpha1.Configuration, name string) *v1alpha1.Rev
 				serving.ConfigurationLabelKey: config.Name,
 			},
 		},
-		Spec: *config.Spec.RevisionTemplate.Spec.DeepCopy(),
+		Spec: *config.Spec.GetTemplate().Spec.DeepCopy(),
 	}
 }
 
@@ -1241,7 +1241,7 @@ func getTestReadyConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revisio
 	})
 
 	// rev1 will use http1, rev2 will use h2c
-	config.Spec.RevisionTemplate.Spec.Container.Ports = []corev1.ContainerPort{{
+	config.Spec.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 		Name: "h2c",
 	}}
 

--- a/pkg/reconciler/v1alpha1/service/resources/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/service/resources/configuration_test.go
@@ -31,7 +31,7 @@ func TestRunLatest(t *testing.T) {
 	if got, want := c.Namespace, testServiceNamespace; got != want {
 		t.Errorf("expected %q for service namespace got %q", want, got)
 	}
-	if got, want := c.Spec.RevisionTemplate.Spec.Container.Name, testContainerNameRunLatest; got != want {
+	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNameRunLatest; got != want {
 		t.Errorf("expected %q for container name got %q", want, got)
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
@@ -56,7 +56,7 @@ func TestPinned(t *testing.T) {
 	if got, want := c.Namespace, testServiceNamespace; got != want {
 		t.Errorf("expected %q for service namespace got %q", want, got)
 	}
-	if got, want := c.Spec.RevisionTemplate.Spec.Container.Name, testContainerNamePinned; got != want {
+	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNamePinned; got != want {
 		t.Errorf("expected %q for container name got %q", want, got)
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
@@ -81,7 +81,7 @@ func TestRelease(t *testing.T) {
 	if got, want := c.Namespace, testServiceNamespace; got != want {
 		t.Errorf("expected %q for service namespace got %q", want, got)
 	}
-	if got, want := c.Spec.RevisionTemplate.Spec.Container.Name, testContainerNameRelease; got != want {
+	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNameRelease; got != want {
 		t.Errorf("expected %q for container name got %q", want, got)
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)

--- a/pkg/reconciler/v1alpha1/service/resources/shared_test.go
+++ b/pkg/reconciler/v1alpha1/service/resources/shared_test.go
@@ -62,9 +62,9 @@ func expectOwnerReferencesSetCorrectly(t *testing.T, ownerRefs []metav1.OwnerRef
 
 func createConfiguration(containerName string) v1alpha1.ConfigurationSpec {
 	return v1alpha1.ConfigurationSpec{
-		RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+		RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 			Spec: v1alpha1.RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Name: containerName,
 				},
 			},

--- a/test/configuration.go
+++ b/test/configuration.go
@@ -50,7 +50,7 @@ func CreateConfiguration(t *testing.T, clients *Clients, names ResourceNames, op
 // PatchConfigImage patches the existing config passed in with a new imagePath. Returns the latest Configuration object
 func PatchConfigImage(clients *Clients, cfg *v1alpha1.Configuration, imagePath string) (*v1alpha1.Configuration, error) {
 	newCfg := cfg.DeepCopy()
-	newCfg.Spec.RevisionTemplate.Spec.Container.Image = imagePath
+	newCfg.Spec.GetTemplate().Spec.GetContainer().Image = imagePath
 	patchBytes, err := createPatch(cfg, newCfg)
 	if err != nil {
 		return nil, err

--- a/test/conformance/container_test.go
+++ b/test/conformance/container_test.go
@@ -40,7 +40,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}{{
 		name: "TestArbitraryPortName",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Ports = []corev1.ContainerPort{{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 				Name:          "arbitrary",
 				ContainerPort: 8080,
 			}}
@@ -49,7 +49,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		name: "TestMountPropagation",
 		options: func(s *v1alpha1.Service) {
 			propagationMode := corev1.MountPropagationHostToContainer
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.VolumeMounts = []corev1.VolumeMount{{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
 				Name:             "VolumeMount",
 				MountPath:        "/",
 				MountPropagation: &propagationMode,
@@ -58,7 +58,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestReadinessHTTPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe = &corev1.Probe{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
@@ -70,7 +70,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestLivenessHTTPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe = &corev1.Probe{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
@@ -82,7 +82,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestReadinessTCPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe = &corev1.Probe{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8888)},
 				},
@@ -91,7 +91,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestLivenessTCPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe = &corev1.Probe{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8888)},
 				},
@@ -129,7 +129,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
 			}
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Lifecycle = &corev1.Lifecycle{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Lifecycle = &corev1.Lifecycle{
 				PostStart: &corev1.Handler{Exec: lifecycleHandler},
 			}
 		},
@@ -139,14 +139,14 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the pre stop handler > /usr/share/message"},
 			}
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Lifecycle = &corev1.Lifecycle{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Lifecycle = &corev1.Lifecycle{
 				PreStop: &corev1.Handler{Exec: lifecycleHandler},
 			}
 		},
 	}, {
 		name: "TestMultiplePorts",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Ports = []corev1.ContainerPort{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{
 				{ContainerPort: 80},
 				{ContainerPort: 81},
 			}
@@ -154,7 +154,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestHostPort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Ports = []corev1.ContainerPort{{
+			s.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 				ContainerPort: 8081,
 				HostPort:      80,
 			}}

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -289,7 +289,7 @@ func TestRunLatestService(t *testing.T) {
 	// Update container with user port.
 	t.Logf("Updating the port of the user container for service %s to %d", names.Service, userPort)
 	desiredSvc := objects.Service.DeepCopy()
-	desiredSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Ports = []corev1.ContainerPort{{
+	desiredSvc.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 		ContainerPort: userPort,
 	}}
 	if objects.Service, err = test.PatchService(t, clients, objects.Service, desiredSvc); err != nil {

--- a/test/crd.go
+++ b/test/crd.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/knative/pkg/ptr"
 	ptest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/helpers"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -117,9 +118,9 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 	}
 
 	spec := &v1alpha1.ConfigurationSpec{
-		RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+		RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 			Spec: v1alpha1.RevisionSpec{
-				Container: corev1.Container{
+				Container: &corev1.Container{
 					Image:           imagePath,
 					Resources:       options.ContainerResources,
 					ReadinessProbe:  options.ReadinessProbe,
@@ -132,11 +133,11 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 	}
 
 	if options.RevisionTimeoutSeconds > 0 {
-		spec.RevisionTemplate.Spec.TimeoutSeconds = options.RevisionTimeoutSeconds
+		spec.GetTemplate().Spec.TimeoutSeconds = ptr.Int64(options.RevisionTimeoutSeconds)
 	}
 
 	if options.EnvVars != nil {
-		spec.RevisionTemplate.Spec.Container.Env = options.EnvVars
+		spec.GetTemplate().Spec.GetContainer().Env = options.EnvVars
 	}
 
 	return spec
@@ -153,7 +154,7 @@ func Configuration(namespace string, names ResourceNames, options *Options, fopt
 		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image), options),
 	}
 	if options.ContainerPorts != nil && len(options.ContainerPorts) > 0 {
-		config.Spec.RevisionTemplate.Spec.Container.Ports = options.ContainerPorts
+		config.Spec.GetTemplate().Spec.GetContainer().Ports = options.ContainerPorts
 	}
 
 	for _, opt := range fopt {
@@ -174,9 +175,9 @@ func ConfigurationWithBuild(namespace string, names ResourceNames, build *v1alph
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			Build: build,
-			RevisionTemplate: v1alpha1.RevisionTemplateSpec{
+			RevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
-					Container: corev1.Container{
+					Container: &corev1.Container{
 						Image: ptest.ImagePath(names.Image),
 					},
 				},

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -55,8 +55,8 @@ func TestActivatorOverload(t *testing.T) {
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
 	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}, func(service *v1alpha1.Service) {
-		service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.ContainerConcurrency = 1
-		service.Spec.RunLatest.Configuration.RevisionTemplate.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
+		service.Spec.RunLatest.Configuration.GetTemplate().Spec.ContainerConcurrency = 1
+		service.Spec.RunLatest.Configuration.GetTemplate().Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 	})
 	if err != nil {
 		t.Fatalf("Unable to create resources: %v", err)

--- a/test/service.go
+++ b/test/service.go
@@ -223,11 +223,11 @@ func PatchManualService(t *testing.T, clients *Clients, svc *v1alpha1.Service) (
 func PatchServiceImage(t *testing.T, clients *Clients, svc *v1alpha1.Service, imagePath string) (*v1alpha1.Service, error) {
 	newSvc := svc.DeepCopy()
 	if svc.Spec.RunLatest != nil {
-		newSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
+		newSvc.Spec.RunLatest.Configuration.GetTemplate().Spec.GetContainer().Image = imagePath
 	} else if svc.Spec.Release != nil {
-		newSvc.Spec.Release.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
+		newSvc.Spec.Release.Configuration.GetTemplate().Spec.GetContainer().Image = imagePath
 	} else if svc.Spec.DeprecatedPinned != nil {
-		newSvc.Spec.DeprecatedPinned.Configuration.RevisionTemplate.Spec.Container.Image = imagePath
+		newSvc.Spec.DeprecatedPinned.Configuration.GetTemplate().Spec.GetContainer().Image = imagePath
 	} else {
 		return nil, fmt.Errorf("UpdateImageService(%v): unable to determine service type", svc)
 	}
@@ -253,11 +253,11 @@ func PatchService(t *testing.T, clients *Clients, curSvc *v1alpha1.Service, desi
 func PatchServiceRevisionTemplateMetadata(t *testing.T, clients *Clients, svc *v1alpha1.Service, metadata metav1.ObjectMeta) (*v1alpha1.Service, error) {
 	newSvc := svc.DeepCopy()
 	if svc.Spec.RunLatest != nil {
-		newSvc.Spec.RunLatest.Configuration.RevisionTemplate.ObjectMeta = metadata
+		newSvc.Spec.RunLatest.Configuration.GetTemplate().ObjectMeta = metadata
 	} else if svc.Spec.Release != nil {
-		newSvc.Spec.Release.Configuration.RevisionTemplate.ObjectMeta = metadata
+		newSvc.Spec.Release.Configuration.GetTemplate().ObjectMeta = metadata
 	} else if svc.Spec.DeprecatedPinned != nil {
-		newSvc.Spec.DeprecatedPinned.Configuration.RevisionTemplate.ObjectMeta = metadata
+		newSvc.Spec.DeprecatedPinned.Configuration.GetTemplate().ObjectMeta = metadata
 	} else {
 		return nil, fmt.Errorf("UpdateServiceRevisionTemplateMetadata(%v): unable to determine service type", svc)
 	}

--- a/vendor/github.com/knative/pkg/ptr/doc.go
+++ b/vendor/github.com/knative/pkg/ptr/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,14 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
-
-import "context"
-
-func (c *Configuration) SetDefaults(ctx context.Context) {
-	c.Spec.SetDefaults(ctx)
-}
-
-func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
-	cs.GetTemplate().Spec.SetDefaults(ctx)
-}
+// Package ptr holds utilities for taking pointer references to values.
+package ptr

--- a/vendor/github.com/knative/pkg/ptr/ptr.go
+++ b/vendor/github.com/knative/pkg/ptr/ptr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,14 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package ptr
 
-import "context"
-
-func (c *Configuration) SetDefaults(ctx context.Context) {
-	c.Spec.SetDefaults(ctx)
+// Int64 is a helper for turning integers into pointers for use in
+// API types that want *int64.
+func Int64(i int64) *int64 {
+	return &i
 }
 
-func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
-	cs.GetTemplate().Spec.SetDefaults(ctx)
+// Bool is a helper for turning bools into pointers for use in
+// API types that want *bool.
+func Bool(b bool) *bool {
+	return &b
 }

--- a/vendor/github.com/knative/pkg/test/clients.go
+++ b/vendor/github.com/knative/pkg/test/clients.go
@@ -95,9 +95,9 @@ func (client *KubeClient) CreatePod(pod *corev1.Pod) (*corev1.Pod, error) {
 	return pods.Create(pod)
 }
 
-// PodLogs returns Pod logs for given Pod and Container
-func (client *KubeClient) PodLogs(podName, containerName string) ([]byte, error) {
-	pods := client.Kube.CoreV1().Pods(Flags.Namespace)
+// PodLogs returns Pod logs for given Pod and Container in the namespace
+func (client *KubeClient) PodLogs(podName, containerName, namespace string) ([]byte, error) {
+	pods := client.Kube.CoreV1().Pods(namespace)
 	podList, err := pods.List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -89,9 +89,9 @@ func DeploymentScaledToZeroFunc() func(d *appsv1.Deployment) (bool, error) {
 
 // WaitForLogContent waits until logs for given Pod/Container include the given content.
 // If the content is not present within timeout it returns error.
-func WaitForLogContent(client *KubeClient, podName, containerName, content string) error {
+func WaitForLogContent(client *KubeClient, podName, containerName, namespace, content string) error {
 	return wait.PollImmediate(interval, logTimeout, func() (bool, error) {
-		logs, err := client.PodLogs(podName, containerName)
+		logs, err := client.PodLogs(podName, containerName, namespace)
 		if err != nil {
 			return true, err
 		}

--- a/vendor/github.com/knative/pkg/test/spoof/error_checks.go
+++ b/vendor/github.com/knative/pkg/test/spoof/error_checks.go
@@ -20,7 +20,6 @@ package spoof
 
 import (
 	"net"
-	"net/url"
 	"strings"
 )
 
@@ -30,14 +29,15 @@ func isTCPTimeout(e error) bool {
 }
 
 func isDNSError(err error) bool {
-	if err, ok := err.(*url.Error); err != nil && ok {
-		if err, ok := err.Err.(*net.OpError); err != nil && ok {
-			if err, ok := err.Err.(*net.DNSError); err != nil && ok {
-				return true
-			}
-		}
+	if err == nil {
+		return false
 	}
-	return false
+	// Checking by casting to url.Error and casting the nested error
+	// seems to be not as robust as string check.
+	msg := strings.ToLower(err.Error())
+	// Example error message:
+	//   > Get http://this.url.does.not.exist: dial tcp: lookup this.url.does.not.exist on 127.0.0.1:53: no such host
+	return strings.Contains(msg, "no such host") || strings.Contains(msg, ":53")
 }
 
 func isTCPConnectRefuse(err error) bool {


### PR DESCRIPTION
This change abstracts how we access the `corev1.Container` within `RevisionSpec` and the `RevisionTemplateSpec` within `ConfigurationSpec`, now both are accessed through getters `GetContainer()` and `GetTemplate()` respectively.  This is in preparation for the "lemonade" proposal to introduce the v1beta1 api in parallel to the v1alpha1 API, but is itself harmless (even if we don't go that way).

This also makes `TimeoutSeconds` a pointer, so we can distinguish not-specified from `0`.

I made this change by renaming the two fields (and then reverting it) to make sure I got everything.

/hold

Holding for now, but feedback appreciated.