### PR TITLE
Add session affinity to our spec to avoid updates during Route's Reconcile.

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -61,8 +61,9 @@ func MakeK8sPlaceholderService(ctx context.Context, route *v1alpha1.Route, targe
 		return nil, err
 	}
 	service.Spec = corev1.ServiceSpec{
-		Type:         corev1.ServiceTypeExternalName,
-		ExternalName: fullName,
+		Type:            corev1.ServiceTypeExternalName,
+		ExternalName:    fullName,
+		SessionAffinity: corev1.ServiceAffinityNone,
 	}
 
 	return service, nil
@@ -122,8 +123,9 @@ func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, 
 	switch {
 	case len(balancer.DomainInternal) != 0:
 		return &corev1.ServiceSpec{
-			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: balancer.DomainInternal,
+			Type:            corev1.ServiceTypeExternalName,
+			ExternalName:    balancer.DomainInternal,
+			SessionAffinity: corev1.ServiceAffinityNone,
 		}, nil
 	case len(balancer.Domain) != 0:
 		return &corev1.ServiceSpec{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1927,13 +1927,11 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 						}},
 					},
 				},
-				[]netv1alpha1.IngressTLS{
-					{
-						Hosts:           []string{"becomes-ready.default.example.com"},
-						SecretName:      "route-12-34",
-						SecretNamespace: "default",
-					},
-				},
+				[]netv1alpha1.IngressTLS{{
+					Hosts:           []string{"becomes-ready.default.example.com"},
+					SecretName:      "route-12-34",
+					SecretNamespace: "default",
+				}},
 			),
 			simpleK8sService(
 				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),


### PR DESCRIPTION
Run the service updates in an errgroup to get some amount of parallelism.

I think this might address the flakes we've been seeing in TestRouteCreation, assuming it is the problem I think it is.