### PR TITLE
Unignore the scale from zero to 50 test

### DIFF
--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -237,7 +237,5 @@ func TestScaleFromZero5(t *testing.T) {
 }
 
 func TestScaleFromZero50(t *testing.T) {
-	// See: #3021
-	t.Skip()
 	testScaleFromZero(t, 50 /* parallelism */, 5 /* runs */)
 }


### PR DESCRIPTION
I've run the test locally and it passes

Fixes #3021 

## Proposed Changes

* unignore the test
* it took  2823.102s (more than 45minutes) to run the 50 test against my cluster 

/cc @mattmoor 