### PR TITLE
Create a new autoscaling base reconciler.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -50,8 +50,8 @@ func NewController(
 	c := &Reconciler{
 		Base: &areconciler.Base{
 			Base:      reconciler.NewBase(ctx, controllerAgentName, cmw),
-			PaLister:  paInformer.Lister(),
-			SksLister: sksInformer.Lister(),
+			PALister:  paInformer.Lister(),
+			SKSLister: sksInformer.Lister(),
 		},
 		hpaLister: hpaInformer.Lister(),
 	}

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/reconciler"
+	areconciler "github.com/knative/serving/pkg/reconciler/autoscaling"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	"k8s.io/client-go/tools/cache"
 )
@@ -47,10 +48,12 @@ func NewController(
 	hpaInformer := hpainformer.Get(ctx)
 
 	c := &Reconciler{
-		Base:      reconciler.NewBase(ctx, controllerAgentName, cmw),
-		paLister:  paInformer.Lister(),
+		Base: &areconciler.Base{
+			Base:      reconciler.NewBase(ctx, controllerAgentName, cmw),
+			PaLister:  paInformer.Lister(),
+			SksLister: sksInformer.Lister(),
+		},
 		hpaLister: hpaInformer.Lister(),
-		sksLister: sksInformer.Lister(),
 	}
 	impl := controller.NewImpl(c, c.Logger, "HPA-Class Autoscaling")
 
@@ -81,7 +84,7 @@ func NewController(
 	})
 	configStore := config.NewStore(c.Logger.Named("config-store"), resync)
 	configStore.WatchConfigs(cmw)
-	c.configStore = configStore
+	c.ConfigStore = configStore
 
 	return impl
 }

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -19,7 +19,6 @@ package hpa
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -28,13 +27,8 @@ import (
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
-	nv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	listers "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
-	nlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler"
+	areconciler "github.com/knative/serving/pkg/reconciler/autoscaling"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/hpa/resources"
-	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
-	"github.com/knative/serving/pkg/reconciler/autoscaling/resources/names"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -46,12 +40,8 @@ import (
 
 // Reconciler implements the control loop for the HPA resources.
 type Reconciler struct {
-	*reconciler.Base
-
-	paLister    listers.PodAutoscalerLister
-	sksLister   nlisters.ServerlessServiceLister
-	hpaLister   autoscalingv2beta1listers.HorizontalPodAutoscalerLister
-	configStore reconciler.ConfigStore
+	*areconciler.Base
+	hpaLister autoscalingv2beta1listers.HorizontalPodAutoscalerLister
 }
 
 var _ controller.Reconciler = (*Reconciler)(nil)
@@ -64,10 +54,10 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 	logger := logging.FromContext(ctx)
-	ctx = c.configStore.ToContext(ctx)
+	ctx = c.ConfigStore.ToContext(ctx)
 	logger.Debug("Reconcile hpa-class PodAutoscaler")
 
-	original, err := c.paLister.PodAutoscalers(namespace).Get(name)
+	original, err := c.PaLister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		logger.Debug("PA no longer exists")
 		return c.deleteHPA(ctx, key)
@@ -90,7 +80,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err = c.updateStatus(pa); err != nil {
+	} else if _, err = c.UpdateStatus(pa); err != nil {
 		logger.Warnw("Failed to update pa status", zap.Error(err))
 		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for PA %q: %v", pa.Name, err)
@@ -147,7 +137,7 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 		}
 	}
 
-	sks, err := c.reconcileSKS(ctx, pa)
+	sks, err := c.ReconcileSKS(ctx, pa)
 	if err != nil {
 		return perrors.Wrap(err, "error reconciling SKS")
 	}
@@ -161,41 +151,6 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 
 	pa.Status.ObservedGeneration = pa.Generation
 	return nil
-}
-
-func (c *Reconciler) reconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (*nv1alpha1.ServerlessService, error) {
-	logger := logging.FromContext(ctx)
-
-	sksName := names.SKS(pa.Name)
-	sks, err := c.sksLister.ServerlessServices(pa.Namespace).Get(sksName)
-	if errors.IsNotFound(err) {
-		logger.Infof("SKS %s/%s does not exist; creating.", pa.Namespace, sksName)
-		// HPA doesn't scale to zero now, so the mode is always `Serve`.
-		sks = aresources.MakeSKS(pa, nv1alpha1.SKSOperationModeServe)
-		_, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Create(sks)
-		if err != nil {
-			return nil, perrors.Wrapf(err, "error creating SKS %s", sksName)
-		}
-		logger.Info("Created SKS:", sksName)
-	} else if err != nil {
-		return nil, perrors.Wrapf(err, "error getting SKS: %s", sksName)
-	} else if !metav1.IsControlledBy(sks, pa) {
-		pa.Status.MarkResourceNotOwned("ServerlessService", sksName)
-		return nil, fmt.Errorf("HPA: %q does not own SKS: %q", pa.Name, sksName)
-	}
-	tmpl := aresources.MakeSKS(pa, nv1alpha1.SKSOperationModeServe)
-	if !equality.Semantic.DeepEqual(tmpl.Spec, sks.Spec) {
-		want := sks.DeepCopy()
-		want.Spec = tmpl.Spec
-		logger.Info("SKS changed; reconciling:", sksName)
-		// Just deploy the template, since the spec change will change
-		// the service and the SKS status will change as a consequence.
-		if sks, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
-			return nil, perrors.Wrapf(err, "error updating SKS %s", sksName)
-		}
-	}
-	logger.Debug("Done reconciling SKS:", sksName)
-	return sks, nil
 }
 
 func (c *Reconciler) deleteHPA(ctx context.Context, key string) error {
@@ -215,19 +170,4 @@ func (c *Reconciler) deleteHPA(ctx context.Context, key string) error {
 	}
 	logger.Infof("Deleted HPA %q", name)
 	return nil
-}
-
-func (c *Reconciler) updateStatus(desired *pav1alpha1.PodAutoscaler) (*pav1alpha1.PodAutoscaler, error) {
-	pa, err := c.paLister.PodAutoscalers(desired.Namespace).Get(desired.Name)
-	if err != nil {
-		return nil, err
-	}
-	// Check if there is anything to update.
-	if !reflect.DeepEqual(pa.Status, desired.Status) {
-		// Don't modify the informers copy
-		existing := pa.DeepCopy()
-		existing.Status = desired.Status
-		return c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).UpdateStatus(existing)
-	}
-	return pa, nil
 }

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -57,7 +57,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	ctx = c.ConfigStore.ToContext(ctx)
 	logger.Debug("Reconcile hpa-class PodAutoscaler")
 
