### PR TITLE
Add permissions to the admin default roles

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -1,0 +1,10 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]


### PR DESCRIPTION
Currently even `admin`  in the namespace cannot access to knative
resources.
It is painful especially in the multi tenant cluster, because
cluster-admin always needs to add the permissions to every namespace
admins.

To solve it, this patch introduces `knative-serving-namespaced-admin`
role which has [aggregated clusterroles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) to manipulate
`serving.knative.dev` resources by namespaced admin.

## Proposed Changes

*  Introduce `knative-serving-namespaced-admin` role which has
aggregated clusterroles to manipulate `serving.knative.dev` resources by namespaced admin.

**Release Note**

```release-note
Aggregated clusterrole for namespace admin to manipulate `serving.knative.dev` resources is introduced.
```
