### PR TITLE
Reduce the default TCP timeout to fix #3700.

### DIFF
--- a/pkg/activator/util/transports.go
+++ b/pkg/activator/util/transports.go
@@ -52,7 +52,5 @@ func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
 	return transport
 }
 
-var DefaultHTTPTransport = newHTTPTransport(network.DefaultConnTimeout)
-
 // AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others
-var AutoTransport = NewAutoTransport(DefaultHTTPTransport, h2cutil.DefaultTransport)
+var AutoTransport = NewAutoTransport(newHTTPTransport(network.DefaultConnTimeout), h2cutil.DefaultTransport)

--- a/pkg/activator/util/transports.go
+++ b/pkg/activator/util/transports.go
@@ -14,9 +14,12 @@ limitations under the License.
 package util
 
 import (
+	"net"
 	"net/http"
+	"time"
 
 	h2cutil "github.com/knative/serving/pkg/http/h2c"
+	"github.com/knative/serving/pkg/network"
 )
 
 // RoundTripperFunc implementation roundtrips a request.
@@ -27,8 +30,8 @@ func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return rt(r)
 }
 
-// NewHTTPTransport will use the appropriate transport for the request's HTTP protocol version
-func NewHTTPTransport(v1 http.RoundTripper, v2 http.RoundTripper) http.RoundTripper {
+// NewAutoTransport will use the appropriate transport for the request's HTTP protocol version
+func NewAutoTransport(v1 http.RoundTripper, v2 http.RoundTripper) http.RoundTripper {
 	return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		t := v1
 		if r.ProtoMajor == 2 {
@@ -39,5 +42,17 @@ func NewHTTPTransport(v1 http.RoundTripper, v2 http.RoundTripper) http.RoundTrip
 	})
 }
 
+func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.DialContext = (&net.Dialer{
+		Timeout:   connTimeout,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}).DialContext
+	return transport
+}
+
+var DefaultHTTPTransport = newHTTPTransport(network.DefaultConnTimeout)
+
 // AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others
-var AutoTransport = NewHTTPTransport(http.DefaultTransport, h2cutil.DefaultTransport)
+var AutoTransport = NewAutoTransport(DefaultHTTPTransport, h2cutil.DefaultTransport)

--- a/pkg/activator/util/transports.go
+++ b/pkg/activator/util/transports.go
@@ -43,13 +43,13 @@ func NewAutoTransport(v1 http.RoundTripper, v2 http.RoundTripper) http.RoundTrip
 }
 
 func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
-	transport := http.DefaultTransport.(*http.Transport)
+	transport := *http.DefaultTransport.(*http.Transport)
 	transport.DialContext = (&net.Dialer{
 		Timeout:   connTimeout,
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
 	}).DialContext
-	return transport
+	return &transport
 }
 
 // AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others

--- a/pkg/activator/util/transports_test.go
+++ b/pkg/activator/util/transports_test.go
@@ -28,7 +28,7 @@ func TestHTTPRoundTripper(t *testing.T) {
 		})
 	}
 
-	rt := NewHTTPTransport(frt("v1"), frt("v2"))
+	rt := NewAutoTransport(frt("v1"), frt("v2"))
 
 	examples := []struct {
 		label      string

--- a/pkg/http/h2c/h2c.go
+++ b/pkg/http/h2c/h2c.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/knative/serving/pkg/network"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -46,11 +47,10 @@ var DefaultTransport http.RoundTripper = &http2.Transport{
 	AllowHTTP: true,
 	DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
 		d := &net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   network.DefaultConnTimeout,
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}
-
 		return d.Dial(netw, addr)
 	},
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -66,8 +66,8 @@ const (
 	//   User-Agent = "kube-probe/{major-version}.{minor-version}".
 	kubeProbeUAPrefix = "kube-probe/"
 
-	// Use a short default connection timeout to avoid hitting the
-	// issue fixed in
+	// DefaultConnTimeout specifies a short default connection timeout
+	// to avoid hitting the issue fixed in
 	// https://github.com/kubernetes/kubernetes/pull/72534 but only
 	// avalailable after Kubernetes 1.14.
 	//

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"strings"
 	"text/template"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -64,6 +65,19 @@ const (
 	// Since K8s 1.8, prober requests have
 	//   User-Agent = "kube-probe/{major-version}.{minor-version}".
 	kubeProbeUAPrefix = "kube-probe/"
+
+	// Use a short default connection timeout to avoid hitting the
+	// issue fixed in
+	// https://github.com/kubernetes/kubernetes/pull/72534 but only
+	// avalailable after Kubernetes 1.14.
+	//
+	// Our connections are usually between pods in the same cluster
+	// like activator <-> queue-proxy, or even between containers
+	// within the same pod queue-proxy <-> user-container, so a
+	// smaller connect timeout would be justifiable.
+	//
+	// We should consider exposing this as a configuration.
+	DefaultConnTimeout = 200 * time.Millisecond
 )
 
 var (


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3700 

I can't find an easy way to test this so added the TODO #3793 after we switch to testing without mesh.

## Proposed Changes

* Use a short default connection timeout to avoid hitting issue in #3700. Because our connections are usually between pods in the same cluster like activator <-> queue-proxy, or between containers within the same pod like queue-proxy <-> user-container, a small connect timeout would be justifiable.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix long activation without mesh #3700 .
```
