### PR TITLE
Make the route prober take a logging.FormatLogger

### DIFF
--- a/test/conformance/api/route_test.go
+++ b/test/conformance/api/route_test.go
@@ -136,7 +136,7 @@ func TestRouteCreation(t *testing.T) {
 	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, domain, "1", test.PizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t, clients, domain)
+	prober := test.RunRouteProber(t.Logf, clients, domain)
 	defer test.AssertProberDefault(t, prober)
 
 	t.Log("Updating the Configuration to use a different image")

--- a/test/conformance/api/service_test.go
+++ b/test/conformance/api/service_test.go
@@ -81,7 +81,7 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -258,7 +258,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -59,7 +59,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 		globalSLO = 0.995
 		minProbes = 20
 	)
-	pm := test.NewProberManager(t, clients, minProbes)
+	pm := test.NewProberManager(t.Logf, clients, minProbes)
 
 	timeoutCh := time.After(duration)
 


### PR DESCRIPTION
Taking a *testing.T is a bit too broad of an interface since we only use
it to log things. Changing this to take a logging.FormatLogger allows
this to log immediately instead of being buffered in the testing logger.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Related: #2786
