### PR TITLE
Add loadfactors to the options when running load test

### DIFF
--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -86,6 +86,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		Domain:         domain,
 		URL:            fmt.Sprintf("http://%s/?%s", *endpoint, query),
 		RequestTimeout: reqTimeout,
+		LoadFactors:    []float64{1},
 	}
 	resp, err := opts.RunLoadTest(false)
 	if err != nil {
@@ -94,6 +95,10 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 
 	// Save the json result for benchmarking
 	resp.SaveJSON(tName)
+
+	if len(resp.Result) == 0 {
+		t.Fatalf("No result found for the load test")
+	}
 
 	// Add latency metrics
 	var tc []junit.TestCase

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -155,6 +155,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 		Domain:         domain,
 		BaseQPS:        qpsPerClient * float64(numClients),
 		URL:            fmt.Sprintf("http://%s/?timeout=%d", *endpoint, processingTimeMillis),
+		LoadFactors:    []float64{1},
 	}
 
 	t.Logf("Starting test with %d clients at %s", numClients, time.Now())


### PR DESCRIPTION
Fixing the tests directly in serving for now. Ideally, we should add the defaults correctly in the loadgen library, which will take a day or two to do and port over.

part of #3812 