### PR TITLE
Remove explicit deletion of HPA.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -64,9 +64,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		if err := c.Metrics.Delete(ctx, namespace, name); err != nil {
 			return err
 		}
-		if err := c.deleteHPA(ctx, key); err != nil {
-			return err
-		}
 		return nil
 	} else if err != nil {
 		return err
@@ -169,24 +166,5 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 	}
 
 	pa.Status.ObservedGeneration = pa.Generation
-	return nil
-}
-
-func (c *Reconciler) deleteHPA(ctx context.Context, key string) error {
-	logger := logging.FromContext(ctx)
-
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
-	}
-	err = c.KubeClientSet.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).Delete(name, nil)
-	if errors.IsNotFound(err) {
-		// This is fine.
-		return nil
-	} else if err != nil {
-		logger.Errorf("Error deleting HPA %q: %v", name, err)
-		return err
-	}
-	logger.Infof("Deleted HPA %q", name)
 	return nil
 }

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -51,7 +51,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ktesting "k8s.io/client-go/testing"
 
 	. "github.com/knative/pkg/reconciler/testing"
@@ -294,63 +293,6 @@ func TestReconcile(t *testing.T) {
 			deploy(testNamespace, testRevision),
 		},
 		Key: key(testRevision, testNamespace),
-	}, {
-		Name: "delete hpa when pa does not exist",
-		Objects: []runtime.Object{
-			hpa(testRevision, testNamespace, pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"))),
-			deploy(testNamespace, testRevision),
-		},
-		Key: key(testRevision, testNamespace),
-		WantDeletes: []ktesting.DeleteActionImpl{{
-			ActionImpl: ktesting.ActionImpl{
-				Namespace: testNamespace,
-				Verb:      "delete",
-				Resource: schema.GroupVersionResource{
-					Group:    "autoscaling",
-					Version:  "v1",
-					Resource: "horizontalpodautoscalers",
-				},
-			},
-			Name: testRevision,
-		}},
-	}, {
-		Name:    "attempt to delete non-existent hpa when pa does not exist",
-		Objects: []runtime.Object{},
-		Key:     key(testRevision, testNamespace),
-		WantDeletes: []ktesting.DeleteActionImpl{{
-			ActionImpl: ktesting.ActionImpl{
-				Namespace: testNamespace,
-				Verb:      "delete",
-				Resource: schema.GroupVersionResource{
-					Group:    "autoscaling",
-					Version:  "v1",
-					Resource: "horizontalpodautoscalers",
-				},
-			},
-			Name: testRevision,
-		}},
-	}, {
-		Name: "failure to delete hpa",
-		Objects: []runtime.Object{
-			hpa(testRevision, testNamespace, pa(testRevision, testNamespace, WithHPAClass, WithMetricAnnotation("cpu"))),
-		},
-		Key: key(testRevision, testNamespace),
-		WantDeletes: []ktesting.DeleteActionImpl{{
-			ActionImpl: ktesting.ActionImpl{
-				Namespace: testNamespace,
-				Verb:      "delete",
-				Resource: schema.GroupVersionResource{
-					Group:    "autoscaling",
-					Version:  "v1",
-					Resource: "horizontalpodautoscalers",
-				},
-			},
-			Name: testRevision,
-		}},
-		WithReactors: []ktesting.ReactionFunc{
-			InduceFailure("delete", "horizontalpodautoscalers"),
-		},
-		WantErr: true,
 	}, {
 		Name: "update pa fails",
 		Objects: []runtime.Object{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* We use OwnerReferences and finalizers everywhere to implicitly remove child-entities rather than explicitly acting on a missing parent-entity.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
