### PR TITLE
Add host header when making calls through loadgenerator

### DIFF
--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -89,7 +89,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		LoadFactors:    []float64{1},
 		FileNamePrefix: tName,
 	}
-	resp, err := opts.RunLoadTest()
+	resp, err := opts.RunLoadTest(loadgenerator.AddHostHeader)
 	if err != nil {
 		t.Fatalf("Generating traffic via fortio failed: %v", err)
 	}

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -159,7 +159,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	}
 
 	t.Logf("Starting test with %d clients at %s", numClients, time.Now())
-	resp, err := opts.RunLoadTest()
+	resp, err := opts.RunLoadTest(loadgenerator.AddHostHeader)
 	if err != nil {
 		t.Fatalf("Generating traffic via fortio failed: %v", err)
 	}


### PR DESCRIPTION
The recent test-infra update broke these tests as we stopped adding the host header. Add them back so that they start passing again.