### PR TITLE
Remove deprecated ObservedPodCount metric

### DIFF
--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -220,11 +220,6 @@ func (r *mockReporter) ReportActualPodCount(v int64) error {
 	return nil
 }
 
-// ReportObservedPodCount of a mockReporter does nothing and return nil for error.
-func (r *mockReporter) ReportObservedPodCount(v float64) error {
-	return nil
-}
-
 // ReportStableRequestConcurrency of a mockReporter does nothing and return nil for error.
 func (r *mockReporter) ReportStableRequestConcurrency(v float64) error {
 	return nil

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -155,7 +155,6 @@ type StatsReporter interface {
 	ReportDesiredPodCount(v int64) error
 	ReportRequestedPodCount(v int64) error
 	ReportActualPodCount(v int64) error
-	ReportObservedPodCount(v float64) error
 	ReportStableRequestConcurrency(v float64) error
 	ReportPanicRequestConcurrency(v float64) error
 	ReportTargetRequestConcurrency(v float64) error
@@ -211,11 +210,6 @@ func (r *Reporter) ReportRequestedPodCount(v int64) error {
 // ReportActualPodCount captures value v for actual pod count measure.
 func (r *Reporter) ReportActualPodCount(v int64) error {
 	return r.report(actualPodCountM.M(v))
-}
-
-// ReportObservedPodCount captures value v for observed pod count measure.
-func (r *Reporter) ReportObservedPodCount(v float64) error {
-	return r.report(observedPodCountM.M(v))
 }
 
 // ReportStableRequestConcurrency captures value v for stable request concurrency measure.

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -41,10 +41,6 @@ var (
 		"actual_pods",
 		"Number of pods that are allocated currently",
 		stats.UnitDimensionless)
-	observedPodCountM = stats.Float64(
-		"observed_pods",
-		"Number of pods that are observed currently",
-		stats.UnitDimensionless)
 	stableRequestConcurrencyM = stats.Float64(
 		"stable_request_concurrency",
 		"Average of requests count per observed pod in each stable window (default 60 seconds)",
@@ -110,12 +106,6 @@ func init() {
 		&view.View{
 			Description: "Number of pods that are allocated currently",
 			Measure:     actualPodCountM,
-			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
-		},
-		&view.View{
-			Description: "Number of pods that are observed currently",
-			Measure:     observedPodCountM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -71,7 +71,6 @@ func TestReporter_Report(t *testing.T) {
 	assertData(t, "requested_pods", wantTags, 7)
 	assertData(t, "actual_pods", wantTags, 5)
 	assertData(t, "panic_mode", wantTags, 0)
-	assertData(t, "observed_pods", wantTags, 1)
 	assertData(t, "stable_request_concurrency", wantTags, 2)
 	assertData(t, "panic_request_concurrency", wantTags, 3)
 	assertData(t, "target_concurrency_per_pod", wantTags, 0.9)

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -64,7 +64,6 @@ func TestReporter_Report(t *testing.T) {
 	expectSuccess(t, "ReportRequestedPodCount", func() error { return r.ReportRequestedPodCount(7) })
 	expectSuccess(t, "ReportActualPodCount", func() error { return r.ReportActualPodCount(5) })
 	expectSuccess(t, "ReportPanic", func() error { return r.ReportPanic(0) })
-	expectSuccess(t, "ReportObservedPodCount", func() error { return r.ReportObservedPodCount(1) })
 	expectSuccess(t, "ReportStableRequestConcurrency", func() error { return r.ReportStableRequestConcurrency(2) })
 	expectSuccess(t, "ReportPanicRequestConcurrency", func() error { return r.ReportPanicRequestConcurrency(3) })
 	expectSuccess(t, "ReportTargetRequestConcurrency", func() error { return r.ReportTargetRequestConcurrency(0.9) })


### PR DESCRIPTION
## Proposed Changes
When fixing #4096, I realized that `ObservedPodCount` is not used anymore.
@yanweiguo [confirmed that it should be removed](https://github.com/knative/serving/pull/4096#issuecomment-492909504).