### PR TITLE
Fix the pod counting target.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -204,7 +204,7 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer, m
 
 func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) func(metric *autoscaler.Metric) (autoscaler.StatsScraper, error) {
 	return func(metric *autoscaler.Metric) (autoscaler.StatsScraper, error) {
-		podCounter := resources.NewScopedEndpointsCounter(endpointsLister, metric.Namespace, metric.Name)
+		podCounter := resources.NewScopedEndpointsCounter(endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
 		return autoscaler.NewServiceScraper(metric, podCounter)
 	}
 }


### PR DESCRIPTION
We need to count the number of pods in the actual revision's metric service.
This way were counting pods in the revision target, which is always 1, since
the activator is hooked in.
Obviously this caused some problems like:

'Failed to scrape metrics,error:fail to get a successful scrape for 1 tries: Get http://s4-v77zd-metrics.default:9090/metrics: dial tcp 10.27.247.15:9090: connect: connection refused'

/assign @mattmoor @greghaynes 