### PR TITLE
Output info message when clusteringress's status was updated successfully

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -174,11 +174,17 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err = c.updateStatus(ci); err != nil {
-		logger.Warnw("Failed to update clusterIngress status", zap.Error(err))
-		c.Recorder.Eventf(ci, corev1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for ClusterIngress %q: %v", ci.Name, err)
-		return err
+	} else {
+		if _, err = c.updateStatus(ci); err != nil {
+			logger.Warnw("Failed to update ClusterIngress status", zap.Error(err))
+			c.Recorder.Eventf(ci, corev1.EventTypeWarning, "UpdateFailed",
+				"Failed to update status for ClusterIngress %q: %v", ci.Name, err)
+			return err
+		} else {
+			logger.Infof("Updated status for ClusterIngress %q", ci.Name)
+			c.Recorder.Eventf(ci, corev1.EventTypeNormal, "Updated",
+				"Updated status for ClusterIngress %q", ci.Name)
+		}
 	}
 	if reconcileErr != nil {
 		c.Recorder.Event(ci, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -211,6 +211,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %q/%q", system.Namespace(), "knative-ingress-gateway"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),
 		},
 		Key: "reconciling-clusteringress",
 	}, {
@@ -256,6 +257,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeWarning, "InternalError", `gateway.networking.istio.io "knative-ingress-gateway" not found`),
 		},
 		// Error should be returned when there is no preinstalled gateways.
@@ -344,6 +346,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Secret %s/%s", "istio-system", targetSecretName),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %q/%q", system.Namespace(), "knative-ingress-gateway"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),
 		},
 		Key: "reconciling-clusteringress",
 	}, {
@@ -427,6 +430,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Secret %s/%s", "istio-system", targetSecretName),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for ClusterIngress %q", "reconciling-clusteringress"),
 		},
 		Key: "reconciling-clusteringress",
 	}}


### PR DESCRIPTION
When `config-domain` configmap was updated, event log from
clusteringress tells us that  `Failed to update status for ClusterIngress`
and `please apply your changes to the latest version and try again` like:

~~~
Events:
  Type     Reason         Age                    From                       Message
  ----     ------         ----                   ----                       -------
  Normal   Updated        12m (x2 over 13m)  clusteringress-controller  Updated status for VirtualService "knative-serving"/"route-81393ac4-7895-11e9-a436-02fb16fbf422"
  Warning  UpdateFailed   12m                clusteringress-controller  Failed to update status for ClusterIngress "route-81393ac4-7895-11e9-a436-02fb16fbf422": Operation cannot be fulfilled on clusteringresses.networking.internal.knative.dev "route-81393ac4-7895-11e9-a436-02fb16fbf422": the object has been modified; please apply your changes to the latest version and try again
~~~

Although this error would be solved automatically by
next reconcile loop, any message does not tell us whether it was solved or not.

To improve it, this patch adds success logs when clusteringress
was updated successfully.

Fixes https://github.com/knative/serving/issues/4143

## Proposed Changes
* Add success log when clusteringress was updated successfully.

**Release Note**

```release-note
NONE
```
