### PR TITLE
Add internal URL fields to the API coverage ignore list

### DIFF
--- a/test/apicoverage/image/kodata/ignoredfields.yaml
+++ b/test/apicoverage/image/kodata/ignoredfields.yaml
@@ -110,3 +110,12 @@
     - DNSConfig
     - ReadinessGates
     - RuntimeClassName
+- package: pkg/apis
+  type: URL
+  fields:
+    - RawPath
+    - RawQuery
+    - Opaque
+    - Path
+    - Fragment
+    - User


### PR DESCRIPTION
Knative Serving changed to use the internal knative/pkg/apis URL library
for parsing and marshaling the various URL fields such as `status.URL`
and `traffic[].URL` instead of manually manipulating the string type.
This new type in pkg uses the golang net/url library. This dependency
causes additional fields to be identified by the webhook coverage test.
As the API only interacts with URL as a string and the reconciler only
interacts with the Scheme and Host the other fields can be ignored.

See https://github.com/knative/pkg/blob/master/apis/url.go and
https://github.com/knative/serving/blob/master/pkg/reconciler/route/domains/domains.go#L79

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->