### PR TITLE
Refactor activator getter functions to listers.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -189,15 +189,7 @@ func main() {
 	}
 
 	params := queue.BreakerParams{QueueDepth: breakerQueueDepth, MaxConcurrency: breakerMaxConcurrency, InitialCapacity: 0}
-
-	throttlerParams := activator.ThrottlerParams{
-		BreakerParams:   params,
-		Logger:          logger,
-		EndpointsLister: endpointInformer.Lister(),
-		RevisionLister:  revisionInformer.Lister(),
-		SksLister:       sksInformer.Lister(),
-	}
-	throttler := activator.NewThrottler(throttlerParams)
+	throttler := activator.NewThrottler(params, endpointInformer.Lister(), sksInformer.Lister(), revisionInformer.Lister(), logger)
 
 	handler := cache.ResourceEventHandlerFuncs{
 		AddFunc:    throttler.UpdateEndpoints,

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -22,21 +22,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/knative/serving/pkg/client/clientset/versioned/fake"
-
-	testing2 "github.com/knative/pkg/logging/testing"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/google/go-cmp/cmp"
-
+	testing2 "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	pkghttp "github.com/knative/serving/pkg/http"
-
+	"github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
 	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
+	pkghttp "github.com/knative/serving/pkg/http"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -22,18 +22,21 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/knative/serving/pkg/client/clientset/versioned/fake"
+
 	testing2 "github.com/knative/pkg/logging/testing"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/pkg/errors"
-
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	pkghttp "github.com/knative/serving/pkg/http"
+
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 )
 
 const (
@@ -49,7 +52,7 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 	})
 	buf := bytes.NewBufferString("")
 	handler, err := pkghttp.NewRequestLogHandler(baseHandler, buf, "",
-		requestLogTemplateInputGetter(getRevisionMock(true)))
+		requestLogTemplateInputGetter(getRevisionLister(true)))
 	if err != nil {
 		t.Fatalf("want: no error, got: %v", err)
 	}
