### PR TITLE
Reconcile ClusterIngress into two VirtualServices.

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -33,7 +33,6 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/system"
-	"github.com/knative/pkg/tracker"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -46,8 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
+
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -42,6 +42,7 @@ import (
 	sharedinformers "github.com/knative/pkg/client/informers/externalversions"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/kmeta"
 	logtesting "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
@@ -155,7 +156,158 @@ var (
 	}
 )
 
-// This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
+func TestReconcile(t *testing.T) {
+	table := TableTest{{
+		Name:                    "bad workqueue key",
+		Key:                     "too/many/parts",
+		SkipNamespaceValidation: true,
+	}, {
+		Name:                    "key not found",
+		Key:                     "foo/not-found",
+		SkipNamespaceValidation: true,
+	}, {
+		Name:                    "skip ingress not matching class key",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			addAnnotations(ingress("no-virtualservice-yet", 1234),
+				map[string]string{networking.IngressClassAnnotationKey: "fake-controller"}),
+		},
+	}, {
+		Name:                    "create VirtualService matching ClusterIngress",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingress("no-virtualservice-yet", 1234),
+		},
+		WantCreates: []metav1.Object{
+			resources.MakeMeshVirtualService(ingress("no-virtualservice-yet", 1234)),
+			resources.MakeIngressVirtualService(ingress("no-virtualservice-yet", 1234),
+				[]string{"knative-test-gateway", "knative-ingress-gateway"}),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithStatus("no-virtualservice-yet", 1234,
+				v1alpha1.IngressStatus{
+					LoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("test-ingressgateway", "istio-system")},
+						},
+					},
+					Status: duckv1beta1.Status{
+						Conditions: duckv1beta1.Conditions{{
+							Type:     v1alpha1.ClusterIngressConditionLoadBalancerReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.ClusterIngressConditionNetworkConfigured,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.ClusterIngressConditionReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "no-virtualservice-yet-mesh"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "no-virtualservice-yet"),
+		},
+		Key: "no-virtualservice-yet",
+	}, {
+		Name:                    "reconcile VirtualService to match desired one",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingress("reconcile-virtualservice", 1234),
+			&v1alpha3.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "reconcile-virtualservice",
+					Namespace: system.Namespace(),
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "reconcile-virtualservice",
+						serving.RouteLabelKey:          "test-route",
+						serving.RouteNamespaceLabelKey: "test-ns",
+					},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
+				},
+				Spec: v1alpha3.VirtualServiceSpec{},
+			},
+			&v1alpha3.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "reconcile-virtualservice-extra",
+					Namespace: system.Namespace(),
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "reconcile-virtualservice",
+						serving.RouteLabelKey:          "test-route",
+						serving.RouteNamespaceLabelKey: "test-ns",
+					},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
+				},
+				Spec: v1alpha3.VirtualServiceSpec{},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: resources.MakeIngressVirtualService(ingress("reconcile-virtualservice", 1234),
+				[]string{"knative-test-gateway", "knative-ingress-gateway"}),
+		}},
+		WantCreates: []metav1.Object{
+			resources.MakeMeshVirtualService(ingress("reconcile-virtualservice", 1234)),
+		},
+		WantDeletes: []clientgotesting.DeleteActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "test-ns",
+				Verb:      "delete",
+			},
+			Name: "reconcile-virtualservice-extra",
+		}},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithStatus("reconcile-virtualservice", 1234,
+				v1alpha1.IngressStatus{
+					LoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("test-ingressgateway", "istio-system")},
+						},
+					},
+					Status: duckv1beta1.Status{
+						Conditions: duckv1beta1.Conditions{{
+							Type:     v1alpha1.ClusterIngressConditionLoadBalancerReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.ClusterIngressConditionNetworkConfigured,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.ClusterIngressConditionReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconcile-virtualservice-mesh"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for VirtualService %q/%q",
+				system.Namespace(), "reconcile-virtualservice"),
+		},
+		Key: "reconcile-virtualservice",
+	}}
+
+	defer logtesting.ClearAll()
+	table.Test(t, MakeFactory(func(listers *Listers, opt reconciler.Options) controller.Reconciler {
+		return &Reconciler{
+			Base:                 reconciler.NewBase(opt, controllerAgentName),
+			virtualServiceLister: listers.GetVirtualServiceLister(),
+			clusterIngressLister: listers.GetClusterIngressLister(),
+			gatewayLister:        listers.GetGatewayLister(),
+			configStore: &testConfigStore{
+				config: ReconcilerTestConfig(),
+			},
+		}
+	}))
+}
+
 func TestReconcile_EnableAutoTLS(t *testing.T) {
 	table := TableTest{{
 		Name:                    "update Gateway to match newly created ClusterIngress",
@@ -170,7 +322,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer}),
 
-			resources.MakeVirtualService(ingress("reconciling-clusteringress", 1234),
+			resources.MakeMeshVirtualService(ingress("reconciling-clusteringress", 1234)),
+			resources.MakeIngressVirtualService(ingress("reconciling-clusteringress", 1234),
 				[]string{"knative-ingress-gateway"}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -208,6 +361,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			),
 		}},
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress-mesh"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %q/%q", system.Namespace(), "knative-ingress-gateway"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),
@@ -221,7 +375,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			originSecret("istio-system", "secret0"),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeVirtualService(ingress("reconciling-clusteringress", 1234),
+			resources.MakeMeshVirtualService(ingress("reconciling-clusteringress", 1234)),
+			resources.MakeIngressVirtualService(ingress("reconciling-clusteringress", 1234),
 				[]string{"knative-ingress-gateway"}),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
@@ -255,6 +410,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			),
 		}},
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress-mesh"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeWarning, "InternalError", `gateway.networking.istio.io "knative-ingress-gateway" not found`),
@@ -298,7 +454,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer}),
 
