### PR TITLE
Change the default tag-to-hostname template.

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -103,7 +103,7 @@ var (
 
 	// DefaultTagTemplate is the default golang template to use when
 	// constructing the Knative Route's tag names.
-	DefaultTagTemplate = "{{.Name}}-{{.Tag}}"
+	DefaultTagTemplate = "{{.Tag}}-{{.Name}}"
 
 	// AutoTLSKey is the name of the configuration entry
 	// that specifies enabling auto-TLS or not.

--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -137,7 +137,7 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 		},
 	}, {
 		Hosts: []string{
-			"test-route-v1.test-ns.example.com",
+			"v1-test-route.test-ns.example.com",
 			"v1.domain.com",
 		},
 		HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
@@ -295,7 +295,7 @@ func TestGetRouteDomains_NamedTarget(t *testing.T) {
 		},
 	}
 	expected := []string{
-		"test-route-v1.test-ns.example.com",
+		"v1-test-route.test-ns.example.com",
 		"v1.domain.com",
 	}
 	domains, err := routeDomains(getContext(), name, r)

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -161,7 +161,7 @@ func TestNewMakeK8SService(t *testing.T) {
 				},
 			},
 			expectedMeta: metav1.ObjectMeta{
-				Name:      "test-route-my-target-name",
+				Name:      "my-target-name-test-route",
 				Namespace: r.Namespace,
 				OwnerReferences: []metav1.OwnerReference{
 					*kmeta.NewControllerRef(r),
@@ -215,7 +215,7 @@ func TestMakePlaceholderK8sService(t *testing.T) {
 
 	service, err := MakeK8sPlaceholderService(ctx, r, target.Tag)
 	expectedMeta := metav1.ObjectMeta{
-		Name:      r.Name + "-" + target.Tag,
+		Name:      target.Tag + "-" + r.Name,
 		Namespace: r.Namespace,
 		OwnerReferences: []metav1.OwnerReference{
 			*kmeta.NewControllerRef(r),
@@ -226,7 +226,7 @@ func TestMakePlaceholderK8sService(t *testing.T) {
 	}
 	expectedSpec := corev1.ServiceSpec{
 		Type:         corev1.ServiceTypeExternalName,
-		ExternalName: "test-route-foo.test-ns.example.com",
+		ExternalName: "foo-test-route.test-ns.example.com",
 	}
 
 	if err != nil {

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -627,7 +627,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			},
 		}, {
 			Hosts: []string{
-				"test-route-test-revision-1.test.test-domain.dev",
+				"test-revision-1-test-route.test.test-domain.dev",
 				"test-revision-1." + domain,
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
@@ -648,7 +648,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			},
 		}, {
 			Hosts: []string{
-				"test-route-test-revision-2.test.test-domain.dev",
+				"test-revision-2-test-route.test.test-domain.dev",
 				"test-revision-2." + domain,
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
@@ -754,7 +754,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			},
 		}, {
 			Hosts: []string{
-				"test-route-bar.test.test-domain.dev",
+				"bar-test-route.test.test-domain.dev",
 				"bar." + domain,
 			},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
@@ -775,7 +775,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			},
 		}, {
 			Hosts: []string{
-				"test-route-foo.test.test-domain.dev",
+				"foo-test-route.test.test-domain.dev",
 				"foo." + domain},
 			HTTP: &netv1alpha1.HTTPClusterIngressRuleValue{
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1441,7 +1441,7 @@ func TestReconcile(t *testing.T) {
 							LatestRevision: ptr.Bool(true),
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   "same-revision-targets-gray.default.example.com",
+								Host:   "gray-same-revision-targets.default.example.com",
 							},
 						},
 					}, v1alpha1.TrafficTarget{
@@ -1452,15 +1452,15 @@ func TestReconcile(t *testing.T) {
 							LatestRevision: ptr.Bool(false),
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   "same-revision-targets-also-gray.default.example.com",
+								Host:   "also-gray-same-revision-targets.default.example.com",
 							},
 						},
 					})),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "same-revision-targets"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "same-revision-targets-also-gray"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "same-revision-targets-gray"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "also-gray-same-revision-targets"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "gray-same-revision-targets"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created ClusterIngress %q", "route-1-2"),
 		},
 		Key:                     "default/same-revision-targets",

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -945,13 +945,13 @@ func TestRoundTripping(t *testing.T) {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:          "beta",
 			RevisionName: goodNewRev.Name,
-			URL:          domains.URL(domains.HTTPScheme, "test-route-beta.test.example.com"),
+			URL:          domains.URL(domains.HTTPScheme, "beta-test-route.test.example.com"),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:          "alpha",
 			RevisionName: niceNewRev.Name,
-			URL:          domains.URL(domains.HTTPScheme, "test-route-alpha.test.example.com"),
+			URL:          domains.URL(domains.HTTPScheme, "alpha-test-route.test.example.com"),
 		},
 	}}
 	route := testRouteWithTrafficTargets(tts)


### PR DESCRIPTION
WIP until https://github.com/knative/serving/pull/4292 merges.

**This is a potentially breaking change.**  In 0.6 we used the effective template
`{{.Name}}-{{.Tag}` for turning Route tags into K8s services.  Unfortunately, when
used in conjunction with the BYO-revision-name feature there is a very natural
collision scenarios:

```
spec:
  template:
    metadata:
      name: prefix-v1234
    spec: ...
  traffic:
  # v1234 is a very natural choice here
  - name: v1234
    percent: 12
  ...
```

Unfortunately, we create a Service for the revision named `prefix-v1234` *and* a
"placeholder" service for the Route tag with `{{.Name=prefix}}-{{.Tag=v1234}}` so
only one can win and we end up with a `NotOwned` failure of some sort because the
two controllers fight.

**To preserve the 0.6 behavior** you can simply update `config-network` to specify:

```
data:
  tagTemplate: "{{.Name}}-{{.Tag}}"
```

This changes the default to `{{.Tag}}-{{.Name}}` to avoid the `{{.Name}}-` prefix,
which is required by BYO-revision-name.

Fixes: https://github.com/knative/serving/issues/4206