### PR TITLE
[RELEASE-0.5] Reduce the default TCP timeout to fix #3700. (#3794)

### DIFF
--- a/pkg/activator/util/transports_test.go
+++ b/pkg/activator/util/transports_test.go
@@ -49,7 +49,7 @@ func TestHTTPRoundTripper(t *testing.T) {
 		})
 	}
 
-	rt := NewHTTPTransport(frt("v1"), frt("v2"))
+	rt := NewAutoTransport(frt("v1"), frt("v2"))
 
 	examples := []struct {
 		label      string

--- a/pkg/http/h2c/h2c.go
+++ b/pkg/http/h2c/h2c.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/knative/serving/pkg/network"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -46,11 +47,10 @@ var DefaultTransport http.RoundTripper = &http2.Transport{
 	AllowHTTP: true,
 	DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
 		d := &net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   network.DefaultConnTimeout,
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}
-
 		return d.Dial(netw, addr)
 	},
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -19,6 +19,7 @@ package network
 import (
 	"net"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -54,6 +55,19 @@ const (
 	// specifies the golang template string to use to construct the
 	// Knative service's DNS name.
 	DomainTemplateKey = "domainTemplate"
+
+	// DefaultConnTimeout specifies a short default connection timeout
+	// to avoid hitting the issue fixed in
+	// https://github.com/kubernetes/kubernetes/pull/72534 but only
+	// avalailable after Kubernetes 1.14.
+	//
+	// Our connections are usually between pods in the same cluster
+	// like activator <-> queue-proxy, or even between containers
+	// within the same pod queue-proxy <-> user-container, so a
+	// smaller connect timeout would be justifiable.
+	//
+	// We should consider exposing this as a configuration.
+	DefaultConnTimeout = 200 * time.Millisecond
 
 	// DefaultDomainTemplate is the default golang template to use when
 	// constructing the Knative Route's Domain(host)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Cherry pick fix for #3700 

## Proposed Changes

* Reduce the default TCP timeout to fix #3700.
* Fix lint comments.
* Don't modify http.DefaultTransport but make a copy.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix long cold-start when probes can go to queue-proxy too quickly #3700.
```
