### PR TITLE
Implement custom-metrics provider for concurrency metrics.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -111,7 +111,7 @@ func main() {
 	endpointsInformer := endpointsinformer.Get(ctx)
 
 	collector := autoscaler.NewMetricCollector(statsScraperFactoryFunc(endpointsInformer.Lister()), logger)
-	customMetricsAdapter.WithCustomMetrics(autoscaler.NewMetricProvider())
+	customMetricsAdapter.WithCustomMetrics(autoscaler.NewMetricProvider(collector))
 
 	// Set up scalers.
 	// uniScalerFactory depends endpointsInformer to be set.

--- a/pkg/autoscaler/metrics_provider.go
+++ b/pkg/autoscaler/metrics_provider.go
@@ -18,34 +18,72 @@ package autoscaler
 
 import (
 	"errors"
+	"math"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 )
 
+var (
+	concurrencyMetricInfo = provider.CustomMetricInfo{
+		GroupResource: v1alpha1.Resource("revisions"),
+		Namespaced:    true,
+		Metric:        autoscaling.Concurrency,
+	}
+
+	errMetricNotSupported = errors.New("metric not supported")
+	errNotImplemented     = errors.New("not implemented")
+)
+
 // MetricProvider is a provider to back a custom-metrics API implementation.
-type MetricProvider struct{}
+type MetricProvider struct {
+	metricClient MetricClient
+}
 
 var _ provider.CustomMetricsProvider = (*MetricProvider)(nil)
 
 // NewMetricProvider creates a new MetricProvider.
-func NewMetricProvider() *MetricProvider {
-	return &MetricProvider{}
+func NewMetricProvider(metricClient MetricClient) *MetricProvider {
+	return &MetricProvider{
+		metricClient: metricClient,
+	}
 }
 
 // GetMetricByName implements the interface.
 func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provider.CustomMetricInfo) (*custom_metrics.MetricValue, error) {
-	return nil, errors.New("not implemented")
+	if !cmp.Equal(info, concurrencyMetricInfo) {
+		return nil, errMetricNotSupported
+	}
+
+	concurrency, _, err := p.metricClient.StableAndPanicConcurrency(name.String())
+	if err != nil {
+		return nil, err
+	}
+	value := *resource.NewQuantity(int64(math.Ceil(concurrency)), resource.DecimalSI)
+
+	return &custom_metrics.MetricValue{
+		Metric: custom_metrics.MetricIdentifier{
+			Name: info.Metric,
+		},
+		Timestamp: metav1.Time{Time: time.Now()},
+		Value:     value,
+	}, nil
 }
 
 // GetMetricBySelector implements the interface.
 func (p *MetricProvider) GetMetricBySelector(namespace string, selector labels.Selector, info provider.CustomMetricInfo) (*custom_metrics.MetricValueList, error) {
-	return nil, errors.New("not implemented")
+	return nil, errNotImplemented
 }
 
 // ListAllMetrics implements the interface.
 func (p *MetricProvider) ListAllMetrics() []provider.CustomMetricInfo {
-	return []provider.CustomMetricInfo{}
+	return []provider.CustomMetricInfo{concurrencyMetricInfo}
 }

--- a/pkg/autoscaler/metrics_provider.go
+++ b/pkg/autoscaler/metrics_provider.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/metrics/pkg/apis/custom_metrics"
+	cmetrics "k8s.io/metrics/pkg/apis/custom_metrics"
 )
 
 var (
@@ -58,7 +58,7 @@ func NewMetricProvider(metricClient MetricClient) *MetricProvider {
 }
 
 // GetMetricByName implements the interface.
-func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provider.CustomMetricInfo) (*custom_metrics.MetricValue, error) {
+func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provider.CustomMetricInfo) (*cmetrics.MetricValue, error) {
 	if !cmp.Equal(info, concurrencyMetricInfo) {
 		return nil, errMetricNotSupported
 	}
@@ -69,8 +69,8 @@ func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provide
 	}
 	value := *resource.NewQuantity(int64(math.Ceil(concurrency)), resource.DecimalSI)
 
