### PR TITLE
Update OCI interface section of runtime contract

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -140,7 +140,7 @@ As specified by OCI.
 
 It is expected that containers do not have direct access to the
 [OCI interface](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/runtime.md#operations)
-as providing accesss allows containers to circumvent runtime restrictions that
+as providing access allows containers to circumvent runtime restrictions that
 are enforced by the Knative control plane. The operator or platform provider
 MAY have the ability to directly interact with the OCI interface, but that is
 beyond the scope of this specification.

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -138,8 +138,10 @@ As specified by OCI.
 
 ### Operations
 
-[The OCI interface](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/runtime.md#operations)
-SHOULD NOT be exposed within the container. The operator or platform provider
+It is expected that containers do not have direct access to the
+[OCI interface](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/runtime.md#operations)
+as providing accesss allows containers to circumvent runtime restrictions that
+are enforced by the Knative control plane. The operator or platform provider
 MAY have the ability to directly interact with the OCI interface, but that is
 beyond the scope of this specification.
 


### PR DESCRIPTION
This change updates the runtime contract to remove the keyword
requirement from the OCI interface section. This change also expands
upon the justification for not allowing containers access to the OCI
interface.

Fixes #2969

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update OCI interface section of runtime contract
```
