### PR TITLE
Remove concurrency model.

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -165,12 +165,7 @@ spec:
       - name: bar
         configMap: ...
 
-      # +optional concurrency strategy.  Defaults to Multi.
-      # Deprecated in favor of ContainerConcurrency.
-      concurrencyModel: ...
       # +optional max request concurrency per instance.  Defaults to `0` (system decides)
-      # when concurrencyModel is unspecified as well.  Defaults to `1` when
-      # concurrencyModel `Single` is provided.
       containerConcurrency: ...
       # +optional. max time the instance is allowed for responding to a request
       timeoutSeconds: ...
@@ -251,8 +246,6 @@ spec:
   # limit request concurrency to that value.  A value of `0` means the
   # system should decide.
   containerConcurrency: 0 | 1 | 2-N
-  # Deprecated in favor of containerConcurrency
-  concurrencyModel: Single | Multi
 
   # Many higher-level systems impose a per-request response deadline.
   timeoutSeconds: ...

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -70,15 +70,9 @@ type PodAutoscalerSpec struct {
 	// +optional
 	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
-	// DeprecatedConcurrencyModel no longer does anything, use ContainerConcurrency.
-	// +optional
-	DeprecatedConcurrencyModel servingv1alpha1.RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
-
 	// ContainerConcurrency specifies the maximum allowed
 	// in-flight (concurrent) requests per container of the Revision.
 	// Defaults to `0` which means unlimited concurrency.
-	// This field replaces ConcurrencyModel. A value of `1`
-	// is equivalent to `Single` and `0` is equivalent to `Multi`.
 	// +optional
 	ContainerConcurrency servingv1alpha1.RevisionContainerConcurrencyType `json:"containerConcurrency,omitempty"`
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -75,9 +75,7 @@ func (rs *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 	if rs.ServiceName == "" {
 		errs = errs.Also(apis.ErrMissingField("serviceName"))
 	}
-
-	if err := servingv1alpha1.ValidateContainerConcurrency(
-		rs.ContainerConcurrency, ""); err != nil {
+	if err := servingv1alpha1.ValidateContainerConcurrency(rs.ContainerConcurrency); err != nil {
 		errs = errs.Also(err)
 	}
 	return errs.Also(validateSKSFields(rs))

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -32,12 +32,6 @@ func (r *Revision) SetDefaults(ctx context.Context) {
 func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 
-	// When ConcurrencyModel is specified but ContainerConcurrency
-	// is not (0), use the ConcurrencyModel value.
-	if rs.DeprecatedConcurrencyModel == RevisionRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {
-		rs.ContainerConcurrency = 1
-	}
-
 	if rs.TimeoutSeconds == nil {
 		ts := cfg.Defaults.RevisionTimeoutSeconds
 		rs.TimeoutSeconds = &ts

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -151,25 +151,6 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
-	}, {
-		name: "fall back to concurrency model",
-		in: &Revision{
-			Spec: RevisionSpec{
-				DeprecatedConcurrencyModel: "Single",
-				ContainerConcurrency:       0, // unspecified
-				Container:                  &corev1.Container{},
-			},
-		},
-		want: &Revision{
-			Spec: RevisionSpec{
-				DeprecatedConcurrencyModel: "Single",
-				ContainerConcurrency:       1,
-				TimeoutSeconds:             ptr.Int64(config.DefaultRevisionTimeoutSeconds),
-				Container: &corev1.Container{
-					Resources: defaultResources,
-				},
-			},
-		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -86,22 +86,6 @@ const (
 	DeprecatedRevisionServingStateRetired DeprecatedRevisionServingStateType = "Retired"
 )
 
-// RevisionRequestConcurrencyModelType is an enumeration of the
-// concurrency models supported by a Revision.
-// Deprecated in favor of RevisionContainerConcurrencyType.
-type RevisionRequestConcurrencyModelType string
-
-const (
-	// RevisionRequestConcurrencyModelSingle guarantees that only one
-	// request will be handled at a time (concurrently) per instance
-	// of Revision Container.
-	RevisionRequestConcurrencyModelSingle RevisionRequestConcurrencyModelType = "Single"
-	// RevisionRequestConcurencyModelMulti allows more than one request to
-	// be handled at a time (concurrently) per instance of Revision
-	// Container.
-	RevisionRequestConcurrencyModelMulti RevisionRequestConcurrencyModelType = "Multi"
-)
-
 // RevisionContainerConcurrencyType is an integer expressing a number of
 // in-flight (concurrent) requests.
 type RevisionContainerConcurrencyType int64
@@ -131,18 +115,9 @@ type RevisionSpec struct {
 	// +optional
 	DeprecatedServingState DeprecatedRevisionServingStateType `json:"servingState,omitempty"`
 
-	// DeprecatedConcurrencyModel specifies the desired concurrency model
-	// (Single or Multi) for the
-	// Revision. Defaults to Multi.
-	// Deprecated in favor of ContainerConcurrency.
-	// +optional
-	DeprecatedConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
-
 	// ContainerConcurrency specifies the maximum allowed
 	// in-flight (concurrent) requests per container of the Revision.
 	// Defaults to `0` which means unlimited concurrency.
-	// This field replaces ConcurrencyModel. A value of `1`
-	// is equivalent to `Single` and `0` is equivalent to `Multi`.
 	// +optional
 	ContainerConcurrency RevisionContainerConcurrencyType `json:"containerConcurrency,omitempty"`
 

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -996,7 +996,6 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 				Args:       []string{"hello", "world"},
 				WorkingDir: "/tmp",
 			},
-			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelSingle,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
@@ -285,9 +285,6 @@ func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxS
 			Name:        testRevision,
 			Annotations: annotations,
 		},
-		Spec: v1alpha1.RevisionSpec{
-			DeprecatedConcurrencyModel: "Multi",
-		},
 	}
 	rev, err := servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	if err != nil {

--- a/pkg/reconciler/v1alpha1/configuration/configuration_test.go
+++ b/pkg/reconciler/v1alpha1/configuration/configuration_test.go
@@ -85,28 +85,6 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo/no-revisions-yet",
 	}, {
-		Name: "webhook validation failure",
-		// If we attempt to create a Revision with a bad ConcurrencyModel set, we fail.
-		WantErr: true,
-		Objects: []runtime.Object{
-			cfg("validation-failure", "foo", 1234, WithConfigConcurrencyModel("Bogus")),
-		},
-		WantCreates: []metav1.Object{
-			rev("validation-failure", "foo", 1234, WithRevConcurrencyModel("Bogus")),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("validation-failure", "foo", 1234, WithConfigConcurrencyModel("Bogus"),
-				// Expect Revision creation to fail with the following error.
-				MarkRevisionCreationFailed(`invalid value: Bogus: spec.concurrencyModel`)),
-		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision for Configuration %q: %v",
-				"validation-failure", `invalid value: Bogus: spec.concurrencyModel`),
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for Configuration %q: %v",
-				"validation-failure", `invalid value: Bogus: spec.revisionTemplate.spec.concurrencyModel`),
-		},
-		Key: "foo/validation-failure",
-	}, {
 		Name: "elide build when a matching one already exists",
 		Objects: []runtime.Object{
 			cfg("need-rev-and-build", "foo", 99998, WithBuild),

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -110,8 +110,7 @@ func getTestRevision() *v1alpha1.Revision {
 				},
 				TerminationMessagePath: "/dev/null",
 			},
-			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
-			TimeoutSeconds:             ptr.Int64(60),
+			TimeoutSeconds: ptr.Int64(60),
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -554,8 +554,8 @@ func TestReconcile(t *testing.T) {
 			Service("update-route-and-config", "foo", WithRunLatestRollout, WithInitSvcConditions),
 			// Mutate the Config/Route to have a different body than we want.
 			config("update-route-and-config", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+				// WithBuild is just an unexpected mutation of the config spec vs. the service spec.
+				WithBuild),
 			route("update-route-and-config", "foo", WithRunLatestRollout, MutateRoute),
 		},
 		Key: "foo/update-route-and-config",
@@ -601,9 +601,7 @@ func TestReconcile(t *testing.T) {
 			// There is no spec.{runLatest,pinned} in this Service, which triggers the error
 			// path updating Configuration.
 			Service("bad-config-update", "foo", WithInitSvcConditions),
-			config("bad-config-update", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+			config("bad-config-update", "foo", WithRunLatestRollout),
 			route("bad-config-update", "foo", WithRunLatestRollout, MutateRoute),
 		},
 		Key:     "foo/bad-config-update",
@@ -694,8 +692,8 @@ func TestReconcile(t *testing.T) {
 			route("update-config-failure", "foo", WithRunLatestRollout),
 			// Mutate the Config to have an unexpected body to trigger an update.
 			config("update-config-failure", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+				// WithBuild is just an unexpected mutation of the config spec vs. the service spec.
+				WithBuild),
 		},
 		Key: "foo/update-config-failure",
 		WantUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -571,13 +571,6 @@ func WithConfigOwnersRemoved(cfg *v1alpha1.Configuration) {
 	cfg.OwnerReferences = nil
 }
 
-// WithConfigConcurrencyModel sets the given Configuration's concurrency model.
-func WithConfigConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) ConfigOption {
-	return func(cfg *v1alpha1.Configuration) {
-		cfg.Spec.GetTemplate().Spec.DeprecatedConcurrencyModel = ss
-	}
-}
-
 // WithGeneration sets the generation of the Configuration.
 func WithGeneration(gen int64) ConfigOption {
 	return func(cfg *v1alpha1.Configuration) {
@@ -677,13 +670,6 @@ func WithBuildRef(name string) RevisionOption {
 func MarkResourceNotOwned(kind, name string) RevisionOption {
 	return func(rev *v1alpha1.Revision) {
 		rev.Status.MarkResourceNotOwned(kind, name)
-	}
-}
-
-// WithRevConcurrencyModel sets the concurrency model on the Revision.
-func WithRevConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) RevisionOption {
-	return func(rev *v1alpha1.Revision) {
-		rev.Spec.DeprecatedConcurrencyModel = ss
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* This has been deprecated since 76469ce653eb23ba2661b7f2a8a26e5530e072dc (28-08-2018). Nothing out there should still be using it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Removed the deprecated ConcurrencyModel from the API surface completely.
```
