### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/testing/service.go
+++ b/pkg/reconciler/v1alpha1/testing/service.go
@@ -42,7 +42,7 @@ func Service(name, namespace string, so ...ServiceOption) *v1alpha1.Service {
 func ServiceWithoutNamespace(name string, so ...ServiceOption) *v1alpha1.Service {
 	s := &v1alpha1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name: name,
 		},
 	}
 	for _, opt := range so {

--- a/test/crd.go
+++ b/test/crd.go
@@ -65,7 +65,7 @@ type ResourceObjects struct {
 func Route(names ResourceNames, fopt ...v1alpha1testing.RouteOption) *v1alpha1.Route {
 	route := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.Route,
+			Name: names.Route,
 		},
 		Spec: v1alpha1.RouteSpec{
 			Traffic: []v1alpha1.TrafficTarget{{
@@ -88,7 +88,7 @@ func Route(names ResourceNames, fopt ...v1alpha1testing.RouteOption) *v1alpha1.R
 func BlueGreenRoute(names, blue, green ResourceNames) *v1alpha1.Route {
 	return &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.Route,
+			Name: names.Route,
 		},
 		Spec: v1alpha1.RouteSpec{
 			Traffic: []v1alpha1.TrafficTarget{{
@@ -146,7 +146,7 @@ func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.Configurati
 func Configuration(names ResourceNames, options *Options, fopt ...v1alpha1testing.ConfigOption) *v1alpha1.Configuration {
 	config := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.Config,
+			Name: names.Config,
 		},
 		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image), options),
 	}
@@ -167,7 +167,7 @@ func Configuration(names ResourceNames, options *Options, fopt ...v1alpha1testin
 func ConfigurationWithBuild(names ResourceNames, build *v1alpha1.RawExtension) *v1alpha1.Configuration {
 	return &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.Config,
+			Name: names.Config,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
 			Build: build,

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -21,8 +21,8 @@ const (
 	pizzaPlanet1 = "pizzaplanetv1"
 	pizzaPlanet2 = "pizzaplanetv2"
 
-	pizzaPlanetText1 = "What a spaceport!"
-	pizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
+	pizzaPlanetText1         = "What a spaceport!"
+	pizzaPlanetText2         = "Re-energize yourself with a slice of pepperoni!"
 	helloWorldExpectedOutput = "Hello World! How about some tasty noodles?"
 )
 

--- a/test/namespace.go
+++ b/test/namespace.go
@@ -19,7 +19,7 @@ limitations under the License.
 package test
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
