### PR TITLE
Fix Istio ClusterIngress controller to use filtered global resync.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   revision = "babf400eeec07acdd0d6864ad28709c2bcee0c82"
 
 [[projects]]
-  digest = "1:01aa33b0dc26e650a7a18c0d2f0437094dc81513b213598f0a7ebe698307d78b"
+  digest = "1:52a75d98bad8b65086883c86e7b617dc2ae425d70a9f950138d40807976f8338"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -490,7 +490,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "dd77be3b9f3c45b4690e45a8bff8925e375442d3"
+  revision = "590eb946f1d3492e3e8d9a60850a6d5c7f85be36"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@ required = [
 [[override]]
   name = "github.com/knative/pkg"
   # HEAD as of 2019-04-10
-  revision = "dd77be3b9f3c45b4690e45a8bff8925e375442d3"
+  revision = "590eb946f1d3492e3e8d9a60850a6d5c7f85be36"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/vendor/github.com/knative/pkg/ptr/ptr.go
+++ b/vendor/github.com/knative/pkg/ptr/ptr.go
@@ -27,3 +27,9 @@ func Int64(i int64) *int64 {
 func Bool(b bool) *bool {
 	return &b
 }
+
+// String is a helper for turning strings into pointers for use in
+// API types that want *string.
+func String(s string) *string {
+	return &s
+}

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -104,12 +104,29 @@ func WaitForAllPodsRunning(client *KubeClient, namespace string) error {
 	return WaitForPodListState(client, PodsRunning, "PodsAreRunning", namespace)
 }
 
+// WaitForPodRunning waits for the given pod to be in running state
+func WaitForPodRunning(client *KubeClient, name string, namespace string) error {
+	p := client.Kube.CoreV1().Pods(namespace)
+	return wait.PollImmediate(interval, podTimeout, func() (bool, error) {
+		p, err := p.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		return PodRunning(p), nil
+	})
+}
+
 // PodsRunning will check the status conditions of the pod list and return true all pods are Running
 func PodsRunning(podList *corev1.PodList) (bool, error) {
 	for _, pod := range podList.Items {
-		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodSucceeded {
+		if isRunning := PodRunning(&pod); !isRunning {
 			return false, nil
 		}
 	}
 	return true, nil
+}
+
+// PodRunning will check the status conditions of the pod and return true if it's Running
+func PodRunning(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Fix Istio-based ClusterIngress controller to filtered global resync to avoid reconciling ClusterIngress having other classes.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix Istio-based ClusterIngress controller to filtered global resync to avoid reconciling ClusterIngress having other classes
```
