### PR TITLE
Make a small adjustment to hack/update-deps.sh

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -591,7 +591,8 @@
   revision = "b6c8f4851e3fb13987782cf8014316141e42fbd3"
 
 [[projects]]
-  digest = "1:1e922ce4df30a162ca548f7b01256c4da474c0eef668f4ee1b382beab493eda9"
+  branch = "master"
+  digest = "1:a3cabcef7cdb39039c0e37353e1d1ac257f4fa926176494ca4bae3f616c3e820"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -680,7 +681,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "463df98531b3b7a9055d062012851c3d0f5583a1"
+  revision = "139b81e637e39b1d7c1763e793e13b364f2dd26a"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,8 +20,7 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2919-06-07
-  revision = "463df98531b3b7a9055d062012851c3d0f5583a1"
+  branch = "master"
 
 [[override]]
   name = "go.uber.org/zap"

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure
@@ -30,7 +31,7 @@ sed -n '11,41p' vendor/bitbucket.org/ww/goautoneg/README.txt > vendor/bitbucket.
 
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')
-rm -fr vendor/github.com/knative/test-infra/devstats
+rm -rf vendor/github.com/knative/test-infra/devstats
 
 update_licenses third_party/VENDOR-LICENSE "./cmd/*"
 remove_broken_symlinks ./vendor

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/breaking-change.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/breaking-change.md
@@ -1,0 +1,22 @@
+---
+name: Breaking Change
+about: Makes a breaking change to knative/pkg
+title: ''
+labels: 
+assignees: 'mattmoor'
+
+---
+
+BREAKING CHANGES MUST STAGE CHANGES ONTO DOWNSTREAM
+KNATIVE REPOSITORIES
+
+
+| Repo              | Pull Request                   |
+|-------------------|--------------------------------|
+| Build             | knative/build#1234             |
+| Eventing          | knative/eventing#1234          |
+| Serving           | knative/serving#1234           |
+| Sample Controller | knative/sample-controller#1234 |
+
+
+cc @n3wscott @jasonhall

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
@@ -1,0 +1,10 @@
+---
+name: Bug Fix
+about: Fixes a bug in knative/pkg
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+Fixes:

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/normal-change.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/normal-change.md
@@ -1,0 +1,8 @@
+---
+name: Normal Change
+about: Makes a boring change to the repo.
+title: ''
+labels: 
+assignees: ''
+
+---

--- a/vendor/github.com/knative/pkg/.github/pull-request-template.md
+++ b/vendor/github.com/knative/pkg/.github/pull-request-template.md
@@ -1,6 +1,0 @@
-<!--
-Pro-tip: To automatically close issues when a PR is merged,
-include the following in your PR description:
-
-Fixes: <LINK TO ISSUE>
--->

--- a/vendor/github.com/knative/pkg/Gopkg.lock
+++ b/vendor/github.com/knative/pkg/Gopkg.lock
@@ -781,6 +781,27 @@
   version = "kubernetes-1.12.6"
 
 [[projects]]
+  digest = "1:6def8acd040e85b3becb1dd73de1f22a787fd9776e32aa3bbac9cf9727b53d0d"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = [
+    "pkg/apis/apiextensions",
+    "pkg/apis/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset",
+    "pkg/client/clientset/clientset/fake",
+    "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
+    "pkg/client/informers/externalversions",
+    "pkg/client/informers/externalversions/apiextensions",
+    "pkg/client/informers/externalversions/apiextensions/v1beta1",
+    "pkg/client/informers/externalversions/internalinterfaces",
+    "pkg/client/listers/apiextensions/v1beta1",
+  ]
+  pruneopts = "NUT"
+  revision = "bd0469a053ff88529a61145790499fe78a09a49d"
+  version = "kubernetes-1.12.6"
+
+[[projects]]
   digest = "1:119ae04ee44c5d179dcde1ee686f057cfe3fc54a7ee8484b920932a80309e88b"
   name = "k8s.io/apimachinery"
   packages = [
@@ -836,7 +857,7 @@
   version = "kubernetes-1.12.6"
 
 [[projects]]
-  digest = "1:07be043078c2dc2ee33e81278b264a84f364c6d711811d2932aa42212fc4f2ae"
+  digest = "1:b7dd0420e85cb2968ffb945f2810ea6c796dc2a08660618e2200c08c596f0624"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -984,11 +1005,9 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
-    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
     "testing",
-    "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
     "tools/clientcmd",
@@ -1006,7 +1025,6 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/jsonpath",
     "util/retry",
     "util/workqueue",
   ]
