### PR TITLE
golang format tools

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -57,7 +57,7 @@ import (
 	"github.com/knative/serving/pkg/tracing"
 	tracingconfig "github.com/knative/serving/pkg/tracing/config"
 
-	"github.com/openzipkin/zipkin-go"
+	zipkin "github.com/openzipkin/zipkin-go"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"

--- a/test/e2e/build/build_test.go
+++ b/test/e2e/build/build_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 const helloWorldExpectedOutput = "Hello World! How about some tasty noodles?"
+
 var buildCondSet = duckv1alpha1.NewBatchConditionSet()
 
 func TestBuildSpecAndServe(t *testing.T) {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
