### PR TITLE
Be strict about env vars reserved by the runtime contract.

### DIFF
--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -568,6 +568,28 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: apis.ErrInvalidValue(corev1.TerminationMessagePolicy("Not a Policy"), "terminationMessagePolicy"),
 	}, {
+		name: "empty env var name",
+		c: corev1.Container{
+			Image: "foo",
+			Env: []corev1.EnvVar{{
+				Value: "Foo",
+			}},
+		},
+		want: apis.ErrMissingField("env[0].name"),
+	}, {
+		name: "reserved env var name",
+		c: corev1.Container{
+			Image: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "PORT",
+				Value: "Foo",
+			}},
+		},
+		want: &apis.FieldError{
+			Message: `"PORT" is a reserved environment variable`,
+			Paths:   []string{"env[0].name"},
+		},
+	}, {
 		name: "disallowed envvarsource",
 		c: corev1.Container{
 			Image: "foo",

--- a/pkg/reconciler/revision/resources/env_var.go
+++ b/pkg/reconciler/revision/resources/env_var.go
@@ -29,18 +29,14 @@ const (
 )
 
 func getKnativeEnvVar(rev *v1alpha1.Revision) []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name:  knativeRevisionEnvVariableKey,
-			Value: rev.Name,
-		},
-		{
-			Name:  knativeConfigurationEnvVariableKey,
-			Value: rev.Labels[serving.ConfigurationLabelKey],
-		},
-		{
-			Name:  knativeServiceEnvVariableKey,
-			Value: rev.Labels[serving.ServiceLabelKey],
-		},
-	}
+	return []corev1.EnvVar{{
+		Name:  knativeRevisionEnvVariableKey,
+		Value: rev.Name,
+	}, {
+		Name:  knativeConfigurationEnvVariableKey,
+		Value: rev.Labels[serving.ConfigurationLabelKey],
+	}, {
+		Name:  knativeServiceEnvVariableKey,
+		Value: rev.Labels[serving.ServiceLabelKey],
+	}}
 }


### PR DESCRIPTION
Add validation analogous to the "reserved paths" validation for
volume mounts, which rejects env vars that take a name that has
been specified as part of the runtime contract.

Fixes: https://github.com/knative/serving/issues/3328

/hold

I want to make sure @dgerd is on board with this, given the back-and-forth in the linked issue.