### PR TITLE
Shift the e2e tests to use the v1beta1 subset.

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -147,8 +147,9 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
-						RevisionName: "config-00001",
-						Percent:      100,
+						RevisionName:   "config-00001",
+						Percent:        100,
+						LatestRevision: ptr.Bool(true),
 					},
 				})),
 		}},
@@ -196,8 +197,9 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
-						RevisionName: "config-00001",
-						Percent:      100,
+						RevisionName:   "config-00001",
+						Percent:        100,
+						LatestRevision: ptr.Bool(true),
 					},
 				})),
 		}},
@@ -249,8 +251,9 @@ func TestReconcile(t *testing.T) {
 				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
-						RevisionName: "config-00001",
-						Percent:      100,
+						RevisionName:   "config-00001",
+						Percent:        100,
+						LatestRevision: ptr.Bool(true),
 					},
 				})),
 		}},
@@ -296,8 +299,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 		}},
@@ -345,8 +349,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 		}},
@@ -398,8 +403,9 @@ func TestReconcile(t *testing.T) {
 				WithDomain, WithDomainInternal, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
-						RevisionName: "config-00001",
-						Percent:      100,
+						RevisionName:   "config-00001",
+						Percent:        100,
+						LatestRevision: ptr.Bool(true),
 					},
 				})),
 		}},
@@ -419,8 +425,9 @@ func TestReconcile(t *testing.T) {
 				WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -490,8 +497,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					}),
 				// The owner is not us, so we are unhappy.
@@ -512,8 +520,9 @@ func TestReconcile(t *testing.T) {
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
-						RevisionName: "config-00001",
-						Percent:      100,
+						RevisionName:   "config-00001",
+						Percent:        100,
+						LatestRevision: ptr.Bool(true),
 					},
 				}), WithRouteLabel("app", "prod")),
 			cfg("default", "config",
@@ -549,8 +558,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -643,8 +653,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00002",
-							Percent:      100,
+							RevisionName:   "config-00002",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 		}},
@@ -717,8 +728,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00002",
-							Percent:      100,
+							RevisionName:   "config-00002",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 		}},
@@ -735,8 +747,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -780,8 +793,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -826,8 +840,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -867,8 +882,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -907,8 +923,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -1022,8 +1039,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "newconfig-00001",
-							Percent:      100,
+							RevisionName:   "newconfig-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 		}},
@@ -1098,8 +1116,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(false),
 						},
 					})),
 		}},
@@ -1182,13 +1201,15 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "blue-00001",
-							Percent:      50,
+							RevisionName:   "blue-00001",
+							Percent:        50,
+							LatestRevision: ptr.Bool(true),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "green-00001",
-							Percent:      50,
+							RevisionName:   "green-00001",
+							Percent:        50,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 		}},
@@ -1288,16 +1309,20 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						DeprecatedName: "gray",
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "gray-00001",
-							Percent:      50,
-							URL:          "http://gray.same-revision-targets.default.example.com",
+							Tag:            "gray",
+							RevisionName:   "gray-00001",
+							Percent:        50,
+							LatestRevision: ptr.Bool(true),
+							URL:            "http://gray.same-revision-targets.default.example.com",
 						},
 					}, v1alpha1.TrafficTarget{
 						DeprecatedName: "also-gray",
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "gray-00001",
-							Percent:      50,
-							URL:          "http://also-gray.same-revision-targets.default.example.com",
+							Tag:            "also-gray",
+							RevisionName:   "gray-00001",
+							Percent:        50,
+							LatestRevision: ptr.Bool(false),
+							URL:            "http://also-gray.same-revision-targets.default.example.com",
 						},
 					})),
 		}},
@@ -1371,8 +1396,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "green-00001",
-							Percent:      100,
+							RevisionName:   "green-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					}), WithRouteFinalizer),
 		}},
@@ -1402,6 +1428,7 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
 							Percent:           100,
+							LatestRevision:    ptr.Bool(true),
 						},
 					},
 				)),
@@ -1449,6 +1476,7 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
 							Percent:           100,
+							LatestRevision:    ptr.Bool(true),
 						},
 					})),
 		}},
@@ -1462,8 +1490,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",
@@ -1503,8 +1532,9 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      100,
+							RevisionName:   "config-00001",
+							Percent:        100,
+							LatestRevision: ptr.Bool(true),
 						},
 					})),
 			cfg("default", "config",

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -101,8 +101,10 @@ func (t *Config) GetRevisionTrafficTargets(domain string) []v1alpha1.TrafficTarg
 		results[i] = v1alpha1.TrafficTarget{
 			DeprecatedName: tt.Tag,
 			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: tt.RevisionName,
-				Percent:      tt.Percent,
+				Tag:            tt.Tag,
+				RevisionName:   tt.RevisionName,
+				Percent:        tt.Percent,
+				LatestRevision: tt.LatestRevision,
 			},
 		}
 		if tt.Tag != "" && domain != "" {

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -723,7 +723,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
 		t.Errorf("Unexpected error %v", err)
-	} else if got, want := expected, tc; !cmp.Equal(got, want, cmpOpts...) {
+	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(got, want, cmpOpts...))
 	}
 
@@ -943,12 +943,14 @@ func TestRoundTripping(t *testing.T) {
 	}, {
 		DeprecatedName: "beta",
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          "beta",
 			RevisionName: goodNewRev.Name,
 			URL:          TagURL(HTTPScheme, "beta", domain),
 		},
 	}, {
 		DeprecatedName: "alpha",
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          "alpha",
 			RevisionName: niceNewRev.Name,
 			URL:          TagURL(HTTPScheme, "alpha", domain),
 		},

--- a/pkg/reconciler/service/resources/route.go
+++ b/pkg/reconciler/service/resources/route.go
@@ -51,8 +51,8 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 
 		// Configure the 'current' route.
 		ttCurrent := v1alpha1.TrafficTarget{
-			DeprecatedName: v1alpha1.CurrentTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:     v1alpha1.CurrentTrafficTarget,
 				Percent: 100 - rolloutPercent,
 			},
 		}
