### PR TITLE
Add coverage for specifying WorkingDir.

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -117,6 +117,7 @@ func ContainerMask(in *corev1.Container) *corev1.Container {
 	out.Args = in.Args
 	out.Command = in.Command
 	out.Env = in.Env
+	out.WorkingDir = in.WorkingDir
 	out.EnvFrom = in.EnvFrom
 	out.Image = in.Image
 	out.ImagePullPolicy = in.ImagePullPolicy

--- a/test/conformance/workingdir_test.go
+++ b/test/conformance/workingdir_test.go
@@ -38,7 +38,7 @@ func TestWorkingDirService(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	wd := "/foo/bar/baz"
+	const wd = "/foo/bar/baz"
 
 	// Setup initial Service
 	_, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{},

--- a/test/conformance/workingdir_test.go
+++ b/test/conformance/workingdir_test.go
@@ -1,0 +1,56 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/test"
+)
+
+func TestWorkingDirService(t *testing.T) {
+	t.Parallel()
+	clients := setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "workingdir",
+	}
+
+	// Clean up on test failure or interrupt
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+
+	wd := "/foo/bar/baz"
+
+	// Setup initial Service
+	_, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{},
+		func(svc *v1alpha1.Service) {
+			c := &svc.Spec.Template.Spec.Containers[0]
+			c.WorkingDir = wd
+		})
+	if err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
+	}
+
+	if err = validateRunLatestDataPlane(t, clients, names, wd); err != nil {
+		t.Error(err)
+	}
+}

--- a/test/test_images/workingdir/README.md
+++ b/test/test_images/workingdir/README.md
@@ -1,0 +1,18 @@
+# WorkingDir test image
+
+This directory contains the test image used in the WorkingDir conformance test.
+
+The image contains a simple Go webserver, `workingdir.go`, that will, by
+default, listen on port `8080` and expose a service at `/` that returns
+the working directory configured by the test.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/workingdir/service.yaml
+++ b/test/test_images/workingdir/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: workingdir-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: github.com/knative/serving/test/test_images/workingdir
+        workingdir: /foo/bar/baz

--- a/test/test_images/workingdir/workingdir.go
+++ b/test/test_images/workingdir/workingdir.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/knative/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	wd, err := os.Getwd()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintln(w, wd)
+}
+
+func main() {
+	flag.Parse()
+	log.Print("WorkingDir app started.")
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/test/test_images/workingdir/workingdir.go
+++ b/test/test_images/workingdir/workingdir.go
@@ -26,18 +26,16 @@ import (
 	"github.com/knative/serving/test"
 )
 
+var wd string
+
 func handler(w http.ResponseWriter, r *http.Request) {
-	wd, err := os.Getwd()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	fmt.Fprintln(w, wd)
 }
 
 func main() {
 	flag.Parse()
-	log.Print("WorkingDir app started.")
+	wd, _ = os.Getwd()
+	log.Printf("WorkingDir app started in %q.", wd)
 
 	test.ListenAndServeGracefully(":8080", handler)
 }


### PR DESCRIPTION
This adds a test image that returns its working directory and a test
that launches that image with a working directory and when ready curls
it expecting to get that working directory back.

Fixes: https://github.com/knative/serving/issues/3483
