### PR TITLE
Detach bucketing from autoscaler.

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import (
+	"sync"
+	"time"
+)
+
+// TimedFloat64Buckets keeps buckets that have been collected at a certain time.
+type TimedFloat64Buckets struct {
+	bucketsMutex sync.RWMutex
+	buckets      map[time.Time]Float64Bucket
+
+	granularity time.Duration
+}
+
+// NewTimedFloat64Buckets generates a new TimedFloat64Buckets with the given
+// granularity.
+func NewTimedFloat64Buckets(granularity time.Duration) *TimedFloat64Buckets {
+	return &TimedFloat64Buckets{
+		buckets:     make(map[time.Time]Float64Bucket),
+		granularity: granularity,
+	}
+}
+
+// Record adds a value with an associated time to the correct bucket.
+func (t *TimedFloat64Buckets) Record(time time.Time, name string, value float64) {
+	t.bucketsMutex.Lock()
+	defer t.bucketsMutex.Unlock()
+
+	bucketKey := time.Truncate(t.granularity)
+	bucket, ok := t.buckets[bucketKey]
+	if !ok {
+		bucket = Float64Bucket{}
+		t.buckets[bucketKey] = bucket
+	}
+	bucket.Record(name, value)
+}
+
+// IsEmpty returns whether or not there are no values currently stored.
+func (t *TimedFloat64Buckets) IsEmpty() bool {
+	t.bucketsMutex.RLock()
+	defer t.bucketsMutex.RUnlock()
+
+	return len(t.buckets) == 0
+}
+
+// GetAndLock returns the buckets and secures them via a mutex. The contents of
+// the returned map can be modified and the modifications will be visible to other
+// readers. Unlock must be called after the client is done reading/manipulating
+// the data.
+func (t *TimedFloat64Buckets) GetAndLock() map[time.Time]Float64Bucket {
+	t.bucketsMutex.Lock()
+	return t.buckets
+}
+
+// Unlock unlocks the mutex locked via GetAndLock.
+func (t *TimedFloat64Buckets) Unlock() {
+	t.bucketsMutex.Unlock()
+}
+
+// Float64Bucket keeps all the stats that fall into a defined bucket.
+type Float64Bucket map[string][]float64
+
+// Record adds a value to the bucket. Buckets with the same given name
+// will be collapsed.
+func (b Float64Bucket) Record(name string, value float64) {
+	b[name] = append(b[name], value)
+}
+
+// Sum calculates the sum over the bucket. Values of the same name in
+// the same bucket will be averaged between themselves first.
+func (b Float64Bucket) Sum() float64 {
+	var total float64
+	for _, perNameValues := range b {
+		var subtotal float64
+		for _, value := range perNameValues {
+			subtotal += value
+		}
+		total += subtotal / float64(len(perNameValues))
+	}
+
+	return total
+}

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTimedFloat64Buckets(t *testing.T) {
+	pod := "pod"
+	zero := time.Now()
+	trunc1 := zero.Truncate(1 * time.Second)
+	trunc5 := zero.Truncate(5 * time.Second)
+
+	type args struct {
+		time  time.Time
+		name  string
+		value float64
+	}
+	tests := []struct {
+		name        string
+		granularity time.Duration
+		stats       []args
+		want        map[time.Time]float64
+	}{{
+		name:        "granularity = 1s",
+		granularity: 1 * time.Second,
+		stats: []args{
+			{zero, pod, 1.0},
+			{zero.Add(100 * time.Millisecond), pod, 1.0}, // same bucket
+			{zero.Add(1 * time.Second), pod, 1.0},        // next bucket
+			{zero.Add(3 * time.Second), pod, 1.0},        // nextnextnext bucket
+		},
+		want: map[time.Time]float64{
+			trunc1:                      1.0,
+			trunc1.Add(1 * time.Second): 1.0,
+			trunc1.Add(3 * time.Second): 1.0,
+		},
+	}, {
+		name:        "granularity = 5s",
+		granularity: 5 * time.Second,
+		stats: []args{
+			{zero, pod, 1.0},
+			{zero.Add(3 * time.Second), pod, 1.0}, // same bucket
+			{zero.Add(6 * time.Second), pod, 1.0}, // next bucket
+		},
+		want: map[time.Time]float64{
+			trunc5:                      1.0,
+			trunc5.Add(5 * time.Second): 1.0,
+		},
+	}, {
+		name:  "empty",
+		stats: []args{},
+		want:  map[time.Time]float64{},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buckets := NewTimedFloat64Buckets(tt.granularity)
+			for _, stat := range tt.stats {
+				buckets.Record(stat.time, stat.name, stat.value)
+			}
+
+			got := make(map[time.Time]float64)
+			for time, bucket := range buckets.GetAndLock() {
+				got[time] = bucket.Sum()
+			}
+			buckets.Unlock()
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Unexpected values (-want +got): %v", diff)
+			}
+			if len(tt.want) == 0 && !buckets.IsEmpty() {
+				t.Errorf("IsEmpty() = false, want true")
+			}
+		})
+	}
+}
+
+func TestFloat64Bucket(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats map[string][]float64
+		want  float64
+	}{{
+		name: "sum of value",
+		stats: map[string][]float64{
+			"test1": {1.0},
+			"test2": {2.0},
+			"test3": {3.0},
+		},
+		want: 6.0,
+	}, {
+		name: "average same first",
+		stats: map[string][]float64{
+			"test1": {1.0, 8.0},      // average = 4.5
+			"test2": {1.0, 3.0, 5.0}, // average = 3
+		},
+		want: 7.5,
+	}, {
+		name:  "no values",
+		stats: map[string][]float64{},
+		want:  0.0,
+	}, {
+		name: "only zeroes",
+		stats: map[string][]float64{
+			"test1": {0.0, 0.0},
+			"test2": {0.0},
+		},
+		want: 0.0,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket := Float64Bucket{}
+			for name, values := range tt.stats {
+				for _, value := range values {
+					bucket.Record(name, value)
+				}
+			}
+
+			if got := bucket.Sum(); got != tt.want {
+				t.Errorf("Average() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -84,11 +84,11 @@ func TestTimedFloat64Buckets(t *testing.T) {
 			}
 			buckets.Unlock()
 
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("Unexpected values (-want +got): %v", diff)
+			if !cmp.Equal(tt.want, got) {
+				t.Errorf("Unexpected values (-want +got): %v", cmp.Diff(tt.want, got))
 			}
 			if len(tt.want) == 0 && !buckets.IsEmpty() {
-				t.Errorf("IsEmpty() = false, want true")
+				t.Error("IsEmpty() = false, want true")
 			}
 		})
 	}

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -43,10 +43,10 @@ func TestTimedFloat64Buckets(t *testing.T) {
 		name:        "granularity = 1s",
 		granularity: 1 * time.Second,
 		stats: []args{
-			{zero, pod, 1.0},
-			{zero.Add(100 * time.Millisecond), pod, 1.0}, // same bucket
-			{zero.Add(1 * time.Second), pod, 1.0},        // next bucket
-			{zero.Add(3 * time.Second), pod, 1.0},        // nextnextnext bucket
+			{trunc1, pod, 1.0},
+			{trunc1.Add(100 * time.Millisecond), pod, 1.0}, // same bucket
+			{trunc1.Add(1 * time.Second), pod, 1.0},        // next bucket
+			{trunc1.Add(3 * time.Second), pod, 1.0},        // nextnextnext bucket
 		},
 		want: map[time.Time]float64{
 			trunc1:                      1.0,
@@ -57,9 +57,9 @@ func TestTimedFloat64Buckets(t *testing.T) {
 		name:        "granularity = 5s",
 		granularity: 5 * time.Second,
 		stats: []args{
-			{zero, pod, 1.0},
-			{zero.Add(3 * time.Second), pod, 1.0}, // same bucket
-			{zero.Add(6 * time.Second), pod, 1.0}, // next bucket
+			{trunc5, pod, 1.0},
+			{trunc5.Add(3 * time.Second), pod, 1.0}, // same bucket
+			{trunc5.Add(6 * time.Second), pod, 1.0}, // next bucket
 		},
 		want: map[time.Time]float64{
 			trunc5:                      1.0,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Bucketing stats isn't really a concern of the autoscaler itself but can be generalized. This is part of an effort to detach aggregation logic from the autoscaler to make a move of the logic into the collector easier to review afterwards.

## Proposed Changes

* Move all bucket related code out of the autoscaler (and the package for that matter).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
