### PR TITLE
Egress traffic e2e test

### DIFF
--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -51,7 +51,10 @@ func TestEgressTraffic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}
-	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, service.Route.Status.Domain)
+	if service.Route.Status.URL == nil {
+		t.Fatalf("Can't get internal request domain: service.Route.Status.URL is nil")
+	}
+	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, service.Route.Status.URL.Host)
 	if err != nil {
 		t.Fatalf("Failed to send request to httpproxy: %v", err)
 	}

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/knative/serving/test"
+	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -47,13 +48,14 @@ func TestEgressTraffic(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	service, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{EnvVars: envVars})
+	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{EnvVars: envVars})
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}
 	if service.Route.Status.URL == nil {
 		t.Fatalf("Can't get internal request domain: service.Route.Status.URL is nil")
 	}
+	t.Log(service.Route.Status.URL.Host)
 	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, service.Route.Status.URL.Host)
 	if err != nil {
 		t.Fatalf("Failed to send request to httpproxy: %v", err)

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -1,3 +1,21 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -38,6 +38,6 @@ func TestEgressTraffic(t *testing.T) {
 		t.Fatalf("Failed to send request to httpproxy: %v", err)
 	}
 	if got, want := response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("httpbin response StatusCode = %v, want %v", got, want)
+		t.Fatalf("%v response StatusCode = %v, want %v", targetHostDomain, got, want)
 	}
 }

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/knative/serving/test"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	targetHostEnvName = "TARGET_HOST"
+	targetHostDomain  = "www.google.com"
+)
+
+func TestEgressTraffic(t *testing.T) {
+	t.Parallel()
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "httpproxy",
+	}
+	envVars := []corev1.EnvVar{{
+		Name:  targetHostEnvName,
+		Value: targetHostDomain,
+	}}
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+
+	service, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{EnvVars: envVars})
+	if err != nil {
+		t.Fatalf("Failed to create a service: %v", err)
+	}
+	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, service.Route.Status.Domain)
+	if err != nil {
+		t.Fatalf("Failed to send request to httpproxy: %v", err)
+	}
+	if got, want := response.StatusCode, http.StatusOK; got != want {
+		t.Errorf("httpbin response StatusCode = %v, want %v", got, want)
+	}
+}

--- a/third_party/istio-1.1.3/download-istio.sh
+++ b/third_party/istio-1.1.3/download-istio.sh
@@ -28,6 +28,8 @@ helm template --namespace=istio-system \
   --set gateways.istio-ingressgateway.enabled=false \
   --set gateways.istio-egressgateway.enabled=false \
   --set gateways.istio-ilbgateway.enabled=false \
+  --set global.outboundTrafficPolicy.mode=ALLOW_ANY \
+  --set pilot.env.PILOT_ENABLE_FALLTHROUGH_ROUTE=1 \
   install/kubernetes/helm/istio \
   -f install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml \
   | sed -e "s/custom-gateway/cluster-local-gateway/g" -e "s/customgateway/clusterlocalgateway/g" \
@@ -92,6 +94,9 @@ helm template --namespace=istio-system \
   --set gateways.istio-ingressgateway.sds.enabled=true \
   `# Set pilot trace sampling to 100%` \
   --set pilot.traceSampling=100 \
+  `# Enable egress traffic.` \
+  --set global.outboundTrafficPolicy.mode=ALLOW_ANY \
+  --set pilot.env.PILOT_ENABLE_FALLTHROUGH_ROUTE=1 \
   install/kubernetes/helm/istio \
   `# Removing trailing whitespaces to make automation happy` \
   | sed 's/[ \t]*$//' \

--- a/third_party/istio-1.1.3/download-istio.sh
+++ b/third_party/istio-1.1.3/download-istio.sh
@@ -42,6 +42,9 @@ helm template --namespace=istio-system \
   --set global.proxy.autoInject=disabled \
   --set global.disablePolicyChecks=true \
   --set prometheus.enabled=false \
+  `# Enable egress traffic.` \
+  --set global.outboundTrafficPolicy.mode=ALLOW_ANY \
+  --set pilot.env.PILOT_ENABLE_FALLTHROUGH_ROUTE=1 \
   `# Disable mixer prometheus adapter to remove istio default metrics.` \
   --set mixer.adapters.prometheus.enabled=false \
   `# Disable mixer policy check, since in our template we set no policy.` \

--- a/third_party/istio-1.1.3/istio-lean.yaml
+++ b/third_party/istio-1.1.3/istio-lean.yaml
@@ -747,6 +747,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: GODEBUG
             value: "gctrace=1"
+          - name: PILOT_ENABLE_FALLTHROUGH_ROUTE
+            value: "1"
           - name: PILOT_PUSH_THROTTLE
             value: "100"
           - name: PILOT_TRACE_SAMPLING

--- a/third_party/istio-1.1.3/istio.yaml
+++ b/third_party/istio-1.1.3/istio.yaml
@@ -2352,6 +2352,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: GODEBUG
             value: "gctrace=1"
+          - name: PILOT_ENABLE_FALLTHROUGH_ROUTE
+            value: "1"
           - name: PILOT_PUSH_THROTTLE
             value: "100"
           - name: PILOT_TRACE_SAMPLING


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Egress traffic e2e test, closes #3426

Test uses httpproxy image to send request to www.google.com and verifies response status code. 
Incorporates recommendations from previous PR #3665 

**NOTE:** this test requires egress traffic to be allowed by default, see [comment](https://github.com/knative/serving/pull/3665#issuecomment-482295163)

**Release Note**

```release-note
NONE
```