### PR TITLE
Factor calculation of final target concurrency out of the KPA.

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -51,15 +50,6 @@ type Config struct {
 	TickInterval time.Duration
 
 	ScaleToZeroGracePeriod time.Duration
-}
-
-// TargetConcurrency calculates the target concurrency for a given container-concurrency
-// taking the container-concurrency-target-percentage into account.
-func (c *Config) TargetConcurrency(concurrency v1beta1.RevisionContainerConcurrencyType) float64 {
-	if concurrency == 0 {
-		return c.ContainerConcurrencyTargetDefault
-	}
-	return float64(concurrency) * c.ContainerConcurrencyTargetPercentage
 }
 
 // NewConfigFromMap creates a Config from the supplied map

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -23,44 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/knative/serving/pkg/apis/serving/v1beta1"
-
 	. "github.com/knative/pkg/configmap/testing"
 )
-
-func TestTargetConcurrency(t *testing.T) {
-	c := &Config{
-		ContainerConcurrencyTargetPercentage: 0.5,
-		ContainerConcurrencyTargetDefault:    10.0,
-	}
-
-	tests := []struct {
-		name                 string
-		containerConcurrency v1beta1.RevisionContainerConcurrencyType
-		want                 float64
-	}{{
-		name:                 "default",
-		containerConcurrency: 0,
-		want:                 10.0,
-	}, {
-		name:                 "single",
-		containerConcurrency: 1,
-		want:                 0.5,
-	}, {
-		name:                 "multi",
-		containerConcurrency: 10,
-		want:                 5.0,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := c.TargetConcurrency(test.containerConcurrency)
-			if got != test.want {
-				t.Errorf("TargetConcurrency() = %v, want %v", got, test.want)
-			}
-		})
-	}
-}
 
 func TestNewConfig(t *testing.T) {
 	tests := []struct {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"context"
 
-	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/resources"
@@ -47,27 +46,14 @@ type Deciders interface {
 // into account the PA's ContainerConcurrency and the relevant
 // autoscaling annotation.
 func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autoscaler.Config, svc string) *autoscaler.Decider {
-	logger := logging.FromContext(ctx)
-
-	target := config.TargetConcurrency(pa.Spec.ContainerConcurrency)
-	if mt, ok := pa.Target(); ok {
-		annotationTarget := float64(mt)
-		if annotationTarget > target {
-			// If the annotation target would cause the autoscaler to maintain
-			// more requests per pod than the container can handle, we ignore
-			// the annotation and use a containerConcurrency based target instead.
-			logger.Warnf("Ignoring target of %v because it would underprovision the Revision.", annotationTarget)
-		} else {
-			logger.Debugf("Using target of %v", annotationTarget)
-			target = annotationTarget
-		}
-	}
 	// Look for a panic threshold percentage annotation.
 	panicThresholdPercentage, ok := pa.PanicThresholdPercentage()
 	if !ok {
 		// Fall back on cluster config.
 		panicThresholdPercentage = config.PanicThresholdPercentage
 	}
+
+	target := resources.ResolveTargetConcurrency(pa, config)
 	panicThreshold := target * panicThresholdPercentage / 100.0
 	// TODO: remove MetricSpec when the custom metrics adapter implements Metric.
 	metricSpec := resources.MakeMetric(ctx, pa, config).Spec

--- a/pkg/reconciler/autoscaling/resources/concurrency.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/autoscaler"
+)
+
+// ResolveTargetConcurrency takes concurrency knobs from multiple locations and resolves them
+// to the final value to be used by the autoscaler.
+func ResolveTargetConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) (target float64) {
+	// If containerConcurrency is 0 we'll always target the default.
+	if pa.Spec.ContainerConcurrency == 0 {
+		target = config.ContainerConcurrencyTargetDefault
+	} else {
+		// For a non-zero containerConcurrency we calculate the actual concurrency using the config.
+		target = float64(pa.Spec.ContainerConcurrency) * config.ContainerConcurrencyTargetPercentage
+	}
+
+	// Use the target provided via annotation, if applicable.
+	if mt, ok := pa.Target(); ok {
+		annotationTarget := float64(mt)
+		// If the annotation target would cause the autoscaler to maintain
+		// more requests per pod than the container can handle, we ignore
+		// the annotation and use a containerConcurrency based target instead.
+		if annotationTarget <= target {
+			target = annotationTarget
+		}
+	}
+
+	return target
+}

--- a/pkg/reconciler/autoscaling/resources/concurrency_test.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency_test.go
@@ -18,13 +18,9 @@ package resources
 
 import (
 	"testing"
-	"time"
 
-	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
-	"github.com/knative/serving/pkg/autoscaler"
 	. "github.com/knative/serving/pkg/reconciler/testing"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestResolveTargetConcurrency(t *testing.T) {
@@ -39,7 +35,7 @@ func TestResolveTargetConcurrency(t *testing.T) {
 	}, {
 		name: "with container concurrency 1",
 		pa:   pa(WithContainerConcurrency(1)),
-		want: 1.5,
+		want: 1,
 	}, {
 		name: "with target annotation 1",
 		pa:   pa(WithTargetAnnotation("1")),
@@ -51,7 +47,7 @@ func TestResolveTargetConcurrency(t *testing.T) {
 	}, {
 		name: "with target annotation greater than container concurrency (ignore annotation for safety)",
 		pa:   pa(WithContainerConcurrency(1), WithTargetAnnotation("10")),
-		want: 1.5,
+		want: 1,
 	}}
 
 	for _, tc := range cases {
@@ -61,37 +57,4 @@ func TestResolveTargetConcurrency(t *testing.T) {
 			}
 		})
 	}
-}
-
-func pa(options ...PodAutoscalerOption) *v1alpha1.PodAutoscaler {
-	p := &v1alpha1.PodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test-namespace",
-			Name:      "test-name",
-			Annotations: map[string]string{
-				autoscaling.ClassAnnotationKey: autoscaling.KPA,
-			},
-		},
-		Spec: v1alpha1.PodAutoscalerSpec{
-			ContainerConcurrency: 0,
-		},
-		Status: v1alpha1.PodAutoscalerStatus{},
-	}
-	for _, fn := range options {
-		fn(p)
-	}
-	return p
-}
-
-var config = &autoscaler.Config{
-	EnableScaleToZero:                    true,
-	ContainerConcurrencyTargetPercentage: 1.5,
-	ContainerConcurrencyTargetDefault:    100.0,
-	MaxScaleUpRate:                       10.0,
-	StableWindow:                         60 * time.Second,
-	PanicThresholdPercentage:             200,
-	PanicWindow:                          6 * time.Second,
-	PanicWindowPercentage:                10,
-	TickInterval:                         2 * time.Second,
-	ScaleToZeroGracePeriod:               30 * time.Second,
 }

