### PR TITLE
Move probing in to activator throttler

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -182,7 +182,7 @@ func main() {
 	}
 
 	params := queue.BreakerParams{QueueDepth: breakerQueueDepth, MaxConcurrency: breakerMaxConcurrency, InitialCapacity: 0}
-	throttler := activator.NewThrottler(params, endpointInformer, sksInformer.Lister(), revisionInformer.Lister(), logger)
+	throttler := activator.NewThrottler(params, network.NewAutoTransport(), endpointInformer, sksInformer.Lister(), serviceInformer.Lister(), revisionInformer.Lister(), logger)
 
 	activatorL3 := fmt.Sprintf("%s:%d", activator.K8sServiceName, networking.ServiceHTTPPort)
 	zipkinEndpoint, err := zipkin.NewEndpoint("activator", activatorL3)

--- a/pkg/activator/breaker.go
+++ b/pkg/activator/breaker.go
@@ -1,0 +1,177 @@
+package activator
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	activatornetwork "github.com/knative/serving/pkg/activator/network"
+	"github.com/knative/serving/pkg/apis/networking"
+	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/network/prober"
+	"github.com/knative/serving/pkg/queue"
+	"go.uber.org/zap"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// Breaker is a wrapper around queue.Breaker which probes a revision before allowing breaker concurrency to rise from zero
+type Breaker struct {
+	*queue.Breaker
+	maxCC           int
+	logger          *zap.SugaredLogger
+	size            int
+	cc              int
+	replicaCount    int
+	isShutdown      bool
+	revId           RevisionID
+	mux             sync.Mutex
+	sizeChangedCond sync.Cond
+
+	sksLister     netlisters.ServerlessServiceLister
+	serviceLister corev1listers.ServiceLister
+	transport     http.RoundTripper
+}
+
+// NewBreaker creates a new Breaker
+func NewBreaker(
+	logger *zap.SugaredLogger,
+	transport http.RoundTripper,
+	breakerParams queue.BreakerParams,
+	replicaCount int,
+	sksLister netlisters.ServerlessServiceLister,
+	serviceLister corev1listers.ServiceLister,
+	revId RevisionID) *Breaker {
+	ret := &Breaker{
+		Breaker:      queue.NewBreaker(breakerParams),
+		maxCC:        breakerParams.MaxConcurrency,
+		logger:       logger,
+		size:         0,
+		cc:           0,
+		replicaCount: replicaCount,
+		isShutdown:   false,
+		revId:        revId,
+
+		sksLister:     sksLister,
+		serviceLister: serviceLister,
+		transport:     transport,
+	}
+	ret.sizeChangedCond.L = &ret.mux
+
+	// Run concurrency updating loop which polls endpoints
+	go func() {
+		ret.mux.Lock()
+		defer ret.mux.Unlock()
+
+		for {
+			if !ret.probeAndSetConcurrency() {
+				return
+			}
+
+			ret.sizeChangedCond.Wait()
+		}
+	}()
+
+	return ret
+}
+
+// Shutdown should be called on a breaker before it is forgotten to exit the probe goroutine
+func (b *Breaker) Shutdown() {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+	b.isShutdown = true
+	// Break out of pollLoop wait
+	b.sizeChangedCond.Broadcast()
+}
+
+func (b *Breaker) probeAndSetConcurrency() bool {
+	for {
+		// If we shutdown already dont wait forever
+		if b.isShutdown {
+			return false
+		}
+
+		// If our size is 0 or were not changing capcity from zero set concurrency, otherwise probe and if successful set concurrency.
+		if b.size == 0 || b.Breaker.Capacity() != 0 {
+			b.setConcurrency()
+			return true
+		} else {
+			// Release lock while we poll
+			b.mux.Unlock()
+			err := b.probe()
+			b.mux.Lock()
+
+			if err != nil {
+				b.logger.Errorw("Failed to probe pod", zap.Error(err))
+			} else {
+				b.setConcurrency()
+				return true
+			}
+
+			b.mux.Unlock()
+			// wait before we try probing again
+			time.Sleep(200 * time.Millisecond)
+			b.mux.Lock()
+		}
+	}
+}
+
+// UpdateSize sets the number of endpoint and containerconcurrency for this breaker's revision
+func (b *Breaker) UpdateSize(size, cc, replicaCount int) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	b.size = size
+	b.cc = cc
+	b.replicaCount = replicaCount
+
+	b.sizeChangedCond.Broadcast()
+}
+
+// minOneOrValue function returns num if its greater than 1
+// else the function returns 1
+func minOneOrValue(num int) int {
+	if num > 1 {
+		return num
+	}
+	return 1
+}
+
+func (b *Breaker) setConcurrency() {
+	targetCapacity := b.cc * b.size
+	if b.size > 0 && (targetCapacity == 0 || targetCapacity > b.maxCC) {
+		// The concurrency is unlimited, thus hand out as many tokens as we can in this breaker.
+		targetCapacity = b.maxCC
+	} else if targetCapacity > 0 {
+		targetCapacity = minOneOrValue(targetCapacity / minOneOrValue(b.replicaCount))
+	}
+	b.logger.Infof("Setting concurrency to %d. cc: %d, size: %d, maxCC: %d", targetCapacity, b.cc, b.size, b.maxCC)
+	if err := b.Breaker.UpdateConcurrency(targetCapacity); err != nil {
+		b.logger.Errorw("Updating concurrency of breaker", zap.Error(err))
+	}
+}
+
+func (b *Breaker) probe() error {
+	host, err := activatornetwork.PrivateEndpointForRevision(b.revId.Namespace, b.revId.Name, networking.ProtocolHTTP1, b.sksLister, b.serviceLister)
+	target := &url.URL{
+		Scheme: "http",
+		Host:   host,
+	}
+
+	ret, err := prober.Do(
+		context.Background(),
+		b.transport,
+		target.String(),
+		prober.WithHeader(network.ProbeHeaderName, queue.Name),
+		prober.ExpectsBody(queue.Name))
+	if err != nil {
+		return err
+	}
+	if !ret {
+		return errors.New("Pod probe unsucessful")
+	}
+	return nil
+}

