### PR TITLE
Drop the use of the configurationMetadataGeneration label

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -61,10 +61,6 @@ const (
 	// metadata generation of the Configuration that created this revision
 	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
 
-	// DeprecatedConfigurationMetadataGenerationLabelKey is the label key attached to a Revision indicating the
-	// metadata generation of the Configuration that created this revision
-	DeprecatedConfigurationMetadataGenerationLabelKey = GroupName + "/configurationMetadataGeneration"
-
 	// BuildHashLabelKey is the label key attached to a Build indicating the
 	// hash of the spec from which they were created.
 	BuildHashLabelKey = GroupName + "/buildHash"

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/knative/pkg/controller"
 	logtesting "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/ptr"
-	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/pkg/gc"
@@ -290,16 +289,6 @@ func TestReconcile(t *testing.T) {
 			cfg("matching-revision-done-idempotent", "foo", 5566,
 				WithObservedGen, WithLatestCreated("matching-revision"), WithLatestReady("matching-revision")),
 			rev("matching-revision-done-idempotent", "foo", 5566,
-				WithCreationTimestamp(now), MarkRevisionReady, WithRevName("matching-revision")),
-		},
-		Key: "foo/matching-revision-done-idempotent",
-	}, {
-		Name: "reconcile revision matching generation (ready: true, idempotent, no deprecated generation label)",
-		Objects: []runtime.Object{
-			cfg("matching-revision-done-idempotent", "foo", 5566,
-				WithObservedGen, WithLatestCreated("matching-revision"), WithLatestReady("matching-revision")),
-			rev("matching-revision-done-idempotent", "foo", 5566,
-				WithoutConfigMetadataGenerationLabel,
 				WithCreationTimestamp(now), MarkRevisionReady, WithRevName("matching-revision")),
 		},
 		Key: "foo/matching-revision-done-idempotent",
@@ -782,8 +771,4 @@ func TestIsRevisionStale(t *testing.T) {
 func WithBuildWarning(c *v1alpha1.Configuration) {
 	c.Status.MarkResourceNotConvertible(v1alpha1.ConvertErrorf("build",
 		"build cannot be migrated forward.").(*v1alpha1.CannotConvertError))
-}
-
-func WithoutConfigMetadataGenerationLabel(rev *v1alpha1.Revision) {
-	delete(rev.Labels, serving.DeprecatedConfigurationMetadataGenerationLabelKey)
 }

--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -64,7 +64,6 @@ func UpdateRevisionLabels(rev *v1alpha1.Revision, config *v1alpha1.Configuration
 		serving.ConfigurationLabelKey,
 		serving.ServiceLabelKey,
 		serving.ConfigurationGenerationLabelKey,
-		serving.DeprecatedConfigurationMetadataGenerationLabelKey,
 	} {
 		rev.Labels[key] = RevisionLabelValueForKey(key, config)
 	}
@@ -78,8 +77,6 @@ func RevisionLabelValueForKey(key string, config *v1alpha1.Configuration) string
 	case serving.ServiceLabelKey:
 		return config.Labels[serving.ServiceLabelKey]
 	case serving.ConfigurationGenerationLabelKey:
-		return fmt.Sprintf("%d", config.Generation)
-	case serving.DeprecatedConfigurationMetadataGenerationLabelKey:
 		return fmt.Sprintf("%d", config.Generation)
 	}
 

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -65,10 +65,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                             "build",
-					serving.ConfigurationGenerationLabelKey:                   "10",
-					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "10",
-					serving.ServiceLabelKey:                                   "",
+					serving.ConfigurationLabelKey:           "build",
+					serving.ConfigurationGenerationLabelKey: "10",
+					serving.ServiceLabelKey:                 "",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -118,10 +117,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                             "build",
-					serving.ConfigurationGenerationLabelKey:                   "100",
-					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
-					serving.ServiceLabelKey:                                   "",
+					serving.ConfigurationLabelKey:           "build",
+					serving.ConfigurationGenerationLabelKey: "100",
+					serving.ServiceLabelKey:                 "",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -172,12 +170,11 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                             "labels",
-					serving.ConfigurationGenerationLabelKey:                   "100",
-					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
-					serving.ServiceLabelKey:                                   "",
-					"foo":                                                     "bar",
-					"baz":                                                     "blah",
+					serving.ConfigurationLabelKey:           "labels",
+					serving.ConfigurationGenerationLabelKey: "100",
+					serving.ServiceLabelKey:                 "",
+					"foo":                                   "bar",
+					"baz":                                   "blah",
 				},
 			},
 			Spec: v1alpha1.RevisionSpec{
@@ -222,10 +219,9 @@ func TestMakeRevisions(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 				Labels: map[string]string{
-					serving.ConfigurationLabelKey:                             "annotations",
-					serving.ConfigurationGenerationLabelKey:                   "100",
-					serving.DeprecatedConfigurationMetadataGenerationLabelKey: "100",
-					serving.ServiceLabelKey:                                   "",
+					serving.ConfigurationLabelKey:           "annotations",
+					serving.ConfigurationGenerationLabelKey: "100",
+					serving.ServiceLabelKey:                 "",
 				},
 				Annotations: map[string]string{
 					"foo": "bar",

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -986,14 +986,3 @@ func WithConfigurationGenerationAnnotation(generation int) RevisionOption {
 		r.Annotations[serving.ConfigurationGenerationLabelKey] = strconv.Itoa(generation)
 	}
 }
-
-// WithDeprecatedConfigurationMetadataGenerationLabel sets the label on the revision
-func WithDeprecatedConfigurationMetadataGenerationLabel(generation int) RevisionOption {
-	return func(r *v1alpha1.Revision) {
-		if r.Labels == nil {
-			r.Labels = make(map[string]string)
-		}
-
-		r.Labels[serving.DeprecatedConfigurationMetadataGenerationLabelKey] = strconv.Itoa(generation)
-	}
-}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Address #643

## Proposed Changes

* Drop the use of the configurationMetadataGeneration label

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
