### PR TITLE
shorten the test output

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -31,7 +31,7 @@ const HelloVolumePath = "/hello/world"
 
 // LogResourceObject logs the resource object with the resource name and value
 func LogResourceObject(t *testing.T, value ResourceObjects) {
-	t.Logf("resource %s", spew.Sdump(value))
+	t.Logf("resource %s", spew.Sprint(value))
 }
 
 // ListenAndServeGracefully calls into ListenAndServeGracefullyWithPattern


### PR DESCRIPTION
The current output is horrendous (I am to blame to introduce Sdump in the first place, but it was using Debug level zap logger before and was controllable, now it's not) .
My chrome basically hang when scrolling Matt's test to 100 failure log file.
I'd remove the log altogether, but it might be useful, so at least make it manageable.

/cc @mattmoor 