### PR TITLE
Change the name to reconcileErr

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -124,22 +124,22 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	pa := original.DeepCopy()
 	// Reconcile this copy of the pa and then write back any status
 	// updates regardless of whether the reconciliation errored out.
-	err = c.reconcile(ctx, key, pa)
+	reconcileErr := c.reconcile(ctx, key, pa)
 	if equality.Semantic.DeepEqual(original.Status, pa.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err := c.updateStatus(pa); err != nil {
+	} else if _, err = c.updateStatus(pa); err != nil {
 		logger.Warnw("Failed to update pa status", zap.Error(err))
 		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for PA %q: %v", pa.Name, err)
 		return err
 	}
-	if err != nil {
-		c.Recorder.Event(pa, corev1.EventTypeWarning, "InternalError", err.Error())
+	if reconcileErr != nil {
+		c.Recorder.Event(pa, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())
 	}
-	return err
+	return reconcileErr
 }
 
 func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.PodAutoscaler) error {

--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -151,22 +151,22 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Reconcile this copy of the ClusterIngress and then write back any status
 	// updates regardless of whether the reconciliation errored out.
-	err = c.reconcile(ctx, ci)
+	reconcileErr := c.reconcile(ctx, ci)
 	if equality.Semantic.DeepEqual(original.Status, ci.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err := c.updateStatus(ci); err != nil {
+	} else if _, err = c.updateStatus(ci); err != nil {
 		logger.Warnw("Failed to update clusterIngress status", zap.Error(err))
 		c.Recorder.Eventf(ci, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for ClusterIngress %q: %v", ci.Name, err)
 		return err
 	}
-	if err != nil {
-		c.Recorder.Event(ci, corev1.EventTypeWarning, "InternalError", err.Error())
+	if reconcileErr != nil {
+		c.Recorder.Event(ci, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())
 	}
-	return err
+	return reconcileErr
 }
 
 // Update the Status of the ClusterIngress.  Caller is responsible for checking

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -124,22 +124,22 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Reconcile this copy of the configuration and then write back any status
 	// updates regardless of whether the reconciliation errored out.
-	err = c.reconcile(ctx, config)
+	reconcileErr := c.reconcile(ctx, config)
 	if equality.Semantic.DeepEqual(original.Status, config.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err := c.updateStatus(config); err != nil {
+	} else if _, err = c.updateStatus(config); err != nil {
 		logger.Warnw("Failed to update configuration status", zap.Error(err))
 		c.Recorder.Eventf(config, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for Configuration %q: %v", config.Name, err)
 		return err
 	}
-	if err != nil {
-		c.Recorder.Event(config, corev1.EventTypeWarning, "InternalError", err.Error())
+	if reconcileErr != nil {
+		c.Recorder.Event(config, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())
 	}
-	return err
+	return reconcileErr
 }
 
 func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configuration) error {

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -237,22 +237,22 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Reconcile this copy of the revision and then write back any status
 	// updates regardless of whether the reconciliation errored out.
-	err = c.reconcile(ctx, rev)
+	reconcileErr := c.reconcile(ctx, rev)
 	if equality.Semantic.DeepEqual(original.Status, rev.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err := c.updateStatus(rev); err != nil {
+	} else if _, err = c.updateStatus(rev); err != nil {
 		logger.Warnw("Failed to update revision status", zap.Error(err))
 		c.Recorder.Eventf(rev, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for Revision %q: %v", rev.Name, err)
 		return err
 	}
-	if err != nil {
-		c.Recorder.Event(rev, corev1.EventTypeWarning, "InternalError", err.Error())
+	if reconcileErr != nil {
+		c.Recorder.Event(rev, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())
 	}
-	return err
+	return reconcileErr
 }
 
 func (c *Reconciler) reconcileBuild(ctx context.Context, rev *v1alpha1.Revision) error {

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -162,10 +162,10 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Don't modify the informers copy.
 	sks := original.DeepCopy()
-	err = r.reconcile(ctx, sks)
-	if err != nil {
-		r.Recorder.Eventf(sks, corev1.EventTypeWarning, "UpdateFailed", "InternalError: %v", err.Error())
-		return err
+	reconcileErr := r.reconcile(ctx, sks)
+	if reconcileErr != nil {
+		r.Recorder.Eventf(sks, corev1.EventTypeWarning, "UpdateFailed", "InternalError: %v", reconcileErr.Error())
+		return reconcileErr
 	}
 	if !equality.Semantic.DeepEqual(sks.Status, original.Status) {
 		// Only update status if it changed.

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -129,6 +129,8 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// Don't modify the informers copy
 	service := original.DeepCopy()
 
+	var reconcileErr error
+
 	if service.Spec.DeprecatedManual != nil {
 		// We do not know the status when in manual mode. The Route can be
 		// updated with Configurations not known to the Service which would
@@ -145,7 +147,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	} else {
 		// Reconcile this copy of the service and then write back any status
 		// updates regardless of whether the reconciliation errored out.
-		err = c.reconcile(ctx, service)
+		reconcileErr = c.reconcile(ctx, service)
 	}
 
 	if equality.Semantic.DeepEqual(original.Status, service.Status) {
@@ -159,14 +161,14 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		c.Recorder.Eventf(service, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for Service %q: %v", service.Name, uErr)
 		return uErr
-	} else if err == nil {
-		// If there was a difference and there was no error.
+	} else if reconcileErr == nil {
+		// There was a difference and updateStatus did not return an error.
 		c.Recorder.Eventf(service, corev1.EventTypeNormal, "Updated", "Updated Service %q", service.GetName())
 	}
-	if err != nil {
-		c.Recorder.Event(service, corev1.EventTypeWarning, "InternalError", err.Error())
+	if reconcileErr != nil {
+		c.Recorder.Event(service, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())
 	}
-	return err
+	return reconcileErr
 }
 
 func (c *Reconciler) reconcile(ctx context.Context, service *v1alpha1.Service) error {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Change the name to reconcileErr to signify that this is not handled like a normal go error.
    - This is similar to https://github.com/knative/eventing/pull/1104.
    - My reasoning is that when reading normal go code, if I see `err` set on one line then checked on the next line, I normally assume that I no longer need that value after the subsequent conditional. However, in this case, we do intend to retain that value, to return in a number of lines later, hence we should give it a distinct name. Otherwise it is very easy to accidentally overwrite the value and return the wrong thing later (which would still compile correctly and work correctly most of the time).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
