### PR TITLE
adding a test for external connectivity

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -23,6 +23,7 @@ const (
 	pizzaPlanetText1         = "What a spaceport!"
 	pizzaPlanetText2         = "Re-energize yourself with a slice of pepperoni!"
 	helloWorldExpectedOutput = "Hello World! How about some tasty noodles?"
+	externalConnectivityExpectedOutput = "Hello! We are connected to the outside world."
 )
 
 // Setup creates the client objects needed in the e2e tests.

--- a/test/e2e/externalconnectivity_test.go
+++ b/test/e2e/externalconnectivity_test.go
@@ -1,7 +1,7 @@
 // +build e2e
 
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/externalconnectivity_test.go
+++ b/test/e2e/externalconnectivity_test.go
@@ -1,0 +1,72 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/serving/test"
+)
+
+func TestExternalConnectivity(t *testing.T) {
+	t.Parallel()
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "externalconnectivity",
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	t.Log("Creating a new Service")
+	resources, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+	domain := resources.Route.Status.Domain
+
+	if _, err = pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		domain,
+		test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(externalConnectivityExpectedOutput))),
+		"ExternalConnectivityServesText",
+		test.ServingFlags.ResolvableDomain); err != nil {
+		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, externalConnectivityExpectedOutput, err)
+	}
+
+	revision := resources.Revision
+	if val, ok := revision.Labels["serving.knative.dev/configuration"]; ok {
+		if val != names.Config {
+			t.Fatalf("Expect confguration name in revision label %q but got %q ", names.Config, val)
+		}
+	} else {
+		t.Fatalf("Failed to get configuration name from Revision label")
+	}
+	if val, ok := revision.Labels["serving.knative.dev/service"]; ok {
+		if val != names.Service {
+			t.Fatalf("Expect Service name in revision label %q but got %q ", names.Service, val)
+		}
+	} else {
+		t.Fatalf("Failed to get Service name from Revision label")
+	}
+}

--- a/test/test_images/externalconnectivity/README.md
+++ b/test/test_images/externalconnectivity/README.md
@@ -1,0 +1,19 @@
+# Externalconnectivity test image
+
+This directory contains the test image used in the external connectivity e2e test.
+
+The image contains a simple Go webserver, `externalconnectivity.go`, that will, by
+default, listen on port `8080` and expose a service at `/`.
+
+When called, the server will curl an external address, and emit a "success" message if successful.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/externalconnectivity/externalconnectivity.go
+++ b/test/test_images/externalconnectivity/externalconnectivity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/test_images/externalconnectivity/externalconnectivity.go
+++ b/test/test_images/externalconnectivity/externalconnectivity.go
@@ -30,7 +30,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Fprintln(w, "Failure to access the outside world.")
 		return
-	} 
+	}
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
         fmt.Fprintln(w, "Hello! We are connected to the outside world.")
     } else {

--- a/test/test_images/externalconnectivity/externalconnectivity.go
+++ b/test/test_images/externalconnectivity/externalconnectivity.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"github.com/knative/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Print("External connectivity received a request.")
+	resp, err := http.Get("http://google.com")
+	if err != nil {
+		fmt.Fprintln(w, "Failure to access the outside world.")
+		return
+	} 
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+        fmt.Fprintln(w, "Hello! We are connected to the outside world.")
+    } else {
+        fmt.Fprintln(w, "Failure to access the outside world.")
+    }
+
+	defer resp.Body.Close()
+}
+
+func main() {
+	flag.Parse()
+	log.Print("External connectivity app started.")
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/test/test_images/externalconnectivity/service.yaml
+++ b/test/test_images/externalconnectivity/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: externalconnectivity-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: github.com/knative/serving/test/test_images/externalconnectivity


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2755

## Proposed Changes
* add externalconnectivity image, which attempts to hit outside url, and returns text based on the result.
* add externalconnectivity_test, which will confirm the success of the external connectivity application

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
