### PR TITLE
Update test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -495,7 +495,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6366bd359a44920aeb314c2da668930c289b1ea2b7172d0d5ddfe957f2e36ef9"
+  digest = "1:4728c42d780b63d894e11879cb1035b3c4b7447f9a9b7a32911bee47e66e4fa7"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -514,7 +514,7 @@
     "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "691caf51f2bb9ef86888772a8cc5d7952687b7c6"
+  revision = "03b0eab127a39bccf71c1eadc3446f7fb13f8669"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -87,6 +87,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		URL:            fmt.Sprintf("http://%s/?%s", *endpoint, query),
 		RequestTimeout: reqTimeout,
 		LoadFactors:    []float64{1},
+		FileNamePrefix: tName,
 	}
 	resp, err := opts.RunLoadTest(false)
 	if err != nil {
@@ -94,7 +95,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	}
 
 	// Save the json result for benchmarking
-	resp.SaveJSON(tName)
+	resp.SaveJSON()
 
 	if len(resp.Result) == 0 {
 		t.Fatalf("No result found for the load test")

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -156,6 +156,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 		BaseQPS:        qpsPerClient * float64(numClients),
 		URL:            fmt.Sprintf("http://%s/?timeout=%d", *endpoint, processingTimeMillis),
 		LoadFactors:    []float64{1},
+		FileNamePrefix: strings.Replace(t.Name(), "/", "_", -1),
 	}
 
 	t.Logf("Starting test with %d clients at %s", numClients, time.Now())
@@ -168,7 +169,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	close(scaleCh)
 
 	// Save the json result for benchmarking
-	resp.SaveJSON(strings.Replace(t.Name(), "/", "_", -1))
+	resp.SaveJSON()
 
 	tc := make([]junit.TestCase, 0)
 

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -258,7 +258,7 @@ function create_test_cluster_with_retries() {
       # Exit if test succeeded
       [[ "$(get_test_return_code)" == "0" ]] && return
       # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources to fulfill the request' ${cluster_creation_log})" ]] && return
+      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill the request' ${cluster_creation_log})" ]] && return
     done
   done
 }

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -43,7 +43,7 @@ IS_DOCUMENTATION_PR=0
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
-  [[ -z "$(echo "${CHANGED_FILES}" | grep -v \(${1// /\\|}\)$))" ]]
+  [[ -z "$(echo "${CHANGED_FILES}" | grep -v "\(${1// /\\|}\)$")" ]]
 }
 
 # List changed files in the current PR.

--- a/vendor/github.com/knative/test-infra/shared/prow/prow.go
+++ b/vendor/github.com/knative/test-infra/shared/prow/prow.go
@@ -110,7 +110,7 @@ type Metadata map[string]interface{}
 
 /* Local logics */
 
-// GetLocalArtifactsDir gets the aritfacts directory where prow looks for artifacts.
+// GetLocalArtifactsDir gets the artifacts directory where prow looks for artifacts.
 // By default, it will look at the env var ARTIFACTS.
 func GetLocalArtifactsDir() string {
 	dir := os.Getenv("ARTIFACTS")


### PR DESCRIPTION
Update vendor: knative/test-infra.

- fix for retrying different GCP regions when e2e test failed due to stock out