### PR TITLE
Fix 'Scaling Debugging' Grafana dashboard.

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
@@ -981,7 +981,7 @@ data:
                   "options":[  
 
                   ],
-                  "query":"label_values(autoscaler_observed_pods, namespace_name)",
+                  "query":"label_values(autoscaler_desired_pods, namespace_name)",
                   "refresh":1,
                   "regex":"",
                   "sort":1,
@@ -1007,7 +1007,7 @@ data:
                   "options":[  
 
                   ],
-                  "query":"label_values(autoscaler_observed_pods{namespace_name=\"$namespace\"}, configuration_name)",
+                  "query":"label_values(autoscaler_desired_pods{namespace_name=\"$namespace\"}, configuration_name)",
                   "refresh":1,
                   "regex":"",
                   "sort":1,
@@ -1033,7 +1033,7 @@ data:
                   "options":[  
 
                   ],
-                  "query":"label_values(autoscaler_observed_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\"}, revision_name)",
+                  "query":"label_values(autoscaler_desired_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\"}, revision_name)",
                   "refresh":1,
                   "regex":"",
                   "sort":2,


### PR DESCRIPTION
## Proposed Changes
The dropdowns are not being populated because they rely on the metric *autoscaler_observed_pods* (https://github.com/knative/serving/blob/master/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml#L984), which is not emitted (https://github.com/knative/serving/search?q=ReportObservedPodCount&unscoped_q=ReportObservedPodCount&type=Code).

Use *autoscaler_desired_pods* instead.