### PR TITLE
Factor out ScaleResource related methods.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
@@ -117,7 +118,7 @@ func main() {
 	multiScaler := autoscaler.NewMultiScaler(ctx.Done(), uniScalerFactoryFunc(endpointsInformer, collector), logger)
 
 	controllers := []*controller.Impl{
-		kpa.NewController(ctx, cmw, multiScaler, collector),
+		kpa.NewController(ctx, cmw, multiScaler, collector, resources.NewPodScalableInformerFactory(ctx)),
 		hpa.NewController(ctx, cmw),
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
-	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection/clients/dynamicclient"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/activator"
@@ -33,9 +31,9 @@ import (
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/network/prober"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
+	"github.com/knative/serving/pkg/resources"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 )
@@ -70,16 +68,14 @@ type scaler struct {
 }
 
 // newScaler creates a scaler.
-func newScaler(ctx context.Context, enqueueCB func(interface{}, time.Duration)) *scaler {
+func newScaler(ctx context.Context, psInformerFactory duck.InformerFactory, enqueueCB func(interface{}, time.Duration)) *scaler {
 	logger := logging.FromContext(ctx)
 	ks := &scaler{
 		// Wrap it in a cache, so that we don't stamp out a new
 		// informer/lister each time.
-		psInformerFactory: &duck.CachedInformerFactory{
-			Delegate: podScalableTypedInformerFactory(ctx),
-		},
-		dynamicClient: dynamicclient.Get(ctx),
-		logger:        logger,
+		psInformerFactory: psInformerFactory,
+		dynamicClient:     dynamicclient.Get(ctx),
+		logger:            logger,
 
 		// Production setup uses the default probe implementation.
 		activatorProbe: activatorProbe,
@@ -110,17 +106,6 @@ func activatorProbe(pa *pav1alpha1.PodAutoscaler) (bool, error) {
 	return prober.Do(context.Background(), paToProbeTarget(pa), activator.Name)
 }
 
-// podScalableTypedInformerFactory returns a duck.InformerFactory that returns
-// lister/informer pairs for PodScalable resources.
-func podScalableTypedInformerFactory(ctx context.Context) duck.InformerFactory {
-	return &duck.TypedInformerFactory{
-		Client:       dynamicclient.Get(ctx),
-		Type:         &pav1alpha1.PodScalable{},
-		ResyncPeriod: controller.GetResyncPeriod(ctx),
-		StopChannel:  ctx.Done(),
-	}
-}
-
 // pre: 0 <= min <= max && 0 <= x
 func applyBounds(min, max, x int32) int32 {
 	if x < min {
@@ -130,38 +115,6 @@ func applyBounds(min, max, x int32) int32 {
 		return max
 	}
 	return x
-}
-
-// GetScaleResource returns the current scale resource for the PA.
-func (ks *scaler) GetScaleResource(pa *pav1alpha1.PodAutoscaler) (*pav1alpha1.PodScalable, error) {
-	gvr, name, err := scaleResourceArgs(pa)
-	if err != nil {
-		ks.logger.Errorf("Error getting the scale arguments", err)
-		return nil, err
-	}
-	_, lister, err := ks.psInformerFactory.Get(*gvr)
-	if err != nil {
-		ks.logger.Errorf("Error getting a lister for a pod scalable resource '%+v': %+v", gvr, err)
-		return nil, err
-	}
-
-	psObj, err := lister.ByNamespace(pa.Namespace).Get(name)
-	if err != nil {
-		ks.logger.Errorf("Error fetching Pod Scalable %q for PodAutoscaler %q: %v",
-			pa.Spec.ScaleTargetRef.Name, pa.Name, err)
-		return nil, err
-	}
-	return psObj.(*pav1alpha1.PodScalable), nil
-}
-
-// scaleResourceArgs returns GroupResource and the resource name, from the PA resource.
-func scaleResourceArgs(pa *pav1alpha1.PodAutoscaler) (*schema.GroupVersionResource, string, error) {
-	gv, err := schema.ParseGroupVersion(pa.Spec.ScaleTargetRef.APIVersion)
-	if err != nil {
-		return nil, "", err
-	}
-	resource := apis.KindToResource(gv.WithKind(pa.Spec.ScaleTargetRef.Kind))
-	return &resource, pa.Spec.ScaleTargetRef.Name, nil
 }
 
 func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale int32, config *autoscaler.Config) (int32, bool) {
@@ -222,7 +175,7 @@ func (ks *scaler) applyScale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, 
 	ps *pav1alpha1.PodScalable) (int32, error) {
 	logger := logging.FromContext(ctx)
 
-	gvr, name, err := scaleResourceArgs(pa)
+	gvr, name, err := resources.ScaleResourceArguments(pa.Spec.ScaleTargetRef)
 	if err != nil {
 		return desiredScale, err
 	}
@@ -269,7 +222,7 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desir
 		return desiredScale, nil
 	}
 
-	ps, err := ks.GetScaleResource(pa)
+	ps, err := resources.GetScaleResource(pa.Namespace, pa.Spec.ScaleTargetRef, ks.psInformerFactory)
 	if err != nil {
 		logger.Errorw(fmt.Sprintf("Resource %q not found", pa.Name), zap.Error(err))
 		return desiredScale, err

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	revisionresources "github.com/knative/serving/pkg/reconciler/revision/resources"
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
+	presources "github.com/knative/serving/pkg/resources"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -238,7 +239,7 @@ func TestScaler(t *testing.T) {
 			revision := newRevision(t, fakeservingclient.Get(ctx), test.minScale, test.maxScale)
 			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
 			cbCount := 0
-			revisionScaler := newScaler(ctx, func(interface{}, time.Duration) {
+			revisionScaler := newScaler(ctx, presources.NewPodScalableInformerFactory(ctx), func(interface{}, time.Duration) {
 				cbCount++
 			})
 			if test.proberfunc != nil {
@@ -344,9 +345,9 @@ func TestDisableScaleToZero(t *testing.T) {
 			revision := newRevision(t, fakeservingclient.Get(ctx), test.minScale, test.maxScale)
 			deployment := newDeployment(t, dynamicClient, names.Deployment(revision), test.startReplicas)
 			revisionScaler := &scaler{
-				psInformerFactory: podScalableTypedInformerFactory(ctx),
 				dynamicClient:     fakedynamicclient.Get(ctx),
 				logger:            logging.FromContext(ctx),
+				psInformerFactory: presources.NewPodScalableInformerFactory(ctx),
 			}
 			pa := newKPA(t, fakeservingclient.Get(ctx), revision)
 
@@ -368,28 +369,6 @@ func TestDisableScaleToZero(t *testing.T) {
 				checkReplicas(t, dynamicClient, deployment, test.wantReplicas)
 			}
 		})
-	}
-}
-
-func TestGetScaleResource(t *testing.T) {
-	defer logtesting.ClearAll()
-	ctx, _ := SetupFakeContext(t)
-
-	revision := newRevision(t, fakeservingclient.Get(ctx), 1, 10)
-	// This setups reactor as well.
-	newDeployment(t, fakedynamicclient.Get(ctx), names.Deployment(revision), 5)
-	revisionScaler := newScaler(ctx, func(interface{}, time.Duration) {})
-
-	pa := newKPA(t, fakeservingclient.Get(ctx), revision)
-	scale, err := revisionScaler.GetScaleResource(pa)
-	if err != nil {
-		t.Fatalf("GetScale got error = %v", err)
-	}
-	if got, want := scale.Status.Replicas, int32(5); got != want {
-		t.Errorf("GetScale.Status.Replicas = %d, want: %d", got, want)
-	}
-	if got, want := scale.Spec.Selector.MatchLabels[serving.RevisionUID], "1982"; got != want {
-		t.Errorf("GetScale.Status.Selector = %q, want = %q", got, want)
 	}
 }
 

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -37,6 +37,7 @@ import (
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	rpkg "github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/serverlessservice/resources"
+	presources "github.com/knative/serving/pkg/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -181,7 +182,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantErr: true,
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: error retrieving deployment selector spec: deployments.apps "blah" not found`),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: error retrieving deployment selector spec: error fetching Pod Scalable on/blah: deployments.apps "blah" not found`),
 		},
 	}, {
 		Name: "OnCreate-deployment-exists",
@@ -592,7 +593,7 @@ func TestReconcile(t *testing.T) {
 			sksLister:         listers.GetServerlessServiceLister(),
 			serviceLister:     listers.GetK8sServiceLister(),
 			endpointsLister:   listers.GetEndpointsLister(),
-			psInformerFactory: podScalableTypedInformerFactory(ctx),
+			psInformerFactory: presources.NewPodScalableInformerFactory(ctx),
 		}
 	}))
 }

--- a/pkg/resources/scale.go
+++ b/pkg/resources/scale.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+
+	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/apis/duck"
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection/clients/dynamicclient"
+	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewPodScalableInformerFactory produces an informer factory for PodScalable resources.
+func NewPodScalableInformerFactory(ctx context.Context) duck.InformerFactory {
+	return &duck.CachedInformerFactory{
+		Delegate: &duck.TypedInformerFactory{
+			Client:       dynamicclient.Get(ctx),
+			Type:         &pav1alpha1.PodScalable{},
+			ResyncPeriod: controller.GetResyncPeriod(ctx),
+			StopChannel:  ctx.Done(),
+		},
+	}
+}
+
+// ScaleResourceArguments returns GroupResource and the resource name.
+func ScaleResourceArguments(ref corev1.ObjectReference) (*schema.GroupVersionResource, string, error) {
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return nil, "", err
+	}
+	resource := apis.KindToResource(gv.WithKind(ref.Kind))
+	return &resource, ref.Name, nil
+}
+
+// GetScaleResource returns the current scale resource for the PA.
+// TODO(markusthoemmes): We shouldn't need to pass namespace here.
+func GetScaleResource(namespace string, ref corev1.ObjectReference, psInformerFactory duck.InformerFactory) (*pav1alpha1.PodScalable, error) {
+	gvr, name, err := ScaleResourceArguments(ref)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting the scale arguments")
+	}
+	_, lister, err := psInformerFactory.Get(*gvr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting a lister for a pod scalable resource '%+v'", gvr)
+	}
+
+	psObj, err := lister.ByNamespace(namespace).Get(name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error fetching Pod Scalable %s/%s", namespace, name)
+	}
+	return psObj.(*pav1alpha1.PodScalable), nil
+}

