### PR TITLE
Proposed feature: Plugable revision deployers

### DIFF
--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -84,4 +84,8 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	for i := range vms {
 		vms[i].ReadOnly = true
 	}
+
+	if rs.Deployer.Name == "" {
+		rs.Deployer.Name = "KnativeServing"
+	}
 }

--- a/pkg/apis/serving/v1beta1/revision_types.go
+++ b/pkg/apis/serving/v1beta1/revision_types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/knative/pkg/kmeta"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"encoding/json"
 )
 
 // +genclient
@@ -127,6 +128,12 @@ type RevisionSpec struct {
 	// be provided.
 	// +optional
 	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
+
+	// The deployer to handle this revision, used to disable Knatives deploying
+	// of revisions and injection of sidecars, and allow a third party controller
+	// to do it instead.
+	// +optional
+	Deployer Deployer `json:"deployer,omitempty"`
 }
 
 const (
@@ -167,4 +174,18 @@ type RevisionList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []Revision `json:"items"`
+}
+
+// A deployer, to allow a third party controller to deploy revisions.
+type Deployer struct {
+
+	// The name of the deployer. If no deployer is specified, or if the deployer
+	// is KnativeServing, then KnativeServing will deploy it.
+	Name string `json:"name"`
+
+	// Deployer specific configuration, if needed. The structure is specific to
+	// the deployer specified, and it's up to the deployer to do any necessary
+	// validation, updating the status if validation fails.
+	// +optional
+	Config json.RawMessage `json:"config,omitempty"`
 }


### PR DESCRIPTION
This PR is being raised primarily to solicit feedback in the context of code. I expect there to be iterations back and forth on this change, and I hope to attend to the knative serving API working group to discuss there as well. Also, no tests yet, so at very least that needs to be addressed before merging.

The context (ie, use case) for this can be seen in this mailing list post:

https://groups.google.com/d/msg/knative-dev/ZjB1EJOkZRg/eu5Gic3iBAAJ

Based on feedback there, I've created this PR. What this PR does is makes the deployment of revisions plugable. This is done by adding a `deployer` field to the revision spec. It defaults to `KnativeServing`, and if it is `KnativeServing`, then the controller will create and update the deployment as normal. However, if it is anything other than `KnativeServing`, then the controller will not create or update the deployment, and it will expect another operator, supplied by a third party, to create and update the deployment instead.

Using this change, we have created an operator that uses this, and deploys functions with a sidecar written in Akka that implements stateful functions (in some ways, similar to Azure's stateful entities, however far more powerful). Note though that this use case is far more than just replacing the sidecar image, a custom deployer is needed to be able to wire the sidecar to an appropriate persistence store, as well as to configure the sidecar to form a cluster (this is used to shard event sourced entities across the user functions). So it wouldn't be enough to just make the sidecar image configurable, we needed to be able to customise the deployment itself.

You can see this work here, though it's a big project:

https://github.com/lightbend/stateful-serverless/tree/knative-integration

Perhaps most pertinent is what it actually looks like to deploy a function that uses this feature, that can be seen here:

```
apiVersion: serving.knative.dev/v1alpha1
kind: Service
metadata:
  name: shopping-cart
spec:
  template:
    spec:
      containers:
      - image: gcr.io/stateserv/js-shopping-cart:latest
        ports:
        - name: h2c
          containerPort: 8080
      deployer:
        name: EventSourced
        config:
          journal:
            name: cassandra
            config:
              keyspace: shoppingcart
```

It was suggested that we might use an annotation to specify the deployer, and while this would work for selecting the deployer, the problem with it is that deployers may need their own configuration, for example, in this case, the function needs to be associated with a configured journal resource (another CRD that our project provides), and some configuration is required to say how that journal should be used (in this case, the keyspace is specified). This configuration could all be supplied using annotations too, but that feels like an abuse of annotations - it feels more natural and logical to include it in the spec. That's why we've gone for an approach of including the deployer in the spec. The deployers `config` property is handled by the knative serving controller as raw JSON message, so it's passed from service to configuration to revision as is, and it's up to the deployer to make sense of it.