### PR TITLE
Forwarded header

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -276,6 +276,7 @@ func main() {
 	// Create queue handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
 	var composedHandler http.Handler = http.HandlerFunc(handler(reqChan, breaker, httpProxy))
+	composedHandler = queue.ForwardedShimHandler(composedHandler)
 	composedHandler = queue.TimeToFirstByteTimeoutHandler(composedHandler,
 		time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout")
 	composedHandler = pushRequestLogHandler(composedHandler)

--- a/pkg/queue/forwarded_shim.go
+++ b/pkg/queue/forwarded_shim.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ForwardedShimHandler attempts to shim a `forwarded` http header from the information
+// available in the `x-forwarded-*` headers. When available, each node in the `x-forwarded-for`
+// header is combined with the `x-forwarded-proto` and `x-forwarded-host` fields to construct
+// a `forwarded` header. The `x-forwarded-by` header is ignored entirely, since it cannot be
+// reliably combined with `x-forwarded-for`. No-op if a `forwarded` header is already present.
+// Note: IPv6 addresses are *not* supported.
+func ForwardedShimHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// X-Forwarded-For: <client>, <proxy1>, <proxy2>
+		xff := strings.TrimSpace(r.Header.Get(http.CanonicalHeaderKey("x-forwarded-for")))
+		// X-Forwarded-Proto: <protocol>
+		xfp := strings.TrimSpace(r.Header.Get(http.CanonicalHeaderKey("x-forwarded-proto")))
+		// X-Forwarded-Host: <host>
+		xfh := strings.TrimSpace(r.Header.Get(http.CanonicalHeaderKey("x-forwarded-host")))
+
+		// Forwarded: by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>
+		fwd := strings.TrimSpace(r.Header.Get(http.CanonicalHeaderKey("forwarded")))
+
+		// Add a shim if the header is not already present
+		if fwd == "" {
+			// The forwarded header is a list of forwarded elements
+			elements := []string{}
+
+			// The x-forwarded-header consists of multiple nodes
+			nodes := strings.Split(xff, ",")
+
+			// The first element has a 'for', 'proto' and 'host' pair, as available
+			pairs := []string{}
+
+			if len(nodes) > 0 && nodes[0] != "" {
+				pairs = append(pairs, "for="+strings.TrimSpace(nodes[0]))
+			}
+			if xfh != "" {
+				pairs = append(pairs, "host="+xfh)
+			}
+			if xfp != "" {
+				pairs = append(pairs, "proto="+xfp)
+			}
+
+			// The pairs are joined with a semi-colon (;) into a single element
+			elements = append(elements, strings.Join(pairs, ";"))
+
+			// Each subsequent x-forwarded-for node gets its own pair element
+			for _, node := range nodes[1:] {
+				elements = append(elements, "for="+strings.TrimSpace(node))
+			}
+
+			// The elements are joined with a comma (,) to form the header
+			fwd = strings.Join(elements, ", ")
+
+			// Only add the forwarded header if we were able to construct one
+			if fwd != "" {
+				r.Header.Set(http.CanonicalHeaderKey("forwarded"), fwd)
+			}
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/pkg/queue/forwarded_shim.go
+++ b/pkg/queue/forwarded_shim.go
@@ -52,13 +52,13 @@ func ForwardedShimHandler(h http.Handler) http.Handler {
 		nodes := strings.Split(xff, ",")
 
 		// Sanitize nodes
-		// * remove extra whitespace
-		// * convert IPv6 address to "[ipv6 addr]" format
 		for i, node := range nodes {
+			// Remove extra whitespace
 			node = strings.TrimSpace(node)
 
-			// For simplicity, and address is IPv6 if there's a ':'
+			// For simplicity, an address is IPv6 it contains a colon (:)
 			if strings.Contains(node, ":") {
+				// Convert IPv6 address to "[ipv6 addr]" format
 				node = fmt.Sprintf("\"[%s]\"", node)
 			}
 
@@ -68,8 +68,8 @@ func ForwardedShimHandler(h http.Handler) http.Handler {
 		// The first element has a 'for', 'proto' and 'host' pair, as available
 		pairs := []string{}
 
-		if len(nodes) > 0 && nodes[0] != "" {
-			pairs = append(pairs, "for="+strings.TrimSpace(nodes[0]))
+		if xff != "" {
+			pairs = append(pairs, "for="+nodes[0])
 		}
 		if xfh != "" {
 			pairs = append(pairs, "host="+xfh)
@@ -83,7 +83,7 @@ func ForwardedShimHandler(h http.Handler) http.Handler {
 
 		// Each subsequent x-forwarded-for node gets its own pair element
 		for _, node := range nodes[1:] {
-			elements = append(elements, "for="+strings.TrimSpace(node))
+			elements = append(elements, "for="+node)
 		}
 
 		// The elements are joined with a comma (,) to form the header

--- a/pkg/queue/forwarded_shim_test.go
+++ b/pkg/queue/forwarded_shim_test.go
@@ -75,6 +75,8 @@ func TestForwardedShimHandler(t *testing.T) {
 		xfp:  "p",
 		fwd:  "for=a, for=b",
 		want: "for=a, for=b",
+	}, {
+		name: "no xf* headers",
 	}}
 
 	for _, test := range tests {

--- a/pkg/queue/forwarded_shim_test.go
+++ b/pkg/queue/forwarded_shim_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package queue
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestForwardedShimHandler(t *testing.T) {
+	tests := []struct {
+		name string
+		xff  string
+		xfh  string
+		xfp  string
+		fwd  string
+		want string
+	}{{
+		name: "multiple xff",
+		xff:  "n1, n2",
+		xfh:  "h",
+		xfp:  "p",
+		want: "for=n1;host=h;proto=p, for=n2",
+	}, {
+		name: "single xff",
+		xff:  "n1",
+		xfh:  "h",
+		xfp:  "p",
+		want: "for=n1;host=h;proto=p",
+	}, {
+		name: "multiple xff, no xfh, no xfp",
+		xff:  "n1, n2",
+		want: "for=n1, for=n2",
+	}, {
+		name: "multiple xff, no xfh",
+		xff:  "n1, n2",
+		xfp:  "p",
+		want: "for=n1;proto=p, for=n2",
+	}, {
+		name: "multiple xff, no xfp",
+		xff:  "n1, n2",
+		xfh:  "h",
+		want: "for=n1;host=h, for=n2",
+	}, {
+		name: "only xfh",
+		xfh:  "h",
+		want: "host=h",
+	}, {
+		name: "only xfp",
+		xfp:  "p",
+		want: "proto=p",
+	}, {
+		name: "only xfp and xfh",
+		xfh:  "h",
+		xfp:  "p",
+		want: "host=h;proto=p",
+	}, {
+		name: "existing fwd",
+		xff:  "n1, n2",
+		xfh:  "h",
+		xfp:  "p",
+		fwd:  "for=a, for=b",
+		want: "for=a, for=b",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ""
+
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.xff != "" {
+				req.Header.Set(http.CanonicalHeaderKey("x-forwarded-for"), test.xff)
+			}
+			if test.xfh != "" {
+				req.Header.Set(http.CanonicalHeaderKey("x-forwarded-host"), test.xfh)
+			}
+			if test.xfp != "" {
+				req.Header.Set(http.CanonicalHeaderKey("x-forwarded-proto"), test.xfp)
+			}
+			if test.fwd != "" {
+				req.Header.Set(http.CanonicalHeaderKey("forwarded"), test.fwd)
+			}
+
+			resp := httptest.NewRecorder()
+
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = req.Header.Get(http.CanonicalHeaderKey("forwarded"))
+			})
+
+			ForwardedShimHandler(h).ServeHTTP(resp, req)
+
+			if test.want != got {
+				t.Errorf("Wrong header value. Want %q, got %q", test.want, got)
+			}
+		})
+	}
+}

--- a/pkg/queue/forwarded_shim_test.go
+++ b/pkg/queue/forwarded_shim_test.go
@@ -31,30 +31,30 @@ func TestForwardedShimHandler(t *testing.T) {
 		want string
 	}{{
 		name: "multiple xff",
-		xff:  "n1, n2",
+		xff:  "127.0.0.1, ::1",
 		xfh:  "h",
 		xfp:  "p",
-		want: "for=n1;host=h;proto=p, for=n2",
+		want: "for=127.0.0.1;host=h;proto=p, for=\"[::1]\"",
 	}, {
 		name: "single xff",
-		xff:  "n1",
+		xff:  "127.0.0.1",
 		xfh:  "h",
 		xfp:  "p",
-		want: "for=n1;host=h;proto=p",
+		want: "for=127.0.0.1;host=h;proto=p",
 	}, {
 		name: "multiple xff, no xfh, no xfp",
-		xff:  "n1, n2",
-		want: "for=n1, for=n2",
+		xff:  "127.0.0.1, ::1",
+		want: "for=127.0.0.1, for=\"[::1]\"",
 	}, {
 		name: "multiple xff, no xfh",
-		xff:  "n1, n2",
+		xff:  "127.0.0.1, ::1",
 		xfp:  "p",
-		want: "for=n1;proto=p, for=n2",
+		want: "for=127.0.0.1;proto=p, for=\"[::1]\"",
 	}, {
 		name: "multiple xff, no xfp",
-		xff:  "n1, n2",
+		xff:  "127.0.0.1, ::1",
 		xfh:  "h",
-		want: "for=n1;host=h, for=n2",
+		want: "for=127.0.0.1;host=h, for=\"[::1]\"",
 	}, {
 		name: "only xfh",
 		xfh:  "h",
@@ -70,7 +70,7 @@ func TestForwardedShimHandler(t *testing.T) {
 		want: "host=h;proto=p",
 	}, {
 		name: "existing fwd",
-		xff:  "n1, n2",
+		xff:  "127.0.0.1, ::1",
 		xfh:  "h",
 		xfp:  "p",
 		fwd:  "for=a, for=b",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3112

## Proposed Changes

Add a `ForwardedShimHandler` to the queue-proxy chain, which constructs a `forwarded` http header from the information available in the `x-forwarded-*` headers. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The `forwarded` header will be set on requests based on the information in the `x-forwarded-for`, `x-forwarded-host` and `x-forwarded-proto` headers. If the request already has a `forwarded` header set, it will be used instead. 
```
