### PR TITLE
Dump cluster state after e2e tests (before scale tests) as well.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,6 +50,9 @@ go_test_e2e -timeout=30m \
   ./test/e2e \
   "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 
+# Dump cluster state after e2e tests to prevent logs being truncated.
+(( failed )) && dump_cluster_state
+
 # Run scale tests.
 go_test_e2e -timeout=10m ./test/scale || failed=1
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The logs get truncated heavily by the scale tests, which makes them unusable to debug e2e tests. This is a stopgap solution only, we should work on something more bulletproof.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
