### PR TITLE
Fix autoscaler shutdown error reporting.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -161,7 +161,7 @@ func main() {
 
 	statsServer.Shutdown(5 * time.Second)
 	if err := eg.Wait(); err != nil {
-		logger.Errorw("Group error.", zap.Error(err))
+		logger.Errorw("Error while shutting down", zap.Error(err))
 	}
 }
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -125,7 +125,6 @@ func main() {
 
 	// Set up a statserver.
 	statsServer := statserver.New(statsServerAddr, statsCh, logger)
-	defer statsServer.Shutdown(time.Second * 5)
 
 	// Start watching the configs.
 	if err := cmw.Start(ctx.Done()); err != nil {
@@ -139,16 +138,6 @@ func main() {
 
 	go controller.StartAll(ctx.Done(), controllers...)
 
-	// Run the controllers and the statserver in a group.
-	var eg errgroup.Group
-	eg.Go(func() error {
-		return customMetricsAdapter.Run(ctx.Done())
-	})
-
-	eg.Go(func() error {
-		return statsServer.ListenAndServe()
-	})
-
 	go func() {
 		for {
 			sm, ok := <-statsCh
@@ -160,18 +149,19 @@ func main() {
 		}
 	}()
 
-	egCh := make(chan struct{})
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return customMetricsAdapter.Run(ctx.Done())
+	})
+	eg.Go(statsServer.ListenAndServe)
 
-	go func() {
-		if err := eg.Wait(); err != nil {
-			logger.Errorw("Group error.", zap.Error(err))
-		}
-		close(egCh)
-	}()
+	// This will block until either a signal arrives or one of the grouped functions
+	// returns an error.
+	<-egCtx.Done()
 
-	select {
-	case <-egCh:
-	case <-ctx.Done():
+	statsServer.Shutdown(5 * time.Second)
+	if err := eg.Wait(); err != nil {
+		logger.Errorw("Group error.", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

If one of the two grouped functions crashed, nothing would happen at all because errgrp.Wait() will only return after **all** functions have returned either nil or an error.

This fixes that situation by exiting gracefully as soon as one of the grouped statements exit. The biggest offender here is the statsServer, which does not listen on a stop-channel to be shut down. We therefore shut it down immediately after the context signal arrives to make sure the entire group shuts down properly so the finishing `Wait()` call returns eventually.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
