### PR TITLE
Format markdown

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -141,9 +141,9 @@ As specified by OCI.
 It is expected that containers do not have direct access to the
 [OCI interface](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/runtime.md#operations)
 as providing access allows containers to circumvent runtime restrictions that
-are enforced by the Knative control plane. The operator or platform provider
-MAY have the ability to directly interact with the OCI interface, but that is
-beyond the scope of this specification.
+are enforced by the Knative control plane. The operator or platform provider MAY
+have the ability to directly interact with the OCI interface, but that is beyond
+the scope of this specification.
 
 An OPTIONAL method of invoking the `kill` operation MAY be exposed to developers
 to provide signalling to the container.


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @mattmoor
