### PR TITLE
Clean some leftover tails from the #1997.

### DIFF
--- a/pkg/apis/networking/ports.go
+++ b/pkg/apis/networking/ports.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+// The ports we setup on our services.
+const (
+	// ServiceHTTPPort is the port that we setup our Serving and Activator K8s services for
+	// HTTP/1 endpoints.
+	ServiceHTTPPort = 80
+
+	// ServiceHTTP2Port is the port that we setup our Serving and Activator K8s services for
+	// HTTP/2 endpoints.
+	ServiceHTTP2Port = 81
+
+	// BackendHTTPPort is the backend, i.e. `targetPort` that we setup for HTTP services.
+	BackendHTTPPort = 8012
+
+	// BackendHTTP2Port is the backend, i.e. `targetPort` that we setup for HTTP services.
+	BackendHTTP2Port = 8013
+
+	// RequestQueueAdminPort specifies the port number for
+	// health check and lifecyle hooks for queue-proxy.
+	RequestQueueAdminPort = 8022
+
+	// RequestQueueMetricsPort specifies the port number for metrics emitted
+	// by queue-proxy.
+	RequestQueueMetricsPort = 9090
+
+	// ServicePortNameHTTP1 is the name of the external port of the service for HTTP/1.1
+	ServicePortNameHTTP1 = "http"
+	// ServicePortNameH2C is the name of the external port of the service for HTTP/2
+	ServicePortNameH2C = "http2"
+)
+
+// ServicePortName returns the port for the app level protocol.
+func ServicePortName(proto ProtocolType) string {
+	if proto == ProtocolH2C {
+		return ServicePortNameH2C
+	}
+	return ServicePortNameHTTP1
+}
+
+// ServicePort chooses the service (load balancer) port for the public service.
+func ServicePort(proto ProtocolType) int32 {
+	if proto == ProtocolH2C {
+		return ServiceHTTP2Port
+	}
+	return ServiceHTTPPort
+}

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -50,11 +50,6 @@ const (
 	// ServiceTypeKey is the label key attached to a service specifying the type of service.
 	// e.g. Public, Metrics
 	ServiceTypeKey = GroupName + "/serviceType"
-
-	// ServicePortNameHTTP1 is the name of the external port of the service for HTTP/1.1
-	ServicePortNameHTTP1 = "http"
-	// ServicePortNameH2C is the name of the external port of the service for HTTP/2
-	ServicePortNameH2C = "http2"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services
@@ -81,35 +76,3 @@ var (
 	// DefaultRetryCount will be set if Attempts not specified.
 	DefaultRetryCount = 3
 )
-
-// The ports we setup on our services.
-const (
-	// ServiceHTTPPort is the port that we setup our Serving and Activator K8s services for
-	// HTTP/1 endpoints.
-	ServiceHTTPPort = 80
-	// ServiceHTTP2Port is the port that we setup our Serving and Activator K8s services for
-	// HTTP/2 endpoints.
-	ServiceHTTP2Port = 81
-
-	// BackendHTTPPort is the backend, i.e. `targetPort` that we setup for HTTP services.
-	BackendHTTPPort = 8012
-
-	// BackendHTTP2Port is the backend, i.e. `targetPort` that we setup for HTTP services.
-	BackendHTTP2Port = 8013
-
-	// RequestQueueAdminPort specifies the port number for
-	// health check and lifecyle hooks for queue-proxy.
-	RequestQueueAdminPort = 8022
-
-	// RequestQueueMetricsPort specifies the port number for metrics emitted
-	// by queue-proxy.
-	RequestQueueMetricsPort = 9090
-)
-
-// ServicePortName returns the port for the app level protocol.
-func ServicePortName(proto ProtocolType) string {
-	if proto == ProtocolH2C {
-		return ServicePortNameH2C
-	}
-	return ServicePortNameHTTP1
-}

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -82,7 +82,7 @@ func TestMakePublicService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameHTTP1,
+					Name:       networking.ServicePortNameHTTP1,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTPPort),
@@ -130,7 +130,7 @@ func TestMakePublicService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameHTTP1,
+					Name:       networking.ServicePortNameHTTP1,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTPPort),
@@ -183,7 +183,7 @@ func TestMakePublicService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameH2C,
+					Name:       networking.ServicePortNameH2C,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTP2Port,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
@@ -236,7 +236,7 @@ func TestMakePublicService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameH2C,
+					Name:       networking.ServicePortNameH2C,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTP2Port,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
@@ -289,7 +289,7 @@ func TestMakePublicService(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameH2C,
+					Name:       networking.ServicePortNameH2C,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTP2Port,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
@@ -499,7 +499,7 @@ func TestMakePrivateService(t *testing.T) {
 					"app": "sadness",
 				},
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameHTTP1,
+					Name:       networking.ServicePortNameHTTP1,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTPPort),
@@ -557,7 +557,7 @@ func TestMakePrivateService(t *testing.T) {
 					"app": "today",
 				},
 				Ports: []corev1.ServicePort{{
-					Name:       servicePortNameH2C,
+					Name:       networking.ServicePortNameH2C,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),


### PR DESCRIPTION
## Proposed Changes
- move port related funcs and constants to its own file. register.go
  sounded wrong for that
- remove duplication
- update the SKS code and tests to deal with the change
- also move a new function there that will be used for probing quite
  often


/lint

/cc @mattmoor 