### PR TITLE
This reverts https://github.com/knative/serving/pull/3940

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -41,12 +41,6 @@ set -o pipefail
 readonly YAML_REPO_ROOT=${1:?"First argument must be the repo root dir"}
 readonly YAML_LIST_FILE=${2:?"Second argument must be the output file"}
 
-# Location of istio YAMLs
-readonly ISTIO_CRD_YAML=${YAML_REPO_ROOT}/third_party/istio-1.1-latest/istio-crds.yaml
-readonly ISTIO_YAML=${YAML_REPO_ROOT}/third_party/istio-1.1-latest/istio.yaml
-readonly ISTIO_LEAN_YAML=${YAML_REPO_ROOT}/third_party/istio-1.1-latest/istio-lean.yaml
-readonly ISTIO_KNATIVE_EXTRAS_YAML=${YAML_REPO_ROOT}/third_party/istio-1.1-latest/istio-knative-extras.yaml
-
 # Set output directory
 if [[ -z "${YAML_OUTPUT_DIR:-}" ]]; then
   readonly YAML_OUTPUT_DIR="$(mktemp -d)"
@@ -117,4 +111,3 @@ echo "All manifests generated"
 
 ls -1 ${SERVING_YAML} > ${YAML_LIST_FILE}
 ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${SERVING_YAML} >> ${YAML_LIST_FILE}
-ls -1 ${ISTIO_CRD_YAML} ${ISTIO_YAML} ${ISTIO_LEAN_YAML} ${ISTIO_KNATIVE_EXTRAS_YAML} >> ${YAML_LIST_FILE}


### PR DESCRIPTION
We now install Istio via the GKE add-on everywhere except serving.

Fixes: https://github.com/knative/serving/issues/3670
