### PR TITLE
Skip GC proces when revision is still used by route

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -107,6 +107,7 @@ func main() {
 			opt,
 			configurationInformer,
 			revisionInformer,
+			routeInformer,
 		),
 		revision.NewController(
 			opt,

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -311,10 +311,17 @@ func (c *Reconciler) gcRevisions(ctx context.Context, config *v1alpha1.Configura
 		return nil
 	}
 
-	route, err := c.routeLister.Routes(config.Namespace).Get(config.Name)
-	if err != nil && !errors.IsNotFound(err) {
-		// Go ahead GC process if route not found.
-		return err
+	var route *v1alpha1.Route
+
+	routeName, ok := config.GetLabels()[serving.RouteLabelKey]
+	if !ok {
+		logger.Warnf("%s does not have %q label", config.Name, serving.RouteLabelKey)
+	} else {
+		route, err = c.routeLister.Routes(config.Namespace).Get(routeName)
+		if err != nil && !errors.IsNotFound(err) {
+			// Go ahead GC process if route not found.
+			return err
+		}
 	}
 
 	// Sort by creation timestamp descending

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -40,12 +40,14 @@ func NewController(
 	opt reconciler.Options,
 	configurationInformer servinginformers.ConfigurationInformer,
 	revisionInformer servinginformers.RevisionInformer,
+	routeInformer servinginformers.RouteInformer,
 ) *controller.Impl {
 
 	c := &Reconciler{
 		Base:                reconciler.NewBase(opt, controllerAgentName),
 		configurationLister: configurationInformer.Lister(),
 		revisionLister:      revisionInformer.Lister(),
+		routeLister:         routeInformer.Lister(),
 	}
 	impl := controller.NewImpl(c, c.Logger, "Configurations")
 

--- a/pkg/reconciler/configuration/queueing_test.go
+++ b/pkg/reconciler/configuration/queueing_test.go
@@ -135,6 +135,7 @@ func newTestController(t *testing.T, stopCh chan struct{}) (
 		},
 		servingInformer.Serving().V1alpha1().Configurations(),
 		servingInformer.Serving().V1alpha1().Revisions(),
+		servingInformer.Serving().V1alpha1().Routes(),
 	)
 
 	return


### PR DESCRIPTION
Currently GC process only skips `LatestReadyRevision`. Hence, even if
route uses non-LatestReadyRevision, GC removes the revision. It causes
service outage with `RevisionMissing` error suddenly.

This patch changes to stop GC when revision is still used by route.

/lint

Fixes https://github.com/knative/serving/issues/4234

(And I am wondering if https://github.com/knative/serving/issues/4208#issue-450929976's original report was caused by this.)

## Proposed Changes

* Skip GC proces when revision is still used by route

**Release Note**

```release-note
Revision is not GC'd when it is used by route
```
