### PR TITLE
Remove unneeded constants.

### DIFF
--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -25,26 +25,23 @@ const (
 	UserContainerName = "user-container"
 	// FluentdContainerName is the name of the fluentd sidecar when enabled
 	FluentdContainerName = "fluentd-proxy"
-	// EnvoyContainerName is the name of the envoy sidecar when enabled
-	EnvoyContainerName = "istio-proxy"
 	// QueueContainerName is the name of the queue proxy side car
 	QueueContainerName = "queue-proxy"
 
 	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
+	// IstioOutboundIPRangeAnnotation defines the outbound ip ranges istio allows.
 	// TODO(mattmoor): Make this private once we remove revision_test.go
 	IstioOutboundIPRangeAnnotation = "traffic.sidecar.istio.io/includeOutboundIPRanges"
 
-	userPortEnvName = "PORT"
-
-	autoscalerPort = 8080
-
-	// ServicePort is the external port of the service
-	ServicePort = int32(80)
+	// AppLabelKey is the label defining the application's name.
 	AppLabelKey = "app"
 )
 
 var (
-	ProgressDeadlineSeconds int32 = 120
+	// ProgressDeadlineSeconds is the time in seconds we wait for the deployment to
+	// be ready before considering it failed.
+	ProgressDeadlineSeconds = int32(120)
+
 	// See https://github.com/knative/serving/pull/1124#issuecomment-397120430
 	// for how CPU and memory values were calculated.
 	fluentdContainerCPU = resource.MustParse("25m")

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -152,7 +152,7 @@ func buildContainerPorts(userPort int32) []corev1.ContainerPort {
 
 func buildUserPortEnv(userPort string) corev1.EnvVar {
 	return corev1.EnvVar{
-		Name:  userPortEnvName,
+		Name:  "PORT",
 		Value: userPort,
 	}
 }

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -85,12 +85,6 @@ var (
 			Name:  "SERVING_REVISION",
 			Value: "bar", // matches name
 		}, {
-			Name:  "SERVING_AUTOSCALER",
-			Value: "autoscaler", // no autoscaler configured.
-		}, {
-			Name:  "SERVING_AUTOSCALER_PORT",
-			Value: "8080",
-		}, {
 			Name:  "QUEUE_SERVING_PORT",
 			Value: "8012",
 		}, {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -88,7 +88,6 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 	}
 	serviceName := rev.Labels[serving.ServiceLabelKey]
 
-	autoscalerAddress := "autoscaler"
 	userPort := getUserPort(rev)
 
 	var loggingLevel string
@@ -128,12 +127,6 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 		}, {
 			Name:  "SERVING_REVISION",
 			Value: rev.Name,
-		}, {
-			Name:  "SERVING_AUTOSCALER",
-			Value: autoscalerAddress,
-		}, {
-			Name:  "SERVING_AUTOSCALER_PORT",
-			Value: strconv.Itoa(autoscalerPort),
 		}, {
 			Name:  "QUEUE_SERVING_PORT",
 			Value: strconv.Itoa(int(ports[len(ports)-1].ContainerPort)),

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -87,12 +87,6 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_REVISION",
 				Value: "bar", // matches name
 			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
-			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",
 			}, {
@@ -181,12 +175,6 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_REVISION",
 				Value: "bar", // matches name
 			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
-			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8013",
 			}, {
@@ -269,12 +257,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_REVISION",
 				Value: "bar", // matches name
-			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
 			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",
@@ -359,12 +341,6 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_REVISION",
 				Value: "blah", // matches name
 			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
-			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",
 			}, {
@@ -447,12 +423,6 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_REVISION",
 				Value: "this", // matches name
 			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
-			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",
 			}, {
@@ -530,12 +500,6 @@ func TestMakeQueueContainer(t *testing.T) {
 				Name:  "SERVING_REVISION",
 				Value: "bar", // matches name
 			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
-			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",
 			}, {
@@ -612,12 +576,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_REVISION",
 				Value: "bar", // matches name
-			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
 			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",
@@ -697,12 +655,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			}, {
 				Name:  "SERVING_REVISION",
 				Value: "bar", // matches name
-			}, {
-				Name:  "SERVING_AUTOSCALER",
-				Value: "autoscaler", // no autoscaler configured.
-			}, {
-				Name:  "SERVING_AUTOSCALER_PORT",
-				Value: "8080",
 			}, {
 				Name:  "QUEUE_SERVING_PORT",
 				Value: "8012",

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler/revision/resources"
 	"github.com/knative/serving/pkg/reconciler/route/resources/names"
 )
 
@@ -90,7 +89,7 @@ func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, 
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{{
 				Name: networking.ServicePortNameHTTP1,
-				Port: resources.ServicePort,
+				Port: networking.ServiceHTTPPort,
 			}},
 		}, nil
 	case len(balancer.IP) != 0:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

There are quite a few things in `constants.go` that don't really need to be there.

## Proposed Changes

* Remove `EnvoyContainerName` constant. It's used nowhere.
* Remove autoscaler connection info from the queue-proxy. It doesn't need to know anymore.
* Replace `ServicePort` with the broader networking constant.
* Add comments to make the linter happy.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
