### PR TITLE
use exec probe for queue proxy readiness check

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -236,6 +236,9 @@ func probeQueueHealthPath(port int) error {
 
 	var lastErr error
 
+	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
+	// started as early as possible while still wanting to give the container some breathing
+	// room to get up and running.
 	timeoutErr := wait.PollImmediate(25*time.Millisecond, queueProbeTimeout, func() (bool, error) {
 		var res *http.Response
 		res, lastErr = httpClient.Get(url)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -65,7 +65,7 @@ const (
 
 	// Set equal to the queue-proxy's ExecProbe timeout to take
 	// advantage of the full window
-	queueProbeTimeout = 10 * time.Second
+	probeTimeout = 10 * time.Second
 
 	badProbeTemplate = "unexpected probe header value: %s"
 )
@@ -150,7 +150,7 @@ func knativeProxyHeader(r *http.Request) string {
 
 func probeUserContainer() bool {
 	var err error
-	wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (bool, error) {
+	wait.PollImmediate(50*time.Millisecond, probeTimeout, func() (bool, error) {
 		logger.Debug("TCP probing the user-container.")
 		err = health.TCPProbe(userTargetAddress, 100*time.Millisecond)
 		return err == nil, nil
@@ -231,7 +231,7 @@ func probeQueueHealthPath(port int) error {
 			// Do not use the cached connection
 			DisableKeepAlives: true,
 		},
-		Timeout: queueProbeTimeout,
+		Timeout: probeTimeout,
 	}
 
 	var lastErr error
@@ -239,7 +239,7 @@ func probeQueueHealthPath(port int) error {
 	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
 	// started as early as possible while still wanting to give the container some breathing
 	// room to get up and running.
-	timeoutErr := wait.PollImmediate(25*time.Millisecond, queueProbeTimeout, func() (bool, error) {
+	timeoutErr := wait.PollImmediate(25*time.Millisecond, probeTimeout, func() (bool, error) {
 		var res *http.Response
 		res, lastErr = httpClient.Get(url)
 

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -156,7 +157,7 @@ func TestCreateVarLogLink(t *testing.T) {
 }
 
 func TestProbeQueueConnectionFailure(t *testing.T) {
-	port := "12345" // some random port (that's not listening)
+	port := 12345 // some random port (that's not listening)
 
 	if err := probeQueueHealthPath(port); err == nil {
 		t.Error("Expected error, got nil")
@@ -172,8 +173,14 @@ func TestProbeQueueNotReady(t *testing.T) {
 
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
-	err := probeQueueHealthPath(port)
+	portStr := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to convert port(%s) to int", portStr)
+	}
+
+	err = probeQueueHealthPath(port)
 
 	if diff := cmp.Diff(err.Error(), "probe returned not ready"); diff != "" {
 		t.Errorf("Unexpected not ready message: %s", diff)
@@ -193,10 +200,15 @@ func TestProbeQueueReady(t *testing.T) {
 
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	portStr := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
 
-	if err := probeQueueHealthPath(port); err != nil {
-		t.Errorf("probeQueueHealthPath(%s) = %s", port, err)
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to convert port(%s) to int", portStr)
+	}
+
+	if err = probeQueueHealthPath(port); err != nil {
+		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
 	}
 
 	if !queueProbed {
@@ -219,9 +231,14 @@ func TestProbeQueueDelayedReady(t *testing.T) {
 
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	portStr := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to convert port(%s) to int", portStr)
+	}
 
 	if err := probeQueueHealthPath(port); err != nil {
-		t.Errorf("probeQueueHealthPath(%s) = %s", port, err)
+		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
 	}
 }

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -154,3 +154,74 @@ func TestCreateVarLogLink(t *testing.T) {
 		t.Errorf("Incorrect symlink = %q, want %q, diff: %s", got, want, cmp.Diff(got, want))
 	}
 }
+
+func TestProbeQueueConnectionFailure(t *testing.T) {
+	port := "12345" // some random port (that's not listening)
+
+	if err := probeQueueHealthPath(port); err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestProbeQueueNotReady(t *testing.T) {
+	queueProbed := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queueProbed = true
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	err := probeQueueHealthPath(port)
+
+	if diff := cmp.Diff(err.Error(), "probe returned not ready"); diff != "" {
+		t.Errorf("Unexpected not ready message: %s", diff)
+	}
+
+	if !queueProbed {
+		t.Errorf("Expected the queue proxy server to be probed")
+	}
+}
+
+func TestProbeQueueReady(t *testing.T) {
+	queueProbed := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queueProbed = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	if err := probeQueueHealthPath(port); err != nil {
+		t.Errorf("probeQueueHealthPath(%s) = %s", port, err)
+	}
+
+	if !queueProbed {
+		t.Errorf("Expected the queue proxy server to be probed")
+	}
+}
+
+func TestProbeQueueDelayedReady(t *testing.T) {
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// we expect roughly 10 probes per second
+		if count < 9 {
+			w.WriteHeader(http.StatusBadRequest)
+			count++
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	if err := probeQueueHealthPath(port); err != nil {
+		t.Errorf("probeQueueHealthPath(%s) = %s", port, err)
+	}
+}

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -219,7 +219,6 @@ func TestProbeQueueReady(t *testing.T) {
 func TestProbeQueueDelayedReady(t *testing.T) {
 	count := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// we expect roughly 10 probes per second
 		if count < 9 {
 			w.WriteHeader(http.StatusBadRequest)
 			count++

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -20,10 +20,6 @@ import (
 	"math"
 	"strconv"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/knative/pkg/logging"
 	pkgmetrics "github.com/knative/pkg/metrics"
 	"github.com/knative/pkg/system"
@@ -33,8 +29,8 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/deployment"
 	"github.com/knative/serving/pkg/metrics"
-	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,9 +59,8 @@ var (
 
 	queueReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port: intstr.FromInt(networking.QueueAdminPort),
-				Path: queue.RequestQueueHealthPath,
+			Exec: &corev1.ExecAction{
+				Command: []string{"/ko-app/queue", "-probe", "true"},
 			},
 		},
 		// We want to mark the service as not ready as soon as the


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3308 

## Proposed Changes

* Replaces HTTPGet ReadinessProbe with ExecAction. The ExecAction recreates the HTTPGet semantics within the queue proxy container and hits the same previous health check HTTP path. This approach was taken since the queue proxy process maintains state on whether it's active.

Also worth noting that this makes us dependent on how `ko` builds images. If the binary ever stops showing up at `/ko-app/queue`, this will break.



**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
