### PR TITLE
Only list services within the same namespace.

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -138,7 +138,7 @@ func (c *Reconciler) deleteServices(namespace string, serviceNames sets.String) 
 }
 
 func (c *Reconciler) getServiceNameSet(route *v1alpha1.Route) (sets.String, error) {
-	currentServices, err := c.serviceLister.List(resources.SelectorFromRoute(route))
+	currentServices, err := c.serviceLister.Services(route.Namespace).List(resources.SelectorFromRoute(route))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In the cleanup logic for the "Kevin" work we list the K8s services for a route
by the label selector with the route name, but we mistakenly did this cluster-wide.

This means that we'd discover services in other namespaces, and then (very likely)
fail deleting the service with that name in our namespace, leading the route to
never become ready.

This could happen if I have Routes in parallel namespaces with the same name, but
different "tags".  However, @tcnghia and I saw this playing with @bbrowning's
Ambassador implementation for ClusterIngress, which creates a K8s service in the
ambassador namespace as part of the ClusterIngress implementation.

Related to: https://github.com/knative/serving/issues/3419

cc @andrew-su 