### PR TITLE
Rename label key "IngressLabelKey" constant name

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -35,9 +35,9 @@ const (
 	// Istio-based ClusterIngress will reconcile into a VirtualService).
 	IngressClassAnnotationKey = "networking.knative.dev/ingress.class"
 
-	// IngressLabelKey is the label key attached to underlying network programming
+	// ClusterIngressLabelKey is the label key attached to underlying network programming
 	// resources to indicate which ClusterIngress triggered their creation.
-	IngressLabelKey = GroupName + "/clusteringress"
+	ClusterIngressLabelKey = GroupName + "/clusteringress"
 
 	// SKSLabelKey is the label key that SKS Controller attaches to the
 	// underlying resources it controls.

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -229,9 +229,9 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice",
 					Namespace: system.Namespace(),
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteLabelKey:          "test-route",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.ClusterIngressLabelKey: "reconcile-virtualservice",
+						serving.RouteLabelKey:             "test-route",
+						serving.RouteNamespaceLabelKey:    "test-ns",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
 				},
@@ -242,7 +242,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice-extra",
 					Namespace: system.Namespace(),
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-virtualservice",
+						networking.ClusterIngressLabelKey:     "reconcile-virtualservice",
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},

--- a/pkg/reconciler/clusteringress/controller.go
+++ b/pkg/reconciler/clusteringress/controller.go
@@ -70,7 +70,7 @@ func NewController(
 
 	virtualServiceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: myFilterFunc,
-		Handler:    controller.HandleAll(impl.EnqueueLabelOfClusterScopedResource(networking.IngressLabelKey)),
+		Handler:    controller.HandleAll(impl.EnqueueLabelOfClusterScopedResource(networking.ClusterIngressLabelKey)),
 	})
 
 	c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))

--- a/pkg/reconciler/clusteringress/resources/virtual_service.go
+++ b/pkg/reconciler/clusteringress/resources/virtual_service.go
@@ -60,7 +60,7 @@ func MakeIngressVirtualService(ci *v1alpha1.ClusterIngress, gateways []string) *
 	if vs.Labels == nil {
 		vs.Labels = make(map[string]string)
 	}
-	vs.Labels[networking.IngressLabelKey] = ci.Name
+	vs.Labels[networking.ClusterIngressLabelKey] = ci.Name
 
 	ingressLabels := ci.Labels
 	vs.Labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
@@ -85,7 +85,7 @@ func MakeMeshVirtualService(ci *v1alpha1.ClusterIngress) *v1alpha3.VirtualServic
 		resources.FilterMap(ci.Labels, func(k string) bool {
 			return k != serving.RouteLabelKey && k != serving.RouteNamespaceLabelKey
 		}),
-		map[string]string{networking.IngressLabelKey: ci.Name})
+		map[string]string{networking.ClusterIngressLabelKey: ci.Name})
 	return vs
 }
 

--- a/pkg/reconciler/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/clusteringress/resources/virtual_service_test.go
@@ -61,17 +61,17 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress-mesh",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
-				networking.IngressLabelKey:     "test-ingress",
-				serving.RouteLabelKey:          "test-route",
-				serving.RouteNamespaceLabelKey: "test-ns",
+				networking.ClusterIngressLabelKey: "test-ingress",
+				serving.RouteLabelKey:             "test-route",
+				serving.RouteNamespaceLabelKey:    "test-ns",
 			},
 		}, {
 			Name:      "test-ingress",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
-				networking.IngressLabelKey:     "test-ingress",
-				serving.RouteLabelKey:          "test-route",
-				serving.RouteNamespaceLabelKey: "test-ns",
+				networking.ClusterIngressLabelKey: "test-ingress",
+				serving.RouteLabelKey:             "test-route",
+				serving.RouteNamespaceLabelKey:    "test-ns",
 			},
 		}},
 	}, {
@@ -91,9 +91,9 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress-mesh",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
-				networking.IngressLabelKey:     "test-ingress",
-				serving.RouteLabelKey:          "test-route",
-				serving.RouteNamespaceLabelKey: "test-ns",
+				networking.ClusterIngressLabelKey: "test-ingress",
+				serving.RouteLabelKey:             "test-route",
+				serving.RouteNamespaceLabelKey:    "test-ns",
 			},
 		}},
 	}} {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Rename  IngressLabelKey to ClusterLabelKey constant key for #3982 so that we can add IngressLabelKey name for Namespaced Ingress.

## Proposed Changes

* Rename  IngressLabelKey to ClusterLabelKey constant key for ##3982 so that we can add IngressLabelKey name for Namespaced Ingress.
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
