### PR TITLE
Delete deprecated subdomain

### DIFF
--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/pkg/system"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -73,11 +72,15 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 	updated := getRouteIngressFromClient(t, servingClient, r)
 	servingInformer.Networking().V1alpha1().ClusterIngresses().Informer().GetIndexer().Add(updated)
 
-	r.Status.URL = &apis.URL{
-		Scheme: "http",
-		Host:   "bar.com",
-	}
-	ci2 := newTestClusterIngress(t, r)
+	ci2 := newTestClusterIngress(t, r, func(tc *traffic.Config) {
+		tc.Targets[traffic.DefaultTarget][0].TrafficTarget.Percent = 50
+		tc.Targets[traffic.DefaultTarget] = append(tc.Targets[traffic.DefaultTarget], traffic.RevisionTarget{
+			TrafficTarget: v1beta1.TrafficTarget{
+				Percent: 50,
+				RevisionName: "revision2",
+			},
+		})
+	})
 	if _, err := c.reconcileClusterIngress(TestContextWithLogger(t), r, ci2); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -147,7 +150,7 @@ func TestReconcileTargetRevisions(t *testing.T) {
 	}
 }
 
-func newTestClusterIngress(t *testing.T, r *v1alpha1.Route) *netv1alpha1.ClusterIngress {
+func newTestClusterIngress(t *testing.T, r *v1alpha1.Route, trafficOpts ...func(tc *traffic.Config)) *netv1alpha1.ClusterIngress {
 	tc := &traffic.Config{Targets: map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1beta1.TrafficTarget{
@@ -156,6 +159,11 @@ func newTestClusterIngress(t *testing.T, r *v1alpha1.Route) *netv1alpha1.Cluster
 			},
 			Active: true,
 		}}}}
+
+	for _, opt := range trafficOpts {
+		opt(tc)
+	}
+
 	tls := []netv1alpha1.ClusterIngressTLS{
 		{
 			Hosts:             []string{"test-route.test-ns.example.com"},

--- a/pkg/reconciler/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/route/resources/cluster_ingress.go
@@ -115,15 +115,6 @@ func routeDomains(ctx context.Context, targetName string, r *servingv1alpha1.Rou
 
 	ruleDomains := []string{fullName}
 
-	// TODO(andrew-su): We are adding this for backwards compatibility. This should be removed when
-	// we feel the users had sufficient time to move away from the deprecated name.
-	if r.Status.URL != nil {
-		deprecatedFullName := traffic.DeprecatedTagDomain(targetName, r.Status.URL.Host)
-		if fullName != deprecatedFullName {
-			ruleDomains = append(ruleDomains, deprecatedFullName)
-		}
-	}
-
 	if targetName == traffic.DefaultTarget {
 		// The default target is also referred to by its internal K8s
 		// generated domain name.

--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -116,7 +116,6 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 	expected := []netv1alpha1.ClusterIngressRule{{
 		Hosts: []string{
 			"test-route.test-ns.example.com",
-			"domain.com",
 			"test-route.test-ns.svc.cluster.local",
 		},
 		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
@@ -138,7 +137,6 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 	}, {
 		Hosts: []string{
 			"test-route-v1.test-ns.example.com",
-			"v1.domain.com",
 		},
 		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -232,7 +230,6 @@ func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
 	}
 	expected := []string{
 		"test-route.test-ns.example.com",
-		base,
 		"test-route.test-ns.svc.cluster.local",
 	}
 	domains, err := routeDomains(getContext(), "", r)
@@ -262,7 +259,6 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 	}
 	expected := []string{
 		"test-route.test-ns.example.com",
-		base,
 		"test-route.test-ns.svc.cluster.local",
 	}
 	domains, err := routeDomains(getContext(), "", r)
@@ -296,7 +292,6 @@ func TestGetRouteDomains_NamedTarget(t *testing.T) {
 	}
 	expected := []string{
 		"test-route-v1.test-ns.example.com",
-		"v1.domain.com",
 	}
 	domains, err := routeDomains(getContext(), name, r)
 	if err != nil {

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -626,7 +626,6 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"test-route-test-revision-1.test.test-domain.dev",
-				"test-revision-1." + domain,
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -647,7 +646,6 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"test-route-test-revision-2.test.test-domain.dev",
-				"test-revision-2." + domain,
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -753,7 +751,6 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"test-route-bar.test.test-domain.dev",
-				"bar." + domain,
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
@@ -774,7 +771,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"test-route-foo.test.test-domain.dev",
-				"foo." + domain},
+			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -18,8 +18,6 @@ package traffic
 
 import (
 	"context"
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	net "github.com/knative/serving/pkg/apis/networking"
@@ -75,15 +73,6 @@ func BuildTrafficConfiguration(configLister listers.ConfigurationLister, revList
 	builder := newBuilder(configLister, revLister, u.Namespace, len(u.Spec.Traffic))
 	builder.applySpecTraffic(u.Spec.Traffic)
 	return builder.build()
-}
-
-// DeprecatedTagDomain returns the deprecated domain name of a traffic target given the traffic target name and the Route's base domain.
-// This function has been deprecated.
-func DeprecatedTagDomain(name, domain string) string {
-	if name == DefaultTarget {
-		return domain
-	}
-	return fmt.Sprintf("%s.%s", name, domain)
 }
 
 // GetRevisionTrafficTargets returns a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -971,33 +971,6 @@ func TestRoundTripping(t *testing.T) {
 	}
 }
 
-func TestDeprecatedTagDomain(t *testing.T) {
-	tests := []struct {
-		TestName string
-		Name     string
-		Domain   string
-		Expected string
-	}{{
-		TestName: "subdomain",
-		Name:     "current",
-		Domain:   "svc.local.com",
-		Expected: "current.svc.local.com",
-	}, {
-		TestName: "default target",
-		Name:     DefaultTarget,
-		Domain:   "default.com",
-		Expected: "default.com",
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.TestName, func(t *testing.T) {
-			if got, want := DeprecatedTagDomain(tt.Name, tt.Domain), tt.Expected; got != want {
-				t.Errorf("DeprecatedTagDomain = %s, want: %s", got, want)
-			}
-		})
-	}
-}
-
 func testConfig(name string) *v1alpha1.Configuration {
 	return &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -95,8 +95,9 @@ func validateDomains(
 	t *testing.T, clients *test.Clients, baseDomain string,
 	baseExpected, trafficTargets, targetsExpected []string) error {
 	var subdomains []string
+	split := strings.Split(baseDomain, ".")
 	for _, target := range trafficTargets {
-		subdomains = append(subdomains, fmt.Sprintf("%s.%s", target, baseDomain))
+		subdomains = append(subdomains, fmt.Sprintf("%s-%s.%s", split[0], target, strings.Join(split[1:], ".")))
 	}
 
 	g, _ := errgroup.WithContext(context.Background())


### PR DESCRIPTION
As part of #3419 in knative 0.6 we kept the old subroutes around but deprecated them. This change removes the deprecated subroute URL format.
