### PR TITLE
Separate out controller.go files

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hpa
+
+import (
+	"github.com/knative/pkg/controller"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions/autoscaling/v1alpha1"
+	ninformers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	autoscalingv1informers "k8s.io/client-go/informers/autoscaling/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "hpa-class-podautoscaler-controller"
+)
+
+// NewController returns a new HPA reconcile controller.
+func NewController(
+	opts *reconciler.Options,
+	paInformer informers.PodAutoscalerInformer,
+	sksInformer ninformers.ServerlessServiceInformer,
+	hpaInformer autoscalingv1informers.HorizontalPodAutoscalerInformer,
+) *controller.Impl {
+	c := &Reconciler{
+		Base:      reconciler.NewBase(*opts, controllerAgentName),
+		paLister:  paInformer.Lister(),
+		hpaLister: hpaInformer.Lister(),
+		sksLister: sksInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, "HPA-Class Autoscaling", reconciler.MustNewStatsReporter("HPA-Class Autoscaling", c.Logger))
+
+	c.Logger.Info("Setting up hpa-class event handlers")
+	onlyHpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.HPA, false)
+	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyHpaClass,
+		Handler:    reconciler.Handler(impl.Enqueue),
+	})
+
+	hpaInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyHpaClass,
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	sksInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyHpaClass,
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+	return impl
+}

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kpa
+
+import (
+	"context"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/autoscaler"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions/autoscaling/v1alpha1"
+	ninformers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const controllerAgentName = "kpa-class-podautoscaler-controller"
+
+// configStore is a minimized interface of the actual configStore.
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+}
+
+// NewController creates an autoscaling Controller.
+func NewController(
+	opts *reconciler.Options,
+	paInformer informers.PodAutoscalerInformer,
+	sksInformer ninformers.ServerlessServiceInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	endpointsInformer corev1informers.EndpointsInformer,
+	kpaDeciders Deciders,
+	metrics Metrics,
+) *controller.Impl {
+	c := &Reconciler{
+		Base:            reconciler.NewBase(*opts, controllerAgentName),
+		paLister:        paInformer.Lister(),
+		sksLister:       sksInformer.Lister(),
+		serviceLister:   serviceInformer.Lister(),
+		endpointsLister: endpointsInformer.Lister(),
+		kpaDeciders:     kpaDeciders,
+		metrics:         metrics,
+	}
+	impl := controller.NewImpl(c, c.Logger, "KPA-Class Autoscaling", reconciler.MustNewStatsReporter("KPA-Class Autoscaling", c.Logger))
+	c.scaler = newScaler(opts, impl.EnqueueAfter)
+
+	c.Logger.Info("Setting up KPA-Class event handlers")
+	// Handle PodAutoscalers missing the class annotation for backward compatibility.
+	onlyKpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.KPA, true)
+	paHandler := cache.FilteringResourceEventHandler{
+		FilterFunc: onlyKpaClass,
+		Handler:    reconciler.Handler(impl.Enqueue),
+	}
+	paInformer.Informer().AddEventHandler(paHandler)
+
+	endpointsInformer.Informer().AddEventHandler(
+		reconciler.Handler(impl.EnqueueLabelOfNamespaceScopedResource("", autoscaling.KPALabelKey)))
+
+	// Watch all the services that we have created.
+	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyKpaClass,
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+	sksInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyKpaClass,
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	// Have the Deciders enqueue the PAs whose decisions have changed.
+	kpaDeciders.Watch(impl.EnqueueKey)
+
+	c.Logger.Info("Setting up ConfigMap receivers")
+	configsToResync := []interface{}{
+		&autoscaler.Config{},
+	}
+	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+		controller.SendGlobalUpdates(paInformer.Informer(), paHandler)
+	})
+	c.configStore = config.NewStore(c.Logger.Named("config-store"), resync)
+	c.configStore.WatchConfigs(opts.ConfigMapWatcher)
+
+	return impl
+}

