### PR TITLE
Remove trailing document headers

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana.yaml
@@ -268,4 +268,3 @@ spec:
       - name: scaling-config
         configMap:
           name: scaling-config
----

--- a/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin-in-mem/100-zipkin.yaml
@@ -65,4 +65,3 @@ spec:
             memory: 1000Mi
           requests:
             memory: 256Mi
----

--- a/config/monitoring/tracing/zipkin/100-zipkin.yaml
+++ b/config/monitoring/tracing/zipkin/100-zipkin.yaml
@@ -73,4 +73,3 @@ spec:
             memory: 1000Mi
           requests:
             memory: 256Mi
----


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4333

Remove trailing document headers.

There is actually a [different separator](https://yaml.org/spec/1.0/#ns-ns-document-end) to indicate a document end (`...`). The `---` is supposed to be for a [document header](https://yaml.org/spec/1.0/#ns-ns-document-start), so it's weird to have this at the end. Also, these had four (`----`), which seems even more wrong.