### PR TITLE
Allow custom-metrics server to generate certs as a non-root user.

### DIFF
--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -57,6 +57,7 @@ spec:
           containerPort: 8443
         args:
         - "--secure-port=8443"
+        - "--cert-dir=/tmp"
         volumeMounts:
         - name: config-autoscaler
           mountPath: /etc/config-autoscaler


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

If the custom-metrics server is not given any certs via the command-line (which is our default behavior for now) it will generate and serve them on the fly. The default directory for this is `apiserver.local.config`, which a non-root user cannot create.

This switches the directory for these throw-away certificates to `/tmp` to make the autoscaler runnable as a non-root user again.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
