### PR TITLE
Add owners to the pkg/resources

### DIFF
--- a/pkg/resources/OWNERS
+++ b/pkg/resources/OWNERS
@@ -1,0 +1,10 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- serving-api-approvers
+
+reviewers:
+- serving-api-reviewers
+
+labels:
+- area/API


### PR DESCRIPTION
This seems like a generic library function set used
mostly in reconcilers and autoscaler, so should generally
be covered by serving approvers.

/assign @mattmoor 