### PR TITLE
Properly setup system.Namespace for e2e tests.

### DIFF
--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"testing"
 
-	_ "github.com/knative/pkg/system/testing"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/test"
 	v1a1test "github.com/knative/serving/test/v1alpha1"

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -28,7 +28,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	_ "github.com/knative/pkg/system/testing"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/test"
 	v1a1test "github.com/knative/serving/test/v1alpha1"

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"testing"
 
-	_ "github.com/knative/pkg/system/testing"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/test"

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -28,7 +28,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	_ "github.com/knative/pkg/system/testing"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/test"
 	v1b1test "github.com/knative/serving/test/v1beta1"

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/knative/pkg/system/testing"
 	pkgTest "github.com/knative/pkg/test"
 	resourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"

--- a/test/system.go
+++ b/test/system.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+
+	"github.com/knative/pkg/system"
+)
+
+func init() {
+	os.Setenv(system.NamespaceEnvKey, "knative-system")
+}

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -21,7 +21,6 @@ package upgrade
 import (
 	"testing"
 
-	_ "github.com/knative/pkg/system/testing"
 	ptest "github.com/knative/pkg/test"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
 	"github.com/knative/serving/test"

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -21,7 +21,6 @@ package upgrade
 import (
 	"testing"
 
-	_ "github.com/knative/pkg/system/testing"
 	revisionresourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/e2e"


### PR DESCRIPTION
Our e2e tests shouldn't be linking `github.com/knative/pkg/system/testing`, which
configures `system.Namespace()` to return `knative-testing`.  Instead, set up the
correct namespace.

This is a precursor to using `system.Namespace()` to determine where our system
components are running to stream relevant log data back to the test log output.