### PR TITLE
Remove MetricSpec from DeciderSpec.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -135,7 +135,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		logger.Info("PANICKING")
 		a.panicTime = &now
 		a.reporter.ReportPanic(1)
-	} else if a.panicTime != nil && !isOverPanicThreshold && a.panicTime.Add(spec.MetricSpec.StableWindow).Before(now) {
+	} else if a.panicTime != nil && !isOverPanicThreshold && a.panicTime.Add(spec.StableWindow).Before(now) {
 		// Stop panicking after the surge has made its way into the stable metric.
 		logger.Info("Un-panicking.")
 		a.panicTime = nil

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	stableWindow = 60 * time.Second
-	panicWindow  = 6 * time.Second
 )
 
 var (
@@ -197,7 +196,7 @@ func TestAutoscaler_UpdateTarget(t *testing.T) {
 		TargetConcurrency: 1.0,
 		PanicThreshold:    2.0,
 		MaxScaleUpRate:    10.0,
-		MetricSpec:        a.deciderSpec.MetricSpec,
+		StableWindow:      stableWindow,
 		ServiceName:       testService,
 	})
 	a.expectScale(t, time.Now(), 100, true)
@@ -245,11 +244,8 @@ func newTestAutoscaler(containerConcurrency int, metrics MetricClient) *Autoscal
 		TargetConcurrency: float64(containerConcurrency),
 		PanicThreshold:    2 * float64(containerConcurrency),
 		MaxScaleUpRate:    10.0,
-		MetricSpec: MetricSpec{
-			StableWindow: stableWindow,
-			PanicWindow:  panicWindow,
-		},
-		ServiceName: testService,
+		StableWindow:      stableWindow,
+		ServiceName:       testService,
 	}
 
 	podCounter := resources.NewScopedEndpointsCounter(kubeInformer.Core().V1().Endpoints().Lister(), testNamespace, deciderSpec.ServiceName)

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -44,9 +44,8 @@ type DeciderSpec struct {
 	MaxScaleUpRate    float64
 	TargetConcurrency float64
 	PanicThreshold    float64
-	// TODO: remove MetricSpec when the custom metrics adapter implements Metric.
-	MetricSpec MetricSpec
-
+	// StableWindow is needed to determine when to exit panicmode.
+	StableWindow time.Duration
 	// The name of the k8s service for pod information.
 	ServiceName string
 }

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -114,10 +114,7 @@ func decider(options ...DeciderOption) *autoscaler.Decider {
 			TickInterval:      config.TickInterval,
 			TargetConcurrency: float64(100),
 			PanicThreshold:    float64(200),
-			MetricSpec: autoscaler.MetricSpec{
-				StableWindow: config.StableWindow,
-				PanicWindow:  config.PanicWindow,
-			},
+			StableWindow:      config.StableWindow,
 		},
 	}
 	for _, fn := range options {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Temporarily we needed the MetricSpec in the DeciderSpec. This is no longer necessary but the StableWindow is still needed to determine when to exit panic mode.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
