### PR TITLE
Increase the "destroy pod timely" deadline.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -136,7 +136,7 @@ const (
 	// Give the pods plenty of time to disappear. It will take them at least 20 seconds to vanish
 	// because we have a hard-coded sleep of 20 seconds before initiating the shutdown process.
 	// This is still well below the 5 minutes it might take them to disappear max.
-	maxTimeToDelete = 60 * time.Second
+	maxTimeToDelete = 90 * time.Second
 )
 
 func TestDestroyPodTimely(t *testing.T) {


### PR DESCRIPTION
We've seen a number of flakes where the pod disappears just over the deadline, but well before the 5 minute mark.
