### PR TITLE
Fewer constants, better maintability

### DIFF
--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -23,11 +23,11 @@ import (
 const (
 	// Name is the name of the component.
 	Name = "activator"
-	// K8sServiceName is the name of the activator Kubernetes service
+	// K8sServiceName is the name of the activator Kubernetes service.
 	K8sServiceName = "activator-service"
-	// RevisionHeaderName is the header key for revision name
+	// RevisionHeaderName is the header key for revision name.
 	RevisionHeaderName string = "knative-serving-revision"
-	// RevisionHeaderNamespace is the header key for revision's namespace
+	// RevisionHeaderNamespace is the header key for revision's namespace.
 	RevisionHeaderNamespace string = "knative-serving-namespace"
 )
 
@@ -37,6 +37,7 @@ type RevisionID struct {
 	Name      string
 }
 
+// String returns the namespaced name of the RevisionID.
 func (rev RevisionID) String() string {
 	return fmt.Sprintf("%s/%s", rev.Namespace, rev.Name)
 }

--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -23,7 +23,7 @@ import (
 const (
 	// Name is the name of the component.
 	Name = "activator"
-	// K8sServiceName is the name of the activator service
+	// K8sServiceName is the name of the activator Kubernetes service
 	K8sServiceName = "activator-service"
 	// RevisionHeaderName is the header key for revision name
 	RevisionHeaderName string = "knative-serving-revision"

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -24,6 +24,7 @@ import (
 
 	ctrl "github.com/knative/pkg/controller"
 	logtesting "github.com/knative/pkg/logging/testing"
+	"github.com/knative/serving/pkg/activator"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	preconciler "github.com/knative/serving/pkg/reconciler"
@@ -177,7 +178,7 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 			t.Logf("Registering expected hook update for endpoints %s", eps.Name)
 			return HookComplete
 		}
-		if eps.Name == activatorService {
+		if eps.Name == activator.K8sServiceName {
 			// Expected, but not the one we're waiting for.
 			t.Log("Registering activator endpoint update")
 		} else {

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -31,6 +31,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/system"
+	"github.com/knative/serving/pkg/activator"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -55,7 +56,6 @@ import (
 const (
 	controllerAgentName = "serverlessservice-controller"
 	reconcilerName      = "ServerlessServices"
-	activatorService    = "activator-service"
 )
 
 // reconciler implements controller.Reconciler for Service resources.
@@ -127,7 +127,7 @@ func NewController(
 		// Accept only ActivatorService K8s service objects.
 		FilterFunc: rbase.ChainFilterFuncs(
 			rbase.NamespaceFilterFunc(system.Namespace()),
-			rbase.NameFilterFunc(activatorService)),
+			rbase.NameFilterFunc(activator.K8sServiceName)),
 		Handler: rbase.Handler(grCb),
 	})
 
@@ -267,7 +267,7 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 		err                   error
 		foundServingEndpoints bool
 	)
-	activatorEps, err = r.endpointsLister.Endpoints(system.Namespace()).Get(activatorService)
+	activatorEps, err = r.endpointsLister.Endpoints(system.Namespace()).Get(activator.K8sServiceName)
 	if err != nil {
 		logger.Errorw("Error obtaining activator service endpoints", zap.Error(err))
 		return err

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	logtesting "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/system"
+	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/apis/networking"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
@@ -627,7 +628,7 @@ func activatorEndpoints(eo ...EndpointsOption) *corev1.Endpoints {
 	ep := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      activatorService,
+			Name:      activator.K8sServiceName,
 		},
 	}
 	for _, opt := range eo {


### PR DESCRIPTION
Use the constant in the activator.go rather than have our own
in the serverlessservice.go.

/cc @mattmoor 
