### PR TITLE
Create an ObjectReference validation method.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -23,7 +23,7 @@ import (
 	net "github.com/knative/serving/pkg/apis/networking"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	servingv1beta1 "github.com/knative/serving/pkg/apis/serving/v1beta1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -85,7 +85,7 @@ type PodAutoscalerSpec struct {
 
 	// ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
 	// is responsible for quickly right-sizing.
-	ScaleTargetRef autoscalingv1.CrossVersionObjectReference `json:"scaleTargetRef"`
+	ScaleTargetRef corev1.ObjectReference `json:"scaleTargetRef"`
 
 	// DeprecatedServiceName holds the name of a core Kubernetes Service resource that
 	// load balances over the pods referenced by the ScaleTargetRef.

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -25,7 +25,6 @@ import (
 	"github.com/knative/pkg/kmp"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -70,7 +69,7 @@ func (rs *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(rs, &PodAutoscalerSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
-	errs := validateReference(rs.ScaleTargetRef).ViaField("scaleTargetRef")
+	errs := serving.ValidateNamespacedObjectReference(&rs.ScaleTargetRef).ViaField("scaleTargetRef")
 	errs = errs.Also(rs.ContainerConcurrency.Validate(ctx).
 		ViaField("containerConcurrency"))
 	return errs.Also(validateSKSFields(ctx, rs))
@@ -83,23 +82,6 @@ func validateSKSFields(ctx context.Context, rs *PodAutoscalerSpec) *apis.FieldEr
 		all = all.Also(rs.ProtocolType.Validate(ctx)).ViaField("protocolType")
 	}
 	return all
-}
-
-func validateReference(ref autoscalingv1.CrossVersionObjectReference) *apis.FieldError {
-	if equality.Semantic.DeepEqual(ref, autoscalingv1.CrossVersionObjectReference{}) {
-		return apis.ErrMissingField(apis.CurrentField)
-	}
-	var errs *apis.FieldError
-	if ref.Kind == "" {
-		errs = errs.Also(apis.ErrMissingField("kind"))
-	}
-	if ref.Name == "" {
-		errs = errs.Also(apis.ErrMissingField("name"))
-	}
-	if ref.APIVersion == "" {
-		errs = errs.Also(apis.ErrMissingField("apiVersion"))
-	}
-	return errs
 }
 
 func (pa *PodAutoscaler) validateMetric() *apis.FieldError {

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
 
 func TestPodAutoscalerSpecValidation(t *testing.T) {
@@ -40,7 +40,7 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		name: "valid",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: 0,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "bar",
@@ -52,12 +52,13 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: 1,
 		},
-		want: apis.ErrMissingField("scaleTargetRef"),
+		want: apis.ErrMissingField("scaleTargetRef.apiVersion", "scaleTargetRef.kind",
+			"scaleTargetRef.name"),
 	}, {
 		name: "has missing scaleTargetRef kind",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: 1,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Name:       "bar",
 			},
@@ -67,7 +68,7 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		name: "has missing scaleTargetRef apiVersion",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: 0,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				Kind: "Deployment",
 				Name: "bar",
 			},
@@ -77,7 +78,7 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		name: "has missing scaleTargetRef name",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: 0,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 			},
@@ -87,7 +88,7 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		name: "bad container concurrency",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: -1,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "bar",
@@ -99,7 +100,7 @@ func TestPodAutoscalerSpecValidation(t *testing.T) {
 		name: "multi invalid, bad concurrency and missing ref kind",
 		rs: &PodAutoscalerSpec{
 			ContainerConcurrency: -2,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Name:       "bar",
 			},
@@ -134,7 +135,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -153,7 +154,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -171,7 +172,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -190,7 +191,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -217,7 +218,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 			},
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: -1,
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -251,7 +252,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -263,7 +264,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -278,7 +279,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -291,7 +292,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -306,7 +307,7 @@ func TestImmutableFields(t *testing.T) {
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -319,7 +320,7 @@ func TestImmutableFields(t *testing.T) {
 			},
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: 1,
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -342,7 +343,7 @@ func TestImmutableFields(t *testing.T) {
 			},
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: 0,
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -355,7 +356,7 @@ func TestImmutableFields(t *testing.T) {
 			},
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency: 1,
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -378,7 +379,7 @@ func TestImmutableFields(t *testing.T) {
 			},
 			Spec: PodAutoscalerSpec{
 				DeprecatedServiceName: "foo",
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar",
@@ -392,7 +393,7 @@ func TestImmutableFields(t *testing.T) {
 			Spec: PodAutoscalerSpec{
 				ContainerConcurrency:  1,
 				DeprecatedServiceName: "food",
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "baz",

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -21,7 +21,7 @@ import (
 	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
 	"github.com/knative/pkg/kmeta"
 	networking "github.com/knative/serving/pkg/apis/networking"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,7 +95,7 @@ type ServerlessServiceSpec struct {
 
 	// ObjectRef defines the resource that this ServerlessService
 	// is responsible for making "serverless".
-	ObjectRef autoscalingv1.CrossVersionObjectReference `json:"objectRef"`
+	ObjectRef corev1.ObjectReference `json:"objectRef"`
 
 	// The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
 	// serving imports networking, so just use string.

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/knative/pkg/apis"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"github.com/knative/serving/pkg/apis/serving"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -46,24 +46,7 @@ func (spec *ServerlessServiceSpec) Validate(ctx context.Context) *apis.FieldErro
 		all = all.Also(apis.ErrInvalidValue(spec.Mode, "mode"))
 	}
 
-	all = all.Also(validateReference(spec.ObjectRef).ViaField("objectRef"))
+	all = all.Also(serving.ValidateNamespacedObjectReference(&spec.ObjectRef).ViaField("objectRef"))
 
 	return all.Also(spec.ProtocolType.Validate(ctx).ViaField("protocolType"))
-}
-
-func validateReference(ref autoscalingv1.CrossVersionObjectReference) *apis.FieldError {
-	if equality.Semantic.DeepEqual(ref, autoscalingv1.CrossVersionObjectReference{}) {
-		return apis.ErrMissingField(apis.CurrentField)
-	}
-	var errs *apis.FieldError
-	if ref.Kind == "" {
-		errs = errs.Also(apis.ErrMissingField("kind"))
-	}
-	if ref.Name == "" {
-		errs = errs.Also(apis.ErrMissingField("name"))
-	}
-	if ref.APIVersion == "" {
-		errs = errs.Also(apis.ErrMissingField("apiVersion"))
-	}
-	return errs
 }

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 	networking "github.com/knative/serving/pkg/apis/networking"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestServerlessServiceSpecValidation(t *testing.T) {
@@ -35,7 +35,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		name: "valid proxy",
 		skss: &ServerlessServiceSpec{
 			Mode: SKSOperationModeProxy,
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "foo",
@@ -47,7 +47,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		name: "valid serve",
 		skss: &ServerlessServiceSpec{
 			Mode: SKSOperationModeServe,
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "foo",
@@ -59,7 +59,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		name: "invalid protocol",
 		skss: &ServerlessServiceSpec{
 			Mode: SKSOperationModeServe,
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "foo",
@@ -71,7 +71,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		name: "wrong mode",
 		skss: &ServerlessServiceSpec{
 			Mode: "bombastic",
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "foo",
@@ -83,7 +83,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 		name: "no mode",
 		skss: &ServerlessServiceSpec{
 			Mode: "",
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "foo",
@@ -97,20 +97,20 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 			Mode:         SKSOperationModeProxy,
 			ProtocolType: networking.ProtocolH2C,
 		},
-		want: apis.ErrMissingField("objectRef"),
+		want: apis.ErrMissingField("objectRef.apiVersion", "objectRef.kind", "objectRef.name"),
 	}, {
 		name: "empty object reference",
 		skss: &ServerlessServiceSpec{
 			Mode:         SKSOperationModeProxy,
-			ObjectRef:    autoscalingv1.CrossVersionObjectReference{},
+			ObjectRef:    corev1.ObjectReference{},
 			ProtocolType: networking.ProtocolHTTP1,
 		},
-		want: apis.ErrMissingField("objectRef"),
+		want: apis.ErrMissingField("objectRef.apiVersion", "objectRef.kind", "objectRef.name"),
 	}, {
 		name: "missing kind",
 		skss: &ServerlessServiceSpec{
 			Mode: SKSOperationModeProxy,
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Name:       "foo",
 			},
@@ -120,7 +120,7 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 	}, {
 		name: "multiple errors",
 		skss: &ServerlessServiceSpec{
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				Kind: "Deployment",
 			},
 			ProtocolType: networking.ProtocolH2C,

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -30,7 +30,7 @@ func VolumeMask(in *corev1.Volume) *corev1.Volume {
 
 	out := new(corev1.Volume)
 
-	//Allowed fields
+	// Allowed fields
 	out.Name = in.Name
 	out.VolumeSource = in.VolumeSource
 
@@ -72,7 +72,7 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.Volumes = in.Volumes
 
 	// Disallowed fields
-	// This list is unneccessry, but added here for clarity
+	// This list is unnecessary, but added here for clarity
 	out.InitContainers = nil
 	out.RestartPolicy = ""
 	out.TerminationGracePeriodSeconds = nil
@@ -130,7 +130,7 @@ func ContainerMask(in *corev1.Container) *corev1.Container {
 	out.VolumeMounts = in.VolumeMounts
 
 	// Disallowed fields
-	// This list is unneccessry, but added here for clarity
+	// This list is unnecessary, but added here for clarity
 	out.Lifecycle = nil
 	out.Name = ""
 	out.Stdin = false
@@ -157,7 +157,7 @@ func VolumeMountMask(in *corev1.VolumeMount) *corev1.VolumeMount {
 	out.MountPath = in.MountPath
 
 	// Disallowed fields
-	// This list is unneccessry, but added here for clarity
+	// This list is unnecessary, but added here for clarity
 	out.SubPath = ""
 	out.MountPropagation = nil
 
@@ -244,7 +244,7 @@ func TCPSocketActionMask(in *corev1.TCPSocketAction) *corev1.TCPSocketAction {
 	}
 	out := new(corev1.TCPSocketAction)
 
-	//Allowed fields
+	// Allowed fields
 	out.Host = in.Host
 
 	return out
@@ -266,7 +266,7 @@ func ContainerPortMask(in *corev1.ContainerPort) *corev1.ContainerPort {
 	out.Protocol = in.Protocol
 
 	//Disallowed fields
-	// This list is unneccessry, but added here for clarity
+	// This list is unnecessary, but added here for clarity
 	out.HostIP = ""
 	out.HostPort = 0
 
@@ -301,12 +301,12 @@ func EnvVarSourceMask(in *corev1.EnvVarSource) *corev1.EnvVarSource {
 
 	out := new(corev1.EnvVarSource)
 
-	//Allowed fields
+	// Allowed fields
 	out.ConfigMapKeyRef = in.ConfigMapKeyRef
 	out.SecretKeyRef = in.SecretKeyRef
 
 	// Disallowed
-	// This list is unneccessry, but added here for clarity
+	// This list is unnecessary, but added here for clarity
 	out.FieldRef = nil
 	out.ResourceFieldRef = nil
 
@@ -452,7 +452,7 @@ func SecurityContextMask(in *corev1.SecurityContext) *corev1.SecurityContext {
 	out.RunAsUser = in.RunAsUser
 
 	// Disallowed
-	// This list is unneccessry, but added here for clarity
+	// This list is unnecessary, but added here for clarity
 	out.Capabilities = nil
 	out.Privileged = nil
 	out.SELinuxOptions = nil
@@ -461,6 +461,31 @@ func SecurityContextMask(in *corev1.SecurityContext) *corev1.SecurityContext {
 	out.ReadOnlyRootFilesystem = nil
 	out.AllowPrivilegeEscalation = nil
 	out.ProcMount = nil
+
+	return out
+}
+
+// NamespacedObjectReferenceMask performs a _shallow_ copy of the Kubernetes ObjectReference
+// object to a new Kubernetes ObjectReference object bringing over only the fields allowed in
+// the Knative API. This does not validate the contents or the bounds of the provided fields.
+func NamespacedObjectReferenceMask(in *corev1.ObjectReference) *corev1.ObjectReference {
+	if in == nil {
+		return nil
+	}
+
+	out := new(corev1.ObjectReference)
+
+	// Allowed fields
+	out.APIVersion = in.APIVersion
+	out.Kind = in.Kind
+	out.Name = in.Name
+
+	// Disallowed
+	// This list is unnecessary, but added here for clarity
+	out.Namespace = ""
+	out.FieldPath = ""
+	out.ResourceVersion = ""
+	out.UID = ""
 
 	return out
 }

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -329,3 +329,27 @@ func validateProbe(p *corev1.Probe) *apis.FieldError {
 	}
 	return errs
 }
+
+func ValidateNamespacedObjectReference(p *corev1.ObjectReference) *apis.FieldError {
+	if p == nil {
+		return nil
+	}
+	errs := apis.CheckDisallowedFields(*p, *NamespacedObjectReferenceMask(p))
+
+	if p.APIVersion == "" {
+		errs = errs.Also(apis.ErrMissingField("apiVersion"))
+	} else if len(validation.IsQualifiedName(p.APIVersion)) != 0 {
+		errs = errs.Also(apis.ErrInvalidValue(p.APIVersion, "apiVersion"))
+	}
+	if p.Kind == "" {
+		errs = errs.Also(apis.ErrMissingField("kind"))
+	} else if len(validation.IsCIdentifier(p.Kind)) != 0 {
+		errs = errs.Also(apis.ErrInvalidValue(p.Kind, "kind"))
+	}
+	if p.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("name"))
+	} else if len(validation.IsDNS1123Label(p.Name)) != 0 {
+		errs = errs.Also(apis.ErrInvalidValue(p.Name, "name"))
+	}
+	return errs
+}

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/knative/pkg/apis"
@@ -338,18 +339,18 @@ func ValidateNamespacedObjectReference(p *corev1.ObjectReference) *apis.FieldErr
 
 	if p.APIVersion == "" {
 		errs = errs.Also(apis.ErrMissingField("apiVersion"))
-	} else if len(validation.IsQualifiedName(p.APIVersion)) != 0 {
-		errs = errs.Also(apis.ErrInvalidValue(p.APIVersion, "apiVersion"))
+	} else if verrs := validation.IsQualifiedName(p.APIVersion); len(verrs) != 0 {
+		errs = errs.Also(apis.ErrInvalidValue(strings.Join(verrs, ", "), "apiVersion"))
 	}
 	if p.Kind == "" {
 		errs = errs.Also(apis.ErrMissingField("kind"))
-	} else if len(validation.IsCIdentifier(p.Kind)) != 0 {
-		errs = errs.Also(apis.ErrInvalidValue(p.Kind, "kind"))
+	} else if verrs := validation.IsCIdentifier(p.Kind); len(verrs) != 0 {
+		errs = errs.Also(apis.ErrInvalidValue(strings.Join(verrs, ", "), "kind"))
 	}
 	if p.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("name"))
-	} else if len(validation.IsDNS1123Label(p.Name)) != 0 {
-		errs = errs.Also(apis.ErrInvalidValue(p.Name, "name"))
+	} else if verrs := validation.IsDNS1123Label(p.Name); len(verrs) != 0 {
+		errs = errs.Also(apis.ErrInvalidValue(strings.Join(verrs, ", "), "name"))
 	}
 	return errs
 }

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -753,7 +753,7 @@ func TestObjectReferenceValidation(t *testing.T) {
 			Kind:       "Bar",
 			Name:       "foo",
 		},
-		want: apis.ErrInvalidValue("/v1alpha1", "apiVersion"),
+		want: apis.ErrInvalidValue("prefix part must be non-empty", "apiVersion"),
 	}, {
 		name: "no kind",
 		r: &corev1.ObjectReference{
@@ -768,7 +768,7 @@ func TestObjectReferenceValidation(t *testing.T) {
 			Kind:       "Bad Kind",
 			Name:       "foo",
 		},
-		want: apis.ErrInvalidValue("Bad Kind", "kind"),
+		want: apis.ErrInvalidValue("a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')", "kind"),
 	}, {
 		name: "no namespace",
 		r: &corev1.ObjectReference{
@@ -791,7 +791,7 @@ func TestObjectReferenceValidation(t *testing.T) {
 			Kind:       "Bar",
 			Name:       "bad name",
 		},
-		want: apis.ErrInvalidValue("bad name", "name"),
+		want: apis.ErrInvalidValue("a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')", "name"),
 	}, {
 		name: "disallowed fields",
 		r: &corev1.ObjectReference{

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -564,7 +564,7 @@ func TestContainerValidation(t *testing.T) {
 	}, {
 		name: "termination message policy",
 		c: corev1.Container{
-			Image: "foo",
+			Image:                    "foo",
 			TerminationMessagePolicy: corev1.TerminationMessagePolicy("Not a Policy"),
 		},
 		want: apis.ErrInvalidValue(corev1.TerminationMessagePolicy("Not a Policy"), "terminationMessagePolicy"),
@@ -727,6 +727,100 @@ func TestVolumeValidation(t *testing.T) {
 			got := validateVolume(test.v)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("validateVolume (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestObjectReferenceValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *corev1.ObjectReference
+		want *apis.FieldError
+	}{{
+		name: "nil",
+	}, {
+		name: "no api version",
+		r: &corev1.ObjectReference{
+			Kind: "Bar",
+			Name: "foo",
+		},
+		want: apis.ErrMissingField("apiVersion"),
+	}, {
+		name: "bad api version",
+		r: &corev1.ObjectReference{
+			APIVersion: "/v1alpha1",
+			Kind:       "Bar",
+			Name:       "foo",
+		},
+		want: apis.ErrInvalidValue("/v1alpha1", "apiVersion"),
+	}, {
+		name: "no kind",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo/v1alpha1",
+			Name:       "foo",
+		},
+		want: apis.ErrMissingField("kind"),
+	}, {
+		name: "bad kind",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo/v1alpha1",
+			Kind:       "Bad Kind",
+			Name:       "foo",
+		},
+		want: apis.ErrInvalidValue("Bad Kind", "kind"),
+	}, {
+		name: "no namespace",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Name:       "the-bar-0001",
+		},
+		want: nil,
+	}, {
+		name: "no name",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+		},
+		want: apis.ErrMissingField("name"),
+	}, {
+		name: "bad name",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Name:       "bad name",
+		},
+		want: apis.ErrInvalidValue("bad name", "name"),
+	}, {
+		name: "disallowed fields",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Name:       "bar0001",
+
+			// None of these are allowed.
+			Namespace:       "foo",
+			FieldPath:       "some.field.path",
+			ResourceVersion: "234234",
+			UID:             "deadbeefcafebabe",
+		},
+		want: apis.ErrDisallowedFields("namespace", "fieldPath", "resourceVersion", "uid"),
+	}, {
+		name: "all good",
+		r: &corev1.ObjectReference{
+			APIVersion: "foo.group/v1alpha1",
+			Kind:       "Bar",
+			Name:       "bar0001",
+		},
+		want: nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ValidateNamespacedObjectReference(test.r)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("ValidateNamespacedObjectReference (-want, +got) = %v", diff)
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -34,92 +34,6 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 )
 
-func TestBuildRefValidation(t *testing.T) {
-	tests := []struct {
-		name string
-		r    *corev1.ObjectReference
-		want *apis.FieldError
-	}{{
-		name: "nil",
-	}, {
-		name: "no api version",
-		r:    &corev1.ObjectReference{},
-		want: apis.ErrInvalidValue("", "apiVersion"),
-	}, {
-		name: "bad api version",
-		r: &corev1.ObjectReference{
-			APIVersion: "/v1alpha1",
-		},
-		want: apis.ErrInvalidValue("/v1alpha1", "apiVersion"),
-	}, {
-		name: "no kind",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo/v1alpha1",
-		},
-		want: apis.ErrInvalidValue("", "kind"),
-	}, {
-		name: "bad kind",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo/v1alpha1",
-			Kind:       "Bad Kind",
-		},
-		want: apis.ErrInvalidValue("Bad Kind", "kind"),
-	}, {
-		name: "no namespace",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo.group/v1alpha1",
-			Kind:       "Bar",
-			Name:       "the-bar-0001",
-		},
-		want: nil,
-	}, {
-		name: "no name",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo.group/v1alpha1",
-			Kind:       "Bar",
-		},
-		want: apis.ErrInvalidValue("", "name"),
-	}, {
-		name: "bad name",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo.group/v1alpha1",
-			Kind:       "Bar",
-			Name:       "bad name",
-		},
-		want: apis.ErrInvalidValue("bad name", "name"),
-	}, {
-		name: "disallowed fields",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo.group/v1alpha1",
-			Kind:       "Bar",
-			Name:       "bar0001",
-
-			Namespace:       "foo",
-			FieldPath:       "some.field.path",
-			ResourceVersion: "234234",
-			UID:             "deadbeefcafebabe",
-		},
-		want: apis.ErrDisallowedFields("namespace", "fieldPath", "resourceVersion", "uid"),
-	}, {
-		name: "all good",
-		r: &corev1.ObjectReference{
-			APIVersion: "foo.group/v1alpha1",
-			Kind:       "Bar",
-			Name:       "bar0001",
-		},
-		want: nil,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := validateBuildRef(test.r)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("validateBuildRef (-want, +got) = %v", diff)
-			}
-		})
-	}
-}
-
 func TestConcurrencyModelValidation(t *testing.T) {
 	tests := []struct {
 		name string
@@ -268,7 +182,8 @@ func TestRevisionSpecValidation(t *testing.T) {
 			},
 			DeprecatedBuildRef: &corev1.ObjectReference{},
 		},
-		want: apis.ErrInvalidValue("", "buildRef.apiVersion"),
+		want: apis.ErrMissingField("buildRef.apiVersion",
+			"buildRef.kind", "buildRef.name"),
 	}, {
 		name: "bad concurrency model",
 		rs: &RevisionSpec{

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -434,7 +434,7 @@ func pa(name, namespace string, options ...PodAutoscalerOption) *autoscalingv1al
 			Namespace: namespace,
 		},
 		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       name + "-deployment",

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -40,7 +40,11 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler) *autoscalingv1.HorizontalPodAutoscaler 
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pa)},
 		},
 		Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: pa.Spec.ScaleTargetRef,
