### PR TITLE
Filter all endpoints informer by the label we're looking for.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -78,8 +78,10 @@ func NewController(
 	}
 	paInformer.Informer().AddEventHandler(paHandler)
 
-	endpointsInformer.Informer().AddEventHandler(
-		controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("", autoscaling.KPALabelKey)))
+	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: reconciler.LabelExistsFilterFunc(autoscaling.KPALabelKey),
+		Handler:    controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("", autoscaling.KPALabelKey)),
+	})
 
 	// Watch all the services that we have created.
 	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -87,8 +87,10 @@ func NewController(
 	c.Logger.Info("Setting up event handlers")
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-	endpointsInformer.Informer().AddEventHandler(controller.HandleAll(
-		impl.EnqueueLabelOfNamespaceScopedResource("", serving.RevisionLabelKey)))
+	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: reconciler.LabelExistsFilterFunc(serving.RevisionLabelKey),
+		Handler:    controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("", serving.RevisionLabelKey)),
+	})
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The `EnqueueLabelOfNamespaceScopedResource` function itself filters as well, but a bit too late. We'll still see a "reconcile succeeded" log for non-managed endpoints, which is noisy and misleading.

This adds top-level filtering to the event-handler to make sure that endpoints that are not managed by Knative don't even reach the controller implementation.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a bug where non-managed endpoints show up in reconciler logs.
```
