### PR TITLE
rename webhook to be serving-webhook to avoid potential clash

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -21,10 +21,6 @@ import (
 	"flag"
 	"log"
 
-	"k8s.io/client-go/tools/clientcmd"
-
-	"go.uber.org/zap"
-
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/logging/logkey"
@@ -37,8 +33,10 @@ import (
 	net "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -99,7 +97,7 @@ func main() {
 		DeploymentName: "webhook",
 		Namespace:      system.Namespace(),
 		Port:           8443,
-		SecretName:     "webhook-certs",
+		SecretName:     "serving-webhook-certs",
 		WebhookName:    "webhook.serving.knative.dev",
 	}
 	controller := webhook.AdmissionController{

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -16,13 +16,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    role: webhook
+    role: serving-webhook
     serving.knative.dev/release: devel
-  name: webhook
+  name: serving-webhook
   namespace: knative-serving
 spec:
   ports:
     - port: 443
       targetPort: 8443
   selector:
-    role: webhook
+    role: serving-webhook

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -15,12 +15,66 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webhook
+  name: serving-webhook
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: serving-webhook
+      role: serving-webhook
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: serving-webhook
+        role: serving-webhook
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: serving-webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: github.com/knative/serving/cmd/webhook
+        resources:
+          # Request 2x what we saw running e2e
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          # Limit to 10x the request (20x the observed peak during e2e)
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        volumeMounts:
+        - name: config-logging
+          mountPath: /etc/config-logging
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+
+## TODO: for 0.8.0 we remove this old 'webhook' Deployment
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  replicas: 0
   selector:
     matchLabels:
       app: webhook


### PR DESCRIPTION
Fixes #4258

## Proposed Changes

- rename `webhook` to be `serving-webhook`
- keep old `webhook` deployment, but with `replicas: 0`

**Release Note**

```release-note
the webhook has been renamed to serving-webhook, and the old webhook will scale to 0
```