@@ -72,8 +72,8 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 		// Configure the 'candidate' route.
 		if numRevisions == 2 {
 			ttCandidate := v1alpha1.TrafficTarget{
-				DeprecatedName: v1alpha1.CandidateTrafficTarget,
 				TrafficTarget: v1beta1.TrafficTarget{
+					Tag:     v1alpha1.CandidateTrafficTarget,
 					Percent: rolloutPercent,
 				},
 			}
@@ -88,8 +88,8 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 
 		// Configure the 'latest' route.
 		ttLatest := v1alpha1.TrafficTarget{
-			DeprecatedName: v1alpha1.LatestTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:               v1alpha1.LatestTrafficTarget,
 				ConfigurationName: names.Configuration(service),
 				Percent:           0,
 			},

--- a/pkg/reconciler/service/resources/route_test.go
+++ b/pkg/reconciler/service/resources/route_test.go
@@ -113,14 +113,14 @@ func TestRouteReleaseSingleRevision(t *testing.T) {
 		t.Errorf("Expected %q for service namespace got %q", want, got)
 	}
 	wantT := []v1alpha1.TrafficTarget{{
-		DeprecatedName: v1alpha1.CurrentTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          v1alpha1.CurrentTrafficTarget,
 			Percent:      100,
 			RevisionName: testRevisionName,
 		},
 	}, {
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.LatestTrafficTarget,
 			ConfigurationName: testConfigName,
 		},
 	}}
@@ -156,20 +156,20 @@ func TestRouteLatestRevisionSplit(t *testing.T) {
 		t.Errorf("Expected %q for service namespace got %q", want, got)
 	}
 	wantT := []v1alpha1.TrafficTarget{{
-		DeprecatedName: v1alpha1.CurrentTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.CurrentTrafficTarget,
 			Percent:           currentPercent,
 			ConfigurationName: testConfigName,
 		},
 	}, {
-		DeprecatedName: v1alpha1.CandidateTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          v1alpha1.CandidateTrafficTarget,
 			Percent:      rolloutPercent,
 			RevisionName: "juicy-revision",
 		},
 	}, {
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.LatestTrafficTarget,
 			ConfigurationName: testConfigName,
 		},
 	}}
@@ -205,20 +205,20 @@ func TestRouteLatestRevisionSplitCandidate(t *testing.T) {
 		t.Errorf("Expected %q for service namespace got %q", want, got)
 	}
 	wantT := []v1alpha1.TrafficTarget{{
-		DeprecatedName: v1alpha1.CurrentTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          v1alpha1.CurrentTrafficTarget,
 			Percent:      currentPercent,
 			RevisionName: "squishy-revision",
 		},
 	}, {
-		DeprecatedName: v1alpha1.CandidateTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.CandidateTrafficTarget,
 			Percent:           rolloutPercent,
 			ConfigurationName: testConfigName,
 		},
 	}, {
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.LatestTrafficTarget,
 			ConfigurationName: testConfigName,
 		},
 	}}
@@ -252,14 +252,14 @@ func TestRouteLatestRevisionNoSplit(t *testing.T) {
 	}
 	// Should have 2 named traffic targets (current, latest)
 	wantT := []v1alpha1.TrafficTarget{{
-		DeprecatedName: v1alpha1.CurrentTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.CurrentTrafficTarget,
 			Percent:           100,
 			ConfigurationName: testConfigName,
 		},
 	}, {
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.LatestTrafficTarget,
 			ConfigurationName: testConfigName,
 		},
 	}}
@@ -296,20 +296,20 @@ func TestRouteReleaseTwoRevisions(t *testing.T) {
 	}
 	// Should have 3 named traffic targets (current, candidate, latest)
 	wantT := []v1alpha1.TrafficTarget{{
-		DeprecatedName: v1alpha1.CurrentTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          v1alpha1.CurrentTrafficTarget,
 			Percent:      currentPercent,
 			RevisionName: testRevisionName,
 		},
 	}, {
-		DeprecatedName: v1alpha1.CandidateTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          v1alpha1.CandidateTrafficTarget,
 			Percent:      100 - currentPercent,
 			RevisionName: testCandidateRevisionName,
 		},
 	}, {
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               v1alpha1.LatestTrafficTarget,
 			ConfigurationName: testConfigName,
 		},
 	}}

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -246,20 +246,16 @@ func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) e
 				if want[idx].ConfigurationName == config.Name {
 					want[idx].RevisionName = config.Status.LatestReadyRevisionName
 					want[idx].ConfigurationName = ""
-					// Normalize Name into Tag for comparison.
-					if want[idx].DeprecatedName != "" {
-						want[idx].Tag = want[idx].DeprecatedName
-						want[idx].DeprecatedName = ""
-					}
-					if got[idx].DeprecatedName != "" {
-						got[idx].Tag = got[idx].DeprecatedName
-						got[idx].DeprecatedName = ""
-					}
 				}
 			}
 			ignoreFields := cmpopts.IgnoreFields(v1alpha1.TrafficTarget{},
-				"TrafficTarget.URL", "TrafficTarget.LatestRevision")
-			if eq, err := kmp.SafeEqual(got, want, ignoreFields); !eq || err != nil {
+				"TrafficTarget.URL", "TrafficTarget.LatestRevision",
+				// We specify the Routing via Tag in spec, but the status surfaces it
+				// via both names for now, so ignore the deprecated name field when
+				// comparing them.
+				"DeprecatedName")
+			if diff, err := kmp.SafeDiff(got, want, ignoreFields); err != nil || diff != "" {
+				logger.Errorf("Route %q is not yet what we want: %s", service.Name, diff)
 				service.Status.MarkRouteNotYetReady()
 			}
 		}

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -151,12 +151,14 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "pinned3-00001",
 						Percent:      100,
 					},
 				}, v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "pinned3-00001",
 						Percent:      0,
 					},
@@ -176,12 +178,14 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "pinned3-00001",
 						Percent:      100,
 					},
 				}, v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "pinned3-00001",
 						Percent:      0,
 					},
@@ -399,12 +403,14 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic([]v1alpha1.TrafficTarget{{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
 						Percent:      100,
 					},
 				}, {
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
 					},
 				}}...), MarkTrafficAssigned, MarkIngressReady),
@@ -424,12 +430,14 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic([]v1alpha1.TrafficTarget{{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
 						Percent:      100,
 					},
 				}, {
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
 					},
 				}}...),
@@ -454,18 +462,21 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic([]v1alpha1.TrafficTarget{{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
 						Percent:      58,
 					},
 				}, {
 					DeprecatedName: v1alpha1.CandidateTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-lr-00002",
 						Percent:      42,
 					},
 				}, {
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-lr-00002",
 					},
 				}}...), MarkTrafficAssigned, MarkIngressReady),
@@ -486,18 +497,21 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic([]v1alpha1.TrafficTarget{{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
 						Percent:      58,
 					},
 				}, {
 					DeprecatedName: v1alpha1.CandidateTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-lr-00002",
 						Percent:      42,
 					},
 				}, {
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-lr-00002",
 					},
 				}}...),