-			resources.MakeVirtualService(ingress("reconciling-clusteringress", 1234),
+			resources.MakeMeshVirtualService(ingress("reconciling-clusteringress", 1234)),
+			resources.MakeIngressVirtualService(ingress("reconciling-clusteringress", 1234),
 				[]string{"knative-ingress-gateway"}),
 
 			// The secret copy under istio-system.
@@ -342,6 +499,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			),
 		}},
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress-mesh"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Secret %s/%s", "istio-system", targetSecretName),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %q/%q", system.Namespace(), "knative-ingress-gateway"),
@@ -376,8 +534,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{*withCredentialName(ingressTLSServer.DeepCopy(), targetSecretName), irrelevantServer}),
-
-			resources.MakeVirtualService(ingress("reconciling-clusteringress", 1234),
+			resources.MakeMeshVirtualService(ingress("reconciling-clusteringress", 1234)),
+			resources.MakeIngressVirtualService(ingress("reconciling-clusteringress", 1234),
 				[]string{"knative-ingress-gateway"}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -427,6 +585,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			),
 		}},
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress-mesh"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Secret %s/%s", "istio-system", targetSecretName),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),

--- a/pkg/reconciler/clusteringress/resources/names/names.go
+++ b/pkg/reconciler/clusteringress/resources/names/names.go
@@ -20,7 +20,16 @@ import (
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 )
 
