### PR TITLE
Improve validation and update directions for network setup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -167,8 +167,10 @@ ko apply -f config/
 
 # Configure outbound network for GKE.
 export PROJECT_ID="my-gcp-project-id"
-export K8S_CLUSTER_ZONE="my-cluster-zone" # Set K8S_CLUSTER_REGION for regional
-clusters
+# Set K8S_CLUSTER_ZONE if using a zonal cluster
+export K8S_CLUSTER_ZONE="my-cluster-zone"
+# Set K8S_CLUSTER_REGION if using a regional cluster
+export K8S_CLUSTER_REGION="my-cluster-region"
 ./hack/dev-patch-config-gke.sh my-k8s-cluster-name
 
 # Run post-install job to setup nice XIP.IO domain name.  This only works

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -166,7 +166,10 @@ ko apply -f config/
 # Optional steps
 
 # Configure outbound network for GKE.
-PROJECT_ID="my-gcp-project-id" ./hack/dev-patch-config-gke.sh my-k8s-cluster-name
+export PROJECT_ID="my-gcp-project-id"
+export K8S_CLUSTER_ZONE="my-cluster-zone" # Set K8S_CLUSTER_REGION for regional
+clusters
+./hack/dev-patch-config-gke.sh my-k8s-cluster-name
 
 # Run post-install job to setup nice XIP.IO domain name.  This only works
 # if your Kubernetes LoadBalancer has an IP address.

--- a/hack/dev-patch-config-gke.sh
+++ b/hack/dev-patch-config-gke.sh
@@ -25,6 +25,18 @@ readonly K8S_CLUSTER_REGION
 readonly K8S_CLUSTER_ZONE
 readonly SET_CLUSTER_CIDR=${SET_CLUSTER_CIDR:-true}
 
+function validate_arguments() {
+  if [ -n "${K8S_CLUSTER_REGION}" -a -n "${K8S_CLUSTER_ZONE}" ]; then
+      echo "Must set one of K8S_CLUSTER_REGION or K8S_CLUSTER_ZONE. Both are set."
+      exit 1
+  fi
+
+  if [ -z "${K8S_CLUSTER_REGION}" -a -z "${K8S_CLUSTER_ZONE}" ]; then
+      echo "Must set one of K8S_CLUSTER_REGION or K8S_CLUSTER_ZONE. Neither are set."
+      exit 1
+  fi
+}
+
 # Patch configmap `config-network` in `knative-serving` namespace.
 function patch_network_config_gke() {
   local ip_ranges=""
@@ -67,4 +79,5 @@ function patch_network_config_gke() {
   fi
 }
 
+validate_arguments
 patch_network_config_gke


### PR DESCRIPTION
Previous directions did not set cluster zone or region variables which
resulted in confusing failure output. Updated validation to improve
error messaging and updated directions.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
