### PR TITLE
Get rid of unnecessary int32s in the code

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -199,13 +199,13 @@ func main() {
 	params := queue.BreakerParams{QueueDepth: breakerQueueDepth, MaxConcurrency: breakerMaxConcurrency, InitialCapacity: 0}
 
 	// Return the number of endpoints, 0 if no endpoints are found.
-	endpointsGetter := func(rev *v1alpha1.Revision) (int32, error) {
+	endpointsGetter := func(rev *v1alpha1.Revision) (int, error) {
 		// We have to read the private service endpoints in activator
 		// in order to count the serving pod count.
 		// TODO(vagababov): reduce the layer jump and use SKS.Status.PrivateService here.
 		sn := names.PrivateService(rev.Name)
 		count, err := resources.FetchReadyAddressCount(endpointInformer.Lister(), rev.Namespace, sn)
-		return int32(count), err
+		return count, err
 	}
 
 	// Return the revision from the observer.

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -247,7 +247,7 @@ func main() {
 		if queueDepth < 10 {
 			queueDepth = 10
 		}
-		params := queue.BreakerParams{QueueDepth: int32(queueDepth), MaxConcurrency: int32(containerConcurrency), InitialCapacity: int32(containerConcurrency)}
+		params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: containerConcurrency, InitialCapacity: containerConcurrency}
 		breaker = queue.NewBreaker(params)
 		logger.Infof("Queue container is starting with %#v", params)
 	}

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -83,10 +83,10 @@ var stubServiceGetter = func(namespace, name string) (*corev1.Service, error) {
 
 func TestActivationHandler(t *testing.T) {
 	defer ClearAll()
-	goodEndpointsGetter := func(*v1alpha1.Revision) (int32, error) {
+	goodEndpointsGetter := func(*v1alpha1.Revision) (int, error) {
 		return 1000, nil
 	}
-	brokenEndpointGetter := func(*v1alpha1.Revision) (int32, error) {
+	brokenEndpointGetter := func(*v1alpha1.Revision) (int, error) {
 		return 0, errors.New("some error")
 	}
 	errMsg := func(msg string) string {
@@ -104,7 +104,7 @@ func TestActivationHandler(t *testing.T) {
 		probeCode       int
 		probeResp       []string
 		gpc             int
-		endpointsGetter func(*v1alpha1.Revision) (int32, error)
+		endpointsGetter func(*v1alpha1.Revision) (int, error)
 		reporterCalls   []reporterCall
 	}{{
 		label:           "active endpoint",
@@ -477,7 +477,7 @@ func sendRequests(count int, namespace, revName string, respCh chan *httptest.Re
 
 // getThrottler returns a fully setup Throttler with some sensible defaults for tests.
 func getThrottler(breakerParams queue.BreakerParams, t *testing.T) *activator.Throttler {
-	endpointsGetter := func(*v1alpha1.Revision) (int32, error) {
+	endpointsGetter := func(*v1alpha1.Revision) (int, error) {
 		// Since revisions have a concurrency of 1, this will cause the very same capacity
 		// as being set initially.
 		return breakerParams.InitialCapacity, nil

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -148,7 +148,7 @@ func (t *Throttler) UpdateEndpoints(newObj interface{}) {
 	endpoints := newObj.(*corev1.Endpoints)
 	addresses := resources.ReadyAddressCount(endpoints)
 	revID := RevisionID{endpoints.Namespace, resources.ParentResourceFromService(endpoints.Name)}
-	if err := t.UpdateCapacity(revID, int(addresses)); err != nil {
+	if err := t.UpdateCapacity(revID, addresses); err != nil {
 		t.logger.With(zap.String(logkey.Key, revID.String())).Errorw("updating capacity failed", zap.Error(err))
 	}
 }

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -36,7 +36,7 @@ var ErrActivatorOverload = errors.New("activator overload")
 type ThrottlerParams struct {
 	BreakerParams queue.BreakerParams
 	Logger        *zap.SugaredLogger
-	GetEndpoints  func(*v1alpha1.Revision) (int32, error)
+	GetEndpoints  func(*v1alpha1.Revision) (int, error)
 	GetRevision   func(RevisionID) (*v1alpha1.Revision, error)
 }
 
@@ -56,7 +56,7 @@ type Throttler struct {
 	breakers      map[RevisionID]*queue.Breaker
 	breakerParams queue.BreakerParams
 	logger        *zap.SugaredLogger
-	getEndpoints  func(*v1alpha1.Revision) (int32, error)
+	getEndpoints  func(*v1alpha1.Revision) (int, error)
 	getRevision   func(RevisionID) (*v1alpha1.Revision, error)
 	mux           sync.Mutex
 }
@@ -69,7 +69,7 @@ func (t *Throttler) Remove(rev RevisionID) {
 }
 
 // UpdateCapacity updates the max concurrency of the Breaker corresponding to a revision.
-func (t *Throttler) UpdateCapacity(rev RevisionID, size int32) error {
+func (t *Throttler) UpdateCapacity(rev RevisionID, size int) error {
 	revision, err := t.getRevision(rev)
 	if err != nil {
 		return err
@@ -97,8 +97,8 @@ func (t *Throttler) Try(rev RevisionID, function func()) error {
 }
 
 // This method updates Breaker's concurrency.
-func (t *Throttler) updateCapacity(revision *v1alpha1.Revision, breaker *queue.Breaker, size int32) (err error) {
-	cc := int32(revision.Spec.ContainerConcurrency)
+func (t *Throttler) updateCapacity(revision *v1alpha1.Revision, breaker *queue.Breaker, size int) (err error) {
+	cc := int(revision.Spec.ContainerConcurrency)
 
 	targetCapacity := cc * size
 	if size > 0 && (cc == 0 || targetCapacity > t.breakerParams.MaxConcurrency) {
@@ -148,7 +148,7 @@ func (t *Throttler) UpdateEndpoints(newObj interface{}) {
 	endpoints := newObj.(*corev1.Endpoints)
 	addresses := resources.ReadyAddressCount(endpoints)
 	revID := RevisionID{endpoints.Namespace, resources.ParentResourceFromService(endpoints.Name)}
-	if err := t.UpdateCapacity(revID, int32(addresses)); err != nil {
+	if err := t.UpdateCapacity(revID, int(addresses)); err != nil {
 		t.logger.With(zap.String(logkey.Key, revID.String())).Errorw("updating capacity failed", zap.Error(err))
 	}
 }

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -25,7 +25,7 @@ import (
 var (
 	// ErrUpdateCapacity the the capacity could not be updated as wished.
 	ErrUpdateCapacity = errors.New("failed to add all capacity to the breaker")
-	// ErrRelease indicates that Release was called more often than acquire.
+	// ErrRelease indicates that release was called more often than acquire.
 	ErrRelease = errors.New("semaphore release error: returned tokens must be <= acquired tokens")
 )
 

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	// semacquireTimeout is a timeout for tests that try to acquire
+	// semAcquireTimeout is a timeout for tests that try to acquire
 	// a token of a semaphore.
-	semacquireTimeout = 10 * time.Second
+	semAcquireTimeout = 10 * time.Second
 
 	// semNoChangeTimeout is some additional wait time after a number
 	// of acquires is reached to assert that no more acquires get through.
@@ -200,7 +200,7 @@ func TestSemaphore_acquire_HasNoCapacity(t *testing.T) {
 	gotChan := make(chan struct{}, 1)
 
 	sem := newSemaphore(1, 0)
-	tryacquire(sem, gotChan)
+	tryAcquire(sem, gotChan)
 
 	select {
 	case <-gotChan:
@@ -216,14 +216,14 @@ func TestSemaphore_acquire_HasCapacity(t *testing.T) {
 	want := 1
 
 	sem := newSemaphore(1, 0)
-	tryacquire(sem, gotChan)
+	tryAcquire(sem, gotChan)
 	sem.release() // Allows 1 acquire
 
 	for i := 0; i < want; i++ {
 		select {
 		case <-gotChan:
 			// Successfully acquired a token.
-		case <-time.After(semacquireTimeout):
+		case <-time.After(semAcquireTimeout):
 			t.Error("Was not able to acquire token before timeout")
 		}
 	}
@@ -423,7 +423,7 @@ func unlockAll(requests []request) {
 	}
 }
 
-func tryacquire(sem *semaphore, gotChan chan struct{}) {
+func tryAcquire(sem *semaphore, gotChan chan struct{}) {
 	go func() {
 		// blocking until someone puts the token into the semaphore
 		sem.acquire()


### PR DESCRIPTION
/lint

## Proposed Changes

* We have lotsa int32 in the breaker/throttler code and there's no need for that at all.
* Run a few find replace and other thingies.
* make all semaphore methods package private, since semaphore is package private and is not exposed.
* Make world a better place.

/cc @markusthoemmes 