--- a/pkg/reconciler/certificate/controller.go
+++ b/pkg/reconciler/certificate/controller.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"context"
+
+	certmanagerclientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	certmanagerinformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/certificate/config"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "certificate-controller"
+)
+
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+}
+
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events.
+func NewController(
+	opt reconciler.Options,
+	knCertificateInformer informers.CertificateInformer,
+	cmCertificateInformer certmanagerinformers.CertificateInformer,
+	certManagerClient certmanagerclientset.Interface,
+) *controller.Impl {
+	c := &Reconciler{
+		Base:                reconciler.NewBase(opt, controllerAgentName),
+		knCertificateLister: knCertificateInformer.Lister(),
+		cmCertificateLister: cmCertificateInformer.Lister(),
+		certManagerClient:   certManagerClient,
+	}
+
+	impl := controller.NewImpl(c, c.Logger, "Certificate", reconciler.MustNewStatsReporter("Certificate", c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+	knCertificateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+		DeleteFunc: impl.Enqueue,
+	})
+
+	cmCertificateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.EnqueueControllerOf,
+		UpdateFunc: controller.PassNew(impl.EnqueueControllerOf),
+		DeleteFunc: impl.EnqueueControllerOf,
+	})
+
+	c.Logger.Info("Setting up ConfigMap receivers")
+	resyncCertOnCertManagerconfigChange := configmap.TypeFilter(&config.CertManagerConfig{})(func(string, interface{}) {
+		impl.GlobalResync(knCertificateInformer.Informer())
+	})
+	c.configStore = config.NewStore(c.Logger.Named("config-store"), resyncCertOnCertManagerconfigChange)
+	c.configStore.WatchConfigs(opt.ConfigMapWatcher)
+
+	return impl
+}

--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -22,23 +22,16 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/knative/pkg/tracker"
-
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/knative/pkg/apis/istio/v1alpha3"
-	istioinformers "github.com/knative/pkg/client/informers/externalversions/istio/v1alpha3"
 	istiolisters "github.com/knative/pkg/client/listers/istio/v1alpha3"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/system"
+	"github.com/knative/pkg/tracker"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	informers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
-	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/clusteringress/config"
 	"github.com/knative/serving/pkg/reconciler/clusteringress/resources"
@@ -47,13 +40,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-)
-
-const (
-	controllerAgentName = "clusteringress-controller"
 )
 
 // clusterIngressFinalizer is the name that we put into the resource finalizer list, e.g.
@@ -86,59 +76,6 @@ type Reconciler struct {
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*Reconciler)(nil)
-
-// NewController initializes the controller and is called by the generated code
-// Registers eventhandlers to enqueue events.
-func NewController(
-	opt reconciler.Options,
-	clusterIngressInformer informers.ClusterIngressInformer,
-	virtualServiceInformer istioinformers.VirtualServiceInformer,
-	gatewayInformer istioinformers.GatewayInformer,
-	secretInfomer corev1informers.SecretInformer,
-) *controller.Impl {
-
-	c := &Reconciler{
-		Base:                 reconciler.NewBase(opt, controllerAgentName),
-		clusterIngressLister: clusterIngressInformer.Lister(),
-		virtualServiceLister: virtualServiceInformer.Lister(),
-		gatewayLister:        gatewayInformer.Lister(),
-		secretLister:         secretInfomer.Lister(),
-	}
-	impl := controller.NewImpl(c, c.Logger, "ClusterIngresses", reconciler.MustNewStatsReporter("ClusterIngress", c.Logger))
-
-	c.Logger.Info("Setting up event handlers")
-	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
-	ciHandler := cache.FilteringResourceEventHandler{
-		FilterFunc: myFilterFunc,
-		Handler:    reconciler.Handler(impl.Enqueue),
-	}
-	clusterIngressInformer.Informer().AddEventHandler(ciHandler)
-
-	virtualServiceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: myFilterFunc,
-		Handler:    reconciler.Handler(impl.EnqueueLabelOfClusterScopedResource(networking.IngressLabelKey)),
-	})
-
-	c.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
-	secretInfomer.Informer().AddEventHandler(reconciler.Handler(
-		controller.EnsureTypeMeta(
-			c.tracker.OnChanged,
-			corev1.SchemeGroupVersion.WithKind("Secret"),
-		),
-	))
-
-	c.Logger.Info("Setting up ConfigMap receivers")
-	configsToResync := []interface{}{
-		&config.Istio{},
-		&network.Config{},
-	}
-	resyncIngressesOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		controller.SendGlobalUpdates(clusterIngressInformer.Informer(), ciHandler)
-	})
-	c.configStore = config.NewStore(c.Logger.Named("config-store"), resyncIngressesOnConfigChange)
-	c.configStore.WatchConfigs(opt.ConfigMapWatcher)
-	return impl
-}
 
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the ClusterIngress resource

