### PR TITLE
Don't delete cluster-admin-binding on uninstall

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -225,7 +225,6 @@ function knative_teardown() {
     fi
     echo ">> Bringing down Istio"
     kubectl delete --ignore-not-found=true -f "${INSTALL_ISTIO_YAML}" || return 1
-    kubectl delete --ignore-not-found=true clusterrolebinding cluster-admin-binding
     echo ">> Bringing down Cert-Manager"
     kubectl delete --ignore-not-found=true -f "${INSTALL_CERT_MANAGER_YAML}" || return 1
   fi


### PR DESCRIPTION
The binding should only be removed if it was created by the test.

Since the creation is not being tracked, deleting it might cause an inconsistent/unexpected state in already existing clusters. For clusters created by kubetest, it doesn't matter since the cluster is deleted after the test.

Fixes https://github.com/knative/serving/issues/4331