### PR TITLE
Remove outdated comment about auto TLS

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,9 +169,6 @@ if you need to set up static IP for Ingresses in the cluster.
 
 1. Deploy `cert-manager`
 
-   **Note**: The auto TLS feature has not been landed in Knative. At this point,
-   you can skip this step.
-
    If you want to use the feature of automatically provisioning TLS for Knative
    services, you need to install the full cert-manager.
 


### PR DESCRIPTION
Auto TLS landed in v0.6, so this documentation is out of date

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Minor edit to `DEVELOPMENT.md` to remove note about auto TLS not being landed

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
