### PR TITLE
Only check for file permissions, ignoring type bits.

### DIFF
--- a/test/conformance/filesystem_test.go
+++ b/test/conformance/filesystem_test.go
@@ -26,14 +26,14 @@ import (
 	"github.com/knative/serving/test/types"
 )
 
-func verifyModeString(resp string, expected string) error {
+func verifyPermissionsString(resp string, expected string) error {
 	if len(resp) != len(expected) {
-		return fmt.Errorf("mode = %q (len:%d), want: %q (len:%d)", resp, len(resp), expected, len(expected))
+		return fmt.Errorf("perm = %q (len:%d), want: %q (len:%d)", resp, len(resp), expected, len(expected))
 	}
 
 	for index := range expected {
 		if expected[index] != '*' && expected[index] != resp[index] {
-			return fmt.Errorf("mode[%d] = %c, want: %c", index, expected[index], resp[index])
+			return fmt.Errorf("perm[%d] = %c, want: %c", index, expected[index], resp[index])
 		}
 	}
 	return nil
@@ -63,9 +63,9 @@ func testFiles(t *testing.T, clients *test.Clients, paths map[string]types.FileI
 			return fmt.Errorf("%s.SourceFile = %s, want: %s", path, riFile.SourceFile, file.SourceFile)
 		}
 
-		if file.Mode != "" {
-			if err := verifyModeString(riFile.Mode, file.Mode); err != nil {
-				return fmt.Errorf("%s has invalid mode string %s: %v", path, riFile.Mode, err)
+		if file.Perm != "" {
+			if err := verifyPermissionsString(riFile.Perm, file.Perm); err != nil {
+				return fmt.Errorf("%s has invalid permissions string %s: %v", path, riFile.Perm, err)
 			}
 		}
 	}

--- a/test/test_images/runtime/handlers/file.go
+++ b/test/test_images/runtime/handlers/file.go
@@ -15,6 +15,7 @@ package handlers
 
 import (
 	"os"
+	"strings"
 
 	"github.com/knative/serving/test/types"
 )
@@ -29,12 +30,15 @@ func fileInfo(paths ...string) map[string]types.FileInfo {
 		}
 		size := file.Size()
 		dir := file.IsDir()
-		mode := file.Mode()
 		source, _ := os.Readlink(path)
+
+		// If we apply the UNIX permissions mask via 'Perm' the leading
+		// character will always be "-" because all the mode bits are dropped.
+		perm := strings.TrimPrefix(file.Mode().Perm().String(), "-")
 
 		files[path] = types.FileInfo{
 			Size:       &size,
-			Mode:       mode.String(),
+			Perm:       perm,
 			ModTime:    file.ModTime(),
 			SourceFile: source,
 			IsDir:      &dir}

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -92,11 +92,11 @@ var MustFiles = map[string]FileInfo{
 	},
 	"/tmp": {
 		IsDir: ptr.Bool(true),
-		Mode:  "dtrwxrwxrwx",
+		Perm:  "rwxrwxrwx",
 	},
 	"/var/log": {
 		IsDir: ptr.Bool(true),
-		Mode:  "drwxrwxrwx",
+		Perm:  "rwxrwxrwx",
 	},
 }
 
@@ -105,7 +105,7 @@ var MustFiles = map[string]FileInfo{
 var ShouldFiles = map[string]FileInfo{
 	"/etc/resolv.conf": {
 		IsDir: ptr.Bool(false),
-		Mode:  "*rw*r**r**",
+		Perm:  "rw*r**r**",
 	},
 	"/dev/console": { // This file SHOULD NOT exist.
 		Error: "stat /dev/console: no such file or directory",
@@ -168,9 +168,9 @@ type UserInfo struct {
 type FileInfo struct {
 	// Size is the length in bytes for regular files; system-dependent for others.
 	Size *int64 `json:"size,omitempty"`
-	// Mode is the file mode bits.
-	Mode string `json:"mode,omitempty"`
-	// ModTime is the file last modified time
+	// Perm are the unix permission bits.
+	Perm string `json:"mode,omitempty"`
+	// ModTime is the file last modified time.
 	ModTime time.Time `json:"modTime,omitempty"`
 	// SourceFile is populated if this file is a symlink. The SourceFile is the file where
 	// the symlink resolves.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Depending on how the security-contexts are configured, there might be additional bits like the setgid bit. Only comparing the unix-file permissions should be sufficient here though.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @dgerd 
