### PR TITLE
fix bug of elasticsearch host server unreachable

### DIFF
--- a/config/monitoring/logging/elasticsearch/100-fluentd-configmap.yaml
+++ b/config/monitoring/logging/elasticsearch/100-fluentd-configmap.yaml
@@ -101,7 +101,7 @@ data:
       @id elasticsearch
       @type elasticsearch
       @log_level info
-      host elasticsearch-logging
+      host elasticsearch-logging.knative-monitoring
       port 9200
       logstash_format true
       <buffer>


### PR DESCRIPTION
update 100-fluentd-configmap.yaml to fix the elasticsearch host server unreachable with namespace knative-monitoring


Fixes #

## Proposed Changes


```release-note
NONE
```
