### PR TITLE
Bump timeout for pod destruction test again.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/davecgh/go-spew/spew"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
@@ -165,9 +166,11 @@ func TestDestroyPodTimely(t *testing.T) {
 	// of the containers of that pod are no longer running. It can take an arbitrarily long time to
 	// actually remove the pod itself while we only care about containers being stopped.
 	deploymentName := rnames.Deployment(objects.Revision)
+	var podList *v1.PodList
 	pkgTest.WaitForPodListState(
 		clients.KubeClient,
 		func(p *v1.PodList) (bool, error) {
+			podList = p
 			for _, pod := range p.Items {
 				if !strings.Contains(pod.Name, deploymentName) {
 					continue
@@ -185,6 +188,7 @@ func TestDestroyPodTimely(t *testing.T) {
 
 	timeToDelete := time.Since(start)
 	if timeToDelete > maxTimeToDelete {
+		t.Logf("Pod list: %s", spew.Sprint(podList))
 		t.Errorf("Time to delete pods = %v, want < %v", timeToDelete, maxTimeToDelete)
 	}
 }

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -136,7 +136,7 @@ const (
 	// Give the pods plenty of time to disappear. It will take them at least 20 seconds to vanish
 	// because we have a hard-coded sleep of 20 seconds before initiating the shutdown process.
 	// This is still well below the 5 minutes it might take them to disappear max.
-	maxTimeToDelete = 90 * time.Second
+	maxTimeToDelete = 180 * time.Second
 )
 
 func TestDestroyPodTimely(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This test still occasionally flakes out. The boundary is still well below the request timeout though.

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
