### PR TITLE
change path to host

### DIFF
--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -83,6 +83,6 @@ func DomainNameFromTemplate(ctx context.Context, r *v1alpha1.Route, name string)
 func URL(scheme, fqdn string) *apis.URL {
 	return &apis.URL{
 		Scheme: scheme,
-		Path:   fqdn,
+		Host:   fqdn,
 	}
 }

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -165,7 +165,7 @@ func TestURL(t *testing.T) {
 		domain: "current.svc.local.com",
 		Expected: apis.URL{
 			Scheme: "http",
-			Path:   "current.svc.local.com",
+			Host:   "current.svc.local.com",
 		},
 	}, {
 		name:   "default target",
@@ -173,7 +173,7 @@ func TestURL(t *testing.T) {
 		domain: "example.com",
 		Expected: apis.URL{
 			Scheme: "http",
-			Path:   "example.com",
+			Host:   "example.com",
 		},
 	}}
 

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1442,7 +1442,7 @@ func TestReconcile(t *testing.T) {
 							LatestRevision: ptr.Bool(true),
 							URL: &apis.URL{
 								Scheme: "http",
-								Path:   "same-revision-targets-gray.default.example.com",
+								Host:   "same-revision-targets-gray.default.example.com",
 							},
 						},
 					}, v1alpha1.TrafficTarget{
@@ -1454,7 +1454,7 @@ func TestReconcile(t *testing.T) {
 							LatestRevision: ptr.Bool(false),
 							URL: &apis.URL{
 								Scheme: "http",
-								Path:   "same-revision-targets-also-gray.default.example.com",
+								Host:   "same-revision-targets-also-gray.default.example.com",
 							},
 						},
 					})),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Changing the `Path` to `Host` when setting URL as it seems incorrect to set fqdn to `Path`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
"NONE"
```
