### PR TITLE
Cleanup autoscaler tests and remove config constants.

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -29,10 +29,6 @@ import (
 const (
 	// ConfigName is the name of the config map of the autoscaler.
 	ConfigName = "config-autoscaler"
-
-	// Default values for several key autoscaler settings.
-	DefaultStableWindow           = 60 * time.Second
-	DefaultScaleToZeroGracePeriod = 30 * time.Second
 )
 
 // Config defines the tunable autoscaler parameters
@@ -133,7 +129,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}{{
 		key:          "stable-window",
 		field:        &lc.StableWindow,
-		defaultValue: DefaultStableWindow,
+		defaultValue: 60 * time.Second,
 	}, {
 		key:          "panic-window",
 		field:        &lc.PanicWindow,
@@ -141,7 +137,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}, {
 		key:          "scale-to-zero-grace-period",
 		field:        &lc.ScaleToZeroGracePeriod,
-		defaultValue: DefaultScaleToZeroGracePeriod,
+		defaultValue: 30 * time.Second,
 	}, {
 		key:          "tick-interval",
 		field:        &lc.TickInterval,

--- a/pkg/reconciler/autoscaling/kpa/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/metric_test.go
@@ -97,7 +97,7 @@ func metric(options ...MetricOption) *autoscaler.Metric {
 			},
 		},
 		Spec: autoscaler.MetricSpec{
-			StableWindow: autoscaler.DefaultStableWindow,
+			StableWindow: 60 * time.Second,
 			PanicWindow:  6 * time.Second,
 		},
 	}

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -63,15 +62,9 @@ func TestActivatorOverload(t *testing.T) {
 	}
 	domain := resources.Route.Status.Domain
 
-	t.Log("Waiting for deployment to scale to zero.")
-	if err := pkgTest.WaitForDeploymentState(
-		clients.KubeClient,
-		rnames.Deployment(resources.Revision),
-		test.DeploymentScaledToZeroFunc,
-		"DeploymentScaledToZero",
-		test.ServingNamespace,
-		3*time.Minute); err != nil {
-		t.Fatalf("Failed waiting for deployment to scale to zero: %v", err)
+	deploymentName := rnames.Deployment(resources.Revision)
+	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
+		t.Fatalf("Unable to observe the Deployment named %s scaling down: %v", deploymentName, err)
 	}
 
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -129,7 +129,7 @@ func setup(t *testing.T) *testContext {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	t.Log("When the Revision can have traffic routed to it, the Route is marked as Ready.")
-	if err = test.WaitForRouteState(
+	if err := test.WaitForRouteState(
 		clients.ServingClient,
 		names.Route,
 		test.IsRouteReady,
@@ -150,7 +150,7 @@ func setup(t *testing.T) *testContext {
 	}
 	domain := route.Status.Domain
 
-	_, err = pkgTest.WaitForEndpointState(
+	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
 		domain,
@@ -158,8 +158,7 @@ func setup(t *testing.T) *testContext {
 		// TODO(tcnghia): Remove this when https://github.com/istio/istio/issues/882 is fixed.
 		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(autoscaleExpectedOutput))),
 		"CheckingEndpointAfterUpdating",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%v\": %v",
 			names.Route, domain, autoscaleExpectedOutput, err)
 	}
@@ -182,19 +181,17 @@ func setup(t *testing.T) *testContext {
 
 func assertScaleUp(ctx *testContext) {
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")
-	err := generateTraffic(ctx, 20, 20*time.Second, nil)
-	if err != nil {
+	if err := generateTraffic(ctx, 20, 20*time.Second, nil); err != nil {
 		ctx.t.Fatalf("Error during initial scale up: %v", err)
 	}
 	ctx.t.Logf("Waiting for scale up revision %s", ctx.names.Revision)
-	err = pkgTest.WaitForDeploymentState(
+	if err := pkgTest.WaitForDeploymentState(
 		ctx.clients.KubeClient,
 		ctx.deploymentName,
 		isDeploymentScaledUp(),
 		"DeploymentIsScaledUp",
 		test.ServingNamespace,
-		2*time.Minute)
-	if err != nil {
+		2*time.Minute); err != nil {
 		ctx.t.Fatalf("Unable to observe the Deployment named %s scaling up. %s", ctx.deploymentName, err)
 	}
 }
@@ -207,7 +204,7 @@ func assertScaleDown(ctx *testContext) {
 	// Account for the case where scaling up uses all available pods.
 	ctx.t.Log("Wait for all pods to terminate.")
 
-	err := pkgTest.WaitForPodListState(
+	if err := pkgTest.WaitForPodListState(
 		ctx.clients.KubeClient,
 		func(p *v1.PodList) (bool, error) {
 			for _, pod := range p.Items {
@@ -218,8 +215,7 @@ func assertScaleDown(ctx *testContext) {
 			}
 			return true, nil
 		},
-		"WaitForAvailablePods", test.ServingNamespace)
-	if err != nil {
+		"WaitForAvailablePods", test.ServingNamespace); err != nil {
 		ctx.t.Fatalf("Waiting for Pod.List to have no non-Evicted pods of %q: %v", ctx.deploymentName, err)
 	}
 

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	ktest "github.com/knative/serving/pkg/reconciler/testing"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/e2e"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/testgrid"
 )
@@ -58,13 +59,7 @@ func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *test.Res
 
 	domain := ro.Route.Status.Domain
 	t.Logf("%02d: waiting for deployment to scale to zero.", idx)
-	if err := pkgTest.WaitForDeploymentState(
-		clients.KubeClient,
-		deploymentName,
-		test.DeploymentScaledToZeroFunc,
-		"DeploymentScaledToZero",
-		test.ServingNamespace,
-		3*time.Minute); err != nil {
+	if err := e2e.WaitForScaleToZero(t, deploymentName, clients); err != nil {
 		m := fmt.Sprintf("%02d: failed waiting for deployment to scale to zero: %v", idx, err)
 		t.Log(m)
 		return 0, errors.New(m)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This started as a linter warning (because of the DefaultStableWindow comment) and ended up in a little rabbit hole making the autoscaler config consistent with all the other configs. That means: Don't expose Default* constants.

In the same vein, this adjusts all the tests to use the `WaitForScaleToZero` and thus work with the correct timeouts derived from the actual config there.

## Proposed Changes

* Removed config constants for the autoscaler.
* Replaced all "manual" scale to zero waits with a common helper.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
