### PR TITLE
Update the testdata used in a number of tests.

### DIFF
--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -44,10 +44,12 @@ import (
 )
 
 var revisionSpec = v1alpha1.RevisionSpec{
-	DeprecatedContainer: &corev1.Container{
-		Image: "busybox",
-	},
 	RevisionSpec: v1beta1.RevisionSpec{
+		PodSpec: v1beta1.PodSpec{
+			Containers: []corev1.Container{{
+				Image: "busybox",
+			}},
+		},
 		TimeoutSeconds: ptr.Int64(60),
 	},
 }
@@ -203,7 +205,7 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision for Configuration %q: %v",
 				"validation-failure", "expected 0 <= -1 <= 1000: spec.containerConcurrency"),
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for Configuration %q: %v",
-				"validation-failure", "expected 0 <= -1 <= 1000: spec.revisionTemplate.spec.containerConcurrency"),
+				"validation-failure", "expected 0 <= -1 <= 1000: spec.template.spec.containerConcurrency"),
 		},
 		Key: "foo/validation-failure",
 	}, {
@@ -556,8 +558,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1
 			Generation: generation,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			DeprecatedGeneration: generation,
-			DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
+			Template: &v1alpha1.RevisionTemplateSpec{
 				Spec: *revisionSpec.DeepCopy(),
 			},
 		},

--- a/pkg/reconciler/configuration/queueing_test.go
+++ b/pkg/reconciler/configuration/queueing_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package configuration
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -35,66 +36,60 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
 	. "github.com/knative/pkg/reconciler/testing"
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
-
-/* TODO tests:
-- syncHandler returns error (in processNextWorkItem)
-- invalid key in workqueue (in processNextWorkItem)
-- object cannot be converted to key (in enqueueConfiguration)
-- invalid key given to syncHandler
-- resource doesn't exist in lister (from syncHandler)
-*/
 
 const (
 	testNamespace = "test"
 )
 
 func getTestConfiguration() *v1alpha1.Configuration {
-	return &v1alpha1.Configuration{
+	cfg := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/configurations/test-config",
 			Name:      "test-config",
 			Namespace: testNamespace,
 		},
 		Spec: v1alpha1.ConfigurationSpec{
-			// TODO(grantr): This is a workaround for generation initialization
-			DeprecatedGeneration: 1,
-			DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
+			Template: &v1alpha1.RevisionTemplateSpec{
 				Spec: v1alpha1.RevisionSpec{
 					RevisionSpec: v1beta1.RevisionSpec{
 						PodSpec: v1beta1.PodSpec{
 							ServiceAccountName: "test-account",
+							// corev1.Container has a lot of setting.  We try to pass many
+							// of them here to verify that we pass through the settings to
+							// the derived Revisions.
+							Containers: []corev1.Container{{
+								Image:      "gcr.io/repo/image",
+								Command:    []string{"echo"},
+								Args:       []string{"hello", "world"},
+								WorkingDir: "/tmp",
+								Env: []corev1.EnvVar{{
+									Name:  "EDITOR",
+									Value: "emacs",
+								}},
+								LivenessProbe: &corev1.Probe{
+									TimeoutSeconds: 42,
+								},
+								ReadinessProbe: &corev1.Probe{
+									TimeoutSeconds: 43,
+								},
+								TerminationMessagePath: "/dev/null",
+							}},
 						},
-					},
-					// corev1.Container has a lot of setting.  We try to pass many
-					// of them here to verify that we pass through the settings to
-					// the derived Revisions.
-					DeprecatedContainer: &corev1.Container{
-						Image:      "gcr.io/repo/image",
-						Command:    []string{"echo"},
-						Args:       []string{"hello", "world"},
-						WorkingDir: "/tmp",
-						Env: []corev1.EnvVar{{
-							Name:  "EDITOR",
-							Value: "emacs",
-						}},
-						LivenessProbe: &corev1.Probe{
-							TimeoutSeconds: 42,
-						},
-						ReadinessProbe: &corev1.Probe{
-							TimeoutSeconds: 43,
-						},
-						TerminationMessagePath: "/dev/null",
 					},
 				},
 			},
 		},
 	}