--- a/pkg/resources/scale_test.go
+++ b/pkg/resources/scale_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis/duck"
+	fakedynamicclient "github.com/knative/pkg/injection/clients/dynamicclient/fake"
+	logtesting "github.com/knative/pkg/logging/testing"
+	"github.com/knative/serving/pkg/apis/serving"
+
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	. "github.com/knative/pkg/reconciler/testing"
+)
+
+func TestScaleResource(t *testing.T) {
+	cases := []struct {
+		name      string
+		objectRef corev1.ObjectReference
+		wantGVR   *schema.GroupVersionResource
+		wantName  string
+		wantErr   bool
+	}{{
+		name: "all good",
+		objectRef: corev1.ObjectReference{
+			Name:       "test",
+			APIVersion: "apps/v1",
+			Kind:       "deployment",
+		},
+		wantGVR: &schema.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		},
+		wantName: "test",
+	}, {
+		name: "broken apiversion",
+		objectRef: corev1.ObjectReference{
+			Name:       "test",
+			APIVersion: "apps///v1",
+			Kind:       "deployment",
+		},
+		wantErr: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gvr, name, err := ScaleResourceArguments(tc.objectRef)
+
+			if !cmp.Equal(gvr, tc.wantGVR) {
+				t.Errorf("ScaleResource() = %v, want: %v, diff: %s", gvr, tc.wantGVR, cmp.Diff(gvr, tc.wantGVR))
+			}
+
+			if name != tc.wantName {
+				t.Errorf("ScaleResource() = %s, want %s", name, tc.wantName)
+			}
+
+			if err == nil && tc.wantErr {
+				t.Error("ScaleResource() didn't return an error")
+			}
+			if err != nil && !tc.wantErr {
+				t.Errorf("ScaleResource() = %v, want no error", err)
+			}
+		})
+	}
+}
+
+func TestGetScaleResource(t *testing.T) {
+	defer logtesting.ClearAll()
+	ctx, _ := SetupFakeContext(t)
+
+	deployment := newDeployment(t, fakedynamicclient.Get(ctx), "testdeployment", 5)
+
+	psInformerFactory := NewPodScalableInformerFactory(ctx)
+	objectRef := corev1.ObjectReference{
+		Name:       deployment.Name,
+		Kind:       "deployment",
+		APIVersion: "apps/v1",
+	}
+	scale, err := GetScaleResource(testNamespace, objectRef, psInformerFactory)
+	if err != nil {
+		t.Fatalf("GetScale got error = %v", err)
+	}
+	if got, want := scale.Status.Replicas, int32(5); got != want {
+		t.Errorf("GetScale.Status.Replicas = %d, want: %d", got, want)
+	}
+	if got, want := scale.Spec.Selector.MatchLabels[serving.RevisionUID], "1982"; got != want {
+		t.Errorf("GetScale.Status.Selector = %q, want = %q", got, want)
+	}
+}
+
+func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, replicas int) *v1.Deployment {
+	t.Helper()
+
+	uns := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"namespace": testNamespace,
+				"name":      name,
+				"uid":       "1982",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(replicas),
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						serving.RevisionUID: "1982",
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"replicas": int64(replicas),
+			},
+		},
+	}
+
+	u, err := dynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}).Namespace(testNamespace).Create(uns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+
+	deployment := &v1.Deployment{}
+	if err := duck.FromUnstructured(u, deployment); err != nil {
+		t.Fatalf("FromUnstructured() = %v", err)
+	}
+	return deployment
+}


### PR DESCRIPTION
/lint
-->

## Proposed Changes

These "helper" methods have been hardwired into the scaler. The scaler however is only used for the KPA case, whereas these helper functions are needed generally to resolve any PodAutoscaler's scaleTargetRef into the actual object. That is needed for example to create the services in the ServerlessService and to create the MetricService from the PodAutoscaler by setting the correct selector.

This is part of the refactoring needed to provide a base reconciler for both HPA and KPA.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
