### PR TITLE
Change revision svc column to config

### DIFF
--- a/config/v1alpha1/300-revision.yaml
+++ b/config/v1alpha1/300-revision.yaml
@@ -39,9 +39,6 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Kn Service Name
-    type: string
-    JSONPath: ".metadata.labels['serving\\.knative\\.dev/service']"
   - name: Config Name
     type: string
     JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"

--- a/config/v1alpha1/300-revision.yaml
+++ b/config/v1alpha1/300-revision.yaml
@@ -39,9 +39,15 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Configuration Name
+  - name: Kn Service Name
+    type: string
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/service']"
+  - name: Config Name
     type: string
     JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+  - name: K8s Service Name
+    type: string
+    JSONPath: ".status.serviceName"
   - name: Generation
     type: string # int in string form :(
     JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"

--- a/config/v1alpha1/300-revision.yaml
+++ b/config/v1alpha1/300-revision.yaml
@@ -39,9 +39,9 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Service Name
+  - name: Configuration Name
     type: string
-    JSONPath: .status.serviceName
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
   - name: Generation
     type: string # int in string form :(
     JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"

--- a/config/v1beta1/300-revision.yaml
+++ b/config/v1beta1/300-revision.yaml
@@ -42,9 +42,15 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Service Name
+  - name: Kn Service Name
     type: string
-    JSONPath: .status.serviceName
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/service']"
+  - name: Config Name
+    type: string
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+  - name: K8s Service Name
+    type: string
+    JSONPath: ".status.serviceName"
   - name: Generation
     type: string # int in string form :(
     JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"

--- a/config/v1beta1/300-revision.yaml
+++ b/config/v1beta1/300-revision.yaml
@@ -42,9 +42,6 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Kn Service Name
-    type: string
-    JSONPath: ".metadata.labels['serving\\.knative\\.dev/service']"
   - name: Config Name
     type: string
     JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"


### PR DESCRIPTION
Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint

## Proposed Changes
Replace SERVICE NAME column with CONFIGURATION NAME in `kubectl get revisions` because
1 - "SERVICE NAME" means K8s svc name, and that's kind of confusing since a Kn user might think it's he KnService name
2 - in the case of the revision not being associated with a KnService, having the Config name makes more sense

```release-note
In the output for the `kubectl get revision` output, the `SERVICE NAME` column has been replace with `CONFIGURATION NAME`.
```
