### PR TITLE
Reduce usage of ConcurrencyModel to places where it's needed.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -138,7 +138,7 @@ func validateTimeoutSeconds(timeoutSeconds int64) *apis.FieldError {
 	return nil
 }
 
-// Validate ensures RevisionRequestConcurrencyModelType is properly configured.
+// Validate ensures DeprecatedRevisionServingStateType is properly configured.
 func (ss DeprecatedRevisionServingStateType) Validate(ctx context.Context) *apis.FieldError {
 	switch ss {
 	case DeprecatedRevisionServingStateType(""),

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -664,7 +664,6 @@ func TestRevisionSpecValidation(t *testing.T) {
 			Container: &corev1.Container{
 				Image: "helloworld",
 			},
-			DeprecatedConcurrencyModel: "Multi",
 		},
 		want: nil,
 	}, {
@@ -700,7 +699,6 @@ func TestRevisionSpecValidation(t *testing.T) {
 					},
 				},
 			}},
-			DeprecatedConcurrencyModel: "Multi",
 		},
 		want: nil,
 	}, {
@@ -727,7 +725,6 @@ func TestRevisionSpecValidation(t *testing.T) {
 					ConfigMap: &corev1.ConfigMapVolumeSource{},
 				},
 			}},
-			DeprecatedConcurrencyModel: "Multi",
 		},
 		want: (&apis.FieldError{
 			Message: fmt.Sprintf(`duplicate volume name "the-name"`),
@@ -810,7 +807,6 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: nil,
@@ -826,7 +822,6 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 					Name:  "kevin",
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.container.name"),
@@ -840,7 +835,6 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: apis.ErrDisallowedFields("metadata.name"),
@@ -871,7 +865,6 @@ func TestRevisionValidation(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: nil,
@@ -894,7 +887,6 @@ func TestRevisionValidation(t *testing.T) {
 					Name:  "kevin",
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: apis.ErrDisallowedFields("spec.container.name"),
@@ -908,7 +900,6 @@ func TestRevisionValidation(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: &apis.FieldError{
@@ -929,7 +920,6 @@ func TestRevisionValidation(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: (&apis.FieldError{
@@ -964,7 +954,6 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -975,7 +964,6 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: nil,
@@ -994,7 +982,6 @@ func TestImmutableFields(t *testing.T) {
 						},
 					},
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -1010,7 +997,6 @@ func TestImmutableFields(t *testing.T) {
 						},
 					},
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: &apis.FieldError{
@@ -1031,7 +1017,6 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		old: &Revision{
@@ -1042,7 +1027,6 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "busybox",
 				},
-				DeprecatedConcurrencyModel: "Multi",
 			},
 		},
 		want: &apis.FieldError{
@@ -1095,7 +1079,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
+				ContainerConcurrency: 100,
 			},
 		},
 		old: &Revision{
@@ -1111,9 +1095,9 @@ func TestImmutableFields(t *testing.T) {
 		want: &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},
-			Details: `{v1alpha1.RevisionSpec}.DeprecatedConcurrencyModel:
-	-: ""
-	+: "Multi"
+			Details: `{v1alpha1.RevisionSpec}.ContainerConcurrency:
+	-: "0"
+	+: "100"
 `,
 		},
 	}, {
@@ -1126,7 +1110,7 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "helloworld",
 				},
-				DeprecatedConcurrencyModel: "Multi",
+				ContainerConcurrency: 100,
 			},
 		},
 		old: &Revision{
@@ -1137,15 +1121,15 @@ func TestImmutableFields(t *testing.T) {
 				Container: &corev1.Container{
 					Image: "busybox",
 				},
-				DeprecatedConcurrencyModel: "Single",
+				ContainerConcurrency: 1,
 			},
 		},
 		want: &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},
-			Details: `{v1alpha1.RevisionSpec}.DeprecatedConcurrencyModel:
-	-: "Single"
-	+: "Multi"
+			Details: `{v1alpha1.RevisionSpec}.ContainerConcurrency:
+	-: "1"
+	+: "100"
 {v1alpha1.RevisionSpec}.Container.Image:
 	-: "busybox"
 	+: "helloworld"

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_test.go
@@ -1273,7 +1273,6 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 				Args:       []string{"hello", "world"},
 				WorkingDir: "/tmp",
 			},
-			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelSingle,
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/scaler_test.go
@@ -285,9 +285,7 @@ func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxS
 			Name:        testRevision,
 			Annotations: annotations,
 		},
-		Spec: v1alpha1.RevisionSpec{
-			DeprecatedConcurrencyModel: "Multi",
-		},
+		Spec: v1alpha1.RevisionSpec{},
 	}
 	rev, err := servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	if err != nil {

--- a/pkg/reconciler/v1alpha1/revision/queueing_test.go
+++ b/pkg/reconciler/v1alpha1/revision/queueing_test.go
@@ -113,8 +113,7 @@ func testRevision() *v1alpha1.Revision {
 				},
 				TerminationMessagePath: "/dev/null",
 			},
-			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
-			TimeoutSeconds:             ptr.Int64(60),
+			TimeoutSeconds: ptr.Int64(60),
 		},
 	}
 }

--- a/pkg/reconciler/v1alpha1/service/service_test.go
+++ b/pkg/reconciler/v1alpha1/service/service_test.go
@@ -554,8 +554,8 @@ func TestReconcile(t *testing.T) {
 			Service("update-route-and-config", "foo", WithRunLatestRollout, WithInitSvcConditions),
 			// Mutate the Config/Route to have a different body than we want.
 			config("update-route-and-config", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+				// WithBuild is just an unexpected mutation of the config spec vs. the service spec.
+				WithBuild),
 			route("update-route-and-config", "foo", WithRunLatestRollout, MutateRoute),
 		},
 		Key: "foo/update-route-and-config",
@@ -601,9 +601,7 @@ func TestReconcile(t *testing.T) {
 			// There is no spec.{runLatest,pinned} in this Service, which triggers the error
 			// path updating Configuration.
 			Service("bad-config-update", "foo", WithInitSvcConditions),
-			config("bad-config-update", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+			config("bad-config-update", "foo", WithRunLatestRollout),
 			route("bad-config-update", "foo", WithRunLatestRollout, MutateRoute),
 		},
 		Key:     "foo/bad-config-update",
@@ -694,8 +692,8 @@ func TestReconcile(t *testing.T) {
 			route("update-config-failure", "foo", WithRunLatestRollout),
 			// Mutate the Config to have an unexpected body to trigger an update.
 			config("update-config-failure", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+				// WithBuild is just an unexpected mutation of the config spec vs. the service spec.
+				WithBuild),
 		},
 		Key: "foo/update-config-failure",
 		WantUpdates: []clientgotesting.UpdateActionImpl{{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We'll remove ConcurrencyModel from our API surface as soon as we go v1beta1. This reduces our overall usage of the fields to the absolute needed minimum and removes it from all tests that do not really need it but have grown to use it over time.

## Proposed Changes

* Remove ConcurrencyModel everywhere it's not needed.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
