### PR TITLE
Make queue port listen only on port.

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -91,6 +91,9 @@ var (
 			Name:  "SERVING_AUTOSCALER_PORT",
 			Value: "8080",
 		}, {
+			Name:  "QUEUE_SERVING_PORT",
+			Value: "8012",
+		}, {
 			Name:  "CONTAINER_CONCURRENCY",
 			Value: "0",
 		}, {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -135,6 +135,9 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 			Name:  "SERVING_AUTOSCALER_PORT",
 			Value: strconv.Itoa(autoscalerPort),
 		}, {
+			Name:  "QUEUE_SERVING_PORT",
+			Value: strconv.Itoa(int(ports[len(ports)-1].ContainerPort)),
+		}, {
 			Name:  "CONTAINER_CONCURRENCY",
 			Value: strconv.Itoa(int(rev.Spec.ContainerConcurrency)),
 		}, {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -93,6 +93,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
 			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
+			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "1",
 			}, {
@@ -184,6 +187,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
 			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8013",
+			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "1",
 			}, {
@@ -269,6 +275,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
+			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
 			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "1",
@@ -356,6 +365,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
 			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
+			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "0",
 			}, {
@@ -441,6 +453,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
 			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
+			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "0",
 			}, {
@@ -521,6 +536,9 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
 			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
+			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "10",
 			}, {
@@ -600,6 +618,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
+			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
 			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "0",
@@ -682,6 +703,9 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_AUTOSCALER_PORT",
 				Value: "8080",
+			}, {
+				Name:  "QUEUE_SERVING_PORT",
+				Value: "8012",
 			}, {
 				Name:  "CONTAINER_CONCURRENCY",
 				Value: "0",


### PR DESCRIPTION
Currently we configure k8s service and the deployment to expose
only one port.
But the queue-proxy binary itself actually listens on two ports,
wasting the port number and the cycles to maintain the port.
Let's not do that but rather tell queue-proxy what port it should
listen on, since revision knows that already.

Also sorted various variables by name.


/lint

/cc @mattmoor @markusthoemmes 