### PR TITLE
Move the sync writer into logging

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -42,7 +42,6 @@ import (
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/queue/health"
 	queuestats "github.com/knative/serving/pkg/queue/stats"
-	"github.com/knative/serving/pkg/utils"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -337,7 +336,7 @@ func pushRequestLogHandler(currentHandler http.Handler) http.Handler {
 		PodName:       servingPodName,
 		PodIP:         servingPodIP,
 	}
-	handler, err := queue.NewRequestLogHandler(currentHandler, utils.NewSyncFileWriter(os.Stdout), templ, revInfo)
+	handler, err := queue.NewRequestLogHandler(currentHandler, logging.NewSyncFileWriter(os.Stdout), templ, revInfo)
 
 	if err != nil {
 		logger.Errorw("Error setting up request logger. Request logs will be unavailable.", zap.Error(err))

--- a/pkg/logging/sync_file_writer.go
+++ b/pkg/logging/sync_file_writer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package logging
 
 import (
 	"io"

--- a/pkg/logging/sync_file_writer_test.go
+++ b/pkg/logging/sync_file_writer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package logging
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
I'm trying to get rid of the unfortunately generic "utils" package, so I'm moving this into logging, which is essentially how it's used.

