### PR TITLE
Prepare `./test/conformance/runtime` for Beta.

### DIFF
--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -158,6 +158,20 @@ func WithServiceLabel(key, value string) ServiceOption {
 	}
 }
 
+// WithNumberedPort sets the Service's port number to what's provided.
+func WithNumberedPort(number int32) ServiceOption {
+	return func(svc *v1alpha1.Service) {
+		c := &svc.Spec.Template.Spec.Containers[0]
+		if len(c.Ports) == 1 {
+			c.Ports[0].ContainerPort = number
+		} else {
+			c.Ports = []corev1.ContainerPort{{
+				ContainerPort: number,
+			}}
+		}
+	}
+}
+
 // WithResourceRequirements attaches resource requirements to the service
 func WithResourceRequirements(resourceRequirements corev1.ResourceRequirements) ServiceOption {
 	return func(svc *v1alpha1.Service) {
@@ -417,4 +431,11 @@ func WithServiceLatestReadyRevision(lrr string) ServiceOption {
 // WithServiceStatusRouteNotReady sets the `RoutesReady` condition on the service to `Unknown`.
 func WithServiceStatusRouteNotReady(s *v1alpha1.Service) {
 	s.Status.MarkRouteNotYetReady()
+}
+
+// WithSecurityContext configures the Service to use the provided security context.
+func WithSecurityContext(sc *corev1.SecurityContext) ServiceOption {
+	return func(s *v1alpha1.Service) {
+		s.Spec.Template.Spec.Containers[0].SecurityContext = sc
+	}
 }

--- a/pkg/testing/v1beta1/service.go
+++ b/pkg/testing/v1beta1/service.go
@@ -82,6 +82,20 @@ func WithNamedPort(name string) ServiceOption {
 	}
 }
 
+// WithNumberedPort sets the Service's port number to what's provided.
+func WithNumberedPort(number int32) ServiceOption {
+	return func(svc *v1beta1.Service) {
+		c := &svc.Spec.Template.Spec.Containers[0]
+		if len(c.Ports) == 1 {
+			c.Ports[0].ContainerPort = number
+		} else {
+			c.Ports = []corev1.ContainerPort{{
+				ContainerPort: number,
+			}}
+		}
+	}
+}
+
 // WithResourceRequirements attaches resource requirements to the service
 func WithResourceRequirements(resourceRequirements corev1.ResourceRequirements) ServiceOption {
 	return func(svc *v1beta1.Service) {
@@ -150,5 +164,26 @@ func WithVolume(name, mountPath string, volumeSource corev1.VolumeSource) Servic
 			Name:         name,
 			VolumeSource: volumeSource,
 		})
+	}
+}
+
+// WithEnv configures the Service to use the provided environment variables.
+func WithEnv(evs ...corev1.EnvVar) ServiceOption {
+	return func(s *v1beta1.Service) {
+		s.Spec.Template.Spec.Containers[0].Env = evs
+	}
+}
+
+// WithEnvFrom configures the Service to use the provided environment variables.
+func WithEnvFrom(evs ...corev1.EnvFromSource) ServiceOption {
+	return func(s *v1beta1.Service) {
+		s.Spec.Template.Spec.Containers[0].EnvFrom = evs
+	}
+}
+
+// WithSecurityContext configures the Service to use the provided security context.
+func WithSecurityContext(sc *corev1.SecurityContext) ServiceOption {
+	return func(s *v1beta1.Service) {
+		s.Spec.Template.Spec.Containers[0].SecurityContext = sc
 	}
 }

