### PR TITLE
Add the revision name to the 'Created' event.

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -322,7 +322,7 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1alpha1.Config
 			if err != nil {
 				return nil, errutil.Wrapf(err, "Failed to create Build for Configuration %q", config.GetName())
 			}
-			logger.Infof("Created Build:\n%+v", result.GetName())
+			logger.Infof("Created Build: %+v", result)
 			c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Build %q", result.GetName())
 		}
 		buildRef = &corev1.ObjectReference{
@@ -337,7 +337,7 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1alpha1.Config
 	if err != nil {
 		return nil, err
 	}
-	c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Revision %q", rev.Name)
+	c.Recorder.Eventf(config, corev1.EventTypeNormal, "Created", "Created Revision %q", created.Name)
 	logger.Infof("Created Revision: %+v", created)
 
 	return created, nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Codewise, this used to work when we incremented the name in the controller ourselves. It no longer does since we usually use `GenerateName`. Using the name of the created element contains the actual (potentially generated) value.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add correct revision name to the 'Created' event.
```