@@ -1121,6 +1139,10 @@
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
+    "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions",
+    "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
@@ -1149,12 +1171,13 @@
     "k8s.io/client-go/informers/apps/v1",
     "k8s.io/client-go/informers/autoscaling/v1",
     "k8s.io/client-go/informers/autoscaling/v2beta1",
+    "k8s.io/client-go/informers/batch/v1",
     "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/informers/rbac/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",

--- a/vendor/github.com/knative/pkg/Gopkg.toml
+++ b/vendor/github.com/knative/pkg/Gopkg.toml
@@ -18,6 +18,10 @@ required = [
   name = "k8s.io/api"
   version = "kubernetes-1.12.6"
 
+[[override]]
+  name = "k8s.io/apiextensions-apiserver"
+  version = "kubernetes-1.12.6"
+
 [[constraint]]
   name = "k8s.io/apimachinery"
   version = "kubernetes-1.12.6"

--- a/vendor/github.com/knative/pkg/hack/update-deps.sh
+++ b/vendor/github.com/knative/pkg/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure

--- a/vendor/github.com/knative/pkg/injection/clients/apiextclient/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/clients/apiextclient/fake/fake.go
@@ -19,12 +19,12 @@ package fake
 import (
 	"context"
 
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/clients/kubeclient"
+	"github.com/knative/pkg/injection/clients/apiextclient"
 	"github.com/knative/pkg/logging"
 )
 
@@ -39,12 +39,12 @@ func withClient(ctx context.Context, cfg *rest.Config) context.Context {
 
 func With(ctx context.Context, objects ...runtime.Object) (context.Context, *fake.Clientset) {
 	cs := fake.NewSimpleClientset(objects...)
-	return context.WithValue(ctx, kubeclient.Key{}, cs), cs
+	return context.WithValue(ctx, apiextclient.Key{}, cs), cs
 }
 
-// Get extracts the Kubernetes client from the context.
+// Get extracts the Kubernetes Api Extensions client from the context.
 func Get(ctx context.Context) *fake.Clientset {
-	untyped := ctx.Value(kubeclient.Key{})
+	untyped := ctx.Value(apiextclient.Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
 			"Unable to fetch %T from context.", (*fake.Clientset)(nil))

--- a/vendor/github.com/knative/pkg/injection/clients/dynamicclient/dynamicclient.go
+++ b/vendor/github.com/knative/pkg/injection/clients/dynamicclient/dynamicclient.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -41,7 +42,8 @@ func withClient(ctx context.Context, cfg *rest.Config) context.Context {
 func Get(ctx context.Context) dynamic.Interface {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (dynamic.Interface)(nil))
 	}
 	return untyped.(dynamic.Interface)
 }

--- a/vendor/github.com/knative/pkg/injection/clients/dynamicclient/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/clients/dynamicclient/fake/fake.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/clients/dynamicclient"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -45,7 +46,8 @@ func With(ctx context.Context, scheme *runtime.Scheme, objects ...runtime.Object
 func Get(ctx context.Context) *fake.FakeDynamicClient {
 	untyped := ctx.Value(dynamicclient.Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (*fake.FakeDynamicClient)(nil))
 	}
 	return untyped.(*fake.FakeDynamicClient)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/apiextinformers/apiextensionsv1beta1/crd/crd.go
+++ b/vendor/github.com/knative/pkg/injection/informers/apiextinformers/apiextensionsv1beta1/crd/crd.go
@@ -14,36 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeclient
+package crd
 
 import (
 	"context"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
 
+	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/apiextinformers/factory"
 	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterClient(withClient)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withClient(ctx context.Context, cfg *rest.Config) context.Context {
-	return context.WithValue(ctx, Key{}, kubernetes.NewForConfigOrDie(cfg))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Apiextensions().V1beta1().CustomResourceDefinitions()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes client from the context.
-func Get(ctx context.Context) kubernetes.Interface {
+// Get extracts the Kubernetes Deployment informer from the context.
+func Get(ctx context.Context) apiextv1beta1.CustomResourceDefinitionInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (kubernetes.Interface)(nil))
+			"Unable to fetch %T from context.", (apiextv1beta1.CustomResourceDefinitionInformer)(nil))
 	}
-	return untyped.(kubernetes.Interface)
+	return untyped.(apiextv1beta1.CustomResourceDefinitionInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/apiextinformers/apiextensionsv1beta1/crd/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/apiextinformers/apiextensionsv1beta1/crd/fake/fake.go
@@ -14,39 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package secret
+package fake
 
 import (
 	"context"
 
-	corev1 "k8s.io/client-go/informers/core/v1"
-
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/informers/apiextinformers/apiextensionsv1beta1/crd"
+	"github.com/knative/pkg/injection/informers/apiextinformers/factory/fake"
 )
 
-func init() {
-	injection.Default.RegisterInformer(withInformer)
-}
+var Get = crd.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
-	f := factory.Get(ctx)
-	inf := f.Core().V1().Secrets()
-	return context.WithValue(ctx, Key{}, inf), inf.Informer()
-}
-
-// Get extracts the Kubernetes Secret informer from the context.
-func Get(ctx context.Context) corev1.SecretInformer {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (corev1.SecretInformer)(nil))
-	}
-	return untyped.(corev1.SecretInformer)
+	f := fake.Get(ctx)
+	inf := f.Apiextensions().V1beta1().CustomResourceDefinitions()
+	return context.WithValue(ctx, crd.Key{}, inf), inf.Informer()
 }

