### PR TITLE
Add proxy mode to the serverlessservice reconciler

### DIFF
--- a/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice.go
@@ -249,7 +249,8 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 		srcEps *corev1.Endpoints
 		err    error
 	)
-	if sks.Spec.Mode == netv1alpha1.SKSOperationModeServe {
+	switch sks.Spec.Mode {
+	case netv1alpha1.SKSOperationModeServe:
 		// Service and Endpoints have the same name.
 		// Get private endpoints first, since if they are not available there's nothing we can do.
 		psn := names.PrivateService(sks.Name)
@@ -259,13 +260,13 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 			return err
 		}
 		logger.Debugf("Private endpoints: %s", spew.Sprint(srcEps))
-	} else {
+	case netv1alpha1.SKSOperationModeProxy:
 		srcEps, err = r.endpointsLister.Endpoints(system.Namespace()).Get(activatorService)
 		if err != nil {
 			logger.Errorw("Error obtaining activator service endpoints", zap.Error(err))
 			return err
 		}
-		logger.Debugf("Private endpoints: %s", spew.Sprint(srcEps))
+		logger.Debugf("Activator endpoints: %s", spew.Sprint(srcEps))
 	}
 
 	sn := names.PublicService(sks.Name)

--- a/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice_test.go
@@ -67,16 +67,16 @@ func TestNewController(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
-		Name:                    "bad workqueue key, Part I",
-		Key:                     "too/many/parts",
+		Name: "bad workqueue key, Part I",
+		Key:  "too/many/parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "bad workqueue key, Part II",
-		Key:                     "too-few-parts",
+		Name: "bad workqueue key, Part II",
+		Key:  "too-few-parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
+		Name: "key not found",
+		Key:  "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "steady state",
@@ -129,6 +129,24 @@ func TestReconcile(t *testing.T) {
 		Key:  "on/cneps",
 		Objects: []runtime.Object{
 			SKS("on", "cneps", WithDeployRef("blah")),
+			deploy("on", "blah"),
+			endpointspriv("on", "cneps"),
+		},
+		WantCreates: []metav1.Object{
+			svcpriv("on", "cneps"),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: SKS("on", "cneps", WithDeployRef("blah"),
+				markNoEndpoints, withTempPubService, WithPrivateService),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "on/cneps"`),
+		},
+	}, {
+		Name: "OnCreate-no-activator-eps",
+		Key:  "on/cneps",
+		Objects: []runtime.Object{
+			SKS("on", "cneps", WithDeployRef("blah"), WithProxyMode),
 			deploy("on", "blah"),
 			endpointspriv("on", "cneps"),
 		},

--- a/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/v1alpha1/serverlessservice/serverlessservice_test.go
@@ -140,6 +140,18 @@ func TestReconcile(t *testing.T) {
 			Object: endpointspub("private", "svc-change", WithSubsets),
 		}},
 	}, {
+		Name: "OnCreate-deployment-does-not-exist",
+		Key:  "on/cde",
+		Objects: []runtime.Object{
+			SKS("on", "cde", WithDeployRef("blah")),
+			deploy("on", "blah-another"),
+			endpointspriv("on", "cde", WithSubsets),
+		},
+		WantErr: true,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: error retrieving deployment selector spec: deployments.apps "blah" not found`),
+		},
+	}, {
 		Name: "OnCreate-deployment-exists",
 		Key:  "on/cde",
 		Objects: []runtime.Object{

--- a/pkg/reconciler/v1alpha1/testing/factory.go
+++ b/pkg/reconciler/v1alpha1/testing/factory.go
@@ -47,8 +47,9 @@ const (
 // Ctor functions create a k8s controller with given params.
 type Ctor func(*Listers, reconciler.Options) controller.Reconciler
 
-// scaleClient returns a fake scale client that will serve a single provided object.
-// Kubernetes does not come currently with a normal fake, as other APIs, so we did this...
+// scaleClient returns a Scale fake K8s client, that returns the scale resource
+// defined by the underlying Deployment resource. That deployment resource must
+// exist in the passed in `f` clientset.
 func scaleClient(f *fakekubeclientset.Clientset) scale.ScalesGetter {
 	scaleClient := &fakescaleclient.FakeScaleClient{}
 	scaleClient.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/reconciler/v1alpha1/testing/factory.go
+++ b/pkg/reconciler/v1alpha1/testing/factory.go
@@ -103,7 +103,7 @@ func MakeFactory(ctor Ctor) Factory {
 			DynamicClientSet: dynamicClient,
 			CachingClientSet: cachingClient,
 			ServingClientSet: client,
-			ScaleClientSet:   scaleClient(&client.Fake, ls.GetKubeObjects()...),
+			ScaleClientSet:   scaleClient(client.Fake, ls.GetKubeObjects()...),
 			Recorder:         eventRecorder,
 			StatsReporter:    statsReporter,
 			Logger:           TestLogger(t),

--- a/pkg/reconciler/v1alpha1/testing/functional.go
+++ b/pkg/reconciler/v1alpha1/testing/functional.go
@@ -1035,6 +1035,11 @@ func WithSKSOwnersRemoved(sks *netv1alpha1.ServerlessService) {
 	sks.OwnerReferences = nil
 }
 
+// WithProxyMode puts SKS into proxy mode.
+func WithProxyMode(sks *netv1alpha1.ServerlessService) {
+	sks.Spec.Mode = netv1alpha1.SKSOperationModeProxy
+}
+
 // SKS creates a generic ServerlessService object.
 func SKS(ns, name string, so ...SKSOption) *netv1alpha1.ServerlessService {
 	s := &netv1alpha1.ServerlessService{


### PR DESCRIPTION
/lint

Part of #1997 

## Proposed Changes

* respect the mode when populating public endpoints, if it's proxy then read the activator endpoints, rather than private service one and fill with them
* update the tests for the new functionality
* update the fake for scales to return errors and cover a case when scales cannot be retrieved :-)


/cc @mattmoor 