### PR TITLE
Better naming of the instances for the scale test.

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -73,7 +73,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 
 		wg.Go(func() error {
 			names := test.ResourceNames{
-				Service: test.SubServiceNameForTest(t, fmt.Sprintf("%[1]*[2]d", width, i)),
+				Service: test.SubServiceNameForTest(t, fmt.Sprintf("%0[1]*[2]d", width, i)),
 				Image:   "helloworld",
 			}
 

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -62,6 +63,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 	pm := test.NewProberManager(t.Logf, clients, minProbes)
 
 	timeoutCh := time.After(duration)
+	width := int(math.Ceil(math.Log10(float64(scale))))
 
 	t.Log("Creating new Services")
 	wg := pool.NewWithCapacity(50 /* maximum in-flight creates */, scale /* capacity */)
@@ -71,7 +73,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 
 		wg.Go(func() error {
 			names := test.ResourceNames{
-				Service: test.SubServiceNameForTest(t, fmt.Sprintf("%d", i)),
+				Service: test.SubServiceNameForTest(t, fmt.Sprintf("%[1]*[2]d", width, i)),
 				Image:   "helloworld",
 			}
 

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -20,6 +20,7 @@ package performance
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -91,7 +92,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 				corev1.ResourceMemory: resource.MustParse("20Mi"),
 			},
 		}},
-		testingv1alpha1.WithConfigAnnotations(map[string]string{"autoscaling.knative.dev/target": fmt.Sprintf("%d", targetConcurrency)}),
+		testingv1alpha1.WithConfigAnnotations(map[string]string{"autoscaling.knative.dev/target": strconv.Itoa(targetConcurrency)}),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)


### PR DESCRIPTION
This makes all the names nicely alingned.
I made it dependent on the scale size, so redudant 0es
won't be printed.
Also replace one redundant formatting with a faster Itoa call.

/assign @mattmoor