+	cfg.SetDefaults(context.Background())
+	return cfg
 }
 
 func newTestController(t *testing.T, stopCh chan struct{}) (
@@ -120,6 +115,7 @@ func newTestController(t *testing.T, stopCh chan struct{}) (
 	// with watches not firing in client-go 1.9. When we update to client-go 1.10
 	// this can probably be removed.
 	servingClient = fakeclientset.NewSimpleClientset()
+	dynamicClient := fakedynamicclientset.NewSimpleDynamicClient(NewScheme())
 
 	// Create informer factories with fake clients. The second parameter sets the
 	// resync period to zero, disabling it.
@@ -131,6 +127,7 @@ func newTestController(t *testing.T, stopCh chan struct{}) (
 			KubeClientSet:    kubeClient,
 			SharedClientSet:  sharedClient,
 			ServingClientSet: servingClient,
+			DynamicClientSet: dynamicClient,
 			ConfigMapWatcher: configMapWatcher,
 			Logger:           logtesting.TestLogger(t),
 			StopChannel:      stopCh,

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -55,6 +55,7 @@ import (
 	logtesting "github.com/knative/pkg/logging/testing"
 
 	. "github.com/knative/pkg/reconciler/testing"
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
 
 type nopResolver struct{}
@@ -92,33 +93,34 @@ func testRevision() *v1alpha1.Revision {
 			UID: "test-rev-uid",
 		},
 		Spec: v1alpha1.RevisionSpec{
-			// corev1.Container has a lot of setting.  We try to pass many
-			// of them here to verify that we pass through the settings to
-			// derived objects.
-			DeprecatedContainer: &corev1.Container{
-				Image:      "gcr.io/repo/image",
-				Command:    []string{"echo"},
-				Args:       []string{"hello", "world"},
-				WorkingDir: "/tmp",
-				Env: []corev1.EnvVar{{
-					Name:  "EDITOR",
-					Value: "emacs",
-				}},
-				LivenessProbe: &corev1.Probe{
-					TimeoutSeconds: 42,
-				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "health",
-						},
-					},
-					TimeoutSeconds: 43,
-				},
-				TerminationMessagePath: "/dev/null",
-			},
-			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelMulti,
 			RevisionSpec: v1beta1.RevisionSpec{
+				PodSpec: v1beta1.PodSpec{
+					// corev1.Container has a lot of setting.  We try to pass many
+					// of them here to verify that we pass through the settings to
+					// derived objects.
+					Containers: []corev1.Container{{
+						Image:      "gcr.io/repo/image",
+						Command:    []string{"echo"},
+						Args:       []string{"hello", "world"},
+						WorkingDir: "/tmp",
+						Env: []corev1.EnvVar{{
+							Name:  "EDITOR",
+							Value: "emacs",
+						}},
+						LivenessProbe: &corev1.Probe{
+							TimeoutSeconds: 42,
+						},
+						ReadinessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "health",
+								},
+							},
+							TimeoutSeconds: 43,
+						},
+						TerminationMessagePath: "/dev/null",
+					}},
+				},
 				TimeoutSeconds: ptr.Int64(60),
 			},
 		},
@@ -160,7 +162,7 @@ func newTestController(t *testing.T, stopCh <-chan struct{}) (
 	kubeClient = fakekubeclientset.NewSimpleClientset()
 	servingClient = fakeclientset.NewSimpleClientset()
 	cachingClient = fakecachingclientset.NewSimpleClientset()
-	dynamicClient = fakedynamicclientset.NewSimpleDynamicClient(runtime.NewScheme())
+	dynamicClient = fakedynamicclientset.NewSimpleDynamicClient(NewScheme())
 
 	configMapWatcher = &configmap.ManualWatcher{Namespace: system.Namespace()}
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -69,6 +69,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	. "github.com/knative/pkg/reconciler/testing"
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
 
 func testConfiguration() *v1alpha1.Configuration {
@@ -126,7 +127,7 @@ func newTestControllerWithConfig(t *testing.T, deploymentConfig *deployment.Conf
 	kubeClient = fakekubeclientset.NewSimpleClientset()
 	servingClient = fakeclientset.NewSimpleClientset()
 	cachingClient = fakecachingclientset.NewSimpleClientset()
-	dynamicClient = fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
+	dynamicClient = fakedynamic.NewSimpleDynamicClient(NewScheme())
 
 	configMapWatcher = &configmap.ManualWatcher{Namespace: system.Namespace()}
 

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -37,20 +37,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
 	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
 	. "github.com/knative/pkg/reconciler/testing"
+	. "github.com/knative/serving/pkg/reconciler/testing"
 )
-
-/* TODO tests:
-- syncHandler returns error (in processNextWorkItem)
-- invalid key in workqueue (in processNextWorkItem)
-- object cannot be converted to key (in enqueueConfiguration)
-- invalid key given to syncHandler
-- resource doesn't exist in lister (from syncHandler)
-*/
 
 func TestNewRouteCallsSyncHandler(t *testing.T) {
 	defer logtesting.ClearAll()
@@ -92,6 +86,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	})
 	sharedClient := fakesharedclientset.NewSimpleClientset()
 	servingClient := fakeclientset.NewSimpleClientset()
+	dynamicClient := fakedynamicclientset.NewSimpleDynamicClient(NewScheme())
 
 	// Create informer factories with fake clients. The second parameter sets the
 	// resync period to zero, disabling it.
@@ -101,6 +96,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	controller := NewController(
 		reconciler.Options{
 			KubeClientSet:    kubeClient,
+			DynamicClientSet: dynamicClient,
 			SharedClientSet:  sharedClient,
 			ServingClientSet: servingClient,
 			ConfigMapWatcher: configMapWatcher,

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -61,7 +61,7 @@ const (
 )
 
 func getTestRouteWithTrafficTargets(traffic []v1alpha1.TrafficTarget) *v1alpha1.Route {
-	return &v1alpha1.Route{
+	route := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/test-route",
 			Name:      "test-route",
@@ -74,6 +74,8 @@ func getTestRouteWithTrafficTargets(traffic []v1alpha1.TrafficTarget) *v1alpha1.
 			Traffic: traffic,
 		},
 	}
+	route.SetDefaults(context.Background())
+	return route
 }
 
 func getTestRevision(name string) *v1alpha1.Revision {
@@ -565,20 +567,20 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				Percent:      5,
 			},
 		}, {
-			DeprecatedName: "test-revision-1",
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "test-revision-1",
 				RevisionName: "test-rev",
 				Percent:      10,
 			},
 		}, {
-			DeprecatedName: "test-revision-1",
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "test-revision-1",
 				RevisionName: "test-rev",
 				Percent:      10,
 			},
 		}, {
-			DeprecatedName: "test-revision-2",
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "test-revision-2",
 				RevisionName: "test-rev",
 				Percent:      15,
 			},
