### PR TITLE
Export TAG to fix our annotation manipulation.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -20,7 +20,7 @@ function build_release() {
   # Run `generate-yamls.sh`, which should be versioned with the
   # branch since the detail of building may change over time.
   local YAML_LIST="$(mktemp)"
-  # We publish our own istio.yaml, so users don't need to use helm
+  export TAG
   $(dirname $0)/generate-yamls.sh "${REPO_ROOT_DIR}" "${YAML_LIST}"
   YAMLS_TO_PUBLISH=$(cat "${YAML_LIST}" | tr '\n' ' ')
   if (( ! PUBLISH_RELEASE )); then


### PR DESCRIPTION
`generate-yamls.sh` performs a sed to rewrite annotations when the `TAG` bash variable is set, which it is in `hack/release.sh` after flag processing.  However, because this variable wasn't exported the child process didn't inherit it and the sed wasn't being performed.  This simply exports TAG before calling `generate-yaml.sh`.

Also drops a stale comment.

Fixes: https://github.com/knative/serving/issues/3626

cc @evankanderson @adrcunha @duglin 

I'd like to get this simple change in, so we can verify it nightly before the 0.6 cut.