### PR TITLE
Single domain cert

### DIFF
--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -34,18 +34,6 @@ const HTTPScheme string = "http"
 func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string) (map[string]string, error) {
 	domainTagMap := make(map[string]string)
 
-	// majorDomain, err := DomainNameFromTemplate(ctx, r, r.Name)
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
-
-	// TODO: is major domain tag-less?
-	// I assume sets has no order?
-	// allDomains := sets.NewString(majorDomain)
-	// allDomains = append(allDomains, majorDomain)
-	// allTags = append(allTags, "")
-	// logger.Info("major domain: ", majorDomain)
-	// logger.Info("dns names: ", names)
 	for _, name := range names {
 		subDomain, err := DomainNameFromTemplate(ctx, r, SubdomainName(r, name))
 		if err != nil {

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -22,30 +22,42 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/route/config"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // HTTPScheme is the string representation of http.
 const HTTPScheme string = "http"
 
-// GetAllDomains returns all of the domains (including subdomains) associated with a Route
-func GetAllDomains(ctx context.Context, r *v1alpha1.Route, names []string) ([]string, error) {
-	majorDomain, err := DomainNameFromTemplate(ctx, r, r.Name)
-	if err != nil {
-		return nil, err
-	}
-	allDomains := sets.NewString(majorDomain)
+// GetAllDomainsAndTags returns all of the domains and tags(including subdomains) associated with a Route
+func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string) ([]string, []string, error) {
+	logger := logging.FromContext(ctx)
+
+	// majorDomain, err := DomainNameFromTemplate(ctx, r, r.Name)
+	// if err != nil {
+	// 	return nil, nil, err
+	// }
+
+	// TODO: is major domain tag-less?
+	// I assume sets has no order?
+	// allDomains := sets.NewString(majorDomain)
+	var allDomains, allTags []string
+	// allDomains = append(allDomains, majorDomain)
+	// allTags = append(allTags, "")
+	// logger.Info("major domain: ", majorDomain)
+	// logger.Info("dns names: ", names)
 	for _, name := range names {
 		subDomain, err := DomainNameFromTemplate(ctx, r, SubdomainName(r, name))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		allDomains.Insert(subDomain)
+		allDomains = append(allDomains, subDomain)
+		allTags = append(allTags, name)
+		logger.Info("tag: ", name, " subdomain: ", subDomain)
 	}
-	return allDomains.List(), nil
+	return allDomains, allTags, nil
 }
 
 // SubdomainName generates a name which represents the subdomain of a route

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/route/config"
@@ -32,8 +31,8 @@ import (
 const HTTPScheme string = "http"
 
 // GetAllDomainsAndTags returns all of the domains and tags(including subdomains) associated with a Route
-func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string) ([]string, []string, error) {
-	logger := logging.FromContext(ctx)
+func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string) (map[string]string, error) {
+	domainTagMap := make(map[string]string)
 
 	// majorDomain, err := DomainNameFromTemplate(ctx, r, r.Name)
 	// if err != nil {
@@ -43,7 +42,6 @@ func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string
 	// TODO: is major domain tag-less?
 	// I assume sets has no order?
 	// allDomains := sets.NewString(majorDomain)
-	var allDomains, allTags []string
 	// allDomains = append(allDomains, majorDomain)
 	// allTags = append(allTags, "")
 	// logger.Info("major domain: ", majorDomain)
@@ -51,13 +49,11 @@ func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string
 	for _, name := range names {
 		subDomain, err := DomainNameFromTemplate(ctx, r, SubdomainName(r, name))
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		allDomains = append(allDomains, subDomain)
-		allTags = append(allTags, name)
-		logger.Info("tag: ", name, " subdomain: ", subDomain)
+		domainTagMap[subDomain] = name
 	}
-	return allDomains, allTags, nil
+	return domainTagMap, nil
 }
 
 // SubdomainName generates a name which represents the subdomain of a route

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -220,6 +220,7 @@ func TestGetAllDomains(t *testing.T) {
 			cfg.Network.DomainTemplate = tt.template
 			ctx = config.ToContext(ctx, cfg)
 
+			// TODO: probably need to rewrite this
 			got, err := GetAllDomains(ctx, route, []string{"target-1", "target-2"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAllDomains() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -186,16 +186,20 @@ func TestURL(t *testing.T) {
 	}
 }
 
-func TestGetAllDomains(t *testing.T) {
+func TestGetAllDomainsAndTags(t *testing.T) {
 	tests := []struct {
 		name     string
 		template string
-		want     []string
+		want     map[string]string
 		wantErr  bool
 	}{{
 		name:     "happy case",
 		template: "{{.Name}}.{{.Namespace}}.{{.Domain}}",
-		want:     []string{"myroute-target-1.default.example.com", "myroute-target-2.default.example.com", "myroute.default.example.com"},
+		want: map[string]string{
+			"myroute-target-1.default.example.com": "target-1",
+			"myroute-target-2.default.example.com": "target-2",
+			"myroute.default.example.com":          "",
+		},
 	}, {
 		name:     "bad template",
 		template: "{{.NNName}}.{{.Namespace}}.{{.Domain}}",
@@ -220,8 +224,8 @@ func TestGetAllDomains(t *testing.T) {
 			cfg.Network.DomainTemplate = tt.template
 			ctx = config.ToContext(ctx, cfg)
 
-			// TODO: probably need to rewrite this
-			got, err := GetAllDomains(ctx, route, []string{"target-1", "target-2"})
+			// here, a tag-less major domain will have empty string as the input
+			got, err := GetAllDomainsAndTags(ctx, route, []string{"", "target-1", "target-2"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAllDomains() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/reconciler/route/resources/certificate.go
+++ b/pkg/reconciler/route/resources/certificate.go
@@ -17,24 +17,53 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
+	"hash/adler32"
+
 	"github.com/knative/pkg/kmeta"
 	networkingv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/route/resources/names"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MakeCertificate creates Certificate for the Route to request TLS certificates.
-func MakeCertificate(route *v1alpha1.Route, dnsNames []string) *networkingv1alpha1.Certificate {
-	return &networkingv1alpha1.Certificate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            names.Certificate(route),
-			Namespace:       route.Namespace,
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
-		},
-		Spec: networkingv1alpha1.CertificateSpec{
-			DNSNames:   dnsNames,
-			SecretName: names.Certificate(route),
-		},
+// MakeCertificates creates Certificate array for the Route to request TLS certificates.
+// Returns one certificate for each domain, that is, each tag and the major
+func MakeCertificates(logger *zap.SugaredLogger, route *v1alpha1.Route, dnsNames []string, tags []string) []*networkingv1alpha1.Certificate {
+	// TODO: why do we pass route here? we only need its namespace and uid?
+	// or should we factor the logic of getting the dnsnames and tags here instead of in reconcile func in route.go
+	// TODO: here it assumes dnsNames and tags have the same length, and is one to one mapping
+	// do need to do valid check?
+
+	var certs []*networkingv1alpha1.Certificate
+	logger.Info("dnsNames: ", dnsNames, " ", len(dnsNames))
+	for i, dnsName := range dnsNames {
+		certs = append(certs, &networkingv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				// Name:            names.Certificate(route), // TODO: does this return the same name?
+				// TODO: fmt.Sprintf("%s-%s", names.Certificate(route), dnsName) this name is too long and kube support cert name
+				// only up to 63 chars, we may want to rewrite the name.Certificate function altogether?
+
+				// kube system supports cert name only up to 63 characters
+				// we decided to adapt the scheme route-[UID]-[tag digest]
+				// where route-UID will take 42 characters and leaves 20 characters for tag digest (need to count `-`)
+				// we use https://golang.org/pkg/hash/adler32/#Checksum to compute the digest which result a positive int of 4 bytes
+				// we represent the digest in integer format gives maximum value of 4,294,967,295 which is 10 digits
+
+				// TODO: do we want to compute the checksum here or in the names.Certificate function
+				// should be fine to put in the names.Certificate func, looks like it's not used elsewhere
+				// TODO: only compute checksum if there's a tag
+				Name:            fmt.Sprintf("%s-%d", names.Certificate(route), adler32.Checksum([]byte(tags[i]))),
+				Namespace:       route.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
+			},
+			Spec: networkingv1alpha1.CertificateSpec{
+				DNSNames: []string{dnsName},
+				// SecretName: names.Certificate(route),
+				SecretName: fmt.Sprintf("%s-%d", names.Certificate(route), adler32.Checksum([]byte(tags[i]))),
+			},
+		})
 	}
+	return certs
 }

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -34,11 +34,10 @@ var route = &v1alpha1.Route{
 	},
 }
 
-var dnsNames = []string{"v1.default.example.com", "v1-current.default.example.com"}
-
-var tags = []string{"", "current"}
-
-var dnsNameTagMap = map[string]string{}
+var dnsNameTagMap = map[string]string{
+	"v1.default.example.com":         "",
+	"v1-current.default.example.com": "current",
+}
 
 func TestMakeCertificates(t *testing.T) {
 	want := []*netv1alpha1.Certificate{
@@ -65,7 +64,7 @@ func TestMakeCertificates(t *testing.T) {
 			},
 		},
 	}
-	got := MakeCertificates(route, dnsNames, tags)
+	got := MakeCertificates(route, dnsNameTagMap)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("MakeCertificate (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/knative/pkg/kmeta"
@@ -35,21 +34,38 @@ var route = &v1alpha1.Route{
 	},
 }
 
-var dnsNames = []string{"v1.default.example.com", "subroute.v1.default.example.com"}
+var dnsNames = []string{"v1.default.example.com", "v1-current.default.example.com"}
 
-func TestMakeCertificate(t *testing.T) {
-	want := &netv1alpha1.Certificate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-%s", route.Name, route.UID),
-			Namespace:       "default",
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
+var tags = []string{"", "current"}
+
+var dnsNameTagMap = map[string]string{}
+
+func TestMakeCertificates(t *testing.T) {
+	want := []*netv1alpha1.Certificate{
+		&netv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "route-12345",
+				Namespace:       "default",
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
+			},
+			Spec: netv1alpha1.CertificateSpec{
+				DNSNames:   []string{"v1.default.example.com"},
+				SecretName: "route-12345",
+			},
 		},
-		Spec: netv1alpha1.CertificateSpec{
-			DNSNames:   dnsNames,
-			SecretName: fmt.Sprintf("%s-%s", route.Name, route.UID),
+		&netv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "route-12345-200999684",
+				Namespace:       "default",
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
+			},
+			Spec: netv1alpha1.CertificateSpec{
+				DNSNames:   []string{"v1-current.default.example.com"},
+				SecretName: "route-12345-200999684",
+			},
 		},
 	}
-	got := MakeCertificate(route, dnsNames)
+	got := MakeCertificates(route, dnsNames, tags)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("MakeCertificate (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -166,7 +166,6 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 		return err
 	}
 
-	// TODO: why would Route.Status has a URL field?
 	r.Status.URL = &apis.URL{
 		Scheme: "http",
 		Host:   host,
@@ -179,7 +178,6 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 		// Traffic targets aren't ready, no need to configure child resources.
 		return err
 	}
-	logger.Infof("Got traffic: %#v", traffic)
 
 	logger.Info("Updating targeted revisions.")
 	// In all cases we will add annotations to the referred targets.  This is so that when they become
@@ -217,7 +215,6 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 			return err
 		}
 		desiredCerts := resources.MakeCertificates(r, allDomainTagMap)
-		logger.Info("MakeCertificates returned %d certs", len(desiredCerts))
 		for _, desiredCert := range desiredCerts {
 
 			cert, err := c.reconcileCertificate(ctx, r, desiredCert)
@@ -231,19 +228,17 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 				r.Status.URL.Scheme = "https"
 				// TODO: we should only mark https for the public visible targets when
 				// we are able to configure visibility per target.
-				setTargetsScheme(logger, &r.Status, cert.Spec.DNSNames, "https")
+				setTargetsScheme(&r.Status, cert.Spec.DNSNames, "https")
 			} else {
 				r.Status.MarkCertificateNotReady(cert.Name)
 				r.Status.URL = &apis.URL{
 					Scheme: "http",
 					Host:   host,
 				}
-				setTargetsScheme(logger, &r.Status, cert.Spec.DNSNames, "http")
+				setTargetsScheme(&r.Status, cert.Spec.DNSNames, "http")
 			}
 
-			// TODO: do we want one ingress tls per cert
 			tls = append(tls, resources.MakeClusterIngressTLS(cert, cert.Spec.DNSNames))
-			logger.Info("Appending new tls for cer %s", desiredCert.Name)
 		}
 	}
 
@@ -394,20 +389,18 @@ func getTrafficNames(targets map[string]traffic.RevisionTargets) []string {
 	return names
 }
 
-// sets the traffic url scheme to the scheme if the url matches a record from dnsNames
-func setTargetsScheme(logger *zap.SugaredLogger, rs *v1alpha1.RouteStatus, dnsNames []string, scheme string) {
+// Sets the traffic URL scheme to scheme if the URL matches the dnsNames.
+// dnsNames are DNS names under a certificate for a particular domain, and so only change
+// the corresponding traffic under the route, rather than all traffic
+func setTargetsScheme(rs *v1alpha1.RouteStatus, dnsNames []string, scheme string) {
 	for i := range rs.Traffic {
 		if rs.Traffic[i].URL == nil {
 			continue
 		}
 		for _, dnsName := range dnsNames {
-			logger.Infof("traffic target: %#v", rs.Traffic[i].URL)
 			if rs.Traffic[i].URL.Host == dnsName {
 				rs.Traffic[i].URL.Scheme = scheme
-				logger.Info("traffic url host ", rs.Traffic[i].URL.Host, " is set to ", scheme)
 				break
-			} else {
-				logger.Info("traffic url host ", rs.Traffic[i].URL.Host, " dnsname ", dnsName)
 			}
 		}
 	}

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -281,7 +281,7 @@ func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) e
 		return err
 	}
 
-	// Update the Route to remove the Finalizer.configureTraffic
+	// Update the Route to remove the Finalizer.
 	logger.Info("Removing Finalizer")
 	r.Finalizers = r.Finalizers[1:]
 	_, err := c.ServingClientSet.ServingV1alpha1().Routes(r.Namespace).Update(r)

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -179,7 +179,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 		// Traffic targets aren't ready, no need to configure child resources.
 		return err
 	}
-	logger.Info("Got traffic: ", traffic)
+	logger.Infof("Got traffic: %#v", traffic)
 
 	logger.Info("Updating targeted revisions.")
 	// In all cases we will add annotations to the referred targets.  This is so that when they become

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: do we need to modify/add new test here for reconcile in route.go?
-
 package route
 
 import (

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: do we need to modify/add new test here for reconcile in route.go?
+
 package route
 
 import (

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1913,8 +1913,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeCertificate(route("default", "becomes-ready", WithConfigTarget("config"), WithDomain, WithRouteUID("12-34")),
-				[]string{"becomes-ready.default.example.com"}),
+			resources.MakeCertificates(route("default", "becomes-ready", WithConfigTarget("config"), WithDomain, WithRouteUID("12-34")),
+				map[string]string{"becomes-ready.default.example.com": ""})[0],
 			ingressWithTLS(
 				route("default", "becomes-ready", WithConfigTarget("config"), WithDomain,
 					WithRouteUID("12-34")),
@@ -2020,8 +2020,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: certificateWithStatus(resources.MakeCertificate(route("default", "becomes-ready", WithConfigTarget("config"), WithDomain, WithRouteUID("12-34")),
-				[]string{"becomes-ready.default.example.com"}), readyCertStatus()),
+			Object: certificateWithStatus(resources.MakeCertificates(route("default", "becomes-ready", WithConfigTarget("config"), WithDomain, WithRouteUID("12-34")),
+				map[string]string{"becomes-ready.default.example.com": ""})[0], readyCertStatus()),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchFinalizers("default", "becomes-ready"),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4004 

## Proposed Changes

* If a route has a traffic that is tagged, there would be a separate domain for that tag: `myapp-tag.default.example.com`. We used to generate one certificate for both domains and we wish to separate them.
* `MakeCertificates` now returns an array of certificates, one for each domain.
* `setTargetsScheme` now takes a `dnsNames` array representing the domains a certificate is entitled to so that the function sets the specific route traffic to target scheme, rather than all the traffic.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
"NONE"
```
