### PR TITLE
Generalize the signature of our naming methods.

### DIFF
--- a/pkg/reconciler/clusteringress/resources/names/names.go
+++ b/pkg/reconciler/clusteringress/resources/names/names.go
@@ -17,19 +17,19 @@ limitations under the License.
 package names
 
 import (
-	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/pkg/kmeta"
 )
 
 // IngressVirtualService returns the name of the VirtualService child
 // resource for given ClusterIngress that programs traffic for Ingress
 // Gateways.
-func IngressVirtualService(i *v1alpha1.ClusterIngress) string {
-	return i.Name
+func IngressVirtualService(i kmeta.Accessor) string {
+	return i.GetName()
 }
 
 // MeshVirtualService returns the name of the VirtualService child
 // resource for given ClusterIngress that programs traffic for Service
 // Mesh.
-func MeshVirtualService(i *v1alpha1.ClusterIngress) string {
-	return i.Name + "-mesh"
+func MeshVirtualService(i kmeta.Accessor) string {
+	return i.GetName() + "-mesh"
 }

--- a/pkg/reconciler/clusteringress/resources/names/names_test.go
+++ b/pkg/reconciler/clusteringress/resources/names/names_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 )
 
@@ -28,7 +29,7 @@ func TestNamer(t *testing.T) {
 	tests := []struct {
 		name    string
 		ingress *v1alpha1.ClusterIngress
-		f       func(*v1alpha1.ClusterIngress) string
+		f       func(kmeta.Accessor) string
 		want    string
 	}{{
 		name: "IngressVirtualService",

--- a/pkg/reconciler/revision/resources/names/names.go
+++ b/pkg/reconciler/revision/resources/names/names.go
@@ -17,19 +17,19 @@ limitations under the License.
 package names
 
 import (
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/pkg/kmeta"
 )
 
-func Deployment(rev *v1alpha1.Revision) string {
-	return rev.Name + "-deployment"
+func Deployment(rev kmeta.Accessor) string {
+	return rev.GetName() + "-deployment"
 }
 
-func ImageCache(rev *v1alpha1.Revision) string {
-	return rev.Name + "-cache"
+func ImageCache(rev kmeta.Accessor) string {
+	return rev.GetName() + "-cache"
 }
 
-func KPA(rev *v1alpha1.Revision) string {
+func KPA(rev kmeta.Accessor) string {
 	// We want the KPA's "key" to match the revision,
 	// to simplify the transition to the KPA.
-	return rev.Name
+	return rev.GetName()
 }

--- a/pkg/reconciler/revision/resources/names/names_test.go
+++ b/pkg/reconciler/revision/resources/names/names_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -28,7 +29,7 @@ func TestNamer(t *testing.T) {
 	tests := []struct {
 		name string
 		rev  *v1alpha1.Revision
-		f    func(*v1alpha1.Revision) string
+		f    func(kmeta.Accessor) string
 		want string
 	}{{
 		name: "Deployment",

--- a/pkg/reconciler/route/resources/names/names.go
+++ b/pkg/reconciler/route/resources/names/names.go
@@ -19,26 +19,26 @@ package names
 import (
 	"fmt"
 
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/network"
 )
 
-func K8sService(route *v1alpha1.Route) string {
-	return route.Name
+func K8sService(route kmeta.Accessor) string {
+	return route.GetName()
 }
 
-func K8sServiceFullname(route *v1alpha1.Route) string {
-	return network.GetServiceHostname(K8sService(route), route.Namespace)
+func K8sServiceFullname(route kmeta.Accessor) string {
+	return network.GetServiceHostname(K8sService(route), route.GetNamespace())
 }
 
 // ClusterIngress returns the name for the ClusterIngress
 // child resource for the given Route.
-func ClusterIngress(route *v1alpha1.Route) string {
-	return fmt.Sprintf("route-%s", route.UID)
+func ClusterIngress(route kmeta.Accessor) string {
+	return fmt.Sprintf("route-%s", route.GetUID())
 }
 
 // Certificate returns the name for the Certificate
 // child resource for the given Route.
-func Certificate(route *v1alpha1.Route) string {
-	return fmt.Sprintf("route-%s", route.UID)
+func Certificate(route kmeta.Accessor) string {
+	return fmt.Sprintf("route-%s", route.GetUID())
 }

--- a/pkg/reconciler/route/resources/names/names_test.go
+++ b/pkg/reconciler/route/resources/names/names_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -28,7 +29,7 @@ func TestNamer(t *testing.T) {
 	tests := []struct {
 		name  string
 		route *v1alpha1.Route
-		f     func(*v1alpha1.Route) string
+		f     func(kmeta.Accessor) string
 		want  string
 	}{{
 		name: "K8sService",

--- a/pkg/reconciler/service/resources/names/names.go
+++ b/pkg/reconciler/service/resources/names/names.go
@@ -16,12 +16,12 @@ limitations under the License.
 
 package names
 
-import "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+import "github.com/knative/pkg/kmeta"
 
-func Configuration(service *v1alpha1.Service) string {
-	return service.Name
+func Configuration(service kmeta.Accessor) string {
+	return service.GetName()
 }
 
-func Route(service *v1alpha1.Service) string {
-	return service.Name
+func Route(service kmeta.Accessor) string {
+	return service.GetName()
 }

--- a/pkg/reconciler/service/resources/names/names_test.go
+++ b/pkg/reconciler/service/resources/names/names_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -28,7 +29,7 @@ func TestNamer(t *testing.T) {
 	tests := []struct {
 		name    string
 		service *v1alpha1.Service
-		f       func(*v1alpha1.Service) string
+		f       func(kmeta.Accessor) string
 		want    string
 	}{{
 		name: "Configuration",


### PR DESCRIPTION
Our naming functions only key off of information within the ObjectMeta of the parent resource, e.g. v1alpha1.Service, but take the concrete parent type.  I was experimenting with migrating the e2e testing to go through v1beta1 while the controllers still go through v1alpha1, which led to a mismatched type being passed from these distinct callsites.  This generalizes the input type to something that both v1beta1 and v1alpha1 forms of our various types will satisfy.
