### PR TITLE
Fix the misleading comment in the table.go

### DIFF
--- a/pkg/reconciler/testing/actions.go
+++ b/pkg/reconciler/testing/actions.go
@@ -22,6 +22,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 )
 
+// Actions stores list of Actions recorded by the reactors.
 type Actions struct {
 	Creates           []clientgotesting.CreateAction
 	Updates           []clientgotesting.UpdateAction
@@ -30,12 +31,16 @@ type Actions struct {
 	Patches           []clientgotesting.PatchAction
 }
 
+// ActionRecorder contains list of K8s request actions.
 type ActionRecorder interface {
 	Actions() []clientgotesting.Action
 }
 
+// ActionRecorderList is a list of ActionRecorder objects.
 type ActionRecorderList []ActionRecorder
 
+// ActionsByVerb fills in Actions objects, sorting the actions
+// by verb.
 func (l ActionRecorderList) ActionsByVerb() (Actions, error) {
 	var a Actions
 
@@ -57,13 +62,11 @@ func (l ActionRecorderList) ActionsByVerb() (Actions, error) {
 			case "patch":
 				a.Patches = append(a.Patches,
 					action.(clientgotesting.PatchAction))
-			case "list": // avoid 'unexpected verb list' error
-			case "watch": // avoid 'unexpected verb watch' error
+			case "list", "watch": // avoid 'unexpected verb list/watch' error
 			default:
 				return a, fmt.Errorf("unexpected verb %v: %+v", action.GetVerb(), action)
 			}
 		}
 	}
-
 	return a, nil
 }

--- a/pkg/reconciler/testing/table.go
+++ b/pkg/reconciler/testing/table.go
@@ -50,26 +50,26 @@ type TableRow struct {
 	// WantErr holds whether we should expect the reconciliation to result in an error.
 	WantErr bool
 
-	// WantCreates holds the set of Create calls we expect during reconciliation.
+	// WantCreates holds the ordered list of Create calls we expect during reconciliation.
 	WantCreates []metav1.Object
 
-	// WantUpdates holds the set of Update calls we expect during reconciliation.
+	// WantUpdates holds the ordered list of Update calls we expect during reconciliation.
 	WantUpdates []clientgotesting.UpdateActionImpl
 
-	// WantStatusUpdates holds the set of Update calls, with `status` subresource set,
+	// WantStatusUpdates holds the ordered list of Update calls, with `status` subresource set,
 	// that we expect during reconciliation.
 	WantStatusUpdates []clientgotesting.UpdateActionImpl
 
-	// WantDeletes holds the set of Delete calls we expect during reconciliation.
+	// WantDeletes holds the ordered list of Delete calls we expect during reconciliation.
 	WantDeletes []clientgotesting.DeleteActionImpl
 
-	// WantDeleteCollections holds the set of DeleteCollection calls we expect during reconciliation.
+	// WantDeleteCollections holds the ordered list of DeleteCollection calls we expect during reconciliation.
 	WantDeleteCollections []clientgotesting.DeleteCollectionActionImpl
 
-	// WantPatches holds the set of Patch calls we expect during reconciliation.
+	// WantPatches holds the ordered list of Patch calls we expect during reconciliation.
 	WantPatches []clientgotesting.PatchActionImpl
 
-	// WantEvents holds the set of events we expect during reconciliation.
+	// WantEvents holds the ordered list of events we expect during reconciliation.
 	WantEvents []string
 
 	// WantServiceReadyStats holds the ServiceReady stats we exepect during reconciliation.


### PR DESCRIPTION
The comment says the objects are "Sets" but they are cetainly not.
In fact they are ordered lists and matched index by index with
the actual create/update/delete/etc objects encountered during the
reconciliation (FWIW, the order is actually backwards).

I can be open to fix this later to actually work like a set, since
currently say we expect A B C to be updated, but the updates were A B D
C, we'll report D as a mismatch and then an unexpected update of C,
while in reality the only mismatch is action D.


/lint

/cc @markusthoemmes @mattmoor 