-// VirtualService returns the name of the VirtualService child resource for given ClusterIngress.
-func VirtualService(i *v1alpha1.ClusterIngress) string {
+// IngressVirtualService returns the name of the VirtualService child
+// resource for given ClusterIngress that programs traffic for Ingress
+// Gateways.
+func IngressVirtualService(i *v1alpha1.ClusterIngress) string {
 	return i.Name
+}
+
+// MeshVirtualService returns the name of the VirtualService child
+// resource for given ClusterIngress that programs traffic for Service
+// Mesh.
+func MeshVirtualService(i *v1alpha1.ClusterIngress) string {
+	return i.Name + "-mesh"
 }

--- a/pkg/reconciler/clusteringress/resources/names/names_test.go
+++ b/pkg/reconciler/clusteringress/resources/names/names_test.go
@@ -31,14 +31,23 @@ func TestNamer(t *testing.T) {
 		f       func(*v1alpha1.ClusterIngress) string
 		want    string
 	}{{
-		name: "VirtualService",
+		name: "IngressVirtualService",
 		ingress: &v1alpha1.ClusterIngress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
 		},
-		f:    VirtualService,
+		f:    IngressVirtualService,
 		want: "foo",
+	}, {
+		name: "MeshVirtualService",
+		ingress: &v1alpha1.ClusterIngress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		f:    MeshVirtualService,
+		want: "foo-mesh",
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/clusteringress/resources/virtual_service.go
@@ -34,20 +34,26 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/clusteringress/resources/names"
+	"github.com/knative/serving/pkg/resources"
 )
 
-// MakeVirtualService creates an Istio VirtualService as network programming.
-// Such VirtualService specifies which Gateways and Hosts that it applies to,
-// as well as the routing rules.
-func MakeVirtualService(ci *v1alpha1.ClusterIngress, gateways []string) *v1alpha3.VirtualService {
+// VirtualServiceNamespace gives the namespace of the child
+// VirtualServices for a given ClusterIngress.
+func VirtualServiceNamespace(_ *v1alpha1.ClusterIngress) string {
+	return system.Namespace()
+}
+
+// MakeIngressVirtualService creates Istio VirtualService as network
+// programming for Istio Gateways other than 'mesh'.
+func MakeIngressVirtualService(ci *v1alpha1.ClusterIngress, gateways []string) *v1alpha3.VirtualService {
 	vs := &v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            names.VirtualService(ci),
-			Namespace:       system.Namespace(),
+			Name:            names.IngressVirtualService(ci),
+			Namespace:       VirtualServiceNamespace(ci),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
 			Annotations:     ci.ObjectMeta.Annotations,
 		},
-		Spec: *makeVirtualServiceSpec(ci, gateways),
+		Spec: *makeVirtualServiceSpec(ci, gateways, expandedHosts(getHosts(ci))),
 	}
 
 	// Populate the ClusterIngress labels.
@@ -59,24 +65,53 @@ func MakeVirtualService(ci *v1alpha1.ClusterIngress, gateways []string) *v1alpha
 	ingressLabels := ci.Labels
 	vs.Labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
 	vs.Labels[serving.RouteNamespaceLabelKey] = ingressLabels[serving.RouteNamespaceLabelKey]
-
 	return vs
 }
 
-func makeVirtualServiceSpec(ci *v1alpha1.ClusterIngress, gateways []string) *v1alpha3.VirtualServiceSpec {
-	spec := v1alpha3.VirtualServiceSpec{
-		// We want to connect to two Gateways: the Knative shared
-		// Gateway, and the 'mesh' Gateway.  The former provides
-		// access from outside of the cluster, and the latter provides
-		// access for services from inside the cluster.
-		Gateways: append(gateways, "mesh"),
-		Hosts:    getHosts(ci),
+// MakeMeshVirtualService creates Istio VirtualService as network
+// programming for Istio network mesh.
+func MakeMeshVirtualService(ci *v1alpha1.ClusterIngress) *v1alpha3.VirtualService {
+	vs := &v1alpha3.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            names.MeshVirtualService(ci),
+			Namespace:       VirtualServiceNamespace(ci),
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
+			Annotations:     ci.ObjectMeta.Annotations,
+		},
+		Spec: *makeVirtualServiceSpec(ci, []string{"mesh"}, retainLocals(getHosts(ci))),
 	}
+	// Populate the ClusterIngress labels.
+	vs.Labels = resources.UnionMaps(
+		resources.FilterMap(ci.Labels, func(k string) bool {
+			return k != serving.RouteLabelKey && k != serving.RouteNamespaceLabelKey
+		}),
+		map[string]string{networking.IngressLabelKey: ci.Name})
+	return vs
+}
 
