### PR TITLE
Regard revisions as stale if they are never pinned and non-ready status after creation

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -345,10 +345,9 @@ func isRevisionStale(ctx context.Context, rev *v1alpha1.Revision, config *v1alph
 	if err != nil {
 		if err.(v1alpha1.LastPinnedParseError).Type != v1alpha1.AnnotationParseErrorTypeMissing {
 			logger.Errorf("Failed to determine revision last pinned: %v", err)
-		}
-		// Revision was never pinned and its RevisionConditionReady is not true after staleRevisionCreateDelay.
-		// It usually happens when ksvc was deployed with wrong configuration.
-		if err.(v1alpha1.LastPinnedParseError).Type == v1alpha1.AnnotationParseErrorTypeMissing {
+		} else {
+			// Revision was never pinned and its RevisionConditionReady is not true after staleRevisionCreateDelay.
+			// It usually happens when ksvc was deployed with wrong configuration.
 			rc := rev.Status.GetCondition(v1beta1.RevisionConditionReady)
 			if rc == nil || rc.Status != corev1.ConditionTrue {
 				return true

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -346,6 +346,14 @@ func isRevisionStale(ctx context.Context, rev *v1alpha1.Revision, config *v1alph
 		if err.(v1alpha1.LastPinnedParseError).Type != v1alpha1.AnnotationParseErrorTypeMissing {
 			logger.Errorf("Failed to determine revision last pinned: %v", err)
 		}
+		// Revision was never pinned and its RevisionConditionReady is not true after staleRevisionCreateDelay.
+		// It usually happens when ksvc was deployed with wrong configuration.
+		if err.(v1alpha1.LastPinnedParseError).Type == v1alpha1.AnnotationParseErrorTypeMissing {
+			rc := rev.Status.GetCondition(v1beta1.RevisionConditionReady)
+			if rc == nil || rc.Status != corev1.ConditionTrue {
+				return true
+			}
+		}
 		return false
 	}
 


### PR DESCRIPTION
If service was deployed with wrong configuration, the revision is
never GCed as it cannot get `serving.knative.dev/lastPinned`
annotation.

This patch changes to regard revisions as stale if they are never
pinned and `RevisionConditionReady` are not true after
`stale-revision-create-delay`.

/lint

Fixes https://github.com/knative/serving/issues/4186

## Proposed Changes

* Regard revisions as stale if they are never pinned and non-ready status after creation.

**Release Note**

```release-note
Revisions will be GCed if they are never pinned and non-ready status after stale-revision-create-delay.
```
