### PR TITLE
Clean up one of the TODO's and match public service name to the revision

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -90,7 +90,7 @@ func TestReconcile(t *testing.T) {
 		Name: "no op",
 		Objects: []runtime.Object{
 			hpa(testRevision, testNamespace, pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"))),
-			pa(testRevision, testNamespace, WithHPAClass, WithTraffic, WithPAStatusService(testRevision+"-pub")),
+			pa(testRevision, testNamespace, WithHPAClass, WithTraffic, WithPAStatusService(testRevision)),
 			deploy(testNamespace, testRevision),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 		},
@@ -124,7 +124,7 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testRevision, testNamespace, WithHPAClass, WithTraffic,
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 		}},
 		Key: key(testRevision, testNamespace),
 	}, {
@@ -138,7 +138,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testRevision, testNamespace, WithHPAClass,
-				WithTraffic, WithPAStatusService(testRevision+"-pub")),
+				WithTraffic, WithPAStatusService(testRevision)),
 		}},
 		Key: key(testRevision, testNamespace),
 	}, {
@@ -152,7 +152,7 @@ func TestReconcile(t *testing.T) {
 				WithSKSReady),
 		},
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
-			Object: pa(testRevision, testNamespace, WithHPAClass, WithTraffic, WithPAStatusService(testRevision+"-pub")),
+			Object: pa(testRevision, testNamespace, WithHPAClass, WithTraffic, WithPAStatusService(testRevision)),
 		}},
 		Key: key(testRevision, testNamespace),
 		WantUpdates: []ktesting.UpdateActionImpl{{
@@ -171,7 +171,7 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testRevision, testNamespace, WithHPAClass,
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 		}},
 		Key: key(testRevision, testNamespace),
 		WantUpdates: []ktesting.UpdateActionImpl{{
@@ -331,7 +331,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testRevision, testNamespace, WithHPAClass,
-				WithTraffic, WithPAStatusService(testRevision+"-pub")),
+				WithTraffic, WithPAStatusService(testRevision)),
 		}},
 		Key:     key(testRevision, testNamespace),
 		WantErr: true,
@@ -345,7 +345,7 @@ func TestReconcile(t *testing.T) {
 		Name: "update hpa fails",
 		Objects: []runtime.Object{
 			pa(testRevision, testNamespace, WithHPAClass, WithTraffic,
-				WithPAStatusService(testRevision+"-pub"), WithTargetAnnotation("1")),
+				WithPAStatusService(testRevision), WithTargetAnnotation("1")),
 			hpa(testRevision, testNamespace, pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"))),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			deploy(testNamespace, testRevision),
@@ -365,7 +365,7 @@ func TestReconcile(t *testing.T) {
 		Name: "update hpa with target usage",
 		Objects: []runtime.Object{
 			pa(testRevision, testNamespace, WithHPAClass, WithTraffic,
-				WithPAStatusService(testRevision+"-pub"), WithTargetAnnotation("1")),
+				WithPAStatusService(testRevision), WithTargetAnnotation("1")),
 			hpa(testRevision, testNamespace, pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"))),
 			deploy(testNamespace, testRevision),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -173,7 +173,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision,
 				WithNoTraffic("NoTraffic", "The target is not receiving traffic."),
-				markOld, WithPAStatusService(testRevision+"-pub")),
+				markOld, WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode, WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision, func(d *appsv1.Deployment) {
@@ -189,7 +189,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision,
 				WithNoTraffic("NoTraffic", "The target is not receiving traffic."),
-				markOld, WithPAStatusService(testRevision+"-pub")),
+				markOld, WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode, WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision),
@@ -208,7 +208,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, markOld,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision),
@@ -217,7 +217,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: kpa(testNamespace, testRevision,
 				WithNoTraffic("NoTraffic", "The target is not receiving traffic."),
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: sks(testNamespace, testRevision, WithSKSReady,
@@ -228,7 +228,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, markOld,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision),
@@ -245,7 +245,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: kpa(testNamespace, testRevision,
 				WithNoTraffic("NoTraffic", "The target is not receiving traffic."),
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: sks(testNamespace, testRevision, WithSKSReady,
@@ -256,7 +256,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision),
@@ -329,7 +329,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			expectedDeploy,
@@ -340,7 +340,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
@@ -357,7 +357,7 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
@@ -374,7 +374,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision),
@@ -396,7 +396,7 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			deploy(testNamespace, testRevision),
@@ -418,7 +418,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
@@ -436,7 +436,7 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
@@ -455,7 +455,7 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector), func(s *corev1.Service) {
 				s.OwnerReferences = nil
@@ -464,7 +464,7 @@ func TestReconcile(t *testing.T) {
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision, markActive, WithPAStatusService(testRevision+"-pub"),
+			Object: kpa(testNamespace, testRevision, markActive, WithPAStatusService(testRevision),
 				// We expect this change in status:
 				markResourceNotOwned("Service", testRevision+"-metrics")),
 		}},
@@ -476,7 +476,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			expectedDeploy,
@@ -491,7 +491,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, WithNoTraffic("NoTraffic", "The target is not receiving traffic."),
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			// SKS is ready here, since its endpoints are populated with Activator endpoints.
 			sks(testNamespace, testRevision, WithProxyMode, WithDeployRef(deployName), WithSKSReady),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
@@ -504,21 +504,21 @@ func TestReconcile(t *testing.T) {
 				WithDeployRef(deployName)),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision, markActivating, WithPAStatusService(testRevision+"-pub")),
