### PR TITLE
Log probe timing stat at debug

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -105,7 +105,7 @@ func (a *activationHandler) probeEndpoint(logger *zap.SugaredLogger, r *http.Req
 	reqCtx, probeSpan := trace.StartSpan(r.Context(), "probe")
 	defer func() {
 		probeSpan.End()
-		a.logger.Infof("Probing %s took %d attempts and %v time", target.String(), attempts, time.Since(st))
+		a.logger.Debugf("Probing %s took %d attempts and %v time", target.String(), attempts, time.Since(st))
 	}()
 
 	err := wait.PollImmediate(100*time.Millisecond, a.probeTimeout, func() (bool, error) {


### PR DESCRIPTION
Activator is inteded to serve a large number of req's so per-request
logging like this should live at debug.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
