### PR TITLE
[Experiment] Add handler to infer revision based on Host header.

### DIFF
--- a/pkg/activator/handler/revision_handler.go
+++ b/pkg/activator/handler/revision_handler.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"math/rand"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -99,7 +100,7 @@ func (h *RevisionHandler) getTargets(domain string) []types.NamespacedName {
 func (h *RevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Only try to infer a revision if the header is not already set.
 	if r.Header.Get(activator.RevisionHeaderName) == "" {
-		targets := h.getTargets(r.Host)
+		targets := h.getTargets(strings.Split(r.Host, ":")[0])
 
 		// pick a target randomly
 		target := targets[rand.Intn(len(targets))]

--- a/pkg/activator/handler/revision_handler.go
+++ b/pkg/activator/handler/revision_handler.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/serving/pkg/activator"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	v1a1inf "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewRevisionHandler creates a new RevisionHandler.
+func NewRevisionHandler(routeInformer v1a1inf.RouteInformer, next http.Handler) *RevisionHandler {
+	rand.Seed(time.Now().Unix())
+
+	handler := &RevisionHandler{
+		nextHandler:   next,
+		domainMapping: make(map[string]*v1alpha1.Route),
+	}
+
+	routeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    handler.addRoute,
+		UpdateFunc: controller.PassNew(handler.addRoute),
+		DeleteFunc: handler.deleteRoute,
+	})
+
+	return handler
+}
+
+// RevisionHandler infers a target revision if no target headers are set.
+type RevisionHandler struct {
+	nextHandler http.Handler
+
+	domainMux     sync.RWMutex
+	domainMapping map[string]*v1alpha1.Route
+}
+
+func (h *RevisionHandler) addRoute(r interface{}) {
+	route := r.(*v1alpha1.Route)
+
+	h.domainMux.Lock()
+	defer h.domainMux.Unlock()
+
+	h.domainMapping[route.Status.Domain] = route
+}
+
+func (h *RevisionHandler) deleteRoute(r interface{}) {
+	route := r.(*v1alpha1.Route)
+
+	h.domainMux.Lock()
+	defer h.domainMux.Unlock()
+
+	delete(h.domainMapping, route.Name)
+}
+
+func (h *RevisionHandler) getRoute(domain string) *v1alpha1.Route {
+	h.domainMux.RLock()
+	defer h.domainMux.RUnlock()
+
+	route, _ := h.domainMapping[domain]
+	return route
+}
+
+func (h *RevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only try to infer a revision if the header is not already set.
+	if r.Header.Get(activator.RevisionHeaderName) == "" {
+		route := h.getRoute(r.Host)
+
+		// pick a target randomly
+		revisionName := route.Status.Traffic[rand.Intn(len(route.Status.Traffic))].RevisionName
+
+		// set headers accordingly
+		r.Header.Add(activator.RevisionHeaderName, revisionName)
+		r.Header.Add(activator.RevisionHeaderNamespace, route.Namespace)
+	}
+
+	h.nextHandler.ServeHTTP(w, r)
+}

--- a/pkg/reconciler/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/clusteringress/resources/virtual_service.go
@@ -101,38 +101,15 @@ func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPa
 	weights := []v1alpha3.HTTPRouteDestination{}
 	for _, split := range http.Splits {
 
-		var h *v1alpha3.Headers
-		// TODO(mattmoor): Switch to Headers when we can have a hard
-		// dependency on 1.1, but 1.0.x rejects the unknown fields.
-		// if len(split.AppendHeaders) > 0 {
-		// 	h = &v1alpha3.Headers{
-		// 		Request: &v1alpha3.HeaderOperations{
-		// 			Add: split.AppendHeaders,
-		// 		},
-		// 	}
-		// }
-
 		weights = append(weights, v1alpha3.HTTPRouteDestination{
 			Destination: v1alpha3.Destination{
 				Host: network.GetServiceHostname(
 					split.ServiceName, split.ServiceNamespace),
 				Port: makePortSelector(split.ServicePort),
 			},
-			Weight:  split.Percent,
-			Headers: h,
+			Weight: split.Percent,
 		})
 	}
-
-	var h *v1alpha3.Headers
-	// TODO(mattmoor): Switch to Headers when we can have a hard
-	// dependency on 1.1, but 1.0.x rejects the unknown fields.
-	// if len(http.AppendHeaders) > 0 {
-	// 	h = &v1alpha3.Headers{
-	// 		Request: &v1alpha3.HeaderOperations{
-	// 			Add: http.AppendHeaders,
-	// 		},
-	// 	}
-	// }
 
 	return &v1alpha3.HTTPRoute{
 		Match:   matches,
@@ -142,12 +119,7 @@ func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPClusterIngressPa
 			Attempts:      http.Retries.Attempts,
 			PerTryTimeout: http.Retries.PerTryTimeout.Duration.String(),
 		},
-		// TODO(mattmoor): Remove AppendHeaders when 1.1 is a hard dependency.
-		// AppendHeaders is deprecated in Istio 1.1 in favor of Headers,
-		// however, 1.0.x doesn't support Headers.
-		DeprecatedAppendHeaders: http.AppendHeaders,
-		Headers:                 h,
-		WebsocketUpgrade:        true,
+		WebsocketUpgrade: true,
 	}
 }
 

--- a/pkg/reconciler/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/route/resources/cluster_ingress.go
@@ -118,11 +118,6 @@ func makeClusterIngressRule(domains []string, ns string, targets traffic.Revisio
 				ServicePort: intstr.FromInt(int(activator.ServicePort(t.Protocol))),
 			},
 			Percent: t.Percent,
-			// TODO(nghia): Append headers per-split.
-			// AppendHeaders: map[string]string{
-			// 	activator.RevisionHeaderName:      t.TrafficTarget.RevisionName,
-			// 	activator.RevisionHeaderNamespace: ns,
-			// },
 		})
 	}
 
@@ -131,11 +126,6 @@ func makeClusterIngressRule(domains []string, ns string, targets traffic.Revisio
 		HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
 			Paths: []v1alpha1.HTTPClusterIngressPath{{
 				Splits: splits,
-				// TODO(lichuqiang): #2201, plumbing to config timeout and retries.
-				AppendHeaders: map[string]string{
-					activator.RevisionHeaderName:      maxInactive(targets),
-					activator.RevisionHeaderNamespace: ns,
-				},
 			}},
 		},
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

As briefly discussed in Slack, this is a quick experiment to show how potential code could look like to remove the need to append headers at ingress for Knative Serving to work correctly.

In this experiment, I'm keeping track of all routes in the system and make sure I can successfully map from domain to a route. If a revision header is unset, that mapping is used to infer the route for the given Host and in case there are multiple traffic targets one is picked at random.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