--- a/pkg/reconciler/clusteringress/controller.go
+++ b/pkg/reconciler/clusteringress/controller.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusteringress
+
+import (
+	istioinformers "github.com/knative/pkg/client/informers/externalversions/istio/v1alpha3"
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/tracker"
+	"github.com/knative/serving/pkg/apis/networking"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/clusteringress/config"
+	corev1 "k8s.io/api/core/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "clusteringress-controller"
+)
+
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events.
+func NewController(
+	opt reconciler.Options,
+	clusterIngressInformer informers.ClusterIngressInformer,
+	virtualServiceInformer istioinformers.VirtualServiceInformer,
+	gatewayInformer istioinformers.GatewayInformer,
+	secretInfomer corev1informers.SecretInformer,
+) *controller.Impl {
+
+	c := &Reconciler{
+		Base:                 reconciler.NewBase(opt, controllerAgentName),
+		clusterIngressLister: clusterIngressInformer.Lister(),
+		virtualServiceLister: virtualServiceInformer.Lister(),
+		gatewayLister:        gatewayInformer.Lister(),
+		secretLister:         secretInfomer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, "ClusterIngresses", reconciler.MustNewStatsReporter("ClusterIngress", c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
+	ciHandler := cache.FilteringResourceEventHandler{
+		FilterFunc: myFilterFunc,
+		Handler:    reconciler.Handler(impl.Enqueue),
+	}
+	clusterIngressInformer.Informer().AddEventHandler(ciHandler)
+
+	virtualServiceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: myFilterFunc,
+		Handler:    reconciler.Handler(impl.EnqueueLabelOfClusterScopedResource(networking.IngressLabelKey)),
+	})
+
+	c.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
+	secretInfomer.Informer().AddEventHandler(reconciler.Handler(
+		controller.EnsureTypeMeta(
+			c.tracker.OnChanged,
+			corev1.SchemeGroupVersion.WithKind("Secret"),
+		),
+	))
+
+	c.Logger.Info("Setting up ConfigMap receivers")
+	configsToResync := []interface{}{
+		&config.Istio{},
+		&network.Config{},
+	}
+	resyncIngressesOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+		controller.SendGlobalUpdates(clusterIngressInformer.Informer(), ciHandler)
+	})
+	c.configStore = config.NewStore(c.Logger.Named("config-store"), resyncIngressesOnConfigChange)
+	c.configStore.WatchConfigs(opt.ConfigMapWatcher)
+	return impl
+}

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"context"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	configns "github.com/knative/serving/pkg/reconciler/configuration/config"
+	"k8s.io/client-go/tools/cache"
+)
+
+const controllerAgentName = "configuration-controller"
+
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+}
+
+// NewController creates a new Configuration controller
+func NewController(
+	opt reconciler.Options,
+	configurationInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
+) *controller.Impl {
+
+	c := &Reconciler{
+		Base:                reconciler.NewBase(opt, controllerAgentName),
+		configurationLister: configurationInformer.Lister(),
+		revisionLister:      revisionInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, "Configurations", reconciler.MustNewStatsReporter("Configurations", c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+	configurationInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
+
+	revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Configuration")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	c.Logger.Info("Setting up ConfigMap receivers")
+	c.configStore = configns.NewStore(c.Logger.Named("config-store"))
+	c.configStore.WatchConfigs(opt.ConfigMapWatcher)
+	return impl
+}

--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labeler
+
+import (
+	"github.com/knative/pkg/controller"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+)
+
+const (
+	controllerAgentName = "labeler-controller"
+)
+
+// NewRouteToConfigurationController wraps a new instance of the labeler that labels
+// Configurations with Routes in a controller.
+func NewRouteToConfigurationController(
+	opt reconciler.Options,
+	routeInformer servinginformers.RouteInformer,
+	configInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
+) *controller.Impl {
+
+	c := &Reconciler{
+		Base:                reconciler.NewBase(opt, controllerAgentName),
+		routeLister:         routeInformer.Lister(),
+		configurationLister: configInformer.Lister(),
+		revisionLister:      revisionInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, "Labels", reconciler.MustNewStatsReporter("Labels", c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+	routeInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
+
+	return impl
+}

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -21,17 +21,11 @@ import (
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
+	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-
-	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
-	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler"
-)
-
-const (
-	controllerAgentName = "labeler-controller"
 )
 
 // Reconciler implements controller.Reconciler for Route resources.
@@ -46,29 +40,6 @@ type Reconciler struct {
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*Reconciler)(nil)
-
-// NewRouteToConfigurationController wraps a new instance of the labeler that labels
-// Configurations with Routes in a controller.
-func NewRouteToConfigurationController(
-	opt reconciler.Options,
-	routeInformer servinginformers.RouteInformer,
-	configInformer servinginformers.ConfigurationInformer,
-	revisionInformer servinginformers.RevisionInformer,
-) *controller.Impl {
-
-	c := &Reconciler{
-		Base:                reconciler.NewBase(opt, controllerAgentName),
-		routeLister:         routeInformer.Lister(),
-		configurationLister: configInformer.Lister(),
-		revisionLister:      revisionInformer.Lister(),
-	}
-	impl := controller.NewImpl(c, c.Logger, "Labels", reconciler.MustNewStatsReporter("Labels", c.Logger))
-
-	c.Logger.Info("Setting up event handlers")
-	routeInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
-
-	return impl
-}
 
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two. In this case, it attempts to label all Configurations

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+	"net/http"
+
+	cachinginformers "github.com/knative/caching/pkg/client/informers/externalversions/caching/v1alpha1"
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/tracker"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	painformers "github.com/knative/serving/pkg/client/informers/externalversions/autoscaling/v1alpha1"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	"github.com/knative/serving/pkg/deployment"
+	"github.com/knative/serving/pkg/metrics"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/revision/config"
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "revision-controller"
+)
+
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+	Load() *config.Config
+}
+
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events
+// config - client configuration for talking to the apiserver
+// si - informer factory shared across all controllers for listening to events and indexing resource properties
+// queue - message queue for handling new events.  unique to this controller.
+func NewController(
+	opt reconciler.Options,
+	revisionInformer servinginformers.RevisionInformer,
+	podAutoscalerInformer painformers.PodAutoscalerInformer,
+	imageInformer cachinginformers.ImageInformer,
+	deploymentInformer appsv1informers.DeploymentInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	endpointsInformer corev1informers.EndpointsInformer,
+	configMapInformer corev1informers.ConfigMapInformer,
+	buildInformerFactory duck.InformerFactory,
+) *controller.Impl {
+	transport := http.DefaultTransport
+	if rt, err := newResolverTransport(k8sCertPath); err != nil {
+		opt.Logger.Errorf("Failed to create resolver transport: %v", err)
+	} else {
+		transport = rt
+	}
+
+	c := &Reconciler{
+		Base:                reconciler.NewBase(opt, controllerAgentName),
+		revisionLister:      revisionInformer.Lister(),
+		podAutoscalerLister: podAutoscalerInformer.Lister(),
+		imageLister:         imageInformer.Lister(),
+		deploymentLister:    deploymentInformer.Lister(),
+		serviceLister:       serviceInformer.Lister(),
+		endpointsLister:     endpointsInformer.Lister(),
+		configMapLister:     configMapInformer.Lister(),
+		resolver: &digestResolver{
+			client:    opt.KubeClientSet,
+			transport: transport,
+		},
+	}
+	impl := controller.NewImpl(c, c.Logger, "Revisions", reconciler.MustNewStatsReporter("Revisions", c.Logger))
+
+	// Set up an event handler for when the resource types of interest change
+	c.Logger.Info("Setting up event handlers")
+	revisionInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
+
+	endpointsInformer.Informer().AddEventHandler(reconciler.Handler(
+		impl.EnqueueLabelOfNamespaceScopedResource("", serving.RevisionLabelKey)))
+
+	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	podAutoscalerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	c.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
+
+	// We don't watch for changes to Image because we don't incorporate any of its
+	// properties into our own status and should work completely in the absence of
+	// a functioning Image controller.
+
+	configMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	c.buildInformerFactory = newDuckInformerFactory(c.tracker, buildInformerFactory)
+
+	configsToResync := []interface{}{
+		&network.Config{},
+		&metrics.ObservabilityConfig{},
+		&deployment.Config{},
+	}
+
+	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+		// Triggers syncs on all revisions when configuration
+		// changes
+		impl.GlobalResync(revisionInformer.Informer())
+	})
+
+	c.configStore = config.NewStore(c.Logger.Named("config-store"), resync)
+	c.configStore.WatchConfigs(opt.ConfigMapWatcher)
+
+	return impl
+}
+
+func KResourceTypedInformerFactory(opt reconciler.Options) duck.InformerFactory {
+	return &duck.TypedInformerFactory{
+		Client:       opt.DynamicClientSet,
+		Type:         &duckv1alpha1.KResource{},
+		ResyncPeriod: opt.ResyncPeriod,
+		StopChannel:  opt.StopChannel,
+	}
+}
+
+func newDuckInformerFactory(t tracker.Interface, delegate duck.InformerFactory) duck.InformerFactory {
+	return &duck.CachedInformerFactory{
+		Delegate: &duck.EnqueueInformerFactory{
+			Delegate:     delegate,
+			EventHandler: reconciler.Handler(t.OnChanged),
+		},
+	}
+}

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -51,10 +51,7 @@ type configStore interface {
 }
 
 // NewController initializes the controller and is called by the generated code
