### PR TITLE
Gopkg.lock file update to get knative/test-infra latest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -495,7 +495,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ad01b9e32abc25aaba8f7b7d9be5abc0d50bf804da30b82af75475af59c0a784"
+  digest = "1:6366bd359a44920aeb314c2da668930c289b1ea2b7172d0d5ddfe957f2e36ef9"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -514,7 +514,7 @@
     "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "3a09cd7f5428743509941d116fdee644041a3507"
+  revision = "691caf51f2bb9ef86888772a8cc5d7952687b7c6"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -155,8 +155,9 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
    (or `report_go_test()` if you need a more fine-grained control) and call
    `fail_test()` or `success()` if any of them failed. The environment variable
-   `KO_DOCKER_REPO` will be set according to the test cluster. You can also use
-   the following boolean (0 is false, 1 is true) environment variables for the logic:
+   `KO_DOCKER_REPO` and `E2E_PROJECT_ID` will be set according to the test cluster.
+   You can also use the following boolean (0 is false, 1 is true) environment
+   variables for the logic:
 
    - `EMIT_METRICS`: true if `--emit-metrics` was passed.
 

--- a/vendor/github.com/knative/test-infra/shared/loadgenerator/loadgenerator.go
+++ b/vendor/github.com/knative/test-infra/shared/loadgenerator/loadgenerator.go
@@ -88,9 +88,7 @@ func (g *GeneratorOptions) addDefaults() {
 
 // CreateRunnerOptions sets up the fortio client with the knobs needed to run the load test
 func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTTPRunnerOptions {
-	g.addDefaults()
 	o := fhttp.NewHTTPOptions(g.URL)
-
 	o.NumConnections = g.NumConnections
 	o.HTTPReqTimeOut = g.RequestTimeout
 
@@ -125,6 +123,7 @@ For LoadFactors=[1,2,4], baseQPS=q, duration=d
             1       2       3  <--- factors
 */
 func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults, error) {
+	g.addDefaults()
 	res := make([]*fhttp.HTTPRunnerResults, len(g.LoadFactors))
 
 	for i, f := range g.LoadFactors {


### PR DESCRIPTION
This change is bringing knative/test-infra that has the fix for the issue: https://github.com/knative/test-infra/issues/702 which was causing pre-submits to be stuck on resource deletion.
