### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -156,7 +156,7 @@ func newTestClusterIngress(r *v1alpha1.Route) *netv1alpha1.ClusterIngress {
 			Active: true,
 		}}}}
 	tls := []netv1alpha1.ClusterIngressTLS{
-		netv1alpha1.ClusterIngressTLS{
+		{
 			Hosts:             []string{"test-route.test-ns.example.com"},
 			PrivateKey:        "tls.key",
 			SecretName:        "test-secret",

--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -570,7 +570,7 @@ func TestMakeClusterIngress_WithTLS(t *testing.T) {
 		},
 	}
 	tls := []netv1alpha1.ClusterIngressTLS{
-		netv1alpha1.ClusterIngressTLS{
+		{
 			Hosts:             []string{"*.default.domain.com"},
 			PrivateKey:        "tls.key",
 			SecretName:        "secret",

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1698,7 +1698,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					},
 				},
 				[]netv1alpha1.ClusterIngressTLS{
-					netv1alpha1.ClusterIngressTLS{
+					{
 						Hosts:           []string{"becomes-ready.default.example.com"},
 						SecretName:      "route-12-34",
 						SecretNamespace: "default",
@@ -1769,7 +1769,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					},
 				},
 				[]netv1alpha1.ClusterIngressTLS{
-					netv1alpha1.ClusterIngressTLS{
+					{
 						Hosts:           []string{"becomes-ready.default.example.com"},
 						SecretName:      "route-12-34",
 						SecretNamespace: "default",

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -1015,9 +1015,9 @@ func TestTagDomain(t *testing.T) {
 func TestGetDomains(t *testing.T) {
 	domain := "default.example.com"
 	targets := map[string]RevisionTargets{
-		"":       RevisionTargets{},
-		"test-1": RevisionTargets{},
-		"test-2": RevisionTargets{},
+		"":       {},
+		"test-1": {},
+		"test-2": {},
 	}
 	want := []string{"default.example.com", "test-1.default.example.com", "test-2.default.example.com"}
 	got := GetDomains(domain, targets)


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
