### PR TITLE
Add knative serving release label for podspec

### DIFF
--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -30,6 +30,7 @@ spec:
         sidecar.istio.io/inject: "true"
       labels:
         app: autoscaler
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -30,6 +30,7 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: controller
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -32,6 +32,7 @@ spec:
       labels:
         app: webhook
         role: webhook
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Add serving release label to all deployment's template podspec
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
