### PR TITLE
Fix leftover todo

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -83,7 +83,7 @@ func (c *MetricCollector) Get(ctx context.Context, namespace, name string) (*Met
 	key := NewMetricKey(namespace, name)
 	collector, ok := c.collections[key]
 	if !ok {
-		return nil, k8serrors.NewNotFound(kpa.Resource("Deciders"), key)
+		return nil, k8serrors.NewNotFound(kpa.Resource("Metrics"), key)
 	}
 
 	return collector.metric.DeepCopy(), nil

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -22,7 +22,6 @@ import (
 	"encoding/gob"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -158,11 +157,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		sm.Stat.Time = &now
 
 		s.logger.Debugf("Received stat message: %+v", sm)
-		// TODO(yanweiguo): Remove this after version 0.5.
-		// Drop stats not from activator
-		if isActivator(sm.Stat.PodName) {
-			s.statsCh <- &sm
-		}
+		s.statsCh <- &sm
 	}
 }
 
@@ -196,8 +191,4 @@ func (s *Server) Shutdown(timeout time.Duration) {
 	case <-ctx.Done():
 		s.logger.Warn("Shutdown timed out")
 	}
-}
-
-func isActivator(podName string) bool {
-	return strings.HasPrefix(podName, "activator")
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Correct resource name in collector.
*  Remove unnecessary filter logic since only activator pushes metrics to autoscaler start from 0.5.1

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