@@ -522,18 +536,21 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-00001",
 						Percent:      42,
 					},
 				}, v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.CandidateTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-00002",
 						Percent:      58,
 					},
 				}, v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-00002",
 						Percent:      0,
 					},
@@ -554,18 +571,21 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.CurrentTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-00001",
 						Percent:      42,
 					},
 				}, v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.CandidateTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-00002",
 						Percent:      58,
 					},
 				}, v1alpha1.TrafficTarget{
 					DeprecatedName: v1alpha1.LatestTrafficTarget,
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-00002",
 						Percent:      0,
 					},

--- a/pkg/reconciler/testing/functional.go
+++ b/pkg/reconciler/testing/functional.go
@@ -185,14 +185,23 @@ func WithServiceLabel(key, value string) ServiceOption {
 // WithResourceRequirements attaches resource requirements to the service
 func WithResourceRequirements(resourceRequirements corev1.ResourceRequirements) ServiceOption {
 	return func(svc *v1alpha1.Service) {
-		svc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Resources = resourceRequirements
+		if svc.Spec.DeprecatedRunLatest != nil {
+			svc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Resources = resourceRequirements
+		} else {
+			svc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources = resourceRequirements
+		}
 	}
 }
 
 // WithVolume adds a volume to the service
 func WithVolume(name, mountPath string, volumeSource corev1.VolumeSource) ServiceOption {
 	return func(svc *v1alpha1.Service) {
-		rt := &svc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec
+		var rt *v1alpha1.RevisionSpec
+		if svc.Spec.DeprecatedRunLatest != nil {
+			rt = &svc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec
+		} else {
+			rt = &svc.Spec.ConfigurationSpec.Template.Spec
+		}
 
 		rt.GetContainer().VolumeMounts = []corev1.VolumeMount{{
 			Name:      name,
@@ -209,14 +218,22 @@ func WithVolume(name, mountPath string, volumeSource corev1.VolumeSource) Servic
 // WithConfigAnnotations assigns config annotations to a service
 func WithConfigAnnotations(annotations map[string]string) ServiceOption {
 	return func(service *v1alpha1.Service) {
-		service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta.Annotations = annotations
+		if service.Spec.DeprecatedRunLatest != nil {
+			service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta.Annotations = annotations
+		} else {
+			service.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations = annotations
+		}
 	}
 }
 
 // WithRevisionTimeoutSeconds sets revision timeout
 func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 	return func(service *v1alpha1.Service) {
-		service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.TimeoutSeconds = ptr.Int64(revisionTimeoutSeconds)
+		if service.Spec.DeprecatedRunLatest != nil {
+			service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.TimeoutSeconds = ptr.Int64(revisionTimeoutSeconds)
+		} else {
+			service.Spec.ConfigurationSpec.Template.Spec.TimeoutSeconds = ptr.Int64(revisionTimeoutSeconds)
+		}
 	}
 }
 

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -29,6 +29,9 @@ import (
 	"github.com/knative/serving/test"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 )
 
 const (
@@ -72,62 +75,75 @@ func TestBlueGreenRoute(t *testing.T) {
 	// The first revision created is "blue"
 	blue.Revision = names.Revision
 
-	t.Log("Updating to a DeprecatedManual Service to allow configuration and route to be manually modified")
-	svc, err := test.PatchManualService(t, clients, objects.Service)
+	service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to update Service %s: %v", names.Service, err)
+		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+	}
+	objects.Service = service
+
+	t.Log("Updating the Service to use a different image")
+	svc, err := test.PatchServiceImage(t, clients, objects.Service, imagePaths[1])
+	if err != nil {
+		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, imagePaths[1], err)
 	}
 	objects.Service = svc
 
-	t.Log("Updating the Configuration to use a different image")
-	cfg, err := test.PatchConfigImage(clients, objects.Config, imagePaths[1])
+	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
+	green.Revision, err = test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("Patch update for Configuration %s with new image %s failed: %v", names.Config, imagePaths[1], err)
+		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, imagePaths[1], err)
 	}
-	objects.Config = cfg
 
-	t.Log("Since the Configuration was updated a new Revision will be created and the Configuration will be updated")
-	green.Revision, err = test.WaitForConfigLatestRevision(clients, names)
+	t.Log("Updating RouteSpec")
+	if _, err := test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
+		Traffic: []v1alpha1.TrafficTarget{{
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "blue",
+				RevisionName: blue.Revision,
+				Percent:      50,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "green",
+				RevisionName: green.Revision,
+				Percent:      50,
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+
+	t.Log("Wait for the service domains to be ready")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
+	}
+
+	service, err = clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, imagePaths[1], err)
-	}
-
-	t.Log("Updating Route")
-	if _, err := test.UpdateBlueGreenRoute(t, clients, names, blue, green); err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
-	}
-
-	t.Log("Wait for the route domains to be ready")
-	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
-	}
-
-	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
 	var blueDomain, greenDomain string
-	for _, tt := range route.Status.Traffic {
-		if tt.DeprecatedName == blue.TrafficTarget {
+	for _, tt := range service.Status.Traffic {
+		if tt.Tag == blue.TrafficTarget {
 			// Strip prefix as WaitForEndPointState expects a domain
 			// without scheme.
 			blueDomain = strings.TrimPrefix(tt.URL, "http://")
 		}
-		if tt.DeprecatedName == green.TrafficTarget {
+		if tt.Tag == green.TrafficTarget {
 			// Strip prefix as WaitForEndPointState expects a domain
 			// without scheme.
 			greenDomain = strings.TrimPrefix(tt.URL, "http://")
 		}
 	}
 	if blueDomain == "" || greenDomain == "" {
-		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", route.Status.Traffic)
+		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
-	tealDomain := route.Status.Domain
+	tealDomain := service.Status.Domain
 
 	// Istio network programming takes some time to be effective.  Currently Istio
 	// does not expose a Status, so we rely on probes to know when they are effective.
-	// Since we are updating the route the teal domain probe will succeed before our changes
+	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
 	t.Logf("Probing domain %s", greenDomain)
 	if _, err := pkgTest.WaitForEndpointState(

--- a/test/conformance/blue_green_test.go
+++ b/test/conformance/blue_green_test.go
@@ -75,12 +75,6 @@ func TestBlueGreenRoute(t *testing.T) {
 	// The first revision created is "blue"
 	blue.Revision = names.Revision
 
-	service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
-	}
-	objects.Service = service
-
 	t.Log("Updating the Service to use a different image")
 	svc, err := test.PatchServiceImage(t, clients, objects.Service, imagePaths[1])
 	if err != nil {
@@ -98,19 +92,19 @@ func TestBlueGreenRoute(t *testing.T) {
 	if _, err := test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
 		Traffic: []v1alpha1.TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
-				Tag:          "blue",
+				Tag:          blue.TrafficTarget,
 				RevisionName: blue.Revision,
 				Percent:      50,
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
-				Tag:          "green",
+				Tag:          green.TrafficTarget,
 				RevisionName: green.Revision,
 				Percent:      50,
 			},
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatalf("Failed to update Service: %v", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -118,7 +112,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
 	}
 
-	service, err = clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
+	service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}

--- a/test/conformance/container_test.go
+++ b/test/conformance/container_test.go
@@ -40,7 +40,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}{{
 		name: "TestArbitraryPortName",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 				Name:          "arbitrary",
 				ContainerPort: 8080,
 			}}
@@ -49,7 +49,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		name: "TestMountPropagation",
 		options: func(s *v1alpha1.Service) {
 			propagationMode := corev1.MountPropagationHostToContainer
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
 				Name:             "VolumeMount",
 				MountPath:        "/",
 				MountPropagation: &propagationMode,
@@ -58,7 +58,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestReadinessHTTPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
@@ -70,7 +70,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestLivenessHTTPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
@@ -82,7 +82,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestReadinessTCPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8888)},
 				},
@@ -91,7 +91,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestLivenessTCPProbePort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8888)},
 				},
