### PR TITLE
Do not scale when there is no metric, and some cleanups.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -133,26 +133,23 @@ func (pas *PodAutoscalerStatus) MarkResourceFailedCreation(kind, name string) {
 // CanScaleToZero checks whether the pod autoscaler has been in an inactive state
 // for at least the specified grace period.
 func (pas *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
-	if cond := pas.GetCondition(PodAutoscalerConditionActive); cond != nil {
-		switch cond.Status {
-		case corev1.ConditionFalse:
-			// Check that this PodAutoscaler has been inactive for
-			// at least the grace period.
-			return time.Now().After(cond.LastTransitionTime.Inner.Add(gracePeriod))
-		}
-	}
-	return false
+	return pas.inStatusFor(corev1.ConditionFalse, gracePeriod)
 }
 
 // CanMarkInactive checks whether the pod autoscaler has been in an active state
 // for at least the specified idle period.
 func (pas *PodAutoscalerStatus) CanMarkInactive(idlePeriod time.Duration) bool {
+	return pas.inStatusFor(corev1.ConditionTrue, idlePeriod)
+}
+
+// inStatusFor returns true if the PodAutoscalerStatus's Active condition has stayed in
+// the specified status for at least the specified duration. Otherwise it returns false,
+// including when the status is undetermined (Active condition is not found.)
+func (pas *PodAutoscalerStatus) inStatusFor(status corev1.ConditionStatus, dur time.Duration) bool {
 	if cond := pas.GetCondition(PodAutoscalerConditionActive); cond != nil {
 		switch cond.Status {
-		case corev1.ConditionTrue:
-			// Check that this PodAutoscaler has been active for
-			// at least the grace period.
-			return time.Now().After(cond.LastTransitionTime.Inner.Add(idlePeriod))
+		case status:
+			return time.Now().After(cond.LastTransitionTime.Inner.Add(dur))
 		}
 	}
 	return false

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -222,17 +222,6 @@ func (m *MultiScaler) Inform(event string) bool {
 	return false
 }
 
-// setScale directly sets the scale for a given metric key. This does not perform any ticking
-// or updating of other scaler components.
-func (m *MultiScaler) setScale(metricKey string, scale int32) bool {
-	scaler, exists := m.scalers[metricKey]
-	if !exists {
-		return false
-	}
-	scaler.updateLatestScale(scale)
-	return true
-}
-
 func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scalerRunner, error) {
 
 	scaler, err := m.uniScalerFactory(decider, m.dynConfig)

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -193,7 +193,10 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	if err != nil {
 		t.Errorf("Create() = %v", err)
 	}
-	if ok := ms.setScale(NewMetricKey(decider.Namespace, decider.Name), 0); !ok {
+	metricKey := NewMetricKey(decider.Namespace, decider.Name)
+	if scaler, exists := ms.scalers[metricKey]; !exists {
+		t.Errorf("Failed to get scaler for metric %s", metricKey)
+	} else if !scaler.updateLatestScale(0) {
 		t.Error("Failed to set scale for metric to 0")
 	}
 


### PR DESCRIPTION
Currently when there is no metrics (desiredScale == -1), we desiredScale to minScale, causing pods mistakenly scaled down to minScale.  Also, when the autoscaler is restarted, it may have PodAutoscaler.Status unknown and when the pod is scaled down to 0, it will be bounced back to 1 (repro'd in [1] below).

Revamp the scaler.Scale() logic to fix these issues, and also to make it easier to read.
    
Some minor cleanups to make the code match the intent (e.g., isPAOwnedByRevision() returns true when the PA is owned by the revision, rather than the other way around).

[1]
Snippet from output of `kubectl get pods -w` (helloworld-go-xhvsq is a healthy revision that had been scaled down to 0):
NAME                                             READY   STATUS    RESTARTS   AGE
helloworld-go-xhvsq-deployment-d4754bf79-p42zz   0/3     Pending   0          1s
helloworld-go-xhvsq-deployment-d4754bf79-p42zz   0/3     Pending   0          1s
helloworld-go-9fttb-deployment-586458d9d4-xk8fj   0/3     Pending   0          1s
helloworld-go-xhvsq-deployment-d4754bf79-p42zz    0/3     Init:0/1   0          1s
...

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2705

## Proposed Changes

* Do not scale when there is no metric.
* Cleanups to make scaling logic easier to read.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix the autoscaler bug that make rash decision when the autoscaler restarts.
```
