### PR TITLE
Remove misleading image and tag to python:3.

### DIFF
--- a/test/conformance/cmd_args_test.go
+++ b/test/conformance/cmd_args_test.go
@@ -32,7 +32,6 @@ func TestCmdArgsService(t *testing.T) {
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
-		Image:   pizzaPlanet1,
 	}
 
 	// Clean up on test failure or interrupt
@@ -45,7 +44,7 @@ func TestCmdArgsService(t *testing.T) {
 	_, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{},
 		func(svc *v1alpha1.Service) {
 			c := &svc.Spec.Template.Spec.Containers[0]
-			c.Image = "python"
+			c.Image = "python:3"
 			c.Command = []string{"python"}
 			c.Args = []string{"-c", fmt.Sprintf(`
 import http.server

--- a/test/conformance/cmd_args_test.go
+++ b/test/conformance/cmd_args_test.go
@@ -32,6 +32,7 @@ func TestCmdArgsService(t *testing.T) {
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
+		Image:   "python:3",
 	}
 
 	// Clean up on test failure or interrupt
@@ -44,7 +45,7 @@ func TestCmdArgsService(t *testing.T) {
 	_, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{},
 		func(svc *v1alpha1.Service) {
 			c := &svc.Spec.Template.Spec.Containers[0]
-			c.Image = "python:3"
+			c.Image = names.Image
 			c.Command = []string{"python"}
 			c.Args = []string{"-c", fmt.Sprintf(`
 import http.server


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

I was debugging this test in another environment and found the image name quite confusing. It's not needed, so let's ditch it. Also denoting the current python version in the actual image reference for more clarity.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
