### PR TITLE
Propagate trace context to activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -55,7 +55,6 @@ import (
 	"github.com/knative/serving/pkg/tracing"
 	tracingconfig "github.com/knative/serving/pkg/tracing/config"
 	zipkin "github.com/openzipkin/zipkin-go"
-	"go.opencensus.io/plugin/ochttp"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -294,8 +293,7 @@ func main() {
 		GetService:    serviceGetter,
 	}
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
-	ah = tracing.HTTPSpanMiddleware("handle_request", ah)
-	ah = &ochttp.Handler{Handler: ah}
+	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",
 		requestLogTemplateInputGetter(revisionGetter))

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/knative/serving/pkg/tracing"
 	tracingconfig "github.com/knative/serving/pkg/tracing/config"
 	zipkin "github.com/openzipkin/zipkin-go"
+	"go.opencensus.io/plugin/ochttp"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -294,6 +295,9 @@ func main() {
 	}
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
 	ah = tracing.HTTPSpanMiddleware("handle_request", ah)
+	ah = &ochttp.Handler{
+		Handler: ah,
+	}
 	ah = configStore.HTTPMiddleware(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",
 		requestLogTemplateInputGetter(revisionGetter))

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -295,9 +295,7 @@ func main() {
 	}
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
 	ah = tracing.HTTPSpanMiddleware("handle_request", ah)
-	ah = &ochttp.Handler{
-		Handler: ah,
-	}
+	ah = &ochttp.Handler{Handler: ah}
 	ah = configStore.HTTPMiddleware(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",
 		requestLogTemplateInputGetter(revisionGetter))

--- a/pkg/tracing/http.go
+++ b/pkg/tracing/http.go
@@ -19,26 +19,10 @@ package tracing
 import (
 	"net/http"
 
-	"go.opencensus.io/trace"
+	"go.opencensus.io/plugin/ochttp"
 )
 
-type spanHandler struct {
-	opName string
-	next   http.Handler
-}
-
-// ServeHTTP is an HTTP handler which injects a tracing span using a TracerRefGetter
-func (h *spanHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, newSpan := trace.StartSpan(r.Context(), h.opName)
-	defer newSpan.End()
-	r = r.WithContext(ctx)
-	h.next.ServeHTTP(w, r)
-}
-
-// HTTPSpanMiddleware is a http.Handler middleware which creats a span and injects a ZipkinTracer in to the request context
-func HTTPSpanMiddleware(opName string, next http.Handler) http.Handler {
-	return &spanHandler{
-		opName: opName,
-		next:   next,
-	}
+// HTTPSpanMiddleware is a http.Handler middleware to create spans for the HTTP endpoint
+func HTTPSpanMiddleware(next http.Handler) http.Handler {
+	return &ochttp.Handler{Handler: next}
 }

--- a/pkg/tracing/http_test.go
+++ b/pkg/tracing/http_test.go
@@ -83,7 +83,8 @@ func TestHTTPSpanMiddleware(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to make fake request: %v", err)
 	}
-	req.Header["X-B3-Traceid"] = []string{"821e0d50d931235a5ba3fa42eddddd8f"}
+	traceID := "821e0d50d931235a5ba3fa42eddddd8f"
+	req.Header["X-B3-Traceid"] = []string{traceID}
 	req.Header["X-B3-Spanid"] = []string{"b3bd5e1c4318c78a"}
 
 	middleware.ServeHTTP(fw, req)
@@ -95,13 +96,13 @@ func TestHTTPSpanMiddleware(t *testing.T) {
 
 	spans := reporter.Flush()
 	if len(spans) != 2 {
-		t.Errorf("Got %d spans, expected 2", len(spans))
+		t.Errorf("Got %d spans, expected 2: spans = %v", len(spans), spans)
 	}
-	if spans[0].TraceID.String() != "821e0d50d931235a5ba3fa42eddddd8f" {
-		t.Error("Span 1's TraceID is not correct")
+	if got := spans[0].TraceID.String(); got != traceID {
+		t.Errorf("spans[0].TraceID = %v, want %v", got, traceID)
 	}
-	if spans[1].TraceID.String() != "821e0d50d931235a5ba3fa42eddddd8f" {
-		t.Error("Span 2's TraceID is not correct")
+	if got := spans[1].TraceID.String(); got != traceID {
+		t.Errorf("spans[1].TraceID = %v, want %v", got, traceID)
 	}
 	if spans[0].ParentID.String() != spans[1].ID.String() {
 		t.Errorf("Span 2 (id %v) should be parent of span 1 (parentId %v)", spans[1].ID.String(), spans[0].ParentID.String())


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3975

## Proposed Changes

* Add OpenCensus HTTP handler to extract span context and create the initial server span

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
Fixed trace looks like this:

![knative-activator-tracing-fix](https://user-images.githubusercontent.com/164562/57086089-6c396980-6cf5-11e9-8a84-04e0aa54b2be.png)
