### PR TITLE
Use new transport in prober.

### DIFF
--- a/pkg/network/prober/prober.go
+++ b/pkg/network/prober/prober.go
@@ -30,6 +30,9 @@ import (
 	"github.com/knative/serving/pkg/network"
 )
 
+// TransportFactory creates new transport.
+var TransportFactory = network.NewAutoTransport
+
 // Do sends a single probe to given target, e.g. `http://revision.default.svc.cluster.local:81`.
 // headerValue is the value for the `k-network-probe` header.
 // Do returns whether the probe was successful or not, or there was an error probing.
@@ -41,7 +44,7 @@ func Do(ctx context.Context, target, headerValue string) (bool, error) {
 
 	req.Header.Set(http.CanonicalHeaderKey(network.ProbeHeaderName), headerValue)
 	req = req.WithContext(ctx)
-	resp, err := network.AutoTransport.RoundTrip(req)
+	resp, err := TransportFactory().RoundTrip(req)
 	if err != nil {
 		return false, errors.Wrapf(err, "error roundtripping %s", target)
 	}

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -558,7 +558,9 @@ func TestActivatorProbe(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			network.AutoTransport = test.rt
+			prober.TransportFactory = func() http.RoundTripper {
+				return test.rt
+			}
 			res, err := activatorProbe(pa)
 			if got, want := res, test.wantRes; got != want {
 				t.Errorf("Result = %v, want: %v", got, want)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -37,6 +37,7 @@ import (
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/network/prober"
 	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	revisionresources "github.com/knative/serving/pkg/reconciler/revision/resources"


### PR DESCRIPTION
Since background prober may poll quite ofter, we need to
connect with a new socket each time to the backend to
see the backends swapped.
If we don't do this and the endpoints change, in the absence of the mesh the socket won't disconnect (and roundtripper therefore won't reconnect) and as a consequence the probe will never succeed.


/cc @mattmoor 