### PR TITLE
Assign specific verions to images missing verions

### DIFF
--- a/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:latest
+        image: docker.io/openzipkin/zipkin:2.13.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9411

--- a/config/monitoring/tracing/zipkin/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin/100-zipkin.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:latest
+        image: docker.io/openzipkin/zipkin:2.13.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9411


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4125

## Proposed Changes

This PR assigns versions to the following images:
* 2.13.0 for docker.io/openzipkin/zipkin
* latest for gcr.io/cloud-builders/gcs-fetcher

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
