### PR TITLE
Pickup runtime.Object change.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -447,7 +447,7 @@
   revision = "afa9ee174c6f2072b12dbb4b3bf64be8ec7bc30b"
 
 [[projects]]
-  digest = "1:b5c0bbf074c00615b94fd65cfbb979c279d72a204d7e2900ee65e56d6e362761"
+  digest = "1:bd44d7f1cd036ca3dd6ae0e5f439321adf7f085acb1224ac7fa29de23d5a7907"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -505,7 +505,7 @@
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "985bff446d4e8da3ed9afaa2cefe9d91d03ae7e2"
+  revision = "15b1aa79be0b927a9e62d1738b03ef3efb2745f3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@ required = [
 [[override]]
   name = "github.com/knative/pkg"
   # HEAD as of 2919-05-28
-  revision = "985bff446d4e8da3ed9afaa2cefe9d91d03ae7e2"
+  revision = "15b1aa79be0b927a9e62d1738b03ef3efb2745f3"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -102,7 +102,7 @@ func TestReconcile(t *testing.T) {
 			deploy(testNamespace, testRevision),
 		},
 		Key: key(testRevision, testNamespace),
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			sks(testNamespace, testRevision, WithDeployRef(deployName)),
 			hpa(testRevision, testNamespace, pa(testRevision, testNamespace,
 				WithHPAClass, WithMetricAnnotation("cpu"))),
@@ -208,7 +208,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "serverlessservices"),
 		},
 		WantErr: true,
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			sks(testNamespace, testRevision, WithDeployRef(deployName)),
 		},
 		WantEvents: []string{
@@ -387,7 +387,7 @@ func TestReconcile(t *testing.T) {
 			deploy(testNamespace, testRevision),
 		},
 		Key: key(testRevision, testNamespace),
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			hpa(testRevision, testNamespace, pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"))),
 		},
 		WithReactors: []ktesting.ReactionFunc{

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -355,7 +355,7 @@ func TestReconcile(t *testing.T) {
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 		},
 	}, {
@@ -372,7 +372,7 @@ func TestReconcile(t *testing.T) {
 			expectedDeploy,
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 		},
 		WantEvents: []string{
@@ -582,7 +582,7 @@ func TestReconcile(t *testing.T) {
 			// SKS does not exist, so we're just creating and have no status.
 			Object: kpa(testNamespace, testRevision, markActivating),
 		}},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			sks(testNamespace, testRevision, WithDeployRef(deployName)),
 		},
 	}, {
@@ -615,7 +615,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "serverlessservices"),
 		},
 		WantErr: true,
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			sks(testNamespace, testRevision, WithDeployRef(deployName)),
 		},
 		WantEvents: []string{

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			knCert("knCert", "foo"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			resources.MakeCertManagerCertificate(certmanagerConfig(), knCert("knCert", "foo")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -167,7 +167,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer}),
 			originSecret("istio-system", "secret0"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer}),
 
@@ -221,7 +221,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			ingressWithTLS("reconciling-clusteringress", 1234, ingressTLS),
 			originSecret("istio-system", "secret0"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			resources.MakeVirtualService(ingress("reconciling-clusteringress", 1234),
 				[]string{"knative-ingress-gateway"}),
 		},
@@ -270,7 +270,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			ingressWithFinalizers("reconciling-clusteringress", 1234, ingressTLS, []string{clusterIngressFinalizer}),
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer, ingressTLSServer}),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer, ingressTLSServer}),
 		},
@@ -295,7 +295,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			// from the namespace (`istio-system`) of Istio gateway service.
 			originSecret("knative-serving", "secret0"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer}),
 
