### PR TITLE
Fix Istio install in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,7 +136,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 ```shell
 kubectl apply -f ./third_party/istio-1.1.2/istio-crds.yaml
-while [ $(kubectl get crd gateways.networking.istio.io -o jsonpath='{.status.conditions[?(@.type=="Established")].status}') != 'True' ]; do
+while [[ $(kubectl get crd gateways.networking.istio.io -o jsonpath='{.status.conditions[?(@.type=="Established")].status}') != 'True' ]]; do
   echo "Waiting on Istio CRDs"; sleep 1
 done
 kubectl apply -f ./third_party/istio-1.1.2/istio.yaml


### PR DESCRIPTION
The operator within test was incorrect causing the while loop to fail and the istio install to proceed and fail. This change updates the while loop to use the built-in bash test functionality which is more relaxed on in doing comparisons.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->