### PR TITLE
disallow exec probes for liveness and readiness checks

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -195,27 +195,11 @@ func HandlerMask(in *corev1.Handler) *corev1.Handler {
 	out := new(corev1.Handler)
 
 	// Allowed fields
-	out.Exec = in.Exec
 	out.HTTPGet = in.HTTPGet
 	out.TCPSocket = in.TCPSocket
 
 	return out
 
-}
-
-// ExecActionMask performs a _shallow_ copy of the Kubernetes ExecAction object to a new
-// Kubernetes ExecAction object bringing over only the fields allowed in the Knative API. This
-// does not validate the contents or the bounds of the provided fields.
-func ExecActionMask(in *corev1.ExecAction) *corev1.ExecAction {
-	if in == nil {
-		return nil
-	}
-	out := new(corev1.ExecAction)
-
-	// Allowed fields
-	out.Command = in.Command
-
-	return out
 }
 
 // HTTPGetActionMask performs a _shallow_ copy of the Kubernetes HTTPGetAction object to a new

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -247,7 +247,6 @@ func TestProbeMask(t *testing.T) {
 
 func TestHandlerMask(t *testing.T) {
 	want := &corev1.Handler{
-		Exec:      &corev1.ExecAction{},
 		HTTPGet:   &corev1.HTTPGetAction{},
 		TCPSocket: &corev1.TCPSocketAction{},
 	}
@@ -267,29 +266,6 @@ func TestHandlerMask(t *testing.T) {
 
 	if got = HandlerMask(nil); got != nil {
 		t.Errorf("HandlerMask(nil) = %v, want: nil", got)
-	}
-}
-
-func TestExecActionMask(t *testing.T) {
-	want := &corev1.ExecAction{
-		Command: []string{"foo", "bar"},
-	}
-	in := want
-
-	got := ExecActionMask(in)
-
-	if &want == &got {
-		t.Errorf("Input and output share addresses. Want different addresses")
-	}
-
-	if diff, err := kmp.SafeDiff(want, got); err != nil {
-		t.Errorf("Got error comparing output, err = %v", err)
-	} else if diff != "" {
-		t.Errorf("ExecActionMask (-want, +got): %s", diff)
-	}
-
-	if got = ExecActionMask(nil); got != nil {
-		t.Errorf("ExecActionMask(nil) = %v, want: nil", got)
 	}
 }
 

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -683,6 +683,28 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: apis.ErrDisallowedFields("livenessProbe.tcpSocket.port"),
 	}, {
+		name: "disallow exec liveness probe type",
+		c: corev1.Container{
+			Image: "foo",
+			LivenessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					Exec: &corev1.ExecAction{},
+				},
+			},
+		},
+		want: apis.ErrDisallowedFields("livenessProbe.exec"),
+	}, {
+		name: "disallow exec readiness probe type",
+		c: corev1.Container{
+			Image: "foo",
+			ReadinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					Exec: &corev1.ExecAction{},
+				},
+			},
+		},
+		want: apis.ErrDisallowedFields("readinessProbe.exec"),
+	}, {
 		name: "has numerous problems",
 		c: corev1.Container{
 			Name:      "foo",

--- a/test/conformance/container_test.go
+++ b/test/conformance/container_test.go
@@ -98,6 +98,24 @@ func TestMustNotContainerConstraints(t *testing.T) {
 				},
 			}
 		},
+	}, {
+		name: "TestLivenessExecProbe",
+		options: func(s *v1alpha1.Service) {
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().LivenessProbe = &corev1.Probe{
+				Handler: corev1.Handler{
+					Exec: &corev1.ExecAction{Command: []string{"echo"}},
+				},
+			}
+		},
+	}, {
+		name: "TestReadinessExecProbe",
+		options: func(s *v1alpha1.Service) {
+			s.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().ReadinessProbe = &corev1.Probe{
+				Handler: corev1.Handler{
+					Exec: &corev1.ExecAction{Command: []string{"echo"}},
+				},
+			}
+		},
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
* remove the allowance for ExecActions as Readiness and Liveness probes

The runtime contract states that [If specified, liveness and readiness probes are REQUIRED to be of the httpGet or tcpSocket types](https://github.com/knative/serving/blob/master/docs/runtime-contract.md#meta-requests)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
