### PR TITLE
Remove the host header from the activator path

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -179,7 +179,7 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, proxy *httputi
 		defer func() {
 			reqChan <- queue.ReqEvent{Time: time.Now(), EventType: out}
 		}()
-		rewriteHost(r)
+		network.RewriteHostOut(r)
 
 		// Enforce queuing and concurrency limits.
 		if breaker != nil {
@@ -192,18 +192,6 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, proxy *httputi
 		} else {
 			proxy.ServeHTTP(w, r)
 		}
-	}
-}
-
-// rewriteHost undoes the `rewriteHost` action in the Activator.
-// rewriteHost checks if OriginalHostHeader was set and if it was,
-// then uses that as the r.Host (which takes priority over Request.Header["Host"].
-// If the request did not have the OriginalHostHeader header set, the request is untouched.
-func rewriteHost(r *http.Request) {
-	if ohh := r.Header.Get(network.OriginalHostHeader); ohh != "" {
-		r.Host = ohh
-		r.Header.Del("Host")
-		r.Header.Del(network.OriginalHostHeader)
 	}
 }
 

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -199,19 +199,8 @@ func (a *ActivationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// rewriteHost removes the `Host` header from the inbound request
-// and replaces it with our custom header. This is done to avoid
-// Istio Host based routing.
-// Queue-Proxy will execute the reverse process.
-func rewriteHost(r *http.Request) {
-	h := r.Host
-	r.Host = ""
-	r.Header.Del("Host")
-	r.Header.Set(network.OriginalHostHeader, h)
-}
-
 func (a *ActivationHandler) proxyRequest(w http.ResponseWriter, r *http.Request, target *url.URL) int {
-	rewriteHost(r)
+	network.RewriteHostIn(r)
 	recorder := pkghttp.NewResponseRecorder(w, http.StatusOK)
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = &ochttp.Transport{

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -35,11 +35,17 @@ const (
 	// requests to probe the knative networking layer.  Requests
 	// with this header will not be passed to the user container or
 	// included in request metrics.
-	ProbeHeaderName = "k-network-probe"
+	ProbeHeaderName = "K-Network-Probe"
 
 	// ProxyHeaderName is the name of an internal header that activator
 	// uses to mark requests going through it.
-	ProxyHeaderName = "k-proxy-request"
+	ProxyHeaderName = "K-Proxy-Request"
+
+	// OriginalHostHeader is used to avoid Istio host based routing rules
+	// in Activator.
+	// The header contains the original Host value that can be rewritten
+	// at the Queue proxy level back to be a host header.
+	OriginalHostHeader = "K-Proxy-Header"
 
 	// ConfigName is the name of the configmap containing all
 	// customizations for networking features.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -45,7 +45,7 @@ const (
 	// in Activator.
 	// The header contains the original Host value that can be rewritten
 	// at the Queue proxy level back to be a host header.
-	OriginalHostHeader = "K-Proxy-Header"
+	OriginalHostHeader = "K-Original-Host"
 
 	// ConfigName is the name of the configmap containing all
 	// customizations for networking features.

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -19,6 +19,7 @@ package network
 import (
 	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"text/template"
 
@@ -509,5 +510,37 @@ func TestIsKubeletProbe(t *testing.T) {
 	req.Header.Set("User-Agent", kubeProbeUAPrefix+"1.14")
 	if !IsKubeletProbe(req) {
 		t.Error("kubelet probe but not counted as such")
+	}
+}
+
+func TestRewriteHost(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "http://love.is/not-hate", nil)
+	r.Header.Set("Host", "love.is")
+
+	RewriteHostIn(r)
+
+	if got, want := r.Host, ""; got != want {
+		t.Errorf("r.Host = %q, want: %q", got, want)
+	}
+
+	if got, want := r.Header.Get("Host"), ""; got != want {
+		t.Errorf("r.Header['Host'] = %q, want: %q", got, want)
+	}
+
+	if got, want := r.Header.Get(OriginalHostHeader), "love.is"; got != want {
+		t.Errorf("r.Header[%s] = %q	, want: %q", OriginalHostHeader, got, want)
+	}
+
+	RewriteHostOut(r)
+	if got, want := r.Host, "love.is"; got != want {
+		t.Errorf("r.Host = %q, want: %q", got, want)
+	}
+
+	if got, want := r.Header.Get("Host"), ""; got != want {
+		t.Errorf("r.Header['Host'] = %q, want: %q", got, want)
+	}
+
+	if got, want := r.Header.Get(OriginalHostHeader), ""; got != want {
+		t.Errorf("r.Header[%s] = %q	, want: %q", OriginalHostHeader, got, want)
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- This removes the host header from the activator paths.
- Add the Host header rewriting to Activator and queue proxy
- and improves queue proxy test coverage

/lint

Fixes #3870
/cc @tcnghia @mattmoor 