### PR TITLE
Add an E2E test to ensure standard Knative install works

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -684,7 +684,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3fe88879908aadbcd03370d3fd48895be54ad89cc5c85ac3f8e4e1a3b0082ab0"
+  digest = "1:0fc98263eb8e0bd0d2d745acfd0f600c38aaeb59990b712c7e3d8c9f09e9df2a"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -703,7 +703,7 @@
     "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "1576da30069624094cf01719452da944b3046826"
+  revision = "4320fcd2e3472fb66665bc2033b2560af3bf15f1"
 
 [[projects]]
   digest = "1:58999a98719fddbac6303cb17e8d85b945f60b72f48e3a2df6b950b97fa926f1"

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -30,6 +30,7 @@ sed -n '11,41p' vendor/bitbucket.org/ww/goautoneg/README.txt > vendor/bitbucket.
 
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')
+rm -fr vendor/github.com/knative/test-infra/devstats
 
 update_licenses third_party/VENDOR-LICENSE "./cmd/*"
 remove_broken_symlinks ./vendor

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -24,32 +24,10 @@ E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-4}
 # This script provides helper methods to perform cluster actions.
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
-# Choose a correct istio-crds.yaml file.
-# - $1 specifies Istio version.
-function istio_crds_yaml() {
-  local istio_version="$1"
-  echo "./third_party/istio-${istio_version}/istio-crds.yaml"
-}
-
-# Choose a correct cert-manager.yaml file.
-# - $1 specifies cert-manager version.
-function cert_manager_yaml() {
-  local cert_manager_version="$1"
-  echo "./third_party/cert-manager-${cert_manager_version}/cert-manager.yaml" 
-}
-
-# Choose a correct istio.yaml file.
-# - $1 specifies Istio version.
-# - $2 specifies whether we should use mesh.
-function istio_yaml() {
-  local istio_version="$1"
-  local istio_mesh=$2
-  local suffix=""
-  if [[ $istio_mesh -eq 0 ]]; then
-    suffix="-lean"
-  fi
-  echo "./third_party/istio-${istio_version}/istio${suffix}.yaml"
-}
+# Default Istio configuration to install: 1.1-latest, no mesh, cert manager 0.6.1.
+ISTIO_VERSION="1.1-latest"
+ISTIO_MESH=0
+CERT_MANAGER_VERSION="0.6.1"
 
 # Current YAMLs used to install Knative Serving.
 INSTALL_RELEASE_YAML=""
