### PR TITLE
Make FetchReadyAddressCount return error on not found as well.

### DIFF
--- a/pkg/resources/endpoints.go
+++ b/pkg/resources/endpoints.go
@@ -20,20 +20,15 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // FetchReadyAddressCount fetches endpoints and returns the total number of addresses ready for them.
 func FetchReadyAddressCount(lister corev1listers.EndpointsLister, ns, name string) (int, error) {
 	endpoints, err := lister.Endpoints(ns).Get(name)
-	if apierrors.IsNotFound(err) {
-		// Treat a not-found error as 0 ready addresses
-		return 0, nil
-	} else if err != nil {
+	if err != nil {
 		return 0, err
 	}
-
 	return ReadyAddressCount(endpoints), nil
 }
 

--- a/pkg/resources/endpoints_test.go
+++ b/pkg/resources/endpoints_test.go
@@ -43,10 +43,12 @@ func TestFetchReadyAddressCount(t *testing.T) {
 		name      string
 		endpoints *corev1.Endpoints
 		want      int
+		wantErr   bool
 	}{{
 		name:      "no endpoints at all",
 		endpoints: nil,
 		want:      0,
+		wantErr:   true,
 	}, {
 		name:      "no ready addresses",
 		endpoints: endpoints(0),
@@ -66,8 +68,12 @@ func TestFetchReadyAddressCount(t *testing.T) {
 			if test.endpoints != nil {
 				createEndpoints(test.endpoints)
 			}
-			if got, _ := FetchReadyAddressCount(endpointsClient.Lister(), testNamespace, testService); got != test.want {
+			got, err := FetchReadyAddressCount(endpointsClient.Lister(), testNamespace, testService)
+			if got != test.want {
 				t.Errorf("ReadyAddressCount() = %d, want: %d", got, test.want)
+			}
+			if got, want := (err != nil), test.wantErr; got != want {
+				t.Errorf("WantErr = %v, want: %v, err: %v", got, want, err)
 			}
 		})
 	}


### PR DESCRIPTION
Currently it swallows the not found errors and returns (0, nil), but
this is the behavior that autoscaler desires, but it's might not be univerally
desired.
Move the check in the autoscaler and let the generic function always
return error should there be one.


/lint
## Proposed Changes

* always return error in helper
* check for NotFound in the places where they care about that

/cc @mattmoor @markusthoemmes 
/assign @mattmoor 
