### PR TITLE
Enable HPA /metric=concurrency.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -117,9 +117,10 @@ func main() {
 	// uniScalerFactory depends endpointsInformer to be set.
 	multiScaler := autoscaler.NewMultiScaler(ctx.Done(), uniScalerFactoryFunc(endpointsInformer, collector), logger)
 
+	psInformerFactory := resources.NewPodScalableInformerFactory(ctx)
 	controllers := []*controller.Impl{
-		kpa.NewController(ctx, cmw, multiScaler, collector, resources.NewPodScalableInformerFactory(ctx)),
-		hpa.NewController(ctx, cmw),
+		kpa.NewController(ctx, cmw, multiScaler, collector, psInformerFactory),
+		hpa.NewController(ctx, cmw, collector, psInformerFactory),
 	}
 
 	// Set up a statserver.

--- a/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
@@ -23,6 +23,17 @@ import (
 	"github.com/knative/serving/pkg/apis/autoscaling"
 )
 
+func defaultMetric(class string) string {
+	switch class {
+	case autoscaling.KPA:
+		return autoscaling.Concurrency
+	case autoscaling.HPA:
+		return autoscaling.CPU
+	default:
+		return ""
+	}
+}
+
 func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
 	if r.Annotations == nil {
@@ -33,15 +44,8 @@ func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
 		r.Annotations[autoscaling.ClassAnnotationKey] = autoscaling.KPA
 	}
 	// Default metric per class
-	switch r.Class() {
-	case autoscaling.KPA:
-		if _, ok := r.Annotations[autoscaling.MetricAnnotationKey]; !ok {
-			r.Annotations[autoscaling.MetricAnnotationKey] = autoscaling.Concurrency
-		}
-	case autoscaling.HPA:
-		if _, ok := r.Annotations[autoscaling.MetricAnnotationKey]; !ok {
-			r.Annotations[autoscaling.MetricAnnotationKey] = autoscaling.CPU
-		}
+	if _, ok := r.Annotations[autoscaling.MetricAnnotationKey]; !ok {
+		r.Annotations[autoscaling.MetricAnnotationKey] = defaultMetric(r.Class())
 	}
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -49,7 +49,7 @@ func (pa *PodAutoscaler) Metric() string {
 	if m, ok := pa.Annotations[autoscaling.MetricAnnotationKey]; ok {
 		return m
 	}
-	// TODO: defaulting here is awkward and is already taken care off by defaulting logic.
+	// TODO: defaulting here is awkward and is already taken care of by defaulting logic.
 	return defaultMetric(pa.Class())
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -44,6 +44,15 @@ func (pa *PodAutoscaler) Class() string {
 	return autoscaling.KPA
 }
 
+// Metric returns the contents of the metric annotation or a default.
+func (pa *PodAutoscaler) Metric() string {
+	if m, ok := pa.Annotations[autoscaling.MetricAnnotationKey]; ok {
+		return m
+	}
+	// TODO: defaulting here is awkward and is already taken care off by defaulting logic.
+	return defaultMetric(pa.Class())
+}
+
 func (pa *PodAutoscaler) annotationInt32(key string) int32 {
 	if s, ok := pa.Annotations[key]; ok {
 		// no error check: relying on validation

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -557,6 +557,47 @@ func TestClass(t *testing.T) {
 	}
 }
 
+func TestMetric(t *testing.T) {
+	cases := []struct {
+		name string
+		pa   *PodAutoscaler
+		want string
+	}{{
+		name: "default class, annotation set",
+		pa: pa(map[string]string{
+			autoscaling.MetricAnnotationKey: autoscaling.Concurrency,
+		}),
+		want: autoscaling.Concurrency,
+	}, {
+		name: "hpa class",
+		pa: pa(map[string]string{
+			autoscaling.ClassAnnotationKey: autoscaling.HPA,
+		}),
+		want: autoscaling.CPU,
+	}, {
+		name: "kpa class",
+		pa: pa(map[string]string{
+			autoscaling.ClassAnnotationKey: autoscaling.KPA,
+		}),
+		want: autoscaling.Concurrency,
+	}, {
+		name: "custom class",
+		pa: pa(map[string]string{
+			autoscaling.ClassAnnotationKey: "yolo.sandwich.com",
+		}),
+		want: "",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.pa.Metric()
+			if got != tc.want {
+				t.Errorf("Metric() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWindowAnnotation(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -62,7 +62,7 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 			}
 		case autoscaling.HPA:
 			switch metric {
-			case autoscaling.CPU:
+			case autoscaling.CPU, autoscaling.Concurrency:
 				return nil
 			}
 			// TODO: implement OPS autoscaling.

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -28,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	areconciler "github.com/knative/serving/pkg/reconciler/autoscaling"
+	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/hpa/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -60,7 +61,13 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := c.PALister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		logger.Debug("PA no longer exists")
-		return c.deleteHPA(ctx, key)
+		if err := c.Metrics.Delete(ctx, namespace, name); err != nil {
+			return err
+		}
+		if err := c.deleteHPA(ctx, key); err != nil {
+			return err
+		}
+		return nil
 	} else if err != nil {
 		return err
 	}
@@ -112,7 +119,7 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 	pa.Status.MarkActive()
 
 	// HPA-class PA delegates autoscaling to the Kubernetes Horizontal Pod Autoscaler.
-	desiredHpa := resources.MakeHPA(pa)
+	desiredHpa := resources.MakeHPA(pa, config.FromContext(ctx).Autoscaler)
 	hpa, err := c.hpaLister.HorizontalPodAutoscalers(pa.Namespace).Get(desiredHpa.Name)
 	if errors.IsNotFound(err) {
 		logger.Infof("Creating HPA %q", desiredHpa.Name)
@@ -134,6 +141,18 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 		if _, err := c.KubeClientSet.AutoscalingV2beta1().HorizontalPodAutoscalers(pa.Namespace).Update(desiredHpa); err != nil {
 			logger.Errorf("Error updating HPA %q: %v", desiredHpa.Name, err)
 			return err
+		}
+	}
+
+	// Only create metrics service and metric entity if we actually need to gather metrics.
+	if pa.Metric() == autoscaling.Concurrency {
+		metricSvc, err := c.ReconcileMetricsService(ctx, pa)
+		if err != nil {
+			return perrors.Wrap(err, "error reconciling metrics service")
+		}
+
+		if err := c.ReconcileMetric(ctx, pa, metricSvc); err != nil {
+			return perrors.Wrap(err, "error reconciling metric")
 		}
 	}
 

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -23,6 +23,7 @@ import (
 	// Inject our fake informers
 	fakekubeclient "github.com/knative/pkg/injection/clients/kubeclient/fake"
 	_ "github.com/knative/pkg/injection/informers/kubeinformers/autoscalingv2beta1/hpa/fake"
+	_ "github.com/knative/pkg/injection/informers/kubeinformers/corev1/service/fake"
 	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
 	fakekpainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
 	_ "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice/fake"
@@ -31,6 +32,8 @@ import (
 	"github.com/knative/pkg/controller"
 	logtesting "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/system"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	asv1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	autoscalingv1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -40,9 +43,12 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/hpa/resources"
 	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
+	presources "github.com/knative/serving/pkg/resources"
+	"go.uber.org/atomic"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,13 +66,17 @@ const (
 
 func TestControllerCanReconcile(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
+
+	psFactory := presources.NewPodScalableInformerFactory(ctx)
+	metrics := newTestMetrics()
+
 	ctl := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
 			Name:      autoscaler.ConfigName,
 		},
 		Data: map[string]string{},
-	}))
+	}), metrics, psFactory)
 
 	podAutoscaler := pa(testRevision, testNamespace, WithHPAClass)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(podAutoscaler)
@@ -85,6 +95,8 @@ func TestControllerCanReconcile(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	const deployName = testRevision + "-deployment"
+	usualSelector := map[string]string{"a": "b"}
+
 	table := TableTest{{
 		Name: "no op",
 		Objects: []runtime.Object{
@@ -109,6 +121,26 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testRevision, testNamespace, WithHPAClass,
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet")),
+		}},
+	}, {
+		Name: "create hpa, sks and metric service",
+		Objects: []runtime.Object{
+			pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency)),
+			deploy(testNamespace, testRevision),
+		},
+		Key: key(testRevision, testNamespace),
+		WantCreates: []runtime.Object{
+			sks(testNamespace, testRevision, WithDeployRef(deployName)),
+			hpa(testRevision, testNamespace, pa(testRevision, testNamespace,
+				WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency))),
+			metricsSvc(testNamespace, testRevision, WithSvcSelector(usualSelector),
+				SvcWithAnnotationValue(autoscaling.ClassAnnotationKey, autoscaling.HPA),
+				SvcWithAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Concurrency)),
+		},
+		WantStatusUpdates: []ktesting.UpdateActionImpl{{
+			Object: pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency),
+				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
+				WithMSvcStatus(testRevision+"-00001")),
 		}},
 	}, {
 		Name: "reconcile sks is still not ready",
@@ -404,12 +436,18 @@ func TestReconcile(t *testing.T) {
 
 	defer logtesting.ClearAll()
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		psFactory := presources.NewPodScalableInformerFactory(ctx)
+		fakeMetrics := newTestMetrics()
+
 		return &Reconciler{
 			Base: &areconciler.Base{
-				Base:        reconciler.NewBase(ctx, controllerAgentName, cmw),
-				PALister:    listers.GetPodAutoscalerLister(),
-				SKSLister:   listers.GetServerlessServiceLister(),
-				ConfigStore: &testConfigStore{config: defaultConfig()},
+				Base:              reconciler.NewBase(ctx, controllerAgentName, cmw),
+				PALister:          listers.GetPodAutoscalerLister(),
+				SKSLister:         listers.GetServerlessServiceLister(),
+				ConfigStore:       &testConfigStore{config: defaultConfig()},
+				ServiceLister:     listers.GetK8sServiceLister(),
+				PSInformerFactory: psFactory,
+				Metrics:           fakeMetrics,
 			},
 			hpaLister: listers.GetHorizontalPodAutoscalerLister(),
 		}
@@ -457,7 +495,7 @@ func withHPAOwnersRemoved(hpa *autoscalingv2beta1.HorizontalPodAutoscaler) {
 }
 
 func hpa(name, namespace string, pa *autoscalingv1alpha1.PodAutoscaler, options ...hpaOption) *autoscalingv2beta1.HorizontalPodAutoscaler {
-	h := resources.MakeHPA(pa)
+	h := resources.MakeHPA(pa, defaultConfig().Autoscaler)
 	for _, o := range options {
 		o(h)
 	}
@@ -487,6 +525,60 @@ func deploy(namespace, name string, opts ...deploymentOption) *appsv1.Deployment
 		opt(s)
 	}
 	return s
+}
+
+func metricsSvc(ns, n string, opts ...K8sServiceOption) *corev1.Service {
+	pa := pa(n, ns)
+	svc := aresources.MakeMetricsService(pa, map[string]string{})
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
+}
+
+func newTestMetrics() *testMetrics {
+	return &testMetrics{
+		createCallCount:    atomic.NewUint32(0),
+		deleteCallCount:    atomic.NewUint32(0),
+		updateCallCount:    atomic.NewUint32(0),
+		deleteBeforeCreate: atomic.NewBool(false),
+	}
+}
+
+type testMetrics struct {
+	createCallCount    *atomic.Uint32
+	deleteCallCount    *atomic.Uint32
+	updateCallCount    *atomic.Uint32
+	deleteBeforeCreate *atomic.Bool
+	metric             *autoscaler.Metric
+}
+
+func (km *testMetrics) Get(ctx context.Context, namespace, name string) (*autoscaler.Metric, error) {
+	if km.metric == nil {
+		return nil, apierrors.NewNotFound(asv1a1.Resource("Metric"), autoscaler.NewMetricKey(namespace, name))
+	}
+	return km.metric, nil
+}
+
+func (km *testMetrics) Create(ctx context.Context, metric *autoscaler.Metric) (*autoscaler.Metric, error) {
+	km.metric = metric
+	km.createCallCount.Add(1)
+	return metric, nil
+}
+
+func (km *testMetrics) Delete(ctx context.Context, namespace, name string) error {
+	km.metric = nil
+	km.deleteCallCount.Add(1)
+	if km.createCallCount.Load() == 0 {
+		km.deleteBeforeCreate.Store(true)
+	}
+	return nil
+}
+
+func (km *testMetrics) Update(ctx context.Context, metric *autoscaler.Metric) (*autoscaler.Metric, error) {
+	km.metric = metric
+	km.updateCallCount.Add(1)
+	return metric, nil
 }
 
 func defaultConfig() *config.Config {

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -168,6 +168,13 @@ func WithLowerScaleBound(i int) PodAutoscalerOption {
 	return withAnnotationValue(autoscaling.MinScaleAnnotationKey, strconv.Itoa(i))
 }
 
+// WithMSvcStatus sets the name of the metrics service.
+func WithMSvcStatus(s string) PodAutoscalerOption {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
+		pa.Status.MetricsServiceName = s
+	}
+}
+
 // K8sServiceOption enables further configuration of the Kubernetes Service.
 type K8sServiceOption func(*corev1.Service)
 
@@ -175,6 +182,15 @@ type K8sServiceOption func(*corev1.Service)
 func OverrideServiceName(name string) K8sServiceOption {
 	return func(svc *corev1.Service) {
 		svc.Name = name
+	}
+}
+
+func SvcWithAnnotationValue(key, value string) K8sServiceOption {
+	return func(svc *corev1.Service) {
+		if svc.Annotations == nil {
+			svc.Annotations = make(map[string]string)
+		}
+		svc.Annotations[key] = value
 	}
 }
 
@@ -201,6 +217,13 @@ func WithExternalName(name string) K8sServiceOption {
 // WithK8sSvcOwnersRemoved clears the owner references of this Service.
 func WithK8sSvcOwnersRemoved(svc *corev1.Service) {
 	svc.OwnerReferences = nil
+}
+
+// WithSvcSelector sets the selector of the service.
+func WithSvcSelector(sel map[string]string) K8sServiceOption {
+	return func(s *corev1.Service) {
+		s.Spec.Selector = sel
+	}
 }
 
 // EndpointsOption enables further configuration of the Kubernetes Endpoints.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2206
Fixes #3132

## Proposed Changes

* This contains all the plumbing that's needed to enable the HPA to scale on the concurrency metrics exposed by the custom-metrics API.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
HPA-class autoscaling now supports "concurrency" as a metric.
```

/cc @mattmoor 
/assign @vagababov 
/assign @josephburnett 