@@ -697,14 +699,14 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 	// targets
 	route := getTestRouteWithTrafficTargets(
 		[]v1alpha1.TrafficTarget{{
-			DeprecatedName: "foo",
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "foo",
 				RevisionName: "test-rev",
 				Percent:      50,
 			},
 		}, {
-			DeprecatedName: "bar",
 			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:               "bar",
 				ConfigurationName: "test-config",
 				Percent:           50,
 			},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1297,14 +1297,14 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			route("default", "same-revision-targets", WithSpecTraffic(
 				v1alpha1.TrafficTarget{
-					DeprecatedName: "gray",
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:               "gray",
 						ConfigurationName: "gray",
 						Percent:           50,
 					},
 				}, v1alpha1.TrafficTarget{
-					DeprecatedName: "also-gray",
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          "also-gray",
 						RevisionName: "gray-00001",
 						Percent:      50,
 					},
@@ -1317,14 +1317,14 @@ func TestReconcile(t *testing.T) {
 			simpleClusterIngress(
 				route("default", "same-revision-targets", WithDomain, WithSpecTraffic(
 					v1alpha1.TrafficTarget{
-						DeprecatedName: "gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:               "gray",
 							ConfigurationName: "gray",
 							Percent:           50,
 						},
 					}, v1alpha1.TrafficTarget{
-						DeprecatedName: "also-gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:          "also-gray",
 							RevisionName: "gray-00001",
 							Percent:      50,
 						},
@@ -1365,14 +1365,14 @@ func TestReconcile(t *testing.T) {
 				getContext(),
 				route("default", "same-revision-targets", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
-						DeprecatedName: "gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:               "gray",
 							ConfigurationName: "gray",
 							Percent:           50,
 						},
 					}, v1alpha1.TrafficTarget{
-						DeprecatedName: "also-gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:          "also-gray",
 							RevisionName: "gray-00001",
 							Percent:      50,
 						},
@@ -1383,14 +1383,14 @@ func TestReconcile(t *testing.T) {
 				getContext(),
 				route("default", "same-revision-targets", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
-						DeprecatedName: "gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:               "gray",
 							ConfigurationName: "gray",
 							Percent:           50,
 						},
 					}, v1alpha1.TrafficTarget{
-						DeprecatedName: "also-gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:          "also-gray",
 							RevisionName: "gray-00001",
 							Percent:      50,
 						},
@@ -1401,14 +1401,14 @@ func TestReconcile(t *testing.T) {
 				getContext(),
 				route("default", "same-revision-targets", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
-						DeprecatedName: "gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:               "gray",
 							ConfigurationName: "gray",
 							Percent:           50,
 						},
 					}, v1alpha1.TrafficTarget{
-						DeprecatedName: "also-gray",
 						TrafficTarget: v1beta1.TrafficTarget{
+							Tag:          "also-gray",
 							RevisionName: "gray-00001",
 							Percent:      50,
 						},
@@ -1419,14 +1419,14 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: route("default", "same-revision-targets",
 				WithSpecTraffic(v1alpha1.TrafficTarget{
-					DeprecatedName: "gray",
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:               "gray",
 						ConfigurationName: "gray",
 						Percent:           50,
 					},
 				}, v1alpha1.TrafficTarget{
-					DeprecatedName: "also-gray",
 					TrafficTarget: v1beta1.TrafficTarget{
+						Tag:          "also-gray",
 						RevisionName: "gray-00001",
 						Percent:      50,
 					},
@@ -2078,6 +2078,7 @@ func route(namespace, name string, ro ...RouteOption) *v1alpha1.Route {
 	for _, opt := range ro {
 		opt(r)
 	}
+	r.SetDefaults(context.Background())
 	return r
 }
 


### PR DESCRIPTION
The purpose of this change is to separate out some of the churn in a subsequent change by cutting down on the number of Reconciles that issue a "patch" to trigger our webhook-based defaulting.
