### PR TITLE
Move the service name from labels to spec.

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -49,10 +49,6 @@ const (
 	// which Autoscaler deployment it is created.
 	AutoscalerLabelKey = GroupName + "/autoscaler"
 
-	// KubernetesServiceLabelKey is the label key attached to the decider, that contains
-	// the kubernetes service is uses for pod counting.
-	KubernetesServiceLabelKey = GroupName + "/kubernetesService"
-
 	// ServiceLabelKey is the label key attached to a Route and Configuration indicating by
 	// which Service they are created.
 	ServiceLabelKey = GroupName + "/service"

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -89,7 +89,6 @@ type Autoscaler struct {
 // New creates a new instance of autoscaler
 func New(
 	namespace string,
-	revisionService string,
 	endpointsInformer corev1informers.EndpointsInformer,
 	deciderSpec DeciderSpec,
 	reporter StatsReporter) (*Autoscaler, error) {
@@ -105,7 +104,7 @@ func New(
 
 	return &Autoscaler{
 		namespace:       namespace,
-		revisionService: revisionService,
+		revisionService: deciderSpec.ServiceName, // To avoid locking to read the decider spec.
 		endpointsLister: endpointsInformer.Lister(),
 		deciderSpec:     deciderSpec,
 		buckets:         aggregation.NewTimedFloat64Buckets(bucketSize),

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -69,7 +69,6 @@ type StatMessage struct {
 // Autoscaler stores current state of an instance of an autoscaler
 type Autoscaler struct {
 	namespace       string
-	revisionService string
 	endpointsLister corev1listers.EndpointsLister
 	reporter        StatsReporter
 
@@ -104,7 +103,6 @@ func New(
 
 	return &Autoscaler{
 		namespace:       namespace,
-		revisionService: deciderSpec.ServiceName, // To avoid locking to read the decider spec.
 		endpointsLister: endpointsInformer.Lister(),
 		deciderSpec:     deciderSpec,
 		buckets:         aggregation.NewTimedFloat64Buckets(bucketSize),
@@ -139,7 +137,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (int32, bool) {
 
 	spec := a.currentSpec()
 
-	originalReadyPodsCount, err := resources.FetchReadyAddressCount(a.endpointsLister, a.namespace, a.revisionService)
+	originalReadyPodsCount, err := resources.FetchReadyAddressCount(a.endpointsLister, a.namespace, spec.ServiceName)
 	if err != nil {
 		// If the error is NotFound, then presume 0.
 		if !apierrors.IsNotFound(err) {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -461,6 +461,7 @@ func TestAutoscaler_UpdateTarget(t *testing.T) {
 		PanicThreshold:    2.0,
 		MaxScaleUpRate:    10.0,
 		MetricSpec:        a.deciderSpec.MetricSpec,
+		ServiceName:       testService,
 	})
 	a.expectScale(t, now, 100, true)
 }

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -43,7 +43,7 @@ var (
 func TestNew_ErrorWhenGivenNilInterface(t *testing.T) {
 	var endpointsInformer corev1informers.EndpointsInformer
 
-	_, err := New(testNamespace, testService, endpointsInformer, DeciderSpec{TargetConcurrency: 10}, &mockReporter{})
+	_, err := New(testNamespace, endpointsInformer, DeciderSpec{TargetConcurrency: 10, ServiceName: testService}, &mockReporter{})
 	if err == nil {
 		t.Error("Expected error when EndpointsInformer interface is nil, but got none.")
 	}
@@ -52,7 +52,8 @@ func TestNew_ErrorWhenGivenNilInterface(t *testing.T) {
 func TestNew_ErrorWhenGivenNilStatsReporter(t *testing.T) {
 	var reporter StatsReporter
 
-	_, err := New(testNamespace, testService, kubeInformer.Core().V1().Endpoints(), DeciderSpec{TargetConcurrency: 10}, reporter)
+	_, err := New(testNamespace, kubeInformer.Core().V1().Endpoints(),
+		DeciderSpec{TargetConcurrency: 10, ServiceName: testService}, reporter)
 	if err == nil {
 		t.Error("Expected error when EndpointsInformer interface is nil, but got none.")
 	}
@@ -550,18 +551,22 @@ func newTestAutoscaler(containerConcurrency int) *Autoscaler {
 			StableWindow: stableWindow,
 			PanicWindow:  panicWindow,
 		},
+		ServiceName: testService,
 	}
 
-	a, _ := New(testNamespace, testService, kubeInformer.Core().V1().Endpoints(), deciderSpec, &mockReporter{})
+	a, _ := New(testNamespace, kubeInformer.Core().V1().Endpoints(), deciderSpec, &mockReporter{})
 	return a
 }
 
 // Record a data point every second, for every pod, for duration of the
 // linear series, on the line from start to end concurrency.
 func (a *Autoscaler) recordLinearSeries(test *testing.T, now time.Time, s linearSeries) time.Time {
-	points := make([]int32, 0)
+	points := make([]int32, 0, int(s.duration.Seconds()+1))
 	for i := 1; i <= int(s.duration.Seconds()); i++ {
-		points = append(points, int32(float64(s.startConcurrency)+float64(s.endConcurrency-s.startConcurrency)*(float64(i)/s.duration.Seconds())))
+		points = append(points,
+			int32(
+				float64(s.startConcurrency)+
+					float64(s.endConcurrency-s.startConcurrency)*(float64(i)/s.duration.Seconds())))
 	}
 	test.Logf("Recording points: %v.", points)
 	for _, point := range points {

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -47,6 +47,9 @@ type DeciderSpec struct {
 	PanicThreshold    float64
 	// TODO: remove MetricSpec when the custom metrics adapter implements Metric.
 	MetricSpec MetricSpec
+
+	// The name of the k8s service for pod information.
+	ServiceName string
 }
 
 // DeciderStatus is the current scale recommendation.

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -309,8 +309,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 }
 
 func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAutoscaler, k8sSvc string) (*autoscaler.Decider, error) {
-	desiredDecider := resources.MakeDecider(ctx, pa, config.FromContext(ctx).Autoscaler)
-	desiredDecider.Labels[serving.KubernetesServiceLabelKey] = k8sSvc
+	desiredDecider := resources.MakeDecider(ctx, pa, config.FromContext(ctx).Autoscaler, k8sSvc)
 	decider, err := c.kpaDeciders.Get(ctx, desiredDecider.Namespace, desiredDecider.Name)
 	if errors.IsNotFound(err) {
 		decider, err = c.kpaDeciders.Create(ctx, desiredDecider)

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -277,7 +277,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		fakeDeciders := newTestDeciders()
 		// Make sure we want to scale to 0.
 		decider := resources.MakeDecider(
-			context.Background(), kpa(testNamespace, testRevision), defaultConfig().Autoscaler)
+			context.Background(), kpa(testNamespace, testRevision), defaultConfig().Autoscaler, "not-important-here")
 		decider.Status.DesiredScale = 0
 		decider.Generation = 42
 		fakeDeciders.Create(context.Background(), decider)
@@ -639,7 +639,7 @@ func TestReconcile(t *testing.T) {
 		// constant namespace and revision names.
 		// Make sure we don't want to scale to 0.
 		decider := resources.MakeDecider(
-			context.Background(), kpa(testNamespace, testRevision), defaultConfig().Autoscaler)
+			context.Background(), kpa(testNamespace, testRevision), defaultConfig().Autoscaler, "trying-hard-to-care-in-this-test")
 		decider.Status.DesiredScale = desiredScale
 		decider.Generation = 2112
 		fakeDeciders.Create(context.Background(), decider)
@@ -941,8 +941,7 @@ func TestUpdate(t *testing.T) {
 	servingClient.NetworkingV1alpha1().ServerlessServices(testNamespace).Create(sks)
 	servingInformer.Networking().V1alpha1().ServerlessServices().Informer().GetIndexer().Add(sks)
 
-	decider := resources.MakeDecider(context.Background(), kpa, defaultConfig().Autoscaler)
-	decider.Labels[serving.KubernetesServiceLabelKey] = msvc.Name
+	decider := resources.MakeDecider(context.Background(), kpa, defaultConfig().Autoscaler, msvc.Name)
 
 	// Wait for the Reconcile to complete.
 	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -27,7 +27,7 @@ import (
 // MakeDecider constructs a Decider resource from a PodAutoscaler taking
 // into account the PA's ContainerConcurrency and the relevant
 // autoscaling annotation.
-func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaler.Decider {
+func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autoscaler.Config, svc string) *autoscaler.Decider {
 	logger := logging.FromContext(ctx)
 
 	target := config.TargetConcurrency(pa.Spec.ContainerConcurrency)
@@ -60,6 +60,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 			TargetConcurrency: target,
 			PanicThreshold:    panicThreshold,
 			MetricSpec:        metricSpec,
+			ServiceName:       svc,
 		},
 	}
 }


### PR DESCRIPTION
This feels more natural. Passing actual specification of the decider via
labels feels hacky.

/lint

## Proposed Changes

* use `DeciderSpec` to pass the service name around
* update the tests

/cc @mattmoor @markusthoemmes 