### PR TITLE
Fixing Webhook API Coverage Job

### DIFF
--- a/test/apicoverage.sh
+++ b/test/apicoverage.sh
@@ -31,12 +31,12 @@ readonly SERVING_TEST_DIR=$(dirname $0)
 readonly APICOVERAGE_IMAGE=$SERVING_TEST_DIR/apicoverage/image
 readonly APICOVERAGE_TOOL=$SERVING_TEST_DIR/apicoverage/tools
 
+function knative_setup() {
+  install_knative_serving
+}
+
 # Script entry point.
 initialize $@
-
-header "Setting up environment"
-
-install_knative_serving || fail_test "Knative Serving installation failed"
 
 header "Setting up API Coverage Webhook"
 kubectl apply -f $APICOVERAGE_IMAGE/service-account.yaml || fail_test "Failed setting up service account for apicoverage-webhook"


### PR DESCRIPTION
A recent change(https://github.com/knative/test-infra/commit/4ce16d390c55c71290f3b285bdfe37a1c5490304#diff-6ec2c321184d8b0b7dcca09680db9171) resulted in breaking the API Coverage job.

This change fixes the broken build.


