### PR TITLE
Check for deprecated fields when in contexts that disallow them.

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -47,8 +47,9 @@ func (cs *ConfigurationSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField("revisionTemplate")
 	}
 
-	var errs *apis.FieldError
-	// TODO(mattmoor): Check ObjectMeta for Name/Namespace/GenerateName
+	errs := CheckDeprecated(ctx, map[string]interface{}{
+		"generation": cs.DeprecatedGeneration,
+	})
 
 	if cs.Build == nil {
 		// No build was specified.

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -87,8 +87,14 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 
+	errs := CheckDeprecated(ctx, map[string]interface{}{
+		"generation":       rs.DeprecatedGeneration,
+		"servingState":     rs.DeprecatedServingState,
+		"concurrencyModel": rs.DeprecatedConcurrencyModel,
+		"buildName":        rs.DeprecatedBuildName,
+	})
+
 	volumes := sets.NewString()
-	var errs *apis.FieldError
 	for i, volume := range rs.Volumes {
 		if volumes.Has(volume.Name) {
 			errs = errs.Also((&apis.FieldError{

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -37,10 +37,13 @@ func (rs *RouteSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 
+	errs := CheckDeprecated(ctx, map[string]interface{}{
+		"generation": rs.DeprecatedGeneration,
+	})
+
 	// Track the targets of named TrafficTarget entries (to detect duplicates).
 	trafficMap := make(map[string]int)
 
-	var errs *apis.FieldError
 	percentSum := 0
 	for i, tt := range rs.Traffic {
 		errs = errs.Also(tt.Validate(ctx).ViaFieldIndex("traffic", i))

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -33,6 +34,22 @@ func (s *Service) Validate(ctx context.Context) *apis.FieldError {
 	return errs
 }
 
+// CheckDeprecated checks whether the provided named deprecated fields
+// are set in a context where deprecation is disallowed.
+func CheckDeprecated(ctx context.Context, fields map[string]interface{}) *apis.FieldError {
+	if apis.IsDeprecatedAllowed(ctx) {
+		return nil
+	}
+	var errs *apis.FieldError
+	for name, field := range fields {
+		// From: https://stackoverflow.com/questions/13901819/quick-way-to-detect-empty-values-via-reflection-in-go
+		if !reflect.DeepEqual(field, reflect.Zero(reflect.TypeOf(field)).Interface()) {
+			errs = errs.Also(apis.ErrDisallowedFields(name))
+		}
+	}
+	return errs
+}
+
 // Validate validates the fields belonging to ServiceSpec recursively
 func (ss *ServiceSpec) Validate(ctx context.Context) *apis.FieldError {
 	// We would do this semantic DeepEqual, but the spec is comprised
@@ -42,7 +59,11 @@ func (ss *ServiceSpec) Validate(ctx context.Context) *apis.FieldError {
 	// 	return apis.ErrMissingField(currentField)
 	// }
 
-	var errs *apis.FieldError
+	errs := CheckDeprecated(ctx, map[string]interface{}{
+		"generation": ss.DeprecatedGeneration,
+		"pinned":     ss.DeprecatedPinned,
+	})
+
 	set := []string{}
 
 	if ss.RunLatest != nil {


### PR DESCRIPTION
This will be more useful as we start to introduce `v1beta1` concepts,
but the intention of this is to avoid `v1alpha1` stuff bleeding into
contexts that are ostensibly `v1beta1`, e.g.

```
apiVersion: serving.knative.dev/v1alpha1
kind: Service
metadata: ...
spec:
  runLatest:
    configuration:
      revisionTemplate:
        spec:
          # This is fine here.
          container: ...
```

vs.

```
apiVersion: serving.knative.dev/v1alpha1
kind: Service
metadata: ...
spec:
  template:
    spec:
      # This is NOT fine here (in the context of "template:" or the
      # inline ConfigurationSpec)
      container: ...
```

This will ensure that as folks opt into the v1beta1 subset that they
do not inadvertently regress.

WIP until https://github.com/knative/serving/pull/3736 lands.