### PR TITLE
 Reduce the idle timeouts in the default transports.

### DIFF
--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -45,14 +45,14 @@ func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
 		// Those match net/http/transport.go
 		Proxy:                 http.ProxyFromEnvironment,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       5 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 
 		// This is bespoke.
 		DialContext: (&net.Dialer{
 			Timeout:   connTimeout,
-			KeepAlive: 30 * time.Second,
+			KeepAlive: 5 * time.Second,
 			DualStack: true,
 		}).DialContext,
 	}


### PR DESCRIPTION
This helps to deal with the problem we're seeing
with the lean Istio, wherein the connection to the K8s
service is not terminated when the underlying endpoint changes,
since in the absence of the sidecar while the socket is alive,
nothing disturbs the connection.
This stops us from scaling to 0.


Fixes #3987
A more comprehensive approach will be in #3986

## Proposed Changes

* reduce the idle timeouts