### PR TITLE
Remove the test that is no longer necessary

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1235,18 +1235,6 @@ func TestScaleFailure(t *testing.T) {
 	}
 }
 
-func TestBadKey(t *testing.T) {
-	defer logtesting.ClearAll()
-	ctx, _ := SetupFakeContext(t)
-
-	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders(), newTestMetrics(), presources.NewPodScalableInformerFactory(ctx))
-
-	err := ctl.Reconciler.Reconcile(context.Background(), "too/many/parts")
-	if err != nil {
-		t.Errorf("Reconcile() = %v", err)
-	}
-}
-
 func pollDeciders(deciders *testDeciders, namespace, name string, cond func(*autoscaler.Decider) bool) (decider *autoscaler.Decider, err error) {
 	wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
 		decider, err = deciders.Get(context.Background(), namespace, name)


### PR DESCRIPTION
Since it is already part of the table test, which is, by the way,
much more elaborate anyway.

/assign @mattmoor @markusthoemmes 