### PR TITLE
Reduce exhaustive logging of a failed 'TestDestroyPodTimely' test.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -174,15 +174,15 @@ func TestDestroyPodTimely(t *testing.T) {
 	// of the containers of that pod are no longer running. It can take an arbitrarily long time to
 	// actually remove the pod itself while we only care about containers being stopped.
 	deploymentName := rnames.Deployment(objects.Revision)
-	var podList *v1.PodList
+	var latestPodState v1.Pod
 	pkgTest.WaitForPodListState(
 		clients.KubeClient,
 		func(p *v1.PodList) (bool, error) {
-			podList = p
 			for _, pod := range p.Items {
 				if !strings.Contains(pod.Name, deploymentName) {
 					continue
 				}
+				latestPodState = pod
 				for _, status := range pod.Status.ContainerStatuses {
 					// There are still containers running, keep retrying.
 					if status.State.Running != nil {
@@ -196,7 +196,7 @@ func TestDestroyPodTimely(t *testing.T) {
 
 	timeToDelete := time.Since(start)
 	if timeToDelete > maxTimeToDelete {
-		t.Logf("Pod list: %s", spew.Sprint(podList))
+		t.Logf("State: %s", spew.Sprint(latestPodState))
 		t.Errorf("Time to delete pods = %v, want < %v", timeToDelete, maxTimeToDelete)
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

We used to print the entire podlist which can be exhaustively long given we run most of the E2E tests in parallel. Only the state of the pod in question really matters though.
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
