### PR TITLE
Refactor StatsScraper

### DIFF
--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+type httpScrapeClient struct {
+	httpClient *http.Client
+}
+
+func newHTTPScrapeClient(httpClient *http.Client) (*httpScrapeClient, error) {
+	if httpClient == nil {
+		return nil, errors.New("HTTP client must not be nil")
+	}
+
+	return &httpScrapeClient{
+		httpClient: httpClient,
+	}, nil
+}
+
+func (c *httpScrapeClient) Scrape(url string) (*Stat, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("GET request for URL %q returned HTTP status %v", url, resp.StatusCode)
+	}
+
+	return extractData(resp.Body)
+}
+
+func extractData(body io.Reader) (*Stat, error) {
+	var parser expfmt.TextParser
+	metricFamilies, err := parser.TextToMetricFamilies(body)
+	if err != nil {
+		return nil, fmt.Errorf("reading text format failed: %v", err)
+	}
+
+	now := time.Now()
+	stat := Stat{
+		Time: &now,
+	}
+
+	if pMetric := prometheusMetric(metricFamilies, "queue_average_concurrent_requests"); pMetric != nil {
+		stat.AverageConcurrentRequests = *pMetric.Gauge.Value
+	} else {
+		return nil, errors.New("could not find value for queue_average_concurrent_requests in response")
+	}
+
+	if pMetric := prometheusMetric(metricFamilies, "queue_average_proxied_concurrent_requests"); pMetric != nil {
+		stat.AverageProxiedConcurrentRequests = *pMetric.Gauge.Value
+	} else {
+		return nil, errors.New("could not find value for queue_average_proxied_concurrent_requests in response")
+	}
+
+	if pMetric := prometheusMetric(metricFamilies, "queue_operations_per_second"); pMetric != nil {
+		stat.RequestCount = int32(*pMetric.Gauge.Value)
+	} else {
+		return nil, errors.New("could not find value for queue_operations_per_second in response")
+	}
+
+	if pMetric := prometheusMetric(metricFamilies, "queue_proxied_operations_per_second"); pMetric != nil {
+		stat.ProxiedRequestCount = int32(*pMetric.Gauge.Value)
+	} else {
+		return nil, errors.New("could not find value for queue_proxied_operations_per_second in response")
+	}
+
+	return &stat, nil
+}
+
+// prometheusMetric returns the point of the first Metric of the MetricFamily
+// with the given key from the given map. If there is no such MetricFamily or it
+// has no Metrics, then returns nil.
+func prometheusMetric(metricFamilies map[string]*dto.MetricFamily, key string) *dto.Metric {
+	if metric, ok := metricFamilies[key]; ok && len(metric.Metric) > 0 {
+		return metric.Metric[0]
+	}
+
+	return nil
+}