--- a/test/conformance/runtime/cgroup_test.go
+++ b/test/conformance/runtime/cgroup_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	corev1 "k8s.io/api/core/v1"
+	. "github.com/knative/serving/pkg/testing/v1alpha1"
 )
 
 const (
@@ -64,7 +64,7 @@ func TestMustHaveCgroupConfigured(t *testing.T) {
 		"/sys/fs/cgroup/cpu/cpu.cfs_quota_us":         cpuLimit * 1000 * 100, // 1000 millicore * 100
 		"/sys/fs/cgroup/cpu/cpu.shares":               cpuRequest * 1024}     // CPURequests * 1024
 
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{ContainerResources: resources})
+	_, ri, err := fetchRuntimeInfo(t, clients, WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestMustHaveCgroupConfigured(t *testing.T) {
 func TestShouldHaveCgroupReadOnly(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}

--- a/test/conformance/runtime/envpropagation_test.go
+++ b/test/conformance/runtime/envpropagation_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/knative/serving/pkg/testing/v1alpha1"
@@ -102,7 +101,7 @@ func TestConfigsViaEnv(t *testing.T) {
 }
 
 func fetchEnvironmentAndVerify(t *testing.T, clients *test.Clients, opts ...ServiceOption) error {
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{}, opts...)
+	_, ri, err := fetchRuntimeInfo(t, clients, opts...)
 	if err != nil {
 		return err
 	}

--- a/test/conformance/runtime/envvars_test.go
+++ b/test/conformance/runtime/envvars_test.go
@@ -25,15 +25,15 @@ import (
 
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/types"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/knative/serving/pkg/testing/v1alpha1"
 )
 
 // TestShouldEnvVars verifies environment variables that are declared as "SHOULD be set" in runtime-contract
 func TestShouldEnvVars(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
-	names, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	names, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,11 +62,7 @@ func TestMustEnvVars(t *testing.T) {
 	if err != nil {
 		t.Fatal("Invalid PORT value in MustEnvVars")
 	}
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{
-		ContainerPorts: []corev1.ContainerPort{
-			{ContainerPort: int32(port)},
-		},
-	})
+	_, ri, err := fetchRuntimeInfo(t, clients, WithNumberedPort(int32(port)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/conformance/runtime/file_descriptor_test.go
+++ b/test/conformance/runtime/file_descriptor_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 
 // TestMustHaveCgroupConfigured verifies using the runtime test container that reading from the
@@ -30,7 +29,7 @@ import (
 func TestShouldHaveStdinEOF(t *testing.T) {
 	clients := test.Setup(t)
 
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}

--- a/test/conformance/runtime/filesystem_test.go
+++ b/test/conformance/runtime/filesystem_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/types"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 
 func verifyPermissionsString(resp string, expected string) error {
@@ -41,7 +40,7 @@ func verifyPermissionsString(resp string, expected string) error {
 }
 
 func testFiles(t *testing.T, clients *test.Clients, paths map[string]types.FileInfo) error {
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		return err
 	}

--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 
 // TestMustHaveHeadersSet verified that all headers declared as "MUST" in the runtime
@@ -35,7 +34,7 @@ func TestMustHaveHeadersSet(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}
@@ -98,7 +97,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 		// required for tracing so we do not validate them.
 	}
 
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}

--- a/test/conformance/runtime/sysctl_test.go
+++ b/test/conformance/runtime/sysctl_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 
 // TestShouldHaveSysctlReadOnly verifies that the /proc/sys filesystem mounted within the container
@@ -32,7 +31,7 @@ import (
 func TestShouldHaveSysctlReadOnly(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}

--- a/test/conformance/runtime/user_test.go
+++ b/test/conformance/runtime/user_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/knative/serving/pkg/testing/v1alpha1"
 )
 
 const (
@@ -43,7 +43,7 @@ func TestMustRunAsUser(t *testing.T) {
 		RunAsUser: &runAsUser,
 	}
 
-	_, ri, err := fetchRuntimeInfo(t, clients, &v1a1test.Options{SecurityContext: securityContext})
+	_, ri, err := fetchRuntimeInfo(t, clients, WithSecurityContext(securityContext))
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestMustRunAsUser(t *testing.T) {
 func TestShouldRunAsUserContainerDefault(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
-	_, ri, err := fetchRuntimeInfoUnprivileged(t, clients, &v1a1test.Options{})
+	_, ri, err := fetchRuntimeInfoUnprivileged(t, clients)
 
 	if err != nil {
 		t.Fatalf("Error fetching runtime info: %v", err)

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -22,26 +22,26 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
-	reconciler "github.com/knative/serving/pkg/testing/v1alpha1"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
-
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/types"
+	v1a1test "github.com/knative/serving/test/v1alpha1"
+
+	. "github.com/knative/serving/pkg/testing/v1alpha1"
 )
 
 // fetchRuntimeInfoUnprivileged creates a Service that uses the 'runtime-unprivileged' test image, and extracts the returned output into the
 // RuntimeInfo object.
-func fetchRuntimeInfoUnprivileged(t *testing.T, clients *test.Clients, options *v1a1test.Options, opts ...reconciler.ServiceOption) (*test.ResourceNames, *types.RuntimeInfo, error) {
-	return runtimeInfo(t, clients, &test.ResourceNames{Image: test.RuntimeUnprivileged}, options, opts...)
+func fetchRuntimeInfoUnprivileged(t *testing.T, clients *test.Clients, opts ...ServiceOption) (*test.ResourceNames, *types.RuntimeInfo, error) {
+	return runtimeInfo(t, clients, &test.ResourceNames{Image: test.RuntimeUnprivileged}, opts...)
 }
 
 // fetchRuntimeInfo creates a Service that uses the 'runtime' test image, and extracts the returned output into the
 // RuntimeInfo object. The 'runtime' image uses uid 0.
-func fetchRuntimeInfo(t *testing.T, clients *test.Clients, options *v1a1test.Options, opts ...reconciler.ServiceOption) (*test.ResourceNames, *types.RuntimeInfo, error) {
-	return runtimeInfo(t, clients, &test.ResourceNames{}, options, opts...)
+func fetchRuntimeInfo(t *testing.T, clients *test.Clients, opts ...ServiceOption) (*test.ResourceNames, *types.RuntimeInfo, error) {
+	return runtimeInfo(t, clients, &test.ResourceNames{}, opts...)
 }
 
-func runtimeInfo(t *testing.T, clients *test.Clients, names *test.ResourceNames, options *v1a1test.Options, opts ...reconciler.ServiceOption) (*test.ResourceNames, *types.RuntimeInfo, error) {
+func runtimeInfo(t *testing.T, clients *test.Clients, names *test.ResourceNames, opts ...ServiceOption) (*test.ResourceNames, *types.RuntimeInfo, error) {
 	names.Service = test.ObjectNameForTest(t)
 	if names.Image == "" {
 		names.Image = test.Runtime
@@ -52,7 +52,7 @@ func runtimeInfo(t *testing.T, clients *test.Clients, names *test.ResourceNames,
 	defer test.TearDown(clients, *names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, *names) })
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, options, opts...)
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, &v1a1test.Options{}, opts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This doesn't actually switch things to Beta, but this should simplify the switch to:

```
sed -i 's/alpha/beta/g' test/conformance/runtime/*.go
sed -i 's/v1a1/v1b1/g' test/conformance/runtime/util.go
```

Then changing the line:
```diff
- objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, &v1a1test.Options{}, opts...)
+ objects, err := v1b1test.CreateServiceReady(t, clients, names, opts...)
```

I'm splitting this off to land early and reduce my merge conflict headache next week after the 0.7 snap.