+			Object: kpa(testNamespace, testRevision, markActivating, WithPAStatusService(testRevision)),
 		}},
 	}, {
 		Name: "sks is still not ready",
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, WithTraffic,
-				WithPAStatusService(testRevision+"-pub")),
+				WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPubService, WithPrivateService),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision, markActivating, WithPAStatusService(testRevision+"-pub")),
+			Object: kpa(testNamespace, testRevision, markActivating, WithPAStatusService(testRevision)),
 		}},
 	}, {
 		Name: "sks becomes ready",
@@ -531,7 +531,7 @@ func TestReconcile(t *testing.T) {
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision, markActive, WithPAStatusService(testRevision+"-pub")),
+			Object: kpa(testNamespace, testRevision, markActive, WithPAStatusService(testRevision)),
 		}},
 	}, {
 		Name: "sks does not exist",
@@ -561,7 +561,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			// SKS just got updated and we don't have up to date status.
-			Object: kpa(testNamespace, testRevision, markActivating, WithPAStatusService(testRevision+"-pub")),
+			Object: kpa(testNamespace, testRevision, markActivating, WithPAStatusService(testRevision)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: sks(testNamespace, testRevision, WithPubService,

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -81,7 +81,7 @@ func testConfiguration() *v1alpha1.Configuration {
 }
 
 func serviceName(rn string) string {
-	return rn + "-pub"
+	return rn
 }
 
 func testReadyEndpoints(revName string) *corev1.Endpoints {

--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -397,7 +397,7 @@ func TestMakeClusterIngressRule_InactiveTarget(t *testing.T) {
 			RevisionName:      "revision",
 			Percent:           100,
 		},
-		ServiceName: "strange-quark-pub",
+		ServiceName: "strange-quark",
 		Active:      false,
 	}}
 	domains := []string{"a.com", "b.org"}
@@ -437,7 +437,7 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 			RevisionName:      "revision",
 			Percent:           80,
 		},
-		ServiceName: "up-quark-pub",
+		ServiceName: "up-quark",
 		Active:      false,
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
@@ -445,7 +445,7 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 			RevisionName:      "new-revision",
 			Percent:           20,
 		},
-		ServiceName: "down-quark-pub",
+		ServiceName: "down-quark",
 		Active:      false,
 	}}
 	domains := []string{"a.com", "b.org"}

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -95,7 +95,7 @@ func getTestRevisionWithCondition(name string, cond apis.Condition) *v1alpha1.Re
 			},
 		},
 		Status: v1alpha1.RevisionStatus{
-			ServiceName: fmt.Sprintf("%s-pub", name),
+			ServiceName: name,
 			Status: duckv1beta1.Status{
 				Conditions: duckv1beta1.Conditions{cond},
 			},
@@ -136,7 +136,7 @@ func getTestRevisionForConfig(config *v1alpha1.Configuration) *v1alpha1.Revision
 		},
 		Spec: *config.Spec.GetTemplate().Spec.DeepCopy(),
 		Status: v1alpha1.RevisionStatus{
-			ServiceName: "p-deadbeef-pub",
+			ServiceName: "p-deadbeef",
 		},
 	}
 	rev.Status.MarkResourcesAvailable()
