### PR TITLE
TestImagePullError accepts another err string to succeed

### DIFF
--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -19,7 +19,6 @@ package e2e
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -30,12 +29,6 @@ import (
 
 func TestImagePullError(t *testing.T) {
 	clients := Setup(t)
-	const (
-		backoffMsg    = "Back-off pulling image"
-		backoffReason = "ImagePullBackOff"
-		daemonMsg     = "Error response from daemon: manifest for"
-		daemonReason  = "ErrImagePull"
-	)
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
 		// TODO: Replace this when sha256 is broken.
@@ -60,8 +53,7 @@ func TestImagePullError(t *testing.T) {
 		cond := r.Status.GetCondition(v1alpha1.ConfigurationConditionReady)
 		if cond != nil && !cond.IsUnknown() {
 			if cond.IsFalse() {
-				if strings.Contains(cond.Message, backoffMsg) ||
-					strings.Contains(cond.Message, daemonMsg) {
+				if cond.Reason == "RevisionFailed" {
 					return true, nil
 				}
 			}
@@ -85,8 +77,7 @@ func TestImagePullError(t *testing.T) {
 	err = test.CheckRevisionState(clients.ServingClient, revisionName, func(r *v1alpha1.Revision) (bool, error) {
 		cond := r.Status.GetCondition(v1alpha1.RevisionConditionReady)
 		if cond != nil {
-			if (cond.Reason == backoffReason && strings.Contains(cond.Message, backoffMsg)) ||
-				(cond.Reason == daemonReason && strings.Contains(cond.Message, daemonMsg)) {
+			if cond.Reason == "ImagePullBackOff" || cond.Reason == "ErrImagePull" {
 				return true, nil
 			}
 			return true, fmt.Errorf("the revision %s was not marked with expected error condition, but with (Reason=%q, Message=%q)",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes a failure on OpenShift 4 where  the error string is slightly different. For a non-existent image SHA it will throw this message: "rpc error: code = Unknown desc = Error reading manifest sha256:0000000000000000000000000000000000000000000000000000000000000000 in docker.io/library/ubuntu: manifest unknown: manifest unknown"


