### PR TITLE
Various cleanups and bug fixes.

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -160,7 +160,7 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// returns a 200 status code.
 		success := a.GetProbeCount == 0
 		if !success {
-			success, httpStatus, attempts = a.probeEndpoint(logger, r, target)
+			success, _, attempts = a.probeEndpoint(logger, r, target)
 		}
 
 		if success {

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -110,7 +110,7 @@ type PodAutoscalerStatus struct {
 
 	// ServiceName is the K8s Service name that serves the revision, scaled by this PA.
 	// The service is created and owned by the ServerlessService object owned by this PA.
-	ServiceName string `json:"serviceName`
+	ServiceName string `json:"serviceName"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -33,14 +33,12 @@ const (
 )
 
 var (
-	testStats = []*Stat{
-		&Stat{
-			AverageConcurrentRequests:        3.0,
-			AverageProxiedConcurrentRequests: 2.0,
-			RequestCount:                     5,
-			ProxiedRequestCount:              4,
-		},
-	}
+	testStats = []*Stat{{
+		AverageConcurrentRequests:        3.0,
+		AverageProxiedConcurrentRequests: 2.0,
+		RequestCount:                     5,
+		ProxiedRequestCount:              4,
+	}}
 )
 
 func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
@@ -179,6 +177,9 @@ func TestScrape_DoNotScrapeIfNoPodsFound(t *testing.T) {
 	createEndpoints(addIps(makeEndpoints(), 0))
 
 	stat, err := scraper.Scrape()
+	if err != nil {
+		t.Errorf("Error calling Scrape: %v", err)
+	}
 	if stat != nil {
 		t.Error("Received unexpected StatMessage.")
 	}

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -233,11 +233,7 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 		return err
 	}
 
-	if err := c.gcRevisions(ctx, config); err != nil {
-		return err
-	}
-
-	return nil
+	return c.gcRevisions(ctx, config)
 }
 
 // CheckNameAvailability checks that if the named Revision specified by the Configuration

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -356,8 +356,8 @@ func (r *reconciler) reconcilePrivateService(ctx context.Context, sks *netv1alph
 	return nil
 }
 
-func (c *reconciler) getSelector(sks *netv1alpha1.ServerlessService) (map[string]string, error) {
-	scale, err := c.getScaleResource(sks)
+func (r *reconciler) getSelector(sks *netv1alpha1.ServerlessService) (map[string]string, error) {
+	scale, err := r.getScaleResource(sks)
 	if err != nil {
 		return nil, err
 	}
@@ -365,13 +365,13 @@ func (c *reconciler) getSelector(sks *netv1alpha1.ServerlessService) (map[string
 }
 
 // getScaleResource returns the current scale resource for the SKS.
-func (c *reconciler) getScaleResource(sks *netv1alpha1.ServerlessService) (*autoscalingapi.Scale, error) {
+func (r *reconciler) getScaleResource(sks *netv1alpha1.ServerlessService) (*autoscalingapi.Scale, error) {
 	resource, resourceName, err := scaleResourceArgs(sks)
 	if err != nil {
 		return nil, err
 	}
 	// Identify the current scale.
-	scl, err := c.scaleClientSet.Scales(sks.Namespace).Get(*resource, resourceName)
+	scl, err := r.scaleClientSet.Scales(sks.Namespace).Get(*resource, resourceName)
 	if err != nil {
 		return nil, err
 	} else if scl == nil {


### PR DESCRIPTION
We have accumulated some bugs and crud in our code, so this does a pass
over the code and cleans up some stuff.

The most important is the removal of the copy of Transport in the
transports.go. Transport is not a copyable type since it has mutex and
other shareds state inside. So replace it with a brand new transport.

/lint

/cc @mattmoor 