### PR TITLE
Use health check to be the first handler

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -301,8 +301,8 @@ func main() {
 		logger.Fatalw("Unable to create request log handler", zap.Error(err))
 	}
 	ah = reqLogHandler
-	ah = &activatorhandler.HealthHandler{HealthCheck: statSink.Status, NextHandler: ah}
 	ah = &activatorhandler.ProbeHandler{NextHandler: ah}
+	ah = &activatorhandler.HealthHandler{HealthCheck: statSink.Status, NextHandler: ah}
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))


### PR DESCRIPTION
This makes sense since there's not reason to any work (e.g. check prober headers)

/cc @dgerd @mattmoor


