### PR TITLE
This changes our handling of the route label in the service controller.

### DIFF
--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -36,6 +36,7 @@ func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, erro
 				*kmeta.NewControllerRef(service),
 			},
 			Labels: resources.UnionMaps(service.GetLabels(), map[string]string{
+				serving.RouteLabelKey:   names.Route(service),
 				serving.ServiceLabelKey: service.Name,
 			}),
 			Annotations: service.GetAnnotations(),

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -45,7 +45,7 @@ func TestRunLatest(t *testing.T) {
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
 
-	if got, want := len(c.Labels), 2; got != want {
+	if got, want := len(c.Labels), 3; got != want {
 		t.Errorf("expected %d labels got %d", want, got)
 	}
 	if got, want := c.Labels[testLabelKey], testLabelValueRunLatest; got != want {
@@ -70,7 +70,7 @@ func TestPinned(t *testing.T) {
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
 
-	if got, want := len(c.Labels), 2; got != want {
+	if got, want := len(c.Labels), 3; got != want {
 		t.Errorf("expected %d labels got %d", want, got)
 	}
 	if got, want := c.Labels[testLabelKey], testLabelValuePinned; got != want {
@@ -95,7 +95,7 @@ func TestRelease(t *testing.T) {
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
 
-	if got, want := len(c.Labels), 2; got != want {
+	if got, want := len(c.Labels), 3; got != want {
 		t.Errorf("expected %d labels got %d", want, got)
 	}
 	if got, want := c.Labels[testLabelKey], testLabelValueRelease; got != want {
@@ -120,7 +120,7 @@ func TestInlineConfigurationSpec(t *testing.T) {
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
 
-	if got, want := len(c.Labels), 1; got != want {
+	if got, want := len(c.Labels), 2; got != want {
 		t.Errorf("expected %d labels got %d", want, got)
 	}
 	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/kmp"
 	"github.com/knative/pkg/logging"
-	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
@@ -291,30 +290,12 @@ func configSemanticEquals(desiredConfig, config *v1alpha1.Configuration) bool {
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Annotations, config.ObjectMeta.Annotations)
 }
 
-// ignoreRouteLabelChange sets desiredConfig[serving.RouteLabelKey] to
-// same as config[serving.RouteLabelKey], so that we do nothing about
-// the configuration label serving.RouteLabelKey in our
-// reconciliation.
-func ignoreRouteLabelChange(desiredConfig, config *v1alpha1.Configuration) {
-	routeLabel, existed := config.ObjectMeta.Labels[serving.RouteLabelKey]
-	if !existed {
-		delete(desiredConfig.ObjectMeta.Labels, serving.RouteLabelKey)
-	} else {
-		desiredConfig.ObjectMeta.Labels[serving.RouteLabelKey] = routeLabel
-	}
-}
-
 func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alpha1.Service, config *v1alpha1.Configuration) (*v1alpha1.Configuration, error) {
 	logger := logging.FromContext(ctx)
 	desiredConfig, err := resources.MakeConfiguration(service)
 	if err != nil {
 		return nil, err
 	}
-	// Route label is automatically set by another reconciler.  We
-	// want to ignore that label in our reconciliation here by setting
-	// desiredConfig[serving.RouteLabelKey] to the same as
-	// config[serving.RouteLabelKey].
-	ignoreRouteLabelChange(desiredConfig, config)
 
 	if configSemanticEquals(desiredConfig, config) {
 		// No differences to reconcile.


### PR DESCRIPTION
We label configurations with routes that reference them, and the service
controller had special logic for ignoring this label.  However, in the
context of service, we always know what route will point to the configuration
so we may as well simply put it there from the start.
