### PR TITLE
Move counter creation to scraper 

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -210,8 +210,7 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer, m
 
 func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) func(metric *autoscaler.Metric) (autoscaler.StatsScraper, error) {
 	return func(metric *autoscaler.Metric) (autoscaler.StatsScraper, error) {
-		podCounter := resources.NewScopedEndpointsCounter(endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
-		return autoscaler.NewServiceScraper(metric, podCounter)
+		return autoscaler.NewServiceScraper(metric, endpointsLister)
 	}
 }
 

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -31,9 +31,7 @@ import (
 	fakeK8s "k8s.io/client-go/kubernetes/fake"
 )
 
-const (
-	stableWindow = 60 * time.Second
-)
+const stableWindow = 60 * time.Second
 
 var (
 	kubeClient   = fakeK8s.NewSimpleClientset()

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -108,6 +108,9 @@ func newServiceScraperWithClient(
 	if sClient == nil {
 		return nil, errors.New("scrape client must not be nil")
 	}
+	if epLister == nil {
+		return nil, errors.New("epLister must not be nil")
+	}
 	revName := metric.Labels[serving.RevisionLabelKey]
 	if revName == "" {
 		return nil, fmt.Errorf("no Revision label found for Metric %s", metric.Name)
@@ -116,7 +119,7 @@ func newServiceScraperWithClient(
 	return &ServiceScraper{
 		sClient:   sClient,
 		epLister:  epLister,
-		counter:   resources.NewScopedEndpointsCounter(epLister, metric.Namespace, metric.Name),
+		counter:   resources.NewScopedEndpointsCounter(epLister, metric.Namespace, metric.Spec.ScrapeTarget),
 		url:       urlFromTarget(metric.Spec.ScrapeTarget, metric.ObjectMeta.Namespace),
 		metricKey: NewMetricKey(metric.Namespace, metric.Name),
 		namespace: metric.Namespace,


### PR DESCRIPTION
Recently @jchesterpivotal  moved the creation of the counter from the internals of the scraper to the scraper factory. But that no longer works, since the target might change (with the future GenerateName'd metric service name, the service/endpoints is going to change and currently it reads the wrong one anyway).
This kind of reverts the change back to passing in informer, so we can reconstruct the endpoint counter inside.

Alternative is of course to reconstruct the scraper each time the target changes (which should be rare event only during KPA creation if we get into a race condition). But for now I've chosen the other path.

/lint

## Proposed Changes

* move counter creation into the scraper itself

/cc @mattmoor 