### PR TITLE
Apply min/max scale first.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -162,6 +162,16 @@ func TestScaler(t *testing.T) {
 			k.Status.MarkActivating("", "")
 		},
 	}, {
+		label:         "scale down to minScale before grace period",
+		startReplicas: 10,
+		scaleTo:       0,
+		minScale:      2,
+		wantReplicas:  2,
+		wantScaling:   true,
+		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+			kpaMarkInactive(k, time.Now().Add(-gracePeriod+time.Second))
+		},
+	}, {
 		label:         "scale down to minScale after grace period",
 		startReplicas: 10,
 		scaleTo:       0,


### PR DESCRIPTION
If we have min/max scale parameters set on the revision, we should apply them first,
so we don't even waste time, for examples, trying to determine whetherwe should scale to 0,
if minScale > 0.

/assign @mattmoor @markusthoemmes 