+// MakeVirtualServices creates Istio VirtualServices as network programming.
+//
+// These VirtualService specifies which Gateways and Hosts that it applies to,
+// as well as the routing rules.
+func MakeVirtualServices(ci *v1alpha1.ClusterIngress, gateways []string) []*v1alpha3.VirtualService {
+	vss := []*v1alpha3.VirtualService{MakeMeshVirtualService(ci)}
+	if len(gateways) > 0 {
+		vss = append(vss, MakeIngressVirtualService(ci, gateways))
+	}
+	return vss
+}
+
+func makeVirtualServiceSpec(ci *v1alpha1.ClusterIngress, gateways []string, hosts []string) *v1alpha3.VirtualServiceSpec {
+	spec := v1alpha3.VirtualServiceSpec{
+		Gateways: gateways,
+		Hosts:    hosts,
+	}
 	for _, rule := range ci.Spec.Rules {
-		hosts := rule.Hosts
 		for _, p := range rule.HTTP.Paths {
-			spec.HTTP = append(spec.HTTP, *makeVirtualServiceRoute(hosts, &p))
+			hosts := intersect(rule.Hosts, hosts)
+			if len(hosts) != 0 {
+				spec.HTTP = append(spec.HTTP, *makeVirtualServiceRoute(hosts, &p))
+			}
 		}
 	}
 	return &spec
@@ -155,6 +190,17 @@ func dedup(hosts []string) []string {
 	return sets.NewString(hosts...).List()
 }
 
+func retainLocals(hosts []string) []string {
+	localSvcSuffix := ".svc." + network.GetClusterDomainName()
+	retained := []string{}
+	for _, h := range hosts {
+		if strings.HasSuffix(h, localSvcSuffix) {
+			retained = append(retained, h)
+		}
+	}
+	return retained
+}
+
 func expandedHosts(hosts []string) []string {
 	expanded := []string{}
 	allowedSuffixes := []string{
@@ -202,4 +248,8 @@ func getHosts(ci *v1alpha1.ClusterIngress) []string {
 		hosts = append(hosts, rule.Hosts...)
 	}
 	return dedup(hosts)
+}
+
+func intersect(h1, h2 []string) []string {
+	return sets.NewString(h1...).Intersection(sets.NewString(h2...)).List()
 }

--- a/pkg/reconciler/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/clusteringress/resources/virtual_service_test.go
@@ -32,36 +32,81 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestMakeVirtualServiceSpec_CorrectMetadata(t *testing.T) {
-	ci := &v1alpha1.ClusterIngress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-ingress",
+func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		gateways []string
+		ci       *v1alpha1.ClusterIngress
+		expected []metav1.ObjectMeta
+	}{{
+		name:     "mesh and ingress",
+		gateways: []string{"gateway"},
+		ci: &v1alpha1.ClusterIngress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ingress",
+				Labels: map[string]string{
+					serving.RouteLabelKey:          "test-route",
+					serving.RouteNamespaceLabelKey: "test-ns",
+				},
+			},
+			Spec: v1alpha1.IngressSpec{},
+		},
+		expected: []metav1.ObjectMeta{{
+			Name:      "test-ingress-mesh",
+			Namespace: system.Namespace(),
 			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
+		}, {
+			Name:      "test-ingress",
+			Namespace: system.Namespace(),
+			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
+				serving.RouteLabelKey:          "test-route",
+				serving.RouteNamespaceLabelKey: "test-ns",
+			},
+		}},
+	}, {
+		name:     "mesh only",
+		gateways: nil,
+		ci: &v1alpha1.ClusterIngress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ingress",
+				Labels: map[string]string{
+					serving.RouteLabelKey:          "test-route",
+					serving.RouteNamespaceLabelKey: "test-ns",
+				},
+			},
+			Spec: v1alpha1.IngressSpec{},
 		},
