### PR TITLE
TickInterval reconciled on configmap update

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -310,6 +310,8 @@ func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAut
 
 	// Ignore status when reconciling
 	desiredDecider.Status = decider.Status
+	resources.UpdateDecider(desiredDecider, config.FromContext(ctx).Autoscaler)
+
 	if !equality.Semantic.DeepEqual(desiredDecider, decider) {
 		decider, err = c.kpaDeciders.Update(ctx, desiredDecider)
 		if err != nil {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -64,3 +64,10 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 		},
 	}
 }
+
+// UpdateDecider updades a Decider resource spec from a PodAutoscaler config
+func UpdateDecider(currentDecider *autoscaler.Decider, config *autoscaler.Config) {
+	if currentDecider.Spec.TickInterval != config.TickInterval {
+		currentDecider.Spec.TickInterval = config.TickInterval
+	}
+}


### PR DESCRIPTION
If TickInterval is adjusted in the autoscaler configmap, it is reconciled on next update

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3977 

**Release Note**

```release-note
NONE
```
