### PR TITLE
Make latency tests more durable by checking route consistency.

### DIFF
--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
 	"github.com/knative/serving/test"
 	"github.com/knative/test-infra/shared/junit"
@@ -66,6 +67,16 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	endpoint, err := ingress.GetIngressEndpoint(clients.KubeClient.Kube)
 	if err != nil {
 		t.Fatalf("Cannot get service endpoint: %v", err)
+	}
+
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		domain,
+		test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain); err != nil {
+		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
 	opts := loadgenerator.GeneratorOptions{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

`TestTimeToServeLatency` and friends fail fairly consistently because of 404 errors reported by fortio. This will retry the route from the client as long as these are observable.

## Proposed Changes

* Retry 404s in service creation in the latency test.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
