### PR TITLE
Set memory request for zipkin pods

### DIFF
--- a/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
@@ -63,6 +63,6 @@ spec:
         resources:
           limits:
             memory: 1000Mi
-          resources:
+          requests:
             memory: 256Mi
 ---

--- a/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
@@ -63,4 +63,6 @@ spec:
         resources:
           limits:
             memory: 1000Mi
+          resources:
+            memory: 256Mi
 ---

--- a/config/monitoring/tracing/zipkin/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin/100-zipkin.yaml
@@ -71,4 +71,6 @@ spec:
         resources:
           limits:
             memory: 1000Mi
+          requests:
+            memory: 256Mi
 ---


### PR DESCRIPTION
/lint

Fixes #4342

## Proposed Changes

* Set a memory request of 256Mi for zipkin.

This lowers the memory necessary to schedule the zipkin pod. In #4342 you will see link to upstream openzipkin issue that give confidence this is a sane number.
