### PR TITLE
Fix a silly mistake in test/system.go

### DIFF
--- a/test/system.go
+++ b/test/system.go
@@ -23,5 +23,5 @@ import (
 )
 
 func init() {
-	os.Setenv(system.NamespaceEnvKey, "knative-system")
+	os.Setenv(system.NamespaceEnvKey, "knative-serving")
 }


### PR DESCRIPTION
I put the wrong namespace in the `system.go` file 🤦‍♂ 

Spent a while debugging why the logstream stuff stopped working, and it turned out to be this.