### PR TITLE
SKS smart port management

### DIFF
--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -398,7 +397,8 @@ func TestMakeClusterIngressRule_InactiveTarget(t *testing.T) {
 			RevisionName:      "revision",
 			Percent:           100,
 		},
-		Active: false,
+		ServiceName: "strange-quark-pub",
+		Active:      false,
 	}}
 	domains := []string{"a.com", "b.org"}
 	rule := makeClusterIngressRule(domains, ns, targets)
@@ -411,8 +411,8 @@ func TestMakeClusterIngressRule_InactiveTarget(t *testing.T) {
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
 				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 					ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-						ServiceNamespace: system.Namespace(),
-						ServiceName:      "activator-service",
+						ServiceNamespace: ns,
+						ServiceName:      targets[0].ServiceName,
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
@@ -437,14 +437,16 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 			RevisionName:      "revision",
 			Percent:           80,
 		},
-		Active: false,
+		ServiceName: "up-quark-pub",
+		Active:      false,
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: "new-config",
 			RevisionName:      "new-revision",
 			Percent:           20,
 		},
-		Active: false,
+		ServiceName: "down-quark-pub",
+		Active:      false,
 	}}
 	domains := []string{"a.com", "b.org"}
 	rule := makeClusterIngressRule(domains, ns, targets)
@@ -457,15 +459,15 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
 				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 					ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-						ServiceNamespace: system.Namespace(),
-						ServiceName:      "activator-service",
+						ServiceNamespace: ns,
+						ServiceName:      targets[0].ServiceName,
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 80,
 				}, {
 					ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-						ServiceNamespace: system.Namespace(),
-						ServiceName:      "activator-service",
+						ServiceNamespace: ns,
+						ServiceName:      targets[1].ServiceName,
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 20,

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -313,8 +313,8 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-							ServiceNamespace: system.Namespace(),
-							ServiceName:      "activator-service",
+							ServiceNamespace: testNamespace,
+							ServiceName:      rev.Status.ServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -400,14 +400,14 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", cfgrev.Name),
+							ServiceName:      cfgrev.Status.ServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
 					}, {
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", rev.Name),
+							ServiceName:      rev.Status.ServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -483,14 +483,14 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", cfgrev.Name),
+							ServiceName:      cfgrev.Status.ServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
 					}, {
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-							ServiceNamespace: system.Namespace(),
-							ServiceName:      "activator-service",
+							ServiceNamespace: testNamespace,
+							ServiceName:      rev.Status.ServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,


### PR DESCRIPTION
/lint

#1997 
This is the last planned PR before positive activator handover.

## Proposed Changes

* make sure the SKS properly reconciles public service and endpoints, making sure services and endpoints match activator
* update cluster ingress resources keep public service always
* update to all SKS tets.
