### PR TITLE
Stream relevant controller logs to test output.

### DIFF
--- a/test/crd.go
+++ b/test/crd.go
@@ -50,9 +50,14 @@ var AppendRandomString = helpers.AppendRandomString
 // and also convert camelcase tokens into dash-delimited lowercase tokens.
 var MakeK8sNamePrefix = helpers.MakeK8sNamePrefix
 
+// ObjectPrefixForTest returns the name prefix for this test's random names.
+func ObjectPrefixForTest(t *testing.T) string {
+	return MakeK8sNamePrefix(strings.TrimPrefix(t.Name(), testNamePrefix))
+}
+
 // ObjectNameForTest generates a random object name based on the test name.
 func ObjectNameForTest(t *testing.T) string {
-	return AppendRandomString(MakeK8sNamePrefix(strings.TrimPrefix(t.Name(), testNamePrefix)))
+	return AppendRandomString(ObjectPrefixForTest(t))
 }
 
 // SubServiceNameForTest generates a random service name based on the test name and

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 
@@ -35,6 +36,9 @@ import (
 // We need to add a similar test for the User pod overload once the second part of overload handling is done.
 func TestActivatorOverload(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	const (
 		// The number of concurrent requests to hit the activator with.
 		concurrency = 100

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -32,6 +32,7 @@ import (
 	resourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	rtesting "github.com/knative/serving/pkg/testing/v1alpha1"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -285,6 +286,8 @@ func assertAutoscaleUpToNumPods(ctx *testContext, curPods, targetPods int32, dur
 
 func TestAutoscaleUpDownUp(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
 
 	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency)
 	defer test.TearDown(ctx.clients, ctx.names)
@@ -309,6 +312,8 @@ func TestAutoscaleUpCountPods(t *testing.T) {
 		name, class := name, class
 		t.Run(name, func(tt *testing.T) {
 			tt.Parallel()
+			cancel := logstream.Start(t)
+			defer cancel()
 
 			ctx := setup(tt, class, autoscaling.Concurrency)
 			defer test.TearDown(ctx.clients, ctx.names)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -338,6 +338,9 @@ func TestAutoscaleSustaining(t *testing.T) {
 	// as long as the traffic sustains, despite whether it is switching modes between
 	// normal and panic.
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency)
 	defer test.TearDown(ctx.clients, ctx.names)
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,9 @@ const (
 
 func TestDestroyPodInflight(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	t.Log("Creating a new Route and Configuration")
@@ -143,6 +147,9 @@ const (
 
 func TestDestroyPodTimely(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -30,6 +30,7 @@ import (
 	ingress "github.com/knative/pkg/test/ingress"
 	resourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	"google.golang.org/grpc"
@@ -151,6 +152,9 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
 func testGRPC(t *testing.T, f grpcTest) {
 	t.Helper()
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	// Setup
 	clients := Setup(t)
 

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -26,6 +26,7 @@ import (
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,6 +35,9 @@ import (
 
 func TestHelloWorld(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{
@@ -82,6 +86,9 @@ func TestHelloWorld(t *testing.T) {
 
 func TestQueueSideCarResourceLimit(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -25,10 +25,15 @@ import (
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
 	v1alpha1testing "github.com/knative/serving/pkg/testing/v1alpha1"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 
 func TestImagePullError(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -25,11 +25,16 @@ import (
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMinScale(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	const minScale = 4
 
 	clients := Setup(t)

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -24,6 +24,7 @@ import (
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +49,8 @@ func checkResponse(t *testing.T, clients *test.Clients, names test.ResourceNames
 
 func TestMultipleNamespace(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
 
 	defaultClients := Setup(t) // This one uses the default namespace `test.ServingNamespace`
 	altClients := SetupAlternativeNamespace(t)
@@ -86,6 +89,8 @@ func TestMultipleNamespace(t *testing.T) {
 // This test is to ensure we do not leak deletion of services in other namespaces when deleting a route.
 func TestConflictingRouteService(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
 
 	names := test.ResourceNames{
 		Service:       test.AppendRandomString("conflicting-route-service"),

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,6 +33,10 @@ import (
 )
 
 func TestPodScheduleError(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 	const (
 		errorReason    = "RevisionFailed"

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -26,6 +26,7 @@ import (
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -139,6 +140,9 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 // to helloworld app.
 func TestServiceToServiceCall(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	t.Log("Creating a Service for the helloworld test app.")
@@ -182,6 +186,9 @@ func TestServiceToServiceCall(t *testing.T) {
 // we're waiting for target app to be scaled to zero
 func TestServiceToServiceCallFromZero(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	t.Log("Creating helloworld Service")

--- a/test/e2e/v1beta1_test.go
+++ b/test/e2e/v1beta1_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,9 @@ import (
 
 func TestV1beta1Translation(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{
@@ -65,6 +69,9 @@ func TestV1beta1Translation(t *testing.T) {
 
 func TestV1beta1Rejection(t *testing.T) {
 	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -28,6 +28,7 @@ import (
 	ingress "github.com/knative/pkg/test/ingress"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
+	"github.com/knative/serving/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -107,6 +108,10 @@ func validateWebSocketConnection(t *testing.T, clients *test.Clients, names test
 // (2) connects to the service using websocket, (3) sends a message, and
 // (4) verifies that we receive back the same message.
 func TestWebSocket(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{
@@ -133,6 +138,10 @@ func TestWebSocket(t *testing.T) {
 // (3) connects to the service using websocket, (4) sends a message, and
 // (5) verifies that we receive back the same message.
 func TestWebSocketFromZero(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
 	clients := Setup(t)
 
 	names := test.ResourceNames{

--- a/test/logstream/doc.go
+++ b/test/logstream/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logstream lets end-to-end tests incorporate controller logs
+// into the error output of tests.  It is enabled by setting the
+// SYSTEM_NAMESPACE environment variable, which tells this package
+// what namespace to stream logs from.
+package logstream

--- a/test/logstream/interface.go
+++ b/test/logstream/interface.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstream
+
+import (
+	"os"
+	"testing"
+
+	"github.com/knative/pkg/system"
+)
+
+// Canceler is the type of a function returned when a logstream is started to be
+// deferred so that the logstream can be stopped when the test is complete.
+type Canceler func()
+
+// Start begins streaming the logs from system components with a `key:` matching
+// `test.ObjectNameForTest(t)` to `t.Log`.  It returns a Canceler, which must
+// be called before the test completes.
+func Start(t *testing.T) Canceler {
+	return stream.Start(t)
+}
+
+type streamer interface {
+	Start(t *testing.T) Canceler
+}
+
+var stream streamer
+
+func init() {
+	ns := os.Getenv(system.NamespaceEnvKey)
+	if ns != "" {
+		// If SYSTEM_NAMESPACE is set, then start the stream.
+		stream = &kubelogs{Namespace: ns}
+	} else {
+		// Otherwise set up a null stream.
+		stream = &null{}
+	}
+}

--- a/test/logstream/interface.go
+++ b/test/logstream/interface.go
@@ -44,7 +44,7 @@ func init() {
 	ns := os.Getenv(system.NamespaceEnvKey)
 	if ns != "" {
 		// If SYSTEM_NAMESPACE is set, then start the stream.
-		stream = &kubelogs{Namespace: ns}
+		stream = &kubelogs{namespace: ns}
 	} else {
 		// Otherwise set up a null stream.
 		stream = &null{}

--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstream
+
+import (
+	"bufio"
+	"encoding/json"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/ptr"
+	"github.com/knative/pkg/test"
+	servingtest "github.com/knative/serving/test"
+)
+
+type kubelogs struct {
+	Namespace string
+
+	once sync.Once
+	m    sync.RWMutex
+	keys map[string]logger
+}
+
+type logger func(string, ...interface{})
+
+var _ streamer = (*kubelogs)(nil)
+
+// Init implements streamer
+func (k *kubelogs) Init() {
+	kc, err := test.NewKubeClient(test.Flags.Kubeconfig, test.Flags.Cluster)
+	if err != nil {
+		log.Fatalf("error loading client config: %v", err)
+	}
+
+	// List the pods in the given namespace.
+	pl, err := kc.Kube.CoreV1().Pods(k.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		log.Fatalf("error listing pods: %v", err)
+	}
+	for _, pod := range pl.Items {
+		// Grab data from all containers in the pods.  We need this in case
+		// an envoy sidecar is injected for mesh installs.  This should be
+		// equivalent to --all-containers.
+		for _, container := range pod.Spec.Containers {
+			go func(pod corev1.Pod, container corev1.Container) {
+				options := &corev1.PodLogOptions{
+					Container: container.Name,
+					// Follow directs the api server to continuously stream logs back.
+					Follow: true,
+					// Only return new logs (this value is being used for "epsilon").
+					SinceSeconds: ptr.Int64(1),
+				}
+
+				req := kc.Kube.CoreV1().Pods(k.Namespace).GetLogs(pod.Name, options)
+				stream, err := req.Stream()
+				if err != nil {
+					log.Fatalf("error streaming pod logs: %v", err)
+				}
+				defer stream.Close()
+
+				// Read this container's stream.
+				for scanner := bufio.NewScanner(stream); scanner.Scan(); {
+					k.handleLine(scanner.Text())
+				}
+			}(pod, container)
+		}
+	}
+}
+
+func (k *kubelogs) handleLine(l string) {
+	// This holds the standard structure of our logs.
+	var line struct {
+		Level      string    `json:"level"`
+		Timestamp  time.Time `json:"ts"`
+		Controller string    `json:"knative.dev/controller"`
+		Caller     string    `json:"caller"`
+		Key        string    `json:"knative.dev/key"`
+		Message    string    `json:"msg"`
+
+		// TODO(mattmoor): Parse out more context.
+	}
+	if err := json.Unmarshal([]byte(l), &line); err != nil {
+		// Ignore malformed lines.
+		return
+	}
+	if line.Key == "" {
+		return
+	}
+
+	k.m.RLock()
+	defer k.m.RUnlock()
+
+	for name, logf := range k.keys {
+		// TODO(mattmoor): Do a slightly smarter match.
+		if !strings.Contains(line.Key, name) {
+			continue
+		}
+		// TODO(mattmoor): What information do we want to display?
+		logf("[%s] %s", line.Controller, line.Message)
+	}
+}
+
+// Start implements streamer
+func (k *kubelogs) Start(t *testing.T) Canceler {
+	k.once.Do(k.Init)
+
+	k.m.Lock()
+	defer k.m.Unlock()
+
+	name := servingtest.ObjectPrefixForTest(t)
+	// Register a key
+	if k.keys == nil {
+		k.keys = make(map[string]logger)
+	}
+	k.keys[name] = t.Logf
+
+	// Return a function that unregisters that key.
+	return func() {
+		k.m.Lock()
+		defer k.m.Unlock()
+
+		delete(k.keys, name)
+	}
+}

--- a/test/logstream/null.go
+++ b/test/logstream/null.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstream
+
+import (
+	"testing"
+)
+
+type null struct{}
+
+var _ streamer = (*null)(nil)
+
+// Start implements streamer
+func (*null) Start(t *testing.T) Canceler {
+	return func() {}
+}


### PR DESCRIPTION
This introduces a new `logstream` package which streams the relevant logs
from controllers in `system.Namespace()` to each test's logs.

For now, just instrument the e2e tests.

I think the only thing this needs from `knative/serving` is the naming function, so if folks find this useful we can promote both to `knative/pkg` and eventing can pick up both.  cc @n3wscott 