### PR TITLE
Explore upgrading resources prior to reconciliation

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -189,7 +189,9 @@ func ValidateContainer(container corev1.Container, volumes sets.String) *apis.Fi
 	// EnvFrom
 	errs = errs.Also(validateEnvFrom(container.EnvFrom).ViaField("envFrom"))
 	// Image
-	if _, err := name.ParseReference(container.Image, name.WeakValidation); err != nil {
+	if container.Image == "" {
+		errs = errs.Also(apis.ErrMissingField("image"))
+	} else if _, err := name.ParseReference(container.Image, name.WeakValidation); err != nil {
 		fe := &apis.FieldError{
 			Message: "Failed to parse image reference",
 			Paths:   []string{"image"},

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -689,12 +689,7 @@ func TestContainerValidation(t *testing.T) {
 			Lifecycle: &corev1.Lifecycle{},
 		},
 		want: apis.ErrDisallowedFields("name", "lifecycle").Also(
-			&apis.FieldError{
-				Message: "Failed to parse image reference",
-				Paths:   []string{"image"},
-				Details: "image: \"\", error: could not parse reference",
-			},
-		),
+			apis.ErrMissingField("image")),
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -115,7 +115,7 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 	// and may not have had all of the assumed defaults specified.  This won't result
 	// in this getting written back to the API Server, but lets downstream logic make
 	// assumptions about defaulting.
-	config.SetDefaults(ctx)
+	config.SetDefaults(v1beta1.WithUpgradeViaDefaulting(ctx))
 	config.Status.InitializeConditions()
 
 	if err := config.ConvertUp(ctx, &v1beta1.Configuration{}); err != nil {

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -638,6 +638,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1
 
 func rev(name, namespace string, generation int64, ro ...RevisionOption) *v1alpha1.Revision {
 	r := resources.MakeRevision(cfg(name, namespace, generation), nil)
+	r.SetDefaults(v1beta1.WithUpgradeViaDefaulting(context.Background()))
 	for _, opt := range ro {
 		opt(r)
 	}

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -214,7 +214,7 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 	// and may not have had all of the assumed defaults specified.  This won't result
 	// in this getting written back to the API Server, but lets downstream logic make
 	// assumptions about defaulting.
-	rev.SetDefaults(ctx)
+	rev.SetDefaults(v1beta1.WithUpgradeViaDefaulting(ctx))
 
 	rev.Status.InitializeConditions()
 	c.updateRevisionLoggingURL(ctx, rev)

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -40,6 +40,7 @@ import (
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	networkinglisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
@@ -144,18 +145,18 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	// and may not have had all of the assumed defaults specified.  This won't result
 	// in this getting written back to the API Server, but lets downstream logic make
 	// assumptions about defaulting.
-	r.SetDefaults(ctx)
+	r.SetDefaults(v1beta1.WithUpgradeViaDefaulting(ctx))
 	r.Status.InitializeConditions()
 
-	// There are no conditions that would trigger this, but if they were we'd have a
-	// block like this here (as the other controllers).
-	// if err := r.ConvertUp(ctx, &v1beta1.Route{}); err != nil {
-	// 	if ce, ok := err.(*v1alpha1.CannotConvertError); ok {
-	// 		r.Status.MarkResourceNotConvertible(ce)
-	// 	} else {
-	// 		return err
-	// 	}
-	// }
+	if err := r.ConvertUp(ctx, &v1beta1.Route{}); err != nil {
+		// There are no conditions that would trigger this, but if they were we'd have a
+		// block like this here (as the other controllers).
+		// if ce, ok := err.(*v1alpha1.CannotConvertError); ok {
+		// 	r.Status.MarkResourceNotConvertible(ce)
+		// } else {
+		return err
+		// }
+	}
 
 	logger.Infof("Reconciling route: %#v", r)
 

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -149,13 +149,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	r.Status.InitializeConditions()
 
 	if err := r.ConvertUp(ctx, &v1beta1.Route{}); err != nil {
-		// There are no conditions that would trigger this, but if they were we'd have a
-		// block like this here (as the other controllers).
-		// if ce, ok := err.(*v1alpha1.CannotConvertError); ok {
-		// 	r.Status.MarkResourceNotConvertible(ce)
-		// } else {
 		return err
-		// }
 	}
 
 	logger.Infof("Reconciling route: %#v", r)

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -140,7 +140,7 @@ func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) e
 	// and may not have had all of the assumed defaults specified.  This won't result
 	// in this getting written back to the API Server, but lets downstream logic make
 	// assumptions about defaulting.
-	service.SetDefaults(ctx)
+	service.SetDefaults(v1beta1.WithUpgradeViaDefaulting(ctx))
 	service.Status.InitializeConditions()
 
 	if err := service.ConvertUp(ctx, &v1beta1.Service{}); err != nil {

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -745,7 +746,7 @@ func TestReconcile(t *testing.T) {
 				}),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "Failed to parse image reference: spec.revisionTemplate.spec.container.image\nimage: \"#\", error: could not parse reference"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "Failed to parse image reference: spec.template.spec.containers[0].image\nimage: \"#\", error: could not parse reference"),
 		},
 	}, {
 		Name: "runLatest - route creation failure",
@@ -1125,6 +1126,7 @@ func TestNew(t *testing.T) {
 
 func config(name, namespace string, so ServiceOption, co ...ConfigOption) *v1alpha1.Configuration {
 	s := Service(name, namespace, so)
+	s.SetDefaults(v1beta1.WithUpgradeViaDefaulting(context.Background()))
 	cfg, err := resources.MakeConfiguration(s)
 	if err != nil {
 		panic(fmt.Sprintf("MakeConfiguration() = %v", err))
@@ -1137,6 +1139,7 @@ func config(name, namespace string, so ServiceOption, co ...ConfigOption) *v1alp
 
 func route(name, namespace string, so ServiceOption, ro ...RouteOption) *v1alpha1.Route {
 	s := Service(name, namespace, so)
+	s.SetDefaults(v1beta1.WithUpgradeViaDefaulting(context.Background()))
 	route, err := resources.MakeRoute(s)
 	if err != nil {
 		panic(fmt.Sprintf("MakeRoute() = %v", err))


### PR DESCRIPTION
The basic idea here is to upgrade the spec we're reconcile, so that even if the incoming Service / Route / Configuration are using old fields, the resources they produce use the new schema.

This is at least WIP until https://github.com/knative/serving/pull/3847 merges, but also contains fixes broken off in https://github.com/knative/serving/pull/3848 and https://github.com/knative/serving/pull/3849.