### PR TITLE
Fix a bug validating containerConcurrency.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -142,7 +142,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 	if err := rs.DeprecatedConcurrencyModel.Validate(ctx).ViaField("concurrencyModel"); err != nil {
 		errs = errs.Also(err)
 	} else {
-		errs = errs.Also(rs.ContainerConcurrency.Validate(ctx))
+		errs = errs.Also(rs.ContainerConcurrency.Validate(ctx).ViaField("containerConcurrency"))
 	}
 
 	if rs.TimeoutSeconds != nil {

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -188,24 +188,24 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/byo-rev-not-owned",
 	}, {
 		Name: "webhook validation failure",
-		// If we attempt to create a Revision with a bad ConcurrencyModel set, we fail.
+		// If we attempt to create a Revision with a bad ContainerConcurrency set, we fail.
 		WantErr: true,
 		Objects: []runtime.Object{
-			cfg("validation-failure", "foo", 1234, WithConfigConcurrencyModel("Bogus")),
+			cfg("validation-failure", "foo", 1234, WithConfigContainerConcurrency(-1)),
 		},
 		WantCreates: []metav1.Object{
-			rev("validation-failure", "foo", 1234, WithRevConcurrencyModel("Bogus")),
+			rev("validation-failure", "foo", 1234, WithRevContainerConcurrency(-1)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("validation-failure", "foo", 1234, WithConfigConcurrencyModel("Bogus"),
+			Object: cfg("validation-failure", "foo", 1234, WithConfigContainerConcurrency(-1),
 				// Expect Revision creation to fail with the following error.
-				MarkRevisionCreationFailed(`invalid value: Bogus: spec.concurrencyModel`)),
+				MarkRevisionCreationFailed("expected 0 <= -1 <= 1000: spec.containerConcurrency")),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision for Configuration %q: %v",
-				"validation-failure", `invalid value: Bogus: spec.concurrencyModel`),
+				"validation-failure", "expected 0 <= -1 <= 1000: spec.containerConcurrency"),
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for Configuration %q: %v",
-				"validation-failure", `invalid value: Bogus: spec.revisionTemplate.spec.concurrencyModel`),
+				"validation-failure", "expected 0 <= -1 <= 1000: spec.revisionTemplate.spec.containerConcurrency"),
 		},
 		Key: "foo/validation-failure",
 	}, {

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -645,8 +645,8 @@ func TestReconcile(t *testing.T) {
 			}, WithInitSvcConditions),
 			// Mutate the Config/Route to have a different body than we want.
 			config("update-route-and-config", "foo", WithRunLatestRollout,
-				// Change the concurrency model to ensure it is corrected.
-				WithConfigConcurrencyModel("Single")),
+				// Change the concurrency to ensure it is corrected.
+				WithConfigContainerConcurrency(5)),
 			route("update-route-and-config", "foo", WithRunLatestRollout, MutateRoute),
 			&v1alpha1.Revision{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/testing/functional.go
+++ b/pkg/reconciler/testing/functional.go
@@ -622,10 +622,10 @@ func WithConfigOwnersRemoved(cfg *v1alpha1.Configuration) {
 	cfg.OwnerReferences = nil
 }
 
-// WithConfigConcurrencyModel sets the given Configuration's concurrency model.
-func WithConfigConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) ConfigOption {
+// WithConfigContainerConcurrency sets the given Configuration's concurrency.
+func WithConfigContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) ConfigOption {
 	return func(cfg *v1alpha1.Configuration) {
-		cfg.Spec.GetTemplate().Spec.DeprecatedConcurrencyModel = ss
+		cfg.Spec.GetTemplate().Spec.ContainerConcurrency = cc
 	}
 }
 
@@ -738,10 +738,10 @@ func MarkResourceNotOwned(kind, name string) RevisionOption {
 	}
 }
 
-// WithRevConcurrencyModel sets the concurrency model on the Revision.
-func WithRevConcurrencyModel(ss v1alpha1.RevisionRequestConcurrencyModelType) RevisionOption {
+// WithRevContainerConcurrency sets the given Revision's concurrency.
+func WithRevContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) RevisionOption {
 	return func(rev *v1alpha1.Revision) {
-		rev.Spec.DeprecatedConcurrencyModel = ss
+		rev.Spec.ContainerConcurrency = cc
 	}
 }
 


### PR DESCRIPTION
I switched a use of ConcurrencyModel to ContainerConcurrency in our table tests and it unexpectedly blew up.

This makes that switch and fixes the bug.