### PR TITLE
Scale zero activating timeout

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -165,6 +165,11 @@ func (pas *PodAutoscalerStatus) MarkInactive(reason, message string) {
 	podCondSet.Manage(pas.duck()).MarkFalse(PodAutoscalerConditionActive, reason, message)
 }
 
+// MarkActivatingTime marks the PA as activating timeout.
+func (pas *PodAutoscalerStatus) MarkActivatingTimeout(reason, message string) {
+	podCondSet.Manage(pas.duck()).MarkTimeout(PodAutoscalerConditionActive, reason, message)
+}
+
 // MarkResourceNotOwned changes the "Active" condition to false to reflect that the
 // resource of the given kind and name has already been created, and we do not own it.
 func (pas *PodAutoscalerStatus) MarkResourceNotOwned(kind, name string) {
@@ -189,6 +194,12 @@ func (pas *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
 // for at least the specified idle period.
 func (pas *PodAutoscalerStatus) CanMarkInactive(idlePeriod time.Duration) bool {
 	return pas.inStatusFor(corev1.ConditionTrue, idlePeriod)
+}
+
+// IsActivatingTimeout checks whether the pod autoscaler has been in activating
+// for at least the specified timeout period.
+func (pas *PodAutoscalerStatus) IsActivatingTimeout(activatingTimeout time.Duration) bool {
+	return pas.inStatusFor(corev1.ConditionUnknown, activatingTimeout)
 }
 
 // inStatusFor returns true if the PodAutoscalerStatus's Active condition has stayed in

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -165,11 +165,6 @@ func (pas *PodAutoscalerStatus) MarkInactive(reason, message string) {
 	podCondSet.Manage(pas.duck()).MarkFalse(PodAutoscalerConditionActive, reason, message)
 }
 
-// MarkActivatingTime marks the PA as activating timeout.
-func (pas *PodAutoscalerStatus) MarkActivatingTimeout(reason, message string) {
-	podCondSet.Manage(pas.duck()).MarkTimeout(PodAutoscalerConditionActive, reason, message)
-}
-
 // MarkResourceNotOwned changes the "Active" condition to false to reflect that the
 // resource of the given kind and name has already been created, and we do not own it.
 func (pas *PodAutoscalerStatus) MarkResourceNotOwned(kind, name string) {

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	TickInterval time.Duration
 
 	ScaleToZeroGracePeriod time.Duration
+	ActivatingTimeout      time.Duration
 }
 
 // TargetConcurrency calculates the target concurrency for a given container-concurrency
@@ -142,6 +143,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key:          "tick-interval",
 		field:        &lc.TickInterval,
 		defaultValue: 2 * time.Second,
+	}, {
+		key:          "activating-timeout",
+		field:        &lc.ActivatingTimeout,
+		defaultValue: 2 * time.Minute,
 	}} {
 		if raw, ok := data[dur.key]; !ok {
 			*dur.field = dur.defaultValue

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -79,6 +79,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		want: &Config{
 			EnableScaleToZero:                    true,
@@ -91,6 +92,7 @@ func TestNewConfig(t *testing.T) {
 			TickInterval:                         2 * time.Second,
 			PanicWindowPercentage:                10.0,
 			PanicThresholdPercentage:             200.0,
+			ActivatingTimeout:                    2 * time.Minute,
 		},
 	}, {
 		name: "with toggles on",
@@ -104,6 +106,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		want: &Config{
 			EnableScaleToZero:                    true,
@@ -116,6 +119,7 @@ func TestNewConfig(t *testing.T) {
 			TickInterval:                         2 * time.Second,
 			PanicWindowPercentage:                10.0,
 			PanicThresholdPercentage:             200.0,
+			ActivatingTimeout:                    2 * time.Minute,
 		},
 	}, {
 		name: "with toggles on strange casing",
@@ -129,6 +133,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		want: &Config{
 			EnableScaleToZero:                    true,
@@ -141,6 +146,7 @@ func TestNewConfig(t *testing.T) {
 			TickInterval:                         2 * time.Second,
 			PanicWindowPercentage:                10.0,
 			PanicThresholdPercentage:             200.0,
+			ActivatingTimeout:                    2 * time.Minute,
 		},
 	}, {
 		name: "with toggles explicitly off",
@@ -154,6 +160,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		want: &Config{
 			ContainerConcurrencyTargetPercentage: 0.5,
@@ -165,6 +172,7 @@ func TestNewConfig(t *testing.T) {
 			TickInterval:                         2 * time.Second,
 			PanicWindowPercentage:                10.0,
 			PanicThresholdPercentage:             200.0,
+			ActivatingTimeout:                    2 * time.Minute,
 		},
 	}, {
 		name: "with explicit grace period",
@@ -179,6 +187,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		want: &Config{
 			ContainerConcurrencyTargetPercentage: 0.5,
@@ -190,6 +199,7 @@ func TestNewConfig(t *testing.T) {
 			TickInterval:                         2 * time.Second,
 			PanicWindowPercentage:                10.0,
 			PanicThresholdPercentage:             200.0,
+			ActivatingTimeout:                    2 * time.Minute,
 		},
 	}, {
 		name: "malformed float",
@@ -202,6 +212,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		wantErr: true,
 	}, {
@@ -215,6 +226,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"activating-timeout":                      "2m",
 		},
 		wantErr: true,
 	}}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -393,9 +393,6 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int, t
 		ret = pa.Status.IsInactive() // If we were inactive and became activating.
 		pa.Status.MarkActivating(
 			"Queued", "Requests to the target are being buffered as resources are provisioned.")
-		if pa.Status.IsActivatingTimeout(timeout) {
-			pa.Status.MarkActivatingTimeout("Timeout", "The target is timeout for activating.")
-		}
 
 	case got >= minReady:
 		// SKS should already be active.

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"time"
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
@@ -215,15 +214,15 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		return perrors.Wrap(err, "error reporting metrics")
 	}
 
-	timeout := config.FromContext(ctx).Autoscaler.ActivatingTimeout
 	if pa.Status.IsActivating() {
+		timeout := config.FromContext(ctx).Autoscaler.ActivatingTimeout
 		logger.Infof("enqueue delay for check activating timeout after %v.", timeout)
 		c.scaler.enqueueCB(pa, timeout)
 	}
 
 	// computeActiveCondition decides if we need to change the SKS mode,
 	// and returns true if the status has changed.
-	if changed := computeActiveCondition(pa, want, got, timeout); changed {
+	if changed := computeActiveCondition(pa, want, got); changed {
 		_, err := c.reconcileSKS(ctx, pa)
 		if err != nil {
 			return perrors.Wrap(err, "error re-reconciling SKS")
@@ -381,7 +380,7 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, got int) error {
 
 // computeActiveCondition updates the status of PA, depending on scales desired and present.
 // computeActiveCondition returns true if it thinks SKS needs an update.
-func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int, timeout time.Duration) (ret bool) {
+func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (ret bool) {
 	minReady := activeThreshold(pa)
 
 	switch {

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -163,13 +163,8 @@ func scaleResourceArgs(pa *pav1alpha1.PodAutoscaler) (*schema.GroupVersionResour
 }
 
 func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale int32, config *autoscaler.Config) (int32, bool) {
-	if desiredScale > 0 {
+	if desiredScale != 0 {
 		return desiredScale, true
-	}
-
-	if desiredScale < 0 && !pa.Status.IsActivating() {
-		ks.logger.Info("Metrics are not yet being collected.")
-		return desiredScale, false
 	}
 
 	// We should only scale to zero when three of the following conditions are true:
@@ -184,11 +179,6 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 	if pa.Status.IsActivating() { // Active=Unknown
 		// Don't scale-to-zero during activation
 		if min, _ := pa.ScaleBounds(); min == 0 {
-			if pa.Status.IsActivatingTimeout(config.ActivatingTimeout) {
-				ks.logger.Infof("activating timeout after %v", config.ActivatingTimeout)
-				return 0, true
-			}
-			ks.logger.Info("activating, don't scale to zero")
 			return scaleUnknown, false
 		}
 	} else if pa.Status.IsReady() { // Active=True
@@ -198,7 +188,7 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 		if pa.Status.CanMarkInactive(config.StableWindow) {
 			// We do not need to enqueue PA here, since this will
 			// make SKS reconcile and when it's done, PA will be reconciled again.
-			return 0, false
+			return desiredScale, false
 		}
 		// Otherwise, scale down to 1 until the idle period elapses and re-enqueue
 		// the PA for reconciliation at that time.
@@ -263,8 +253,19 @@ func (ks *scaler) applyScale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, 
 // Scale attempts to scale the given PA's target reference to the desired scale.
 func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desiredScale int32) (int32, error) {
 	logger := logging.FromContext(ctx)
+	autoscalerConfig := config.FromContext(ctx).Autoscaler
 
-	desiredScale, shouldApplyScale := ks.handleScaleToZero(pa, desiredScale, config.FromContext(ctx).Autoscaler)
+	if desiredScale < 0 {
+		// check is activating timeout
+		if pa.Status.IsActivatingTimeout(autoscalerConfig.ActivatingTimeout) {
+			logger.Infof("Activating pa timeout after %v", autoscalerConfig.ActivatingTimeout)
+		} else {
+			logger.Debug("Metrics are not yet being collected.")
+			return desiredScale, nil
+		}
+	}
+
+	desiredScale, shouldApplyScale := ks.handleScaleToZero(pa, desiredScale, autoscalerConfig)
 	if !shouldApplyScale {
 		return desiredScale, nil
 	}

--- a/vendor/github.com/knative/pkg/apis/condition_set.go
+++ b/vendor/github.com/knative/pkg/apis/condition_set.go
@@ -27,10 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	ConditionTimeout corev1.ConditionStatus = "Timeout"
-)
-
 // Conditions is the interface for a Resource that implements the getter and
 // setter for accessing a Condition collection.
 // +k8s:deepcopy-gen=true
@@ -74,9 +70,6 @@ type ConditionManager interface {
 
 	// MarkFalse sets the status of t and the happy condition to False.
 	MarkFalse(t ConditionType, reason, messageFormat string, messageA ...interface{})
-
-	// MarkTimeout sets the status of t and the happy condition to Timeout.
-	MarkTimeout(t ConditionType, reason, messageFormat string, messageA ...interface{})
 
 	// InitializeConditions updates all Conditions in the ConditionSet to Unknown
 	// if not set.
@@ -296,26 +289,6 @@ func (r conditionsImpl) MarkFalse(t ConditionType, reason, messageFormat string,
 		r.SetCondition(Condition{
 			Type:     t,
 			Status:   corev1.ConditionFalse,
-			Reason:   reason,
-			Message:  fmt.Sprintf(messageFormat, messageA...),
-			Severity: r.severity(t),
-		})
-	}
-}
-
-// MarkTimeout sets the status of t and the happy condition to timeout.
-func (r conditionsImpl) MarkTimeout(t ConditionType, reason, messageFormat string, messageA ...interface{}) {
-	types := []ConditionType{t}
-	for _, cond := range r.dependents {
-		if cond == t {
-			types = append(types, r.happy)
-		}
-	}
-
-	for _, t := range types {
-		r.SetCondition(Condition{
-			Type:     t,
-			Status:   ConditionTimeout,
 			Reason:   reason,
 			Message:  fmt.Sprintf(messageFormat, messageA...),
 			Severity: r.severity(t),


### PR DESCRIPTION
Fixes #
problematic pods can't be scale to zero forever.
## Proposed Changes
check whether activating is timeout or not, if timeout, then scale to zero if `min==0`, and `EnableScaleToZero=true`

**Release Note**
```release-note
enable to scale to zero when activating timeout when the pod can't be ready like crashlooping or some other status
```
