### PR TITLE
Move informer handler into throttler.

### DIFF
--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -22,15 +22,21 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging/logkey"
+	"github.com/knative/serving/pkg/apis/networking"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/queue"
+	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 // ErrActivatorOverload indicates that throttler has no free slots to buffer the request.
@@ -55,18 +61,40 @@ type Throttler struct {
 // NewThrottler creates a new Throttler.
 func NewThrottler(
 	params queue.BreakerParams,
-	endpointsLister corev1listers.EndpointsLister,
+	endpointsInformer corev1informers.EndpointsInformer,
 	sksLister netlisters.ServerlessServiceLister,
 	revisionLister servinglisters.RevisionLister,
 	logger *zap.SugaredLogger) *Throttler {
-	return &Throttler{
+
+	throttler := &Throttler{
 		breakers:        make(map[RevisionID]*queue.Breaker),
 		breakerParams:   params,
 		logger:          logger,
-		endpointsLister: endpointsLister,
+		endpointsLister: endpointsInformer.Lister(),
 		revisionLister:  revisionLister,
 		sksLister:       sksLister,
 	}
+
+	// Update/create the breaker in the throttler when the number of endpoints changes.
+	// Pass only the endpoints created by revisions.
+	// TODO(greghaynes) we have to allow unset and use the old RevisionUID filter for backwards compat.
+	// When we can assume our ServiceTypeKey label is present in all services we can filter all but
+	// networking.ServiceTypeKey == networking.ServiceTypePublic
+	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: reconciler.ChainFilterFuncs(
+			reconciler.LabelExistsFilterFunc(serving.RevisionUID),
+			// We are only interested in the private services, since that is
+			// what is populated by the actual revision backends.
+			reconciler.LabelFilterFunc(networking.ServiceTypeKey, string(networking.ServiceTypePrivate), true),
+		),
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    throttler.endpointsUpdated,
+			UpdateFunc: controller.PassNew(throttler.endpointsUpdated),
+			DeleteFunc: throttler.endpointsDeleted,
+		},
+	})
+
+	return throttler
 }
 
 // Remove deletes the breaker from the bookkeeping.
@@ -162,7 +190,7 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker) 
 // that do not belong to any revision).
 //
 // This function must not be called in parallel to not induce a wrong order of events.