--- a/vendor/github.com/knative/pkg/injection/informers/apiextinformers/factory/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/apiextinformers/factory/fake/fake.go
@@ -14,39 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package fake
 
 import (
 	"context"
 
-	"k8s.io/client-go/informers"
+	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/clients/kubeclient"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/clients/apiextclient/fake"
+	"github.com/knative/pkg/injection/informers/apiextinformers/factory"
 )
 
-func init() {
-	injection.Default.RegisterInformerFactory(withInformerFactory)
-}
+var Get = factory.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformerFactory(withInformerFactory)
+}
 
 func withInformerFactory(ctx context.Context) context.Context {
-	kc := kubeclient.Get(ctx)
-	return context.WithValue(ctx, Key{},
+	kc := fake.Get(ctx)
+	return context.WithValue(ctx, factory.Key{},
 		informers.NewSharedInformerFactory(kc, controller.GetResyncPeriod(ctx)))
-}
-
-// Get extracts the Kubernetes InformerFactory from the context.
-func Get(ctx context.Context) informers.SharedInformerFactory {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (informers.SharedInformerFactory)(nil))
-	}
-	return untyped.(informers.SharedInformerFactory)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/appsv1/deployment/deployment.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/appsv1/deployment/deployment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -44,7 +45,8 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 func Get(ctx context.Context) appsv1.DeploymentInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (appsv1.DeploymentInformer)(nil))
 	}
 	return untyped.(appsv1.DeploymentInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/autoscalingv1/hpa/hpa.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/autoscalingv1/hpa/hpa.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -44,7 +45,8 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 func Get(ctx context.Context) autoscalingv1.HorizontalPodAutoscalerInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (autoscalingv1.HorizontalPodAutoscalerInformer)(nil))
 	}
 	return untyped.(autoscalingv1.HorizontalPodAutoscalerInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/autoscalingv2beta1/hpa/hpa.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/autoscalingv2beta1/hpa/hpa.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -44,7 +45,8 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 func Get(ctx context.Context) autoscalingv2beta1.HorizontalPodAutoscalerInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (autoscalingv2beta1.HorizontalPodAutoscalerInformer)(nil))
 	}
 	return untyped.(autoscalingv2beta1.HorizontalPodAutoscalerInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/fake/fake.go
@@ -14,39 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package secret
+package fake
 
 import (
 	"context"
 
-	corev1 "k8s.io/client-go/informers/core/v1"
-
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
 )
 
-func init() {
-	injection.Default.RegisterInformer(withInformer)
-}
+var Get = job.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
-	f := factory.Get(ctx)
-	inf := f.Core().V1().Secrets()
-	return context.WithValue(ctx, Key{}, inf), inf.Informer()
-}
-
-// Get extracts the Kubernetes Secret informer from the context.
-func Get(ctx context.Context) corev1.SecretInformer {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (corev1.SecretInformer)(nil))
-	}
-	return untyped.(corev1.SecretInformer)
+	f := fake.Get(ctx)
+	inf := f.Batch().V1().Jobs()
+	return context.WithValue(ctx, job.Key{}, inf), inf.Informer()
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/configmap/configmap.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/configmap/configmap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -44,7 +45,8 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 func Get(ctx context.Context) corev1.ConfigMapInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (corev1.ConfigMapInformer)(nil))
 	}
 	return untyped.(corev1.ConfigMapInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/endpoints/endpoints.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/endpoints/endpoints.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -44,7 +45,8 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 func Get(ctx context.Context) corev1.EndpointsInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (corev1.EndpointsInformer)(nil))
 	}
 	return untyped.(corev1.EndpointsInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace/fake/fake.go
@@ -14,39 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package secret
+package fake
 
 import (
 	"context"
 
-	corev1 "k8s.io/client-go/informers/core/v1"
-
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
 )
 
-func init() {
-	injection.Default.RegisterInformer(withInformer)
-}
+var Get = namespace.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
-	f := factory.Get(ctx)
-	inf := f.Core().V1().Secrets()
-	return context.WithValue(ctx, Key{}, inf), inf.Informer()
-}
-
-// Get extracts the Kubernetes Secret informer from the context.
-func Get(ctx context.Context) corev1.SecretInformer {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (corev1.SecretInformer)(nil))
-	}
-	return untyped.(corev1.SecretInformer)
+	f := fake.Get(ctx)
+	inf := f.Core().V1().Namespaces()
+	return context.WithValue(ctx, namespace.Key{}, inf), inf.Informer()
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/pod/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/pod/fake/fake.go
@@ -14,39 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package secret
+package fake
 
 import (
 	"context"
 
-	corev1 "k8s.io/client-go/informers/core/v1"
-
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/informers/kubeinformers/corev1/pod"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
 )
 
