### PR TITLE
Unprivileged user conformance test

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,7 @@
+# Use the Jenkins base image as it is a public image that
+# reliably sets up and uses a non-root user (uid 1000).
+# https://github.com/jenkinsci/docker/blob/master/Dockerfile-slim#L15
+# Ideally we should use an unprivileged distroless user if
+# https://github.com/GoogleContainerTools/distroless/issues/235 is implemented.
+baseImageOverrides:
+        github.com/knative/serving/test/test_images/runtime-unprivileged: jenkins/jenkins:lts-slim

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -33,7 +33,7 @@ import (
 )
 
 // The 'runtime-unprivileged' test image uses uid 1000.
-const unprivilegedUserId = 1000
+const unprivilegedUserID = 1000
 
 // fetchRuntimeInfoUnprivileged creates a Service that uses the 'runtime-unprivileged' test image, and extracts the returned output into the
 // RuntimeInfo object.

--- a/test/conformance/conformancetest_helper.go
+++ b/test/conformance/conformancetest_helper.go
@@ -52,7 +52,7 @@ func runtimeInfo(t *testing.T, clients *test.Clients, names *test.ResourceNames,
 	if names.Image == "" {
 		names.Image = runtime
 	} else if names.Image != runtimeUnprivileged {
-		return nil, nil, fmt.Errorf("Invalid image provided: %s", names.Image)
+		return nil, nil, fmt.Errorf("invalid image provided: %s", names.Image)
 	}
 
 	defer test.TearDown(clients, *names)

--- a/test/conformance/user_test.go
+++ b/test/conformance/user_test.go
@@ -26,15 +26,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const userID = 2020
+const securityContextUserID = 2020
 
 // TestMustRunAsUser verifies that a supplied runAsUser through securityContext takes
-// effect as delared by "MUST" in the runtime-contract.
+// effect as declared by "MUST" in the runtime-contract.
 func TestMustRunAsUser(t *testing.T) {
 	t.Parallel()
 	clients := setup(t)
 
-	runAsUser := int64(userID)
+	runAsUser := int64(securityContextUserID)
 	securityContext := &corev1.SecurityContext{
 		RunAsUser: &runAsUser,
 	}
@@ -52,13 +52,45 @@ func TestMustRunAsUser(t *testing.T) {
 		t.Fatal("Missing user information from runtime info.")
 	}
 
-	if got, want := ri.Host.User.UID, userID; got != want {
+	if got, want := ri.Host.User.UID, securityContextUserID; got != want {
 		t.Errorf("uid = %d, want: %d", got, want)
 	}
 
 	// We expect the effective userID to match the userID as we
 	// did not use setuid.
-	if got, want := ri.Host.User.EUID, userID; got != want {
+	if got, want := ri.Host.User.EUID, securityContextUserID; got != want {
 		t.Errorf("euid = %d, want: %d", got, want)
 	}
+}
+
+// TestShouldRunAsUserContainerDefault verifies that a container that sets runAsUser
+// in the Dockerfile is respected when executed in Knative as declared by "SHOULD"
+// in the runtime-contract.
+func TestShouldRunAsUserContainerDefault(t *testing.T) {
+	t.Parallel()
+	clients := setup(t)
+	_, ri, err := fetchRuntimeInfoUnprivileged(t, clients, &test.Options{})
+
+	if err != nil {
+		t.Fatalf("Error fetching runtime info: %v", err)
+	}
+
+	if ri.Host == nil {
+		t.Fatal("Missing host information from runtime info.")
+	}
+
+	if ri.Host.User == nil {
+		t.Fatal("Missing user information from runtime info.")
+	}
+
+	if got, want := ri.Host.User.UID, unprivilegedUserId; got != want {
+		t.Errorf("uid = %d, want: %d", got, want)
+	}
+
+	// We expect the effective userID to match the userID as we
+	// did not use setuid.
+	if got, want := ri.Host.User.EUID, unprivilegedUserId; got != want {
+		t.Errorf("euid = %d, want: %d", got, want)
+	}
+
 }

--- a/test/conformance/user_test.go
+++ b/test/conformance/user_test.go
@@ -83,13 +83,13 @@ func TestShouldRunAsUserContainerDefault(t *testing.T) {
 		t.Fatal("Missing user information from runtime info.")
 	}
 
-	if got, want := ri.Host.User.UID, unprivilegedUserId; got != want {
+	if got, want := ri.Host.User.UID, unprivilegedUserID; got != want {
 		t.Errorf("uid = %d, want: %d", got, want)
 	}
 
 	// We expect the effective userID to match the userID as we
 	// did not use setuid.
-	if got, want := ri.Host.User.EUID, unprivilegedUserId; got != want {
+	if got, want := ri.Host.User.EUID, unprivilegedUserID; got != want {
 		t.Errorf("euid = %d, want: %d", got, want)
 	}
 

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -40,17 +40,18 @@ import (
 
 // Constants for test images located in test/test_images.
 const (
-	pizzaPlanet1        = "pizzaplanetv1"
-	pizzaPlanet2        = "pizzaplanetv2"
+	failing             = "failing"
 	helloworld          = "helloworld"
 	httpproxy           = "httpproxy"
+	invalidhelloworld   = "invalidhelloworld"
+	pizzaPlanet1        = "pizzaplanetv1"
+	pizzaPlanet2        = "pizzaplanetv2"
+	printport           = "printport"
+	protocols           = "protocols"
+	runtime             = "runtime"
+	runtimeUnprivileged = "runtime-unprivileged"
 	singleThreadedImage = "singlethreaded"
 	timeout             = "timeout"
-	printport           = "printport"
-	runtime             = "runtime"
-	protocols           = "protocols"
-	failing             = "failing"
-	invalidhelloworld   = "invalidhelloworld"
 
 	concurrentRequests = 50
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.

--- a/test/test_images/runtime-unprivileged/main.go
+++ b/test/test_images/runtime-unprivileged/main.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Knative Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/knative/serving/test/test_images/runtime/handlers"
+)
+
+func main() {
+
+	// We expect PORT to be defined in a Knative environment
+	// and don't want to mask this failure in a test image.
+	port, isSet := os.LookupEnv("PORT")
+	if !isSet {
+		log.Fatal("Environment variable PORT is not set.")
+	}
+
+	mux := http.NewServeMux()
+	handlers.InitHandlers(mux)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: mux,
+	}
+
+	log.Printf("Server starting on port %s", port)
+	log.Fatal(server.ListenAndServe())
+}

--- a/test/test_images/runtime-unprivileged/main.go
+++ b/test/test_images/runtime-unprivileged/main.go
@@ -14,7 +14,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -35,7 +34,7 @@ func main() {
 	handlers.InitHandlers(mux)
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
+		Addr:    ":" + port,
 		Handler: mux,
 	}
 

--- a/test/test_images/runtime-unprivileged/service.yaml
+++ b/test/test_images/runtime-unprivileged/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: runtime-unprivileged-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: github.com/knative/serving/test/test_images/runtime-unprivileged

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -14,7 +14,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -35,7 +34,7 @@ func main() {
 	handlers.InitHandlers(mux)
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
+		Addr:    ":" + port,
 		Handler: mux,
 	}
 

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -18,7 +18,10 @@ set -o errexit
 
 function upload_test_images() {
   echo ">> Publishing test images"
-  local image_dir="$(dirname $0)/test_images"
+  # Script needs to be executed from the root directory
+  # to pickup .ko.yaml
+  cd "$( dirname "$0")/.."
+  local image_dir="test/test_images"
   local docker_tag=$1
   local tag_option=""
   if [ -n "${docker_tag}" ]; then


### PR DESCRIPTION
This adds a test to validate that a container specified user is
respected when executed within Knative.

Fixes #3223

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->