@@ -123,7 +126,7 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 		want     pkghttp.RequestLogRevision
 	}{{
 		name:   "success",
-		getter: requestLogTemplateInputGetter(getRevisionMock(true)),
+		getter: requestLogTemplateInputGetter(getRevisionLister(true)),
 		request: &http.Request{Header: map[string][]string{
 			http.CanonicalHeaderKey(activator.RevisionHeaderName):      {testRevisionName},
 			http.CanonicalHeaderKey(activator.RevisionHeaderNamespace): {testNamespaceName},
@@ -137,7 +140,7 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 		},
 	}, {
 		name:   "revision not found",
-		getter: requestLogTemplateInputGetter(getRevisionMock(true)),
+		getter: requestLogTemplateInputGetter(getRevisionLister(true)),
 		request: &http.Request{Header: map[string][]string{
 			http.CanonicalHeaderKey(activator.RevisionHeaderName):      {"foo"},
 			http.CanonicalHeaderKey(activator.RevisionHeaderNamespace): {"bar"},
@@ -149,7 +152,7 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 		},
 	}, {
 		name:   "labels not found",
-		getter: requestLogTemplateInputGetter(getRevisionMock(false)),
+		getter: requestLogTemplateInputGetter(getRevisionLister(false)),
 		request: &http.Request{Header: map[string][]string{
 			http.CanonicalHeaderKey(activator.RevisionHeaderName):      {testRevisionName},
 			http.CanonicalHeaderKey(activator.RevisionHeaderNamespace): {testNamespaceName},
@@ -177,20 +180,20 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 	}
 }
 
-func getRevisionMock(addLabels bool) func(revID activator.RevisionID) (*v1alpha1.Revision, error) {
-	return func(revID activator.RevisionID) (*v1alpha1.Revision, error) {
-		rev := &v1alpha1.Revision{}
-		if revID.Name != testRevisionName || revID.Namespace != testNamespaceName {
-			return nil, errors.New("revision not found")
+func getRevisionLister(addLabels bool) servinglisters.RevisionLister {
+	rev := &v1alpha1.Revision{}
+	rev.Name = testRevisionName
+	rev.Namespace = testNamespaceName
+	if addLabels {
+		rev.Labels = map[string]string{
+			serving.ConfigurationLabelKey: testConfigName,
+			serving.ServiceLabelKey:       testServiceName,
 		}
-		rev.Name = revID.Name
-		rev.Namespace = revID.Namespace
-		if addLabels {
-			rev.Labels = map[string]string{
-				serving.ConfigurationLabelKey: testConfigName,
-				serving.ServiceLabelKey:       testServiceName,
-			}
-		}
-		return rev, nil
 	}
+
+	fake := fake.NewSimpleClientset(rev)
+	informer := servinginformers.NewSharedInformerFactory(fake, 0)
+	informer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
+
+	return informer.Serving().V1alpha1().Revisions().Lister()
 }

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -189,7 +189,8 @@ func getRevisionLister(addLabels bool) servinglisters.RevisionLister {
 
 	fake := fake.NewSimpleClientset(rev)
 	informer := servinginformers.NewSharedInformerFactory(fake, 0)
-	informer.Serving().V1alpha1().Revisions().Informer().GetIndexer().Add(rev)
+	revisions := informer.Serving().V1alpha1().Revisions()
+	revisions.Informer().GetIndexer().Add(rev)
 
-	return informer.Serving().V1alpha1().Revisions().Lister()
+	return revisions.Lister()
 }

--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -18,11 +18,6 @@ package activator
 
 import (
 	"fmt"
-
-	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -45,19 +40,3 @@ type RevisionID struct {
 func (rev RevisionID) String() string {
 	return fmt.Sprintf("%s/%s", rev.Namespace, rev.Name)
 }
-
-// EndpointsCountGetter is a functor that given namespace and name will
-// return the number of endpoints in the endpoinst resource or an error.
-type EndpointsCountGetter func(*nv1a1.ServerlessService) (int, error)
-
-// SKSGetter is a functor that given namespace and name will return the
-// corresponding SKS resource, or an error.
-type SKSGetter func(string, string) (*nv1a1.ServerlessService, error)
-
-// ServiceGetter is a functor that given namespace and name will return the
-// corresponding K8s Service resource, or an error.
-type ServiceGetter func(namespace, name string) (*corev1.Service, error)
-
-// RevisionGetter is a functor that given a RevisionID will return
-// the corresponding Revision resource, or an error.
-type RevisionGetter func(RevisionID) (*v1alpha1.Revision, error)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -34,109 +34,26 @@ import (
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	servingfake "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/queue"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 const (
-	wantBody      = "everything good!"
-	testNamespace = "real-namespace"
-	testRevName   = "real-name"
+	wantBody         = "everything good!"
+	testNamespace    = "real-namespace"
+	testRevName      = "real-name"
+	testRevNameOther = "other-name"
 )
-
-func stubRevisionGetter(revID activator.RevisionID) (*v1alpha1.Revision, error) {
-	if revID.Namespace != testNamespace {
-		return nil, &k8serrors.StatusError{
-			ErrStatus: metav1.Status{
-				Status:  metav1.StatusFailure,
-				Code:    http.StatusNotFound,
-				Reason:  metav1.StatusReasonNotFound,
-				Message: fmt.Sprintf("not found"),
-			}}
-	}
-	revision := &v1alpha1.Revision{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: revID.Namespace,
-			Name:      revID.Name,
-			Labels: map[string]string{
-				serving.ConfigurationLabelKey: "config-" + revID.Name,
-				serving.ServiceLabelKey:       "service-" + revID.Name,
-			},
-		},
-		Spec: v1alpha1.RevisionSpec{
-			RevisionSpec: v1beta1.RevisionSpec{
-				ContainerConcurrency: 1,
-			},
-		},
-	}
-	return revision, nil
-}
-
-func sksErrorGetter(string, string) (*nv1a1.ServerlessService, error) {
-	return nil, errors.New("no luck in this land")
-}
-
-func stubSKSGetter(namespace, name string) (*nv1a1.ServerlessService, error) {
-	return &nv1a1.ServerlessService{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Status: nv1a1.ServerlessServiceStatus{
-			// Randomize the test.
-			PrivateServiceName: helpers.AppendRandomString(name),
-			ServiceName:        helpers.AppendRandomString(name),
-		},
-	}, nil
-}
-
-func erroringServiceGetter(string, string) (*corev1.Service, error) {
-	return nil, errors.New("wish this call succeeded")
-}
-
-func incorrectServiceGetter(namespace, name string) (*corev1.Service, error) {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name: "julio",
-				Port: 8080,
-			}},
-		}}, nil
-}
-
-func stubServiceGetter(namespace, name string) (*corev1.Service, error) {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name: "http",
-				Port: 8080,
-			}},
-		}}, nil
-}
-
-func errMsg(msg string) string {
-	return fmt.Sprintf("Error getting active endpoint: %v\n", msg)
-}
-
-func goodEndpointsGetter(*nv1a1.ServerlessService) (int, error) {
-	return 1000, nil
-}
-
-func brokenEndpointsCountGetter(*nv1a1.ServerlessService) (int, error) {
-	return 0, errors.New("some error")
-}
 
 func TestActivationHandler(t *testing.T) {
 	defer ClearAll()
@@ -152,9 +69,9 @@ func TestActivationHandler(t *testing.T) {
 		probeCode       int
 		probeResp       []string
 		gpc             int
-		endpointsGetter activator.EndpointsCountGetter
-		sksGetter       activator.SKSGetter
-		svcGetter       activator.ServiceGetter
+		endpointsLister corev1listers.EndpointsLister
+		sksLister       netlisters.ServerlessServiceLister
+		svcLister       corev1listers.ServiceLister
 		reporterCalls   []reporterCall
 	}{{
 		label:           "active endpoint",
@@ -163,7 +80,7 @@ func TestActivationHandler(t *testing.T) {
 		wantBody:        "everything good!",
 		wantCode:        http.StatusOK,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
 			Namespace:  testNamespace,
@@ -190,7 +107,7 @@ func TestActivationHandler(t *testing.T) {
 		wantCode:        http.StatusOK,
 		wantErr:         nil,
 		probeResp:       []string{activator.Name, queue.Name},
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
 			Namespace:  testNamespace,
@@ -216,7 +133,7 @@ func TestActivationHandler(t *testing.T) {
 		wantBody:        "everything good!",
 		wantCode:        http.StatusOK,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
 			Namespace:  testNamespace,
@@ -238,10 +155,10 @@ func TestActivationHandler(t *testing.T) {
 		label:           "no active endpoint",
 		namespace:       "fake-namespace",
 		name:            "fake-name",
-		wantBody:        errMsg("not found"),
+		wantBody:        errMsg("revision.serving.knative.dev \"fake-name\" not found"),
 		wantCode:        http.StatusNotFound,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		reporterCalls:   nil,
 	}, {
 		label:           "active endpoint (probe failure)",
@@ -249,7 +166,7 @@ func TestActivationHandler(t *testing.T) {
 		name:            testRevName,
 		probeErr:        errors.New("probe error"),
 		wantCode:        http.StatusInternalServerError,
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		gpc:             1,
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
@@ -274,7 +191,7 @@ func TestActivationHandler(t *testing.T) {
 		name:            testRevName,
 		probeCode:       http.StatusServiceUnavailable,
 		wantCode:        http.StatusInternalServerError,
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		gpc:             1,
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
@@ -300,7 +217,7 @@ func TestActivationHandler(t *testing.T) {
 		wantBody:        "",
 		wantCode:        http.StatusBadGateway,
 		wantErr:         errors.New("request error"),
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
 			Namespace:  testNamespace,
@@ -325,7 +242,7 @@ func TestActivationHandler(t *testing.T) {
 		wantBody:        "everything good!",
 		wantCode:        http.StatusOK,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
 			Namespace:  testNamespace,
@@ -347,11 +264,11 @@ func TestActivationHandler(t *testing.T) {
 		label:           "broken get SKS",
 		namespace:       testNamespace,
 		name:            testRevName,
-		wantBody:        errMsg("no luck in this land"),
-		wantCode:        http.StatusInternalServerError,
+		wantBody:        errMsg("serverlessservice.networking.internal.knative.dev \"real-name\" not found"),
+		wantCode:        http.StatusNotFound,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
-		sksGetter:       sksErrorGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
+		sksLister:       sksLister(sks("bogus-namespace", testRevName)),
 		reporterCalls:   nil,
 	}, {
 		label:           "k8s svc incorrectly spec'd",
@@ -360,27 +277,27 @@ func TestActivationHandler(t *testing.T) {
 		wantBody:        errMsg("revision needs external HTTP port"),
 		wantCode:        http.StatusInternalServerError,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
-		svcGetter:       incorrectServiceGetter,
+		endpointsLister: endpointsLister(endpoints(testNamespace, testRevName, 1000)),
+		svcLister:       serviceLister(service(testNamespace, testRevName, "bogus")),
 		reporterCalls:   nil,
 	}, {
 		label:           "broken get k8s svc",
 		namespace:       testNamespace,
 		name:            testRevName,
-		wantBody:        errMsg("wish this call succeeded"),
-		wantCode:        http.StatusInternalServerError,
+		wantBody:        errMsg("service \"real-name\" not found"),
+		wantCode:        http.StatusNotFound,
 		wantErr:         nil,
-		endpointsGetter: goodEndpointsGetter,
-		svcGetter:       erroringServiceGetter,
+		endpointsLister: endpointsLister(endpoints("bogus-namespace", testRevName, 1000)),
+		svcLister:       serviceLister(service("bogus-namespace", testRevName, "http")),
 		reporterCalls:   nil,
 	}, {
-		label:           "broken GetEndpoints",
+		label:           "broken get endpoints",
 		namespace:       testNamespace,
 		name:            testRevName,
 		wantBody:        "",
 		wantCode:        http.StatusInternalServerError,
 		wantErr:         nil,
-		endpointsGetter: brokenEndpointsCountGetter,
+		endpointsLister: endpointsLister(endpoints("bogus-namespace", testRevName, 1000)),
 		reporterCalls:   nil,
 	}}
 
@@ -432,28 +349,28 @@ func TestActivationHandler(t *testing.T) {
 
 			reporter := &fakeReporter{}
 			params := queue.BreakerParams{QueueDepth: 1000, MaxConcurrency: 1000, InitialCapacity: 0}
-			throttlerParams := activator.ThrottlerParams{
-				BreakerParams: params,
-				Logger:        TestLogger(t),
-				GetRevision:   stubRevisionGetter,
-				GetEndpoints:  test.endpointsGetter,
-				GetSKS:        stubSKSGetter,
-			}
+			throttler := activator.NewThrottler(
+				params,
+				test.endpointsLister,
+				sksLister(sks(testNamespace, testRevName)),
+				revisionLister(revision(testNamespace, testRevName)),
+				TestLogger(t))
+
 			handler := ActivationHandler{
-				Transport:     rt,
-				Logger:        TestLogger(t),
-				Reporter:      reporter,
-				Throttler:     activator.NewThrottler(throttlerParams),
-				GetProbeCount: test.gpc,
-				GetRevision:   stubRevisionGetter,
-				GetService:    stubServiceGetter,
-				GetSKS:        stubSKSGetter,
+				Transport:      rt,
+				Logger:         TestLogger(t),
+				Reporter:       reporter,
+				Throttler:      throttler,
+				GetProbeCount:  test.gpc,
+				RevisionLister: revisionLister(revision(testNamespace, testRevName)),
+				ServiceLister:  serviceLister(service(testNamespace, testRevName, "http")),
+				SksLister:      sksLister(sks(testNamespace, testRevName)),
 			}
-			if test.sksGetter != nil {
-				handler.GetSKS = test.sksGetter
+			if test.sksLister != nil {
+				handler.SksLister = test.sksLister
 			}
-			if test.svcGetter != nil {
-				handler.GetService = test.svcGetter
+			if test.svcLister != nil {
+				handler.ServiceLister = test.svcLister
 			}
 
 			resp := httptest.NewRecorder()
@@ -490,13 +407,16 @@ func TestActivationHandler_Overflow(t *testing.T) {
 		requests      = wantedSuccess + wantedFailure
 	)
 	respCh := make(chan *httptest.ResponseRecorder, requests)
-	// overall max 20 requests in the Breaker
-	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
-
 	namespace := testNamespace
 	revName := testRevName
 
-	throttler := getThrottler(breakerParams, t)
+	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+	throttler := activator.NewThrottler(
+		breakerParams,
+		endpointsLister(endpoints(namespace, revName, breakerParams.InitialCapacity)),
+		sksLister(sks(namespace, revName)),
+		revisionLister(revision(namespace, revName)),
+		TestLogger(t))
 
 	lockerCh := make(chan struct{})
 	handler := getHandler(throttler, lockerCh, t)
@@ -511,20 +431,30 @@ func TestActivationHandler_OverflowSeveralRevisions(t *testing.T) {
 		wantedSuccess   = 40
 		wantedFailure   = 2
 		overallRequests = wantedSuccess + wantedFailure
-		revisions       = 2
 	)
 
-	respCh := make(chan *httptest.ResponseRecorder, overallRequests)
+	rev1 := testRevName
+	rev2 := testRevNameOther
+	revisions := []string{rev1, rev2}
+
 	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
-	throttler := getThrottler(breakerParams, t)
+	epClient := endpointsLister(endpoints(testNamespace, rev1, breakerParams.InitialCapacity), endpoints(testNamespace, rev2, breakerParams.InitialCapacity))
+	sksClient := sksLister(sks(testNamespace, rev1), sks(testNamespace, rev2))
+	revClient := revisionLister(revision(testNamespace, rev1), revision(testNamespace, rev2))
+	svcClient := serviceLister(service(testNamespace, rev1, "http"), service(testNamespace, rev2, "http"))
+
+	respCh := make(chan *httptest.ResponseRecorder, overallRequests)
+	throttler := activator.NewThrottler(breakerParams, epClient, sksClient, revClient, TestLogger(t))
+
 	lockerCh := make(chan struct{})
 
-	for rev := 0; rev < revisions; rev++ {
-		revName := fmt.Sprintf("%s-%d", testRevName, rev)
-
+	for _, revName := range revisions {
 		handler := getHandler(throttler, lockerCh, t)
+		handler.SksLister = sksClient
+		handler.RevisionLister = revClient
+		handler.ServiceLister = svcClient
 
-		requestCount := overallRequests / revisions
+		requestCount := overallRequests / len(revisions)
 		sendRequests(requestCount, testNamespace, revName, respCh, handler)
 	}
 	assertResponses(wantedSuccess, wantedFailure, overallRequests, lockerCh, respCh, t)
@@ -540,16 +470,21 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 		fake := httptest.NewRecorder()
 		return fake.Result(), nil
 	})
-	throttler := getThrottler(breakerParams, t)
+	throttler := activator.NewThrottler(
+		breakerParams,
+		endpointsLister(endpoints(namespace, revName, breakerParams.InitialCapacity)),
+		sksLister(sks(namespace, revName)),
+		revisionLister(revision(namespace, revName)),
+		TestLogger(t))
 
 	handler := ActivationHandler{
-		Transport:   rt,
-		Logger:      TestLogger(t),
-		Reporter:    &fakeReporter{},
-		Throttler:   throttler,
-		GetRevision: stubRevisionGetter,
-		GetService:  stubServiceGetter,
-		GetSKS:      stubSKSGetter,
+		Transport:      rt,
+		Logger:         TestLogger(t),
+		Reporter:       &fakeReporter{},
+		Throttler:      throttler,
+		RevisionLister: revisionLister(revision(testNamespace, testRevName)),
+		ServiceLister:  serviceLister(service(testNamespace, testRevName, "http")),
+		SksLister:      sksLister(sks(testNamespace, testRevName)),
 	}
 
 	writer := httptest.NewRecorder()
@@ -583,24 +518,6 @@ func sendRequests(count int, namespace, revName string, respCh chan *httptest.Re
 	}
 }
 
-// getThrottler returns a fully setup Throttler with some sensible defaults for tests.
-func getThrottler(breakerParams queue.BreakerParams, t *testing.T) *activator.Throttler {
-	endpointsGetter := func(*nv1a1.ServerlessService) (int, error) {
-		// Since revisions have a concurrency of 1, this will cause the very same capacity
-		// as being set initially.
-		return breakerParams.InitialCapacity, nil
-	}
-	throttlerParams := activator.ThrottlerParams{
-		BreakerParams: breakerParams,
-		Logger:        TestLogger(t),
-		GetRevision:   stubRevisionGetter,
-		GetEndpoints:  endpointsGetter,
-		GetSKS:        stubSKSGetter,
-	}
-	throttler := activator.NewThrottler(throttlerParams)
-	return throttler
-}
-
 // getHandler returns an already setup ActivationHandler. The roundtripper is controlled
 // via the given `lockerCh`.
 func getHandler(throttler *activator.Throttler, lockerCh chan struct{}, t *testing.T) ActivationHandler {
@@ -616,13 +533,13 @@ func getHandler(throttler *activator.Throttler, lockerCh chan struct{}, t *testi
 	})
 
 	handler := ActivationHandler{
-		Transport:   rt,
-		Logger:      TestLogger(t),
-		Reporter:    &fakeReporter{},
-		Throttler:   throttler,
-		GetRevision: stubRevisionGetter,
-		GetService:  stubServiceGetter,
-		GetSKS:      stubSKSGetter,
+		Transport:      rt,
+		Logger:         TestLogger(t),
+		Reporter:       &fakeReporter{},
+		Throttler:      throttler,
+		RevisionLister: revisionLister(revision(testNamespace, testRevName)),
+		ServiceLister:  serviceLister(service(testNamespace, testRevName, "http")),
+		SksLister:      sksLister(sks(testNamespace, testRevName)),
 	}
 	return handler
 }
@@ -689,7 +606,6 @@ func assertResponses(wantedSuccess, wantedFailure, overallRequests int, lockerCh
 	if succeeded != wantedSuccess {
 		t.Errorf("successful request count = %d, want: %d", succeeded, wantedSuccess)
 	}
-
 }
 
 var ignoreDurationOption = cmpopts.IgnoreFields(reporterCall{}, "Duration")
@@ -742,4 +658,125 @@ func (f *fakeReporter) ReportResponseTime(ns, service, config, rev string, respo
 	})
 
 	return nil
+}
+
+func revision(namespace, name string) *v1alpha1.Revision {
+	return &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				serving.ConfigurationLabelKey: "config-" + testRevName,
+				serving.ServiceLabelKey:       "service-" + testRevName,
+			},
+		},
+		Spec: v1alpha1.RevisionSpec{
+			RevisionSpec: v1beta1.RevisionSpec{
+				ContainerConcurrency: 1,
+			},
+		},
+	}
+}
+
+func revisionLister(revs ...*v1alpha1.Revision) servinglisters.RevisionLister {
+	fake := servingfake.NewSimpleClientset()
+	informer := servinginformers.NewSharedInformerFactory(fake, 0)
+	revisions := informer.Serving().V1alpha1().Revisions()
+
+	for _, rev := range revs {
+		fake.Serving().Revisions(rev.Namespace).Create(rev)
+		revisions.Informer().GetIndexer().Add(rev)
+	}
+
+	return revisions.Lister()
+}
+
+func service(namespace, name string, portName string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name: portName,
+				Port: 8080,
+			}},
+		}}
+}
+
+func serviceLister(svcs ...*corev1.Service) corev1listers.ServiceLister {
+	fake := kubefake.NewSimpleClientset()
+	informer := kubeinformers.NewSharedInformerFactory(fake, 0)
+	services := informer.Core().V1().Services()
+
+	for _, svc := range svcs {
+		fake.Core().Services(svc.Namespace).Create(svc)
+		services.Informer().GetIndexer().Add(svc)
+	}
+
+	return services.Lister()
+}
+
+func sks(namespace, name string) *nv1a1.ServerlessService {
+	return &nv1a1.ServerlessService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: nv1a1.ServerlessServiceStatus{
+			// Randomize the test.
+			PrivateServiceName: name,
+			ServiceName:        helpers.AppendRandomString(name),
+		},
+	}
+}
+
+func sksLister(skss ...*nv1a1.ServerlessService) netlisters.ServerlessServiceLister {
+	fake := servingfake.NewSimpleClientset()
+	informer := servinginformers.NewSharedInformerFactory(fake, 0)
+	services := informer.Networking().V1alpha1().ServerlessServices()
+
+	for _, sks := range skss {
+		fake.Networking().ServerlessServices(sks.Namespace).Create(sks)
+		services.Informer().GetIndexer().Add(sks)
+	}
+
+	return services.Lister()
+}
+
+func endpoints(namespace, name string, count int) *corev1.Endpoints {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		}}
+
+	epAddresses := []corev1.EndpointAddress{}
+	for i := 1; i <= count; i++ {
+		ip := fmt.Sprintf("127.0.0.%v", i)
+		epAddresses = append(epAddresses, corev1.EndpointAddress{IP: ip})
+	}
+	ep.Subsets = []corev1.EndpointSubset{{
+		Addresses: epAddresses,
+	}}
+
+	return ep
+}
+
+func endpointsLister(eps ...*corev1.Endpoints) corev1listers.EndpointsLister {
+	fake := kubefake.NewSimpleClientset()
+	informer := kubeinformers.NewSharedInformerFactory(fake, 0)
+	endpoints := informer.Core().V1().Endpoints()
+
+	for _, ep := range eps {
+		fake.Core().Endpoints(ep.Namespace).Create(ep)
+		endpoints.Informer().GetIndexer().Add(ep)
+	}
+
+	return endpoints.Lister()
+}
+
+func errMsg(msg string) string {
+	return fmt.Sprintf("Error getting active endpoint: %v\n", msg)
 }

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -36,15 +36,6 @@ import (
 // ErrActivatorOverload indicates that throttler has no free slots to buffer the request.
 var ErrActivatorOverload = errors.New("activator overload")
 
-// ThrottlerParams defines the parameters of the Throttler.
-type ThrottlerParams struct {
-	BreakerParams   queue.BreakerParams
-	Logger          *zap.SugaredLogger
-	EndpointsLister corev1listers.EndpointsLister
-	SksLister       netlisters.ServerlessServiceLister
-	RevisionLister  servinglisters.RevisionLister
-}
-
 // Throttler keeps the mapping of Revisions to Breakers
 // and allows updating max concurrency dynamically of respective Breakers.
 // Max concurrency is essentially the number of semaphore tokens the Breaker has in rotation.
@@ -62,14 +53,19 @@ type Throttler struct {
 }
 
 // NewThrottler creates a new Throttler.
-func NewThrottler(params ThrottlerParams) *Throttler {
+func NewThrottler(
+	params queue.BreakerParams,
+	endpointsLister corev1listers.EndpointsLister,
+	sksLister netlisters.ServerlessServiceLister,
+	revisionLister servinglisters.RevisionLister,
+	logger *zap.SugaredLogger) *Throttler {
 	return &Throttler{
 		breakers:        make(map[RevisionID]*queue.Breaker),
-		breakerParams:   params.BreakerParams,
-		logger:          params.Logger,
-		endpointsLister: params.EndpointsLister,
-		revisionLister:  params.RevisionLister,
-		sksLister:       params.SksLister,
+		breakerParams:   params,
+		logger:          logger,
+		endpointsLister: endpointsLister,
+		revisionLister:  revisionLister,
+		sksLister:       sksLister,
 	}
 }
 

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -78,7 +78,7 @@ func (t *Throttler) Remove(rev RevisionID) {
 
 // UpdateCapacity updates the max concurrency of the Breaker corresponding to a revision.
 func (t *Throttler) UpdateCapacity(rev RevisionID, size int) error {
-	revision, err := t.revisionLister.Revisions(rev.Name).Get(rev.Name)
+	revision, err := t.revisionLister.Revisions(rev.Namespace).Get(rev.Name)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (t *Throttler) getOrCreateBreaker(rev RevisionID) (*queue.Breaker, bool) {
 // This avoids a potential deadlock in case if we missed the updates from the Endpoints informer.
 // This could happen because of a restart of the Activator or when a new one is added as part of scale out.
 func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) (err error) {
-	revision, err := t.revisionLister.Revisions(rev.Name).Get(rev.Name)
+	revision, err := t.revisionLister.Revisions(rev.Namespace).Get(rev.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -24,10 +24,13 @@ import (
 
 	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // ErrActivatorOverload indicates that throttler has no free slots to buffer the request.
@@ -35,24 +38,11 @@ var ErrActivatorOverload = errors.New("activator overload")
 
 // ThrottlerParams defines the parameters of the Throttler.
 type ThrottlerParams struct {
-	BreakerParams queue.BreakerParams
-	Logger        *zap.SugaredLogger
-	GetEndpoints  EndpointsCountGetter
-	GetSKS        SKSGetter
-	GetRevision   RevisionGetter
-}
-
-// NewThrottler creates a new Throttler.
-func NewThrottler(params ThrottlerParams) *Throttler {
-	breakers := make(map[RevisionID]*queue.Breaker)
-	return &Throttler{
-		breakers:      breakers,
-		breakerParams: params.BreakerParams,
-		logger:        params.Logger,
-		getEndpoints:  params.GetEndpoints,
-		getRevision:   params.GetRevision,
-		getSKS:        params.GetSKS,
-	}
+	BreakerParams   queue.BreakerParams
+	Logger          *zap.SugaredLogger
+	EndpointsLister corev1listers.EndpointsLister
+	SksLister       netlisters.ServerlessServiceLister
+	RevisionLister  servinglisters.RevisionLister
 }
 
 // Throttler keeps the mapping of Revisions to Breakers
@@ -62,13 +52,25 @@ func NewThrottler(params ThrottlerParams) *Throttler {
 // It enables the use case to start with max concurrency set to 0 (no requests are sent because no endpoints are available)
 // and gradually increase its value depending on the external condition (e.g. new endpoints become available)
 type Throttler struct {
-	breakers      map[RevisionID]*queue.Breaker
-	breakerParams queue.BreakerParams
-	logger        *zap.SugaredLogger
-	getEndpoints  EndpointsCountGetter
-	getRevision   RevisionGetter
-	getSKS        SKSGetter
-	mux           sync.Mutex
+	breakers        map[RevisionID]*queue.Breaker
+	breakerParams   queue.BreakerParams
+	logger          *zap.SugaredLogger
+	endpointsLister corev1listers.EndpointsLister
+	revisionLister  servinglisters.RevisionLister
+	sksLister       netlisters.ServerlessServiceLister
+	mux             sync.Mutex
+}
+
+// NewThrottler creates a new Throttler.
+func NewThrottler(params ThrottlerParams) *Throttler {
+	return &Throttler{
+		breakers:        make(map[RevisionID]*queue.Breaker),
+		breakerParams:   params.BreakerParams,
+		logger:          params.Logger,
+		endpointsLister: params.EndpointsLister,
+		revisionLister:  params.RevisionLister,
+		sksLister:       params.SksLister,
+	}
 }
 
 // Remove deletes the breaker from the bookkeeping.
@@ -80,7 +82,7 @@ func (t *Throttler) Remove(rev RevisionID) {
 
 // UpdateCapacity updates the max concurrency of the Breaker corresponding to a revision.
 func (t *Throttler) UpdateCapacity(rev RevisionID, size int) error {
-	revision, err := t.getRevision(rev)
+	revision, err := t.revisionLister.Revisions(rev.Name).Get(rev.Name)
 	if err != nil {
 		return err
 	}
@@ -137,13 +139,13 @@ func (t *Throttler) getOrCreateBreaker(rev RevisionID) (*queue.Breaker, bool) {
 // This avoids a potential deadlock in case if we missed the updates from the Endpoints informer.
 // This could happen because of a restart of the Activator or when a new one is added as part of scale out.
 func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) (err error) {
-	revision, err := t.getRevision(rev)
+	revision, err := t.revisionLister.Revisions(rev.Name).Get(rev.Name)
 	if err != nil {
 		return err
 	}
 
 	// SKS name matches revision name.
-	sks, err := t.getSKS(rev.Namespace, rev.Name)
+	sks, err := t.sksLister.ServerlessServices(rev.Namespace).Get(rev.Name)
 	if err != nil {
 		return err
 	}
@@ -151,7 +153,7 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 	// We have to read the private service endpoints in activator
 	// in order to count the serving pod count, since the public one
 	// may point at ourselves.
-	size, err := t.getEndpoints(sks)
+	size, err := resources.FetchReadyAddressCount(t.endpointsLister, sks.Namespace, sks.Status.PrivateServiceName)
 	if err != nil {
 		return err
 	}

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -27,16 +27,25 @@ import (
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	servingfake "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions"
+	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/queue"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 var (
-	revID   = RevisionID{"good-namespace", "good-name"}
-	errTest = errors.New("some error")
+	testNamespace = "good-namespace"
+	testRevision  = "good-name"
+	revID         = RevisionID{testNamespace, testRevision}
+	errTest       = errors.New("some error")
 )
 
 const (
@@ -44,90 +53,106 @@ const (
 	initCapacity          = 0
 )
 
-func existingRevisionGetter(concurrency v1beta1.RevisionContainerConcurrencyType) func(RevisionID) (*v1alpha1.Revision, error) {
-	return func(RevisionID) (*v1alpha1.Revision, error) {
-		return &v1alpha1.Revision{
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1beta1.RevisionSpec{
-					ContainerConcurrency: concurrency,
-				},
+func revisionLister(namespace, name string, concurrency v1beta1.RevisionContainerConcurrencyType) servinglisters.RevisionLister {
+	rev := &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.RevisionSpec{
+			RevisionSpec: v1beta1.RevisionSpec{
+				ContainerConcurrency: concurrency,
 			},
-		}, nil
+		},
 	}
-}
-func erroringRevisionGetter(RevisionID) (*v1alpha1.Revision, error) {
-	return nil, errTest
+
+	fake := servingfake.NewSimpleClientset(rev)
+	informer := servinginformers.NewSharedInformerFactory(fake, 0)
+	revisions := informer.Serving().V1alpha1().Revisions()
+	revisions.Informer().GetIndexer().Add(rev)
+
+	return revisions.Lister()
 }
 
-func existingEndpointsGetter(count int) EndpointsCountGetter {
-	return func(*nv1a1.ServerlessService) (int, error) {
-		return count, nil
+func endpointsLister(namespace, name string, count int) corev1listers.EndpointsLister {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Subsets: endpointsSubset(count, 1),
 	}
-}
-func erroringEndpointsCountGetter(*nv1a1.ServerlessService) (int, error) {
-	return initCapacity, errTest
+
+	fake := kubefake.NewSimpleClientset(ep)
+	informer := kubeinformers.NewSharedInformerFactory(fake, 0)
+	endpoints := informer.Core().V1().Endpoints()
+	endpoints.Informer().GetIndexer().Add(ep)
+
+	return endpoints.Lister()
 }
 
-func sksGetError(string, string) (*nv1a1.ServerlessService, error) {
-	return nil, errTest
-}
-
-func sksGetSuccess(namespace, name string) (*nv1a1.ServerlessService, error) {
-	return &nv1a1.ServerlessService{
+func sksLister(namespace, name string) netlisters.ServerlessServiceLister {
+	sks := &nv1a1.ServerlessService{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 		},
 		Status: nv1a1.ServerlessServiceStatus{
-			// Randomize the test.
-			PrivateServiceName: helpers.AppendRandomString(name),
+			PrivateServiceName: name,
 			ServiceName:        helpers.AppendRandomString(name),
 		},
-	}, nil
+	}
+
+	fake := servingfake.NewSimpleClientset(sks)
+	informer := servinginformers.NewSharedInformerFactory(fake, 0)
+	skss := informer.Networking().V1alpha1().ServerlessServices()
+	skss.Informer().GetIndexer().Add(sks)
+
+	return skss.Lister()
 }
 
 func TestThrottler_UpdateCapacity(t *testing.T) {
 	samples := []struct {
 		label          string
-		revisionGetter RevisionGetter
+		revisionLister servinglisters.RevisionLister
 		numEndpoints   int
 		maxConcurrency int
 		want           int
-		wantError      error
+		wantError      bool
 	}{{
 		label:          "all good",
-		revisionGetter: existingRevisionGetter(10),
+		revisionLister: revisionLister(testNamespace, testRevision, 10),
 		numEndpoints:   1,
 		maxConcurrency: defaultMaxConcurrency,
 		want:           10,
 	}, {
 		label:          "unlimited concurrency",
-		revisionGetter: existingRevisionGetter(0),
+		revisionLister: revisionLister(testNamespace, testRevision, 0),
 		numEndpoints:   1,
 		maxConcurrency: 100,
 		want:           100,
 	}, {
 		label:          "non-existing revision",
-		revisionGetter: erroringRevisionGetter,
+		revisionLister: revisionLister("bogus-namespace", testRevision, 10),
 		numEndpoints:   1,
 		maxConcurrency: defaultMaxConcurrency,
 		want:           0,
-		wantError:      errTest,
+		wantError:      true,
 	}, {
 		label:          "exceeds maxConcurrency",
-		revisionGetter: existingRevisionGetter(10),
+		revisionLister: revisionLister(testNamespace, testRevision, 10),
 		numEndpoints:   1,
 		maxConcurrency: 5,
 		want:           5,
 	}, {
 		label:          "no endpoints",
-		revisionGetter: existingRevisionGetter(1),
+		revisionLister: revisionLister(testNamespace, testRevision, 1),
 		numEndpoints:   0,
 		maxConcurrency: 5,
 		want:           0,
 	}, {
 		label:          "no endpoints, unlimited concurrency",
-		revisionGetter: existingRevisionGetter(0),
+		revisionLister: revisionLister(testNamespace, testRevision, 0),
 		numEndpoints:   0,
 		maxConcurrency: 5,
 		want:           0,
@@ -135,15 +160,22 @@ func TestThrottler_UpdateCapacity(t *testing.T) {
 	for _, s := range samples {
 		t.Run(s.label, func(t *testing.T) {
 			throttler := getThrottler(
-				s.maxConcurrency, s.revisionGetter, nil, /*getEndpoints*/
-				nil /*getSKS*/, TestLogger(t), initCapacity)
+				s.maxConcurrency,
+				s.revisionLister,
+				nil, /*endpointsLister*/
+				nil, /*sksLister*/
+				TestLogger(t),
+				initCapacity)
+
 			err := throttler.UpdateCapacity(revID, s.numEndpoints)
-			if got, want := err, s.wantError; got != want {
-				t.Errorf("Update capacity error = %v, want: %v", got, want)
+			if err == nil && s.wantError {
+				t.Errorf("UpdateCapacity() did not return an error")
+			} else if err != nil && !s.wantError {
+				t.Errorf("UpdateCapacity() = %v, wanted no error", err)
 			}
 			if s.want > 0 {
 				if got := throttler.breakers[revID].Capacity(); got != s.want {
-					t.Errorf("Breaker Capacity = %d, want: %d", got, s.want)
+					t.Errorf("breakers[revID].Capacity() = %d, want %d", got, s.want)
 				}
 			}
 		})
@@ -155,55 +187,62 @@ func TestThrottler_Try(t *testing.T) {
 	samples := []struct {
 		label           string
 		addCapacity     bool
+		revisionLister  servinglisters.RevisionLister
+		endpointsLister corev1listers.EndpointsLister
+		sksLister       netlisters.ServerlessServiceLister
 		wantCalls       int
-		wantError       error
-		revisionGetter  RevisionGetter
-		endpointsGetter EndpointsCountGetter
-		sksGetter       SKSGetter
+		wantError       bool
 	}{{
 		label:           "all good",
 		addCapacity:     true,
+		revisionLister:  revisionLister(testNamespace, testRevision, 10),
+		endpointsLister: endpointsLister(testNamespace, testRevision, 0),
+		sksLister:       sksLister(testNamespace, testRevision),
 		wantCalls:       1,
-		revisionGetter:  existingRevisionGetter(10),
-		endpointsGetter: existingEndpointsGetter(0),
-		sksGetter:       sksGetSuccess,
 	}, {
 		label:           "non-existing revision",
 		addCapacity:     true,
+		revisionLister:  revisionLister("bogus-namespace", testRevision, 10),
+		endpointsLister: endpointsLister(testNamespace, testRevision, 0),
+		sksLister:       sksLister(testNamespace, testRevision),
 		wantCalls:       0,
-		revisionGetter:  erroringRevisionGetter,
-		endpointsGetter: existingEndpointsGetter(0),
-		sksGetter:       sksGetSuccess,
-		wantError:       errTest,
+		wantError:       true,
 	}, {
 		label:           "error getting SKS",
+		revisionLister:  revisionLister(testNamespace, testRevision, 10),
+		endpointsLister: endpointsLister(testNamespace, testRevision, 1),
+		sksLister:       sksLister("bogus-namespace", testRevision),
 		wantCalls:       0,
-		revisionGetter:  existingRevisionGetter(10),
-		endpointsGetter: existingEndpointsGetter(1),
-		sksGetter:       sksGetError,
-		wantError:       errTest,
+		wantError:       true,
 	}, {
 		label:           "error getting endpoint",
+		revisionLister:  revisionLister(testNamespace, testRevision, 10),
+		endpointsLister: endpointsLister("bogus-namespace", testRevision, 0),
+		sksLister:       sksLister(testNamespace, testRevision),
 		wantCalls:       0,
-		wantError:       errTest,
-		revisionGetter:  existingRevisionGetter(10),
-		endpointsGetter: erroringEndpointsCountGetter,
-		sksGetter:       sksGetSuccess,
+		wantError:       true,
 	}}
 	for _, s := range samples {
 		t.Run(s.label, func(t *testing.T) {
 			var called int
 			throttler := getThrottler(
-				defaultMaxConcurrency, s.revisionGetter, s.endpointsGetter,
-				s.sksGetter, TestLogger(t), initCapacity)
+				defaultMaxConcurrency,
+				s.revisionLister,
+				s.endpointsLister,
+				s.sksLister,
+				TestLogger(t),
+				initCapacity)
+
 			if s.addCapacity {
 				throttler.UpdateCapacity(revID, 1)
 			}
 			err := throttler.Try(revID, func() {
 				called++
 			})
-			if got, want := err, s.wantError; got != want {
-				t.Errorf("Update capacity error = %v, want: %v", got, want)
+			if err == nil && s.wantError {
+				t.Errorf("UpdateCapacity() did not return an error")
+			} else if err != nil && !s.wantError {
+				t.Errorf("UpdateCapacity() = %v, wanted no error", err)
 			}
 			if got, want := called, s.wantCalls; got != want {
 				t.Errorf("Unexpected number of function runs in Try = %d, want: %d", got, want)
@@ -216,9 +255,13 @@ func TestThrottler_TryOverload(t *testing.T) {
 	maxConcurrency := 1
 	initialCapacity := 1
 	queueLength := 1
-	th := getThrottler(maxConcurrency, existingRevisionGetter(1),
-		existingEndpointsGetter(1), sksGetSuccess,
-		TestLogger(t), initialCapacity)
+	th := getThrottler(
+		maxConcurrency,
+		revisionLister(testNamespace, testRevision, 1),
+		endpointsLister(testNamespace, testRevision, 1),
+		sksLister(testNamespace, testRevision),
+		TestLogger(t),
+		initialCapacity)
 
 	doneCh := make(chan struct{})
 	errCh := make(chan error)
@@ -290,9 +333,13 @@ func TestUpdateEndpoints(t *testing.T) {
 	for _, s := range samples {
 		t.Run(s.label, func(t *testing.T) {
 			throttler := getThrottler(
-				defaultMaxConcurrency, existingRevisionGetter(
-					v1beta1.RevisionContainerConcurrencyType(revisionConcurrency)),
-				existingEndpointsGetter(0), sksGetSuccess, TestLogger(t), s.initCapacity)
+				defaultMaxConcurrency,
+				revisionLister(testNamespace, testRevision, v1beta1.RevisionContainerConcurrencyType(revisionConcurrency)),
+				endpointsLister(testNamespace, testRevision, 0),
+				sksLister(testNamespace, testRevision),
+				TestLogger(t),
+				s.initCapacity)
+
 			breaker := queue.NewBreaker(throttler.breakerParams)
 			throttler.breakers[revID] = breaker
 			endpointsAfter := corev1.Endpoints{
@@ -309,27 +356,22 @@ func TestUpdateEndpoints(t *testing.T) {
 		})
 	}
 }
-func TestUpdateCapacityFail(t *testing.T) {
-	throttler := getThrottler(
-		defaultMaxConcurrency, erroringRevisionGetter, nil, nil,
-		TestLogger(t), int(1))
-	if got, want := throttler.UpdateCapacity(revID, 42), errTest; got != want {
-		t.Errorf("UpdateCapacity error = %v, want: %v", got, want)
-	}
-}
 
 func TestThrottler_Remove(t *testing.T) {
 	throttler := getThrottler(
-		defaultMaxConcurrency, existingRevisionGetter(10),
-		existingEndpointsGetter(0), sksGetSuccess,
-		TestLogger(t), initCapacity)
-	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+		defaultMaxConcurrency,
+		revisionLister(testNamespace, testRevision, 10),
+		endpointsLister(testNamespace, testRevision, 0),
+		sksLister(testNamespace, testRevision),
+		TestLogger(t),
+		initCapacity)
 
+	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
 	if got := len(throttler.breakers); got != 1 {
 		t.Errorf("Number of Breakers created = %d, want: 1", got)
 	}
-	throttler.Remove(revID)
 
+	throttler.Remove(revID)
 	if got := len(throttler.breakers); got != 0 {
 		t.Errorf("Number of Breakers created = %d, want: %d", got, 0)
 	}
@@ -337,9 +379,13 @@ func TestThrottler_Remove(t *testing.T) {
 
 func TestHelper_DeleteBreaker(t *testing.T) {
 	throttler := getThrottler(
-		int(20), existingRevisionGetter(10),
-		existingEndpointsGetter(0), sksGetSuccess,
-		TestLogger(t), initCapacity)
+		20,
+		revisionLister(testNamespace, testRevision, 10),
+		endpointsLister(testNamespace, testRevision, 0),
+		sksLister(testNamespace, testRevision),
+		TestLogger(t),
+		initCapacity)
+
 	endpoints := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      revID.Name + "-suffix",
@@ -351,6 +397,7 @@ func TestHelper_DeleteBreaker(t *testing.T) {
 	if got := len(throttler.breakers); got != 1 {
 		t.Errorf("Breaker map size got %d, want: 1", got)
 	}
+
 	throttler.DeleteBreaker(endpoints)
 	if len(throttler.breakers) != 0 {
 		t.Errorf("Breaker map is not empty, got: %v", throttler.breakers)
@@ -358,8 +405,10 @@ func TestHelper_DeleteBreaker(t *testing.T) {
 }
 
 func getThrottler(
-	maxConcurrency int, revisionGetter RevisionGetter,
-	endpointsGetter EndpointsCountGetter, sksGetter SKSGetter,
+	maxConcurrency int,
+	revisionLister servinglisters.RevisionLister,
+	endpointsLister corev1listers.EndpointsLister,
+	sksLister netlisters.ServerlessServiceLister,
 	logger *zap.SugaredLogger,
 	initCapacity int) *Throttler {
 	params := queue.BreakerParams{
@@ -367,14 +416,7 @@ func getThrottler(
 		MaxConcurrency:  maxConcurrency,
 		InitialCapacity: initCapacity,
 	}
-	throttlerParams := ThrottlerParams{
-		BreakerParams: params,
-		Logger:        logger,
-		GetRevision:   revisionGetter,
-		GetEndpoints:  endpointsGetter,
-		GetSKS:        sksGetter,
-	}
-	return NewThrottler(throttlerParams)
+	return NewThrottler(params, endpointsLister, sksLister, revisionLister, logger)
 }
 
 func endpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is the only place we're relying on proxying listers into getter functions. This gets rid of that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