-// Registers eventhandlers to enqueue events
-// config - client configuration for talking to the apiserver
-// si - informer factory shared across all controllers for listening to events and indexing resource properties
-// queue - message queue for handling new events.  unique to this controller.
+// Registers eventhandlers to enqueue events.
 func NewController(
 	opt reconciler.Options,
 	revisionInformer servinginformers.RevisionInformer,

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route
+
+import (
+	"context"
+
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/system"
+	"github.com/knative/pkg/tracker"
+	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	networkinginformers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "route-controller"
+)
+
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+}
+
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events
+// config - client configuration for talking to the apiserver
+// si - informer factory shared across all controllers for listening to events and indexing resource properties
+// reconcileKey - function for mapping queue keys to resource names
+func NewController(
+	opt reconciler.Options,
+	routeInformer servinginformers.RouteInformer,
+	configInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	clusterIngressInformer networkinginformers.ClusterIngressInformer,
+	certificateInformer networkinginformers.CertificateInformer,
+) *controller.Impl {
+	return NewControllerWithClock(opt, routeInformer, configInformer, revisionInformer,
+		serviceInformer, clusterIngressInformer, certificateInformer, system.RealClock{})
+}
+
+func NewControllerWithClock(
+	opt reconciler.Options,
+	routeInformer servinginformers.RouteInformer,
+	configInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	clusterIngressInformer networkinginformers.ClusterIngressInformer,
+	certificateInformer networkinginformers.CertificateInformer,
+	clock system.Clock,
+) *controller.Impl {
+
+	// No need to lock domainConfigMutex yet since the informers that can modify
+	// domainConfig haven't started yet.
+	c := &Reconciler{
+		Base:                 reconciler.NewBase(opt, controllerAgentName),
+		routeLister:          routeInformer.Lister(),
+		configurationLister:  configInformer.Lister(),
+		revisionLister:       revisionInformer.Lister(),
+		serviceLister:        serviceInformer.Lister(),
+		clusterIngressLister: clusterIngressInformer.Lister(),
+		certificateLister:    certificateInformer.Lister(),
+		clock:                clock,
+	}
+	impl := controller.NewImpl(c, c.Logger, "Routes", reconciler.MustNewStatsReporter("Routes", c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+	routeInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
+
+	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Route")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	clusterIngressInformer.Informer().AddEventHandler(reconciler.Handler(
+		impl.EnqueueLabelOfNamespaceScopedResource(
+			serving.RouteNamespaceLabelKey, serving.RouteLabelKey)))
+
+	c.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
+
+	configInformer.Informer().AddEventHandler(reconciler.Handler(
+		// Call the tracker's OnChanged method, but we've seen the objects
+		// coming through this path missing TypeMeta, so ensure it is properly
+		// populated.
+		controller.EnsureTypeMeta(
+			c.tracker.OnChanged,
+			v1alpha1.SchemeGroupVersion.WithKind("Configuration"),
+		),
+	))
+
+	revisionInformer.Informer().AddEventHandler(reconciler.Handler(
+		// Call the tracker's OnChanged method, but we've seen the objects
+		// coming through this path missing TypeMeta, so ensure it is properly
+		// populated.
+		controller.EnsureTypeMeta(
+			c.tracker.OnChanged,
+			v1alpha1.SchemeGroupVersion.WithKind("Revision"),
+		),
+	))
+
+	certificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Route")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	c.Logger.Info("Setting up ConfigMap receivers")
+	configsToResync := []interface{}{
+		&network.Config{},
+		&config.Domain{},
+	}
+	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+		impl.GlobalResync(routeInformer.Informer())
+	})
+	c.configStore = config.NewStore(c.Logger.Named("config-store"), resync)
+	c.configStore.WatchConfigs(opt.ConfigMapWatcher)
+	return impl
+}

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -45,9 +45,6 @@ type configStore interface {
 
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
-// config - client configuration for talking to the apiserver
-// si - informer factory shared across all controllers for listening to events and indexing resource properties
-// reconcileKey - function for mapping queue keys to resource names
 func NewController(
 	opt reconciler.Options,
 	routeInformer servinginformers.RouteInformer,

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serverlessservice
+
+import (
+	"github.com/knative/pkg/apis/duck"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/system"
+	"github.com/knative/serving/pkg/activator"
+	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking"
+	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	informers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
+	rbase "github.com/knative/serving/pkg/reconciler"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "serverlessservice-controller"
+)
+
+// podScalableTypedInformerFactory returns a duck.InformerFactory that returns
+// lister/informer pairs for PodScalable resources.
+func podScalableTypedInformerFactory(opt rbase.Options) duck.InformerFactory {
+	return &duck.TypedInformerFactory{
+		Client:       opt.DynamicClientSet,
+		Type:         &pav1alpha1.PodScalable{},
+		ResyncPeriod: opt.ResyncPeriod,
+		StopChannel:  opt.StopChannel,
+	}
+}
+
+// NewController initializes the controller and is called by the generated code.
+// Registers eventhandlers to enqueue events.
+func NewController(
+	opt rbase.Options,
+	sksInformer informers.ServerlessServiceInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	endpointsInformer corev1informers.EndpointsInformer,
+) *controller.Impl {
+	c := &reconciler{
+		Base:            rbase.NewBase(opt, controllerAgentName),
+		endpointsLister: endpointsInformer.Lister(),
+		serviceLister:   serviceInformer.Lister(),
+		sksLister:       sksInformer.Lister(),
+		psInformerFactory: &duck.CachedInformerFactory{
+			Delegate: podScalableTypedInformerFactory(opt),
+		},
+	}
+	impl := controller.NewImpl(c, c.Logger, reconcilerName, rbase.MustNewStatsReporter(reconcilerName, c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+
+	// Watch all the SKS objects.
+	sksInformer.Informer().AddEventHandler(rbase.Handler(impl.Enqueue))
+
+	// Watch all the endpoints that we have attached our label to.
+	endpointsInformer.Informer().AddEventHandler(
+		rbase.Handler(impl.EnqueueLabelOfNamespaceScopedResource("" /*any namespace*/, networking.SKSLabelKey)))
+
+	// Watch all the services that we have created.
+	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(netv1alpha1.SchemeGroupVersion.WithKind("ServerlessService")),
+		Handler:    rbase.Handler(impl.EnqueueControllerOf),
+	})
+
+	// Watch activator-service endpoints.
+	grCb := func(obj interface{}) {
+		// Since changes in the Activator Service endpoints affect all the SKS objects,
+		// do a global resync.
+		c.Logger.Info("Doing a global resync due to activator endpoint changes")
+		impl.GlobalResync(sksInformer.Informer())
+	}
+	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		// Accept only ActivatorService K8s service objects.
+		FilterFunc: rbase.ChainFilterFuncs(
+			rbase.NamespaceFilterFunc(system.Namespace()),
+			rbase.NameFilterFunc(activator.K8sServiceName)),
+		Handler: rbase.Handler(grCb),
+	})
+
+	return impl
+}

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 The Knative Authors
+Copyright 2019 The Knative Authors
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package serverlessservice

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 The Knative Authors
+Copyright 2019 The Knative Authors
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package serverlessservice
@@ -23,9 +23,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	perrors "github.com/pkg/errors"
-	"go.uber.org/zap"
-
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/controller"
@@ -33,29 +30,26 @@ import (
 	"github.com/knative/pkg/system"
 	"github.com/knative/serving/pkg/activator"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
-	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	informers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	rbase "github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/serverlessservice/resources"
 	"github.com/knative/serving/pkg/reconciler/serverlessservice/resources/names"
 	presources "github.com/knative/serving/pkg/resources"
-
+	perrors "github.com/pkg/errors"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
 const (
-	controllerAgentName = "serverlessservice-controller"
-	reconcilerName      = "ServerlessServices"
+	reconcilerName = "ServerlessServices"
 )
 
 // reconciler implements controller.Reconciler for Service resources.
@@ -69,69 +63,6 @@ type reconciler struct {
 
 	// Used to get PodScalables from object references.
 	psInformerFactory duck.InformerFactory
-}
-
-// podScalableTypedInformerFactory returns a duck.InformerFactory that returns
-// lister/informer pairs for PodScalable resources.
-func podScalableTypedInformerFactory(opt rbase.Options) duck.InformerFactory {
-	return &duck.TypedInformerFactory{
-		Client:       opt.DynamicClientSet,
-		Type:         &pav1alpha1.PodScalable{},
-		ResyncPeriod: opt.ResyncPeriod,
-		StopChannel:  opt.StopChannel,
-	}
-}
-
-// NewController initializes the controller and is called by the generated code.
-// Registers eventhandlers to enqueue events.
-func NewController(
-	opt rbase.Options,
-	sksInformer informers.ServerlessServiceInformer,
-	serviceInformer corev1informers.ServiceInformer,
-	endpointsInformer corev1informers.EndpointsInformer,
-) *controller.Impl {
-	c := &reconciler{
-		Base:            rbase.NewBase(opt, controllerAgentName),
-		endpointsLister: endpointsInformer.Lister(),
-		serviceLister:   serviceInformer.Lister(),
-		sksLister:       sksInformer.Lister(),
-		psInformerFactory: &duck.CachedInformerFactory{
-			Delegate: podScalableTypedInformerFactory(opt),
-		},
-	}
-	impl := controller.NewImpl(c, c.Logger, reconcilerName, rbase.MustNewStatsReporter(reconcilerName, c.Logger))
-
-	c.Logger.Info("Setting up event handlers")
-
-	// Watch all the SKS objects.
-	sksInformer.Informer().AddEventHandler(rbase.Handler(impl.Enqueue))
-
-	// Watch all the endpoints that we have attached our label to.
-	endpointsInformer.Informer().AddEventHandler(
-		rbase.Handler(impl.EnqueueLabelOfNamespaceScopedResource("" /*any namespace*/, networking.SKSLabelKey)))
-
-	// Watch all the services that we have created.
-	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(netv1alpha1.SchemeGroupVersion.WithKind("ServerlessService")),
-		Handler:    rbase.Handler(impl.EnqueueControllerOf),
-	})
-
-	// Watch activator-service endpoints.
-	grCb := func(obj interface{}) {
-		// Since changes in the Activator Service endpoints affect all the SKS objects,
-		// do a global resync.
-		c.Logger.Info("Doing a global resync due to activator endpoint changes")
-		impl.GlobalResync(sksInformer.Informer())
-	}
-	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		// Accept only ActivatorService K8s service objects.
-		FilterFunc: rbase.ChainFilterFuncs(
-			rbase.NamespaceFilterFunc(system.Namespace()),
-			rbase.NameFilterFunc(activator.K8sServiceName)),
-		Handler: rbase.Handler(grCb),
-	})
-
-	return impl
 }
 
 // Check that our Reconciler implements controller.Reconciler

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 The Knative Authors
+Copyright 2019 The Knative Authors
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package serverlessservice

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"github.com/knative/pkg/controller"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servinginformers "github.com/knative/serving/pkg/client/informers/externalversions/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controllerAgentName = "service-controller"
+)
+
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events
+func NewController(
+	opt reconciler.Options,
+	serviceInformer servinginformers.ServiceInformer,
+	configurationInformer servinginformers.ConfigurationInformer,
+	revisionInformer servinginformers.RevisionInformer,
+	routeInformer servinginformers.RouteInformer,
+) *controller.Impl {
+
+	c := &Reconciler{
+		Base:                reconciler.NewBase(opt, controllerAgentName),
+		serviceLister:       serviceInformer.Lister(),
+		configurationLister: configurationInformer.Lister(),
+		revisionLister:      revisionInformer.Lister(),
+		routeLister:         routeInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, ReconcilerName, reconciler.MustNewStatsReporter(ReconcilerName, c.Logger))
+
+	c.Logger.Info("Setting up event handlers")
+	serviceInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
+
+	configurationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Service")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	routeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Service")),
+		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
+	})
+
+	return impl
+}


### PR DESCRIPTION
This change splits off the controller constructor from the main reconciler definition for each of our reconcilers.

Controllers deal with informers, informer events and workqueues.  Reconcilers deal with listers, clients and largely deal with reconciling a single item.  We have N reconcilers, but 1 controller implementation.  `controller.go` is the "glue" between these worlds, it deals with wiring up the Reconciler-specific events with the controller's generic workqueue logic.