### PR TITLE
Make Target() return float64

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -83,14 +84,15 @@ func (pa *PodAutoscaler) ScaleBounds() (min, max int32) {
 	return
 }
 
-// Target returns the target annotation value or false if not present.
-func (pa *PodAutoscaler) Target() (target int32, ok bool) {
+// Target returns the target annotation value or false if not present, or invalid.
+func (pa *PodAutoscaler) Target() (float64, bool) {
 	if s, ok := pa.Annotations[autoscaling.TargetAnnotationKey]; ok {
-		if i, err := strconv.Atoi(s); err == nil {
-			if i < 1 {
+		if ta, err := strconv.ParseFloat(s, 64 /*width*/); err == nil {
+			// Max check for backwards compatibility.
+			if ta < 1 || ta > math.MaxInt32 {
 				return 0, false
 			}
-			return int32(i), true
+			return ta, true
 		}
 	}
 	return 0, false

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -371,7 +371,7 @@ func TestTargetAnnotation(t *testing.T) {
 	cases := []struct {
 		name       string
 		pa         *PodAutoscaler
-		wantTarget int32
+		wantTarget float64
 		wantOk     bool
 	}{{
 		name:       "not present",

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -20,6 +20,7 @@ import (
 	"math"
 
 	"github.com/knative/pkg/kmeta"
+	"github.com/knative/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -65,7 +66,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
 					Name:                     corev1.ResourceCPU,
-					TargetAverageUtilization: &target,
+					TargetAverageUtilization: ptr.Int32(int32(target)),
 				},
 			}}
 		}

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -66,7 +66,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
 					Name:                     corev1.ResourceCPU,
-					TargetAverageUtilization: ptr.Int32(int32(target)),
+					TargetAverageUtilization: ptr.Int32(int32(math.Ceil(target))),
 				},
 			}}
 		}

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -73,6 +73,19 @@ func TestMakeHPA(t *testing.T) {
 				},
 			})),
 	}, {
+		name: "with an actual fractional target",
+		pa:   pa(WithTargetAnnotation("1982.4"), WithMetricAnnotation(autoscaling.CPU)),
+		want: hpa(
+			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.CPU),
+			withAnnotationValue(autoscaling.TargetAnnotationKey, "1982.4"),
+			withMetric(autoscalingv2beta1.MetricSpec{
+				Type: autoscalingv2beta1.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta1.ResourceMetricSource{
+					Name:                     corev1.ResourceCPU,
+					TargetAverageUtilization: ptr.Int32(1983),
+				},
+			})),
+	}, {
 		name: "with metric=concurrency",
 		pa:   pa(WithMetricAnnotation(autoscaling.Concurrency)),
 		want: hpa(

--- a/pkg/reconciler/autoscaling/resources/concurrency.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency.go
@@ -38,7 +38,7 @@ func ResolveTargetConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Con
 		// We pick the smaller value between the calculated target and the annotationTarget
 		// to make sure the autoscaler does not aim for a higher concurrency than the application
 		// can handle per containerConcurrency.
-		target = math.Min(target, float64(annotationTarget))
+		target = math.Min(target, annotationTarget)
 	}
 
 	return target


### PR DESCRIPTION
I had wanted to this change earlier, when the only usage was in KPA, where we cast
it to float.
But now it's in use in HPA as well, so the change is not as clear-cut as before.
I still think it's useful, and FWIW, we might want to permit non whole CC  :-)

/assign @markusthoemmes @mattmoor 

