### PR TITLE
Enable setting the resource request/limits via annotations for queue-proxy side-car container

### DIFF
--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -29,16 +29,16 @@ const (
 	QueueContainerName = "queue-proxy"
 
 	// queueContainerRequestCPUAnnotation is the request.cpu of the queue proxy side car
-	queueContainerRequestCPUAnnotation = "sidecar.istio.io/queue-proxy/RequestCpu"
+	queueContainerRequestCPUAnnotation = "queue.sidecar.serving.knative.dev/RequestCpu"
 
 	// queueContainerLimitCPUAnnotation is the limit.cpu of the queue proxy side car
-	queueContainerLimitCPUAnnotation = "sidecar.istio.io/queue-proxy/LimitCpu"
+	queueContainerLimitCPUAnnotation = "queue.sidecar.serving.knative.dev/LimitCpu"
 
 	// queueContainerRequestMemoryAnnotation is the request.memory of the queue proxy side car
-	queueContainerRequestMemoryAnnotation = "sidecar.istio.io/queue-proxy/RequestMemory"
+	queueContainerRequestMemoryAnnotation = "queue.sidecar.serving.knative.dev/RequestMemory"
 
 	// queueContainerLimitMemoryAnnotation is the limit.memory of the queue proxy side car
-	queueContainerLimitMemoryAnnotation = "sidecar.istio.io/queue-proxy/LimitMemory"
+	queueContainerLimitMemoryAnnotation = "queue.sidecar.serving.knative.dev/LimitMemory"
 
 	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
 	// IstioOutboundIPRangeAnnotation defines the outbound ip ranges istio allows.

--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -28,6 +28,18 @@ const (
 	// QueueContainerName is the name of the queue proxy side car
 	QueueContainerName = "queue-proxy"
 
+	// queueContainerRequestCPUAnnotation is the request.cpu of the queue proxy side car
+	queueContainerRequestCPUAnnotation = "sidecar.istio.io/queue-proxy/RequestCpu"
+
+	// queueContainerLimitCPUAnnotation is the limit.cpu of the queue proxy side car
+	queueContainerLimitCPUAnnotation = "sidecar.istio.io/queue-proxy/LimitCpu"
+
+	// queueContainerRequestMemoryAnnotation is the request.memory of the queue proxy side car
+	queueContainerRequestMemoryAnnotation = "sidecar.istio.io/queue-proxy/RequestMemory"
+
+	// queueContainerLimitMemoryAnnotation is the limit.memory of the queue proxy side car
+	queueContainerLimitMemoryAnnotation = "sidecar.istio.io/queue-proxy/LimitMemory"
+
 	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
 	// IstioOutboundIPRangeAnnotation defines the outbound ip ranges istio allows.
 	// TODO(mattmoor): Make this private once we remove revision_test.go

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -67,7 +67,7 @@ var (
 
 	defaultQueueContainer = &corev1.Container{
 		Name:           QueueContainerName,
-		Resources:      queueResources,
+		Resources:      getResources(make(map[string]string)),
 		Ports:          append(queueNonServingPorts, queueHTTPPort),
 		ReadinessProbe: queueReadinessProbe,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -78,8 +78,8 @@ var (
 	}
 )
 
-func setResources(rev *v1alpha1.Revision) corev1.ResourceRequirements {
-	annotations := rev.GetAnnotations()
+func getResources(annotations map[string]string) corev1.ResourceRequirements {
+
 	resources := corev1.ResourceRequirements{}
 	resourcesRequest := corev1.ResourceList{corev1.ResourceCPU: queueContainerCPU}
 	resourcesLimits := corev1.ResourceList{}
@@ -101,11 +101,11 @@ func setResources(rev *v1alpha1.Revision) corev1.ResourceRequirements {
 		resourcesLimits[corev1.ResourceMemory] = limitMemory
 	}
 
-	if len(resourcesRequest) == 0 {
+	if len(resourcesRequest) != 0 {
 		resources.Requests = resourcesRequest
 	}
 
-	if len(resourcesRequest) == 0 {
+	if len(resourcesRequest) != 0 {
 		resources.Limits = resourcesLimits
 	}
 
@@ -121,6 +121,7 @@ func getResourceFromAnnotations(m map[string]string, k string) (bool, resource.Q
 	if err != nil {
 		return false, resource.Quantity{}
 	}
+
 	return true, quantity
 }
 
@@ -157,7 +158,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 	return &corev1.Container{
 		Name:           QueueContainerName,
 		Image:          deploymentConfig.QueueSidecarImage,
-		Resources:      setResources(rev),
+		Resources:      getResources(rev.GetAnnotations()),
 		Ports:          ports,
 		ReadinessProbe: queueReadinessProbe,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -19,6 +19,8 @@ package resources
 import (
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/knative/pkg/logging"
@@ -37,12 +39,6 @@ import (
 const requestQueueHTTPPortName = "queue-port"
 
 var (
-	queueResources = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceName("cpu"): queueContainerCPU,
-		},
-	}
-
 	queueHTTPPort = corev1.ContainerPort{
 		Name:          requestQueueHTTPPortName,
 		ContainerPort: int32(networking.BackendHTTPPort),
@@ -82,6 +78,52 @@ var (
 	}
 )
 
+func setResources(rev *v1alpha1.Revision) corev1.ResourceRequirements {
+	annotations := rev.GetAnnotations()
+	resources := corev1.ResourceRequirements{}
+	resourcesRequest := corev1.ResourceList{corev1.ResourceCPU: queueContainerCPU}
+	resourcesLimits := corev1.ResourceList{}
+	ok := false
+	var requestCPU, limitCPU, requestMemory, limitMemory resource.Quantity
+	if ok, requestCPU = getResourceFromAnnotations(annotations, queueContainerRequestCPUAnnotation); ok {
+		resourcesRequest[corev1.ResourceCPU] = requestCPU
+	}
+
+	if ok, limitCPU = getResourceFromAnnotations(annotations, queueContainerLimitCPUAnnotation); ok {
+		resourcesLimits[corev1.ResourceCPU] = limitCPU
+	}
+
+	if ok, requestMemory = getResourceFromAnnotations(annotations, queueContainerRequestMemoryAnnotation); ok {
+		resourcesRequest[corev1.ResourceMemory] = requestMemory
+	}
+
+	if ok, limitMemory = getResourceFromAnnotations(annotations, queueContainerLimitMemoryAnnotation); ok {
+		resourcesLimits[corev1.ResourceMemory] = limitMemory
+	}
+
+	if len(resourcesRequest) == 0 {
+		resources.Requests = resourcesRequest
+	}
+
+	if len(resourcesRequest) == 0 {
+		resources.Limits = resourcesLimits
+	}
+
+	return resources
+}
+
+func getResourceFromAnnotations(m map[string]string, k string) (bool, resource.Quantity) {
+	v, ok := m[k]
+	if !ok {
+		return false, resource.Quantity{}
+	}
+	quantity, err := resource.ParseQuantity(v)
+	if err != nil {
+		return false, resource.Quantity{}
+	}
+	return true, quantity
+}
+
 // makeQueueContainer creates the container spec for the queue sidecar.
 func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, observabilityConfig *metrics.ObservabilityConfig,
 	autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) *corev1.Container {
@@ -115,7 +157,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, o
 	return &corev1.Container{
 		Name:           QueueContainerName,
 		Image:          deploymentConfig.QueueSidecarImage,
-		Resources:      queueResources,
+		Resources:      setResources(rev),
 		Ports:          ports,
 		ReadinessProbe: queueReadinessProbe,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -73,7 +73,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -111,7 +111,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTP2Port),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -148,7 +148,89 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
+			Ports:          append(queueNonServingPorts, queueHTTPPort),
+			ReadinessProbe: queueReadinessProbe,
+			// These changed based on the Revision and configs passed in.
+			Image: "alpine",
+			Env: env(map[string]string{
+				"SERVING_SERVICE": "svc",
+			}),
+		}}, {
+		name: "resources in annotations ",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+				Labels: map[string]string{
+					serving.ServiceLabelKey: "svc",
+				},
+				Annotations: map[string]string{
+					queueContainerRequestCPUAnnotation:    "25m",
+					queueContainerRequestMemoryAnnotation: "100Mi",
+				},
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1beta1.RevisionSpec{
+					ContainerConcurrency: 1,
+					TimeoutSeconds:       ptr.Int64(45),
+				},
+			},
+		},
+		lc: &logging.Config{},
+		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
+		cc: &deployment.Config{
+			QueueSidecarImage: "alpine",
+		},
+		want: &corev1.Container{
+			// These are effectively constant
+			Name: QueueContainerName,
+			Resources: getResources(map[string]string{
+				queueContainerRequestCPUAnnotation:    "25m",
+				queueContainerRequestMemoryAnnotation: "100Mi",
+			}),
+			Ports:          append(queueNonServingPorts, queueHTTPPort),
+			ReadinessProbe: queueReadinessProbe,
+			// These changed based on the Revision and configs passed in.
+			Image: "alpine",
+			Env: env(map[string]string{
+				"SERVING_SERVICE": "svc",
+			}),
+		}}, {
+		name: "Invalid data for resources in annotations ",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+				Labels: map[string]string{
+					serving.ServiceLabelKey: "svc",
+				},
+				Annotations: map[string]string{
+					queueContainerRequestMemoryAnnotation: "100Mx",
+				},
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1beta1.RevisionSpec{
+					ContainerConcurrency: 1,
+					TimeoutSeconds:       ptr.Int64(45),
+				},
+			},
+		},
+		lc: &logging.Config{},
+		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
+		cc: &deployment.Config{
+			QueueSidecarImage: "alpine",
+		},
+		want: &corev1.Container{
+			// These are effectively constant
+			Name: QueueContainerName,
+			Resources: getResources(map[string]string{
+				queueContainerRequestCPUAnnotation: "25m",
+			}),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -185,7 +267,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -223,7 +305,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -257,7 +339,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -287,7 +369,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.
@@ -320,7 +402,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: &corev1.Container{
 			// These are effectively constant
 			Name:           QueueContainerName,
-			Resources:      queueResources,
+			Resources:      getResources(make(map[string]string)),
 			Ports:          append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe: queueReadinessProbe,
 			// These changed based on the Revision and configs passed in.

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -37,6 +37,7 @@ func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, erro
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(service),
 			},
+			Annotations: service.GetAnnotations(),
 			Labels: resources.UnionMaps(service.GetLabels(), map[string]string{
 				serving.ServiceLabelKey: service.Name,
 			}),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
https://github.com/knative/serving/issues/4134
## Proposed Changes

* Allow setting up the resource request and limits for the proxy-queue via annotations


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
