### PR TITLE
Cleanup all usages of CreateRouteAndConfig to a simpler method.

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -26,14 +26,14 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
+	resourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type grpcTest func(*testing.T, test.ResourceNames, *test.Clients, string, string)
+type grpcTest func(*testing.T, *test.ResourceObjects, *test.Clients, string, string)
 
 func dial(host, domain string) (*grpc.ClientConn, error) {
 	if host != domain {
@@ -56,7 +56,7 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 	)
 }
 
-func unaryTest(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
+func unaryTest(t *testing.T, resources *test.ResourceObjects, clients *test.Clients, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	conn, err := dial(host, domain)
@@ -80,7 +80,7 @@ func unaryTest(t *testing.T, names test.ResourceNames, clients *test.Clients, ho
 	}
 }
 
-func streamTest(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
+func streamTest(t *testing.T, resources *test.ResourceObjects, clients *test.Clients, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	conn, err := dial(host, domain)
@@ -137,48 +137,33 @@ func testGRPC(t *testing.T, f grpcTest) {
 	// Setup
 	clients := Setup(t)
 
-	t.Log("Creating route and configuration for grpc-ping")
+	t.Log("Creating service for grpc-ping")
 
-	options := &test.Options{
-		ContainerPorts: []corev1.ContainerPort{{
-			Name:          "h2c",
-			ContainerPort: 8080,
-		}},
-	}
-	names, err := CreateRouteAndConfig(t, clients, "grpc-ping", options)
-	if err != nil {
-		t.Fatalf("Failed to create Route and Configuration: %v", err)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "grpc-ping",
 	}
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-
-	t.Log("Waiting for route to be ready")
-
-	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
-	}
-
-	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{
+		ContainerPorts: []corev1.ContainerPort{{
+			Name:          "h2c",
+			ContainerPort: 8080,
+		}},
+	})
 	if err != nil {
-		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
-	domain := route.Status.Domain
+	domain := resources.Route.Status.Domain
 
-	config, err := clients.ServingClient.Configs.Get(names.Config, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
-	}
-	names.Revision = config.Status.LatestCreatedRevisionName
-
-	_, err = pkgTest.WaitForEndpointState(
+	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
 		domain,
 		test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"gRPCPingReadyToServe",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't return success: %v", names.Route, domain, err)
 	}
 
@@ -190,7 +175,7 @@ func testGRPC(t *testing.T, f grpcTest) {
 		}
 	}
 
-	f(t, names, clients, *host, domain)
+	f(t, resources, clients, *host, domain)
 }
 
 func TestGRPCUnaryPing(t *testing.T) {
@@ -202,25 +187,21 @@ func TestGRPCStreamingPing(t *testing.T) {
 }
 
 func TestGRPCUnaryPingFromZero(t *testing.T) {
-	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		deploymentName := names.Revision + "-deployment"
-
-		if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
+	testGRPC(t, func(t *testing.T, resources *test.ResourceObjects, clients *test.Clients, host, domain string) {
+		if err := WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
 			t.Fatalf("Could not scale to zero: %v", err)
 		}
 
-		unaryTest(t, names, clients, host, domain)
+		unaryTest(t, resources, clients, host, domain)
 	})
 }
 
 func TestGRPCStreamingPingFromZero(t *testing.T) {
-	testGRPC(t, func(t *testing.T, names test.ResourceNames, clients *test.Clients, host, domain string) {
-		deploymentName := names.Revision + "-deployment"
-
-		if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
+	testGRPC(t, func(t *testing.T, resources *test.ResourceObjects, clients *test.Clients, host, domain string) {
+		if err := WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
 			t.Fatalf("Could not scale to zero: %v", err)
 		}
 
-		streamTest(t, names, clients, host, domain)
+		streamTest(t, resources, clients, host, domain)
 	})
 }

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -22,64 +22,39 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestHelloWorld(t *testing.T) {
 	t.Parallel()
 	clients := Setup(t)
 
-	t.Log("Creating a new Route and Configuration")
-	names, err := CreateRouteAndConfig(t, clients, "helloworld", &test.Options{})
-
-	if err != nil {
-		t.Fatalf("Failed to create Route and Configuration: %v", err)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
 	}
+
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	t.Log("When the Revision can have traffic routed to it, the Route is marked as Ready.")
-	if err := test.WaitForRouteState(clients.ServingClient, names.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", names.Route, err)
-	}
-
-	route, err := clients.ServingClient.Routes.Get(names.Route, metav1.GetOptions{})
+	t.Log("Creating a new Service")
+	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{})
 	if err != nil {
-		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
-	domain := route.Status.Domain
+	domain := resources.Route.Status.Domain
 
-	_, err = pkgTest.WaitForEndpointState(
+	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
 		domain,
 		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(helloWorldExpectedOutput))),
 		"HelloWorldServesText",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, helloWorldExpectedOutput, err)
 	}
 
-	var revName string
-	err = test.WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
-		if c.Status.LatestCreatedRevisionName != names.Revision {
-			revName = c.Status.LatestCreatedRevisionName
-			return true, nil
-		}
-		return false, nil
-	}, "ConfigurationUpdatedWithRevision")
-
-	if err != nil {
-		t.Fatalf("Error fetching Revision %v", err)
-	}
-
-	revision, err := clients.ServingClient.Revisions.Get(revName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Revision %s: %v", revName, err)
-	}
-
+	revision := resources.Revision
 	if val, ok := revision.Labels["serving.knative.dev/configuration"]; ok {
 		if val != names.Config {
 			t.Fatalf("Expect confguration name in revision label %q but got %q ", names.Config, val)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/knative/serving/test"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	routeconfig "github.com/knative/serving/pkg/reconciler/route/config"
@@ -76,29 +75,27 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	}}
 
 	// Set up httpproxy app.
