### PR TITLE
Bump flakey scaler tick poll test timeout

### DIFF
--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -159,7 +159,7 @@ func TestMultiScalerTickUpdate(t *testing.T) {
 		t.Errorf("Update() = %v", err)
 	}
 
-	if err := wait.PollImmediate(time.Millisecond, 5*time.Millisecond, func() (bool, error) {
+	if err := wait.PollImmediate(time.Millisecond, 10*time.Millisecond, func() (bool, error) {
 		// Expected count to be greater than 1 as the tick interval is updated to be 1ms
 		if uniScaler.getScaleCount() >= 1 {
 			return true, nil


### PR DESCRIPTION
I just saw this test fail flakily, it seems this timeout is too
aggressive for expecting the coroutines it is waiting on to execute.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
