### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/knative/pkg/apis"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/network"

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -17,10 +17,11 @@ package domains
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/knative/pkg/apis"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/gc"
@@ -159,20 +160,20 @@ func TestURL(t *testing.T) {
 		domain   string
 		Expected apis.URL
 	}{{
-		name:     "subdomain",
-		scheme:   HTTPScheme,
-		domain:   "current.svc.local.com",
+		name:   "subdomain",
+		scheme: HTTPScheme,
+		domain: "current.svc.local.com",
 		Expected: apis.URL{
 			Scheme: "http",
-			Path : "current.svc.local.com",
+			Path:   "current.svc.local.com",
 		},
 	}, {
-		name:     "default target",
-		scheme:   HTTPScheme,
-		domain:   "example.com",
+		name:   "default target",
+		scheme: HTTPScheme,
+		domain: "example.com",
 		Expected: apis.URL{
 			Scheme: "http",
-			Path : "example.com",
+			Path:   "example.com",
 		},
 	}}
 

--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -18,8 +18,9 @@ package resources
 
 import (
 	"context"
-	"github.com/knative/serving/pkg/reconciler/route/config"
 	"testing"
+
+	"github.com/knative/serving/pkg/reconciler/route/config"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
