### PR TITLE
Add CleanupOnInterrupt to TestMultipleNamespace

### DIFF
--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -58,6 +58,7 @@ func TestMultipleNamespace(t *testing.T) {
 		Service: serviceName,
 		Image:   pizzaPlanet1,
 	}
+	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
 	if _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources, &v1a1test.Options{}); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
@@ -67,6 +68,7 @@ func TestMultipleNamespace(t *testing.T) {
 		Service: serviceName,
 		Image:   pizzaPlanet2,
 	}
+	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
 	if _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources, &v1a1test.Options{}); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)


### PR DESCRIPTION
Currently `TestMultipleNamespace` does not call CleanupOnInterrupt, so
this patch adds the function to surely clean up resources on the
cluster.

/lint

## Proposed Changes

* Add CleanupOnInterrupt to TestMultipleNamespace

**Release Note**

```release-note
NONE
```
