### PR TITLE
Improve the development guide by adding the requirement for resource allocation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,8 +117,8 @@ Your user must be a cluster admin to perform the setup needed for Knative.
 
 The value you use depends on
 [your cluster setup](https://www.knative.dev/docs/install/): when using
-Minikube, the user is your local user; when using GKE, the user is your GCP
-user.
+Minikube or Kubernetes on Docker Desktop, the user is your local user;
+when using GKE, the user is your GCP user.
 
 ```shell
 # For GCP
@@ -126,11 +126,19 @@ kubectl create clusterrolebinding cluster-admin-binding \
   --clusterrole=cluster-admin \
   --user=$(gcloud config get-value core/account)
 
-# For minikube
+# For minikube or Kubernetes on Docker Desktop
 kubectl create clusterrolebinding cluster-admin-binding \
   --clusterrole=cluster-admin \
   --user=$USER
 ```
+
+### Resource allocation for Kubernetes
+
+Please allocate sufficient resources for Kubernetes, especially when you run a Kubernetes cluster on your local machine.
+We recommend allocating at least 6 CPUs and 8G memory assuming a single node Kubernetes installation, and allocating
+at least 4 CPUs and 8G memory for each node assuming a 3-node Kubernetes installation. Please go back
+to [your cluster setup](https://www.knative.dev/docs/install/) to reconfigure your Kubernetes cluster in your designated
+environment, if necessary.
 
 ### Deploy Istio
 
@@ -197,6 +205,9 @@ data:
   istio.sidecar.includeOutboundIPRanges: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
   clusteringress.class: "istio.ingress.networking.knative.dev"
 ```
+
+You should keep the default value for "istio.sidecar.includeOutboundIPRanges", when you use Minikube or
+Docker Desktop as the Kubernetes environment.
 
 Next, run:
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4057

## Proposed Changes

* Add the minimum requirement of resources allocation for Kubernetes to the development document

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
