### PR TITLE
Fix typo for k8s object field name for scaling

### DIFF
--- a/docs/scaling/README.md
+++ b/docs/scaling/README.md
@@ -8,7 +8,7 @@ There are cases when Operators need to set lower and upper bounds on the number
 of pods serving their apps (e.g. avoiding cold-start, control compute costs,
 etc).
 
-The following annotations can be used on `spec.template.metadata.annotation`
+The following annotations can be used on `spec.template.metadata.annotations`
 (propagated to `PodAutoscaler` objects) to do exactly that:
 
 ```yaml


### PR DESCRIPTION
`spec.template.metadata.annotation` -> `spec.template.metadata.annotations`

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* The field name `annotation` as in `spec.template.metadata.annotation` must be plural.