@@ -129,7 +129,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
 			}
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Lifecycle = &corev1.Lifecycle{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Lifecycle = &corev1.Lifecycle{
 				PostStart: &corev1.Handler{Exec: lifecycleHandler},
 			}
 		},
@@ -139,14 +139,14 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the pre stop handler > /usr/share/message"},
 			}
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Lifecycle = &corev1.Lifecycle{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Lifecycle = &corev1.Lifecycle{
 				PreStop: &corev1.Handler{Exec: lifecycleHandler},
 			}
 		},
 	}, {
 		name: "TestMultiplePorts",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{
 				{ContainerPort: 80},
 				{ContainerPort: 81},
 			}
@@ -154,7 +154,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 	}, {
 		name: "TestHostPort",
 		options: func(s *v1alpha1.Service) {
-			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 				ContainerPort: 8081,
 				HostPort:      80,
 			}}

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -175,7 +175,7 @@ func TestRevisionTimeout(t *testing.T) {
 			},
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatalf("Failed to update Service: %v", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")

--- a/test/conformance/revision_timeout_test.go
+++ b/test/conformance/revision_timeout_test.go
@@ -22,11 +22,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
 	. "github.com/knative/serving/pkg/reconciler/testing"
 	"github.com/knative/serving/test"
@@ -44,17 +46,17 @@ func createLatestService(t *testing.T, clients *test.Clients, names test.Resourc
 	return svc, err
 }
 
-func updateConfigWithTimeout(clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int) error {
+func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int) error {
 	patches := []jsonpatch.JsonPatchOperation{{
 		Operation: "replace",
-		Path:      "/spec/revisionTemplate/spec/timeoutSeconds",
+		Path:      "/spec/template/spec/timeoutSeconds",
 		Value:     revisionTimeoutSeconds,
 	}}
 	patchBytes, err := json.Marshal(patches)
 	if err != nil {
 		return err
 	}
-	_, err = clients.ServingClient.Configs.Patch(names.Config, types.JSONPatchType, patchBytes, "")
+	_, err = clients.ServingClient.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
 	if err != nil {
 		return err
 	}
@@ -129,25 +131,19 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
 	}
 
-	t.Log("Patching to a DeprecatedManual Service to allow configuration and route to be manually modified")
-	_, err = test.PatchManualService(t, clients, svc)
+	t.Log("Updating the Service to use a different revision timeout")
+	err = updateServiceWithTimeout(clients, names, 5)
 	if err != nil {
-		t.Fatalf("Failed to update Service %s: %v", names.Service, err)
-	}
-
-	t.Log("Updating the Configuration to use a different revision timeout")
-	err = updateConfigWithTimeout(clients, names, 5)
-	if err != nil {
-		t.Fatalf("Patch update for Configuration %s with new timeout 5s failed: %v", names.Config, err)
+		t.Fatalf("Patch update for Service %s with new timeout 5s failed: %v", names.Service, err)
 	}
 
 	// getNextRevisionName waits for names.Revision to change, so we set it to the rev2s revision and wait for the (new) rev5s revision.
 	names.Revision = rev2s.Revision
 
-	t.Log("Since the Configuration was updated a new Revision will be created and the Configuration will be updated")
-	rev5s.Revision, err = test.WaitForConfigLatestRevision(clients, names)
+	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
+	rev5s.Revision, err = test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("Configuration %s was not updated with the Revision with timeout 5s: %v", names.Config, err)
+		t.Fatalf("Service %s was not updated with the Revision with timeout 5s: %v", names.Service, err)
 	}
 
 	t.Logf("Waiting for revision %q to be ready", rev2s.Revision)
