### PR TITLE
Generalize aggregational computations.

### DIFF
--- a/pkg/autoscaler/aggregation/aggregation.go
+++ b/pkg/autoscaler/aggregation/aggregation.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import "time"
+
+// Accumulator is a function accumulating buckets and their time..
+type Accumulator func(time time.Time, bucket float64Bucket)
+
+// YoungerThan only applies the accumulator to buckets that are younger than the given
+// time.
+func YoungerThan(oldest time.Time, acc Accumulator) Accumulator {
+	return func(time time.Time, bucket float64Bucket) {
+		if !time.Before(oldest) {
+			acc(time, bucket)
+		}
+	}
+}
+
+// Average is used to keep the values necessary to compute an average.
+type Average struct {
+	sum   float64
+	count float64
+}
+
+// Accumulate accumulates the values needed to compute an average.
+func (a *Average) Accumulate(_ time.Time, bucket float64Bucket) {
+	a.sum += bucket.Sum()
+	a.count++
+}
+
+// Value returns the average or 0 if no buckets have been accumulated.
+func (a *Average) Value() float64 {
+	if a.count == 0 {
+		return 0
+	}
+	return a.sum / a.count
+}

--- a/pkg/autoscaler/aggregation/aggregation_test.go
+++ b/pkg/autoscaler/aggregation/aggregation_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []float64
+		want   float64
+	}{{
+		name:   "empty",
+		values: []float64{},
+		want:   0.0,
+	}, {
+		name:   "not empty",
+		values: []float64{2.0, 4.0},
+		want:   3.0,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			average := Average{}
+			for _, value := range tt.values {
+				bucket := float64Bucket{}
+				bucket.Record("pod", value)
+				average.Accumulate(time.Now(), bucket)
+			}
+
+			if got := average.Value(); got != tt.want {
+				t.Errorf("Value() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestYoungerThan(t *testing.T) {
+	t0 := time.Now()
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+
+	tests := []struct {
+		name   string
+		times  []time.Time
+		oldest time.Time
+		want   []time.Time
+	}{{
+		name:  "empty",
+		times: []time.Time{},
+		want:  []time.Time{},
+	}, {
+		name:   "drop all",
+		times:  []time.Time{t0, t1, t2},
+		oldest: t3,
+		want:   []time.Time{},
+	}, {
+		name:   "keep all",
+		times:  []time.Time{t0, t1, t2},
+		oldest: t0,
+		want:   []time.Time{t0, t1, t2},
+	}, {
+		name:   "drop some",
+		times:  []time.Time{t0, t1, t2},
+		oldest: t2,
+		want:   []time.Time{t2},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := make(map[time.Time]bool)
+			acc := YoungerThan(tt.oldest, func(time time.Time, bucket float64Bucket) {
+				got[time] = true
+			})
+			for _, t := range tt.times {
+				bucket := float64Bucket{}
+				bucket.Record("pod", 1.0)
+				acc(t, bucket)
+			}
+
+			if got, want := len(got), len(tt.want); got != want {
+				t.Errorf("len(got) = %v, want %v", got, want)
+			}
+
+			for _, want := range tt.want {
+				if !got[want] {
+					t.Errorf("Expected buckets to contain %v, buckets: %v", want, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -60,8 +60,8 @@ func (t *TimedFloat64Buckets) IsEmpty() bool {
 	return len(t.buckets) == 0
 }
 
-// Process processes all buckets saved currently with the given Accumulutor functions.
-func (t *TimedFloat64Buckets) Process(accs ...Accumulator) {
+// ForEachBucket calls the given Accumulator function for each bucket.
+func (t *TimedFloat64Buckets) ForEachBucket(accs ...Accumulator) {
 	t.bucketsMutex.RLock()
 	defer t.bucketsMutex.RUnlock()
 

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -92,7 +92,7 @@ func TestTimedFloat64Buckets(t *testing.T) {
 	}
 }
 
-func TestTimedFloat64Buckets_Process(t *testing.T) {
+func TestTimedFloat64Buckets_ForEachBucket(t *testing.T) {
 	pod := "pod"
 	granularity := 1 * time.Second
 	trunc1 := time.Now().Truncate(granularity)
@@ -105,7 +105,7 @@ func TestTimedFloat64Buckets_Process(t *testing.T) {
 
 	acc1 := 0
 	acc2 := 0
-	buckets.Process(
+	buckets.ForEachBucket(
 		func(time time.Time, bucket float64Bucket) {
 			acc1++
 		},

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -25,9 +25,8 @@ import (
 
 func TestTimedFloat64Buckets(t *testing.T) {
 	pod := "pod"
-	zero := time.Now()
-	trunc1 := zero.Truncate(1 * time.Second)
-	trunc5 := zero.Truncate(5 * time.Second)
+	trunc1 := time.Now().Truncate(1 * time.Second)
+	trunc5 := time.Now().Truncate(5 * time.Second)
 
 	type args struct {
 		time  time.Time
@@ -79,16 +78,129 @@ func TestTimedFloat64Buckets(t *testing.T) {
 			}
 
 			got := make(map[time.Time]float64)
-			for time, bucket := range buckets.GetAndLock() {
+			for time, bucket := range buckets.buckets {
 				got[time] = bucket.Sum()
 			}
-			buckets.Unlock()
 
 			if !cmp.Equal(tt.want, got) {
 				t.Errorf("Unexpected values (-want +got): %v", cmp.Diff(tt.want, got))
 			}
 			if len(tt.want) == 0 && !buckets.IsEmpty() {
 				t.Error("IsEmpty() = false, want true")
+			}
+		})
+	}
+}
+
+func TestTimedFloat64Buckets_Process(t *testing.T) {
+	pod := "pod"
+	granularity := 1 * time.Second
+	trunc1 := time.Now().Truncate(granularity)
+	buckets := NewTimedFloat64Buckets(granularity)
+
+	buckets.Record(trunc1, pod, 10.0)
+	buckets.Record(trunc1.Add(1*time.Second), pod, 10.0)
+	buckets.Record(trunc1.Add(2*time.Second), pod, 5.0)
+	buckets.Record(trunc1.Add(3*time.Second), pod, 5.0)
+
+	acc1 := 0
+	acc2 := 0
+	buckets.Process(
+		func(time time.Time, bucket float64Bucket) {
+			acc1++
+		},
+		func(time time.Time, bucket float64Bucket) {
+			acc2++
+		},
+	)
+
+	want := 4
+	if acc1 != want {
+		t.Errorf("acc1 = %v, want %v", acc1, want)
+	}
+	if acc2 != want {
+		t.Errorf("acc2 = %v, want %v", acc1, want)
+	}
+}
+
+func TestTimedFloat64Buckets_RemoveOlderThan(t *testing.T) {
+	pod := "pod"
+	zero := time.Now()
+	trunc1 := zero.Truncate(1 * time.Second)
+
+	tests := []struct {
+		name            string
+		granularity     time.Duration
+		times           []time.Time
+		removeOlderThan time.Time
+		want            []time.Time
+	}{{
+		name:        "remove one",
+		granularity: 1 * time.Second,
+		times: []time.Time{
+			trunc1,
+			trunc1.Add(1 * time.Second),
+			trunc1.Add(2 * time.Second),
+		},
+		removeOlderThan: trunc1.Add(1 * time.Second),
+		want: []time.Time{
+			trunc1.Add(1 * time.Second),
+			trunc1.Add(2 * time.Second),
+		},
+	}, {
+		name:        "remove all",
+		granularity: 1 * time.Second,
+		times: []time.Time{
+			trunc1,
+			trunc1.Add(1 * time.Second),
+		},
+		removeOlderThan: trunc1.Add(2 * time.Second),
+		want:            []time.Time{},
+	}, {
+		name:        "remove none",
+		granularity: 1 * time.Second,
+		times: []time.Time{
+			trunc1,
+			trunc1.Add(1 * time.Second),
+		},
+		removeOlderThan: trunc1,
+		want: []time.Time{
+			trunc1,
+			trunc1.Add(1 * time.Second),
+		},
+	}, {
+		name:            "empty",
+		granularity:     1 * time.Second,
+		times:           []time.Time{},
+		removeOlderThan: trunc1.Add(1 * time.Second),
+		want:            []time.Time{},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buckets := NewTimedFloat64Buckets(tt.granularity)
+			for _, time := range tt.times {
+				buckets.Record(time, pod, 1.0)
+			}
+
+			if got, want := len(buckets.buckets), len(tt.times); got != want {
+				t.Errorf("len(buckets) = %v, want %v", got, want)
+			}
+
+			buckets.RemoveOlderThan(tt.removeOlderThan)
+
+			if got, want := len(buckets.buckets), len(tt.want); got != want {
+				t.Errorf("len(buckets) = %v, want %v", got, want)
+			}
+
+			got := make(map[time.Time]bool)
+			for time := range buckets.buckets {
+				got[time] = true
+			}
+			for _, want := range tt.want {
+				if !got[want] {
+					t.Errorf("Expected buckets to contain %v, buckets: %v", want, got)
+				}
 			}
 		})
 	}
@@ -128,7 +240,7 @@ func TestFloat64Bucket(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bucket := Float64Bucket{}
+			bucket := float64Bucket{}
 			for name, values := range tt.stats {
 				for _, value := range values {
 					bucket.Record(name, value)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -162,7 +162,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	// Compute data to scale on.
 	panicAverage := aggregation.Average{}
 	stableAverage := aggregation.Average{}
-	a.buckets.Process(
+	a.buckets.ForEachBucket(
 		aggregation.YoungerThan(now.Add(-spec.MetricSpec.PanicWindow), panicAverage.Accumulate),
 		stableAverage.Accumulate, // No need to add a YoungerThan condition as we already deleted all outdated stats above.
 	)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -152,14 +152,22 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 	// Use 1 if there are zero current pods.
 	readyPodsCount := math.Max(1, float64(originalReadyPodsCount))
 
-	observedStableConcurrency, observedPanicConcurrency, lastBucket := a.aggregateData(now, spec.MetricSpec.StableWindow, spec.MetricSpec.PanicWindow)
+	// Remove outdated data.
+	a.buckets.RemoveOlderThan(now.Add(-spec.MetricSpec.StableWindow))
 	if a.buckets.IsEmpty() {
 		logger.Debug("No data to scale on.")
 		return 0, false
 	}
 
-	// Log system totals.
-	logger.Debugf("Current concurrent clients: %0.3f", lastBucket.Sum())
+	// Compute data to scale on.
+	panicAverage := aggregation.Average{}
+	stableAverage := aggregation.Average{}
+	a.buckets.Process(
+		aggregation.YoungerThan(now.Add(-spec.MetricSpec.PanicWindow), panicAverage.Accumulate),
+		stableAverage.Accumulate, // No need to add a YoungerThan condition as we already deleted all outdated stats above.
+	)
+	observedStableConcurrency := stableAverage.Value()
+	observedPanicConcurrency := panicAverage.Value()
 
 	// Desired pod count is observed concurrency of the revision over desired (stable) concurrency per pod.
 	// The scaling up rate is limited to the MaxScaleUpRate.
@@ -211,52 +219,6 @@ func (a *Autoscaler) currentSpec() DeciderSpec {
 	a.specMux.RLock()
 	defer a.specMux.RUnlock()
 	return a.deciderSpec
-}
-
-// aggregateData aggregates bucketed stats over the stableWindow and panicWindow
-// respectively and returns the observedStableConcurrency, observedPanicConcurrency
-// and the last bucket that was aggregated.
-func (a *Autoscaler) aggregateData(now time.Time, stableWindow, panicWindow time.Duration) (
-	stableConcurrency float64, panicConcurrency float64, lastBucket aggregation.Float64Bucket) {
-	buckets := a.buckets.GetAndLock()
-	defer a.buckets.Unlock()
-
-	var (
-		stableBuckets float64
-		stableTotal   float64
-
-		panicBuckets float64
-		panicTotal   float64
-
-		lastBucketTime time.Time
-	)
-	for bucketTime, bucket := range buckets {
-		if !bucketTime.Add(panicWindow).Before(now) {
-			panicBuckets++
-			panicTotal += bucket.Sum()
-		}
-
-		if !bucketTime.Add(stableWindow).Before(now) {
-			stableBuckets++
-			stableTotal += bucket.Sum()
-		} else {
-			delete(buckets, bucketTime)
-		}
-
-		if bucketTime.After(lastBucketTime) {
-			lastBucketTime = bucketTime
-			lastBucket = bucket
-		}
-	}
-
-	if stableBuckets > 0 {
-		stableConcurrency = stableTotal / stableBuckets
-	}
-	if panicBuckets > 0 {
-		panicConcurrency = panicTotal / panicBuckets
-	}
-
-	return stableConcurrency, panicConcurrency, lastBucket
 }
 
 func (a *Autoscaler) podCountLimited(desiredPodCount, currentPodCount float64) int32 {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -366,19 +366,8 @@ func TestAutoscaler_Stats_TrimAfterStableWindow(t *testing.T) {
 			podCount:         1,
 		})
 	a.expectScale(t, now, 1, true)
-	currentValues := a.buckets.GetAndLock()
-	if len(currentValues) != 30 {
-		t.Errorf("Unexpected stat count. Expected 30. Got %v.", len(currentValues))
-	}
-	a.buckets.Unlock()
 	now = now.Add(time.Minute)
-
 	a.expectScale(t, now, 0, false)
-	currentValues = a.buckets.GetAndLock()
-	if len(currentValues) != 0 {
-		t.Errorf("Unexpected stat count. Expected 0. Got %v.", len(currentValues))
-	}
-	a.buckets.Unlock()
 }
 
 func TestAutoscaler_Stats_DenyNoTime(t *testing.T) {
@@ -390,12 +379,7 @@ func TestAutoscaler_Stats_DenyNoTime(t *testing.T) {
 		RequestCount:              5,
 	}
 	a.Record(TestContextWithLogger(t), stat)
-
 	a.expectScale(t, roundedNow(), 0, false)
-	currentValues := a.buckets.GetAndLock()
-	if len(currentValues) != 0 {
-		t.Errorf("Unexpected stat count. Expected 0. Got %v.", len(currentValues))
-	}
 }
 
 func TestAutoscaler_RateLimit_ScaleUp(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Pulls out the calculation of aggregations from the autoscaler entirely and leaves it only being a client to such calculations.

Opening early to outline the concept. Tests are needed for the aggregation functions obviously.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
