### PR TITLE
Fix the diagnoser not to panic on test end.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -203,9 +203,10 @@ func assertScaleDown(ctx *testContext) {
 func TestAutoscaleUpDownUp(t *testing.T) {
 	t.Parallel()
 	ctx := setup(t)
-	stopChan := DiagnoseMeEvery(t, 15*time.Second, ctx.clients)
-	defer close(stopChan)
 	defer test.TearDown(ctx.clients, ctx.names)
+
+	sc := startDiagnosis(t, ctx.clients, 15*time.Second)
+	defer sc.stop()
 
 	assertScaleUp(ctx)
 	assertScaleDown(ctx)


### PR DESCRIPTION
Make sure we finish the probing goroutine before we proceed with test termination.
Also log time, since it's helpful to correlate events

Fixes #4298

/assign @mattmoor

