### PR TITLE
Refactor the "Env Propagation" tests to cover EnvFrom.

### DIFF
--- a/pkg/reconciler/testing/functional.go
+++ b/pkg/reconciler/testing/functional.go
@@ -109,6 +109,20 @@ func WithServiceDeletionTimestamp(r *v1alpha1.Service) {
 	r.ObjectMeta.SetDeletionTimestamp(&t)
 }
 
+// WithEnv configures the Service to use the provided environment variables.
+func WithEnv(evs ...corev1.EnvVar) ServiceOption {
+	return func(s *v1alpha1.Service) {
+		s.Spec.Template.Spec.Containers[0].Env = evs
+	}
+}
+
+// WithEnvFrom configures the Service to use the provided environment variables.
+func WithEnvFrom(evs ...corev1.EnvFromSource) ServiceOption {
+	return func(s *v1alpha1.Service) {
+		s.Spec.Template.Spec.Containers[0].EnvFrom = evs
+	}
+}
+
 // WithInlineRollout configures the Service to be "run latest" via inline
 // Route/Configuration
 func WithInlineRollout(s *v1alpha1.Service) {

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -32,6 +32,8 @@ import (
 	"github.com/knative/serving/test/types"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
 
 // fetchRuntimeInfo creates a Service that uses the 'runtime' test image, and extracts the returned output into the
@@ -70,12 +72,12 @@ func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *test.Options
 }
 
 // fetchEnvInfo creates the service using test_images/environment and fetches environment info defined inside the container dictated by urlPath.
-func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, options *test.Options) ([]byte, *test.ResourceNames, error) {
+func fetchEnvInfo(t *testing.T, clients *test.Clients, urlPath string, opts ...ServiceOption) ([]byte, *test.ResourceNames, error) {
 	t.Log("Creating a new Service")
 	var names test.ResourceNames
 	names.Service = test.ObjectNameForTest(t)
 	names.Image = "environment"
-	svc, err := test.CreateLatestService(t, clients, names, options)
+	svc, err := test.CreateLatestService(t, clients, names, &test.Options{}, opts...)
 	if err != nil {
 		return nil, nil, errors.New(fmt.Sprintf("Failed to create Service: %v", err))
 	}

--- a/test/conformance/envvars_test.go
+++ b/test/conformance/envvars_test.go
@@ -30,7 +30,7 @@ import (
 func TestShouldEnvVars(t *testing.T) {
 	t.Parallel()
 	clients := setup(t)
-	resp, names, err := fetchEnvInfo(t, clients, test.EnvImageEnvVarsPath, &test.Options{})
+	resp, names, err := fetchEnvInfo(t, clients, test.EnvImageEnvVarsPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestShouldEnvVars(t *testing.T) {
 func TestMustEnvVars(t *testing.T) {
 	t.Parallel()
 	clients := setup(t)
-	resp, _, err := fetchEnvInfo(t, clients, test.EnvImageEnvVarsPath, &test.Options{})
+	resp, _, err := fetchEnvInfo(t, clients, test.EnvImageEnvVarsPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/conformance/filesystem_perm_test.go
+++ b/test/conformance/filesystem_perm_test.go
@@ -45,8 +45,7 @@ func verifyPermString(resp string, expected string) error {
 func testFileSystemPermissions(t *testing.T, clients *test.Clients, paths map[string]FilePathInfo) error {
 	for key, value := range paths {
 		resp, _, err := fetchEnvInfo(t, clients,
-			fmt.Sprintf("%s?%s=%s", test.EnvImageFilePathInfoPath, test.EnvImageFilePathQueryParam, key),
-			&test.Options{})
+			fmt.Sprintf("%s?%s=%s", test.EnvImageFilePathInfoPath, test.EnvImageFilePathQueryParam, key))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This refactors the current test coverage for projecting CM/S into
environment variables to enable us to more easily add a variant
covering the `envFrom` style of projection.

Fixes: https://github.com/knative/serving/issues/3481

/hold

I want @dgerd to actually TAL at this given his comments on the linked issue.