### PR TITLE
TickInterval reconciled on configmap update

### DIFF
--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -171,8 +171,12 @@ func (m *MultiScaler) Update(ctx context.Context, decider *Decider) (*Decider, e
 	if scaler, exists := m.scalers[key]; exists {
 		scaler.mux.Lock()
 		defer scaler.mux.Unlock()
+		oldDeciderSpec := scaler.decider.Spec
 		scaler.decider = *decider
 		scaler.scaler.Update(decider.Spec)
+		if oldDeciderSpec.TickInterval != decider.Spec.TickInterval {
+			m.updateRunner(ctx, scaler)
+		}
 		return decider, nil
 	}
 	// This GroupResource is a lie, but unfortunately this interface requires one.
@@ -213,6 +217,31 @@ func (m *MultiScaler) Inform(event string) bool {
 	}
 	return false
 }
+func (m *MultiScaler) updateRunner(ctx context.Context, runner *scalerRunner) {
+	runner.stopCh <- struct{}{}
+	m.runScalerTicker(ctx, runner)
+}
+
+func (m *MultiScaler) runScalerTicker(ctx context.Context, runner *scalerRunner) {
+	metricKey := NewMetricKey(runner.decider.Namespace, runner.decider.Name)
+	ticker := time.NewTicker(runner.decider.Spec.TickInterval)
+	go func() {
+		for {
+			select {
+			case <-m.scalersStopCh:
+				ticker.Stop()
+				return
+			case <-runner.stopCh:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				m.tickScaler(ctx, runner.scaler, runner, metricKey)
+			case <-runner.pokeCh:
+				m.tickScaler(ctx, runner.scaler, runner, metricKey)
+			}
+		}
+	}()
+}
 
 func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scalerRunner, error) {
 	scaler, err := m.uniScalerFactory(decider)
@@ -228,27 +257,8 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 		pokeCh:  make(chan struct{}),
 	}
 	runner.decider.Status.DesiredScale = -1
-	metricKey := NewMetricKey(decider.Namespace, decider.Name)
 
-	// TODO(#3977): Make sure this is reconciled if the tick interval changes.
-	ticker := time.NewTicker(decider.Spec.TickInterval)
-	go func() {
-		for {
-			select {
-			case <-m.scalersStopCh:
-				ticker.Stop()
-				return
-			case <-stopCh:
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				m.tickScaler(ctx, scaler, runner, metricKey)
-			case <-runner.pokeCh:
-				m.tickScaler(ctx, scaler, runner, metricKey)
-			}
-		}
-	}()
-
+	m.runScalerTicker(ctx, runner)
 	return runner, nil
 }
 


### PR DESCRIPTION
When autoscaler config is updated reconciler updates all PAs with new tick interval

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3977 

**Release Note**

```release-note
NONE
```
