### PR TITLE
Generate hashed names when they are long

### DIFF
--- a/pkg/reconciler/revision/resources/names/names.go
+++ b/pkg/reconciler/revision/resources/names/names.go
@@ -17,34 +17,18 @@ limitations under the License.
 package names
 
 import (
-	"crypto/md5"
-	"fmt"
-
 	"github.com/knative/pkg/kmeta"
+	"github.com/knative/serving/pkg/resources"
 )
-
-const (
-	// K8s restriction for the resource name.
-	longest = 63
-	md5Len  = 32
-	head    = longest - md5Len
-)
-
-func maybeShortenName(n string) string {
-	if len(n) > longest {
-		n = fmt.Sprintf("%s%x", n[:head], md5.Sum([]byte(n)))
-	}
-	return n
-}
 
 // Deployment returns the precomputed name for the revision deployment
 func Deployment(rev kmeta.Accessor) string {
-	return maybeShortenName(rev.GetName() + "-deployment")
+	return resources.ChildName(rev.GetName(), "-deployment")
 }
 
 // ImageCache returns the precomputed name for the image cache.
 func ImageCache(rev kmeta.Accessor) string {
-	return maybeShortenName(rev.GetName() + "-cache")
+	return resources.ChildName(rev.GetName(), "-cache")
 }
 
 // KPA returns the PA name for the revision.

--- a/pkg/reconciler/revision/resources/names/names.go
+++ b/pkg/reconciler/revision/resources/names/names.go
@@ -17,17 +17,37 @@ limitations under the License.
 package names
 
 import (
+	"crypto/md5"
+	"fmt"
+
 	"github.com/knative/pkg/kmeta"
 )
 
+const (
+	// K8s restriction for the resource name.
+	longest = 63
+	md5Len  = 32
+	head    = longest - md5Len
+)
+
+func maybeShortenName(n string) string {
+	if len(n) > longest {
+		n = fmt.Sprintf("%s%x", n[:head], md5.Sum([]byte(n)))
+	}
+	return n
+}
+
+// Deployment returns the precomputed name for the revision deployment
 func Deployment(rev kmeta.Accessor) string {
-	return rev.GetName() + "-deployment"
+	return maybeShortenName(rev.GetName() + "-deployment")
 }
 
+// ImageCache returns the precomputed name for the image cache.
 func ImageCache(rev kmeta.Accessor) string {
-	return rev.GetName() + "-cache"
+	return maybeShortenName(rev.GetName() + "-cache")
 }
 
+// KPA returns the PA name for the revision.
 func KPA(rev kmeta.Accessor) string {
 	// We want the KPA's "key" to match the revision,
 	// to simplify the transition to the KPA.

--- a/pkg/reconciler/revision/resources/names/names_test.go
+++ b/pkg/reconciler/revision/resources/names/names_test.go
@@ -40,7 +40,7 @@ func TestNamer(t *testing.T) {
 			},
 		},
 		f:    Deployment,
-		want: "fffffffffffffffffffffffffffffffd79284ec10a12ef1b3cc73b212018b89",
+		want: "ffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deployment",
 	}, {
 		name: "Deployment long enough",
 		rev: &v1alpha1.Revision{
@@ -76,7 +76,7 @@ func TestNamer(t *testing.T) {
 			},
 		},
 		f:    ImageCache,
-		want: "uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuf57130621e0118c593bdee629d7976fa",
+		want: "uuuuuuuuuuuuuuuuuuuuuuuuuca47ad1ce8479df271ec0d23653ce256-cache",
 	}, {
 		name: "ImageCache",
 		rev: &v1alpha1.Revision{

--- a/pkg/reconciler/revision/resources/names/names_test.go
+++ b/pkg/reconciler/revision/resources/names/names_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package names
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,24 @@ func TestNamer(t *testing.T) {
 		f    func(kmeta.Accessor) string
 		want string
 	}{{
+		name: "Deployment too long",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("f", 63),
+			},
+		},
+		f:    Deployment,
+		want: "fffffffffffffffffffffffffffffffd79284ec10a12ef1b3cc73b212018b89",
+	}, {
+		name: "Deployment long enough",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("f", 52),
+			},
+		},
+		f:    Deployment,
+		want: strings.Repeat("f", 52) + "-deployment",
+	}, {
 		name: "Deployment",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
@@ -40,6 +59,24 @@ func TestNamer(t *testing.T) {
 		},
 		f:    Deployment,
 		want: "foo-deployment",
+	}, {
+		name: "ImageCache, barely fits",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("u", 57),
+			},
+		},
+		f:    ImageCache,
+		want: strings.Repeat("u", 57) + "-cache",
+	}, {
+		name: "ImageCache, already too long",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("u", 63),
+			},
+		},
+		f:    ImageCache,
+		want: "uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuf57130621e0118c593bdee629d7976fa",
 	}, {
 		name: "ImageCache",
 		rev: &v1alpha1.Revision{

--- a/pkg/resources/meta.go
+++ b/pkg/resources/meta.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package resources
 
+import (
+	"crypto/md5"
+	"fmt"
+)
+
 // CopyMap makes a copy of the map.
 func CopyMap(a map[string]string) map[string]string {
 	ret := make(map[string]string, len(a))
@@ -51,4 +56,23 @@ func FilterMap(in map[string]string, filter func(string) bool) map[string]string
 		ret[k] = v
 	}
 	return ret
+}
+
+// The longest name supported by the K8s is 63.
+// These constants
+const (
+	longest = 63
+	md5Len  = 32
+	head    = longest - md5Len
+)
+
+// ChildName generates a name for the resource based upong the parent resource and suffix.
+// If the concatenated name is longer than K8s permits the name is hashed and truncated to permit
+// construction of the resource, but still keeps it unique.
+func ChildName(parent, suffix string) string {
+	n := parent
+	if len(parent) > (longest - len(suffix)) {
+		n = fmt.Sprintf("%s%x", parent[:head-len(suffix)], md5.Sum([]byte(parent)))
+	}
+	return n + suffix
 }

--- a/pkg/resources/meta_test.go
+++ b/pkg/resources/meta_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -135,4 +136,31 @@ func TestCopy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChildName(t *testing.T) {
+	tests := []struct {
+		parent string
+		suffix string
+		want   string
+	}{{
+		parent: "asdf",
+		suffix: "-deployment",
+		want:   "asdf-deployment",
+	}, {
+		parent: strings.Repeat("f", 63),
+		suffix: "-deployment",
+		want:   "ffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deployment",
+	}, {
+		parent: strings.Repeat("f", 63),
+		suffix: "-deploy",
+		want:   "ffffffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deploy",
+	}}
+
+	for _, test := range tests {
+		if got, want := ChildName(test.parent, test.suffix), test.want; got != want {
+			t.Errorf("%s-%s: got: %63s want: %63s\ndiff:%s", test.parent, test.suffix, got, want, cmp.Diff(got, want))
+		}
+	}
+
 }


### PR DESCRIPTION
## Proposed Changes

* when deployment or image cache names are long, hash them to a shorter name
* this is backwards compatible since there exist 0 services with longer names