### PR TITLE
Validate that terminal is not allowed in container

### DIFF
--- a/test/conformance/container_test.go
+++ b/test/conformance/container_test.go
@@ -159,6 +159,21 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 				HostPort:      80,
 			}}
 		},
+	}, {
+		name: "TestStdin",
+		options: func(s *v1alpha1.Service) {
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Stdin = true
+		},
+	}, {
+		name: "TestStdinOnce",
+		options: func(s *v1alpha1.Service) {
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().StdinOnce = true
+		},
+	}, {
+		name: "TestTTY",
+		options: func(s *v1alpha1.Service) {
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().TTY = true
+		},
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4027

## Proposed Changes

Conformance test validates that stdin, stdinOnce, and tty cannot be set in container runtime 

**Release Note**

```release-note
NONE
```
