### PR TITLE
Make scraper url updateable

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -217,6 +217,7 @@ type collection struct {
 	metricMutex sync.RWMutex
 	metric      *Metric
 
+	scraper StatsScraper
 	buckets *aggregation.TimedFloat64Buckets
 
 	grp    sync.WaitGroup
@@ -228,6 +229,7 @@ func newCollection(metric *Metric, scraper StatsScraper, logger *zap.SugaredLogg
 	c := &collection{
 		metric:  metric,
 		buckets: aggregation.NewTimedFloat64Buckets(bucketSize),
+		scraper: scraper,
 
 		stopCh: make(chan struct{}),
 	}
@@ -263,6 +265,7 @@ func (c *collection) updateMetric(metric *Metric) {
 	defer c.metricMutex.Unlock()
 
 	c.metric = metric
+	c.scraper.UpdateTarget(metric.Spec.ScrapeTarget, metric.ObjectMeta.Namespace)
 }
 
 // currentMetric safely returns the current metric stored in the collection.

--- a/pkg/autoscaler/http_scrape_client_test.go
+++ b/pkg/autoscaler/http_scrape_client_test.go
@@ -19,13 +19,14 @@ package autoscaler
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 )
 
 const (
-	testURL = "http://test-revision-metrics.test-namespace:9090/metrics"
+	testURL = "http://test-revision-zhudex.test-namespace:9090/metrics"
 
 	// TODO: Use Prometheus lib to generate the following text instead of using text format directly.
 	testAverageConcurrencyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
@@ -107,12 +108,12 @@ func TestHTTPScrapeClient_Scrape_ErrorCases(t *testing.T) {
 	}{{
 		name:         "Non 200 return code",
 		responseCode: http.StatusForbidden,
-		expectedErr:  `GET request for URL "http://test-revision-metrics.test-namespace:9090/metrics" returned HTTP status 403`,
+		expectedErr:  fmt.Sprintf(`GET request for URL "%s" returned HTTP status 403`, testURL),
 	}, {
 		name:         "Error got when sending request",
 		responseCode: http.StatusOK,
 		responseErr:  errors.New("upstream closed"),
-		expectedErr:  "Get http://test-revision-metrics.test-namespace:9090/metrics: upstream closed",
+		expectedErr:  fmt.Sprintf("Get %s: upstream closed", testURL),
 	}, {
 		name:            "Bad response context format",
 		responseCode:    http.StatusOK,


### PR DESCRIPTION
This is required for the #3236, since due to eventual consistency problems we may endup
with a changing metrics service name that needs to be scraped.
Rather than reconstruct the whole collector and clients, etc, here we just
patch the URL


/lint

/cc @greghaynes @mattmoor 