### PR TITLE
Don't overwrite K-Original-Host

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -276,7 +276,10 @@ func RewriteHostIn(r *http.Request) {
 	h := r.Host
 	r.Host = ""
 	r.Header.Del("Host")
-	r.Header.Set(OriginalHostHeader, h)
+	// Don't overwrite an existing OriginalHostHeader.
+	if r.Header.Get(OriginalHostHeader) == "" {
+		r.Header.Set(OriginalHostHeader, h)
+	}
 }
 
 // RewriteHostOut undoes the `RewriteHostIn` action.

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -536,7 +536,23 @@ func TestRewriteHost(t *testing.T) {
 	}
 
 	if got, want := r.Header.Get(OriginalHostHeader), "love.is"; got != want {
-		t.Errorf("r.Header[%s] = %q	, want: %q", OriginalHostHeader, got, want)
+		t.Errorf("r.Header[%s] = %q, want: %q", OriginalHostHeader, got, want)
+	}
+
+	// Do it again, but make sure that the ORIGINAL domain is still preserved.
+	r.Header.Set("Host", "hate.is")
+	RewriteHostIn(r)
+
+	if got, want := r.Host, ""; got != want {
+		t.Errorf("r.Host = %q, want: %q", got, want)
+	}
+
+	if got, want := r.Header.Get("Host"), ""; got != want {
+		t.Errorf("r.Header['Host'] = %q, want: %q", got, want)
+	}
+
+	if got, want := r.Header.Get(OriginalHostHeader), "love.is"; got != want {
+		t.Errorf("r.Header[%s] = %q, want: %q", OriginalHostHeader, got, want)
 	}
 
 	RewriteHostOut(r)


### PR DESCRIPTION
When we're clearing the Host header, only put it into K-Original-Host when
it isn't already specified.  This enables us to front Knative services
with an Istio VirtualService for "vanity domains" that rewrite from e.g.
`www.mattmoor.io` to `foo.bar.mattmoor.io` by sticking the original host
in this header.

Fixes: https://github.com/knative/serving/issues/4029

cc @vaikas-google 