### PR TITLE
Add timeout to throttler

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -197,7 +197,7 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, proxy *httputi
 
 		// Enforce queuing and concurrency limits.
 		if breaker != nil {
-			ok := breaker.Maybe(func() {
+			ok := breaker.Maybe(0 /* Infinite timeout */, func() {
 				proxy.ServeHTTP(w, r)
 			})
 			if !ok {

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -55,6 +55,7 @@ type activationHandler struct {
 
 	probeTimeout          time.Duration
 	probeTransportFactory prober.TransportFactory
+	endpointTimeout       time.Duration
 
 	revisionLister servinglisters.RevisionLister
 	serviceLister  corev1listers.ServiceLister
@@ -85,6 +86,7 @@ func New(l *zap.SugaredLogger, r activator.StatsReporter, t *activator.Throttler
 				Base: network.NewAutoTransport(),
 			}
 		},
+		endpointTimeout: defaulTimeout,
 	}
 }
 
@@ -161,7 +163,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	_, ttSpan := trace.StartSpan(r.Context(), "throttler_try")
 	ttStart := time.Now()
-	err = a.throttler.Try(revID, func() {
+	err = a.throttler.Try(a.endpointTimeout, revID, func() {
 		var (
 			httpStatus int
 		)

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -255,7 +255,7 @@ func TestThrottlerTry(t *testing.T) {
 			if s.addCapacity {
 				throttler.UpdateCapacity(revID, 1)
 			}
-			err := throttler.Try(revID, func() {
+			err := throttler.Try(0, revID, func() {
 				called++
 			})
 			if err == nil && s.wantError {
@@ -289,7 +289,7 @@ func TestThrottlerTryOverload(t *testing.T) {
 	allowedRequests := initialCapacity + queueLength
 	for i := 0; i < allowedRequests+1; i++ {
 		go func() {
-			err := th.Try(revID, func() {
+			err := th.Try(0, revID, func() {
 				doneCh <- struct{}{} // Blocks forever
 			})
 			if err != nil {


### PR DESCRIPTION
This adds a timeout for while we wait in throttler. This is needed when
we move probing in to throttler in order to implement a probeTimeout and
reduces changes needed there.

Related to: #3885

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
