### PR TITLE
golang format tools

### DIFF
--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -19,9 +19,10 @@ package autoscaler
 import (
 	"errors"
 	"fmt"
-	"github.com/knative/serving/pkg/resources"
 	"testing"
 	"time"
+
+	"github.com/knative/serving/pkg/resources"
 
 	. "github.com/knative/pkg/logging/testing"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
