### PR TITLE
Fix ultra-verbose decider error.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -171,7 +171,7 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer) f
 	return func(decider *autoscaler.Decider) (autoscaler.UniScaler, error) {
 		for _, l := range []string{serving.KubernetesServiceLabelKey, serving.ConfigurationLabelKey} {
 			if v, ok := decider.Labels[l]; !ok || v == "" {
-				return nil, fmt.Errorf("label %q not found or empty in Decider: %v", l, decider)
+				return nil, fmt.Errorf("label %q not found or empty in Decider %s", l, decider.Name)
 			}
 		}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Without this change, the event that gets produced if reconciling a decider fails is huge:

```
14m         Warning   InternalError        PodAutoscaler       error reconciling decider: error creating decider: label "serving.knative.dev/kubernetesService" not found or empty in Decider: &ObjectMeta{Name:helloworld-test-image-7vkdf,GenerateName:,Namespace:default,SelfLink:/apis/autoscaling.internal.knative.dev/v1alpha1/namespaces/default/podautoscalers/helloworld-test-image-7vkdf,UID:e38a4697-7016-11e9-a385-025000000001,ResourceVersion:3026378,Generation:1,CreationTimestamp:2019-05-06 15:52:02 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{app: helloworld-test-image-7vkdf,serving.knative.dev/configuration: helloworld-test-image,serving.knative.dev/configurationGeneration: 1,serving.knative.dev/configurationMetadataGeneration: 1,serving.knative.dev/kubernetesService: ,serving.knative.dev/revision: helloworld-test-image-7vkdf,serving.knative.dev/revisionUID: e384d1de-7016-11e9-a385-025000000001,serving.knative.dev/service: helloworld-test-image,},Annotations:map[string]string{autoscaling.knative.dev/class: kpa.autoscaling.knative.dev,autoscaling.knative.dev/metric: concurrency,},OwnerReferences:[{serving.knative.dev/v1alpha1 Revision helloworld-test-image-7vkdf e384d1de-7016-11e9-a385-025000000001 0xc0002096fa 0xc0002096fb}],Finalizers:[],ClusterName:,Initializers:nil,}
```

It's also not deduplicated. This adjusts the event message to the "usual".

```
25s         Warning   InternalError        PodAutoscaler       error reconciling decider: error creating decider: label "serving.knative.dev/kubernetesService" not found or empty in Decider helloworld-test-image-md8hb
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
