### PR TITLE
Surface internal scraping errors and other refactors.

### DIFF
--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -19,8 +19,9 @@ package autoscaler
 import (
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -72,12 +73,11 @@ var cacheDisabledClient = &http.Client{
 // https://kubernetes.io/docs/concepts/services-networking/network-policies/
 // for details.
 type ServiceScraper struct {
-	sClient             scrapeClient
-	counter             resources.ReadyPodCounter
-	url                 string
-	namespace           string
-	scrapeTargetService string
-	metricKey           string
+	sClient   scrapeClient
+	counter   resources.ReadyPodCounter
+	url       string
+	namespace string
+	metricKey string
 }
 
 // NewServiceScraper creates a new StatsScraper for the Revision which
@@ -110,12 +110,11 @@ func newServiceScraperWithClient(
 
 	serviceName := names.MetricsServiceName(revName)
 	return &ServiceScraper{
-		sClient:             sClient,
-		counter:             counter,
-		url:                 fmt.Sprintf("http://%s.%s:%d/metrics", serviceName, metric.Namespace, networking.AutoscalingQueueMetricsPort),
-		metricKey:           NewMetricKey(metric.Namespace, metric.Name),
-		namespace:           metric.Namespace,
-		scrapeTargetService: serviceName,
+		sClient:   sClient,
+		counter:   counter,
+		url:       fmt.Sprintf("http://%s.%s:%d/metrics", serviceName, metric.Namespace, networking.AutoscalingQueueMetricsPort),
+		metricKey: NewMetricKey(metric.Namespace, metric.Name),
+		namespace: metric.Namespace,
 	}, nil
 }
 
@@ -134,41 +133,38 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 	sampleSize := populationMeanSampleSize(readyPodsCount)
 	statCh := make(chan *Stat, sampleSize)
 
+	grp := errgroup.Group{}
+	for i := 0; i < sampleSize; i++ {
+		grp.Go(func() error {
+			stat, err := s.sClient.Scrape(s.url)
+			if err != nil {
+				return err
+			}
+			statCh <- stat
+			return nil
+		})
+	}
+
+	// Return the inner error if all of the scrape calls failed.
+	if err := grp.Wait(); err != nil && len(statCh) == 0 {
+		return nil, errors.Wrapf(err, "fail to get a successful scrape for %d tries", sampleSize)
+	}
+	close(statCh)
+
 	var (
 		avgConcurrency        float64
 		avgProxiedConcurrency float64
 		reqCount              int32
 		proxiedReqCount       int32
 		successCount          float64
-
-		waitGroup sync.WaitGroup
 	)
 
-	waitGroup.Add(sampleSize)
-	for i := 0; i < sampleSize; i++ {
-		go func() {
-			defer waitGroup.Done()
-			if stat, err := s.sClient.Scrape(s.url); err == nil {
-				statCh <- stat
-			}
-		}()
-	}
-
-	waitGroup.Wait()
-	close(statCh)
 	for stat := range statCh {
-		// This SHOULD NOT happen. Just to be safe.
-		if stat == nil {
-			continue
-		}
 		successCount++
 		avgConcurrency += stat.AverageConcurrentRequests
 		avgProxiedConcurrency += stat.AverageProxiedConcurrentRequests
 		reqCount += stat.RequestCount
 		proxiedReqCount += stat.ProxiedRequestCount
-	}
-	if successCount == 0 {
-		return nil, fmt.Errorf("fail to get a successful scrape for %d tries", sampleSize)
 	}
 
 	avgConcurrency = avgConcurrency / successCount

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/resources"
-
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -199,8 +198,8 @@ func TestScrape_ReportErrorIfAllFail(t *testing.T) {
 	endpoints(2)
 
 	_, err = scraper.Scrape()
-	if err == nil {
-		t.Errorf("Expected error from scraper.Scrape(), got nil")
+	if errors.Cause(err) != errTest {
+		t.Errorf("scraper.Scrape() = %v, want %v", err, errTest)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- Surface internal errors returned by the scraper to increase debuggability.
- Remove redundant struct fields.
- Refactor implementation to use errgroup.
- Shuffle code around so variables are closer to where they are needed.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
