### PR TITLE
allow grpc and websocket e2e tests to pass when --ingressendpoint is …

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -37,17 +37,18 @@ import (
 
 type grpcTest func(*testing.T, *test.ResourceObjects, *test.Clients, string, string)
 
-// getPort gets port from a URL
-func getPort(u string) (int, error) {
+// hasPort checks if a URL contains a port number
+func hasPort(u string) bool {
 	parts := strings.Split(u, ":")
-	return strconv.Atoi(parts[len(parts)-1])
+	_, err := strconv.Atoi(parts[len(parts)-1])
+	return err == nil
 }
 
 func dial(host, domain string) (*grpc.ClientConn, error) {
-	if _, err := getPort(host); err != nil {
+	if !hasPort(host) {
 		host = host + ":80"
 	}
-	if _, err := getPort(domain); err != nil {
+	if !hasPort(domain) {
 		domain = domain + ":80"
 	}
 

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -20,9 +20,9 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,25 +38,16 @@ import (
 type grpcTest func(*testing.T, *test.ResourceObjects, *test.Clients, string, string)
 
 // getPort gets port from a URL
-func getPort(u string) (string, error) {
-	var port string
-
-	asURL, err := url.Parse(fmt.Sprintf("http://%s", u))
-	if err != nil {
-		asURL, err = url.Parse(u)
-		if err != nil {
-			return port, err
-		}
-	}
-
-	return asURL.Port(), nil
+func getPort(u string) (int, error) {
+	parts := strings.Split(u, ":")
+	return strconv.Atoi(parts[len(parts)-1])
 }
 
 func dial(host, domain string) (*grpc.ClientConn, error) {
-	if p, _ := getPort(host); p == "" {
+	if _, err := getPort(host); err != nil {
 		host = host + ":80"
 	}
-	if p, _ := getPort(domain); p == "" {
+	if _, err := getPort(domain); err != nil {
 		domain = domain + ":80"
 	}
 

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -71,8 +71,7 @@ func validateWebSocketConnection(t *testing.T, clients *test.Clients, names test
 	var err error
 	gatewayIP := &pkgTest.Flags.IngressEndpoint
 	if pkgTest.Flags.IngressEndpoint == "" {
-		gatewayIP, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)
-		if err != nil {
+		if gatewayIP, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
@@ -67,9 +68,13 @@ func connect(t *testing.T, ingressIP string, domain string) (*websocket.Conn, er
 }
 
 func validateWebSocketConnection(t *testing.T, clients *test.Clients, names test.ResourceNames) error {
-	gatewayIP, err := ingress.GetIngressEndpoint(clients.KubeClient.Kube)
-	if err != nil {
-		return err
+	var err error
+	gatewayIP := &pkgTest.Flags.IngressEndpoint
+	if pkgTest.Flags.IngressEndpoint == "" {
+		gatewayIP, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Establish the websocket connection.


### PR DESCRIPTION
Some of the grpc and websocket e2e tests are failing when `--ingressendpoint` is passed in (see here for reference: https://github.com/knative/serving/blob/master/test/README.md#using-a-custom-ingress-endpoint). Add logic in these tests to make them pass when `--ingressendpoint` is passed