-		Spec: v1alpha1.IngressSpec{},
-	}
-	expected := metav1.ObjectMeta{
-		Name:      "test-ingress",
-		Namespace: system.Namespace(),
-		Labels: map[string]string{
-			networking.IngressLabelKey:     "test-ingress",
-			serving.RouteLabelKey:          "test-route",
-			serving.RouteNamespaceLabelKey: "test-ns",
-		},
-		OwnerReferences: []metav1.OwnerReference{
-			*kmeta.NewControllerRef(ci),
-		},
-	}
-	meta := MakeVirtualService(ci, []string{}).ObjectMeta
-	if diff := cmp.Diff(expected, meta); diff != "" {
-		t.Errorf("Unexpected metadata (-want +got): %v", diff)
+		expected: []metav1.ObjectMeta{{
+			Name:      "test-ingress-mesh",
+			Namespace: system.Namespace(),
+			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
+				serving.RouteLabelKey:          "test-route",
+				serving.RouteNamespaceLabelKey: "test-ns",
+			},
+		}},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			vss := MakeVirtualServices(tc.ci, tc.gateways)
+			if len(vss) != len(tc.expected) {
+				t.Errorf("Expected %d VirtualService, saw %d", len(tc.expected), len(vss))
+			}
+			for i := range tc.expected {
+				tc.expected[i].OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(tc.ci)}
+				if diff := cmp.Diff(tc.expected[i], vss[i].ObjectMeta); diff != "" {
+					t.Errorf("Unexpected metadata (-want +got): %v", diff)
+				}
+			}
+		})
 	}
 }
 
-func TestMakeVirtualServiceSpec_CorrectGateways(t *testing.T) {
+func TestMakeMeshVirtualServiceSpec_CorrectGateways(t *testing.T) {
 	ci := &v1alpha1.ClusterIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-ingress",
@@ -72,14 +117,145 @@ func TestMakeVirtualServiceSpec_CorrectGateways(t *testing.T) {
 		},
 		Spec: v1alpha1.IngressSpec{},
 	}
-	expected := []string{"gateway-one", "gateway-two", "mesh"}
-	gateways := MakeVirtualService(ci, []string{"gateway-one", "gateway-two"}).Spec.Gateways
+	expected := []string{"mesh"}
+	gateways := MakeMeshVirtualService(ci).Spec.Gateways
 	if diff := cmp.Diff(expected, gateways); diff != "" {
 		t.Errorf("Unexpected gateways (-want +got): %v", diff)
 	}
 }
 