--- a/pkg/reconciler/autoscaling/resources/concurrency_test.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/autoscaler"
+	. "github.com/knative/serving/pkg/reconciler/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestResolveTargetConcurrency(t *testing.T) {
+	cases := []struct {
+		name string
+		pa   *v1alpha1.PodAutoscaler
+		want float64
+	}{{
+		name: "defaults",
+		pa:   pa(),
+		want: 100,
+	}, {
+		name: "with container concurrency 1",
+		pa:   pa(WithContainerConcurrency(1)),
+		want: 1.5,
+	}, {
+		name: "with target annotation 1",
+		pa:   pa(WithTargetAnnotation("1")),
+		want: 1,
+	}, {
+		name: "with container concurrency greater than target annotation (ok)",
+		pa:   pa(WithContainerConcurrency(10), WithTargetAnnotation("1")),
+		want: 1,
+	}, {
+		name: "with target annotation greater than container concurrency (ignore annotation for safety)",
+		pa:   pa(WithContainerConcurrency(1), WithTargetAnnotation("10")),
+		want: 1.5,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveTargetConcurrency(tc.pa, config); got != tc.want {
+				t.Errorf("ResolveTargetConcurrency(%v, %v) = %v, want %v", tc.pa, config, got, tc.want)
+			}
+		})
+	}
+}
+
+func pa(options ...PodAutoscalerOption) *v1alpha1.PodAutoscaler {
+	p := &v1alpha1.PodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-name",
+			Annotations: map[string]string{
+				autoscaling.ClassAnnotationKey: autoscaling.KPA,
+			},
+		},
+		Spec: v1alpha1.PodAutoscalerSpec{
+			ContainerConcurrency: 0,
+		},
+		Status: v1alpha1.PodAutoscalerStatus{},
+	}
+	for _, fn := range options {
+		fn(p)
+	}
+	return p
+}
+
+var config = &autoscaler.Config{
+	EnableScaleToZero:                    true,
+	ContainerConcurrencyTargetPercentage: 1.5,
+	ContainerConcurrencyTargetDefault:    100.0,
+	MaxScaleUpRate:                       10.0,
+	StableWindow:                         60 * time.Second,
+	PanicThresholdPercentage:             200,
+	PanicWindow:                          6 * time.Second,
+	PanicWindowPercentage:                10,
+	TickInterval:                         2 * time.Second,
+	ScaleToZeroGracePeriod:               30 * time.Second,
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Closes #3373

## Proposed Changes

The KPA has some intricate calculations going on to figure out the final target concurrency based on defaults, the PA and the current config. This factors this knowledge out into a function that can be used both by the KPA and the HPA for consistency. It also centralizes this knowledge in one place (it used to be spread across the config and the PA).

/cc @josephburnett 

I think this supersedes #3373 in that moving all that logic into Metric (or now the Decider really) isn't going to cut it for what we plan to do with the HPA.

/assign @vagababov 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
