### PR TITLE
Fix Prometheus metrics example

### DIFF
--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -42,7 +42,7 @@ promAPI, err := prometheus.PromAPI()
 if err != nil {
   logger.Error("Cannot setup prometheus API")
 }
-query := fmt.Sprintf("%s{namespace_name=%q, configuration_name=%q, revision_name=%q}", metric, test.ServingNamespace, names.Config, names.Revision)
+query := fmt.Sprintf("%s{namespace_name=\"%q\", configuration_name=\"%q\", revision_name=\"%q\"}", metric, test.ServingNamespace, names.Config, names.Revision)
 val, err := prometheus.RunQuery(context.Background(), logger, promAPI, query)
 if err != nil {
   logger.Infof("Error querying metric %s: %v", metric, err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

When calling `prometheus.RunQuery` with query arguments that are not enclosed in quotes, the Prometheus API returns an unexpected identifier error. As a result, the Prometheus example here needs to be updated to enclose query arguments in quotes.

Example error when using `test` as `namespace_name`:
```
{"status":"error","errorType":"bad_data","error":"parse error at char 42: unexpected identifier \"test\" in label matching, expected string"}
```