-func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
+func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
+	ci := &v1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ingress",
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.ClusterIngressRule{{
+				Hosts: []string{
+					"test-route.test-ns.svc.cluster.local",
+					"test-route.test-ns.svc",
+					"test-route.test-ns",
+				},
+				HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
+					Paths: []v1alpha1.HTTPClusterIngressPath{{
+						Path: "^/pets/(.*?)?",
+						Splits: []v1alpha1.ClusterIngressBackendSplit{{
+							ClusterIngressBackend: v1alpha1.ClusterIngressBackend{
+								ServiceNamespace: "test-ns",
+								ServiceName:      "v2-service",
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+							AppendHeaders: map[string]string{
+								"ugh": "blah",
+							},
+						}},
+						AppendHeaders: map[string]string{
+							"foo": "bar",
+						},
+						Timeout: &metav1.Duration{Duration: networking.DefaultTimeout},
+						Retries: &v1alpha1.HTTPRetry{
+							PerTryTimeout: &metav1.Duration{Duration: networking.DefaultTimeout},
+							Attempts:      networking.DefaultRetryCount,
+						},
+					}},
+				},
+			}, {
+				Hosts: []string{
+					"v1.domain.com",
+				},
+				HTTP: &v1alpha1.HTTPClusterIngressRuleValue{
+					Paths: []v1alpha1.HTTPClusterIngressPath{{
+						Path: "^/pets/(.*?)?",
+						Splits: []v1alpha1.ClusterIngressBackendSplit{{
+							ClusterIngressBackend: v1alpha1.ClusterIngressBackend{
+								ServiceNamespace: "test-ns",
+								ServiceName:      "v1-service",
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+						AppendHeaders: map[string]string{
+							"foo": "baz",
+						},
+						Timeout: &metav1.Duration{Duration: networking.DefaultTimeout},
+						Retries: &v1alpha1.HTTPRetry{
+							PerTryTimeout: &metav1.Duration{Duration: networking.DefaultTimeout},
+							Attempts:      networking.DefaultRetryCount,
+						},
+					}},
+				},
+			}},
+		},
+	}
+	expected := []v1alpha3.HTTPRoute{{
+		Match: []v1alpha3.HTTPMatchRequest{{
+			URI:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns(?::\d{1,5})?$`},
+		}, {
+			URI:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns\.svc(?::\d{1,5})?$`},
+		}, {
+			URI:       &istiov1alpha1.StringMatch{Regex: "^/pets/(.*?)?"},
+			Authority: &istiov1alpha1.StringMatch{Regex: `^test-route\.test-ns\.svc\.cluster\.local(?::\d{1,5})?$`},
+		}},
+		Route: []v1alpha3.HTTPRouteDestination{{
+			Destination: v1alpha3.Destination{
+				Host: "v2-service.test-ns.svc.cluster.local",
+				Port: v1alpha3.PortSelector{Number: 80},
+			},
+			Weight: 100,
+			// Headers: &v1alpha3.Headers{
+			// 	Request: &v1alpha3.HeaderOperations{
+			// 		Add: map[string]string{
+			// 			"ugh": "blah",
+			// 		},
+			// 	},
+			// },
+		}},
+		// Headers: &v1alpha3.Headers{
+		// 	Request: &v1alpha3.HeaderOperations{
+		// 		Add: map[string]string{
+		// 			"foo": "bar",
+		// 		},
+		// 	},
+		// },
+		DeprecatedAppendHeaders: map[string]string{
+			"foo": "bar",
+		},
+		Timeout: networking.DefaultTimeout.String(),
+		Retries: &v1alpha3.HTTPRetry{
+			Attempts:      networking.DefaultRetryCount,
+			PerTryTimeout: networking.DefaultTimeout.String(),
+		},
+		WebsocketUpgrade: true,
+	}}
+
+	routes := MakeMeshVirtualService(ci).Spec.HTTP
+	if diff := cmp.Diff(expected, routes); diff != "" {
+		t.Errorf("Unexpected routes (-want +got): %v", diff)
+	}
+}
+
+func TestMakeIngressVirtualServiceSpec_CorrectGateways(t *testing.T) {
+	ci := &v1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				serving.RouteLabelKey:          "test-route",
+				serving.RouteNamespaceLabelKey: "test-ns",
+			},
+		},
+		Spec: v1alpha1.IngressSpec{},
+	}
+	expected := []string{"gateway-one", "gateway-two"}
+	gateways := MakeIngressVirtualService(ci, []string{"gateway-one", "gateway-two"}).Spec.Gateways
+	if diff := cmp.Diff(expected, gateways); diff != "" {
+		t.Errorf("Unexpected gateways (-want +got): %v", diff)
+	}
+}
+
+func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	ci := &v1alpha1.ClusterIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-ingress",
@@ -219,14 +395,14 @@ func TestMakeVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		WebsocketUpgrade: true,
 	}}
 
-	routes := MakeVirtualService(ci, []string{}).Spec.HTTP
+	routes := MakeIngressVirtualService(ci, []string{"gateway"}).Spec.HTTP
 	if diff := cmp.Diff(expected, routes); diff != "" {
 		t.Errorf("Unexpected routes (-want +got): %v", diff)
 	}
 }
 
 // One active target.
-func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
+func TestMakeIngressVirtualServiceRoute_Vanilla(t *testing.T) {
 	ingressPath := &v1alpha1.HTTPClusterIngressPath{
 		Splits: []v1alpha1.ClusterIngressBackendSplit{{
 			ClusterIngressBackend: v1alpha1.ClusterIngressBackend{
@@ -270,7 +446,7 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 }
 
 // Two active targets.
-func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
+func TestMakeIngressVirtualServiceRoute_TwoTargets(t *testing.T) {
 	ingressPath := &v1alpha1.HTTPClusterIngressPath{
 		Splits: []v1alpha1.ClusterIngressBackendSplit{{
 			ClusterIngressBackend: v1alpha1.ClusterIngressBackend{


### PR DESCRIPTION
One VirtualService will be exposed to Gateways, while the other will
be exposed to `mesh` Gateway.  This allow us to expose short names into
both cases, since the handling of 'mesh' and non-'mesh' VirtualService
are slightly differences by Istio.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3824 

## Proposed Changes

*  Reconcile a ClusterIngress into two VirtualServices.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix #3824 
```