@@ -163,23 +159,51 @@ func TestRevisionTimeout(t *testing.T) {
 	rev2s.TrafficTarget = "rev2s"
 	rev5s.TrafficTarget = "rev5s"
 
-	t.Log("Updating Route")
-	if _, err := test.UpdateBlueGreenRoute(t, clients, names, rev2s, rev5s); err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
+	t.Log("Updating RouteSpec")
+	if _, err := test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
+		Traffic: []v1alpha1.TrafficTarget{{
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          rev2s.TrafficTarget,
+				RevisionName: rev2s.Revision,
+				Percent:      50,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          rev5s.TrafficTarget,
+				RevisionName: rev5s.Revision,
+				Percent:      50,
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
 	}
 
-	t.Log("Wait for the route domains to be ready")
-	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
+	t.Log("Wait for the service domains to be ready")
+	if err := test.WaitForServiceState(clients.ServingClient, names.Service, test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
 	}
 
-	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	rev2sDomain := fmt.Sprintf("%s.%s", rev2s.TrafficTarget, route.Status.Domain)
-	rev5sDomain := fmt.Sprintf("%s.%s", rev5s.TrafficTarget, route.Status.Domain)
+	var rev2sDomain, rev5sDomain string
+	for _, tt := range service.Status.Traffic {
+		if tt.Tag == rev2s.TrafficTarget {
+			// Strip prefix as WaitForEndPointState expects a domain
+			// without scheme.
+			rev2sDomain = strings.TrimPrefix(tt.URL, "http://")
+		}
+		if tt.Tag == rev5s.TrafficTarget {
+			// Strip prefix as WaitForEndPointState expects a domain
+			// without scheme.
+			rev5sDomain = strings.TrimPrefix(tt.URL, "http://")
+		}
+	}
+	if rev2sDomain == "" || rev5sDomain == "" {
+		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
+	}
 
 	t.Logf("Probing domain %s", rev5sDomain)
 	if _, err := pkgTest.WaitForEndpointState(

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -399,10 +399,10 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 // TestReleaseService creates a Service with a variety of "release"-like traffic shapes.
 // Currently tests for the following combinations:
 // 1. One Revision Specified, current == latest
-// 2. One Revision Specified, current != latset
+// 2. One Revision Specified, current != latest
 // 3. Two Revisions Specified, 50% rollout,  candidate == latest
 // 4. Two Revisions Specified, 50% rollout, candidate != latest
-// 5. Two Revisions Specified, 50% rollout, candidate != latest, latest referred to as `@latest`.
+// 5. Two Revisions Specified, 50% rollout, candidate != latest, candidate is configurationName.
 func TestReleaseService(t *testing.T) {
 	t.Parallel()
 	// Create Initial Service

--- a/test/conformance/service_test.go
+++ b/test/conformance/service_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/ptr"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -153,10 +154,6 @@ func validateAnnotations(objs *test.ResourceObjects) error {
 }
 
 func validateReleaseServiceShape(objs *test.ResourceObjects) error {
-	// Check that Spec.Revisions is as expected.
-	if got, want := objs.Service.Spec.DeprecatedRelease.Revisions, []string{v1alpha1.ReleaseLatestRevisionKeyword}; !cmp.Equal(got, want) {
-		return fmt.Errorf("Spec.DeprecatedRelease.Revisions mismatch: diff: %s", cmp.Diff(got, want))
-	}
 	// Traffic should be routed to the lastest created revision.
 	if got, want := objs.Service.Status.Traffic[0].RevisionName, objs.Config.Status.LatestReadyRevisionName; got != want {
 		return fmt.Errorf("Status.Traffic[0].RevisionsName = %s, want: %s", got, want)
@@ -248,7 +245,7 @@ func TestRunLatestService(t *testing.T) {
 			"labelY": "def",
 		},
 	}
-	if objects.Service, err = test.PatchServiceRevisionTemplateMetadata(t, clients, objects.Service, metadata); err != nil {
+	if objects.Service, err = test.PatchServiceTemplateMetadata(t, clients, objects.Service, metadata); err != nil {
 		t.Fatalf("Service %s was not updated with labels in its RevisionTemplateSpec: %v", names.Service, err)
 	}
 
@@ -265,7 +262,7 @@ func TestRunLatestService(t *testing.T) {
 			"annotationB": "456",
 		},
 	}
-	if objects.Service, err = test.PatchServiceRevisionTemplateMetadata(t, clients, objects.Service, metadata); err != nil {
+	if objects.Service, err = test.PatchServiceTemplateMetadata(t, clients, objects.Service, metadata); err != nil {
 		t.Fatalf("Service %s was not updated with annotation in its RevisionTemplateSpec: %v", names.Service, err)
 	}
 
@@ -291,7 +288,7 @@ func TestRunLatestService(t *testing.T) {
 	// Update container with user port.
 	t.Logf("Updating the port of the user container for service %s to %d", names.Service, userPort)
 	desiredSvc := objects.Service.DeepCopy()
-	desiredSvc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
+	desiredSvc.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Ports = []corev1.ContainerPort{{
 		ContainerPort: userPort,
 	}}
 	if objects.Service, err = test.PatchService(t, clients, objects.Service, desiredSvc); err != nil {
@@ -328,10 +325,10 @@ func waitForDesiredTrafficShape(t *testing.T, sName string, want map[string]v1al
 			// Match the traffic shape.
 			got := map[string]v1alpha1.TrafficTarget{}
 			for _, tt := range s.Status.Traffic {
-				got[tt.DeprecatedName] = tt
+				got[tt.Tag] = tt
 			}
 			ignoreURLs := cmpopts.IgnoreFields(v1alpha1.TrafficTarget{},
-				"TrafficTarget.URL")
+				"TrafficTarget.URL", "DeprecatedName")
 			if !cmp.Equal(got, want, ignoreURLs) {
 				t.Logf("For service %s traffic shape mismatch: (-got, +want) %s",
 					sName, cmp.Diff(got, want, ignoreURLs))
@@ -359,7 +356,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 
 	// Setup initial Service
 	objects, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}, func(svc *v1alpha1.Service) {
-		svc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Name = revName
+		svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
 	})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
@@ -399,9 +396,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	}
 }
 
-// TestReleaseService creates a Service in `release` mode with the only revision
-// being `@latest`. Once this succeeded, the test goes through Update/Validate to
-// try different possible configurations for a release service.
+// TestReleaseService creates a Service with a variety of "release"-like traffic shapes.
 // Currently tests for the following combinations:
 // 1. One Revision Specified, current == latest
 // 2. One Revision Specified, current != latset
@@ -428,7 +423,8 @@ func TestReleaseService(t *testing.T) {
 		expectedThirdRev  = helloWorldText
 	)
 
-	objects, err := test.CreateReleaseServiceWithLatest(t, clients, &names, &test.Options{})
+	// Setup initial Service
+	objects, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -440,26 +436,42 @@ func TestReleaseService(t *testing.T) {
 	if err := validateAnnotations(objects); err != nil {
 		t.Errorf("Service annotations are incorrect: %v", err)
 	}
-	revisions := []string{names.Revision}
+	firstRevision := names.Revision
 
 	// 1. One Revision Specified, current == latest.
 	t.Log("1. Updating Service to ReleaseType using lastCreatedRevision")
-	objects.Service, err = test.PatchReleaseService(t, clients, objects.Service, revisions, 0)
+	objects.Service, err = test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
+		Traffic: []v1alpha1.TrafficTarget{{
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "current",
+				RevisionName: firstRevision,
+				Percent:      100,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:     "latest",
+				Percent: 0,
+			},
+		}},
+	})
 	if err != nil {
-		t.Fatalf("Service %s was not updated to release: %v", names.Service, err)
+		t.Fatalf("Failed to update Service: %v", err)
 	}
+
 	desiredTrafficShape := map[string]v1alpha1.TrafficTarget{
 		v1alpha1.CurrentTrafficTarget: {
-			DeprecatedName: v1alpha1.CurrentTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: objects.Config.Status.LatestReadyRevisionName,
-				Percent:      100,
+				Tag:            v1alpha1.CurrentTrafficTarget,
+				RevisionName:   objects.Config.Status.LatestReadyRevisionName,
+				Percent:        100,
+				LatestRevision: ptr.Bool(false),
 			},
 		},
 		v1alpha1.LatestTrafficTarget: {
-			DeprecatedName: v1alpha1.LatestTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: objects.Config.Status.LatestReadyRevisionName,
+				Tag:            v1alpha1.LatestTrafficTarget,
+				RevisionName:   objects.Config.Status.LatestReadyRevisionName,
+				LatestRevision: ptr.Bool(true),
 			},
 		},
 	}
