### PR TITLE
Scale down a revision when it fails to become ready.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -252,6 +252,9 @@ func (ks *scaler) applyScale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, 
 func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desiredScale int32) (int32, error) {
 	logger := logging.FromContext(ctx)
 
+	if desiredScale < 0 && pa.Status.IsInactive() {
+		desiredScale = 0
+	}
 	desiredScale, shouldApplyScale := ks.handleScaleToZero(pa, desiredScale)
 	if !shouldApplyScale {
 		return desiredScale, nil

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -115,6 +115,15 @@ func TestScaler(t *testing.T) {
 			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 	}, {
+		label:         "scale to zero when inactive and no metric",
+		startReplicas: 1,
+		scaleTo:       -1,
+		wantReplicas:  0,
+		wantScaling:   true,
+		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
+		},
+	}, {
 		label:         "scale to zero after grace period, but fail prober",
 		startReplicas: 1,
 		scaleTo:       0,


### PR DESCRIPTION
Currently a revision can fail and the pod autoscaler keeps trying to
activate with no luck, leading to crashlooping.  The fix is to scale
down the pods when their revision failed.

As a byproduct, fix a bug that updates an immutable field of
PodAutoscaler.Spec, making the reconcilation of Revision's Active
condition deadcode.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3456 

## Proposed Changes

* When a revision's Ready condition is False, mark the pod autoscaler inactive, which led to the pod autoscaler's Ready condition False and the revision's Active condition False as well.
* Autoscaler scales the revision to 0 (or minScale) if the pod autoscaler is inactive.
* (Byproduct) Do not try to set PodAutoscaler.Spec.DeprecatedServiceName, as it is immutable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Scale down a revision when it fails to become ready.
```
