### PR TITLE
Add subroutes based on route's traffic stanza

### DIFF
--- a/pkg/reconciler/route/domains/doc.go
+++ b/pkg/reconciler/route/domains/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package domains holds simple functions for generating domains.
+package domains

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package domains
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/knative/pkg/apis"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/reconciler/route/config"
+)
+
+// HTTPScheme is the string representation of http.
+const HTTPScheme string = "http"
+
+// SubdomainName generates a name which represents the subdomain of a route
+func SubdomainName(r *v1alpha1.Route, suffix string) string {
+	if suffix == "" {
+		return r.Name
+	}
+	return fmt.Sprintf("%s-%s", r.Name, suffix)
+}
+
+// DomainNameFromTemplate generates domain name base on the template specified in the `config-network` ConfigMap.
+// name is the "subdomain" which will be referred as the "name" in the template
+func DomainNameFromTemplate(ctx context.Context, r *v1alpha1.Route, name string) (string, error) {
+	domainConfig := config.FromContext(ctx).Domain
+	domain := domainConfig.LookupDomainForLabels(r.ObjectMeta.Labels)
+
+	// These are the available properties they can choose from.
+	// We could add more over time - e.g. RevisionName if we thought that
+	// might be of interest to people.
+	data := network.DomainTemplateValues{
+		Name:      name,
+		Namespace: r.Namespace,
+		Domain:    domain,
+	}
+
+	networkConfig := config.FromContext(ctx).Network
+	buf := bytes.Buffer{}
+	if err := networkConfig.GetDomainTemplate().Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("error executing the DomainTemplate: %v", err)
+	}
+	return buf.String(), nil
+}
+
+// URL generates the a string representation of a URL.
+func URL(scheme, fqdn string) *apis.URL {
+	return &apis.URL{
+		Scheme: scheme,
+		Path:   fqdn,
+	}
+}

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package domains
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
+	"testing"
+	"time"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/gc"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Domain: &config.Domain{
+			Domains: map[string]*config.LabelSelector{
+				"example.com": {},
+				"another-example.com": {
+					Selector: map[string]string{"app": "prod"},
+				},
+			},
+		},
+		Network: &network.Config{
+			DefaultClusterIngressClass: "ingress-class-foo",
+			DomainTemplate:             network.DefaultDomainTemplate,
+		},
+		GC: &gc.Config{
+			StaleRevisionLastpinnedDebounce: time.Duration(1 * time.Minute),
+		},
+	}
+}
+
+func TestDomainNameFromTemplate(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name     string
+		template string
+		args     args
+		want     string
+		wantErr  bool
+	}{{
+		name:     "Default",
+		template: "{{.Name}}.{{.Namespace}}.{{.Domain}}",
+		args:     args{name: "test-name"},
+		want:     "test-name.default.example.com",
+	}, {
+		name:     "Dash",
+		template: "{{.Name}}-{{.Namespace}}.{{.Domain}}",
+		args:     args{name: "test-name"},
+		want:     "test-name-default.example.com",
+	}, {
+		name:     "Short",
+		template: "{{.Name}}.{{.Domain}}",
+		args:     args{name: "test-name"},
+		want:     "test-name.example.com",
+	}, {
+		name:     "SuperShort",
+		template: "{{.Name}}",
+		args:     args{name: "test-name"},
+		want:     "test-name",
+	}, {
+		// This cannot get through our validation, but verify we handle errors.
+		name:     "BadVarName",
+		template: "{{.Name}}.{{.NNNamespace}}.{{.Domain}}",
+		args:     args{name: "test-name"},
+		wantErr:  true,
+	}}
+
+	route := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/myapp",
+			Name:      "myroute",
+			Namespace: "default",
+			Labels: map[string]string{
+				"route": "myapp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cfg := testConfig()
+			cfg.Network.DomainTemplate = tt.template
+			ctx = config.ToContext(ctx, cfg)
+
+			got, err := DomainNameFromTemplate(ctx, route, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildSubRouteWithName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("BuildSubRouteWithName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubdomainName(t *testing.T) {
+	route := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/myapp",
+			Name:      "myroute",
+			Namespace: "default",
+			Labels: map[string]string{
+				"route": "myapp",
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		suffix string
+		want   string
+	}{
+		{
+			name:   "has suffix",
+			suffix: "mysuffix",
+			want:   "myroute-mysuffix",
+		}, {
+			name: "no suffix",
+			want: "myroute",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubdomainName(route, tt.suffix); got != tt.want {
+				t.Errorf("BuildName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		scheme   string
+		domain   string
+		Expected apis.URL
+	}{{
+		name:     "subdomain",
+		scheme:   HTTPScheme,
+		domain:   "current.svc.local.com",
+		Expected: apis.URL{
+			Scheme: "http",
+			Path : "current.svc.local.com",
+		},
+	}, {
+		name:     "default target",
+		scheme:   HTTPScheme,
+		domain:   "example.com",
+		Expected: apis.URL{
+			Scheme: "http",
+			Path : "example.com",
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := *URL(tt.scheme, tt.domain), tt.Expected; !cmp.Equal(want, got) {
+				t.Errorf("URL = %v, want: %v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -21,15 +21,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/knative/pkg/apis/duck"
-	"github.com/knative/pkg/logging"
-	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/route/config"
-	"github.com/knative/serving/pkg/reconciler/route/resources"
-	resourcenames "github.com/knative/serving/pkg/reconciler/route/resources/names"
-	"github.com/knative/serving/pkg/reconciler/route/traffic"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +29,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/knative/pkg/apis/duck"
+	"github.com/knative/pkg/logging"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	"github.com/knative/serving/pkg/reconciler/route/domains"
+	"github.com/knative/serving/pkg/reconciler/route/resources"
+	resourcenames "github.com/knative/serving/pkg/reconciler/route/resources/names"
+	"github.com/knative/serving/pkg/reconciler/route/traffic"
 )
 
 func (c *Reconciler) getClusterIngressForRoute(route *v1alpha1.Route) (*netv1alpha1.ClusterIngress, error) {
@@ -123,37 +126,100 @@ func (c *Reconciler) reconcileClusterIngress(
 	return clusterIngress, err
 }
 
-func (c *Reconciler) reconcilePlaceholderService(ctx context.Context, route *v1alpha1.Route, ingress *netv1alpha1.ClusterIngress) error {
-	logger := logging.FromContext(ctx)
-	ns := route.Namespace
-	name := resourcenames.K8sService(route)
-
-	desiredService, err := resources.MakeK8sService(route, ingress)
-	if err != nil {
-		// Loadbalancer not ready, no need to create.
-		logger.Warnf("Failed to construct placeholder k8s service: %v", err)
-		return nil
-	}
-
-	service, err := c.serviceLister.Services(ns).Get(name)
-	if apierrs.IsNotFound(err) {
-		// Doesn't exist, create it.
-		service, err = c.KubeClientSet.CoreV1().Services(ns).Create(desiredService)
-		if err != nil {
-			logger.Errorw("Failed to create service", zap.Error(err))
-			c.Recorder.Eventf(route, corev1.EventTypeWarning, "CreationFailed",
-				"Failed to create service %q: %v", name, err)
+func (c *Reconciler) deleteServices(namespace string, serviceNames sets.String) error {
+	for _, serviceName := range serviceNames.List() {
+		if err := c.KubeClientSet.CoreV1().Services(namespace).Delete(serviceName, nil); err != nil {
+			c.Logger.Errorw("Failed to delete service", zap.Error(err))
 			return err
 		}
-		logger.Infof("Created service %s", name)
-		c.Recorder.Eventf(route, corev1.EventTypeNormal, "Created", "Created service %q", name)
-	} else if err != nil {
-		return err
-	} else if !metav1.IsControlledBy(service, route) {
-		// Surface an error in the route's status, and return an error.
-		route.Status.MarkServiceNotOwned(name)
-		return fmt.Errorf("Route: %q does not own Service: %q", route.Name, name)
-	} else {
+	}
+
+	return nil
+}
+
+func (c *Reconciler) getServiceNameSet(route *v1alpha1.Route) (sets.String, error) {
+	currentServices, err := c.serviceLister.List(resources.SelectorFromRoute(route))
+	if err != nil {
+		return nil, err
+	}
+
+	serviceNames := sets.NewString()
+	for _, svc := range currentServices {
+		serviceNames.Insert(svc.Name)
+	}
+
+	return serviceNames, nil
+}
+
+func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1alpha1.Route, targets map[string]traffic.RevisionTargets) ([]*corev1.Service, error) {
+	logger := logging.FromContext(ctx)
+	ns := route.Namespace
+
+	currentServices, err := c.getServiceNameSet(route)
+	if err != nil {
+		return nil, err
+	}
+
+	names := sets.NewString()
+	for name := range targets {
+		names.Insert(name)
+	}
+
+	var services []*corev1.Service
+	for _, name := range names.List() {
+		desiredServiceName := domains.SubdomainName(route, name)
+		desiredService, err := resources.MakeK8sPlaceholderService(ctx, route, name)
+		if err != nil {
+			logger.Warnw("Failed to construct placeholder k8s service", zap.Error(err))
+			return nil, err
+		}
+
+		service, err := c.serviceLister.Services(ns).Get(desiredService.Name)
+		if apierrs.IsNotFound(err) {
+			// Doesn't exist, create it.
+			service, err = c.KubeClientSet.CoreV1().Services(ns).Create(desiredService)
+			if err != nil {
+				logger.Errorw("Failed to create placeholder service", zap.Error(err))
+				c.Recorder.Eventf(route, corev1.EventTypeWarning, "CreationFailed",
+					"Failed to create placeholder service %q: %v", desiredServiceName, err)
+				return nil, err
+			}
+			logger.Infof("Created service %s", desiredServiceName)
+			c.Recorder.Eventf(route, corev1.EventTypeNormal, "Created", "Created placeholder service %q", desiredServiceName)
+		} else if err != nil {
+			return nil, err
+		} else if !metav1.IsControlledBy(service, route) {
+			// Surface an error in the route's status, and return an error.
+			route.Status.MarkServiceNotOwned(desiredServiceName)
+			return nil, fmt.Errorf("route: %q does not own Service: %q", route.Name, desiredServiceName)
+		}
+
+		services = append(services, service)
+		delete(currentServices, desiredServiceName)
+	}
+
+	// Delete any current services that was no longer desired.
+	if err := c.deleteServices(ns, currentServices); err != nil {
+		return nil, err
+	}
+
+	// TODO(mattmoor): This is where we'd look at the state of the Service and
+	// reflect any necessary state into the Route.
+	return services, nil
+}
+
+func (c *Reconciler) updatePlaceholderServices(ctx context.Context, route *v1alpha1.Route, services []*corev1.Service, ingress *netv1alpha1.ClusterIngress) error {
+	logger := logging.FromContext(ctx)
+	ns := route.Namespace
+
+	for _, service := range services {
+		desiredService, err := resources.MakeK8sService(route, service.Name, ingress)
+		if err != nil {
+			// Loadbalancer not ready, no need to update.
+			logger.Warnf("Failed to update k8s service: %v", err)
+			return nil
+		}
+
 		// Make sure that the service has the proper specification.
 		if !equality.Semantic.DeepEqual(service.Spec, desiredService.Spec) {
 			// Don't modify the informers copy

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -17,16 +17,15 @@ limitations under the License.
 package route
 
 import (
+	"context"
 	"testing"
 	"time"
-
-	"github.com/knative/pkg/kmeta"
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/apis"
-	. "github.com/knative/pkg/logging/testing"
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/pkg/system"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -35,6 +34,8 @@ import (
 	"github.com/knative/serving/pkg/reconciler/route/config"
 	"github.com/knative/serving/pkg/reconciler/route/resources"
 	"github.com/knative/serving/pkg/reconciler/route/traffic"
+
+	. "github.com/knative/pkg/logging/testing"
 )
 
 func TestReconcileClusterIngress_Insert(t *testing.T) {
@@ -45,7 +46,7 @@ func TestReconcileClusterIngress_Insert(t *testing.T) {
 			Namespace: "test-ns",
 		},
 	}
-	ci := newTestClusterIngress(r)
+	ci := newTestClusterIngress(t, r)
 	if _, err := c.reconcileClusterIngress(TestContextWithLogger(t), r, ci); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 		},
 	}
 
-	ci := newTestClusterIngress(r)
+	ci := newTestClusterIngress(t, r)
 	if _, err := c.reconcileClusterIngress(TestContextWithLogger(t), r, ci); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 		Scheme: "http",
 		Host:   "bar.com",
 	}
-	ci2 := newTestClusterIngress(r)
+	ci2 := newTestClusterIngress(t, r)
 	if _, err := c.reconcileClusterIngress(TestContextWithLogger(t), r, ci2); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -146,7 +147,7 @@ func TestReconcileTargetRevisions(t *testing.T) {
 	}
 }
 
-func newTestClusterIngress(r *v1alpha1.Route) *netv1alpha1.ClusterIngress {
+func newTestClusterIngress(t *testing.T, r *v1alpha1.Route) *netv1alpha1.ClusterIngress {
 	tc := &traffic.Config{Targets: map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1beta1.TrafficTarget{
@@ -164,7 +165,11 @@ func newTestClusterIngress(r *v1alpha1.Route) *netv1alpha1.ClusterIngress {
 			ServerCertificate: "tls.crt",
 		},
 	}
-	return resources.MakeClusterIngress(r, tc, tls, "foo-ingress")
+	ingress, err := resources.MakeClusterIngress(getContext(), r, tc, tls, "foo-ingress")
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	return ingress
 }
 
 func TestReconcileCertificates_Insert(t *testing.T) {
@@ -227,4 +232,10 @@ func newCerts(dnsNames []string, r *v1alpha1.Route) *netv1alpha1.Certificate {
 			SecretName: "test-secret",
 		},
 	}
+}
+
+func getContext() context.Context {
+	ctx := context.Background()
+	cfg := ReconcilerTestConfig(false)
+	return config.ToContext(ctx, cfg)
 }

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -17,41 +17,79 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/route/resources/names"
+	"github.com/knative/serving/pkg/reconciler/route/domains"
 )
 
 var errLoadBalancerNotFound = errors.New("failed to fetch loadbalancer domain/IP from ingress status")
 
+// SelectorFromRoute creates a label selector given a specific route.
+func SelectorFromRoute(route *v1alpha1.Route) labels.Selector {
+	return labels.SelectorFromSet(
+		labels.Set{
+			serving.RouteLabelKey: route.Name,
+		},
+	)
+}
+
+// MakeK8sPlaceholderService creates a placeholder Service to prevent naming collisions. It's owned by the
+// provided v1alpha1.Route. The purpose of this service is to provide a placeholder domain name for Istio routing.
+func MakeK8sPlaceholderService(ctx context.Context, route *v1alpha1.Route, targetName string) (*corev1.Service, error) {
+	name := domains.SubdomainName(route, targetName)
+	fullName, err := domains.DomainNameFromTemplate(ctx, route, name)
+	if err != nil {
+		return nil, err
+	}
+
+	service := makeK8sService(route, targetName)
+	service.Spec = corev1.ServiceSpec{
+		Type:         corev1.ServiceTypeExternalName,
+		ExternalName: fullName,
+	}
+
+	return service, nil
+}
+
 // MakeK8sService creates a Service that redirect to the loadbalancer specified
 // in ClusterIngress status. It's owned by the provided v1alpha1.Route.
 // The purpose of this service is to provide a domain name for Istio routing.
-func MakeK8sService(route *v1alpha1.Route, ingress *netv1alpha1.ClusterIngress) (*corev1.Service, error) {
+func MakeK8sService(route *v1alpha1.Route, targetName string, ingress *netv1alpha1.ClusterIngress) (*corev1.Service, error) {
 	svcSpec, err := makeServiceSpec(ingress)
 	if err != nil {
 		return nil, err
 	}
 
+	service := makeK8sService(route, targetName)
+	service.Spec = *svcSpec
+	return service, nil
+}
+
+func makeK8sService(route *v1alpha1.Route, targetName string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.K8sService(route),
+			Name:      domains.SubdomainName(route, targetName),
 			Namespace: route.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				// This service is owned by the Route.
 				*kmeta.NewControllerRef(route),
 			},
+			Labels: map[string]string{
+				serving.RouteLabelKey: route.Name,
+			},
 		},
-		Spec: *svcSpec,
-	}, nil
+	}
 }
 
 func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, error) {

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -17,15 +17,25 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/kmeta"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"github.com/knative/serving/pkg/gc"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	"github.com/knative/serving/pkg/reconciler/route/domains"
+	"github.com/knative/serving/pkg/reconciler/route/traffic"
 )
 
 var (
@@ -41,6 +51,9 @@ var (
 		OwnerReferences: []metav1.OwnerReference{
 			*kmeta.NewControllerRef(r),
 		},
+		Labels: map[string]string{
+			serving.RouteLabelKey: r.Name,
+		},
 	}
 )
 
@@ -49,7 +62,9 @@ func TestNewMakeK8SService(t *testing.T) {
 		// Inputs
 		route        *v1alpha1.Route
 		ingress      *netv1alpha1.ClusterIngress
+		targetName   string
 		expectedSpec corev1.ServiceSpec
+		expectedMeta metav1.ObjectMeta
 		shouldFail   bool
 	}{
 		"no-loadbalancer": {
@@ -57,7 +72,8 @@ func TestNewMakeK8SService(t *testing.T) {
 			ingress: &netv1alpha1.ClusterIngress{
 				Status: netv1alpha1.IngressStatus{},
 			},
-			shouldFail: true,
+			expectedMeta: expectedMeta,
+			shouldFail:   true,
 		},
 		"empty-loadbalancer": {
 			route: r,
@@ -68,7 +84,8 @@ func TestNewMakeK8SService(t *testing.T) {
 					},
 				},
 			},
-			shouldFail: true,
+			expectedMeta: expectedMeta,
+			shouldFail:   true,
 		},
 		"multi-loadbalancer": {
 			route: r,
@@ -83,7 +100,8 @@ func TestNewMakeK8SService(t *testing.T) {
 					},
 				},
 			},
-			shouldFail: true,
+			expectedMeta: expectedMeta,
+			shouldFail:   true,
 		},
 		"ingress-with-domain": {
 			route: r,
@@ -94,6 +112,7 @@ func TestNewMakeK8SService(t *testing.T) {
 					},
 				},
 			},
+			expectedMeta: expectedMeta,
 			expectedSpec: corev1.ServiceSpec{
 				Type:         corev1.ServiceTypeExternalName,
 				ExternalName: "domain.com",
@@ -108,6 +127,7 @@ func TestNewMakeK8SService(t *testing.T) {
 					},
 				},
 			},
+			expectedMeta: expectedMeta,
 			expectedSpec: corev1.ServiceSpec{
 				Type:         corev1.ServiceTypeExternalName,
 				ExternalName: "istio-ingressgateway.istio-system.svc.cluster.local",
@@ -122,6 +142,35 @@ func TestNewMakeK8SService(t *testing.T) {
 					},
 				},
 			},
+			expectedMeta: expectedMeta,
+			expectedSpec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{{
+					Name: "http",
+					Port: 80,
+				}},
+			},
+		},
+		"with-target-name-specified": {
+			route:      r,
+			targetName: "my-target-name",
+			ingress: &netv1alpha1.ClusterIngress{
+				Status: netv1alpha1.IngressStatus{
+					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+					},
+				},
+			},
+			expectedMeta: metav1.ObjectMeta{
+				Name:      "test-route-my-target-name",
+				Namespace: r.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					*kmeta.NewControllerRef(r),
+				},
+				Labels: map[string]string{
+					serving.RouteLabelKey: r.Name,
+				},
+			},
 			expectedSpec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeClusterIP,
 				Ports: []corev1.ServicePort{{
@@ -133,7 +182,7 @@ func TestNewMakeK8SService(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		service, err := MakeK8sService(scenario.route, scenario.ingress)
+		service, err := MakeK8sService(scenario.route, scenario.targetName, scenario.ingress)
 		// Validate
 		if scenario.shouldFail && err == nil {
 			t.Errorf("Test %q failed: returned success but expected error", name)
@@ -142,12 +191,79 @@ func TestNewMakeK8SService(t *testing.T) {
 			if err != nil {
 				t.Errorf("Test %q failed: returned error: %v", name, err)
 			}
-			if diff := cmp.Diff(expectedMeta, service.ObjectMeta); diff != "" {
-				t.Errorf("Unexpected Metadata  (-want +got): %v", diff)
+
+			if !cmp.Equal(scenario.expectedMeta, service.ObjectMeta) {
+				t.Errorf("Unexpected Metadata (-want +got): %s", cmp.Diff(scenario.expectedMeta, service.ObjectMeta))
 			}
-			if diff := cmp.Diff(scenario.expectedSpec, service.Spec); diff != "" {
-				t.Errorf("Unexpected ServiceSpec (-want +got): %v", diff)
+			if !cmp.Equal(scenario.expectedSpec, service.Spec) {
+				t.Errorf("Unexpected ServiceSpec (-want +got): %s", cmp.Diff(scenario.expectedSpec, service.Spec))
 			}
 		}
+	}
+}
+
+func TestMakePlaceholderK8sService(t *testing.T) {
+	target := traffic.RevisionTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+			Tag: "foo",
+		},
+	}
+
+	ctx := context.Background()
+	cfg := testConfig()
+	ctx = config.ToContext(ctx, cfg)
+
+	service, err := MakeK8sPlaceholderService(ctx, r, target.Tag)
+	expectedMeta := metav1.ObjectMeta{
+		Name:      domains.SubdomainName(r, target.Tag),
+		Namespace: r.Namespace,
+		OwnerReferences: []metav1.OwnerReference{
+			*kmeta.NewControllerRef(r),
+		},
+		Labels: map[string]string{
+			serving.RouteLabelKey: r.Name,
+		},
+	}
+	expectedSpec := corev1.ServiceSpec{
+		Type:         corev1.ServiceTypeExternalName,
+		ExternalName: "test-route-foo.test-ns.example.com",
+	}
+
+	if err != nil {
+		t.Errorf("Unexpected error %v returned", err)
+	}
+
+	if !cmp.Equal(expectedMeta, service.ObjectMeta) {
+		t.Errorf("Unexpected Metadata (-want +got): %s", cmp.Diff(expectedMeta, service.ObjectMeta))
+	}
+	if !cmp.Equal(expectedSpec, service.Spec) {
+		t.Errorf("Unexpected ServiceSpec (-want +got): %s", cmp.Diff(expectedSpec, service.Spec))
+	}
+}
+
+func TestSelectorFromRoute(t *testing.T) {
+	selector := SelectorFromRoute(r)
+	if !selector.Matches(labels.Set{serving.RouteLabelKey: r.Name}) {
+		t.Errorf("Unexpected labels in selector")
+	}
+}
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Domain: &config.Domain{
+			Domains: map[string]*config.LabelSelector{
+				"example.com": {},
+				"another-example.com": {
+					Selector: map[string]string{"app": "prod"},
+				},
+			},
+		},
+		Network: &network.Config{
+			DefaultClusterIngressClass: "test-ingress-class",
+			DomainTemplate:             network.DefaultDomainTemplate,
+		},
+		GC: &gc.Config{
+			StaleRevisionLastpinnedDebounce: time.Duration(1 * time.Minute),
+		},
 	}
 }

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -17,25 +17,23 @@ limitations under the License.
 package traffic
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/knative/pkg/apis"
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/route/domains"
 )
 
 const (
 	// DefaultTarget is the unnamed default target for the traffic.
 	DefaultTarget = ""
-
-	// HTTPScheme is the string representation of http.
-	HTTPScheme string = "http"
 )
 
 // A RevisionTarget adds the Active/Inactive state and the transport protocol of a
