### PR TITLE
Deployment logic move

### DIFF
--- a/pkg/deployment/constants.go
+++ b/pkg/deployment/constants.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/deployment/deploy_test.go
+++ b/pkg/deployment/deploy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"testing"
@@ -30,7 +30,6 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/pkg/autoscaler"
-	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/metrics"
 	"github.com/knative/serving/pkg/network"
 	appsv1 "k8s.io/api/apps/v1"
@@ -367,7 +366,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc   *logging.Config
 		oc   *metrics.ObservabilityConfig
 		ac   *autoscaler.Config
-		cc   *deployment.Config
+		cc   *Config
 		want *corev1.PodSpec
 	}{{
 		name: "user-defined user port, queue proxy have PORT env",
@@ -382,7 +381,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				func(container *corev1.Container) {
@@ -420,7 +419,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				func(container *corev1.Container) {
@@ -450,7 +449,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc:   &logging.Config{},
 		oc:   &metrics.ObservabilityConfig{},
 		ac:   &autoscaler.Config{},
-		cc:   &deployment.Config{},
+		cc:   &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(),
 			queueContainer(
@@ -470,7 +469,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(func(container *corev1.Container) {
 				container.Image = "busybox@sha256:deadbeef"
@@ -488,7 +487,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(),
 			queueContainer(
@@ -506,7 +505,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				withHTTPReadinessProbe(networking.BackendHTTPPort),
@@ -527,7 +526,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				withExecReadinessProbe(
@@ -552,7 +551,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				withHTTPReadinessProbe(networking.BackendHTTPPort),
@@ -573,7 +572,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				withLivenessProbe(corev1.Handler{
@@ -595,7 +594,7 @@ func TestMakePodSpec(t *testing.T) {
 			FluentdSidecarImage:    "indiana:jones",
 		},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec(
 			[]corev1.Container{
 				userContainer(),
@@ -645,7 +644,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: podSpec([]corev1.Container{
 			userContainer(
 				func(container *corev1.Container) {
@@ -719,7 +718,7 @@ func TestMakeDeployment(t *testing.T) {
 		nc   *network.Config
 		oc   *metrics.ObservabilityConfig
 		ac   *autoscaler.Config
-		cc   *deployment.Config
+		cc   *Config
 		want *appsv1.Deployment
 	}{{
 		name: "simple concurrency=single no owner",
@@ -731,7 +730,7 @@ func TestMakeDeployment(t *testing.T) {
 		nc:   &network.Config{},
 		oc:   &metrics.ObservabilityConfig{},
 		ac:   &autoscaler.Config{},
-		cc:   &deployment.Config{},
+		cc:   &Config{},
 		want: makeDeployment(),
 	}, {
 		name: "simple concurrency=multi with owner",
@@ -743,7 +742,7 @@ func TestMakeDeployment(t *testing.T) {
 		nc:   &network.Config{},
 		oc:   &metrics.ObservabilityConfig{},
 		ac:   &autoscaler.Config{},
-		cc:   &deployment.Config{},
+		cc:   &Config{},
 		want: makeDeployment(),
 	}, {
 		name: "simple concurrency=multi with outbound IP range configured",
@@ -754,7 +753,7 @@ func TestMakeDeployment(t *testing.T) {
 		},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "*"
 		}),
@@ -774,7 +773,7 @@ func TestMakeDeployment(t *testing.T) {
 		},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
 			deploy.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "10.4.0.0/14,10.7.240.0/20"

--- a/pkg/deployment/env_var.go
+++ b/pkg/deployment/env_var.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"github.com/knative/serving/pkg/apis/serving"

--- a/pkg/deployment/fluentd.go
+++ b/pkg/deployment/fluentd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	corev1 "k8s.io/api/core/v1"
@@ -23,8 +23,8 @@ import (
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/pkg/metrics"
-	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/pkg/resources"
 )
 
@@ -92,7 +92,7 @@ func MakeFluentdConfigMap(rev *v1alpha1.Revision, observabilityConfig *metrics.O
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.FluentdConfigMap(rev),
 			Namespace: rev.Namespace,
-			Labels:    makeLabels(rev),
+			Labels:    MakeRevisionLabels(rev),
 			Annotations: resources.FilterMap(rev.GetAnnotations(), func(k string) bool {
 				// Ignore last pinned annotation.
 				return k == serving.RevisionLastPinnedAnnotationKey

--- a/pkg/deployment/fluentd_test.go
+++ b/pkg/deployment/fluentd_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"testing"

--- a/pkg/deployment/meta.go
+++ b/pkg/deployment/meta.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"github.com/knative/serving/pkg/apis/serving"
@@ -23,8 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// makeLabels constructs the labels we will apply to K8s resources.
-func makeLabels(revision *v1alpha1.Revision) map[string]string {
+// MakeRevisionLabels constructs the labels we will apply to K8s resources for a given revision.
+func MakeRevisionLabels(revision *v1alpha1.Revision) map[string]string {
 	labels := resources.UnionMaps(revision.GetLabels(), map[string]string{
 		serving.RevisionLabelKey: revision.Name,
 		serving.RevisionUID:      string(revision.UID),
@@ -39,8 +39,8 @@ func makeLabels(revision *v1alpha1.Revision) map[string]string {
 	return labels
 }
 
-// makeSelector constructs the Selector we will apply to K8s resources.
-func makeSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
+// MakeRevisionSelector constructs the Selector we will apply to K8s resources for a given revision.
+func MakeRevisionSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			serving.RevisionUID: string(revision.UID),

--- a/pkg/deployment/meta_test.go
+++ b/pkg/deployment/meta_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"testing"
@@ -26,7 +26,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
-func TestMakeLabels(t *testing.T) {
+func TestMakeRevisionLabels(t *testing.T) {
 	tests := []struct {
 		name string
 		rev  *v1alpha1.Revision
@@ -86,7 +86,7 @@ func TestMakeLabels(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := makeLabels(test.rev)
+			got := MakeRevisionLabels(test.rev)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("makeLabels (-want, +got) = %v", diff)
 			}
@@ -94,7 +94,7 @@ func TestMakeLabels(t *testing.T) {
 			wantSelector := &metav1.LabelSelector{
 				MatchLabels: map[string]string{serving.RevisionUID: "1234"},
 			}
-			gotSelector := makeSelector(test.rev)
+			gotSelector := MakeRevisionSelector(test.rev)
 			if diff := cmp.Diff(wantSelector, gotSelector); diff != "" {
 				t.Errorf("makeLabels (-want, +got) = %v", diff)
 			}

--- a/pkg/deployment/names/names.go
+++ b/pkg/deployment/names/names.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
-func ImageCache(rev *v1alpha1.Revision) string {
-	return rev.Name + "-cache"
+// Deployment returns the deployment name for a given revision
+func Deployment(rev *v1alpha1.Revision) string {
+	return rev.Name + "-deployment"
 }
 
-func KPA(rev *v1alpha1.Revision) string {
-	// We want the KPA's "key" to match the revision,
-	// to simplify the transition to the KPA.
-	return rev.Name
+// FluentdConfigMap returns the fluentd configmap name for a given revision
+func FluentdConfigMap(rev *v1alpha1.Revision) string {
+	return rev.Name + "-fluentd"
 }

--- a/pkg/deployment/names/names_test.go
+++ b/pkg/deployment/names/names_test.go
@@ -31,23 +31,23 @@ func TestNamer(t *testing.T) {
 		f    func(*v1alpha1.Revision) string
 		want string
 	}{{
-		name: "ImageCache",
+		name: "Deployment",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
 		},
-		f:    ImageCache,
-		want: "foo-cache",
+		f:    Deployment,
+		want: "foo-deployment",
 	}, {
-		name: "KPA",
+		name: "FluentdConfigMap",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "baz",
+				Name: "bazinga",
 			},
 		},
-		f:    KPA,
-		want: "baz",
+		f:    FluentdConfigMap,
+		want: "bazinga-fluentd",
 	}}
 
 	for _, test := range tests {

--- a/pkg/deployment/queue.go
+++ b/pkg/deployment/queue.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"strconv"
@@ -27,7 +27,6 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
-	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/metrics"
 	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
@@ -81,7 +80,7 @@ var (
 
 // makeQueueContainer creates the container spec for the queue sidecar.
 func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, observabilityConfig *metrics.ObservabilityConfig,
-	autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) *corev1.Container {
+	autoscalerConfig *autoscaler.Config, deploymentConfig *Config) *corev1.Container {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name

--- a/pkg/deployment/queue_test.go
+++ b/pkg/deployment/queue_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package deployment
 
 import (
 	"strconv"
@@ -31,7 +31,6 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/pkg/autoscaler"
-	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/metrics"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -46,7 +45,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc   *logging.Config
 		oc   *metrics.ObservabilityConfig
 		ac   *autoscaler.Config
-		cc   *deployment.Config
+		cc   *Config
 		want *corev1.Container
 	}{{
 		name: "no owner no autoscaler single",
@@ -66,7 +65,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
@@ -154,7 +153,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{
+		cc: &Config{
 			QueueSidecarImage: "alpine",
 		},
 		want: &corev1.Container{
@@ -240,7 +239,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{
+		cc: &Config{
 			QueueSidecarImage: "alpine",
 		},
 		want: &corev1.Container{
@@ -329,7 +328,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
@@ -414,7 +413,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
@@ -494,7 +493,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
@@ -574,7 +573,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		oc: &metrics.ObservabilityConfig{RequestLogTemplate: "test template"},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
@@ -656,7 +655,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			RequestMetricsBackend: "prometheus",
 		},
 		ac: &autoscaler.Config{},
-		cc: &deployment.Config{},
+		cc: &Config{},
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -33,9 +33,9 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/pkg/reconciler"
 	revisionresources "github.com/knative/serving/pkg/reconciler/revision/resources"
-	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -188,7 +188,7 @@ func TestScaler(t *testing.T) {
 			}
 
 			revision := newRevision(t, servingClient, test.minScale, test.maxScale)
-			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
+			deployment := newDeployment(t, dynamicClient, deploymentnames.Deployment(revision), test.startReplicas)
 			revisionScaler := NewScaler(opts)
 
 			// We test like this because the dynamic client's fake doesn't properly handle
@@ -283,7 +283,7 @@ func TestDisableScaleToZero(t *testing.T) {
 				})
 
 			revision := newRevision(t, servingClient, test.minScale, test.maxScale)
-			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
+			deployment := newDeployment(t, dynamicClient, deploymentnames.Deployment(revision), test.startReplicas)
 			revisionScaler := &scaler{
 				psInformerFactory: podScalableTypedInformerFactory(opts),
 				dynamicClient:     opts.DynamicClientSet,
@@ -325,7 +325,7 @@ func TestGetScaleResource(t *testing.T) {
 
 	revision := newRevision(t, servingClient, 1, 10)
 	// This setups reactor as well.
-	newDeployment(t, dynamicClient, names.Deployment(revision), 5)
+	newDeployment(t, dynamicClient, deploymentnames.Deployment(revision), 5)
 	revisionScaler := NewScaler(opts)
 
 	pa := newKPA(t, servingClient, revision)

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -25,6 +25,7 @@ import (
 	"github.com/knative/pkg/logging"
 	kpav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/reconciler/revision/config"
 	"github.com/knative/serving/pkg/reconciler/revision/resources"
 	presources "github.com/knative/serving/pkg/resources"
@@ -36,7 +37,7 @@ import (
 func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revision) (*appsv1.Deployment, error) {
 	cfgs := config.FromContext(ctx)
 
-	deployment := resources.MakeDeployment(
+	deployment := deployment.MakeDeployment(
 		rev,
 		cfgs.Logging,
 		cfgs.Network,
@@ -52,7 +53,7 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 	logger := logging.FromContext(ctx)
 	cfgs := config.FromContext(ctx)
 
-	deployment := resources.MakeDeployment(
+	deployment := deployment.MakeDeployment(
 		rev,
 		cfgs.Logging,
 		cfgs.Network,

--- a/pkg/reconciler/revision/resources/imagecache.go
+++ b/pkg/reconciler/revision/resources/imagecache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/pkg/resources"
 )
@@ -38,7 +39,7 @@ func MakeImageCache(rev *v1alpha1.Revision) *caching.Image {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.ImageCache(rev),
 			Namespace: rev.Namespace,
-			Labels:    makeLabels(rev),
+			Labels:    deployment.MakeRevisionLabels(rev),
 			Annotations: resources.FilterMap(rev.GetAnnotations(), func(k string) bool {
 				// Ignore last pinned annotation.
 				return k == serving.RevisionLastPinnedAnnotationKey

--- a/pkg/reconciler/revision/resources/imagecache_test.go
+++ b/pkg/reconciler/revision/resources/imagecache_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"github.com/knative/serving/pkg/deployment"
 )
 
 func TestMakeImageCache(t *testing.T) {
@@ -66,7 +67,7 @@ func TestMakeImageCache(t *testing.T) {
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "bar",
 					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
+					deployment.AppLabelKey:   "bar",
 				},
 				Annotations: map[string]string{
 					"a": "b",
@@ -111,7 +112,7 @@ func TestMakeImageCache(t *testing.T) {
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "bar",
 					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
+					deployment.AppLabelKey:   "bar",
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{

--- a/pkg/reconciler/revision/resources/kpa.go
+++ b/pkg/reconciler/revision/resources/kpa.go
@@ -24,6 +24,8 @@ import (
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/deployment"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/pkg/resources"
 )
@@ -34,7 +36,7 @@ func MakeKPA(rev *v1alpha1.Revision) *kpa.PodAutoscaler {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.KPA(rev),
 			Namespace: rev.Namespace,
-			Labels:    makeLabels(rev),
+			Labels:    deployment.MakeRevisionLabels(rev),
 			Annotations: resources.FilterMap(rev.GetAnnotations(), func(k string) bool {
 				// Ignore last pinned annotation.
 				return k == serving.RevisionLastPinnedAnnotationKey
@@ -46,7 +48,7 @@ func MakeKPA(rev *v1alpha1.Revision) *kpa.PodAutoscaler {
 			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
-				Name:       names.Deployment(rev),
+				Name:       deploymentnames.Deployment(rev),
 			},
 			ProtocolType: rev.GetProtocol(),
 		},

--- a/pkg/reconciler/revision/resources/kpa_test.go
+++ b/pkg/reconciler/revision/resources/kpa_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"github.com/knative/serving/pkg/deployment"
 )
 
 func TestMakeKPA(t *testing.T) {
@@ -63,7 +64,7 @@ func TestMakeKPA(t *testing.T) {
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "bar",
 					serving.RevisionUID:      "1234",
-					AppLabelKey:              "bar",
+					deployment.AppLabelKey:   "bar",
 				},
 				Annotations: map[string]string{
 					"a": "b",
@@ -114,7 +115,7 @@ func TestMakeKPA(t *testing.T) {
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "baz",
 					serving.RevisionUID:      "4321",
-					AppLabelKey:              "baz",
+					deployment.AppLabelKey:   "baz",
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
+	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/metrics"
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler"
@@ -876,7 +877,7 @@ func deploy(namespace, name string, opts ...interface{}) *appsv1.Deployment {
 	// Do this here instead of in `rev` itself to ensure that we populate defaults
 	// before calling MakeDeployment within Reconcile.
 	rev.SetDefaults(context.Background())
-	return resources.MakeDeployment(rev, cfg.Logging, cfg.Network,
+	return deployment.MakeDeployment(rev, cfg.Logging, cfg.Network,
 		cfg.Observability, cfg.Autoscaler, cfg.Deployment,
 	)
 
@@ -898,7 +899,7 @@ func fluentdConfigMap(namespace, name string, co ...configOption) *corev1.Config
 	}
 
 	rev := rev(namespace, name)
-	return resources.MakeFluentdConfigMap(rev, config.Observability)
+	return deployment.MakeFluentdConfigMap(rev, config.Observability)
 }
 
 func kpa(namespace, name string, ko ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -27,7 +27,7 @@ import (
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/revision/resources"
+	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/reconciler/route/resources/names"
 )
 
@@ -90,7 +90,7 @@ func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, 
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{{
 				Name: networking.ServicePortNameHTTP1,
-				Port: resources.ServicePort,
+				Port: deployment.ServicePort,
 			}},
 		}, nil
 	case len(balancer.IP) != 0:

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -26,7 +26,7 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/test"
 )
 
@@ -62,7 +62,7 @@ func TestActivatorOverload(t *testing.T) {
 	}
 	domain := resources.Route.Status.Domain
 
-	deploymentName := rnames.Deployment(resources.Revision)
+	deploymentName := deploymentnames.Deployment(resources.Revision)
 	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
 		t.Fatalf("Unable to observe the Deployment named %s scaling down: %v", deploymentName, err)
 	}

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -30,7 +30,7 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/test"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -162,7 +162,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	clients.ServingClient.Services.Delete(names.Service, nil)
 
 	// Wait until the pods have disappeared.
-	deploymentName := rnames.Deployment(objects.Revision)
+	deploymentName := deploymentnames.Deployment(objects.Revision)
 	pkgTest.WaitForPodListState(
 		clients.KubeClient,
 		func(p *v1.PodList) (bool, error) {

--- a/test/e2e/diagnose.go
+++ b/test/e2e/diagnose.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/test"
 
 	v1types "k8s.io/api/core/v1"
@@ -52,7 +52,7 @@ func checkCurrentPodCount(t *testing.T, clients *test.Clients) {
 		return
 	}
 	for _, r := range revs.Items {
-		deploymentName := rnames.Deployment(&r)
+		deploymentName := deploymentnames.Deployment(&r)
 		dep, err := clients.KubeClient.Kube.AppsV1().Deployments(test.ServingNamespace).Get(deploymentName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Could not get deployment %v", deploymentName)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -30,7 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	routeconfig "github.com/knative/serving/pkg/reconciler/route/config"
 	. "github.com/knative/serving/pkg/reconciler/testing"
 )
@@ -221,7 +221,7 @@ func TestServiceToServiceCallFromZero(t *testing.T) {
 	}
 
 	// Wait for service to be scaled to zero
-	deploymentName := names.Deployment(helloWorld.Revision)
+	deploymentName := deploymentnames.Deployment(helloWorld.Revision)
 	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
 		t.Fatalf("Could not scale to zero: %v", err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	ingress "github.com/knative/pkg/test/ingress"
-	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	"github.com/knative/serving/test"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -144,7 +144,7 @@ func TestWebSocketFromZero(t *testing.T) {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
-	deploymentName := rnames.Deployment(resources.Revision)
+	deploymentName := deploymentnames.Deployment(resources.Revision)
 
 	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
 		t.Fatalf("Could not scale to zero: %v", err)

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -31,7 +31,7 @@ import (
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/zipkin"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	deploymentnames "github.com/knative/serving/pkg/deployment/names"
 	ktest "github.com/knative/serving/pkg/reconciler/testing"
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/e2e"
@@ -55,7 +55,7 @@ type stats struct {
 
 func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *test.ResourceObjects) (time.Duration, error) {
 	t.Helper()
-	deploymentName := names.Deployment(ro.Revision)
+	deploymentName := deploymentnames.Deployment(ro.Revision)
 
 	domain := ro.Route.Status.Domain
 	t.Logf("%02d: waiting for deployment to scale to zero.", idx)


### PR DESCRIPTION
Move the remaining logic from under the revision controller in to the
new deployment dir. This has the benefit of route controller no longer
needing to import revision controller for serviceport constants and
allows other systems to refer to deployment creation logic. This also
plublic-ifys makeLabels and makeSelectors as
deployment.MakeRevision{Labels,Selectors}.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
