### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -415,7 +415,7 @@ func TestReconcile(t *testing.T) {
 				"default", "ingress-create-failure", "inducing failure for create clusteringresses"),
 			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create clusteringresses"),
 		},
-		Key: "default/ingress-create-failure",
+		Key:                     "default/ingress-create-failure",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "steady state",
@@ -660,7 +660,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})),
 		}},
-		Key: "default/new-latest-ready",
+		Key:                     "default/new-latest-ready",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "failure updating cluster ingress",
@@ -738,7 +738,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update clusteringresses"),
 		},
-		Key: "default/update-ci-failure",
+		Key:                     "default/update-ci-failure",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "reconcile service mutation",
@@ -971,7 +971,7 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 		}},
-		Key: "default/ingress-mutation",
+		Key:                     "default/ingress-mutation",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "switch to a different config",
@@ -1123,7 +1123,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})),
 		}},
-		Key: "default/pinned-becomes-ready",
+		Key:                     "default/pinned-becomes-ready",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "traffic split becomes ready",
@@ -1217,7 +1217,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", "route-34-78"),
 		},
-		Key: "default/named-traffic-split",
+		Key:                     "default/named-traffic-split",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "same revision targets",
@@ -1330,7 +1330,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", "route-1-2"),
 		},
-		Key: "default/same-revision-targets",
+		Key:                     "default/same-revision-targets",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "change route configuration",
@@ -1403,7 +1403,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}), WithRouteFinalizer),
 		}},
-		Key: "default/switch-configs",
+		Key:                     "default/switch-configs",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "update single target to traffic split with unready revision",
@@ -1481,7 +1481,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})),
 		}},
-		Key: "default/split",
+		Key:                     "default/split",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "Update stale lastPinned",
@@ -1630,7 +1630,7 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		SkipNamespaceValidation: true,
-		Key: "default/delete-in-progress",
+		Key:                     "default/delete-in-progress",
 	}}
 
 	// TODO(mattmoor): Revision inactive (direct reference)


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