-	original, err := c.PaLister.PodAutoscalers(namespace).Get(name)
+	original, err := c.PALister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		logger.Debug("PA no longer exists")
 		return c.deleteHPA(ctx, key)

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -407,8 +407,8 @@ func TestReconcile(t *testing.T) {
 		return &Reconciler{
 			Base: &areconciler.Base{
 				Base:        reconciler.NewBase(ctx, controllerAgentName, cmw),
-				PaLister:    listers.GetPodAutoscalerLister(),
-				SksLister:   listers.GetServerlessServiceLister(),
+				PALister:    listers.GetPodAutoscalerLister(),
+				SKSLister:   listers.GetServerlessServiceLister(),
 				ConfigStore: &testConfigStore{config: defaultConfig()},
 			},
 			hpaLister: listers.GetHorizontalPodAutoscalerLister(),

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -36,6 +36,7 @@ import (
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/reconciler"
+	areconciler "github.com/knative/serving/pkg/reconciler/autoscaling"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/hpa/resources"
 	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
@@ -226,7 +227,7 @@ func TestReconcile(t *testing.T) {
 			Object: pa(testRevision, testNamespace, WithHPAClass, MarkResourceNotOwnedByPA("ServerlessService", testRevision)),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", `error reconciling SKS: HPA: "test-revision" does not own SKS: "test-revision"`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `error reconciling SKS: PA: test-revision does not own SKS: test-revision`),
 		},
 	}, {
 		Name: "pa is disowned",
@@ -404,11 +405,13 @@ func TestReconcile(t *testing.T) {
 	defer logtesting.ClearAll()
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
-			Base:        reconciler.NewBase(ctx, controllerAgentName, cmw),
-			paLister:    listers.GetPodAutoscalerLister(),
-			sksLister:   listers.GetServerlessServiceLister(),
-			hpaLister:   listers.GetHorizontalPodAutoscalerLister(),
-			configStore: &testConfigStore{config: defaultConfig()},
+			Base: &areconciler.Base{
+				Base:        reconciler.NewBase(ctx, controllerAgentName, cmw),
+				PaLister:    listers.GetPodAutoscalerLister(),
+				SksLister:   listers.GetServerlessServiceLister(),
+				ConfigStore: &testConfigStore{config: defaultConfig()},
+			},
+			hpaLister: listers.GetHorizontalPodAutoscalerLister(),
 		}
 	}))
 }

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -57,11 +57,11 @@ func NewController(
 	c := &Reconciler{
 		Base: &areconciler.Base{
 			Base:              reconciler.NewBase(ctx, controllerAgentName, cmw),
-			PaLister:          paInformer.Lister(),
-			SksLister:         sksInformer.Lister(),
+			PALister:          paInformer.Lister(),
+			SKSLister:         sksInformer.Lister(),
 			ServiceLister:     serviceInformer.Lister(),
 			Metrics:           metrics,
-			PsInformerFactory: psInformerFactory,
+			PSInformerFactory: psInformerFactory,
 		},
 		endpointsLister: endpointsInformer.Lister(),
 		deciders:        deciders,

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -67,7 +67,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	logger.Debug("Reconcile kpa-class PodAutoscaler")
 
-	original, err := c.PaLister.PodAutoscalers(namespace).Get(name)
+	original, err := c.PALister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		logger.Debug("PA no longer exists")
 		if err := c.deciders.Delete(ctx, namespace, name); err != nil {

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -19,35 +19,25 @@ package kpa
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 
 	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
-	"github.com/knative/serving/pkg/apis/networking"
-	nv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/autoscaler"
-	listers "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
-	nlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
-	"github.com/knative/serving/pkg/reconciler"
+	areconciler "github.com/knative/serving/pkg/reconciler/autoscaling"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/kpa/resources"
-	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
-	anames "github.com/knative/serving/pkg/reconciler/autoscaling/resources/names"
 	resourceutil "github.com/knative/serving/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -56,16 +46,10 @@ import (
 // Reconciler tracks PAs and right sizes the ScaleTargetRef based on the
 // information from Deciders.
 type Reconciler struct {
-	*reconciler.Base
-	paLister          listers.PodAutoscalerLister
-	serviceLister     corev1listers.ServiceLister
-	sksLister         nlisters.ServerlessServiceLister
-	endpointsLister   corev1listers.EndpointsLister
-	kpaDeciders       resources.Deciders
-	metrics           aresources.Metrics
-	scaler            *scaler
-	configStore       reconciler.ConfigStore
-	psInformerFactory duck.InformerFactory
+	*areconciler.Base
+	endpointsLister corev1listers.EndpointsLister
+	deciders        resources.Deciders
+	scaler          *scaler
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -79,17 +63,17 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 	logger := logging.FromContext(ctx)
-	ctx = c.configStore.ToContext(ctx)
+	ctx = c.ConfigStore.ToContext(ctx)
 
 	logger.Debug("Reconcile kpa-class PodAutoscaler")
 
-	original, err := c.paLister.PodAutoscalers(namespace).Get(name)
+	original, err := c.PaLister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		logger.Debug("PA no longer exists")
-		if err := c.kpaDeciders.Delete(ctx, namespace, name); err != nil {
+		if err := c.deciders.Delete(ctx, namespace, name); err != nil {
 			return err
 		}
-		if err := c.metrics.Delete(ctx, namespace, name); err != nil {
+		if err := c.Metrics.Delete(ctx, namespace, name); err != nil {
 			return err
 		}
 		return nil
@@ -113,7 +97,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-	} else if _, err = c.updateStatus(pa); err != nil {
+	} else if _, err = c.UpdateStatus(pa); err != nil {
 		logger.Warnw("Failed to update kpa status", zap.Error(err))
 		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for PA %q: %v", pa.Name, err)
@@ -141,12 +125,12 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	pa.Status.InitializeConditions()
 	logger.Debug("PA exists")
 
-	metricSvc, err := c.reconcileMetricsService(ctx, pa)
+	metricSvc, err := c.ReconcileMetricsService(ctx, pa)
 	if err != nil {
 		return perrors.Wrap(err, "error reconciling metrics service")
 	}
 
-	sks, err := c.reconcileSKS(ctx, pa)
+	sks, err := c.ReconcileSKS(ctx, pa)
 	if err != nil {
 		return perrors.Wrap(err, "error reconciling SKS")
 	}
@@ -159,7 +143,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		return perrors.Wrap(err, "error reconciling decider")
 	}
 
-	if err := c.reconcileMetric(ctx, pa, metricSvc); err != nil {
+	if err := c.ReconcileMetric(ctx, pa, metricSvc); err != nil {
 		return perrors.Wrap(err, "error reconciling metric")
 	}
 
@@ -193,7 +177,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	// computeActiveCondition decides if we need to change the SKS mode,
 	// and returns true if the status has changed.
 	if changed := computeActiveCondition(pa, want, got); changed {
-		_, err := c.reconcileSKS(ctx, pa)
+		_, err := c.ReconcileSKS(ctx, pa)
 		if err != nil {
 			return perrors.Wrap(err, "error re-reconciling SKS")
 		}
@@ -203,9 +187,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 
 func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAutoscaler, k8sSvc string) (*autoscaler.Decider, error) {
 	desiredDecider := resources.MakeDecider(ctx, pa, config.FromContext(ctx).Autoscaler, k8sSvc)
-	decider, err := c.kpaDeciders.Get(ctx, desiredDecider.Namespace, desiredDecider.Name)
+	decider, err := c.deciders.Get(ctx, desiredDecider.Namespace, desiredDecider.Name)
 	if errors.IsNotFound(err) {
-		decider, err = c.kpaDeciders.Create(ctx, desiredDecider)
+		decider, err = c.deciders.Create(ctx, desiredDecider)
 		if err != nil {
 			return nil, perrors.Wrap(err, "error creating decider")
 		}
@@ -216,144 +200,13 @@ func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAut
 	// Ignore status when reconciling
 	desiredDecider.Status = decider.Status
 	if !equality.Semantic.DeepEqual(desiredDecider, decider) {
-		decider, err = c.kpaDeciders.Update(ctx, desiredDecider)
+		decider, err = c.deciders.Update(ctx, desiredDecider)
 		if err != nil {
 			return nil, perrors.Wrap(err, "error updating decider")
 		}
 	}
 
 	return decider, nil
-}
-
-func (c *Reconciler) reconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (*nv1alpha1.ServerlessService, error) {
-	logger := logging.FromContext(ctx)
-
-	mode := nv1alpha1.SKSOperationModeServe
-	if pa.Status.IsInactive() {
-		mode = nv1alpha1.SKSOperationModeProxy
-	}
-	sksName := anames.SKS(pa.Name)
-	sks, err := c.sksLister.ServerlessServices(pa.Namespace).Get(sksName)
-	if errors.IsNotFound(err) {
-		logger.Infof("SKS %s/%s does not exist; creating.", pa.Namespace, sksName)
-		sks = aresources.MakeSKS(pa, mode)
-		_, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Create(sks)
-		if err != nil {
-			return nil, perrors.Wrapf(err, "error creating SKS %s", sksName)
-		}
-		logger.Info("Created SKS:", sksName)
-	} else if err != nil {
-		return nil, perrors.Wrapf(err, "error getting SKS %s", sksName)
-	} else if !metav1.IsControlledBy(sks, pa) {
-		pa.Status.MarkResourceNotOwned("ServerlessService", sksName)
-		return nil, fmt.Errorf("KPA: %s does not own SKS: %s", pa.Name, sksName)
-	} else {
-		tmpl := aresources.MakeSKS(pa, mode)
-		if !equality.Semantic.DeepEqual(tmpl.Spec, sks.Spec) {
-			want := sks.DeepCopy()
-			want.Spec = tmpl.Spec
-			logger.Info("SKS changed; reconciling:", sksName)
-			if sks, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
-				return nil, perrors.Wrapf(err, "error updating SKS %s", sksName)
-			}
-		}
-	}
-	logger.Debug("Done reconciling SKS", sksName)
-	return sks, nil
-}
-
-func (c *Reconciler) metricService(pa *pav1alpha1.PodAutoscaler) (*corev1.Service, error) {
-	svcs, err := c.serviceLister.Services(pa.Namespace).List(labels.SelectorFromSet(map[string]string{
-		autoscaling.KPALabelKey:   pa.Name,
-		networking.ServiceTypeKey: string(networking.ServiceTypeMetrics),
-	}))
-	if err != nil {
-		return nil, err
-	}
-	var ret *corev1.Service
-	for _, s := range svcs {
-		// TODO(vagababov): determine if this is better to be in the ownership check.
-		// TODO(vagababov): remove the second check after 0.7 is cut.
-		// Found a match or we had nothing set up, then pick any of them, to reduce churn.
-		if s.Name == pa.Status.MetricsServiceName || pa.Status.MetricsServiceName == "" {
-			ret = s
-			continue
-		}
-		// If it's not the metrics service recorded in status,
-		// but we control it then it is a duplicate and should be deleted.
-		if metav1.IsControlledBy(s, pa) {
-			c.KubeClientSet.CoreV1().Services(pa.Namespace).Delete(s.Name, &metav1.DeleteOptions{})
-		}
-	}
-	if ret == nil {
-		return nil, errors.NewNotFound(corev1.Resource("Services"), pa.Name)
-	}
-	return ret, nil
-}
-
-func (c *Reconciler) reconcileMetricsService(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (string, error) {
-	logger := logging.FromContext(ctx)
-
-	scale, err := resourceutil.GetScaleResource(pa.Namespace, pa.Spec.ScaleTargetRef, c.psInformerFactory)
-	if err != nil {
-		return "", perrors.Wrap(err, "error retrieving scale")
-	}
-	selector := scale.Spec.Selector.MatchLabels
-	logger.Debugf("PA's %s selector: %v", pa.Name, selector)
-
-	svc, err := c.metricService(pa)
-	if errors.IsNotFound(err) {
-		logger.Infof("Metrics K8s service for KPA %s/%s does not exist; creating.", pa.Namespace, pa.Name)
-		svc = resources.MakeMetricsService(pa, selector)
-		svc, err = c.KubeClientSet.CoreV1().Services(pa.Namespace).Create(svc)
-		if err != nil {
-			return "", perrors.Wrapf(err, "error creating metrics K8s service for %s/%s", pa.Namespace, pa.Name)
-		}
-		logger.Info("Created K8s service:", svc.Name)
-	} else if err != nil {
-		return "", perrors.Wrap(err, "error getting metrics K8s service")
-	} else if !metav1.IsControlledBy(svc, pa) {
-		pa.Status.MarkResourceNotOwned("Service", svc.Name)
-		return "", fmt.Errorf("KPA: %s does not own Service: %s", pa.Name, svc.Name)
-	} else {
-		tmpl := resources.MakeMetricsService(pa, selector)
-		want := svc.DeepCopy()
-		want.Spec.Ports = tmpl.Spec.Ports
-		want.Spec.Selector = tmpl.Spec.Selector
-
-		if !equality.Semantic.DeepEqual(want.Spec, svc.Spec) {
-			logger.Info("Metrics K8s Service changed; reconciling:", svc.Name)
-			if _, err = c.KubeClientSet.CoreV1().Services(pa.Namespace).Update(want); err != nil {
-				return "", perrors.Wrapf(err, "error updating K8s Service %s", svc.Name)
-			}
-		}
-	}
-	pa.Status.MetricsServiceName = svc.Name
-	logger.Debug("Done reconciling metrics K8s service: ", svc.Name)
-	return svc.Name, nil
-}
-
-func (c *Reconciler) reconcileMetric(ctx context.Context, pa *pav1alpha1.PodAutoscaler, metricSN string) error {
-	desiredMetric := aresources.MakeMetric(ctx, pa, metricSN, config.FromContext(ctx).Autoscaler)
-	metric, err := c.metrics.Get(ctx, desiredMetric.Namespace, desiredMetric.Name)
-	if errors.IsNotFound(err) {
-		metric, err = c.metrics.Create(ctx, desiredMetric)
-		if err != nil {
-			return perrors.Wrap(err, "error creating metric")
-		}
-	} else if err != nil {
-		return perrors.Wrap(err, "error fetching metric")
-	}
-
-	// Ignore status when reconciling
-	desiredMetric.Status = metric.Status
-	if !equality.Semantic.DeepEqual(desiredMetric, metric) {
-		if _, err = c.metrics.Update(ctx, desiredMetric); err != nil {
-			return perrors.Wrap(err, "error updating metric")
-		}
-	}
-
-	return nil
 }
 
 func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, got int) error {
@@ -414,20 +267,4 @@ func activeThreshold(pa *pav1alpha1.PodAutoscaler) int {
 	}
 
 	return 1
-}
-
-func (c *Reconciler) updateStatus(desired *pav1alpha1.PodAutoscaler) (*pav1alpha1.PodAutoscaler, error) {
-	pa, err := c.paLister.PodAutoscalers(desired.Namespace).Get(desired.Name)
-	if err != nil {
-		return nil, err
-	}
-	// If there's nothing to update, just return.
-	if reflect.DeepEqual(pa.Status, desired.Status) {
-		return pa, nil
-	}
-	// Don't modify the informers copy
-	existing := pa.DeepCopy()
-	existing.Status = desired.Status
-
-	return c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).UpdateStatus(existing)
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -306,12 +306,12 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		return &Reconciler{
 			Base: &areconciler.Base{
 				Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),
-				PaLister:          listers.GetPodAutoscalerLister(),
-				SksLister:         listers.GetServerlessServiceLister(),
+				PALister:          listers.GetPodAutoscalerLister(),
+				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
 				Metrics:           fakeMetrics,
 				ConfigStore:       &testConfigStore{config: defaultConfig()},
-				PsInformerFactory: psFactory,
+				PSInformerFactory: psFactory,
 			},
 			endpointsLister: listers.GetEndpointsLister(),
 			deciders:        fakeDeciders,
@@ -778,12 +778,12 @@ func TestReconcile(t *testing.T) {
 		return &Reconciler{
 			Base: &areconciler.Base{
 				Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),
-				PaLister:          listers.GetPodAutoscalerLister(),
-				SksLister:         listers.GetServerlessServiceLister(),
+				PALister:          listers.GetPodAutoscalerLister(),
+				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
 				Metrics:           fakeMetrics,
 				ConfigStore:       &testConfigStore{config: defaultConfig()},
-				PsInformerFactory: psFactory,
+				PSInformerFactory: psFactory,
 			},
 			endpointsLister: listers.GetEndpointsLister(),
 			deciders:        fakeDeciders,

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -49,12 +49,12 @@ import (
 // Base implements the core controller logic for autoscaling, given a Reconciler.
 type Base struct {
 	*reconciler.Base
-	PaLister          listers.PodAutoscalerLister
+	PALister          listers.PodAutoscalerLister
 	ServiceLister     corev1listers.ServiceLister
-	SksLister         nlisters.ServerlessServiceLister
+	SKSLister         nlisters.ServerlessServiceLister
 	Metrics           aresources.Metrics
 	ConfigStore       reconciler.ConfigStore
-	PsInformerFactory duck.InformerFactory
+	PSInformerFactory duck.InformerFactory
 }
 
 // ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.
@@ -66,7 +66,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 	sksName := anames.SKS(pa.Name)
-	sks, err := c.SksLister.ServerlessServices(pa.Namespace).Get(sksName)
+	sks, err := c.SKSLister.ServerlessServices(pa.Namespace).Get(sksName)
 	if errors.IsNotFound(err) {
 		logger.Infof("SKS %s/%s does not exist; creating.", pa.Namespace, sksName)
 		sks = aresources.MakeSKS(pa, mode)
@@ -128,7 +128,7 @@ func (c *Base) metricService(pa *pav1alpha1.PodAutoscaler) (*corev1.Service, err
 func (c *Base) ReconcileMetricsService(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (string, error) {
 	logger := logging.FromContext(ctx)
 
-	scale, err := resourceutil.GetScaleResource(pa.Namespace, pa.Spec.ScaleTargetRef, c.PsInformerFactory)
+	scale, err := resourceutil.GetScaleResource(pa.Namespace, pa.Spec.ScaleTargetRef, c.PSInformerFactory)
 	if err != nil {
 		return "", perrors.Wrap(err, "error retrieving scale")
 	}
@@ -193,7 +193,7 @@ func (c *Base) ReconcileMetric(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 
 // UpdateStatus updates the status of the given PodAutoscaler.
 func (c *Base) UpdateStatus(desired *pav1alpha1.PodAutoscaler) (*pav1alpha1.PodAutoscaler, error) {
-	pa, err := c.PaLister.PodAutoscalers(desired.Namespace).Get(desired.Name)
+	pa, err := c.PALister.PodAutoscalers(desired.Namespace).Get(desired.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	perrors "github.com/pkg/errors"
+
+	"github.com/knative/pkg/apis/duck"
+	"github.com/knative/pkg/logging"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/apis/networking"
+	nv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	listers "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
+	nlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler"
+	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
+	"github.com/knative/serving/pkg/reconciler/autoscaling/kpa/resources"
+	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
+	anames "github.com/knative/serving/pkg/reconciler/autoscaling/resources/names"
+	resourceutil "github.com/knative/serving/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// Base implements the core controller logic for autoscaling, given a Reconciler.
+type Base struct {
+	*reconciler.Base
+	PaLister          listers.PodAutoscalerLister
+	ServiceLister     corev1listers.ServiceLister
+	SksLister         nlisters.ServerlessServiceLister
+	Metrics           aresources.Metrics
+	ConfigStore       reconciler.ConfigStore
+	PsInformerFactory duck.InformerFactory
+}
+
+// ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.
+func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (*nv1alpha1.ServerlessService, error) {
+	logger := logging.FromContext(ctx)
+
+	mode := nv1alpha1.SKSOperationModeServe
+	if pa.Status.IsInactive() {
+		mode = nv1alpha1.SKSOperationModeProxy
+	}
+	sksName := anames.SKS(pa.Name)
+	sks, err := c.SksLister.ServerlessServices(pa.Namespace).Get(sksName)
+	if errors.IsNotFound(err) {
+		logger.Infof("SKS %s/%s does not exist; creating.", pa.Namespace, sksName)
+		sks = aresources.MakeSKS(pa, mode)
+		_, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Create(sks)
+		if err != nil {
+			return nil, perrors.Wrapf(err, "error creating SKS %s", sksName)
+		}
+		logger.Info("Created SKS:", sksName)
+	} else if err != nil {
+		return nil, perrors.Wrapf(err, "error getting SKS %s", sksName)
+	} else if !metav1.IsControlledBy(sks, pa) {
+		pa.Status.MarkResourceNotOwned("ServerlessService", sksName)
+		return nil, fmt.Errorf("PA: %s does not own SKS: %s", pa.Name, sksName)
+	} else {
+		tmpl := aresources.MakeSKS(pa, mode)
+		if !equality.Semantic.DeepEqual(tmpl.Spec, sks.Spec) {
+			want := sks.DeepCopy()
+			want.Spec = tmpl.Spec
+			logger.Info("SKS changed; reconciling:", sksName)
+			if sks, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
+				return nil, perrors.Wrapf(err, "error updating SKS %s", sksName)
+			}
+		}
+	}
+	logger.Debug("Done reconciling SKS", sksName)
+	return sks, nil
+}
+
+func (c *Base) metricService(pa *pav1alpha1.PodAutoscaler) (*corev1.Service, error) {
+	svcs, err := c.ServiceLister.Services(pa.Namespace).List(labels.SelectorFromSet(map[string]string{
+		autoscaling.KPALabelKey:   pa.Name,
+		networking.ServiceTypeKey: string(networking.ServiceTypeMetrics),
+	}))
+	if err != nil {
+		return nil, err
+	}
+	var ret *corev1.Service
+	for _, s := range svcs {
+		// TODO(vagababov): determine if this is better to be in the ownership check.
+		// TODO(vagababov): remove the second check after 0.7 is cut.
+		// Found a match or we had nothing set up, then pick any of them, to reduce churn.
+		if s.Name == pa.Status.MetricsServiceName || pa.Status.MetricsServiceName == "" {
+			ret = s
+			continue
+		}
+		// If it's not the metrics service recorded in status,
+		// but we control it then it is a duplicate and should be deleted.
+		if metav1.IsControlledBy(s, pa) {
+			c.KubeClientSet.CoreV1().Services(pa.Namespace).Delete(s.Name, &metav1.DeleteOptions{})
+		}
+	}
+	if ret == nil {
+		return nil, errors.NewNotFound(corev1.Resource("Services"), pa.Name)
+	}
+	return ret, nil
+}
+
+// ReconcileMetricsService reconciles a metrics service for the given PodAutoscaler.
+func (c *Base) ReconcileMetricsService(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (string, error) {
+	logger := logging.FromContext(ctx)
+
+	scale, err := resourceutil.GetScaleResource(pa.Namespace, pa.Spec.ScaleTargetRef, c.PsInformerFactory)
+	if err != nil {
+		return "", perrors.Wrap(err, "error retrieving scale")
+	}
+	selector := scale.Spec.Selector.MatchLabels
+	logger.Debugf("PA's %s selector: %v", pa.Name, selector)
+
+	svc, err := c.metricService(pa)
+	if errors.IsNotFound(err) {
+		logger.Infof("Metrics K8s service for KPA %s/%s does not exist; creating.", pa.Namespace, pa.Name)
+		svc = resources.MakeMetricsService(pa, selector)
+		svc, err = c.KubeClientSet.CoreV1().Services(pa.Namespace).Create(svc)
+		if err != nil {
+			return "", perrors.Wrapf(err, "error creating metrics K8s service for %s/%s", pa.Namespace, pa.Name)
+		}
+		logger.Info("Created K8s service:", svc.Name)
+	} else if err != nil {
+		return "", perrors.Wrap(err, "error getting metrics K8s service")
+	} else if !metav1.IsControlledBy(svc, pa) {
+		pa.Status.MarkResourceNotOwned("Service", svc.Name)
+		return "", fmt.Errorf("PA: %s does not own Service: %s", pa.Name, svc.Name)
+	} else {
+		tmpl := resources.MakeMetricsService(pa, selector)
+		want := svc.DeepCopy()
+		want.Spec.Ports = tmpl.Spec.Ports
+		want.Spec.Selector = tmpl.Spec.Selector
+
+		if !equality.Semantic.DeepEqual(want.Spec, svc.Spec) {
+			logger.Info("Metrics K8s Service changed; reconciling:", svc.Name)
+			if _, err = c.KubeClientSet.CoreV1().Services(pa.Namespace).Update(want); err != nil {
+				return "", perrors.Wrapf(err, "error updating K8s Service %s", svc.Name)
+			}
+		}
+	}
+	pa.Status.MetricsServiceName = svc.Name
+	logger.Debug("Done reconciling metrics K8s service: ", svc.Name)
+	return svc.Name, nil
+}
+
+// ReconcileMetric reconciles a metric instance out of the given PodAutoscaler to control metric collection.
+func (c *Base) ReconcileMetric(ctx context.Context, pa *pav1alpha1.PodAutoscaler, metricSN string) error {
+	desiredMetric := aresources.MakeMetric(ctx, pa, metricSN, config.FromContext(ctx).Autoscaler)
+	metric, err := c.Metrics.Get(ctx, desiredMetric.Namespace, desiredMetric.Name)
+	if errors.IsNotFound(err) {
+		metric, err = c.Metrics.Create(ctx, desiredMetric)
+		if err != nil {
+			return perrors.Wrap(err, "error creating metric")
+		}
+	} else if err != nil {
+		return perrors.Wrap(err, "error fetching metric")
+	}
+
+	// Ignore status when reconciling
+	desiredMetric.Status = metric.Status
+	if !equality.Semantic.DeepEqual(desiredMetric, metric) {
+		if _, err = c.Metrics.Update(ctx, desiredMetric); err != nil {
+			return perrors.Wrap(err, "error updating metric")
+		}
+	}
+
+	return nil
+}
+
+// UpdateStatus updates the status of the given PodAutoscaler.
+func (c *Base) UpdateStatus(desired *pav1alpha1.PodAutoscaler) (*pav1alpha1.PodAutoscaler, error) {
+	pa, err := c.PaLister.PodAutoscalers(desired.Namespace).Get(desired.Name)
+	if err != nil {
+		return nil, err
+	}
+	// If there's nothing to update, just return.
+	if reflect.DeepEqual(pa.Status, desired.Status) {
+		return pa, nil
+	}
+	// Don't modify the informers copy
+	existing := pa.DeepCopy()
+	existing.Status = desired.Status
+
+	return c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).UpdateStatus(existing)
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

HPA and KPA share a lot of setup logic and code so this factors out a general autoscaling Base reconciler which contains the necessary bits that are needed for both.

Note that this already take the future of the HPA into account in that it also contains the functions to fully reconcile the metrics service and to generate the Metrics entity to trigger metric collection.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
