### PR TITLE
Metric svc field

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -56,6 +56,7 @@ type Metric struct {
 type MetricSpec struct {
 	StableWindow time.Duration
 	PanicWindow  time.Duration
+	ScrapeTarget string
 }
 
 // MetricStatus reflects the status of metric collection for this specific entity.

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -56,6 +56,9 @@ type Metric struct {
 type MetricSpec struct {
 	StableWindow time.Duration
 	PanicWindow  time.Duration
+
+	// ScrapeTarget is the K8s service that is publishes the metric
+	// endpoint.
 	ScrapeTarget string
 }
 

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
-	"github.com/knative/serving/pkg/reconciler/autoscaling/kpa/resources/names"
 	"github.com/knative/serving/pkg/resources"
 	"github.com/pkg/errors"
 )
@@ -108,11 +107,10 @@ func newServiceScraperWithClient(
 		return nil, fmt.Errorf("no Revision label found for Metric %s", metric.Name)
 	}
 
-	serviceName := names.MetricsServiceName(revName)
 	return &ServiceScraper{
 		sClient:   sClient,
 		counter:   counter,
-		url:       fmt.Sprintf("http://%s.%s:%d/metrics", serviceName, metric.Namespace, networking.AutoscalingQueueMetricsPort),
+		url:       fmt.Sprintf("http://%s.%s:%d/metrics", metric.Spec.ScrapeTarget, metric.Namespace, networking.AutoscalingQueueMetricsPort),
 		metricKey: NewMetricKey(metric.Namespace, metric.Name),
 		namespace: metric.Namespace,
 	}, nil

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -237,6 +237,9 @@ func getTestMetric() *Metric {
 				serving.RevisionLabelKey: testRevision,
 			},
 		},
+		Spec: MetricSpec{
+			ScrapeTarget: testRevision + "-metrics",
+		},
 	}
 }
 

--- a/pkg/reconciler/autoscaling/resources/metric.go
+++ b/pkg/reconciler/autoscaling/resources/metric.go
@@ -40,7 +40,8 @@ type Metrics interface {
 }
 
 // MakeMetric constructs a Metric resource from a PodAutoscaler
-func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaler.Metric {
+func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, metricSvc string,
+	config *autoscaler.Config) *autoscaler.Metric {
 	stableWindow, ok := pa.Window()
 	if !ok {
 		stableWindow = config.StableWindow
@@ -57,6 +58,7 @@ func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosca
 		Spec: autoscaler.MetricSpec{
 			StableWindow: stableWindow,
 			PanicWindow:  panicWindow,
+			ScrapeTarget: metricSvc,
 		},
 	}
 }


### PR DESCRIPTION
For #3236
/lint

## Proposed Changes

* this makes metrics service name part of the metric object, so it can be passed around from the PA around
* consumption is also done via this field, so we have no dependency on the "name generator"

In the next step KPA will be changed to stop producing constant name

/assign @mattmoor 
/cc @mattmoor 