### PR TITLE
Implement positive handoff and remove the 30sec resync

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -79,8 +79,8 @@ func main() {
 	opt.ConfigMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
 
 	// Set up informer factories.
-	servingInformerFactory := informers.NewSharedInformerFactory(opt.ServingClientSet, time.Second*30)
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(opt.KubeClientSet, time.Second*30)
+	servingInformerFactory := informers.NewSharedInformerFactory(opt.ServingClientSet, opt.ResyncPeriod)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(opt.KubeClientSet, opt.ResyncPeriod)
 
 	// Set up informers.
 	paInformer := servingInformerFactory.Autoscaling().V1alpha1().PodAutoscalers()

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -132,8 +132,10 @@ func NewController(
 		metrics:         metrics,
 	}
 	impl := controller.NewImpl(c, c.Logger, "KPA-Class Autoscaling", reconciler.MustNewStatsReporter("KPA-Class Autoscaling", c.Logger))
-	c.scaler = newScaler(opts, func(pa string, after time.Duration) {
-		impl.EnqueueKeyAfter(pa, after)
+	c.scaler = newScaler(opts, func(pa *pav1alpha1.PodAutoscaler, after time.Duration) {
+		// TODO(vagababov): remove this after pkg is updated to have `EnqueueAfter`.
+		key := fmt.Sprintf("%s/%s", pa.Namespace, pa.Name)
+		impl.EnqueueKeyAfter(key, after)
 	})
 
 	c.Logger.Info("Setting up KPA-Class event handlers")

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -133,7 +133,6 @@ func NewController(
 	}
 	impl := controller.NewImpl(c, c.Logger, "KPA-Class Autoscaling", reconciler.MustNewStatsReporter("KPA-Class Autoscaling", c.Logger))
 	c.scaler = newScaler(opts, func(pa string, after time.Duration) {
-		c.Logger.Warnf("#### CALLING THE CB: %s", pa)
 		impl.EnqueueKeyAfter(pa, after)
 	})
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -285,7 +285,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		opt.ConfigMapWatcher = newConfigWatcher()
 
 		fakeMetrics := newTestMetrics()
-		scaler := newScaler(&opt, func(string, time.Duration) {})
+		scaler := newScaler(&opt, func(*asv1a1.PodAutoscaler, time.Duration) {})
 		scaler.activatorProbe = func(*asv1a1.PodAutoscaler) (bool, error) { return true, nil }
 		return &Reconciler{
 			Base:            rpkg.NewBase(opt, controllerAgentName),
@@ -655,7 +655,7 @@ func TestReconcile(t *testing.T) {
 			endpointsLister: listers.GetEndpointsLister(),
 			kpaDeciders:     fakeDeciders,
 			metrics:         fakeMetrics,
-			scaler:          newScaler(&opt, func(string, time.Duration) {}),
+			scaler:          newScaler(&opt, func(*asv1a1.PodAutoscaler, time.Duration) {}),
 			configStore:     &testConfigStore{config: defaultConfig()},
 		}
 	}))

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -285,8 +285,8 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		opt.ConfigMapWatcher = newConfigWatcher()
 
 		fakeMetrics := newTestMetrics()
-		kpaScaler := newScaler(&opt)
-		kpaScaler.activatorProbe = func(*asv1a1.PodAutoscaler) (bool, error) { return true, nil }
+		scaler := newScaler(&opt, func(string, time.Duration) {})
+		scaler.activatorProbe = func(*asv1a1.PodAutoscaler) (bool, error) { return true, nil }
 		return &Reconciler{
 			Base:            rpkg.NewBase(opt, controllerAgentName),
 			paLister:        listers.GetPodAutoscalerLister(),
@@ -295,7 +295,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 			endpointsLister: listers.GetEndpointsLister(),
 			kpaDeciders:     fakeDeciders,
 			metrics:         fakeMetrics,
-			scaler:          kpaScaler,
+			scaler:          scaler,
 			configStore:     &testConfigStore{config: defaultConfig()},
 		}
 	}))