@@ -374,7 +374,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				},
 			},
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{*withCredentialName(ingressTLSServer.DeepCopy(), targetSecretName), irrelevantServer}),
 

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -75,7 +75,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("no-revisions-yet", "foo", 1234),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			rev("no-revisions-yet", "foo", 1234),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -95,7 +95,7 @@ func TestReconcile(t *testing.T) {
 				cfg.Spec.GetTemplate().Name = "byo-name-create-foo"
 			}),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			rev("byo-name-create", "foo", 1234, func(rev *v1alpha1.Revision) {
 				rev.Name = "byo-name-create-foo"
 				rev.GenerateName = ""
@@ -192,7 +192,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("validation-failure", "foo", 1234, WithConfigContainerConcurrency(-1)),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			rev("validation-failure", "foo", 1234, WithRevContainerConcurrency(-1)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -214,7 +214,7 @@ func TestReconcile(t *testing.T) {
 			// An existing build is reused!
 			build("something-else-12345", cfg("something-else", "foo", 12345, WithBuild)),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			rev("need-rev-and-build", "foo", 99998, WithBuildRef("something-else-12345")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -232,7 +232,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("need-rev-and-build", "foo", 99998, WithBuild),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			resources.MakeBuild(cfg("need-rev-and-build", "foo", 99998, WithBuild)),
 			rev("need-rev-and-build", "foo", 99998, WithBuildRef("need-rev-and-build-00001")),
 		},
@@ -342,7 +342,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("create-build-failure", "foo", 99998, WithBuild),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			resources.MakeBuild(cfg("create-build-failure", "foo", 99998, WithBuild)),
 			// No Revision gets created.
 		},
@@ -368,7 +368,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("create-revision-failure", "foo", 99998),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			rev("create-revision-failure", "foo", 99998),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -393,7 +393,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("update-config-failure", "foo", 1234),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			rev("update-config-failure", "foo", 1234),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -74,7 +74,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			rev("foo", "first-reconcile"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The first reconciliation of a Revision creates the following resources.
 			kpa("foo", "first-reconcile"),
 			deploy("foo", "first-reconcile"),
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 			rev("foo", "update-status-failure"),
 			kpa("foo", "update-status-failure"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// We still see the following creates before the failure is induced.
 			deploy("foo", "update-status-failure"),
 			image("foo", "update-status-failure"),
@@ -124,7 +124,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			rev("foo", "create-kpa-failure"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// We still see the following creates before the failure is induced.
 			kpa("foo", "create-kpa-failure"),
 			deploy("foo", "create-kpa-failure"),
@@ -152,7 +152,7 @@ func TestReconcile(t *testing.T) {
 			rev("foo", "create-user-deploy-failure"),
 			kpa("foo", "create-user-deploy-failure"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// We still see the following creates before the failure is induced.
 			deploy("foo", "create-user-deploy-failure"),
 		},
@@ -482,7 +482,7 @@ func TestReconcile(t *testing.T) {
 			rev("foo", "done-build", WithBuildRef("the-build"), WithInitRevConditions),
 			build("foo", "the-build", WithSucceededTrue),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The first reconciliation of a Revision creates the following resources.
 			kpa("foo", "done-build"),
 			deploy("foo", "done-build"),
@@ -650,7 +650,7 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		Objects: []runtime.Object{
 			rev("foo", "first-reconcile-var-log"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			// The first reconciliation of a Revision creates the following resources.
 			kpa("foo", "first-reconcile-var-log"),
 			deploy("foo", "first-reconcile-var-log", EnableVarLog),
@@ -673,7 +673,7 @@ func TestReconcileWithVarLogEnabled(t *testing.T) {
 		Objects: []runtime.Object{
 			rev("foo", "create-configmap-failure"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			deploy("foo", "create-configmap-failure", EnableVarLog),
 			fluentdConfigMap("foo", "create-configmap-failure", EnableVarLog),
 			image("foo", "create-configmap-failure", EnableVarLog),

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			simpleClusterIngress(
 				route("default", "becomes-ready", WithConfigTarget("config"), WithDomain,
 					WithRouteUID("12-34")),
@@ -178,7 +178,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("bk")),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			ingressWithClass(
 				route("default", "becomes-ready", WithConfigTarget("config"), WithDomain, WithRouteUID("12-34")),
 				&traffic.Config{
@@ -236,7 +236,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			simpleClusterIngress(
 				route("default", "becomes-ready", WithConfigTarget("config"),
 					WithLocalDomain, WithRouteUID("65-23"),
@@ -310,7 +310,7 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			simplePlaceholderK8sService(getContext(), route("default", "becomes-ready", WithConfigTarget("config")), ""),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -364,7 +364,7 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			simplePlaceholderK8sService(getContext(), route("default", "create-svc-failure", WithConfigTarget("config")), ""),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -401,7 +401,7 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "clusteringresses"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			//This is the Create we see for the cluter ingress, but we induce a failure.
 			simpleClusterIngress(
 				route("default", "ingress-create-failure", WithConfigTarget("config"),
@@ -1204,7 +1204,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001"), WithServiceName("blue-ridge")),
 			rev("default", "green", 1, MarkRevisionReady, WithRevName("green-00001"), WithServiceName("green-lake")),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			simpleClusterIngress(
 				route("default", "named-traffic-split", WithDomain, WithSpecTraffic(
 					v1alpha1.TrafficTarget{
@@ -1313,7 +1313,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("gray-00001"), WithLatestReady("gray-00001")),
 			rev("default", "gray", 1, MarkRevisionReady, WithRevName("gray-00001"), WithServiceName("shades")),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			simpleClusterIngress(
 				route("default", "same-revision-targets", WithDomain, WithSpecTraffic(
 					v1alpha1.TrafficTarget{
@@ -1912,7 +1912,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			resources.MakeCertificate(route("default", "becomes-ready", WithConfigTarget("config"), WithDomain, WithRouteUID("12-34")),
 				[]string{"becomes-ready.default.example.com"}),
 			ingressWithTLS(
@@ -1989,7 +1989,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				Status: readyCertStatus(),
 			},
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			ingressWithTLS(
 				route("default", "becomes-ready", WithConfigTarget("config"), WithDomain,
 					WithRouteUID("12-34")),

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -176,7 +176,7 @@ func TestReconcile(t *testing.T) {
 			endpointspriv("on", "cde", WithSubsets),
 			activatorEndpoints(WithSubsets),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpriv("on", "cde"),
 			svcpub("on", "cde"),
 			endpointspub("on", "cde", WithSubsets),
@@ -224,7 +224,7 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "services"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpub("svc", "fail2"),
 		},
 		WantEvents: []string{
@@ -244,7 +244,7 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "endpoints"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpub("eps", "fail3"),
 			endpointspub("eps", "fail3", WithSubsets),
 		},
@@ -260,7 +260,7 @@ func TestReconcile(t *testing.T) {
 			endpointspriv("on", "cneps"),
 			activatorEndpoints(WithSubsets),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpriv("on", "cneps"),
 			svcpub("on", "cneps"),
 			endpointspub("on", "cneps", WithSubsets),
@@ -282,7 +282,7 @@ func TestReconcile(t *testing.T) {
 			endpointspub("on", "cnaeps", WithSubsets),
 			activatorEndpoints(),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpriv("on", "cnaeps"),
 			svcpub("on", "cnaeps"),
 		},
@@ -302,7 +302,7 @@ func TestReconcile(t *testing.T) {
 			endpointspriv("on", "cnaeps", WithSubsets), // This should be ignored.
 			activatorEndpoints(),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpriv("on", "cnaeps"),
 			svcpub("on", "cnaeps", withTargetPortNum(8012)),
 			endpointspub("on", "cnaeps"),
@@ -327,7 +327,7 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "services"),
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			svcpriv("svc", "fail"),
 		},
 		WantEvents: []string{

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -61,7 +61,7 @@ func TestReconcile(t *testing.T) {
 			Service("run-latest", "foo", WithInlineRollout),
 		},
 		Key: "foo/run-latest",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("run-latest", "foo", WithInlineRollout),
 			route("run-latest", "foo", WithInlineRollout),
 		},
@@ -81,7 +81,7 @@ func TestReconcile(t *testing.T) {
 			Service("run-latest", "foo", WithRunLatestRollout),
 		},
 		Key: "foo/run-latest",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("run-latest", "foo", WithRunLatestRollout),
 			route("run-latest", "foo", WithRunLatestRollout),
 		},
@@ -101,7 +101,7 @@ func TestReconcile(t *testing.T) {
 			Service("pinned", "foo", WithPinnedRollout("pinned-0001")),
 		},
 		Key: "foo/pinned",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("pinned", "foo", WithPinnedRollout("pinned-0001")),
 			route("pinned", "foo", WithPinnedRollout("pinned-0001")),
 		},
@@ -123,7 +123,7 @@ func TestReconcile(t *testing.T) {
 			Service("pinned2", "foo", WithReleaseRollout("pinned2-0001")),
 		},
 		Key: "foo/pinned2",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("pinned2", "foo", WithReleaseRollout("pinned2-0001")),
 			route("pinned2", "foo", WithReleaseRollout("pinned2-0001")),
 		},
@@ -203,7 +203,7 @@ func TestReconcile(t *testing.T) {
 			Service("release", "foo", WithReleaseRollout(v1alpha1.ReleaseLatestRevisionKeyword)),
 		},
 		Key: "foo/release",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("release", "foo", WithReleaseRollout("release-00001")),
 			route("release", "foo", WithReleaseRollout(v1alpha1.ReleaseLatestRevisionKeyword)),
 		},
@@ -223,7 +223,7 @@ func TestReconcile(t *testing.T) {
 			Service("release", "foo", WithReleaseRollout("release-00001", "release-00002")),
 		},
 		Key: "foo/release",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("release", "foo", WithReleaseRollout("release-00001", "release-00002")),
 			route("release", "foo", WithReleaseRollout("release-00001", "release-00002")),
 		},
@@ -605,7 +605,7 @@ func TestReconcile(t *testing.T) {
 				"release-with-percent-00001", "release-with-percent-00002")),
 		},
 		Key: "foo/release-with-percent",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("release-with-percent", "foo", WithReleaseRolloutAndPercentage(10, "release-with-percent-00001", "release-with-percent-00002")),
 			route("release-with-percent", "foo", WithReleaseRolloutAndPercentage(10, "release-with-percent-00001", "release-with-percent-00002")),
 		},
@@ -758,7 +758,7 @@ func TestReconcile(t *testing.T) {
 			Service("create-route-failure", "foo", WithRunLatestRollout),
 		},
 		Key: "foo/create-route-failure",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("create-route-failure", "foo", WithRunLatestRollout),
 			route("create-route-failure", "foo", WithRunLatestRollout),
 		},
@@ -784,7 +784,7 @@ func TestReconcile(t *testing.T) {
 			Service("create-config-failure", "foo", WithRunLatestRollout),
 		},
 		Key: "foo/create-config-failure",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("create-config-failure", "foo", WithRunLatestRollout),
 			// We don't get to creating the Route.
 		},
@@ -851,7 +851,7 @@ func TestReconcile(t *testing.T) {
 			Service("run-latest", "foo", WithRunLatestRollout),
 		},
 		Key: "foo/run-latest",
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			config("run-latest", "foo", WithRunLatestRollout),
 			route("run-latest", "foo", WithRunLatestRollout),
 		},

--- a/vendor/github.com/knative/pkg/reconciler/testing/table.go
+++ b/vendor/github.com/knative/pkg/reconciler/testing/table.go
@@ -29,7 +29,6 @@ import (
 	"github.com/knative/pkg/kmeta"
 	_ "github.com/knative/pkg/system/testing" // Setup system.Namespace()
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -54,7 +53,7 @@ type TableRow struct {
 	WantErr bool
 
 	// WantCreates holds the ordered list of Create calls we expect during reconciliation.
-	WantCreates []metav1.Object
+	WantCreates []runtime.Object
 
 	// WantUpdates holds the ordered list of Update calls we expect during reconciliation.
 	WantUpdates []clientgotesting.UpdateActionImpl


### PR DESCRIPTION
We allow a more permissive type for WantCreates, which requires a change to most existing table tests which use a different slice type.
