### PR TITLE
Make autoscaling configuration available to the HPA reconciler.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -17,11 +17,16 @@ limitations under the License.
 package hpa
 
 import (
+	"context"
+
+	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/autoscaler"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions/autoscaling/v1alpha1"
 	ninformers "github.com/knative/serving/pkg/client/informers/externalversions/networking/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	autoscalingv2beta1informers "k8s.io/client-go/informers/autoscaling/v2beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +34,12 @@ import (
 const (
 	controllerAgentName = "hpa-class-podautoscaler-controller"
 )
+
+// configStore is a minimized interface of the actual configStore.
+type configStore interface {
+	ToContext(ctx context.Context) context.Context
+	WatchConfigs(w configmap.Watcher)
+}
 
 // NewController returns a new HPA reconcile controller.
 func NewController(
@@ -47,10 +58,11 @@ func NewController(
 
 	c.Logger.Info("Setting up hpa-class event handlers")
 	onlyHpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.HPA, false)
-	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	paHandler := cache.FilteringResourceEventHandler{
 		FilterFunc: onlyHpaClass,
 		Handler:    controller.HandleAll(impl.Enqueue),
-	})
+	}
+	paInformer.Informer().AddEventHandler(paHandler)
 
 	hpaInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: onlyHpaClass,
@@ -61,5 +73,16 @@ func NewController(
 		FilterFunc: onlyHpaClass,
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
+
+	c.Logger.Info("Setting up ConfigMap receivers")
+	configsToResync := []interface{}{
+		&autoscaler.Config{},
+	}
+	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+		controller.SendGlobalUpdates(paInformer.Informer(), paHandler)
+	})
+	c.configStore = config.NewStore(c.Logger.Named("config-store"), resync)
+	c.configStore.WatchConfigs(opts.ConfigMapWatcher)
+
 	return impl
 }

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -48,9 +48,10 @@ import (
 type Reconciler struct {
 	*reconciler.Base
 
-	paLister  listers.PodAutoscalerLister
-	sksLister nlisters.ServerlessServiceLister
-	hpaLister autoscalingv2beta1listers.HorizontalPodAutoscalerLister
+	paLister    listers.PodAutoscalerLister
+	sksLister   nlisters.ServerlessServiceLister
+	hpaLister   autoscalingv2beta1listers.HorizontalPodAutoscalerLister
+	configStore configStore
 }
 
 var _ controller.Reconciler = (*Reconciler)(nil)
@@ -63,6 +64,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 	logger := logging.FromContext(ctx)
+	ctx = c.configStore.ToContext(ctx)
 	logger.Debug("Reconcile hpa-class PodAutoscaler")
 
 	original, err := c.paLister.PodAutoscalers(namespace).Get(name)


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The HPA reconciler used to not need this configuration but future changes will rely on the autoscaler config. In particular, the default target knobs will need to be able to the HPA reconciler to be able to correctly determine the target concurrency for the HPA spec once /metric=concurrency gets plumbed into the HPA as well.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
