### PR TITLE
Simplify the Service Reconciler to the beta subset.

### DIFF
--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/kmeta"
@@ -30,7 +28,7 @@ import (
 
 // MakeConfiguration creates a Configuration from a Service object.
 func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, error) {
-	c := &v1alpha1.Configuration{
+	return &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Configuration(service),
 			Namespace: service.Namespace,
@@ -41,19 +39,6 @@ func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, erro
 				serving.ServiceLabelKey: service.Name,
 			}),
 		},
-	}
-
-	if service.Spec.DeprecatedRunLatest != nil {
-		c.Spec = service.Spec.DeprecatedRunLatest.Configuration
-	} else if service.Spec.DeprecatedPinned != nil {
-		c.Spec = service.Spec.DeprecatedPinned.Configuration
-	} else if service.Spec.DeprecatedRelease != nil {
-		c.Spec = service.Spec.DeprecatedRelease.Configuration
-	} else if service.Spec.DeprecatedManual != nil {
-		// DeprecatedManual does not have a configuration and should not reach this path.
-		return nil, errors.New("malformed Service: MakeConfiguration requires one of runLatest, pinned, or release must be present")
-	} else {
-		c.Spec = service.Spec.ConfigurationSpec
-	}
-	return c, nil
+		Spec: service.Spec.ConfigurationSpec,
+	}, nil
 }

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -17,14 +17,23 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"testing"
 
 	"github.com/knative/serving/pkg/apis/serving"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 )