@@ -479,7 +491,7 @@ func TestReleaseService(t *testing.T) {
 
 	// 2. One Revision Specified, current != latest.
 	t.Log("2. Updating the Service Spec with a new image")
-	if _, err := test.PatchServiceImage(t, clients, objects.Service, releaseImagePath2); err != nil {
+	if objects.Service, err = test.PatchServiceImage(t, clients, objects.Service, releaseImagePath2); err != nil {
 		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, releaseImagePath2, err)
 	}
 
@@ -487,13 +499,14 @@ func TestReleaseService(t *testing.T) {
 	if names.Revision, err = test.WaitForServiceLatestRevision(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
-	revisions = append(revisions, names.Revision)
+	secondRevision := names.Revision
 
 	// Also verify traffic is in the correct shape.
 	desiredTrafficShape[v1alpha1.LatestTrafficTarget] = v1alpha1.TrafficTarget{
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
-			RevisionName: names.Revision,
+			Tag:            v1alpha1.LatestTrafficTarget,
+			RevisionName:   secondRevision,
+			LatestRevision: ptr.Bool(true),
 		},
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
@@ -512,29 +525,52 @@ func TestReleaseService(t *testing.T) {
 
 	// 3. Two Revisions Specified, 50% rollout, candidate == latest.
 	t.Log("3. Updating Service to split traffic between two revisions using Release mode")
-	if objects.Service, err = test.PatchReleaseService(t, clients, objects.Service, revisions, 50); err != nil {
-		t.Fatalf("Service %s was not updated to release: %v", names.Service, err)
+	objects.Service, err = test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
+		Traffic: []v1alpha1.TrafficTarget{{
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "current",
+				RevisionName: firstRevision,
+				Percent:      50,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "candidate",
+				RevisionName: secondRevision,
+				Percent:      50,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:     "latest",
+				Percent: 0,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to update Service: %v", err)
 	}
 
 	desiredTrafficShape = map[string]v1alpha1.TrafficTarget{
 		v1alpha1.CurrentTrafficTarget: {
-			DeprecatedName: v1alpha1.CurrentTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: revisions[0],
-				Percent:      50,
+				Tag:            v1alpha1.CurrentTrafficTarget,
+				RevisionName:   firstRevision,
+				Percent:        50,
+				LatestRevision: ptr.Bool(false),
 			},
 		},
 		v1alpha1.CandidateTrafficTarget: {
-			DeprecatedName: v1alpha1.CandidateTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: revisions[1],
-				Percent:      50,
+				Tag:            v1alpha1.CandidateTrafficTarget,
+				RevisionName:   secondRevision,
+				Percent:        50,
+				LatestRevision: ptr.Bool(false),
 			},
 		},
 		v1alpha1.LatestTrafficTarget: {
-			DeprecatedName: v1alpha1.LatestTrafficTarget,
 			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: revisions[1],
+				Tag:            v1alpha1.LatestTrafficTarget,
+				RevisionName:   secondRevision,
+				LatestRevision: ptr.Bool(true),
 			},
 		},
 	}
@@ -554,18 +590,20 @@ func TestReleaseService(t *testing.T) {
 
 	// 4. Two Revisions Specified, 50% rollout, candidate != latest.
 	t.Log("4. Updating the Service Spec with a new image")
-	if _, err := test.PatchServiceImage(t, clients, objects.Service, releaseImagePath3); err != nil {
+	if objects.Service, err = test.PatchServiceImage(t, clients, objects.Service, releaseImagePath3); err != nil {
 		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, releaseImagePath3, err)
 	}
 	t.Log("Since the Service was updated a new Revision will be created")
 	if names.Revision, err = test.WaitForServiceLatestRevision(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
+	thirdRevision := names.Revision
 
 	desiredTrafficShape[v1alpha1.LatestTrafficTarget] = v1alpha1.TrafficTarget{
-		DeprecatedName: v1alpha1.LatestTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
-			RevisionName: names.Revision,
+			Tag:            v1alpha1.LatestTrafficTarget,
+			RevisionName:   thirdRevision,
+			LatestRevision: ptr.Bool(true),
 		},
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
@@ -583,11 +621,31 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	// Now update the service to use `@latest` as candidate.
-	revisions[1] = v1alpha1.ReleaseLatestRevisionKeyword
 	t.Log("5. Updating Service to split traffic between two `current` and `@latest`")
-	if objects.Service, err = test.PatchReleaseService(t, clients, objects.Service, revisions, 50); err != nil {
-		t.Fatalf("Service %s was not updated to release: %v", names.Service, err)
+
+	objects.Service, err = test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
+		Traffic: []v1alpha1.TrafficTarget{{
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "current",
+				RevisionName: firstRevision,
+				Percent:      50,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:     "candidate",
+				Percent: 50,
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:     "latest",
+				Percent: 0,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to update Service: %v", err)
 	}
+
 	// Verify in the end it's still the case.
 	if err := validateAnnotations(objects); err != nil {
 		t.Errorf("Service annotations are incorrect: %v", err)
@@ -595,10 +653,11 @@ func TestReleaseService(t *testing.T) {
 
 	// `candidate` now points to the latest.
 	desiredTrafficShape[v1alpha1.CandidateTrafficTarget] = v1alpha1.TrafficTarget{
-		DeprecatedName: v1alpha1.CandidateTrafficTarget,
 		TrafficTarget: v1beta1.TrafficTarget{
-			RevisionName: names.Revision,
-			Percent:      50,
+			Tag:            v1alpha1.CandidateTrafficTarget,
+			RevisionName:   thirdRevision,
+			Percent:        50,
+			LatestRevision: ptr.Bool(true),
 		},
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
@@ -614,5 +673,3 @@ func TestReleaseService(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
-// TODO(jonjohnsonjr): Examples of deploying from source.

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -55,8 +55,8 @@ func TestActivatorOverload(t *testing.T) {
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
 	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}, func(service *v1alpha1.Service) {
-		service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.ContainerConcurrency = 1
-		service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
+		service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = 1
+		service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 	})
 	if err != nil {
 		t.Fatalf("Unable to create resources: %v", err)

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -127,7 +127,7 @@ func parallelScaleFromZero(t *testing.T, count int) ([]time.Duration, error) {
 	sos := []ktest.ServiceOption{
 		// We set a small resource alloc so that we can pack more pods into the cluster.
 		func(svc *v1alpha1.Service) {
-			svc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.GetContainer().Resources = corev1.ResourceRequirements{
+			svc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
 					corev1.ResourceMemory: resource.MustParse("50Mi"),

--- a/test/route.go
+++ b/test/route.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	rtesting "github.com/knative/serving/pkg/reconciler/testing"
 )
@@ -35,31 +33,6 @@ func CreateRoute(t *testing.T, clients *Clients, names ResourceNames, fopt ...rt
 	route := Route(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Route: route})
 	return clients.ServingClient.Routes.Create(route)
-}
-
-// CreateBlueGreenRoute creates a route in the given namespace using the route name in names.
-// Traffic is evenly split between the two routes specified by blue and green.
-func CreateBlueGreenRoute(t *testing.T, clients *Clients, names, blue, green ResourceNames) error {
-	route := BlueGreenRoute(names, blue, green)
-	LogResourceObject(t, ResourceObjects{Route: route})
-	_, err := clients.ServingClient.Routes.Create(route)
-	return err
-}
-
-// UpdateBlueGreenRoute updates a route in the given namespace using the route name in names.
-func UpdateBlueGreenRoute(t *testing.T, clients *Clients, names, blue, green ResourceNames) (*v1alpha1.Route, error) {
-	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	newRoute := BlueGreenRoute(names, blue, green)
-	newRoute.ObjectMeta = route.ObjectMeta
-	LogResourceObject(t, ResourceObjects{Route: newRoute})
-	patchBytes, err := createPatch(route, newRoute)
-	if err != nil {
-		return nil, err
-	}
-	return clients.ServingClient.Routes.Patch(names.Route, types.JSONPatchType, patchBytes, "")
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route

--- a/test/service.go
+++ b/test/service.go
@@ -19,12 +19,14 @@ limitations under the License.
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
+	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -50,9 +52,6 @@ func validateCreatedServiceStatus(clients *Clients, names *ResourceNames) error 
 			return false, fmt.Errorf("lastCreatedRevision is not present in Service status: %v", s)
 		}
 		names.Revision = s.Status.LatestCreatedRevisionName
-		if s.Status.DeprecatedDomainInternal == "" {
-			return false, fmt.Errorf("domainInternal is not present in Service status: %v", s)
-		}
 		if s.Status.LatestReadyRevisionName == "" {
 			return false, fmt.Errorf("lastReadyRevision is not present in Service status: %v", s)
 		}
@@ -96,50 +95,7 @@ func GetResourceObjects(clients *Clients, names ResourceNames) (*ResourceObjects
 	}, nil
 }
 
-// CreateReleaseServiceWithLatest creates a `Release` service using `@latest`
-// as the only revision.
-// This function expects `Service` and `Image` name passed in through `names`.
-// Names is updated with the `Route` and `Configuration` created by the Service
-// and `ResourceObjects` is returned with the `Service`, `Route`, and `Configuration` objects.
-// Returns an error if the service does not come up correctly.
-func CreateReleaseServiceWithLatest(
-	t *testing.T, clients *Clients,
-	names *ResourceNames, options *Options) (*ResourceObjects, error) {
-	if names.Image == "" {
-		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
-	}
-
-	t.Log("Creating a new Service as Release with @latest.")
-	svc, err := CreateReleaseService(t, clients, *names, options)
-	if err != nil {
-		return nil, err
-	}
-
-	// Populate Route and Configuration Objects with name
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
-
-	// If the Service name was not specified, populate it
-	if names.Service == "" {
-		names.Service = svc.Name
-	}
-
-	t.Log("Waiting for Service to transition to Ready.")
-	if err := WaitForServiceState(clients.ServingClient, names.Service, IsServiceReady, "ServiceIsReady"); err != nil {
-		return nil, err
-	}
-
-	t.Log("Checking to ensure Service Status is populated for Ready service.")
-	err = validateCreatedServiceStatus(clients, names)
-	if err != nil {
-		return nil, err
-	}
-
-	t.Log("Getting latest objects Created by Service.")
-	return GetResourceObjects(clients, *names)
-}
-
-// CreateRunLatestServiceReady creates a new DeprecatedRunLatest Service in state 'Ready'. This function expects Service and Image name passed in through 'names'.
+// CreateRunLatestServiceReady creates a new Service in state 'Ready'. This function expects Service and Image name passed in through 'names'.
 // Names is updated with the Route and Configuration created by the Service and ResourceObjects is returned with the Service, Route, and Configuration objects.
 // Returns error if the service does not come up correctly.
 func CreateRunLatestServiceReady(t *testing.T, clients *Clients, names *ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
@@ -147,7 +103,7 @@ func CreateRunLatestServiceReady(t *testing.T, clients *Clients, names *Resource
 		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
 	}
 
-	t.Logf("Creating a new Service %s as DeprecatedRunLatest.", names.Service)
+	t.Logf("Creating a new Service %s.", names.Service)
 	svc, err := CreateLatestService(t, clients, *names, options, fopt...)
 	if err != nil {
 		return nil, err
@@ -181,14 +137,6 @@ func CreateRunLatestServiceReady(t *testing.T, clients *Clients, names *Resource
 	return resources, err
 }
 
-// CreateReleaseService creates a service in namespace with the name names.Service and names.Image,
-// configured with `@latest` revision.
-func CreateReleaseService(t *testing.T, clients *Clients, names ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
-	service := ReleaseLatestService(names, options, fopt...)
-	LogResourceObject(t, ResourceObjects{Service: service})
-	return clients.ServingClient.Services.Create(service)
-}
-
 // CreateLatestService creates a service in namespace with the name names.Service and names.Image
 func CreateLatestService(t *testing.T, clients *Clients, names ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
 	service := LatestService(names, options, fopt...)
@@ -197,26 +145,12 @@ func CreateLatestService(t *testing.T, clients *Clients, names ResourceNames, op
 	return svc, err
 }
 
-// PatchReleaseService patches an existing service in namespace with the name names.Service
-func PatchReleaseService(t *testing.T, clients *Clients, svc *v1alpha1.Service, revisions []string, rolloutPercent int) (*v1alpha1.Service, error) {
-	newSvc := ReleaseService(svc, revisions, rolloutPercent)
-	LogResourceObject(t, ResourceObjects{Service: newSvc})
-	patchBytes, err := createPatch(svc, newSvc)
-	if err != nil {
-		return nil, err
-	}
-	return clients.ServingClient.Services.Patch(svc.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
-}
-
-// PatchManualService patches an existing service in namespace with the name names.Service
-func PatchManualService(t *testing.T, clients *Clients, svc *v1alpha1.Service) (*v1alpha1.Service, error) {
-	newSvc := ManualService(svc)
-	LogResourceObject(t, ResourceObjects{Service: newSvc})
-	patchBytes, err := createPatch(svc, newSvc)
-	if err != nil {
-		return nil, err
-	}
-	return clients.ServingClient.Services.Patch(svc.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
+// CreateLatestServiceLegacy creates a service in namespace with the name names.Service and names.Image
+func CreateLatestServiceLegacy(t *testing.T, clients *Clients, names ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
+	service := LatestServiceLegacy(names, options, fopt...)
+	LogResourceObject(t, ResourceObjects{Service: service})
+	svc, err := clients.ServingClient.Services.Create(service)
+	return svc, err
 }
 
 // PatchServiceImage patches the existing service passed in with a new imagePath. Returns the latest service object
@@ -228,8 +162,10 @@ func PatchServiceImage(t *testing.T, clients *Clients, svc *v1alpha1.Service, im
 		newSvc.Spec.DeprecatedRelease.Configuration.GetTemplate().Spec.GetContainer().Image = imagePath
 	} else if svc.Spec.DeprecatedPinned != nil {
 		newSvc.Spec.DeprecatedPinned.Configuration.GetTemplate().Spec.GetContainer().Image = imagePath
+	} else if svc.Spec.DeprecatedManual != nil {
+		return nil, fmt.Errorf("UpdateImageService(%v): manual is not supported", svc)
 	} else {
-		return nil, fmt.Errorf("UpdateImageService(%v): unable to determine service type", svc)
+		newSvc.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Image = imagePath
 	}
 	LogResourceObject(t, ResourceObjects{Service: newSvc})
 	patchBytes, err := createPatch(svc, newSvc)
@@ -249,18 +185,24 @@ func PatchService(t *testing.T, clients *Clients, curSvc *v1alpha1.Service, desi
 	return clients.ServingClient.Services.Patch(curSvc.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
 }
 
-// PatchServiceRevisionTemplateMetadata patches an existing service by adding metadata to the service's RevisionTemplateSpec.
-func PatchServiceRevisionTemplateMetadata(t *testing.T, clients *Clients, svc *v1alpha1.Service, metadata metav1.ObjectMeta) (*v1alpha1.Service, error) {
-	newSvc := svc.DeepCopy()
-	if svc.Spec.DeprecatedRunLatest != nil {
-		newSvc.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta = metadata
-	} else if svc.Spec.DeprecatedRelease != nil {
-		newSvc.Spec.DeprecatedRelease.Configuration.GetTemplate().ObjectMeta = metadata
-	} else if svc.Spec.DeprecatedPinned != nil {
-		newSvc.Spec.DeprecatedPinned.Configuration.GetTemplate().ObjectMeta = metadata
-	} else {
-		return nil, fmt.Errorf("UpdateServiceRevisionTemplateMetadata(%v): unable to determine service type", svc)
+// UpdateServiceRouteSpec updates a service to use the route name in names.
+func UpdateServiceRouteSpec(t *testing.T, clients *Clients, names ResourceNames, rs v1alpha1.RouteSpec) (*v1alpha1.Service, error) {
+	patches := []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/spec/traffic",
+		Value:     rs.Traffic,
+	}}
+	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
 	}
+	return clients.ServingClient.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
+}
+
+// PatchServiceTemplateMetadata patches an existing service by adding metadata to the service's RevisionTemplateSpec.
+func PatchServiceTemplateMetadata(t *testing.T, clients *Clients, svc *v1alpha1.Service, metadata metav1.ObjectMeta) (*v1alpha1.Service, error) {
+	newSvc := svc.DeepCopy()
+	newSvc.Spec.ConfigurationSpec.Template.ObjectMeta = metadata
 	LogResourceObject(t, ResourceObjects{Service: newSvc})
 	patchBytes, err := createPatch(svc, newSvc)
 	if err != nil {

--- a/test/states.go
+++ b/test/states.go
@@ -39,8 +39,8 @@ func AllRouteTrafficAtRevision(names ResourceNames) func(r *v1alpha1.Route) (boo
 					return true, fmt.Errorf("expected traffic revision name to be %s but actually is %s", names.Revision, tt.RevisionName)
 				}
 
-				if tt.DeprecatedName != names.TrafficTarget {
-					return true, fmt.Errorf("expected traffic target name to be %s but actually is %s", names.TrafficTarget, tt.DeprecatedName)
+				if tt.Tag != names.TrafficTarget {
+					return true, fmt.Errorf("expected traffic target name to be %s but actually is %s", names.TrafficTarget, tt.Tag)
 				}
 
 				return true, nil

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -35,7 +35,7 @@ func TestRunLatestServicePreUpgrade(t *testing.T) {
 	names.Image = image1
 
 	t.Log("Creating a new Service")
-	svc, err := test.CreateLatestService(t, clients, names, &test.Options{})
+	svc, err := test.CreateLatestServiceLegacy(t, clients, names, &test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}


### PR DESCRIPTION
The most superficial part of thst is shifting the fields we use in tests from
`revisionTemplate` to `template`, `container` to `containers`, `name` to `tag`.

Things get more interesting when we look at Service "modes", where I've changed
things as follows:
 * "run latest" tests now test the path where we omit and default `traffic`
 * "release" tests not test an inline `traffic` block.
 * "manual" tests have been reworked to deal with Service and `traffic`.

The remaining "legacy" testing paths are:
 * We still test that the build integration works, but due to our contextual
   validation, it is only allowed within the legacy modes.  These tests also
   cover `runLatest`, `revisionTemplate` and `container`.
 * Upgrade testing still functions in terms of fields that existed at 0.5.

So while the bulk of our coverage has shifted to the new fields, we do have
basic coverage that the old way still works.

In order to have the tests consume `tag`, this also modifies the Route
controller to surface both `tag` and `name` in status, and `latestRevision`.
