### PR TITLE
Inject ReadyPodCounter into NewServiceScraper

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -204,7 +204,8 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer, m
 
 func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) func(metric *autoscaler.Metric) (autoscaler.StatsScraper, error) {
 	return func(metric *autoscaler.Metric) (autoscaler.StatsScraper, error) {
-		return autoscaler.NewServiceScraper(metric, endpointsLister)
+		podCounter := resources.NewScopedEndpointsCounter(endpointsLister, metric.Namespace, metric.Name)
+		return autoscaler.NewServiceScraper(metric, podCounter)
 	}
 }
 


### PR DESCRIPTION
This PR isolates the statistics module from counting pods in the same way that the decider module was isolated from counting pods.

<!--
/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
