### PR TITLE
Use the metrics service to pass to the decider

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -942,7 +942,7 @@ func TestUpdate(t *testing.T) {
 	servingInformer.Networking().V1alpha1().ServerlessServices().Informer().GetIndexer().Add(sks)
 
 	decider := resources.MakeDecider(context.Background(), kpa, defaultConfig().Autoscaler)
-	decider.Labels[serving.KubernetesServiceLabelKey] = sks.Status.PrivateServiceName
+	decider.Labels[serving.KubernetesServiceLabelKey] = msvc.Name
 
 	// Wait for the Reconcile to complete.
 	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {


### PR DESCRIPTION
Since the metrics service endpoints must be a proper representation
of the revision deployment, we can pass that to the decider, rather than
passing along the SKS created serving deployment (especially that the service
that autoscaler scrapes is _this_ service anyway).
This will prevent us from failing to reconcile decider on the first run
since the metrics service name will be known already

/cc @mattmoor