--- a/pkg/activator/breaker_test.go
+++ b/pkg/activator/breaker_test.go
@@ -1,0 +1,77 @@
+package activator
+
+import (
+	"testing"
+
+	activatortest "github.com/knative/serving/pkg/activator/testing"
+	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/queue"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	. "knative.dev/pkg/logging/testing"
+)
+
+func TestBreakerUpdateSize(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		size           int
+		cc             int
+		maxCC          int
+		expectCapacity int
+		probeResponses []activatortest.FakeResponse
+
+		sksLister     netlisters.ServerlessServiceLister
+		serviceLister corev1listers.ServiceLister
+	}{{
+		name:           "no capacity",
+		size:           0,
+		cc:             0,
+		expectCapacity: 0,
+		sksLister:      sksLister(testNamespace, testRevision),
+		serviceLister:  serviceLister(service(testNamespace, testRevision, "http")),
+	}, {
+		name:           "update size and cc",
+		size:           2,
+		cc:             3,
+		maxCC:          10,
+		expectCapacity: 6,
+		sksLister:      sksLister(testNamespace, testRevision),
+		serviceLister:  serviceLister(service(testNamespace, testRevision, "http")),
+	}, {
+		name:           "maxCC limited",
+		size:           10,
+		cc:             5,
+		maxCC:          20,
+		expectCapacity: 20,
+		sksLister:      sksLister(testNamespace, testRevision),
+		serviceLister:  serviceLister(service(testNamespace, testRevision, "http")),
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			// Setup fake roundtripper
+			fakeRT := activatortest.FakeRoundTripper{}
+
+			rt := network.RoundTripperFunc(fakeRT.RT)
+
+			// Create a breaker which isnt running poll goroutine
+			breaker := Breaker{
+				Breaker:       queue.NewBreaker(queue.BreakerParams{QueueDepth: 10, MaxConcurrency: test.maxCC, InitialCapacity: 0}),
+				maxCC:         test.maxCC,
+				logger:        TestLogger(t),
+				sksLister:     test.sksLister,
+				serviceLister: test.serviceLister,
+				transport:     rt,
+			}
+			breaker.sizeChangedCond.L = &breaker.mux
+
+			breaker.UpdateSize(test.size, test.cc, 1)
+
+			breaker.mux.Lock()
+			breaker.probeAndSetConcurrency()
+			breaker.mux.Unlock()
+
+			if breaker.Breaker.Capacity() != test.expectCapacity {
+				t.Errorf("Got capacity %d, expected %d", breaker.Breaker.Capacity(), test.expectCapacity)
+			}
+		})
+	}
+}

--- a/pkg/activator/network/sks.go
+++ b/pkg/activator/network/sks.go
@@ -1,0 +1,47 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/knative/serving/pkg/apis/networking"
+	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	"github.com/knative/serving/pkg/network"
+
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// PrivateEndpointForRevision returns the name of the private endpoint resource for a given revision
+func PrivateEndpointForRevision(namespace, name string, protocol networking.ProtocolType, sksLister netlisters.ServerlessServiceLister, serviceLister corev1listers.ServiceLister) (string, error) {
+	// SKS name matches that of revision.
+	sks, err := sksLister.ServerlessServices(namespace).Get(name)
+	if err != nil {
+		return "", err
+	}
+	return serviceEndpoint(namespace, sks.Status.PrivateServiceName, protocol, serviceLister)
+}
+
+// serviceHostName obtains the hostname of the underlying service and the correct
+// port to send requests to.
+func serviceEndpoint(namespace, serviceName string, protocol networking.ProtocolType, serviceLister corev1listers.ServiceLister) (string, error) {
+	svc, err := serviceLister.Services(namespace).Get(serviceName)
+	if err != nil {
+		return "", err
+	}
+
+	// Search for the appropriate port
+	port := -1
+	for _, p := range svc.Spec.Ports {
+		if p.Name == networking.ServicePortName(protocol) {
+			port = int(p.Port)
+			break
+		}
+	}
+	if port == -1 {
+		return "", errors.New("revision needs external HTTP port")
+	}
+
+	serviceFQDN := network.GetServiceHostname(serviceName, namespace)
+
+	return fmt.Sprintf("%s:%d", serviceFQDN, port), nil
+}

--- a/pkg/activator/testing/roundtripper.go
+++ b/pkg/activator/testing/roundtripper.go
@@ -48,6 +48,7 @@ type FakeRoundTripper struct {
 	// Response to non-probe requests
 	RequestResponse *FakeResponse
 	responseMux     sync.Mutex
+	ProbeCnt        int
 }
 
 func defaultProbeResponse() *FakeResponse {
@@ -76,6 +77,8 @@ func response(fr *FakeResponse) (*http.Response, error) {
 func (rt *FakeRoundTripper) popResponse() *FakeResponse {
 	rt.responseMux.Lock()
 	defer rt.responseMux.Unlock()
+
+	rt.ProbeCnt += 1
 
 	responses := rt.ProbeResponses
 	if responses == nil || len(responses) == 0 {


### PR DESCRIPTION
Rather than have each request perform its own probing we can operate
more like a typical LB in activator and probe our backend (here,
clusterIP of sks private service) independently of requests. Later on
when we would like to forward to podIPs directly this pattern is a
requirement.

Related to #3885 

This depends on #4121, #4124 and #4065 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
