### PR TITLE
Surface deployment replica failure status

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -160,6 +160,12 @@ func (rs *RevisionStatus) MarkProgressDeadlineExceeded(message string) {
 	revCondSet.Manage(rs).MarkFalse(RevisionConditionResourcesAvailable, "ProgressDeadlineExceeded", message)
 }
 
+// MarkNoDeployment changes the "ResourcesAvailable" condition to false to reflect that the
+// deployment has already been created, and replica is failed to be created
+func (rs *RevisionStatus) MarkNoDeployment(message string) {
+	revCondSet.Manage(rs).MarkFalse(RevisionConditionResourcesAvailable, "NoDeployment", message)
+}
+
 func (rs *RevisionStatus) MarkContainerHealthy() {
 	revCondSet.Manage(rs).MarkTrue(RevisionConditionContainerHealthy)
 }

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -139,6 +139,13 @@ func MarkContainerExiting(exitCode int32, message string) RevisionOption {
 	}
 }
 
+// MarkNoDeployment calls .Status.MarkNoDeployment on the Revision
+func MarkNoDeployment(message string) RevisionOption {
+	return func(r *v1alpha1.Revision) {
+		r.Status.MarkNoDeployment(message)
+	}
+}
+
 // MarkResourcesUnavailable calls .Status.MarkResourcesUnavailable on the Revision.
 func MarkResourcesUnavailable(reason, message string) RevisionOption {
 	return func(r *v1alpha1.Revision) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #496

## Proposed Changes

* Following [spec](https://github.com/knative/serving/blob/master/docs/spec/errors.md#resource-exhausted-while-creating-a-revision), surfaced deployment replica failure due ti insufficient quota, limit ranges, etc.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
