### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -122,7 +122,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			Spec: RevisionSpec{
 				ContainerConcurrency: 1,
 				TimeoutSeconds:       ptr.Int64(99),
-				Container:  &corev1.Container{},
+				Container:            &corev1.Container{},
 			},
 		},
 		want: &Revision{
@@ -139,7 +139,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		in: &Revision{
 			Spec: RevisionSpec{
 				ContainerConcurrency: 123,
-				Container:  &corev1.Container{},
+				Container:            &corev1.Container{},
 			},
 		},
 		want: &Revision{
@@ -157,7 +157,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			Spec: RevisionSpec{
 				DeprecatedConcurrencyModel: "Single",
 				ContainerConcurrency:       0, // unspecified
-				Container:        &corev1.Container{},
+				Container:                  &corev1.Container{},
 			},
 		},
 		want: &Revision{

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -91,7 +91,7 @@ func TestServiceDefaulting(t *testing.T) {
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
-								Container:  &corev1.Container{},
+								Container:            &corev1.Container{},
 							},
 						},
 					},
@@ -156,7 +156,7 @@ func TestServiceDefaulting(t *testing.T) {
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
 								TimeoutSeconds:       ptr.Int64(99),
-								Container:  &corev1.Container{},
+								Container:            &corev1.Container{},
 							},
 						},
 					},
@@ -221,7 +221,7 @@ func TestServiceDefaulting(t *testing.T) {
 							Spec: RevisionSpec{
 								ContainerConcurrency: 1,
 								TimeoutSeconds:       ptr.Int64(99),
-								Container:  &corev1.Container{},
+								Container:            &corev1.Container{},
 							},
 						},
 					},


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
