### PR TITLE
Fix the problem where old PAs go into unknown state.

### DIFF
--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa.go
@@ -278,8 +278,8 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		if err != nil {
 			return perrors.Wrapf(err, "error checking endpoints %s", sks.Status.PrivateServiceName)
 		}
-		logger.Infof("PA scale got=%v, want=%v", got, want)
 	}
+	logger.Infof("PA scale got=%v, want=%v", got, want)
 
 	err = reportMetrics(pa, want, got)
 	if err != nil {
@@ -444,7 +444,7 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 		ret = !pa.Status.IsInactive() // Any state but inactive should change SKS.
 		pa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")
 
-	case got == 0 && want != 0:
+	case got == 0 && want > 0:
 		ret = pa.Status.IsInactive() // If we were inactive and became activating.
 		pa.Status.MarkActivating(
 			"Queued", "Requests to the target are being buffered as resources are provisioned.")
@@ -452,6 +452,8 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 	case got > 0:
 		// SKS should already be active.
 		pa.Status.MarkActive()
+	case want == scaleUnknown:
+		// We don't know what scale we want, so don't touch PA at all.
 	}
 
 	pa.Status.ObservedGeneration = pa.Generation


### PR DESCRIPTION
Origianally (even before my changes) the old updatePAStatus
method would change the status of the PA to unknown, even if it's
inactive. The reason for that is that after restart for an inactive
revision the desired scale is always -1.
Now, this was not much of a problem in the previous life, since when
activated the desired scale would become 1 and everything would unfold
as desired. But in this new brave world, this causes SKS to reconcile to
serve more, which removes the activator endpoints from the public k8s
service and prohibits our future endeavours like positive handoff.

The change is simple: basically ignore want==-1 scale events, when
changing status. This works because:
if want == -1 and we're inactive => stay inactive
if want == -1 and we're active => stay active
if want == -1 and we're activating => continue activating.

/cc @mattmoor 
#1997 