### PR TITLE
update docs to reflect changes in #3878

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -103,10 +103,11 @@ These tests require:
    ko apply -f test/config
    ```
 
-1. The namespace `serving-tests`:
+1. The namespaces `serving-tests` and `serving-tests-alt`:
 
    ```bash
    kubectl create namespace serving-tests
+   kubectl create namespace serving-tests-alt
    ```
 
 1. A docker repo containing [the test images](#test-images)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Updates the test documentation to incorporate changes made in #3878. 

As it stands now, the instructions in test/README for running end-to-end tests result in a failing test because of the missing namespace.