### PR TITLE
More specific requests/limits in TestPodScheduleError test

### DIFF
--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -34,7 +34,7 @@ func TestPodScheduleError(t *testing.T) {
 	clients := Setup(t)
 	const (
 		errorReason    = "RevisionFailed"
-		errorMsg       = "nodes are available"
+		errorMsg       = "Insufficient cpu"
 		revisionReason = "Unschedulable"
 	)
 	names := test.ResourceNames{
@@ -47,11 +47,11 @@ func TestPodScheduleError(t *testing.T) {
 
 	t.Logf("Creating a new Service %s", names.Image)
 	resources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU: resource.MustParse("50000"),
-		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
+			corev1.ResourceCPU: resource.MustParse("50000m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("50000m"),
 		},
 	}
 	var (


### PR DESCRIPTION
On OpenShift this test has been failing because requests/memory was set to 350Mi (not sure why the test was setting this because it looks like we're targeting lots of CPU) and it was bigger than the default limit/memory which was 200M. So the test failed on OpenShift with different error complaining about the requests being higher than the limits.

The changes in this PR make it clear that we're requesting too many CPUs and the test passes. And also make sure that requests are not higher than limits

