### PR TITLE
Drop the ConcurrencyModel fields from PodAutoscaler.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/knative/serving/pkg/apis/autoscaling"
-	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
 func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
@@ -45,10 +44,4 @@ func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
 	}
 }
 
-func (rs *PodAutoscalerSpec) SetDefaults(ctx context.Context) {
-	// When ConcurrencyModel is specified but ContainerConcurrency
-	// is not (0), use the ConcurrencyModel value.
-	if rs.ConcurrencyModel == servingv1alpha1.RevisionRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {
-		rs.ContainerConcurrency = 1
-	}
-}
+func (rs *PodAutoscalerSpec) SetDefaults(ctx context.Context) {}

--- a/pkg/apis/autoscaling/v1alpha1/pa_defaults_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_defaults_test.go
@@ -79,26 +79,6 @@ func TestPodAutoscalerDefaulting(t *testing.T) {
 			},
 		},
 	}, {
-		name: "fall back to concurrency model",
-		in: &PodAutoscaler{
-			Spec: PodAutoscalerSpec{
-				ConcurrencyModel:     "Single",
-				ContainerConcurrency: 0, // unspecified
-			},
-		},
-		want: &PodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					autoscaling.ClassAnnotationKey:  autoscaling.KPA,
-					autoscaling.MetricAnnotationKey: autoscaling.Concurrency,
-				},
-			},
-			Spec: PodAutoscalerSpec{
-				ConcurrencyModel:     "Single",
-				ContainerConcurrency: 1,
-			},
-		},
-	}, {
 		name: "hpa class is not overwritten and defaults to cpu",
 		in: &PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -70,11 +70,9 @@ type PodAutoscalerSpec struct {
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
-	// ConcurrencyModel specifies the desired concurrency model
-	// (Single or Multi) for the scale target. Defaults to Multi.
-	// Deprecated in favor of ContainerConcurrency.
+	// DeprecatedConcurrencyModel no longer does anything, use ContainerConcurrency.
 	// +optional
-	ConcurrencyModel servingv1alpha1.RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
+	DeprecatedConcurrencyModel servingv1alpha1.RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
 
 	// ContainerConcurrency specifies the maximum allowed
 	// in-flight (concurrent) requests per container of the Revision.

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -79,9 +79,9 @@ func (rs *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 	if rs.ServiceName == "" {
 		errs = errs.Also(apis.ErrMissingField("serviceName"))
 	}
-	if err := rs.ConcurrencyModel.Validate(ctx); err != nil {
-		errs = errs.Also(err.ViaField("concurrencyModel"))
-	} else if err := servingv1alpha1.ValidateContainerConcurrency(rs.ContainerConcurrency, rs.ConcurrencyModel); err != nil {
+
+	if err := servingv1alpha1.ValidateContainerConcurrency(
+		rs.ContainerConcurrency, ""); err != nil {
 		errs = errs.Also(err)
 	}
 	return errs.Also(validateSKSFields(rs))

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -99,18 +99,6 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		},
 		want: apis.ErrMissingField("serviceName"),
 	}, {
-		name: "bad concurrency model",
-		rs: &PodAutoscalerSpec{
-			ConcurrencyModel: "bogus",
-			ServiceName:      "foo",
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-				Name:       "bar",
-			},
-		},
-		want: apis.ErrInvalidValue("bogus", "concurrencyModel"),
-	}, {
 		name: "bad container concurrency",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: -1,
@@ -123,31 +111,17 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		},
 		want: apis.ErrInvalidValue(-1, "containerConcurrency"),
 	}, {
-		name: "bad concurrency model and container concurrency combination",
+		name: "multi invalid, bad concurrency and missing ref kind",
 		rs: &PodAutoscalerSpec{
-			ConcurrencyModel:     "Single",
-			ContainerConcurrency: 0,
+			ContainerConcurrency: -2,
 			ServiceName:          "foo",
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-				Name:       "bar",
-			},
-		},
-		want: apis.ErrMultipleOneOf("containerConcurrency", "concurrencyModel"),
-	}, {
-		name: "multi invalid, bad concurrency model and missing ref kind",
-		rs: &PodAutoscalerSpec{
-			ContainerConcurrency: -0,
-			ServiceName:          "foo",
-			ConcurrencyModel:     "super-bogus",
 			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
 				Name:       "bar",
 			},
 		},
-		want: apis.ErrMissingField("scaleTargetRef.kind").
-			Also(apis.ErrInvalidValue("super-bogus", "concurrencyModel")),
+		want: apis.ErrInvalidValue(-2, "containerConcurrency").Also(
+			apis.ErrMissingField("scaleTargetRef.kind")),
 	}}
 
 	for _, test := range tests {
@@ -175,8 +149,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -196,8 +169,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -216,8 +188,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -237,8 +208,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -265,8 +235,8 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "BadValue",
-				ServiceName:      "foo",
+				ContainerConcurrency: -1,
+				ServiceName:          "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -274,7 +244,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("BadValue", "spec.concurrencyModel"),
+		want: apis.ErrInvalidValue(-1, "spec.containerConcurrency"),
 	}}
 
 	for _, test := range tests {
@@ -300,8 +270,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -314,8 +283,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -331,8 +299,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -346,8 +313,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -363,8 +329,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -377,8 +342,8 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Single",
-				ServiceName:      "foo",
+				ContainerConcurrency: 1,
+				ServiceName:          "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -389,9 +354,9 @@ func TestImmutableFields(t *testing.T) {
 		want: &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},
-			Details: `{v1alpha1.PodAutoscalerSpec}.ConcurrencyModel:
-	-: v1alpha1.RevisionRequestConcurrencyModelType("Single")
-	+: v1alpha1.RevisionRequestConcurrencyModelType("Multi")
+			Details: `{v1alpha1.PodAutoscalerSpec}.ContainerConcurrency:
+	-: v1alpha1.RevisionContainerConcurrencyType(1)
+	+: v1alpha1.RevisionContainerConcurrencyType(0)
 `,
 		},
 	}, {
@@ -439,8 +404,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Multi",
-				ServiceName:      "foo",
+				ServiceName: "foo",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -453,8 +417,8 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ConcurrencyModel: "Single",
-				ServiceName:      "food",
+				ContainerConcurrency: 1,
+				ServiceName:          "food",
 				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
@@ -465,9 +429,9 @@ func TestImmutableFields(t *testing.T) {
 		want: &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},
-			Details: `{v1alpha1.PodAutoscalerSpec}.ConcurrencyModel:
-	-: v1alpha1.RevisionRequestConcurrencyModelType("Single")
-	+: v1alpha1.RevisionRequestConcurrencyModelType("Multi")
+			Details: `{v1alpha1.PodAutoscalerSpec}.ContainerConcurrency:
+	-: v1alpha1.RevisionContainerConcurrencyType(1)
+	+: v1alpha1.RevisionContainerConcurrencyType(0)
 {v1alpha1.PodAutoscalerSpec}.ScaleTargetRef.Name:
 	-: "baz"
 	+: "bar"


### PR DESCRIPTION
As far as I can tell this has virtually always been deprecated since its
inception, and the one place that creates these also updates them (Victor
added this in 0.5 to backfill fields we need to expand its responsibilities).

We also have validation that not both fields are specified, but default
from one field to the other (guaranteeing both are set).

At a minimum as of 0.5 there should be zero instances of this field.
