### PR TITLE
Remove no longer needed test flag defaulting.

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -52,8 +52,6 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	flag.Set("alsologtostderr", "true")
 	logging.InitializeLogger(test.Flags.LogVerbose)
 
-	// TODO(srinivashegde86): remove this once pkg is updated.
-	test.Flags.Tag = "latest"
 	if test.Flags.EmitMetrics {
 		logging.InitializeMetricExporter(E2EMetricExporter)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* As per title, the defaulting is already done via pkg.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
