### PR TITLE
Make scaler implementation detail of the KPA

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -94,10 +94,9 @@ func main() {
 	// Set up scalers.
 	// uniScalerFactory depends endpointsInformer to be set.
 	multiScaler := autoscaler.NewMultiScaler(stopCh, uniScalerFactoryFunc(endpointsInformer), logger)
-	scaler := kpa.NewScaler(opt)
 
 	controllers := []*controller.Impl{
-		kpa.NewController(&opt, paInformer, sksInformer, serviceInformer, endpointsInformer, multiScaler, collector, scaler),
+		kpa.NewController(&opt, paInformer, sksInformer, serviceInformer, endpointsInformer, multiScaler, collector),
 		hpa.NewController(&opt, paInformer, sksInformer, hpaInformer),
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -49,8 +49,8 @@ type scaler struct {
 	activatorProbe func(pa *pav1alpha1.PodAutoscaler) (bool, error)
 }
 
-// NewScaler creates a scaler.
-func NewScaler(opt reconciler.Options) Scaler {
+// newScaler creates a scaler.
+func newScaler(opt *reconciler.Options) *scaler {
 	ks := &scaler{
 		// Wrap it in a cache, so that we don't stamp out a new
 		// informer/lister each time.
@@ -82,7 +82,7 @@ func activatorProbe(pa *pav1alpha1.PodAutoscaler) (bool, error) {
 
 // podScalableTypedInformerFactory returns a duck.InformerFactory that returns
 // lister/informer pairs for PodScalable resources.
-func podScalableTypedInformerFactory(opt reconciler.Options) duck.InformerFactory {
+func podScalableTypedInformerFactory(opt *reconciler.Options) duck.InformerFactory {
 	return &duck.TypedInformerFactory{
 		Client:       opt.DynamicClientSet,
 		Type:         &pav1alpha1.PodScalable{},

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -208,7 +208,7 @@ func TestScaler(t *testing.T) {
 			servingClient := fakeKna.NewSimpleClientset()
 			dynamicClient := fakedynamic.NewSimpleDynamicClient(NewScheme())
 
-			opts := reconciler.Options{
+			opts := &reconciler.Options{
 				DynamicClientSet: dynamicClient,
 				Logger:           logtesting.TestLogger(t),
 				ConfigMapWatcher: newConfigWatcher(),
@@ -216,7 +216,7 @@ func TestScaler(t *testing.T) {
 
 			revision := newRevision(t, servingClient, test.minScale, test.maxScale)
 			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
-			revisionScaler := NewScaler(opts).(*scaler)
+			revisionScaler := newScaler(opts)
 			if test.proberfunc != nil {
 				revisionScaler.activatorProbe = test.proberfunc
 			} else {
@@ -319,7 +319,7 @@ func TestDisableScaleToZero(t *testing.T) {
 			revision := newRevision(t, servingClient, test.minScale, test.maxScale)
 			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
 			revisionScaler := &scaler{
-				psInformerFactory: podScalableTypedInformerFactory(opts),
+				psInformerFactory: podScalableTypedInformerFactory(&opts),
 				dynamicClient:     opts.DynamicClientSet,
 				logger:            opts.Logger,
 			}
@@ -352,7 +352,7 @@ func TestGetScaleResource(t *testing.T) {
 	servingClient := fakeKna.NewSimpleClientset()
 	dynamicClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
 
-	opts := reconciler.Options{
+	opts := &reconciler.Options{
 		DynamicClientSet: dynamicClient,
 		Logger:           logtesting.TestLogger(t),
 		ConfigMapWatcher: newConfigWatcher(),
@@ -361,7 +361,7 @@ func TestGetScaleResource(t *testing.T) {
 	revision := newRevision(t, servingClient, 1, 10)
 	// This setups reactor as well.
 	newDeployment(t, dynamicClient, names.Deployment(revision), 5)
-	revisionScaler := NewScaler(opts)
+	revisionScaler := newScaler(opts)
 
 	pa := newKPA(t, servingClient, revision)
 	scale, err := revisionScaler.GetScaleResource(pa)


### PR DESCRIPTION
There is no reason why it should be constructed in `main.go`.
Nor there is any reason why it should be public interface.
Great things will happenw when this merges!


/lint

## Proposed Changes

* remove Scaler interface
* remove injection of scaler into kpa
* construct scaler inside kpa
* update the tests

/cc @mattmoor 
