### PR TITLE
Allow configuring HTTP server of Knative Ingress Gateway by using `httpProtocol`

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -432,6 +432,16 @@ func (c *Reconciler) reconcileGateway(ctx context.Context, ci *v1alpha1.ClusterI
 	}
 
 	existing := resources.GetServers(gateway, ci)
+	existingHTTPServer := resources.GetHTTPServer(gateway)
+	if existingHTTPServer != nil {
+		existing = append(existing, *existingHTTPServer)
+	}
+
+	desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol)
+	if desiredHTTPServer != nil {
+		desired = append(desired, *desiredHTTPServer)
+	}
+
 	if equality.Semantic.DeepEqual(existing, desired) {
 		return nil
 	}


### PR DESCRIPTION


## Proposed Changes

 Allow configuring HTTP server of Knative Ingress Gateway by using `httpProtocol` in the ConfigMap `config-network`.

Currently there are 3 modes of `httpProtocol`. See the [definition](https://github.com/knative/serving/blob/master/config/config-network.yaml#L115)


