### PR TITLE
Move one other thing into controller.go for consistency.

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/knative/pkg/apis/istio/v1alpha3"
 	istiolisters "github.com/knative/pkg/client/listers/istio/v1alpha3"
-	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/system"
@@ -54,11 +53,6 @@ var (
 	clusterIngressResource  = v1alpha1.Resource("clusteringresses")
 	clusterIngressFinalizer = clusterIngressResource.String()
 )
-
-type configStore interface {
-	ToContext(ctx context.Context) context.Context
-	WatchConfigs(w configmap.Watcher)
-}
 
 // Reconciler implements controller.Reconciler for ClusterIngress resources.
 type Reconciler struct {

--- a/pkg/reconciler/clusteringress/controller.go
+++ b/pkg/reconciler/clusteringress/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clusteringress
 
 import (
+	"context"
+
 	istioinformers "github.com/knative/pkg/client/informers/externalversions/istio/v1alpha3"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
@@ -34,6 +36,11 @@ import (
 const (
 	controllerAgentName = "clusteringress-controller"
 )
+
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+}
 
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events.


### PR DESCRIPTION
In #4161 I split out controller.go files, and one of the things I moved was
mistakenly omitted from clusteringress's version.  This fixes that.

