### PR TITLE
Remove prober transportfactory global

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -45,7 +45,6 @@ import (
 	netlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/network"
-	"github.com/knative/serving/pkg/network/prober"
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/tracing"
 	tracingconfig "github.com/knative/serving/pkg/tracing/config"
@@ -307,12 +306,7 @@ func TestActivationHandler(t *testing.T) {
 
 			// Setup transports.
 			handler.transport = rt
-			prober.TransportFactory = func() http.RoundTripper {
-				return rt
-			}
-			defer func() {
-				prober.TransportFactory = network.NewAutoTransport
-			}()
+			handler.probeTransportFactory = rtFact(rt)
 
 			if test.sksLister != nil {
 				handler.sksLister = test.sksLister
@@ -378,15 +372,9 @@ func TestActivationHandler_Overflow(t *testing.T) {
 
 	// Setup transports.
 	handler.transport = rt
-	prober.TransportFactory = func() http.RoundTripper {
-		return rt
-	}
-	defer func() {
-		prober.TransportFactory = network.NewAutoTransport
-	}()
+	handler.probeTransportFactory = rtFact(rt)
 
 	sendRequests(requests, namespace, revName, respCh, *handler)
-
 	assertResponses(wantedSuccess, wantedFailure, requests, lockerCh, respCh, t)
 }
 
@@ -417,15 +405,10 @@ func TestActivationHandler_OverflowSeveralRevisions(t *testing.T) {
 	rt := getRT(t, nil, 200, []string{}, nil, wantBody, "", lockerCh)
 	handler := (New(TestLogger(t), reporter, throttler,
 		revClient, svcClient, sksClient)).(*activationHandler)
-	handler.transport = rt
 
 	// Setup transports.
-	prober.TransportFactory = func() http.RoundTripper {
-		return rt
-	}
-	defer func() {
-		prober.TransportFactory = network.NewAutoTransport
-	}()
+	handler.transport = rt
+	handler.probeTransportFactory = rtFact(rt)
 
 	for _, revName := range revisions {
 		requestCount := overallRequests / len(revisions)
@@ -452,22 +435,16 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 		TestLogger(t))
 
 	probeRt := getRT(t, nil, 200, []string{}, nil, wantBody, "", nil)
-	// Setup transports.
-	prober.TransportFactory = func() http.RoundTripper {
-		return probeRt
-	}
-	defer func() {
-		prober.TransportFactory = network.NewAutoTransport
-	}()
 
 	handler := activationHandler{
-		transport:      rt,
-		logger:         TestLogger(t),
-		reporter:       &fakeReporter{},
-		throttler:      throttler,
-		revisionLister: revisionLister(revision(testNamespace, testRevName)),
-		serviceLister:  serviceLister(service(testNamespace, testRevName, "http")),
-		sksLister:      sksLister(sks(testNamespace, testRevName)),
+		transport:             rt,
+		probeTransportFactory: rtFact(probeRt),
+		logger:                TestLogger(t),
+		reporter:              &fakeReporter{},
+		throttler:             throttler,
+		revisionLister:        revisionLister(revision(testNamespace, testRevName)),
+		serviceLister:         serviceLister(service(testNamespace, testRevName, "http")),
+		sksLister:             sksLister(sks(testNamespace, testRevName)),
 	}
 
 	writer := httptest.NewRecorder()
@@ -489,12 +466,6 @@ func TestActivationHandler_ProxyHeader(t *testing.T) {
 func TestActivationHandler_TraceSpans(t *testing.T) {
 	// Setup transport
 	rt := getRT(t, nil, 200, []string{}, nil, "hello", "", nil)
-	prober.TransportFactory = func() http.RoundTripper {
-		return rt
-	}
-	defer func() {
-		prober.TransportFactory = network.NewAutoTransport
-	}()
 
 	// Create tracer with reporter recorder
 	reporter := reporterrecorder.NewReporter()
@@ -533,6 +504,8 @@ func TestActivationHandler_TraceSpans(t *testing.T) {
 		serviceLister:  serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister:      sksLister(sks(testNamespace, testRevName)),
 	}
+	handler.transport = rt
+	handler.probeTransportFactory = rtFact(rt)
 
 	_ = sendRequest(namespace, revName, handler)
 
@@ -860,4 +833,10 @@ func endpointsInformer(eps ...*corev1.Endpoints) corev1informers.EndpointsInform
 
 func errMsg(msg string) string {
 	return fmt.Sprintf("Error getting active endpoint: %v\n", msg)
+}
+
+func rtFact(rt http.RoundTripper) func() http.RoundTripper {
+	return func() http.RoundTripper {
+		return rt
+	}
 }

--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -70,7 +70,7 @@ func TestDoServing(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Do(context.Background(), ts.URL, test.headerValue)
+			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, test.headerValue)
 			if want := test.want; got != want {
 				t.Errorf("Got = %v, want: %v", got, want)
 			}
@@ -82,7 +82,7 @@ func TestDoServing(t *testing.T) {
 }
 
 func TestBlackHole(t *testing.T) {
-	got, err := Do(context.Background(), "http://gone.fishing.svc.custer.local:8080", systemName)
+	got, err := Do(context.Background(), network.NewAutoTransport(), "http://gone.fishing.svc.custer.local:8080", systemName)
 	if want := false; got != want {
 		t.Errorf("Got = %v, want: %v", got, want)
 	}
@@ -92,7 +92,7 @@ func TestBlackHole(t *testing.T) {
 }
 
 func TestBadURL(t *testing.T) {
-	_, err := Do(context.Background(), ":foo", systemName)
+	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo", systemName)
 	if err == nil {
 		t.Error("Do did not return an error")
 	}
@@ -149,7 +149,7 @@ func TestDoAsync(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := New(test.cb)
+			m := New(test.cb, network.NewAutoTransport)
 			m.Offer(context.Background(), ts.URL, test.headerValue, test.name, 50*time.Millisecond, 2*time.Second)
 			<-wch
 		})
@@ -186,7 +186,7 @@ func TestDoAsyncRepeat(t *testing.T) {
 		}
 		wch <- arg
 	}
-	m := New(cb)
+	m := New(cb, network.NewAutoTransport)
 	m.Offer(context.Background(), ts.URL, systemName, 42, 50*time.Millisecond, 3*time.Second)
 	<-wch
 	if got, want := c.calls, 3; got != want {
@@ -209,7 +209,7 @@ func TestDoAsyncTimeout(t *testing.T) {
 		}
 		wch <- arg
 	}
-	m := New(cb)
+	m := New(cb, network.NewAutoTransport)
 	m.Offer(context.Background(), ts.URL, systemName, 2009, 10*time.Millisecond, 200*time.Millisecond)
 	<-wch
 }
@@ -224,7 +224,7 @@ func TestAsyncMultiple(t *testing.T) {
 		<-wch
 		wch <- 2006
 	}
-	m := New(cb)
+	m := New(cb, network.NewAutoTransport)
 	if !m.Offer(context.Background(), ts.URL, systemName, 1984, 100*time.Millisecond, 1*time.Second) {
 		t.Error("First call to offer returned false")
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -19,6 +19,7 @@ package kpa
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 	"testing"
@@ -301,7 +302,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		fakeMetrics := newTestMetrics()
 		psFactory := presources.NewPodScalableInformerFactory(ctx)
 		scaler := newScaler(ctx, psFactory, func(interface{}, time.Duration) {})
-		scaler.activatorProbe = func(*asv1a1.PodAutoscaler) (bool, error) { return true, nil }
+		scaler.activatorProbe = func(*asv1a1.PodAutoscaler, http.RoundTripper) (bool, error) { return true, nil }
 		return &Reconciler{
 			Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),
 			paLister:          listers.GetPodAutoscalerLister(),


### PR DESCRIPTION
This global causes some issues with testing as we have to properly
manage it. When performing more complex tests it is difficult to avoid
data races as a result.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
