### PR TITLE
Add test to ensure services in another namespace does not affect route.

### DIFF
--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -116,6 +116,9 @@ func TestConflictingRouteService(t *testing.T) {
 	defer cleanup()
 
 	clients := Setup(t)
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 	if _, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/knative/pkg/apis"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 
 	corev1 "k8s.io/api/core/v1"
@@ -122,12 +120,4 @@ func TestConflictingRouteService(t *testing.T) {
 	if _, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
-}
-
-func configurationIsReady(c *v1alpha1.Configuration) (bool, error) {
-	return c.Status.GetCondition(apis.ConditionReady).IsTrue(), nil
-}
-
-func routeIsReady(c *v1alpha1.Route) (bool, error) {
-	return c.Status.GetCondition(apis.ConditionReady).IsTrue(), nil
 }

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -122,10 +122,6 @@ func TestConflictingRouteService(t *testing.T) {
 	if _, err := test.CreateRunLatestServiceReady(t, clients, &names, &test.Options{}); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
-
-	if readyErr := test.WaitForRouteState(clients.ServingClient, names.Route, routeIsReady, "waiting for route to be ready"); readyErr != nil {
-		t.Errorf("Route did not become ready.")
-	}
 }
 
 func configurationIsReady(c *v1alpha1.Configuration) (bool, error) {


### PR DESCRIPTION
Adds an e2e test for the scenario described by #4069 

Services in one namespace should not affect route created service in another.

Fixes #4073 