@@ -655,7 +655,7 @@ func TestReconcile(t *testing.T) {
 			endpointsLister: listers.GetEndpointsLister(),
 			kpaDeciders:     fakeDeciders,
 			metrics:         fakeMetrics,
-			scaler:          newScaler(&opt),
+			scaler:          newScaler(&opt, func(string, time.Duration) {}),
 			configStore:     &testConfigStore{config: defaultConfig()},
 		}
 	}))

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -19,6 +19,7 @@ package kpa
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
@@ -38,7 +39,20 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-const scaleUnknown = -1
+const (
+	scaleUnknown = -1
+	probePeriod  = 1 * time.Second
+	probeTimeout = 45 * time.Second
+	// The time after which the PA will be re-enqueued.
+	// This number is small, since `handleScaleToZero` below will
+	// re-enque for the configured grace period.
+	reenqeuePeriod = 1 * time.Second
+)
+
+// for mocking in tests
+type asyncProber interface {
+	Offer(context.Context, string, string, interface{}, time.Duration, time.Duration) bool
+}
 
 // scaler scales the target of a kpa-class PA up or down including scaling to zero.
 type scaler struct {
@@ -46,11 +60,16 @@ type scaler struct {
 	dynamicClient     dynamic.Interface
 	logger            *zap.SugaredLogger
 
+	// For sync probes.
 	activatorProbe func(pa *pav1alpha1.PodAutoscaler) (bool, error)
+
+	// For async probes.
+	probeManager asyncProber
+	enqueueCB    func(string, time.Duration)
 }
 
 // newScaler creates a scaler.
-func newScaler(opt *reconciler.Options) *scaler {
+func newScaler(opt *reconciler.Options, enqueueCB func(string, time.Duration)) *scaler {
 	ks := &scaler{
 		// Wrap it in a cache, so that we don't stamp out a new
 		// informer/lister each time.
@@ -62,8 +81,22 @@ func newScaler(opt *reconciler.Options) *scaler {
 
 		// Production setup uses the default probe implementation.
 		activatorProbe: activatorProbe,
+		probeManager: prober.New(func(arg interface{}, success bool, err error) {
+			pa := arg.(string)
+			opt.Logger.Infof("Async prober is done for key %s: success?: %v error: %v", pa, success, err)
+			// Re-enqeue the PA in any case. If the probe timed out to retry again, if succeeded to scale to 0.
+			enqueueCB(pa, reenqeuePeriod)
+		}),
+		enqueueCB: enqueueCB,
 	}
 	return ks
+}
+
+// Resolves the pa to hostname:port.
+func paToProbeTarget(pa *pav1alpha1.PodAutoscaler) string {
+	svc := network.GetServiceHostname(pa.Status.ServiceName, pa.Namespace)
+	port := networking.ServicePort(pa.Spec.ProtocolType)
+	return fmt.Sprintf("http://%s:%d/", svc, port)
 }
 
 // activatorProbe returns true if via probe it determines that the
@@ -73,11 +106,7 @@ func activatorProbe(pa *pav1alpha1.PodAutoscaler) (bool, error) {
 	if pa.Status.ServiceName == "" {
 		return false, nil
 	}
-
-	// Resolve the hostname and port to probe.
-	svc := network.GetServiceHostname(pa.Status.ServiceName, pa.Namespace)
-	port := networking.ServicePort(pa.Spec.ProtocolType)
-	return prober.Do(context.Background(), fmt.Sprintf("http://%s:%d/", svc, port), activator.Name)
+	return prober.Do(context.Background(), paToProbeTarget(pa), activator.Name)
 }
 
 // podScalableTypedInformerFactory returns a duck.InformerFactory that returns
@@ -146,6 +175,7 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 	if config.EnableScaleToZero == false {
 		return 1, true
 	}
+	key := pa.GetNamespace() + "/" + pa.GetName()
 
 	if pa.Status.IsActivating() { // Active=Unknown
 		// Don't scale-to-zero during activation
@@ -155,26 +185,34 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 
 		// Do not scale to 0, but return desiredScale of 0 to mark PA inactive.
 		if pa.Status.CanMarkInactive(config.StableWindow) {
+			// We do not need to enqueue PA here, since this will
+			// make SKS reconcile and when it's done, PA will be reconciled again.
 			return desiredScale, false
 		}
-		// Otherwise, scale down to 1 until the idle period elapses.
+		// Otherwise, scale down to 1 until the idle period elapses and re-enqueue
+		// the PA for reconciliation at that time.
+		ks.enqueueCB(key, config.StableWindow)
 		desiredScale = 1
 	} else { // Active=False
 		r, err := ks.activatorProbe(pa)
 		ks.logger.Infof("%s probing activator = %v, err = %v", pa.Name, r, err)
-		if err != nil {
-			ks.logger.Errorf("Error probing activator: %v", err)
+		if r {
+			// Make sure we've been inactive for enough time.
+			if pa.Status.CanScaleToZero(config.ScaleToZeroGracePeriod) {
+				return desiredScale, true
+			}
+			// Re-enqeue the PA for reconciliation after grace period.
+			// In istio-lean this can be close to 0.
+			ks.enqueueCB(key, config.ScaleToZeroGracePeriod)
 			return desiredScale, false
 		}
-		if !r {
-			ks.logger.Infof("%s is not yet backed by activator, cannot scale to zero", pa.Name)
-			return desiredScale, false
+
+		// Otherwise (any prober failure) start the async probe.
+		ks.logger.Infof("%s is not yet backed by activator, cannot scale to zero", pa.Name)
+		if !ks.probeManager.Offer(context.Background(), paToProbeTarget(pa), activator.Name, key, probePeriod, probeTimeout) {
+			ks.logger.Infof("Probe for %s is already in flight", pa.Name)
 		}
-		// Don't scale-to-zero if the grace period hasn't elapsed.
-		// TODO(vagababov): perhaps get rid of this?
-		if !pa.Status.CanScaleToZero(config.ScaleToZeroGracePeriod) {
-			return desiredScale, false
-		}
+		return desiredScale, false
 	}
 	return desiredScale, true
 }

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -229,7 +229,7 @@ func TestScaler(t *testing.T) {
 			revision := newRevision(t, servingClient, test.minScale, test.maxScale)
 			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
 			cbCount := 0
-			revisionScaler := newScaler(opts, func(string, time.Duration) {
+			revisionScaler := newScaler(opts, func(*pav1alpha1.PodAutoscaler, time.Duration) {
 				cbCount++
 			})
 			if test.proberfunc != nil {
@@ -384,7 +384,7 @@ func TestGetScaleResource(t *testing.T) {
 	revision := newRevision(t, servingClient, 1, 10)
 	// This setups reactor as well.
 	newDeployment(t, dynamicClient, names.Deployment(revision), 5)
-	revisionScaler := newScaler(opts, func(string, time.Duration) {})
+	revisionScaler := newScaler(opts, func(*pav1alpha1.PodAutoscaler, time.Duration) {})
 
 	pa := newKPA(t, servingClient, revision)
 	scale, err := revisionScaler.GetScaleResource(pa)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kpa
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -60,16 +61,22 @@ const (
 
 func TestScaler(t *testing.T) {
 	defer logtesting.ClearAll()
+	ptf := prober.TransportFactory
+	defer func() {
+		prober.TransportFactory = ptf
+	}()
 	tests := []struct {
-		label         string
-		startReplicas int
-		scaleTo       int32
-		minScale      int32
-		maxScale      int32
-		wantReplicas  int32
-		wantScaling   bool
-		kpaMutation   func(*pav1alpha1.PodAutoscaler)
-		proberfunc    func(*pav1alpha1.PodAutoscaler) (bool, error)
+		label               string
+		startReplicas       int
+		scaleTo             int32
+		minScale            int32
+		maxScale            int32
+		wantReplicas        int32
+		wantScaling         bool
+		kpaMutation         func(*pav1alpha1.PodAutoscaler)
+		proberfunc          func(*pav1alpha1.PodAutoscaler) (bool, error)
+		wantCBCount         int
+		wantAsyncProbeCount int
 	}{{
 		label:         "waits to scale to zero (just before idle period)",
 		startReplicas: 1,
@@ -79,6 +86,7 @@ func TestScaler(t *testing.T) {
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
 			kpaMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
 		},
+		wantCBCount: 1,
 	}, {
 		label:         "scale to 1 waiting for idle expires",
 		startReplicas: 10,
@@ -88,6 +96,7 @@ func TestScaler(t *testing.T) {
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
 			kpaMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
 		},
+		wantCBCount: 1,
 	}, {
 		label:         "waits to scale to zero after idle period",
 		startReplicas: 1,
@@ -96,15 +105,6 @@ func TestScaler(t *testing.T) {
 		wantScaling:   false,
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
 			kpaMarkActive(k, time.Now().Add(-stableWindow))
-		},
-	}, {
-		label:         "waits to scale to zero (just before grace period)",
-		startReplicas: 1,
-		scaleTo:       0,
-		wantReplicas:  0,
-		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
 		},
 	}, {
 		label:         "scale to zero after grace period",
@@ -116,6 +116,16 @@ func TestScaler(t *testing.T) {
 			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 	}, {
+		label:         "waits to scale to zero (just before grace period)",
+		startReplicas: 1,
+		scaleTo:       0,
+		wantReplicas:  0,
+		wantScaling:   false,
+		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+			kpaMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
+		},
+		wantCBCount: 1,
+	}, {
 		label:         "scale to zero after grace period, but fail prober",
 		startReplicas: 1,
 		scaleTo:       0,
@@ -124,7 +134,8 @@ func TestScaler(t *testing.T) {
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
 			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
-		proberfunc: func(*pav1alpha1.PodAutoscaler) (bool, error) { return true, errors.New("hell or high water") },
+		proberfunc:          func(*pav1alpha1.PodAutoscaler) (bool, error) { return false, errors.New("hell or high water") },
+		wantAsyncProbeCount: 1,
 	}, {
 		label:         "scale to zero after grace period, but wrong prober response",
 		startReplicas: 1,
@@ -134,7 +145,8 @@ func TestScaler(t *testing.T) {
 		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
 			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
-		proberfunc: func(*pav1alpha1.PodAutoscaler) (bool, error) { return false, nil },
+		proberfunc:          func(*pav1alpha1.PodAutoscaler) (bool, error) { return false, nil },
+		wantAsyncProbeCount: 1,
 	}, {
 		label:         "does not scale while activating",
 		startReplicas: 1,
@@ -216,12 +228,17 @@ func TestScaler(t *testing.T) {
 
 			revision := newRevision(t, servingClient, test.minScale, test.maxScale)
 			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
-			revisionScaler := newScaler(opts)
+			cbCount := 0
+			revisionScaler := newScaler(opts, func(string, time.Duration) {
+				cbCount++
+			})
 			if test.proberfunc != nil {
 				revisionScaler.activatorProbe = test.proberfunc
 			} else {
 				revisionScaler.activatorProbe = func(*pav1alpha1.PodAutoscaler) (bool, error) { return true, nil }
 			}
+			cp := &countingProber{}
+			revisionScaler.probeManager = cp
 
 			// We test like this because the dynamic client's fake doesn't properly handle
 			// patch modes prior to 1.13 (where vaikas added JSON Patch support).
@@ -249,6 +266,12 @@ func TestScaler(t *testing.T) {
 			}
 			if err == nil && desiredScale != test.wantReplicas {
 				t.Errorf("desiredScale = %d, wanted %d", desiredScale, test.wantReplicas)
+			}
+			if got, want := cp.count, test.wantAsyncProbeCount; got != want {
+				t.Errorf("Async probe invoked = %d time, want: %d", got, want)
+			}
+			if got, want := cbCount, test.wantCBCount; got != want {
+				t.Errorf("Enqueue callback invoked = %d time, want: %d", got, want)
 			}
 			if test.wantScaling {
 				if !gotScaling {
@@ -361,7 +384,7 @@ func TestGetScaleResource(t *testing.T) {
 	revision := newRevision(t, servingClient, 1, 10)
 	// This setups reactor as well.
 	newDeployment(t, dynamicClient, names.Deployment(revision), 5)
-	revisionScaler := newScaler(opts)
+	revisionScaler := newScaler(opts, func(string, time.Duration) {})
 
 	pa := newKPA(t, servingClient, revision)
 	scale, err := revisionScaler.GetScaleResource(pa)
@@ -571,4 +594,13 @@ func TestActivatorProbe(t *testing.T) {
 			}
 		})
 	}
+}
+
+type countingProber struct {
+	count int
+}
+
+func (c *countingProber) Offer(ctx context.Context, target, headerValue string, arg interface{}, period, timeout time.Duration) bool {
+	c.count++
+	return true
 }


### PR DESCRIPTION
/lint
Fixes #2132
Fixed #2949

## Proposed Changes
* the scaler will now start async probing when the probe is not successfull
* the scaler will automatically re-enqueue PA for resync, rather than just rely on 30s full reconciliation
* other minor changes
* tests

**Release Note**

```release-note
This is the final step for the positive handoff, where in we no longer rely on constant PA reconciliation.
This also means that we can probably reduce that 30second wait to actually scale to zero, especially in case of lean mesh scenarios, where it can be as small as few seconds.
```

/cc @mattmoor 
