### PR TITLE
Add initialDelaySeconds=2 to queue-proxy readiness probe

### DIFF
--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -62,6 +62,8 @@ var (
 		// bit more often than the default.  It is a small
 		// sacrifice for a low rate of 503s.
 		PeriodSeconds: 1,
+		// Give the queue-proxy some time to get started.
+		InitialDelaySeconds: 2,
 		// We keep the connection open for a while because we're
 		// actively probing the user-container on that endpoint and
 		// thus don't want to be limited by K8s granularity here.


### PR DESCRIPTION
Fixes #3308

There's a race between the `queue-proxy` health check handler and the readiness probe. We get falsely alarming warnings like this in the k8s event log:

```
Readiness probe failed: Get http://10.36.0.97:8022/health: dial tcp 10.36.0.97:8022: connect: connection refused
```

This change gives the `queue-proxy` a few seconds to get started.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Add `initialDelaySeconds = 2` to the `queue-proxy` readiness probe

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

**Update:** Fix incorrect root cause, thanks @markusthoemmes 