### PR TITLE
This does some cleanup around throttler and service manipulation.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -221,9 +221,9 @@ func main() {
 	throttler := activator.NewThrottler(throttlerParams)
 
 	handler := cache.ResourceEventHandlerFuncs{
-		AddFunc:    activator.UpdateEndpoints(throttler),
-		UpdateFunc: controller.PassNew(activator.UpdateEndpoints(throttler)),
-		DeleteFunc: activator.DeleteBreaker(throttler),
+		AddFunc:    throttler.UpdateEndpoints,
+		UpdateFunc: controller.PassNew(throttler.UpdateEndpoints),
+		DeleteFunc: throttler.DeleteBreaker,
 	}
 
 	// Update/create the breaker in the throttler when the number of endpoints changes.

--- a/pkg/reconciler/names.go
+++ b/pkg/reconciler/names.go
@@ -19,8 +19,6 @@ package reconciler
 import (
 	"fmt"
 
-	"strings"
-
 	"github.com/knative/serving/pkg/utils"
 )
 
@@ -32,9 +30,4 @@ func GetK8sServiceFullname(name string, namespace string) string {
 // GetServingK8SServiceNameForObj returns the service name for the object
 func GetServingK8SServiceNameForObj(name string) string {
 	return name + "-service"
-}
-
-// GetServingRevisionNameForK8sService returns the revision name from the service name
-func GetServingRevisionNameForK8sService(name string) string {
-	return strings.TrimSuffix(name, "-service")
 }

--- a/pkg/resources/endpoints.go
+++ b/pkg/resources/endpoints.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -42,4 +44,17 @@ func ReadyAddressCount(endpoints *corev1.Endpoints) int {
 		total += len(subset.Addresses)
 	}
 	return total
+}
+
+// ParentResourceFromService returns the parent resource name from
+// endpoints or k8s service resource.
+// The function is based upon knowledge that all knative built services
+// have `parent-resource-<svc-unique-suffix` format.
+func ParentResourceFromService(name string) string {
+	li := strings.LastIndex(name, "-")
+	if li == -1 {
+		// Presume same.
+		return name
+	}
+	return name[:li]
 }

--- a/pkg/resources/endpoints_test.go
+++ b/pkg/resources/endpoints_test.go
@@ -117,3 +117,18 @@ func endpoints(ipCount int) *corev1.Endpoints {
 	}}
 	return ep
 }
+
+func TestParentResourceFromService(t *testing.T) {
+	tests := map[string]string{
+		"":      "",
+		"a":     "a",
+		"a-":    "a",
+		"a-b":   "a",
+		"a-b-c": "a-b",
+	}
+	for in, want := range tests {
+		if got := ParentResourceFromService(in); got != want {
+			t.Errorf("%s => got: %s, want: %s", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
This also fixes the code that wasn't really correct in how the revision
nam was generated from the service name and in anticipation of SKS
stuff, make it more generic, rather than "-service" const suffix.


/lint

## Proposed Changes

* remove the old and mostly bad function to generate revision from k8s service name
* add a new one in the resources/endpoints.go that is more generic
* update throttler code to use the new function
* remove complexity in UpdateEndpoints/DeleteBreaker code, which was unreasonably complex.

/cc @mattmoor 