@@ -590,14 +590,14 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", cfgrev.Name),
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
 					}, {
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", rev.Name),
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
@@ -615,7 +615,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      "test-rev-pub",
+							ServiceName:      "test-rev",
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -633,7 +633,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      "test-rev-pub",
+							ServiceName:      "test-rev",
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -710,14 +710,14 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", rev.Name),
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
 					}, {
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", cfgrev.Name),
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
@@ -735,7 +735,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", cfgrev.Name),
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -753,7 +753,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      fmt.Sprintf("%s-pub", rev.Name),
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,

--- a/pkg/reconciler/serverlessservice/resources/names/names.go
+++ b/pkg/reconciler/serverlessservice/resources/names/names.go
@@ -19,8 +19,7 @@ package names
 // PublicService returns the public service name for the `s`.
 func PublicService(sks string) string {
 	// TODO(vagababov): evolve this use generateName (for #3236).
-	// TODO(vagababov): remove "-pub", once revision stops creating the service.
-	return sks + "-pub"
+	return sks
 }
 
 // PrivateService returns the private service name for the `s`.

--- a/pkg/reconciler/serverlessservice/resources/names/names_test.go
+++ b/pkg/reconciler/serverlessservice/resources/names/names_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestServiceNames(t *testing.T) {
-	if got, want := PublicService("test-name"), "test-name-pub"; got != want {
+	if got, want := PublicService("test-name"), "test-name"; got != want {
 		t.Errorf("PublicService name = %s, want: %s", got, want)
 	}
 	if got, want := PrivateService("test-name"), "test-name-priv"; got != want {

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -62,7 +62,7 @@ func TestMakePublicService(t *testing.T) {
 		want: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "melon",
-				Name:      "collie-pub",
+				Name:      "collie",
 				Labels: map[string]string{
 					// Those should be propagated.
 					serving.RevisionLabelKey:  "collie",
@@ -110,7 +110,7 @@ func TestMakePublicService(t *testing.T) {
 		want: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "melon",
-				Name:      "collie-pub",
+				Name:      "collie",
 				Labels: map[string]string{
 					// Those should be propagated.
 					serving.RevisionLabelKey:  "collie",
@@ -161,7 +161,7 @@ func TestMakePublicService(t *testing.T) {
 		want: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "siamese",
-				Name:      "dream-pub",
+				Name:      "dream",
 				Labels: map[string]string{
 					// Those should be propagated.
 					serving.RevisionLabelKey:  "dream",
@@ -214,7 +214,7 @@ func TestMakePublicService(t *testing.T) {
 		want: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "siamese",
-				Name:      "dream-pub",
+				Name:      "dream",
 				Labels: map[string]string{
 					// Those should be propagated.
 					serving.RevisionLabelKey:  "dream",
@@ -267,7 +267,7 @@ func TestMakePublicService(t *testing.T) {
 		want: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "siamese",
-				Name:      "dream-pub",
+				Name:      "dream",
 				Labels: map[string]string{
 					// Those should be propagated.
 					serving.RevisionLabelKey:  "dream",
@@ -339,7 +339,7 @@ func TestMakeEndpoints(t *testing.T) {
 		want: &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "melon",
-				Name:      "collie-pub",
+				Name:      "collie",
 				Labels: map[string]string{
 					serving.RevisionLabelKey:  "collie",
 					serving.RevisionUID:       "1982",
@@ -399,7 +399,7 @@ func TestMakeEndpoints(t *testing.T) {
 		want: &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "melon",
-				Name:      "collie-pub",
+				Name:      "collie",
 				Labels: map[string]string{
 					serving.RevisionLabelKey:  "collie",
 					serving.RevisionUID:       "1982",

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -374,20 +374,20 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: SKS: fail5 does not own Service: fail5-priv`),
 		},
 	}, {
-		Name:    "ronin-pub-service/fail5",
-		Key:     "ronin-pub-service/fail5",
+		Name:    "ronin-pub-service/fail6",
+		Key:     "ronin-pub-service/fail6",
 		WantErr: true,
 		Objects: []runtime.Object{
-			SKS("ronin-pub-service", "fail5", WithPubService, WithPrivateService, WithDeployRef("blah")),
+			SKS("ronin-pub-service", "fail6", WithPubService, WithPrivateService, WithDeployRef("blah")),
 			deploy("ronin-pub-service", "blah"),
-			svcpub("ronin-pub-service", "fail5", WithK8sSvcOwnersRemoved),
-			svcpriv("ronin-pub-service", "fail5"),
-			endpointspub("ronin-pub-service", "fail5", WithSubsets),
-			endpointspriv("ronin-pub-service", "fail5", WithSubsets),
+			svcpub("ronin-pub-service", "fail6", WithK8sSvcOwnersRemoved),
+			svcpriv("ronin-pub-service", "fail6"),
+			endpointspub("ronin-pub-service", "fail6", WithSubsets),
+			endpointspriv("ronin-pub-service", "fail6", WithSubsets),
 			activatorEndpoints(WithSubsets),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: SKS: fail5 does not own Service: fail5-pub`),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: SKS: fail6 does not own Service: fail6`),
 		},
 	}, {
 		Name:    "ronin-pub-eps/fail7",
@@ -403,7 +403,7 @@ func TestReconcile(t *testing.T) {
 			activatorEndpoints(WithSubsets),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: SKS: fail7 does not own Endpoints: fail7-pub`),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: SKS: fail7 does not own Endpoints: fail7`),
 		},
 	}, {
 		Name:    "update-svc-fail-priv",


### PR DESCRIPTION
There is no reason, why revision public service name should be different
from the revision.
So do just that.


/lint
Fixes #1997

## Proposed Changes

* use the revision name as the public service name
* clean up tests

/cc @mattmoor @tcnghia 