### PR TITLE
Add permission for RestrictedEndpointsAdmission

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -21,6 +21,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
+    verbs: ["create"]
   - apiGroups: ["apps"]
     resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]


### PR DESCRIPTION
When namespace isolation plugin such as `RestrictedEndpointsAdmission`
is enabled on the cluster, service endpoints are not allowed to create from other
namespace. Since knative service's endpoints are same with
`activator-service`'s endpoints, it fails to create endpoints if
cluster enabled `RestrictedEndpointsAdmission`.

This patch adds permission `endpoints/restricted` into clusterrole for
address the problem.

## Proposed Changes

* Add `create` permission on a virtual resource `endpoints/restricted`.

**Release Note**

```release-note
NONE
```
