### PR TITLE
Update target capacity with number of activators

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	. "github.com/knative/pkg/logging/testing"
+	_ "github.com/knative/pkg/system/testing"
 	"github.com/knative/serving/pkg/activator"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"


### PR DESCRIPTION
Activator process is aware of the number of its own of replicas to prevent overflowing the user pods.
number of requests = Number of pods * ContainerConcurrency / Activator Replicas instead of Number of pods * ContainerConcurrency.

Co-authored-by: Andrew Su <asu@pivotal.io>
Fixes #3165

/lint
cc @andrew-su 