### PR TITLE
Validate if stale-revision-minimum-generations is not less than zero

### DIFF
--- a/pkg/gc/config.go
+++ b/pkg/gc/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gc
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
@@ -72,6 +73,8 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 		c.StaleRevisionMinimumGenerations = 1
 	} else if val, err := strconv.ParseInt(raw, 10, 64); err != nil {
 		return nil, err
+	} else if val < 0 {
+		return nil, errors.New("stale-revision-minimum-generations must be zero or greater")
 	} else {
 		c.StaleRevisionMinimumGenerations = val
 	}

--- a/pkg/gc/config_test.go
+++ b/pkg/gc/config_test.go
@@ -77,6 +77,15 @@ func TestOurConfig(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Invalid negative minimum generation",
+		fail: true,
+		want: Config{},
+		data: &corev1.ConfigMap{
+			Data: map[string]string{
+				"stale-revision-minimum-generations": "-1",
+			},
+		},
+	}, {
 		name: "Invalid minimum generation",
 		fail: true,
 		want: Config{},


### PR DESCRIPTION
When stale-revision-minimum-generations is set to less than 0,
controller produces go panic as the minimum-generations is used for
index of slice.

This patch validates if stale-revision-minimum-generations is not less
than zero.

/lint

Fixes https://github.com/knative/serving/issues/4169

## Proposed Changes

* Validate if stale-revision-minimum-generations is not less than zero instead of go panic.

**Release Note**

```release-note
NONE
```