@@ -97,17 +95,8 @@ func TagDomain(name, domain string) string {
 	return fmt.Sprintf("%s.%s", name, domain)
 }
 
-// TagURL returns the URL of the tag given the scheme, traffic target name, and base domain. Curently
-// the tag is represented as a subdomain of the base domain.
-func TagURL(scheme, name, domain string) *apis.URL {
-	return &apis.URL{
-		Scheme: scheme,
-		Host:   TagDomain(name, domain),
-	}
-}
-
 // GetRevisionTrafficTargets returns a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.
-func (t *Config) GetRevisionTrafficTargets(domain string) []v1alpha1.TrafficTarget {
+func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1alpha1.Route) ([]v1alpha1.TrafficTarget, error) {
 	results := make([]v1alpha1.TrafficTarget, len(t.revisionTargets))
 	for i, tt := range t.revisionTargets {
 		// We cannot `DeepCopy` here, since tt.TrafficTarget might contain both
@@ -121,12 +110,16 @@ func (t *Config) GetRevisionTrafficTargets(domain string) []v1alpha1.TrafficTarg
 				LatestRevision: tt.LatestRevision,
 			},
 		}
-		if tt.Tag != "" && domain != "" {
+		if tt.Tag != "" {
 			// http is currently the only supported scheme
-			results[i].URL = TagURL(HTTPScheme, tt.Tag, domain)
+			fullDomain, err := domains.DomainNameFromTemplate(ctx, r, domains.SubdomainName(r, tt.Tag))
+			if err != nil {
+				return nil, err
+			}
+			results[i].URL = domains.URL(domains.HTTPScheme, fullDomain)
 		}
 	}
-	return results
+	return results, nil
 }
 
 type configBuilder struct {


### PR DESCRIPTION
This implements part 1 detailed in issue #3419.

A new service is created for each tagged `tag` or named `deprecatedName` a new service will be created. A service will also be created for the default route.

These services will be update based on the cluster ingress created.

Things left to do:
- ~~There's still some table tests left to fix.~~
- ~~Delete old services we no longer need or care about (deleted traffic element from Route)~~
- Refactor all the things, there's a lot of duplication, as trying to refactor while implementing it got super messy and hard to follow.

Looking for feedback:
- I wanted to move the stuff generating the "domains" or "url" to its own package but couldn't think of a nice package name. I've currently chosen "domains" but doesn't feel right. Looking for ideas/suggestions.

