### PR TITLE
Allow users' pods to opt out of the Istio mesh.

### DIFF
--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -166,7 +166,10 @@ func MakeDeployment(rev *v1alpha1.Revision,
 		return k == serving.RevisionLastPinnedAnnotationKey
 	})
 	// TODO(nghia): Remove the need for this
-	podTemplateAnnotations[sidecarIstioInjectAnnotation] = "true"
+	// Only force-set the inject annotation if the revision does not state otherwise.
+	if _, ok := podTemplateAnnotations[sidecarIstioInjectAnnotation]; !ok {
+		podTemplateAnnotations[sidecarIstioInjectAnnotation] = "true"
+	}
 	// TODO(mattmoor): Once we have a mechanism for decorating arbitrary deployments (and opting
 	// out via annotation) we should explicitly disable that here to avoid redundant Image
 	// resources.

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -165,6 +165,7 @@ func MakeDeployment(rev *v1alpha1.Revision,
 	podTemplateAnnotations := resources.FilterMap(rev.GetAnnotations(), func(k string) bool {
 		return k == serving.RevisionLastPinnedAnnotationKey
 	})
+
 	// TODO(nghia): Remove the need for this
 	// Only force-set the inject annotation if the revision does not state otherwise.
 	if _, ok := podTemplateAnnotations[sidecarIstioInjectAnnotation]; !ok {

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -722,7 +722,7 @@ func TestMakeDeployment(t *testing.T) {
 		cc   *deployment.Config
 		want *appsv1.Deployment
 	}{{
-		name: "simple concurrency=single no owner",
+		name: "with concurrency=1",
 		rev: revision(
 			withoutLabels,
 			withContainerConcurrency(1),
@@ -734,7 +734,7 @@ func TestMakeDeployment(t *testing.T) {
 		cc:   &deployment.Config{},
 		want: makeDeployment(),
 	}, {
-		name: "simple concurrency=multi with owner",
+		name: "with owner",
 		rev: revision(
 			withoutLabels,
 			withOwnerReference("parent-config"),
@@ -746,7 +746,7 @@ func TestMakeDeployment(t *testing.T) {
 		cc:   &deployment.Config{},
 		want: makeDeployment(),
 	}, {
-		name: "simple concurrency=multi with outbound IP range configured",
+		name: "with outbound IP range configured",
 		rev:  revision(withoutLabels),
 		lc:   &logging.Config{},
 		nc: &network.Config{
@@ -756,10 +756,26 @@ func TestMakeDeployment(t *testing.T) {
 		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
-			deploy.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "*"
+			deploy.Spec.Template.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "*"
 		}),
 	}, {
-		name: "simple concurrency=multi with outbound IP range override",
+		name: "with sidecar annotation override",
+		rev: revision(withoutLabels, func(revision *v1alpha1.Revision) {
+			revision.ObjectMeta.Annotations = map[string]string{
+				sidecarIstioInjectAnnotation: "false",
+			}
+		}),
+		lc: &logging.Config{},
+		nc: &network.Config{},
+		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
+		cc: &deployment.Config{},
+		want: makeDeployment(func(deploy *appsv1.Deployment) {
+			deploy.ObjectMeta.Annotations[sidecarIstioInjectAnnotation] = "false"
+			deploy.Spec.Template.ObjectMeta.Annotations[sidecarIstioInjectAnnotation] = "false"
+		}),
+	}, {
+		name: "with outbound IP range override",
 		rev: revision(
 			withoutLabels,
 			func(revision *v1alpha1.Revision) {
@@ -777,7 +793,7 @@ func TestMakeDeployment(t *testing.T) {
 		cc: &deployment.Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
-			deploy.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "10.4.0.0/14,10.7.240.0/20"
+			deploy.Spec.Template.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
 		}),
 	}}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Related to #3620 

This is only allowing the user to override this for now. Tests need to be added hence not fixing the issue with this PR.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow the user to override the sidecar injection behavior per revision.
```