+			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				APIVersion: pa.Spec.ScaleTargetRef.APIVersion,
+				Kind:       pa.Spec.ScaleTargetRef.Kind,
+				Name:       pa.Spec.ScaleTargetRef.Name,
+			},
 		},
 	}
 	hpa.Spec.MaxReplicas = max

--- a/pkg/reconciler/autoscaling/kpa/resources/service_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/service_test.go
@@ -25,7 +25,6 @@ import (
 	pav1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
 
 func TestMakeService(t *testing.T) {
@@ -44,7 +43,7 @@ func TestMakeService(t *testing.T) {
 			},
 		},
 		Spec: pav1a1.PodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "with-you",

--- a/pkg/reconciler/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/autoscaling/resources/sks_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/serving/pkg/apis/networking"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +47,7 @@ func TestMakeSKS(t *testing.T) {
 		},
 		Spec: pav1a1.PodAutoscalerSpec{
 			ProtocolType: networking.ProtocolHTTP1,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "blah",
@@ -81,7 +81,7 @@ func TestMakeSKS(t *testing.T) {
 		Spec: nv1a1.ServerlessServiceSpec{
 			ProtocolType: networking.ProtocolHTTP1,
 			Mode:         nv1a1.SKSOperationModeServe,
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "blah",

--- a/pkg/reconciler/revision/resources/kpa.go
+++ b/pkg/reconciler/revision/resources/kpa.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resources
 
 import (
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/kmeta"
@@ -43,12 +43,12 @@ func MakeKPA(rev *v1alpha1.Revision) *kpa.PodAutoscaler {
 		},
 		Spec: kpa.PodAutoscalerSpec{
 			ContainerConcurrency: rev.Spec.ContainerConcurrency,
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       names.Deployment(rev),
 			},
-			ProtocolType:          rev.GetProtocol(),
+			ProtocolType: rev.GetProtocol(),
 		},
 	}
 }

--- a/pkg/reconciler/revision/resources/kpa_test.go
+++ b/pkg/reconciler/revision/resources/kpa_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +46,7 @@ func TestMakeKPA(t *testing.T) {
 				Name:      "bar",
 				UID:       "1234",
 				Annotations: map[string]string{
-					"a": "b",
+					"a":                                     "b",
 					serving.RevisionLastPinnedAnnotationKey: "timeless",
 				},
 			},
@@ -80,7 +79,7 @@ func TestMakeKPA(t *testing.T) {
 			},
 			Spec: kpa.PodAutoscalerSpec{
 				ContainerConcurrency: 1,
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "bar-deployment",
@@ -129,7 +128,7 @@ func TestMakeKPA(t *testing.T) {
 			},
 			Spec: kpa.PodAutoscalerSpec{
 				ContainerConcurrency: 0,
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "baz-deployment",

--- a/pkg/reconciler/testing/functional.go
+++ b/pkg/reconciler/testing/functional.go
@@ -34,7 +34,6 @@ import (
 	"github.com/knative/serving/pkg/reconciler/route/traffic"
 	"github.com/knative/serving/pkg/reconciler/serverlessservice/resources/names"
 	servicenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1097,7 +1096,7 @@ func WithPubService(sks *netv1alpha1.ServerlessService) {
 // WithDeployRef annotates SKS with a deployment objectRef
 func WithDeployRef(name string) SKSOption {
 	return func(sks *netv1alpha1.ServerlessService) {
-		sks.Spec.ObjectRef = autoscalingv1.CrossVersionObjectReference{
+		sks.Spec.ObjectRef = corev1.ObjectReference{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 			Name:       name,
@@ -1138,7 +1137,7 @@ func SKS(ns, name string, so ...SKSOption) *netv1alpha1.ServerlessService {
 		Spec: netv1alpha1.ServerlessServiceSpec{
 			Mode:         netv1alpha1.SKSOperationModeServe,
 			ProtocolType: networking.ProtocolHTTP1,
-			ObjectRef: autoscalingv1.CrossVersionObjectReference{
+			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "foo-deployment",

--- a/test/conformance/generatename_test.go
+++ b/test/conformance/generatename_test.go
@@ -145,7 +145,7 @@ func TestServiceGenerateName(t *testing.T) {
 // the system using metadata.generateName. It ensures that routes and configurations created this way both:
 // 1. Become ready
 // 2. Can serve requests.
-func TestRouteAndConfigurationGenerateName(t *testing.T) {
+func TestRouteAndConfigGenerateName(t *testing.T) {
 	t.Parallel()
 	clients := setup(t)
 


### PR DESCRIPTION
This moves the `BuildRef` validation to use Dan's field-mask based validation.
It also moves the PA/SKS APIs to use ObjectReference in place of the HPA's
filtered knock-off (the above validation ensures the same subset).

Fixes: https://github.com/knative/serving/issues/3789