### PR TITLE
Floats for counters

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -59,7 +59,7 @@ func (cr *ConcurrencyReporter) report(key string, concurrency, requestCount int3
 	stat := autoscaler.Stat{
 		PodName:                   cr.podName,
 		AverageConcurrentRequests: float64(concurrency),
-		RequestCount:              requestCount,
+		RequestCount:              float64(requestCount),
 	}
 
 	// Send the stat to another goroutine to transmit

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -84,10 +84,10 @@ type Stat struct {
 	AverageProxiedConcurrentRequests float64
 
 	// Number of requests received since last Stat (approximately QPS).
-	RequestCount int32
+	RequestCount float64
 
 	// Part of RequestCount, for requests going through a proxy.
-	ProxiedRequestCount int32
+	ProxiedRequestCount float64
 }
 
 // StatMessage wraps a Stat with identifying information so it can be routed

--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -68,22 +68,14 @@ func extractData(body io.Reader) (*Stat, error) {
 	for m, pv := range map[string]*float64{
 		"queue_average_concurrent_requests":         &stat.AverageConcurrentRequests,
 		"queue_average_proxied_concurrent_requests": &stat.AverageProxiedConcurrentRequests,
+		"queue_operations_per_second":               &stat.RequestCount,
+		"queue_proxied_operations_per_second":       &stat.ProxiedRequestCount,
 	} {
 		pm := prometheusMetric(metricFamilies, m)
 		if pm == nil {
 			return nil, fmt.Errorf("could not find value for %s in response", m)
 		}
 		*pv = *pm.Gauge.Value
-	}
-	for m, pv := range map[string]*int32{
-		"queue_operations_per_second":         &stat.RequestCount,
-		"queue_proxied_operations_per_second": &stat.ProxiedRequestCount,
-	} {
-		pm := prometheusMetric(metricFamilies, m)
-		if pm == nil {
-			return nil, fmt.Errorf("could not find value for %s in response", m)
-		}
-		*pv = int32(*pm.Gauge.Value)
 	}
 	return &stat, nil
 }

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -179,8 +179,8 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 	var (
 		avgConcurrency        float64
 		avgProxiedConcurrency float64
-		reqCount              int32
-		proxiedReqCount       int32
+		reqCount              float64
+		proxiedReqCount       float64
 		successCount          float64
 	)
 
@@ -192,10 +192,11 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 		proxiedReqCount += stat.ProxiedRequestCount
 	}
 
+	frpc := float64(readyPodsCount)
 	avgConcurrency = avgConcurrency / successCount
 	avgProxiedConcurrency = avgProxiedConcurrency / successCount
-	reqCount = int32(float64(reqCount) / successCount)
-	proxiedReqCount = int32(float64(proxiedReqCount) / successCount)
+	reqCount = reqCount / successCount
+	proxiedReqCount = proxiedReqCount / successCount
 	now := time.Now()
 
 	// Assumptions:
@@ -210,10 +211,10 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 	extrapolatedStat := Stat{
 		Time:                             &now,
 		PodName:                          scraperPodName,
-		AverageConcurrentRequests:        avgConcurrency * float64(readyPodsCount),
-		AverageProxiedConcurrentRequests: avgProxiedConcurrency * float64(readyPodsCount),
-		RequestCount:                     reqCount * int32(readyPodsCount),
-		ProxiedRequestCount:              proxiedReqCount * int32(readyPodsCount),
+		AverageConcurrentRequests:        avgConcurrency * frpc,
+		AverageProxiedConcurrentRequests: avgProxiedConcurrency * frpc,
+		RequestCount:                     reqCount * frpc,
+		ProxiedRequestCount:              proxiedReqCount * frpc,
 	}
 
 	return &StatMessage{

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -145,22 +145,22 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 	if got.Stat.PodName != scraperPodName {
 		t.Errorf("StatMessage.Stat.PodName=%v, want %v", got.Stat.PodName, scraperPodName)
 	}
-	// (3.0 + 5.0 + 3.0) / 3.0 * 3
+	// (3.0 + 5.0 + 3.0) / 3.0 * 3 = 11
 	if got.Stat.AverageConcurrentRequests != 11.0 {
 		t.Errorf("StatMessage.Stat.AverageConcurrentRequests=%v, want %v",
 			got.Stat.AverageConcurrentRequests, 11.0)
 	}
-	// int32((5 + 7 + 5) / 3.0) * 3 = 15
-	if got.Stat.RequestCount != 15 {
+	// ((5 + 7 + 5) / 3.0) * 3 = 17
+	if got.Stat.RequestCount != 17 {
 		t.Errorf("StatMessage.Stat.RequestCount=%v, want %v", got.Stat.RequestCount, 15)
 	}
-	// (2.0 + 4.0 + 2.0) / 3.0 * 3
+	// (2.0 + 4.0 + 2.0) / 3.0 * 3 = 8
 	if got.Stat.AverageProxiedConcurrentRequests != 8.0 {
 		t.Errorf("StatMessage.Stat.AverageProxiedConcurrentRequests=%v, want %v",
 			got.Stat.AverageProxiedConcurrentRequests, 8.0)
 	}
-	// int32((4 + 6 + 4) / 3.0) * 3 = 12
-	if got.Stat.ProxiedRequestCount != 12 {
+	// ((4 + 6 + 4) / 3.0) * 3 = 14
+	if got.Stat.ProxiedRequestCount != 14 {
 		t.Errorf("StatMessage.Stat.ProxiedCount=%v, want %v", got.Stat.ProxiedRequestCount, 12)
 	}
 }

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -139,7 +139,7 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	server.Shutdown(time.Second)
 }
 
-func newStatMessage(revKey string, podName string, averageConcurrentRequests float64, requestCount int32) *autoscaler.StatMessage {
+func newStatMessage(revKey string, podName string, averageConcurrentRequests float64, requestCount float64) *autoscaler.StatMessage {
 	return &autoscaler.StatMessage{
 		Key: revKey,
 		Stat: autoscaler.Stat{

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -114,8 +114,8 @@ func (r *PrometheusStatsReporter) Report(stat *autoscaler.Stat) error {
 		return errors.New("PrometheusStatsReporter is not initialized yet")
 	}
 
-	operationsPerSecondGV.With(r.labels).Set(float64(stat.RequestCount))
-	proxiedOperationsPerSecondGV.With(r.labels).Set(float64(stat.ProxiedRequestCount))
+	operationsPerSecondGV.With(r.labels).Set(stat.RequestCount)
+	proxiedOperationsPerSecondGV.With(r.labels).Set(stat.ProxiedRequestCount)
 	averageConcurrentRequestsGV.With(r.labels).Set(stat.AverageConcurrentRequests)
 	averageProxiedConcurrentRequestsGV.With(r.labels).Set(stat.AverageProxiedConcurrentRequests)
 

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -68,8 +68,8 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 
 	go func() {
 		var (
-			requestCount       int32
-			proxiedCount       int32
+			requestCount       float64
+			proxiedCount       float64
 			concurrency        int32
 			proxiedConcurrency int32
 		)


### PR DESCRIPTION
Switch request count and proxied request counts to be floats.
There is no real reason why they shouldn't be so (especially that we convert them to floats a few times).

I'd be very happy with the change, but apparently it changes how we calculate the rates as the changes for the test were required. I am for precision, so I think that's fine, but let me know if you think otherwise.

/assign @markusthoemmes @yanweiguo 
/cc @mattmoor 