### PR TITLE
Fix order in which stats are recorded and the scaler is poked.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -135,8 +135,8 @@ func main() {
 			if !ok {
 				break
 			}
-			multiScaler.Poke(sm.Key, sm.Stat)
 			collector.Record(sm.Key, sm.Stat)
+			multiScaler.Poke(sm.Key, sm.Stat)
 		}
 	}()
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We should record the stat before poking the scaler to make sure the poked run actually observes the recorded stats and the autoscaler scales up.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