--- a/pkg/autoscaler/http_scrape_client_test.go
+++ b/pkg/autoscaler/http_scrape_client_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const (
+	testURL = "http://test-revision-metrics.test-namespace:9090/metrics"
+
+	testAverageConcurrencyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
+# TYPE queue_average_concurrent_requests gauge
+queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 3.0
+`
+	testQPSContext = `# HELP queue_operations_per_second Number of requests received since last Stat
+# TYPE queue_operations_per_second gauge
+queue_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 5
+`
+	testAverageProxiedConcurrenyContext = `# HELP queue_average_proxied_concurrent_requests Number of proxied requests currently being handled by this pod
+# TYPE queue_average_proxied_concurrent_requests gauge
+queue_average_proxied_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 2.0
+`
+	testProxiedQPSContext = `# HELP queue_proxied_operations_per_second Number of proxied requests received since last Stat
+# TYPE queue_proxied_operations_per_second gauge
+queue_proxied_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 4
+`
+	testFullContext = testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext
+)
+
+func TestNewHTTPScrapeClient_ErrorCases(t *testing.T) {
+	testCases := []struct {
+		name        string
+		client      *http.Client
+		expectedErr string
+	}{{
+		name:        "Empty HTTP client",
+		expectedErr: "HTTP client must not be nil",
+	}}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := newHTTPScrapeClient(test.client); err != nil {
+				got := err.Error()
+				want := test.expectedErr
+				if got != want {
+					t.Errorf("Got error message: %v. Want: %v", got, want)
+				}
+			} else {
+				t.Errorf("Expected error from newHTTPScrapeClient, got nil")
+			}
+		})
+	}
+}
+
+func TestHTTPScrapeClient_Scrape_HappyCase(t *testing.T) {
+	hClient := newTestHTTPClient(getHTTPResponse(http.StatusOK, testFullContext), nil)
+	sClient, err := newHTTPScrapeClient(hClient)
+	if err != nil {
+		t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
+	}
+
+	// Scrape will set a timestamp bigger than this.
+	now := time.Now()
+	stat, err := sClient.Scrape(testURL)
+	if err != nil {
+		t.Errorf("scrapeViaURL = %v, want no error", err)
+	}
+	if stat.AverageConcurrentRequests != 3.0 {
+		t.Errorf("stat.AverageConcurrentRequests = %v, want 3.0", stat.AverageConcurrentRequests)
+	}
+	if stat.RequestCount != 5 {
+		t.Errorf("stat.RequestCount = %v, want 5", stat.RequestCount)
+	}
+	if stat.AverageProxiedConcurrentRequests != 2.0 {
+		t.Errorf("stat.AverageProxiedConcurrency = %v, want 2.0", stat.AverageProxiedConcurrentRequests)
+	}
+	if stat.ProxiedRequestCount != 4 {
+		t.Errorf("stat.ProxiedCount = %v, want 4", stat.ProxiedRequestCount)
+	}
+	if stat.Time.Before(now) {
+		t.Errorf("stat.Time=%v, want bigger than %v", stat.Time, now)
+	}
+}
+
+func TestHTTPScrapeClient_Scrape_ErrorCases(t *testing.T) {
+	testCases := []struct {
+		name            string
+		responseCode    int
+		responseErr     error
+		responseContext string
+		expectedErr     string
+	}{{
+		name:         "Non 200 return code",
+		responseCode: http.StatusForbidden,
+		expectedErr:  `GET request for URL "http://test-revision-metrics.test-namespace:9090/metrics" returned HTTP status 403`,
+	}, {
+		name:         "Error got when sending request",
+		responseCode: http.StatusOK,
+		responseErr:  errors.New("upstream closed"),
+		expectedErr:  "Get http://test-revision-metrics.test-namespace:9090/metrics: upstream closed",
+	}, {
+		name:            "Bad response context format",
+		responseCode:    http.StatusOK,
+		responseContext: "bad context",
+		expectedErr:     "reading text format failed: text format parsing error in line 1: unexpected end of input stream",
+	}, {
+		name:            "Missing average concurrency",
+		responseCode:    http.StatusOK,
+		responseContext: testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext,
+		expectedErr:     "could not find value for queue_average_concurrent_requests in response",
+	}, {
+		name:            "Missing QPS",
+		responseCode:    http.StatusOK,
+		responseContext: testAverageConcurrencyContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext,
+		expectedErr:     "could not find value for queue_operations_per_second in response",
+	}, {
+		name:            "Missing average proxied concurrency",
+		responseCode:    http.StatusOK,
+		responseContext: testAverageConcurrencyContext + testQPSContext + testProxiedQPSContext,
+		expectedErr:     "could not find value for queue_average_proxied_concurrent_requests in response",
+	}, {
+		name:            "Missing proxied QPS",
+		responseCode:    http.StatusOK,
+		responseContext: testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext,
+		expectedErr:     "could not find value for queue_proxied_operations_per_second in response",
+	}}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			hClient := newTestHTTPClient(getHTTPResponse(test.responseCode, test.responseContext), test.responseErr)
+			sClient, err := newHTTPScrapeClient(hClient)
+			if err != nil {
+				t.Errorf("newHTTPScrapeClient=%v, want no error", err)
+			}
+			if _, err := sClient.Scrape(testURL); err != nil {
+				if err.Error() != test.expectedErr {
+					t.Errorf("Got error message: %q, want: %q", err.Error(), test.expectedErr)
+				}
+			} else {
+				t.Errorf("Expected error from newServiceScraperWithClient, got nil")
+			}
+		})
+	}
+}
+
+func getHTTPResponse(statusCode int, context string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(context)),
+	}
+}
+
+type fakeRoundTripper struct {
+	response      *http.Response
+	responseError error
+}
+
+func (frt fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return frt.response, frt.responseError
+}
+
+func newTestHTTPClient(response *http.Response, err error) *http.Client {
+	return &http.Client{
+		Transport: fakeRoundTripper{
+			response:      response,
+			responseError: err,
+		},
+	}
+}

--- a/pkg/autoscaler/http_scrape_client_test.go
+++ b/pkg/autoscaler/http_scrape_client_test.go
@@ -28,6 +28,7 @@ import (
 const (
 	testURL = "http://test-revision-metrics.test-namespace:9090/metrics"
 
+	// TODO: Use Prometheus lib to generate the following text instead of using text format directly.
 	testAverageConcurrencyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
 # TYPE queue_average_concurrent_requests gauge
 queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 3.0

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -18,7 +18,6 @@ package autoscaler
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -27,8 +26,6 @@ import (
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/autoscaling/kpa/resources/names"
 	"github.com/knative/serving/pkg/resources"
 	"github.com/pkg/errors"
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
@@ -49,6 +46,13 @@ type StatsScraper interface {
 	Scrape() (*StatMessage, error)
 }
 
+// scrapeClient defines the interface for collecting Revision metrics for a given
+// URL. Internal used only.
+type scrapeClient interface {
+	// Scrape scrapes the given URL.
+	Scrape(url string) (*Stat, error)
+}
+
 // cacheDisabledClient is a http client with cache disabled. It is shared by
 // every goruntime for a revision scraper.
 var cacheDisabledClient = &http.Client{
@@ -64,7 +68,7 @@ var cacheDisabledClient = &http.Client{
 // https://kubernetes.io/docs/concepts/services-networking/network-policies/
 // for details.
 type ServiceScraper struct {
-	httpClient          *http.Client
+	sClient             scrapeClient
 	endpointsLister     corev1listers.EndpointsLister
 	url                 string
 	namespace           string
@@ -75,21 +79,25 @@ type ServiceScraper struct {
 // NewServiceScraper creates a new StatsScraper for the Revision which
 // the given Metric is responsible for.
 func NewServiceScraper(metric *Metric, endpointsLister corev1listers.EndpointsLister) (*ServiceScraper, error) {
-	return newServiceScraperWithClient(metric, endpointsLister, cacheDisabledClient)
+	sClient, err := newHTTPScrapeClient(cacheDisabledClient)
+	if err != nil {
+		return nil, err
+	}
+	return newServiceScraperWithClient(metric, endpointsLister, sClient)
 }
 
 func newServiceScraperWithClient(
 	metric *Metric,
 	endpointsLister corev1listers.EndpointsLister,
-	httpClient *http.Client) (*ServiceScraper, error) {
+	sClient scrapeClient) (*ServiceScraper, error) {
 	if metric == nil {
 		return nil, errors.New("metric must not be nil")
 	}
 	if endpointsLister == nil {
 		return nil, errors.New("endpoints lister must not be nil")
 	}
-	if httpClient == nil {
-		return nil, errors.New("HTTP client must not be nil")
+	if sClient == nil {
+		return nil, errors.New("scrape client must not be nil")
 	}
 	revName := metric.Labels[serving.RevisionLabelKey]
 	if revName == "" {
@@ -98,7 +106,7 @@ func newServiceScraperWithClient(
 
 	serviceName := names.MetricsServiceName(revName)
 	return &ServiceScraper{
-		httpClient:          httpClient,
+		sClient:             sClient,
 		endpointsLister:     endpointsLister,
 		url:                 fmt.Sprintf("http://%s.%s:%d/metrics", serviceName, metric.Namespace, v1alpha1.RequestQueueMetricsPort),
 		metricKey:           NewMetricKey(metric.Namespace, metric.Name),
@@ -119,7 +127,7 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 		return nil, nil
 	}
 
-	stat, err := s.scrapeViaURL()
+	stat, err := s.sClient.Scrape(s.url)
 	if err != nil {
 		return nil, err
 	}
@@ -146,71 +154,4 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 		Stat: extrapolatedStat,
 		Key:  s.metricKey,
 	}, nil
-}
-
-func (s *ServiceScraper) scrapeViaURL() (*Stat, error) {
-	req, err := http.NewRequest(http.MethodGet, s.url, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("GET request for URL %q returned HTTP status %v", s.url, resp.StatusCode)
-	}
-
-	return extractData(resp.Body)
-}
-
-func extractData(body io.Reader) (*Stat, error) {
-	var parser expfmt.TextParser
-	metricFamilies, err := parser.TextToMetricFamilies(body)
-	if err != nil {
-		return nil, fmt.Errorf("reading text format failed: %v", err)
-	}
-
-	now := time.Now()
-	stat := Stat{
-		Time: &now,
-	}
-
-	if pMetric := prometheusMetric(metricFamilies, "queue_average_concurrent_requests"); pMetric != nil {
-		stat.AverageConcurrentRequests = *pMetric.Gauge.Value
-	} else {
-		return nil, errors.New("could not find value for queue_average_concurrent_requests in response")
-	}
-
-	if pMetric := prometheusMetric(metricFamilies, "queue_average_proxied_concurrent_requests"); pMetric != nil {
-		stat.AverageProxiedConcurrentRequests = *pMetric.Gauge.Value
-	} else {
-		return nil, errors.New("could not find value for queue_average_proxied_concurrent_requests in response")
-	}
-
-	if pMetric := prometheusMetric(metricFamilies, "queue_operations_per_second"); pMetric != nil {
-		stat.RequestCount = int32(*pMetric.Gauge.Value)
-	} else {
-		return nil, errors.New("could not find value for queue_operations_per_second in response")
-	}
-
-	if pMetric := prometheusMetric(metricFamilies, "queue_proxied_operations_per_second"); pMetric != nil {
-		stat.ProxiedRequestCount = int32(*pMetric.Gauge.Value)
-	} else {
-		return nil, errors.New("could not find value for queue_proxied_operations_per_second in response")
-	}
-
-	return &stat, nil
-}
-
-// prometheusMetric returns the point of the first Metric of the MetricFamily
-// with the given key from the given map. If there is no such MetricFamily or it
-// has no Metrics, then returns nil.
-func prometheusMetric(metricFamilies map[string]*dto.MetricFamily, key string) *dto.Metric {
-	if metric, ok := metricFamilies[key]; ok && len(metric.Metric) > 0 {
-		return metric.Metric[0]
-	}
-
-	return nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Split the part of dealing with HTTP request/response to an individual file `http_scrape_client.go` from `stats_scraper.go`. This makes writing units tests easier for changes to the scraping logic. No need to deal with HTTP client/response in tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
