### PR TITLE
Default single traffic target percent to 100

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_defaults.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults.go
@@ -50,4 +50,9 @@ func (rs *RouteSpec) SetDefaults(ctx context.Context) {
 	for i := range rs.Traffic {
 		rs.Traffic[i].SetDefaults(ctx)
 	}
+
+	// If only one trrafic target is specified, we default to 100.
+	if len(rs.Traffic) == 1 && rs.Traffic[0].Percent == 0 {
+		rs.Traffic[0].Percent = 100
+	}
 }

--- a/pkg/apis/serving/v1alpha1/route_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults_test.go
@@ -71,6 +71,27 @@ func TestRouteDefaulting(t *testing.T) {
 			},
 		},
 	}, {
+		name: "only one trrafic target defaulting",
+		in: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					TrafficTarget: v1beta1.TrafficTarget{
+						LatestRevision: ptr.Bool(true),
+					},
+				}},
+			},
+		},
+		want: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					TrafficTarget: v1beta1.TrafficTarget{
+						Percent:        100,
+						LatestRevision: ptr.Bool(true),
+					},
+				}},
+			},
+		},
+	}, {
 		name: "lemonade",
 		wc:   v1beta1.WithUpgradeViaDefaulting,
 		in: &Route{

--- a/pkg/apis/serving/v1beta1/route_defaults.go
+++ b/pkg/apis/serving/v1beta1/route_defaults.go
@@ -40,6 +40,11 @@ func (rs *RouteSpec) SetDefaults(ctx context.Context) {
 	for idx := range rs.Traffic {
 		rs.Traffic[idx].SetDefaults(ctx)
 	}
+
+	// If only one trrafic target is specified, we default to 100.
+	if len(rs.Traffic) == 1 && rs.Traffic[0].Percent == 0 {
+		rs.Traffic[0].Percent = 100
+	}
 }
 
 // SetDefaults implements apis.Defaultable

--- a/pkg/apis/serving/v1beta1/route_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/route_defaults_test.go
@@ -47,6 +47,23 @@ func TestRouteDefaulting(t *testing.T) {
 		},
 		wc: WithDefaultConfigurationName,
 	}, {
+		name: "only one trrafic target defaulting",
+		in: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					LatestRevision: ptr.Bool(true),
+				}},
+			},
+		},
+		want: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Percent:        100,
+					LatestRevision: ptr.Bool(true),
+				}},
+			},
+		},
+	}, {
 		name: "latest revision defaulting",
 		in: &Route{
 			Spec: RouteSpec{


### PR DESCRIPTION
Currently service must set `percent` even when it uses only single traffic
target.

This patch changes to set default percent to `100` when service has only
single traffic target.

/lint

Fixes https://github.com/knative/serving/issues/4215

## Proposed Changes

* Default single traffic split percent to `100`

**Release Note**

```release-note
Single traffic target's default percent is 100
```