### PR TITLE
Increase 'queueDepth' value to allow Auoscaler to scale up

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -239,7 +239,6 @@ func main() {
 		// allow the autoscaler to get a strong enough signal.
 		//
 		queueDepth := containerConcurrency * 10
-		
 		params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: containerConcurrency, InitialCapacity: containerConcurrency}
 		breaker = queue.NewBreaker(params)
 		logger.Infof("Queue container is starting with %#v", params)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -235,10 +235,10 @@ func main() {
 
 	// If containerConcurrency == 0 then concurrency is unlimited.
 	if containerConcurrency > 0 {
-		// We set the queue depth to be equal to the container concurrency * 100 to
+		// We set the queue depth to be equal to the container concurrency * 10 to
 		// allow the autoscaler to get a strong enough signal.
 		//
-		queueDepth := containerConcurrency * 100
+		queueDepth := containerConcurrency * 10
 		
 		params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: containerConcurrency, InitialCapacity: containerConcurrency}
 		breaker = queue.NewBreaker(params)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -237,7 +237,6 @@ func main() {
 	if containerConcurrency > 0 {
 		// We set the queue depth to be equal to the container concurrency * 10 to
 		// allow the autoscaler to get a strong enough signal.
-		//
 		queueDepth := containerConcurrency * 10
 		params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: containerConcurrency, InitialCapacity: containerConcurrency}
 		breaker = queue.NewBreaker(params)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -235,9 +235,10 @@ func main() {
 
 	// If containerConcurrency == 0 then concurrency is unlimited.
 	if containerConcurrency > 0 {
-		// We set the queue depth to be equal to the container concurrency but at least 10 to
+		// We set the queue depth to be equal to the container concurrency * 100 to
 		// allow the autoscaler to get a strong enough signal.
-		queueDepth := containerConcurrency
+		//
+		queueDepth := containerConcurrency * 100
 		if queueDepth < 10 {
 			queueDepth = 10
 		}

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -239,9 +239,7 @@ func main() {
 		// allow the autoscaler to get a strong enough signal.
 		//
 		queueDepth := containerConcurrency * 100
-		if queueDepth < 10 {
-			queueDepth = 10
-		}
+		
 		params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: containerConcurrency, InitialCapacity: containerConcurrency}
 		breaker = queue.NewBreaker(params)
 		logger.Infof("Queue container is starting with %#v", params)


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
- This is a superficial/temp fix for [Issue 2579](https://github.com/knative/serving/issues/2579)
- It's a workaround to avoid the 503 error code.


* Running performance tests with a high number of clients reveals issues with autoscaler. Autoscaler fails to scale up due to low queue size.
* Slow scaling up is due to the autoscaler receiving biased numbers for concurrency levels.
* The queue depth is set to the same number as desired container concurrency level. When there are a lot of requests coming in the queue-proxy will start refusing requests with 503 error code. And it will start refusing them immediately when the number of pending requests exceeds queueDepth+maxConcurrency .

## Proposed Changes

* Make 'queueDepth' relative to the concurrency level but much longer than it is now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```NONE

```