-func (t *Throttler) UpdateEndpoints(newObj interface{}) {
+func (t *Throttler) endpointsUpdated(newObj interface{}) {
 	endpoints := newObj.(*corev1.Endpoints)
 	addresses := resources.ReadyAddressCount(endpoints)
 	revID := RevisionID{endpoints.Namespace, resources.ParentResourceFromService(endpoints.Name)}
@@ -173,7 +201,7 @@ func (t *Throttler) UpdateEndpoints(newObj interface{}) {
 
 // DeleteBreaker is a handler function to be used by the Endpoints informer.
 // It removes the Breaker from the Throttler bookkeeping.
-func (t *Throttler) DeleteBreaker(obj interface{}) {
+func (t *Throttler) endpointsDeleted(obj interface{}) {
 	ep := obj.(*corev1.Endpoints)
 	name := resources.ParentResourceFromService(ep.Name)
 	revID := RevisionID{ep.Namespace, name}

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -18,12 +18,18 @@ package activator
 
 import (
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"go.uber.org/zap"
 
+	"github.com/knative/pkg/controller"
 	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/test/helpers"
+	"github.com/knative/serving/pkg/apis/networking"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	servingfake "github.com/knative/serving/pkg/client/clientset/versioned/fake"
@@ -36,8 +42,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -102,7 +108,7 @@ func TestThrottler_UpdateCapacity(t *testing.T) {
 			throttler := getThrottler(
 				s.maxConcurrency,
 				s.revisionLister,
-				nil, /*endpointsLister*/
+				endpointsInformer(testNamespace, testRevision, 1),
 				nil, /*sksLister*/
 				TestLogger(t),
 				initCapacity)
@@ -125,42 +131,42 @@ func TestThrottler_UpdateCapacity(t *testing.T) {
 func TestThrottler_Try(t *testing.T) {
 	defer ClearAll()
 	samples := []struct {
-		label           string
-		addCapacity     bool
-		revisionLister  servinglisters.RevisionLister
-		endpointsLister corev1listers.EndpointsLister
-		sksLister       netlisters.ServerlessServiceLister
-		wantCalls       int
-		wantError       bool
+		label             string
+		addCapacity       bool
+		revisionLister    servinglisters.RevisionLister
+		endpointsInformer corev1informers.EndpointsInformer
+		sksLister         netlisters.ServerlessServiceLister
+		wantCalls         int
+		wantError         bool
 	}{{
-		label:           "all good",
-		addCapacity:     true,
-		revisionLister:  revisionLister(testNamespace, testRevision, 10),
-		endpointsLister: endpointsLister(testNamespace, testRevision, 0),
-		sksLister:       sksLister(testNamespace, testRevision),
-		wantCalls:       1,
+		label:             "all good",
+		addCapacity:       true,
+		revisionLister:    revisionLister(testNamespace, testRevision, 10),
+		endpointsInformer: endpointsInformer(testNamespace, testRevision, 0),
+		sksLister:         sksLister(testNamespace, testRevision),
+		wantCalls:         1,
 	}, {
-		label:           "non-existing revision",
-		addCapacity:     true,
-		revisionLister:  revisionLister("bogus-namespace", testRevision, 10),
-		endpointsLister: endpointsLister(testNamespace, testRevision, 0),
-		sksLister:       sksLister(testNamespace, testRevision),
-		wantCalls:       0,
-		wantError:       true,
+		label:             "non-existing revision",
+		addCapacity:       true,
+		revisionLister:    revisionLister("bogus-namespace", testRevision, 10),
+		endpointsInformer: endpointsInformer(testNamespace, testRevision, 0),
+		sksLister:         sksLister(testNamespace, testRevision),
+		wantCalls:         0,
+		wantError:         true,
 	}, {
-		label:           "error getting SKS",
-		revisionLister:  revisionLister(testNamespace, testRevision, 10),
-		endpointsLister: endpointsLister(testNamespace, testRevision, 1),
-		sksLister:       sksLister("bogus-namespace", testRevision),
-		wantCalls:       0,
-		wantError:       true,
+		label:             "error getting SKS",
+		revisionLister:    revisionLister(testNamespace, testRevision, 10),
+		endpointsInformer: endpointsInformer(testNamespace, testRevision, 1),
+		sksLister:         sksLister("bogus-namespace", testRevision),
+		wantCalls:         0,
+		wantError:         true,
 	}, {
-		label:           "error getting endpoint",
-		revisionLister:  revisionLister(testNamespace, testRevision, 10),
-		endpointsLister: endpointsLister("bogus-namespace", testRevision, 0),
-		sksLister:       sksLister(testNamespace, testRevision),
-		wantCalls:       0,
-		wantError:       true,
+		label:             "error getting endpoint",
+		revisionLister:    revisionLister(testNamespace, testRevision, 10),
+		endpointsInformer: endpointsInformer("bogus-namespace", testRevision, 0),
+		sksLister:         sksLister(testNamespace, testRevision),
+		wantCalls:         0,
+		wantError:         true,
 	}}
 	for _, s := range samples {
 		t.Run(s.label, func(t *testing.T) {
@@ -168,7 +174,7 @@ func TestThrottler_Try(t *testing.T) {
 			throttler := getThrottler(
 				defaultMaxConcurrency,
 				s.revisionLister,
-				s.endpointsLister,
+				s.endpointsInformer,
 				s.sksLister,
 				TestLogger(t),
 				initCapacity)
@@ -198,7 +204,7 @@ func TestThrottler_TryOverload(t *testing.T) {
 	th := getThrottler(
 		maxConcurrency,
 		revisionLister(testNamespace, testRevision, 1),
-		endpointsLister(testNamespace, testRevision, 1),
+		endpointsInformer(testNamespace, testRevision, 1),
 		sksLister(testNamespace, testRevision),
 		TestLogger(t),
 		initialCapacity)
@@ -238,70 +244,11 @@ func TestThrottler_TryOverload(t *testing.T) {
 	}
 }
 
-func TestUpdateEndpoints(t *testing.T) {
-	revisionConcurrency := 10
-
-	samples := []struct {
-		label          string
-		endpointsAfter int
-		wantCapacity   int
-		initCapacity   int
-	}{{
-		label:          "add single endpoint",
-		endpointsAfter: 1,
-		wantCapacity:   1 * revisionConcurrency,
-	}, {
-		label:          "add several endpoints",
-		endpointsAfter: 2,
-		wantCapacity:   2 * revisionConcurrency,
-	}, {
-		label:          "do nothing",
-		endpointsAfter: 1,
-		wantCapacity:   1 * revisionConcurrency,
-		initCapacity:   10,
-	}, {
-		label:          "reduce endpoints",
-		endpointsAfter: 0,
-		wantCapacity:   0,
-		initCapacity:   10,
-	}, {
-		label:          "exceed max concurrency",
-		endpointsAfter: 101 * revisionConcurrency,
-		wantCapacity:   defaultMaxConcurrency,
-	}}
-
-	for _, s := range samples {
-		t.Run(s.label, func(t *testing.T) {
-			throttler := getThrottler(
-				defaultMaxConcurrency,
-				revisionLister(testNamespace, testRevision, v1beta1.RevisionContainerConcurrencyType(revisionConcurrency)),
-				endpointsLister(testNamespace, testRevision, 0),
-				sksLister(testNamespace, testRevision),
-				TestLogger(t),
-				s.initCapacity)
-
-			breaker := queue.NewBreaker(throttler.breakerParams)
-			throttler.breakers[revID] = breaker
-			endpointsAfter := corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      helpers.AppendRandomString(revID.Name),
-					Namespace: revID.Namespace,
-				},
-				Subsets: endpointsSubset(s.endpointsAfter, 1),
-			}
-			throttler.UpdateEndpoints(&endpointsAfter)
-			if got := breaker.Capacity(); got != s.wantCapacity {
-				t.Errorf("Breaker capacity = %d, want: %d", got, s.wantCapacity)
-			}
-		})
-	}
-}
-
 func TestThrottler_Remove(t *testing.T) {
 	throttler := getThrottler(
 		defaultMaxConcurrency,
 		revisionLister(testNamespace, testRevision, 10),
-		endpointsLister(testNamespace, testRevision, 0),
+		endpointsInformer(testNamespace, testRevision, 0),
 		sksLister(testNamespace, testRevision),
 		TestLogger(t),
 		initCapacity)
@@ -317,28 +264,64 @@ func TestThrottler_Remove(t *testing.T) {
 	}
 }
 
-func TestHelper_DeleteBreaker(t *testing.T) {
+func TestHelper_ReactToEndpoints(t *testing.T) {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRevision + "-service",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				serving.RevisionUID:       "test",
+				networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
+			},
+		},
+		Subsets: endpointsSubset(0, 1),
+	}
+
+	fake := kubefake.NewSimpleClientset()
+	informer := kubeinformers.NewSharedInformerFactory(fake, 0)
+	endpointsInformer := informer.Core().V1().Endpoints()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	controller.StartInformers(stopCh, endpointsInformer.Informer())
+
 	throttler := getThrottler(
-		20,
+		200,
 		revisionLister(testNamespace, testRevision, 10),
-		endpointsLister(testNamespace, testRevision, 0),
+		endpointsInformer,
 		sksLister(testNamespace, testRevision),
 		TestLogger(t),
 		initCapacity)
 
-	endpoints := &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      revID.Name + "-suffix",
-			Namespace: revID.Namespace,
-		},
-	}
-	revID := RevisionID{Namespace: revID.Namespace, Name: revID.Name}
-	throttler.breakers[revID] = queue.NewBreaker(throttler.breakerParams)
+	// Breaker is created with 0 ready addresses.
+	fake.CoreV1().Endpoints(ep.Namespace).Create(ep)
+	wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
+		return len(throttler.breakers) == 1, nil
+	})
 	if got := len(throttler.breakers); got != 1 {
 		t.Errorf("Breaker map size got %d, want: 1", got)
 	}
+	breaker := throttler.breakers[RevisionID{Name: testRevision, Namespace: testNamespace}]
+	if got := breaker.Capacity(); got != 0 {
+		t.Errorf("Capacity() = %v, want 0", got)
+	}
 
-	throttler.DeleteBreaker(endpoints)
+	// Add 10 addresses, 10 * 10 = 100 = new capacity
+	newEp := ep.DeepCopy()
+	newEp.Subsets = endpointsSubset(10, 1)
+	fake.Core().Endpoints(ep.Namespace).Update(newEp)
+	wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
+		return breaker.Capacity() == 100, nil
+	})
+	if got := breaker.Capacity(); got != 100 {
+		t.Errorf("Capacity() = %v, want 100", got)
+	}
+
+	// Removing the endpoints causes the breaker to be removed.
+	fake.Core().Endpoints(ep.Namespace).Delete(ep.Name, &metav1.DeleteOptions{})
+	wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
+		return len(throttler.breakers) == 0, nil
+	})
 	if len(throttler.breakers) != 0 {
 		t.Errorf("Breaker map is not empty, got: %v", throttler.breakers)
 	}
@@ -365,7 +348,7 @@ func revisionLister(namespace, name string, concurrency v1beta1.RevisionContaine
 	return revisions.Lister()
 }
 
-func endpointsLister(namespace, name string, count int) corev1listers.EndpointsLister {
+func endpointsInformer(namespace, name string, count int) corev1informers.EndpointsInformer {
 	ep := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -379,7 +362,7 @@ func endpointsLister(namespace, name string, count int) corev1listers.EndpointsL
 	endpoints := informer.Core().V1().Endpoints()
 	endpoints.Informer().GetIndexer().Add(ep)
 
-	return endpoints.Lister()
+	return endpoints
 }
 
 func sksLister(namespace, name string) netlisters.ServerlessServiceLister {
@@ -405,7 +388,7 @@ func sksLister(namespace, name string) netlisters.ServerlessServiceLister {
 func getThrottler(
 	maxConcurrency int,
 	revisionLister servinglisters.RevisionLister,
-	endpointsLister corev1listers.EndpointsLister,
+	endpointsInformer corev1informers.EndpointsInformer,
 	sksLister netlisters.ServerlessServiceLister,
 	logger *zap.SugaredLogger,
 	initCapacity int) *Throttler {
@@ -414,7 +397,7 @@ func getThrottler(
 		MaxConcurrency:  maxConcurrency,
 		InitialCapacity: initCapacity,
 	}
-	return NewThrottler(params, endpointsLister, sksLister, revisionLister, logger)
+	return NewThrottler(params, endpointsInformer, sksLister, revisionLister, logger)
 }
 
 func endpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This moves the event handlers on the endpointsInformer into the throttler itself to make them testable and to encapsulate them where they belong.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
