### PR TITLE
Just have NewScaler take reconciler.Options

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -98,7 +98,7 @@ func main() {
 	// Set up scalers.
 	// uniScalerFactory depends endpointsInformer to be set.
 	multiScaler := autoscaler.NewMultiScaler(dynConfig, stopCh, uniScalerFactoryFunc(endpointsInformer), logger)
-	scaler := kpa.NewScaler(opt.ScaleClientSet, logger, opt.ConfigMapWatcher)
+	scaler := kpa.NewScaler(opt)
 
 	controllers := []*controller.Impl{
 		kpa.NewController(&opt, paInformer, sksInformer, serviceInformer, endpointsInformer, multiScaler, collector, scaler, dynConfig),

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -22,10 +22,10 @@ import (
 	"sync"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/logging"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
+	"github.com/knative/serving/pkg/reconciler"
 	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	autoscalingapi "k8s.io/api/autoscaling/v1"
@@ -48,15 +48,14 @@ type scaler struct {
 }
 
 // NewScaler creates a scaler.
-func NewScaler(scaleClientSet scale.ScalesGetter,
-	logger *zap.SugaredLogger, configMapWatcher configmap.Watcher) Scaler {
+func NewScaler(opt reconciler.Options) Scaler {
 	ks := &scaler{
-		scaleClientSet: scaleClientSet,
-		logger:         logger,
+		scaleClientSet: opt.ScaleClientSet,
+		logger:         opt.Logger,
 	}
 
 	// Watch for config changes.
-	configMapWatcher.Watch(autoscaler.ConfigName, ks.receiveAutoscalerConfig)
+	opt.ConfigMapWatcher.Watch(autoscaler.ConfigName, ks.receiveAutoscalerConfig)
 	return ks
 }
 


### PR DESCRIPTION
For what I have in mind, I want access to the dynamic client and the tracker,
so this just ends up being cleaner.

(Sorry for the extra churn, I was hoping to post this as just another update to the previous PR that was refactoring this, but Victor had already reviewed it).