@@ -150,23 +128,10 @@ function install_knative_serving_standard() {
     fi
   fi
 
-  # Decide the Istio configuration to install.
-  if [[ -z "$ISTIO_VERSION" ]]; then
-     # Defaults to 1.1-latest
-     ISTIO_VERSION=1.1-latest
-  fi
-  if [[ -z "$ISTIO_MESH" ]]; then
-    # Defaults to not using sidecar.
-    ISTIO_MESH=0
-  fi
-  INSTALL_ISTIO_CRD_YAML="$(istio_crds_yaml $ISTIO_VERSION)"
-  INSTALL_ISTIO_YAML="$(istio_yaml $ISTIO_VERSION $ISTIO_MESH)"
-
-  if [[ -z "$CERT_MANAGER_VERSION" ]]; then
-    # Defaults to 0.6.1
-    CERT_MANAGER_VERSION=0.6.1
-  fi
-  INSTALL_CERT_MANAGER_YAML="$(cert_manager_yaml $CERT_MANAGER_VERSION)"
+  local istio_base="./third_party/istio-${ISTIO_VERSION}"
+  INSTALL_ISTIO_CRD_YAML="${istio_base}/istio-crds.yaml"
+  (( ISTIO_MESH )) && INSTALL_ISTIO_YAML="${istio_base}/istio.yaml" || INSTALL_ISTIO_YAML="${istio_base}/istio-lean.yaml"
+  INSTALL_CERT_MANAGER_YAML="./third_party/cert-manager-${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
   echo ">> Installing Knative serving"
   echo "Istio CRD YAML: ${INSTALL_ISTIO_CRD_YAML}"
@@ -250,7 +215,7 @@ function knative_teardown() {
   else
     echo ">> Uninstalling Knative serving"
     echo "Istio YAML: ${INSTALL_ISTIO_YAML}"
-    echo "Cert-Manager CRD YAML: ${INSTALL_CERT_MANAGER_CRD_YAML}"
+    echo "Cert-Manager YAML: ${INSTALL_CERT_MANAGER_YAML}"
     echo "Knative YAML: ${INSTALL_RELEASE_YAML}"
     echo ">> Bringing down Serving"
     ko delete --ignore-not-found=true -f "${INSTALL_RELEASE_YAML}" || return 1
@@ -270,10 +235,6 @@ function knative_teardown() {
 function test_setup() {
   echo ">> Creating test resources (test/config/)"
   ko apply -f test/config/ || return 1
-  echo ">> Creating test namespaces"
-  kubectl create namespace serving-tests
-  kubectl create namespace serving-tests-alt
-
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
   wait_until_pods_running knative-serving || return 1
   wait_until_pods_running istio-system || return 1
@@ -287,9 +248,23 @@ function test_setup() {
 function test_teardown() {
   echo ">> Removing test resources (test/config/)"
   ko delete --ignore-not-found=true --now -f test/config/
-  echo ">> Removing test namespaces"
+  echo ">> Ensuring test namespaces are clean"
   kubectl delete all --all --ignore-not-found --now --timeout 60s -n serving-tests
   kubectl delete --ignore-not-found --now --timeout 60s namespace serving-tests
   kubectl delete all --all --ignore-not-found --now --timeout 60s -n serving-tests-alt
   kubectl delete --ignore-not-found --now --timeout 60s namespace serving-tests-alt
+}
+
+# Dump more information when test fails.
+function dump_extra_cluster_state() {
+  echo ">>> Routes:"
+  kubectl get routes -o yaml --all-namespaces
+  echo ">>> Configurations:"
+  kubectl get configurations -o yaml --all-namespaces
+  echo ">>> Revisions:"
+  kubectl get revisions -o yaml --all-namespaces
+
+  for app in controller webhook autoscaler activator; do
+    dump_app_logs ${app} knative-serving
+  done
 }

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -27,33 +27,26 @@
 
 source $(dirname $0)/e2e-common.sh
 
-# Helper functions.
-
 function knative_setup() {
-  install_knative_serving
+  # Build serving, create $SERVING_YAML
+  build_knative_from_source
+  start_knative_serving "${SERVING_YAML}"
 }
 
 # Script entry point.
 
-# Skip installing istio as an add-on
-initialize $@ --skip-istio-addon
+initialize $@
 
-# Run the tests
-header "Running tests"
+# Ensure Knative Serving can be uninstalled/reinstalled cleanly
+subheader "Uninstalling Knative Serving"
+kubectl delete --ignore-not-found=true -f ${SERVING_YAML} || fail_test
+wait_until_object_does_not_exist namespaces knative-serving || fail_test
 
-failed=0
+subheader "Reinstalling Knative Serving"
+start_knative_serving "${SERVING_YAML}" || fail_test
 
-# Run conformance and e2e tests.
-go_test_e2e -timeout=30m \
-  ./test/conformance/api \
-  ./test/conformance/runtime \
-  ./test/e2e \
-  "--resolvabledomain=$(use_resolvable_domain)" || failed=1
-
-# Run scale tests.
-go_test_e2e -timeout=10m ./test/scale || failed=1
-
-# Require that both set of tests succeeded.
-(( failed )) && fail_test
+# Run smoke test
+subheader "Running smoke test"
+go_test_e2e ./test/e2e -run HelloWorld || fail_test
 
 success

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -257,11 +257,18 @@ function create_test_cluster_with_retries() {
         kubetest "$@" ${geoflag}; } 2>&1 | tee ${cluster_creation_log}
 
       # Exit if test succeeded
-      [[ "$(get_test_return_code)" == "0" ]] && return
-      # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill' ${cluster_creation_log})" ]] && return
+      [[ "$(get_test_return_code)" == "0" ]] && return 0
+      # Retry if cluster creation failed because of:
+      # - stockout (https://github.com/knative/test-infra/issues/592)
+      # - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
+      [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' ${cluster_creation_log})" \
+          && -z "$(grep -Fo 'ResponseError: code=400, message=No valid versions with the prefix' ${cluster_creation_log})" \
+          && -z "$(grep -Po 'ResponseError: code=400, message=Master version "[0-9a-z\-\.]+" is unsupported' ${cluster_creation_log})" ]] \
+          && return 1
     done
   done
+  echo "No more region/zones to try, quitting"
+  return 1
 }
 
 # Setup the test cluster for running the tests.
@@ -273,7 +280,7 @@ function setup_test_cluster() {
   header "Setting up test cluster"
 
   # Set the actual project the test cluster resides in
-  # It will be a project assigned by Boskos if test is running on Prow, 
+  # It will be a project assigned by Boskos if test is running on Prow,
   # otherwise will be ${GCP_PROJECT} set up by user.
   readonly export E2E_PROJECT_ID="$(gcloud config get-value project)"
 
@@ -283,6 +290,9 @@ function setup_test_cluster() {
   local k8s_user=$(gcloud config get-value core/account)
   local k8s_cluster=$(kubectl config current-context)
 
+  is_protected_cluster ${k8s_cluster} && \
+    abort "kubeconfig context set to ${k8s_cluster}, which is forbidden"
+
   # If cluster admin role isn't set, this is a brand new cluster
   # Setup the admin role and also KO_DOCKER_REPO
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
@@ -290,6 +300,10 @@ function setup_test_cluster() {
     kubectl config set-context ${k8s_cluster} --namespace=default
     export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi
+
+  # Safety checks
+  is_protected_gcr ${KO_DOCKER_REPO} && \
+    abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
   echo "- Project is ${E2E_PROJECT_ID}"
   echo "- Cluster is ${k8s_cluster}"
@@ -305,6 +319,8 @@ function setup_test_cluster() {
   set +o pipefail
 
   if (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_setup; then
+    # Wait for Istio installation to complete, if necessary, before calling knative_setup.
+    (( ! SKIP_ISTIO_ADDON )) && (wait_until_batch_job_complete istio-system || return 1)
     knative_setup || fail_test "Knative setup failed"
   fi
   if function_exists test_setup; then
@@ -411,10 +427,6 @@ function initialize() {
   fi
 
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
-
-  # Safety checks
-  is_protected_gcr ${KO_DOCKER_REPO} && \
-    abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
   (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
 


### PR DESCRIPTION
Fixes #4202.

"standard Knative install" means what's described in the official documentation.

Requires updating test-infra to latest version.

Bonuses:
* move extra cluster state dump when test fails to `e2e-common.sh`
* simplify Istio installation in `e2e-common.sh`
* fix cert-manager CRD log on uninstall
* remove unnecessary double test namespace creation during setup