### PR TITLE
Clean-up Runtime Contract

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -324,8 +324,8 @@ Serverless applications which scale horizontally are expected to be managed in a
 declarative fashion, and individual instances SHOULD NOT be interacted with or
 connected directly.
 
-- As the `stdin` file descriptor is not allocated, the environment SHOULD NOT allocate a `tty` to
-  the container.
+- The environment [SHOULD NOT](https://github.com/knative/serving/blob/master/test/conformance/container_test.go)
+  allocate a `tty` to the container. As a result, the `/dev/console` device SHOULD NOT be present within the container.
 - The [linux process](https://github.com/opencontainers/runtime-spec/blob/29686dbc5559d93fb1ef402eeda3e35c38d75af4/config.md#linux-process)
   OCI properties MUST NOT be configurable by the developer, and MAY be set by the operator or platform provider.
 

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -275,7 +275,7 @@ providers.
 
 #### DNS
 
-To enable local DNS lookups, Platform providers MAY override the DNS related
+To enable local DNS lookups, platform providers MAY override the DNS related
 configuration files under `/etc` to enable local DNS lookups in the target environment
 (see [Default Filesystems](#default-filesystems)).
 
@@ -283,7 +283,7 @@ configuration files under `/etc` to enable local DNS lookups in the target envir
 
 Platform providers MAY provide a network service to provide introspection and
 environment information to the running process. If the network service is provided, the
-service SHOULD be an HTTP server with an operator- or provider-define URL schema.
+service SHOULD be an HTTP server with an operator- or provider-defined URL schema.
 If a metadata-service is provided, the schema MUST be documented. Sample use cases for such
 metadata include:
 
@@ -327,7 +327,7 @@ connected directly.
 - As the `stdin` file descriptor is not allocated, the environment SHOULD NOT allocate a `tty` to
   the container.
 - The [linux process](https://github.com/opencontainers/runtime-spec/blob/29686dbc5559d93fb1ef402eeda3e35c38d75af4/config.md#linux-process)
-  OCI properties MUST NOT be configurable by the developer, and MAY set by the operator or platform provider.
+  OCI properties MUST NOT be configurable by the developer, and MAY be set by the operator or platform provider.
 
 The following environment variables
 [MUST](https://github.com/knative/serving/blob/master/test/conformance/envvars_test.go) be set:

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -47,7 +47,7 @@ Knative authors is to push as much of the required functionality into Kubernetes
 and/or Istio as possible, rather than implementing reach-around layers.
 
 This document is aimed at _operators_ with the goal of providing a consistent
-runtime enviornment for _developers_.
+runtime environment for _developers_.
 
 - **Developers** write code which is packaged into a container which is run on
   the Knative cluster.

--- a/docs/runtime-user-guide.md
+++ b/docs/runtime-user-guide.md
@@ -2,7 +2,7 @@
 
 This document is focused on clarifying the expectations of the user
 container running in a Knative envioronment. This is separate from the expectations of the
-environment itself. The expectations of the enviornment are detailed in the [runtime
+environment itself. The expectations of the environment are detailed in the [runtime
 contract](https://github.com/knative/serving/blob/master/docs/runtime-contract.md).
 
 The target audience of this document are _developers_ and _language and tooling

--- a/docs/runtime-user-guide.md
+++ b/docs/runtime-user-guide.md
@@ -47,8 +47,8 @@ proxy.
 All Knative containers must listen for incoming traffic on a specific port. A
 port may be specified through the API otherwise a platform-provided port will be chosen.
 
-The selected port will be made available within the container as the enviornment variable `$PORT`.
-It is recommended to consume the enviornment variable `$PORT` rather than hard-code a particular
+The selected port will be made available within the container as the environment variable `$PORT`.
+It is recommended to consume the environment variable `$PORT` rather than hard-code a particular
 port within the application.
 
 Example (See

--- a/docs/runtime-user-guide.md
+++ b/docs/runtime-user-guide.md
@@ -85,7 +85,7 @@ Container storage may remain across requests, but no local storage should be use
 persistent data as it is not retained in the event of container termination.
 
 It is recommended to store temporary state such as local caches or working data in `/tmp`
-as this space is guarenteed to be present and mounted Read-Write.
+as this space is guaranteed to be present and mounted Read-Write.
 
 # Probes
 

--- a/docs/runtime-user-guide.md
+++ b/docs/runtime-user-guide.md
@@ -1,7 +1,7 @@
 # Runtime User Guide
 
 This document is focused on clarifying the expectations of the user
-container running in a Knative envioronment. This is separate from the expectations of the
+container running in a Knative environment. This is separate from the expectations of the
 environment itself. The expectations of the environment are detailed in the [runtime
 contract](https://github.com/knative/serving/blob/master/docs/runtime-contract.md).
 
@@ -23,7 +23,7 @@ containers should have the following properties:
   minmized to enable the platform to provide rapid autoscaling and scale-to-zero
   semantics.
 - Minimize local state: The container may be killed and replaced to support
-  autoscaling and cluster maintence operations. The performance or correctness
+  autoscaling and cluster maintenance operations. The performance or correctness
   of the application should not rely on state persisted locally.
 - CPU usage only while requests are active: As containers may be killed or
   suspended when no connections are active the container should only perform
@@ -39,7 +39,7 @@ necessary for a graceful shutdown.
 A Knative container must package a webserver that can respond to HTTP/1.1
 requests on a specified port.
 
-All traffic the comes to the container should be expected to pass through a
+All traffic that comes to the container should be expected to pass through a
 proxy.
 
 ### Ports

--- a/docs/runtime-user-guide.md
+++ b/docs/runtime-user-guide.md
@@ -5,7 +5,7 @@ container running in a Knative environment. This is separate from the expectatio
 environment itself. The expectations of the environment are detailed in the [runtime
 contract](https://github.com/knative/serving/blob/master/docs/runtime-contract.md).
 
-The target audience of this document are _developers_ and _language and tooling
+The target audience of this document is _developers_ and _language and tooling
 developers_ as defined below:
 
 - **Developers** write code which is packaged into a container which is run on
@@ -32,7 +32,7 @@ containers should have the following properties:
 ## Container Termination
 
 Knative containers should respond to `SIGTERM` signals to clean-up any resources
-necessary for a graceful shutdown.
+necessary for a graceful shutdown including open streams.
 
 ## Connection
 
@@ -104,7 +104,7 @@ Example (See
    - image: example-image:1.0
      readinessProbe:
        httpGet:
-         path: /health
+         path: /healthz
          periodSeconds: 10
          initialDelaySeconds: 0
 ...

--- a/docs/runtime-user-guide.md
+++ b/docs/runtime-user-guide.md
@@ -1,0 +1,119 @@
+# Runtime User Guide
+
+This document is focused on clarifying the expectations of the user
+container running in a Knative envioronment. This is separate from the expectations of the
+environment itself. The expectations of the enviornment are detailed in the [runtime
+contract](https://github.com/knative/serving/blob/master/docs/runtime-contract.md).
+
+The target audience of this document are _developers_ and _language and tooling
+developers_ as defined below:
+
+- **Developers** write code which is packaged into a container which is run on
+  the Knative cluster.
+- **Language and tooling developers** typically write tools used by
+    _developers_ to package code into containers. As such, they are concerned
+    that tooling which wraps developer code complies with this runtime contract.
+
+## General Behavior
+
+Containers running in Knative should be stateless containers. Stateless
+containers should have the following properties:
+
+- Fast startup time: The time from container launch to serving traffic should be
+  minmized to enable the platform to provide rapid autoscaling and scale-to-zero
+  semantics.
+- Minimize local state: The container may be killed and replaced to support
+  autoscaling and cluster maintence operations. The performance or correctness
+  of the application should not rely on state persisted locally.
+- CPU usage only while requests are active: As containers may be killed or
+  suspended when no connections are active the container should only perform
+  operations that complete synchronously with the request's response.
+
+## Container Termination
+
+Knative containers should respond to `SIGTERM` signals to clean-up any resources
+necessary for a graceful shutdown.
+
+## Connection
+
+A Knative container must package a webserver that can respond to HTTP/1.1
+requests on a specified port.
+
+All traffic the comes to the container should be expected to pass through a
+proxy.
+
+### Ports
+
+All Knative containers must listen for incoming traffic on a specific port. A
+port may be specified through the API otherwise a platform-provided port will be chosen.
+
+The selected port will be made available within the container as the enviornment variable `$PORT`.
+It is recommended to consume the enviornment variable `$PORT` rather than hard-code a particular
+port within the application.
+
+Example (See
+[Container](https://github.com/knative/serving/blob/master/docs/spec/spec.md#container))
+```yaml
+...
+  containers:
+   - image: example-image:1.0
+     ports:
+      - containerPort: 8081
+...
+```
+
+### Protocols
+
+HTTP/1.1 is the default protocol for Knative. To use HTTP/2.0 you must specify
+`h2c` in the API using the port `name` field.
+
+Example (See
+[Container](https://github.com/knative/serving/blob/master/docs/spec/spec.md#container))
+```yaml
+...
+  containers:
+   - image: example-image:1.0
+     ports:
+      - name: "h2c"
+        containerPort: 8081
+...
+```
+
+## Storage
+
+Container storage may remain across requests, but no local storage should be used for
+persistent data as it is not retained in the event of container termination.
+
+It is recommended to store temporary state such as local caches or working data in `/tmp`
+as this space is guarenteed to be present and mounted Read-Write.
+
+# Probes
+
+By default, the readiness of a Knative container is determined by a successful TCP
+response on the specified port for incoming traffic. If this readiness check is not
+sufficient to determine the readiness of the container to serve traffic, then an
+additional check should be specified through the `readinessProbes` section of
+the API.
+
+Example (See
+[Container](https://github.com/knative/serving/blob/master/docs/spec/spec.md#container))
+
+```yaml
+...
+  containers:
+   - image: example-image:1.0
+     readinessProbe:
+       httpGet:
+         path: /health
+         periodSeconds: 10
+         initialDelaySeconds: 0
+...
+```
+
+It is recommended to set the `initialDelaySeconds` of any readiness or liveness
+check to 0 as any higher values set a floor on container cold-start performance.
+
+# Logging
+
+Log statements should be sent to `stdout` and `stderr`. Log statements sent to
+these locations will be collected by the underlying platform and made visible.


### PR DESCRIPTION
This change makes numerous cleanups to the runtime contract in an
attempt to improve the readability of the document and make the document
more useful for the intended audience.

* Moves developer facing statements to a new `runtime-user-guide`.
Focuses `runtime-contract` on operator/platform-provider.
* Add links to Conformance tests that test Runtime Contract statements.
* Corrects, updates, or removes statements to more accurately represent
today's Knative runtime.
* Updates to informative or removes most untestable statements
* Copies in important OCI runtime requirements we previously referenced
* Removes reference to OCI specification that didn't bring new
requirements.

Ref: #2539, #2973, #4014, #4027 

/cc @evankanderson @mattmoor @tanzeeb @markusthoemmes @vaikas-google @tcnghia 