-	return &custom_metrics.MetricValue{
-		Metric: custom_metrics.MetricIdentifier{
+	return &cmetrics.MetricValue{
+		Metric: cmetrics.MetricIdentifier{
 			Name: info.Metric,
 		},
 		Timestamp: metav1.Time{Time: time.Now()},
@@ -79,7 +79,7 @@ func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provide
 }
 
 // GetMetricBySelector implements the interface.
-func (p *MetricProvider) GetMetricBySelector(namespace string, selector labels.Selector, info provider.CustomMetricInfo) (*custom_metrics.MetricValueList, error) {
+func (p *MetricProvider) GetMetricBySelector(namespace string, selector labels.Selector, info provider.CustomMetricInfo) (*cmetrics.MetricValueList, error) {
 	return nil, errNotImplemented
 }
 

--- a/pkg/autoscaler/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics_provider_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/kmp"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
@@ -102,7 +102,9 @@ func TestListAllMetrics(t *testing.T) {
 	provider := NewMetricProvider(staticConcurrency(10.0))
 	got := provider.ListAllMetrics()[0]
 
-	if !cmp.Equal(got, concurrencyMetricInfo) {
+	if equal, err := kmp.SafeEqual(got, concurrencyMetricInfo); err != nil {
+		t.Errorf("Got error comparing output, err = %v", err)
+	} else if !equal {
 		t.Errorf("ListAllMetrics() = %v, want %v", got, concurrencyMetricInfo)
 	}
 }

--- a/pkg/autoscaler/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics_provider_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	existingNamespace    = "existing"
+	nonExistingNamespace = "non-existing"
+)
+
+func TestGetMetricByName(t *testing.T) {
+	type args struct {
+		name types.NamespacedName
+		info provider.CustomMetricInfo
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int64
+		wantErr bool
+	}{{
+		name: "all good",
+		args: args{
+			name: types.NamespacedName{Namespace: existingNamespace, Name: "test"},
+			info: concurrencyMetricInfo,
+		},
+		want: 11,
+	}, {
+		name: "requesting unsupported metric",
+		args: args{
+			name: types.NamespacedName{Namespace: existingNamespace, Name: "test"},
+			info: provider.CustomMetricInfo{
+				GroupResource: v1alpha1.Resource("services"),
+				Namespaced:    true,
+				Metric:        autoscaling.Concurrency,
+			},
+		},
+		wantErr: true,
+	}, {
+		name: "error from metric client",
+		args: args{
+			name: types.NamespacedName{Namespace: nonExistingNamespace, Name: "test"},
+			info: concurrencyMetricInfo,
+		},
+		wantErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewMetricProvider(staticConcurrency(10.3))
+			got, err := p.GetMetricByName(tt.args.name, tt.args.info)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMetricByName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			gotValue, _ := got.Value.AsInt64()
+			if gotValue != tt.want {
+				t.Errorf("GetMetricByName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMetricBySelector(t *testing.T) {
+	provider := NewMetricProvider(staticConcurrency(10.0))
+	_, got := provider.GetMetricBySelector("foo", labels.NewSelector(), concurrencyMetricInfo)
+	if got != errNotImplemented {
+		t.Errorf("GetMetricBySelector() = %v, want %v", got, errNotImplemented)
+	}
+}
+
+func TestListAllMetrics(t *testing.T) {
+	provider := NewMetricProvider(staticConcurrency(10.0))
+	got := provider.ListAllMetrics()[0]
+
+	if !cmp.Equal(got, concurrencyMetricInfo) {
+		t.Errorf("ListAllMetrics() = %v, want %v", got, concurrencyMetricInfo)
+	}
+}
+
+type staticConcurrency float64
+
+func (s staticConcurrency) StableAndPanicConcurrency(key string) (float64, float64, error) {
+	if strings.HasPrefix(key, existingNamespace) {
+		return (float64)(s), 0.0, nil
+	}
+	return 0.0, 0.0, errors.New("doesn't exist")
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This implements the previous stub for the custom-metrics API. It reports concurrency metrics based on a given revision.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Custom-metric interface serves concurrency metrics.
```

/assign @mattmoor 