+
+func makeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, error) {
+	// We do this prior to reconciliation, so test with it enabled.
+	service.SetDefaults(v1beta1.WithUpgradeViaDefaulting(context.Background()))
+	return MakeConfiguration(service)
+}
 
 func TestRunLatest(t *testing.T) {
 	s := createServiceWithRunLatest()
-	c, _ := MakeConfiguration(s)
+	c, _ := makeConfiguration(s)
 	if got, want := c.Name, testServiceName; got != want {
 		t.Errorf("expected %q for service name got %q", want, got)
 	}
@@ -49,7 +58,7 @@ func TestRunLatest(t *testing.T) {
 
 func TestPinned(t *testing.T) {
 	s := createServiceWithPinned()
-	c, _ := MakeConfiguration(s)
+	c, _ := makeConfiguration(s)
 	if got, want := c.Name, testServiceName; got != want {
 		t.Errorf("expected %q for service name got %q", want, got)
 	}
@@ -74,7 +83,7 @@ func TestPinned(t *testing.T) {
 
 func TestRelease(t *testing.T) {
 	s := createServiceWithRelease(1, 0)
-	c, _ := MakeConfiguration(s)
+	c, _ := makeConfiguration(s)
 	if got, want := c.Name, testServiceName; got != want {
 		t.Errorf("expected %q for service name got %q", want, got)
 	}
@@ -97,17 +106,9 @@ func TestRelease(t *testing.T) {
 	}
 }
 
-func TestManual(t *testing.T) {
-	s := createServiceWithManual()
-	c, err := MakeConfiguration(s)
-	if err == nil {
-		t.Errorf("MakeConfiguration(%v) = %v, wanted error", s, c)
-	}
-}
-
 func TestInlineConfigurationSpec(t *testing.T) {
 	s := createServiceInline()
-	c, _ := MakeConfiguration(s)
+	c, _ := makeConfiguration(s)
 	if got, want := c.Name, testServiceName; got != want {
 		t.Errorf("expected %q for service name got %q", want, got)
 	}

--- a/pkg/reconciler/service/resources/route.go
+++ b/pkg/reconciler/service/resources/route.go
@@ -17,14 +17,11 @@ limitations under the License.
 package resources
 
 import (
-	"errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/pkg/reconciler/service/resources/names"
 	"github.com/knative/serving/pkg/resources"
 )
@@ -44,85 +41,14 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 				serving.ServiceLabelKey: service.Name,
 			}),
 		},
+		Spec: *service.Spec.RouteSpec.DeepCopy(),
 	}
 
-	if service.Spec.DeprecatedRelease != nil {
-		rolloutPercent := service.Spec.DeprecatedRelease.RolloutPercent
-		numRevisions := len(service.Spec.DeprecatedRelease.Revisions)
-
-		// Configure the 'current' route.
-		ttCurrent := v1alpha1.TrafficTarget{
-			TrafficTarget: v1beta1.TrafficTarget{
-				Tag:     v1alpha1.CurrentTrafficTarget,
-				Percent: 100 - rolloutPercent,
-			},
-		}
-		currentRevisionName := service.Spec.DeprecatedRelease.Revisions[0]
-
-		// If the `current` revision refers to the well known name of the last
-		// known revision, use `Configuration` instead.
-		// Same for the `candidate` below.
-		// Part of #2819.
-		if currentRevisionName == v1alpha1.ReleaseLatestRevisionKeyword {
-			ttCurrent.ConfigurationName = names.Configuration(service)
-		} else {
-			ttCurrent.RevisionName = currentRevisionName
-		}
-		c.Spec.Traffic = append(c.Spec.Traffic, ttCurrent)
-
-		// Configure the 'candidate' route.
-		if numRevisions == 2 {
-			ttCandidate := v1alpha1.TrafficTarget{
-				TrafficTarget: v1beta1.TrafficTarget{
-					Tag:     v1alpha1.CandidateTrafficTarget,
-					Percent: rolloutPercent,
-				},
-			}
-			candidateRevisionName := service.Spec.DeprecatedRelease.Revisions[1]
-			if candidateRevisionName == v1alpha1.ReleaseLatestRevisionKeyword {
-				ttCandidate.ConfigurationName = names.Configuration(service)
-			} else {
-				ttCandidate.RevisionName = candidateRevisionName
-			}
-			c.Spec.Traffic = append(c.Spec.Traffic, ttCandidate)
-		}
-
-		// Configure the 'latest' route.
-		ttLatest := v1alpha1.TrafficTarget{
-			TrafficTarget: v1beta1.TrafficTarget{
-				Tag:               v1alpha1.LatestTrafficTarget,
-				ConfigurationName: names.Configuration(service),
-				Percent:           0,
-			},
-		}
-		c.Spec.Traffic = append(c.Spec.Traffic, ttLatest)
-	} else if service.Spec.DeprecatedRunLatest != nil {
-		tt := v1alpha1.TrafficTarget{
-			TrafficTarget: v1beta1.TrafficTarget{
-				ConfigurationName: names.Configuration(service),
-				Percent:           100,
-			},
-		}
-		c.Spec.Traffic = append(c.Spec.Traffic, tt)
-	} else if service.Spec.DeprecatedPinned != nil {
-		tt := v1alpha1.TrafficTarget{
-			TrafficTarget: v1beta1.TrafficTarget{
-				RevisionName: service.Spec.DeprecatedPinned.RevisionName,
-				Percent:      100,
-			},
-		}
-		c.Spec.Traffic = append(c.Spec.Traffic, tt)
-	} else if service.Spec.DeprecatedManual != nil {
-		// DeprecatedManual does not have a route and should not reach this path.
-		return nil, errors.New("malformed Service: MakeRoute requires one of runLatest, pinned, or release must be present")
-	} else {
-		c.Spec = *service.Spec.RouteSpec.DeepCopy()
-		// Fill in any missing ConfigurationName fields when translating
-		// from Service to Route.
-		for idx := range c.Spec.Traffic {
-			if c.Spec.Traffic[idx].RevisionName == "" {
-				c.Spec.Traffic[idx].ConfigurationName = names.Configuration(service)
-			}
+	// Fill in any missing ConfigurationName fields when translating
+	// from Service to Route.
+	for idx := range c.Spec.Traffic {
+		if c.Spec.Traffic[idx].RevisionName == "" {
+			c.Spec.Traffic[idx].ConfigurationName = names.Configuration(service)
 		}
 	}
 


### PR DESCRIPTION
Now that we convert resources at the beginning of reconciliation, we can make certain shape assumptions to dramatically reduce the amount of code we maintain.