-	t.Log("Creating a Route and Configuration for httpproxy test app.")
+	t.Log("Creating a Service for the httpproxy test app.")
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "httpproxy",
+	}
 
-	httpProxyNames, err := CreateRouteAndConfig(t, clients, "httpproxy", &test.Options{
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{
 		EnvVars: envVars,
 	})
 	if err != nil {
-		t.Fatalf("Failed to create Route and Configuration: %v", err)
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, httpProxyNames) })
-	defer test.TearDown(clients, httpProxyNames)
-
-	if err := test.WaitForRouteState(clients.ServingClient, httpProxyNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", httpProxyNames.Route, err)
-	}
-	httpProxyRoute, err := clients.ServingClient.Routes.Get(httpProxyNames.Route, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get Route %s: %v", httpProxyNames.Route, err)
-	}
+	domain := resources.Route.Status.Domain
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		httpProxyRoute.Status.Domain, pkgTest.Retrying(pkgTest.IsStatusOK, http.StatusNotFound),
+		domain,
+		pkgTest.Retrying(pkgTest.IsStatusOK, http.StatusNotFound),
 		"HTTPProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)
@@ -106,7 +103,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	t.Log("httpproxy is ready.")
 
 	// Send request to httpproxy to trigger the http call from httpproxy Pod to internal service of helloworld app.
-	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, httpProxyRoute.Status.Domain)
+	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, domain)
 	if err != nil {
 		t.Fatalf("Failed to send request to httpproxy: %v", err)
 	}
@@ -142,54 +139,37 @@ func TestServiceToServiceCall(t *testing.T) {
 	t.Parallel()
 	clients := Setup(t)
 
-	// Set up helloworld app.
-	t.Log("Creating a Route and Configuration for helloworld test app.")
-
-	svcName := test.ObjectNameForTest(t)
-	helloWorldNames := test.ResourceNames{
-		Config: svcName,
-		Route:  svcName,
-		Image:  "helloworld",
+	t.Log("Creating a Service for the helloworld test app.")
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, helloWorldNames) })
-	defer test.TearDown(clients, helloWorldNames)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
-	if _, err := test.CreateConfiguration(t, clients, helloWorldNames, &test.Options{}); err != nil {
-		t.Fatalf("Failed to create Configuration: %v", err)
-	}
-
-	withInternalVisibility := WithRouteLabel(
+	withInternalVisibility := WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
-
-	if _, err := test.CreateRoute(t, clients, helloWorldNames, withInternalVisibility); err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
-	}
-
-	// Verify that Route is set up correctly to helloworld app.
-	if err := test.WaitForRouteState(clients.ServingClient, helloWorldNames.Route, test.IsRouteReady, "RouteIsReady"); err != nil {
-		t.Fatalf("The Route %s was not marked as Ready to serve traffic: %v", helloWorldNames.Route, err)
-	}
-
-	helloWorldRoute, err := clients.ServingClient.Routes.Get(helloWorldNames.Route, metav1.GetOptions{})
+	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}, withInternalVisibility)
 	if err != nil {
-		t.Fatalf("Failed to get Route %q of helloworld app: %v", helloWorldNames.Route, err)
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
-	if helloWorldRoute.Status.Domain == "" {
-		t.Fatalf("Route is missing .Status.Domain: %#v", helloWorldRoute.Status)
+
+	if resources.Route.Status.Domain == "" {
+		t.Fatalf("Route is missing .Status.Domain: %#v", resources.Route.Status)
 	}
-	if helloWorldRoute.Status.Address == nil {
-		t.Fatalf("Route is missing .Status.Address: %#v", helloWorldRoute.Status)
+	if resources.Route.Status.Address == nil {
+		t.Fatalf("Route is missing .Status.Address: %#v", resources.Route.Status)
 	}
 	// Check that the target Route's Domain matches its cluster local address.
-	if want, got := helloWorldRoute.Status.Address.Hostname, helloWorldRoute.Status.Domain; got != want {
+	if want, got := resources.Route.Status.Address.Hostname, resources.Route.Status.Domain; got != want {
 		t.Errorf("Route.Domain = %v, want %v", got, want)
 	}
-	t.Logf("helloworld internal domain is %s.", helloWorldRoute.Status.Domain)
+	t.Logf("helloworld internal domain is %s.", resources.Route.Status.Domain)
 
 	// helloworld app and its route are ready. Running the test cases now.
 	for _, tc := range testCases {
-		helloworldDomain := strings.TrimSuffix(helloWorldRoute.Status.Domain, tc.suffix)
+		helloworldDomain := strings.TrimSuffix(resources.Route.Status.Domain, tc.suffix)
 		t.Run(tc.name, func(t *testing.T) {
 			testProxyToHelloworld(t, clients, helloworldDomain)
 		})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Use test helpers in grpc tests.
* Simplify helloworld test with helpers.
* Simplify service to service test with helpers.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
