### PR TITLE
Remove minimal scale of 1

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -104,10 +104,8 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 						corev1.ResourceMemory: resource.MustParse("20Mi"),
 					},
 				}),
-				// See #2946 for why we do this.
-				// turns off auto scaling by setting max and min scale to 1
 				WithConfigAnnotations(map[string]string{
-					"autoscaling.knative.dev/minScale": "1",
+					"autoscaling.knative.dev/minScale": "0",
 					"autoscaling.knative.dev/maxScale": "1",
 				}))
 

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -105,7 +105,6 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 					},
 				}),
 				WithConfigAnnotations(map[string]string{
-					"autoscaling.knative.dev/minScale": "0",
 					"autoscaling.knative.dev/maxScale": "1",
 				}))
 

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -56,7 +56,7 @@ func TestScaleToN(t *testing.T) {
 		timeout: 60 * time.Second,
 	}, {
 		size:    50,
-		timeout: 5 * time.Minute,
+		timeout: 8 * time.Minute,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #2946 
## Proposed Changes

* remove minimal scale of 1, since KPA will now probe for activator to be installed in the backend service before it will permit scale to 0.

