### PR TITLE
Migrate the bulk of our e2e testing to v1beta1

### DIFF
--- a/pkg/testing/v1beta1/configuration.go
+++ b/pkg/testing/v1beta1/configuration.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 )
 
@@ -37,5 +38,12 @@ func WithConfigReadinessProbe(p *corev1.Probe) ConfigOption {
 func WithConfigImage(img string) ConfigOption {
 	return func(cfg *v1beta1.Configuration) {
 		cfg.Spec.Template.Spec.Containers[0].Image = img
+	}
+}
+
+// WithConfigTimeoutSeconds sets revision timeout
+func WithConfigTimeoutSeconds(revisionTimeoutSeconds int64) ConfigOption {
+	return func(cfg *v1beta1.Configuration) {
+		cfg.Spec.Template.Spec.TimeoutSeconds = ptr.Int64(revisionTimeoutSeconds)
 	}
 }

--- a/pkg/testing/v1beta1/service.go
+++ b/pkg/testing/v1beta1/service.go
@@ -66,6 +66,14 @@ func WithInlineConfigSpec(config v1beta1.ConfigurationSpec) ServiceOption {
 	}
 }
 
+// WithReadinessProbe sets the provided probe to be the readiness
+// probe on the service.
+func WithReadinessProbe(p *corev1.Probe) ServiceOption {
+	return func(svc *v1beta1.Service) {
+		svc.Spec.Template.Spec.Containers[0].ReadinessProbe = p
+	}
+}
+
 // WithNamedPort sets the name on the Service's port to the provided name
 func WithNamedPort(name string) ServiceOption {
 	return func(svc *v1beta1.Service) {
@@ -132,6 +140,16 @@ func WithServiceImage(img string) ServiceOption {
 func WithServiceTemplateMeta(m metav1.ObjectMeta) ServiceOption {
 	return func(svc *v1beta1.Service) {
 		svc.Spec.Template.ObjectMeta = m
+	}
+}
+
+// WithServiceLabel attaches a particular label to the service.
+func WithServiceLabel(key, value string) ServiceOption {
+	return func(service *v1beta1.Service) {
+		if service.Labels == nil {
+			service.Labels = make(map[string]string)
+		}
+		service.Labels[key] = value
 	}
 }
 

--- a/test/apicoverage/image/common/common.go
+++ b/test/apicoverage/image/common/common.go
@@ -19,16 +19,16 @@ package common
 import (
 	"github.com/knative/pkg/system"
 	pkgWebhook "github.com/knative/pkg/webhook"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
 	ResourceMap = map[schema.GroupVersionKind]pkgWebhook.GenericCRD{
-		v1alpha1.SchemeGroupVersion.WithKind("Revision"):      &v1alpha1.Revision{},
-		v1alpha1.SchemeGroupVersion.WithKind("Configuration"): &v1alpha1.Configuration{},
-		v1alpha1.SchemeGroupVersion.WithKind("Route"):         &v1alpha1.Route{},
-		v1alpha1.SchemeGroupVersion.WithKind("Service"):       &v1alpha1.Service{},
+		v1beta1.SchemeGroupVersion.WithKind("Revision"):      &v1beta1.Revision{},
+		v1beta1.SchemeGroupVersion.WithKind("Configuration"): &v1beta1.Configuration{},
+		v1beta1.SchemeGroupVersion.WithKind("Route"):         &v1beta1.Route{},
+		v1beta1.SchemeGroupVersion.WithKind("Service"):       &v1beta1.Service{},
 	}
 	WebhookNamespace = system.Namespace()
 )

--- a/test/apicoverage/image/webhook/webhook_server.go
+++ b/test/apicoverage/image/webhook/webhook_server.go
@@ -39,7 +39,7 @@ func SetupWebhookServer() {
 	ac := webhook.APICoverageRecorder{
 		Logger: webhookConf.Logger,
 		ResourceForest: resourcetree.ResourceForest{
-			Version:        "v1alpha1",
+			Version:        "v1beta1",
 			ConnectedNodes: make(map[string]*list.List),
 			TopLevelTrees:  make(map[string]resourcetree.ResourceTree),
 		},

--- a/test/conformance/runtime/cgroup_test.go
+++ b/test/conformance/runtime/cgroup_test.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	. "github.com/knative/serving/pkg/testing/v1beta1"
 )
 
 const (

--- a/test/conformance/runtime/envpropagation_test.go
+++ b/test/conformance/runtime/envpropagation_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/serving/test"
 	corev1 "k8s.io/api/core/v1"
 
-	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	. "github.com/knative/serving/pkg/testing/v1beta1"
 )
 
 // TestSecretsViaEnv verifies propagation of Secrets through environment variables.

--- a/test/conformance/runtime/envvars_test.go
+++ b/test/conformance/runtime/envvars_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/types"
 
-	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	. "github.com/knative/serving/pkg/testing/v1beta1"
 )
 
 // TestShouldEnvVars verifies environment variables that are declared as "SHOULD be set" in runtime-contract

--- a/test/conformance/runtime/user_test.go
+++ b/test/conformance/runtime/user_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/knative/serving/test"
 	corev1 "k8s.io/api/core/v1"
 
-	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	. "github.com/knative/serving/pkg/testing/v1beta1"
 )
 
 const (

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/test"
 	"github.com/knative/serving/test/types"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 
-	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	. "github.com/knative/serving/pkg/testing/v1beta1"
 )
 
 // fetchRuntimeInfo creates a Service that uses the 'runtime' test image, and extracts the returned output into the
@@ -62,12 +62,12 @@ func runtimeInfo(
 		return nil, nil, err
 	}
 
-	serviceOpts = append(serviceOpts, func(svc *v1alpha1.Service) {
+	serviceOpts = append(serviceOpts, func(svc *v1beta1.Service) {
 		// Always fetch the latest runtime image.
 		svc.Spec.Template.Spec.Containers[0].ImagePullPolicy = "Always"
 	})
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, &v1a1test.Options{}, serviceOpts...)
+	objects, err := v1b1test.CreateServiceReady(t, clients, names, serviceOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,7 +76,7 @@ func runtimeInfo(
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.URL.Host,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"RuntimeInfo",
 		test.ServingFlags.ResolvableDomain,
 		reqOpts...)

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -26,10 +26,10 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logstream"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 )
 
 // TestActivatorOverload makes sure that activator can handle the load when scaling from 0.
@@ -58,9 +58,9 @@ func TestActivatorOverload(t *testing.T) {
 	t.Log("Creating a service with run latest configuration.")
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, func(service *v1alpha1.Service) {
-		service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = 1
-		service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
+	resources, err := v1b1test.CreateServiceReady(t, clients, &names, func(service *v1beta1.Service) {
+		service.Spec.Template.Spec.ContainerConcurrency = 1
+		service.Spec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 	})
 	if err != nil {
 		t.Fatalf("Unable to create resources: %v", err)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -12,8 +12,9 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/serving/pkg/autoscaler"
+	rtesting "github.com/knative/serving/pkg/testing/v1beta1"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 	perrors "github.com/pkg/errors"
 )
 
@@ -42,7 +43,7 @@ func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
 
 // CreateRouteAndConfig will create Route and Config objects using clients.
 // The Config object will serve requests to a container started from the image at imagePath.
-func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, options *v1a1test.Options) (test.ResourceNames, error) {
+func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, opts ...rtesting.ConfigOption) (test.ResourceNames, error) {
 	svcName := test.ObjectNameForTest(t)
 	names := test.ResourceNames{
 		Config: svcName,
@@ -50,10 +51,10 @@ func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, opt
 		Image:  image,
 	}
 
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, options); err != nil {
+	if _, err := v1b1test.CreateConfiguration(t, clients, names, opts...); err != nil {
 		return test.ResourceNames{}, err
 	}
-	_, err := v1a1test.CreateRoute(t, clients, names)
+	_, err := v1b1test.CreateRoute(t, clients, names)
 	return names, err
 }
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/autoscaling"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,7 +44,7 @@ func TestMinScale(t *testing.T) {
 		Image:  "helloworld",
 	}
 
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}, func(cfg *v1alpha1.Configuration) {
+	if _, err := v1b1test.CreateConfiguration(t, clients, names, func(cfg *v1beta1.Configuration) {
 		if cfg.Spec.Template.Annotations == nil {
 			cfg.Spec.Template.Annotations = make(map[string]string)
 		}
@@ -59,18 +59,18 @@ func TestMinScale(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	// Wait for the Config have a LatestCreatedRevisionName
-	if err := v1a1test.WaitForConfigurationState(clients.ServingAlphaClient, names.Config, v1a1test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision"); err != nil {
+	if err := v1b1test.WaitForConfigurationState(clients.ServingBetaClient, names.Config, v1b1test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision"); err != nil {
 		t.Fatalf("The Configuration %q does not have a LatestCreatedRevisionName: %v", names.Config, err)
 	}
 
-	config, err := clients.ServingAlphaClient.Configs.Get(names.Config, metav1.GetOptions{})
+	config, err := clients.ServingBetaClient.Configs.Get(names.Config, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Configuration after it was seen to be live: %v", err)
 	}
 
 	revName := config.Status.LatestCreatedRevisionName
 
-	if err = v1a1test.WaitForRevisionState(clients.ServingAlphaClient, revName, v1a1test.IsRevisionReady, "RevisionIsReady"); err != nil {
+	if err = v1b1test.WaitForRevisionState(clients.ServingBetaClient, revName, v1b1test.IsRevisionReady, "RevisionIsReady"); err != nil {
 		t.Fatal("Revision did not become ready.")
 	}
 

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +37,7 @@ func checkResponse(t *testing.T, clients *test.Clients, names test.ResourceNames
 		clients.KubeClient,
 		t.Logf,
 		names.Domain,
-		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
+		v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources, &v1a1test.Options{}); err != nil {
+	if _, err := v1b1test.CreateServiceReady(t, defaultClients, &defaultResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
 
@@ -73,7 +73,7 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources, &v1a1test.Options{}); err != nil {
+	if _, err := v1b1test.CreateServiceReady(t, altClients, &altResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
 
@@ -125,7 +125,7 @@ func TestConflictingRouteService(t *testing.T) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}); err != nil {
+	if _, err := v1b1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
 }

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -27,14 +27,14 @@ import (
 	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	routeconfig "github.com/knative/serving/pkg/reconciler/route/config"
 
-	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	rtesting "github.com/knative/serving/pkg/testing/v1beta1"
 )
 
 const (
@@ -71,11 +71,11 @@ func sendRequest(t *testing.T, clients *test.Clients, resolvableDomain bool, dom
 }
 
 func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain string) {
-	// Create envVars to be used in httpproxy app.
-	envVars := []corev1.EnvVar{{
+	// Create envVar to be used in httpproxy app.
+	envVar := corev1.EnvVar{
 		Name:  targetHostEnv,
 		Value: helloworldDomain,
-	}}
+	}
 
 	// Set up httpproxy app.
 	t.Log("Creating a Service for the httpproxy test app.")
@@ -86,9 +86,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		EnvVars: envVars,
-	})
+	resources, err := v1b1test.CreateServiceReady(t, clients, &names, rtesting.WithEnv(envVar))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -154,9 +152,9 @@ func TestServiceToServiceCall(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	withInternalVisibility := WithServiceLabel(
+	withInternalVisibility := rtesting.WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withInternalVisibility)
+	resources, err := v1b1test.CreateServiceReady(t, clients, &names, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -198,13 +196,13 @@ func TestServiceToServiceCallFromZero(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	withInternalVisibility := WithServiceLabel(
+	withInternalVisibility := rtesting.WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, helloWorldNames) })
 	defer test.TearDown(clients, helloWorldNames)
 
-	helloWorld, err := v1a1test.CreateRunLatestServiceReady(t, clients, &helloWorldNames, &v1a1test.Options{}, withInternalVisibility)
+	helloWorld, err := v1b1test.CreateServiceReady(t, clients, &helloWorldNames, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/knative/pkg/test/logstream"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -123,7 +123,7 @@ func TestWebSocket(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}); err != nil {
+	if _, err := v1b1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
@@ -153,7 +153,7 @@ func TestWebSocketFromZero(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	resources, err := v1b1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}

--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -27,7 +27,7 @@ import (
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/ingress"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/loadgenerator"
 	perf "github.com/knative/test-infra/shared/performance"
@@ -64,7 +64,7 @@ func runTest(t *testing.T, img string, baseQPS float64, loadFactors []float64) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objs, err := v1b1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
@@ -79,7 +79,7 @@ func runTest(t *testing.T, img string, baseQPS float64, loadFactors []float64) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -28,7 +28,7 @@ import (
 	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
 	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
+	v1b1test "github.com/knative/serving/test/v1beta1"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/loadgenerator"
 	perf "github.com/knative/test-infra/shared/performance"
@@ -60,7 +60,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objs, err := v1b1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
@@ -75,7 +75,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing domain %s: %v", domain, err)

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -26,12 +26,10 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
-	// 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	// 	"github.com/knative/pkg/ptr"
 	ptest "github.com/knative/pkg/test"
 	rtesting "github.com/knative/serving/pkg/testing/v1beta1"
 	"github.com/knative/serving/test"
@@ -155,17 +153,7 @@ func CheckConfigurationState(client *test.ServingBetaClients, name string, inSta
 	return nil
 }
 
-// // ConfigurationHasCreatedRevision returns whether the Configuration has created a Revision.
-// func ConfigurationHasCreatedRevision(c *v1beta1.Configuration) (bool, error) {
-// 	return c.Status.LatestCreatedRevisionName != "", nil
-// }
-
-// // IsConfigRevisionCreationFailed will check the status conditions of the
-// // configuration and return true if the configuration's revision failed to
-// // create.
-// func IsConfigRevisionCreationFailed(c *v1beta1.Configuration) (bool, error) {
-// 	if cond := c.Status.GetCondition(v1beta1.ConfigurationConditionReady); cond != nil {
-// 		return cond.Status == corev1.ConditionFalse && cond.Reason == "RevisionFailed", nil
-// 	}
-// 	return false, nil
-// }
+// ConfigurationHasCreatedRevision returns whether the Configuration has created a Revision.
+func ConfigurationHasCreatedRevision(c *v1beta1.Configuration) (bool, error) {
+	return c.Status.LatestCreatedRevisionName != "", nil
+}


### PR DESCRIPTION
This migrates essentially all of the e2e testing except for test/conformance/api/v1alpha1
to test things through the v1beta1 endpoint.

/hold

I don't plan to land this until 0.7 cuts next week, but wanted to tee it up so we can land it Tuesday after the branch is cut.