-func init() {
-	injection.Default.RegisterInformer(withInformer)
-}
+var Get = pod.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
-	f := factory.Get(ctx)
-	inf := f.Core().V1().Secrets()
-	return context.WithValue(ctx, Key{}, inf), inf.Informer()
-}
-
-// Get extracts the Kubernetes Secret informer from the context.
-func Get(ctx context.Context) corev1.SecretInformer {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (corev1.SecretInformer)(nil))
-	}
-	return untyped.(corev1.SecretInformer)
+	f := fake.Get(ctx)
+	inf := f.Core().V1().Pods()
+	return context.WithValue(ctx, pod.Key{}, inf), inf.Informer()
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/pod/pod.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/pod/pod.go
@@ -14,36 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeclient
+package pod
 
 import (
 	"context"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	corev1 "k8s.io/client-go/informers/core/v1"
 
+	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
 	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterClient(withClient)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withClient(ctx context.Context, cfg *rest.Config) context.Context {
-	return context.WithValue(ctx, Key{}, kubernetes.NewForConfigOrDie(cfg))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Core().V1().Pods()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes client from the context.
-func Get(ctx context.Context) kubernetes.Interface {
+// Get extracts the Kubernetes Pod informer from the context.
+func Get(ctx context.Context) corev1.PodInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (kubernetes.Interface)(nil))
+			"Unable to fetch %T from context.", (corev1.PodInformer)(nil))
 	}
