### PR TITLE
golang format tools

### DIFF
--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -25,10 +25,10 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -31,11 +31,11 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	resourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	rtesting "github.com/knative/serving/pkg/testing/v1alpha1"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -28,9 +28,9 @@ import (
 
 	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
+	"github.com/knative/pkg/test/logstream"
 	resourcenames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	ping "github.com/knative/serving/test/test_images/grpc-ping/proto"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	"google.golang.org/grpc"

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
 	v1alpha1testing "github.com/knative/serving/pkg/testing/v1alpha1"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 )
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -22,10 +22,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "github.com/knative/serving/pkg/reconciler/service/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 
 	pkgTest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logstream"
 	"github.com/knative/pkg/test/spoof"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/gorilla/websocket"
 	pkgTest "github.com/knative/pkg/test"
 	ingress "github.com/knative/pkg/test/ingress"
+	"github.com/knative/pkg/test/logstream"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
-	"github.com/knative/pkg/test/logstream"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
