### PR TITLE
Add test for invalid user

### DIFF
--- a/test/conformance/container_test.go
+++ b/test/conformance/container_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	corev1 "k8s.io/api/core/v1"
@@ -173,6 +174,13 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 		name: "TestTTY",
 		options: func(s *v1alpha1.Service) {
 			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().TTY = true
+		},
+	}, {
+		name: "TestInvalidUID",
+		options: func(s *v1alpha1.Service) {
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().SecurityContext = &corev1.SecurityContext{
+				RunAsUser: ptr.Int64(-10),
+			}
 		},
 	}}
 


### PR DESCRIPTION
Now that we have validation of user-id in the webhook this test adds
coverage for the statement:

"In this case, if the identity selected by the developer is invalid, the
container execution MUST be failed."

Our way of enforcing this is at the time of the request to create the
container.

Ref #3223 