-	return untyped.(kubernetes.Interface)
+	return untyped.(corev1.PodInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/service/service.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/service/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
@@ -44,7 +45,8 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 func Get(ctx context.Context) corev1.ServiceInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		return nil
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (corev1.ServiceInformer)(nil))
 	}
 	return untyped.(corev1.ServiceInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/fake/fake.go
@@ -14,39 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package secret
+package fake
 
 import (
 	"context"
 
-	corev1 "k8s.io/client-go/informers/core/v1"
-
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
 )
 
-func init() {
-	injection.Default.RegisterInformer(withInformer)
-}
+var Get = serviceaccount.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
-	f := factory.Get(ctx)
-	inf := f.Core().V1().Secrets()
-	return context.WithValue(ctx, Key{}, inf), inf.Informer()
-}
-
-// Get extracts the Kubernetes Secret informer from the context.
-func Get(ctx context.Context) corev1.SecretInformer {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (corev1.SecretInformer)(nil))
-	}
-	return untyped.(corev1.SecretInformer)
+	f := fake.Get(ctx)
+	inf := f.Core().V1().ServiceAccounts()
+	return context.WithValue(ctx, serviceaccount.Key{}, inf), inf.Informer()
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/service.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/service.go
@@ -14,36 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeclient
+package serviceaccount
 
 import (
 	"context"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	corev1 "k8s.io/client-go/informers/core/v1"
 
+	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
 	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterClient(withClient)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withClient(ctx context.Context, cfg *rest.Config) context.Context {
-	return context.WithValue(ctx, Key{}, kubernetes.NewForConfigOrDie(cfg))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Core().V1().ServiceAccounts()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes client from the context.
-func Get(ctx context.Context) kubernetes.Interface {
+// Get extracts the Kubernetes Service Account informer from the context.
+func Get(ctx context.Context) corev1.ServiceAccountInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (kubernetes.Interface)(nil))
+			"Unable to fetch %T from context.", (corev1.ServiceAccountInformer)(nil))
 	}
-	return untyped.(kubernetes.Interface)
+	return untyped.(corev1.ServiceAccountInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding/fake/fake.go
@@ -14,39 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package secret
+package fake
 
 import (
 	"context"
 
-	corev1 "k8s.io/client-go/informers/core/v1"
-
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+	"github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding"
 )
 
-func init() {
-	injection.Default.RegisterInformer(withInformer)
-}
+var Get = rolebinding.Get
 
-// Key is used as the key for associating information
-// with a context.Context.
-type Key struct{}
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
-	f := factory.Get(ctx)
-	inf := f.Core().V1().Secrets()
-	return context.WithValue(ctx, Key{}, inf), inf.Informer()
-}
-
-// Get extracts the Kubernetes Secret informer from the context.
-func Get(ctx context.Context) corev1.SecretInformer {
-	untyped := ctx.Value(Key{})
-	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (corev1.SecretInformer)(nil))
-	}
-	return untyped.(corev1.SecretInformer)
+	f := fake.Get(ctx)
+	inf := f.Rbac().V1().RoleBindings()
+	return context.WithValue(ctx, rolebinding.Key{}, inf), inf.Informer()
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding/rolebinding.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding/rolebinding.go
@@ -14,36 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeclient
+package rolebinding
 
 import (
 	"context"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	rbacv1 "k8s.io/client-go/informers/rbac/v1"
 
+	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
 	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterClient(withClient)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withClient(ctx context.Context, cfg *rest.Config) context.Context {
-	return context.WithValue(ctx, Key{}, kubernetes.NewForConfigOrDie(cfg))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Rbac().V1().RoleBindings()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes client from the context.
-func Get(ctx context.Context) kubernetes.Interface {
+// Get extracts the Kubernetes Role Binding informer from the context.
+func Get(ctx context.Context) rbacv1.RoleBindingInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (kubernetes.Interface)(nil))
+			"Unable to fetch %T from context.", (rbacv1.RoleBindingInformer)(nil))
 	}
-	return untyped.(kubernetes.Interface)
+	return untyped.(rbacv1.RoleBindingInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/sharedmain/main.go
+++ b/vendor/github.com/knative/pkg/injection/sharedmain/main.go
@@ -24,9 +24,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"


### PR DESCRIPTION
This form should be more hospitable to running things to auto-update `knative/pkg` and `knative/test-infra`.

I canaried this change in `knative/sample-controller`, and was able to produce: https://github.com/knative/sample-controller/pull/11
