### PR TITLE
Fix the bug where we might have ended up with 0 target concurrency.

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -123,6 +123,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		lc.ContainerConcurrencyTargetFraction /= 100.0
 	}
 
+	if x := lc.ContainerConcurrencyTargetFraction * lc.ContainerConcurrencyTargetDefault; x < 1.0 {
+		return nil, fmt.Errorf("container-concurrency-target-percentage and container-concurrency-target-default yield target concurrency of %f, can't be less 1", x)
+	}
+
 	// Process Duration fields
 	for _, dur := range []struct {
 		key          string

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -232,6 +232,19 @@ func TestNewConfig(t *testing.T) {
 			"panic-threshold-percentage":              "200",
 		},
 		wantErr: true,
+	}, {
+		name: "target capacity less than 1",
+		input: map[string]string{
+			"max-scale-up-rate":                       "1.0",
+			"container-concurrency-target-percentage": "30.0",
+			"container-concurrency-target-default":    "2",
+			"stable-window":                           "not a duration",
+			"panic-window":                            "10s",
+			"tick-interval":                           "2s",
+			"panic-window-percentage":                 "10",
+			"panic-threshold-percentage":              "200",
+		},
+		wantErr: true,
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -71,7 +71,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 			}}
 		}
 	case autoscaling.Concurrency:
-		target := int64(math.Ceil(aresources.ResolveTargetConcurrency(pa, config)))
+		target := int64(math.Ceil(aresources.ResolveConcurrency(pa, config)))
 		hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
 			Type: autoscalingv2beta1.ObjectMetricSourceType,
 			Object: &autoscalingv2beta1.ObjectMetricSource{

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -56,7 +56,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 		stableWindow = config.StableWindow
 	}
 
-	target := resources.ResolveTargetConcurrency(pa, config)
+	target := resources.ResolveConcurrency(pa, config)
 	panicThreshold := target * panicThresholdPercentage / 100.0
 
 	return &autoscaler.Decider{

--- a/pkg/reconciler/autoscaling/resources/concurrency.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency.go
@@ -23,10 +23,10 @@ import (
 	"github.com/knative/serving/pkg/autoscaler"
 )
 
-// ResolveTargetConcurrency takes concurrency knobs from multiple locations and resolves them
+// ResolveConcurrency takes concurrency knobs from multiple locations and resolves them
 // to the final value to be used by the autoscaler.
-func ResolveTargetConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) float64 {
-	target := float64(pa.Spec.ContainerConcurrency) * config.ContainerConcurrencyTargetFraction
+func ResolveConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) float64 {
+	target := math.Max(1, float64(pa.Spec.ContainerConcurrency)*config.ContainerConcurrencyTargetFraction)
 
 	// If containerConcurrency is 0 we'll always target the default.
 	if pa.Spec.ContainerConcurrency == 0 {

--- a/pkg/reconciler/autoscaling/resources/concurrency_test.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency_test.go
@@ -20,23 +20,45 @@ import (
 	"testing"
 
 	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	"github.com/knative/serving/pkg/autoscaler"
 
 	. "github.com/knative/serving/pkg/testing"
 )
 
-func TestResolveTargetConcurrency(t *testing.T) {
+func TestResolveConcurrency(t *testing.T) {
 	cases := []struct {
-		name string
-		pa   *v1alpha1.PodAutoscaler
-		want float64
+		name   string
+		pa     *v1alpha1.PodAutoscaler
+		cfgOpt func(autoscaler.Config) *autoscaler.Config
+		want   float64
 	}{{
 		name: "defaults",
 		pa:   pa(),
 		want: 100,
 	}, {
+		name: "with container concurrency 10 and TU=80%",
+		pa:   pa(WithContainerConcurrency(10)),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.8
+			return &c
+		},
+		want: 8,
+	}, {
+		name: "with container concurrency 1 and TU=80%",
+		pa:   pa(WithContainerConcurrency(1)),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.8
+			return &c
+		},
+		want: 1, // Not permitting less than 1.
+	}, {
 		name: "with container concurrency 1",
 		pa:   pa(WithContainerConcurrency(1)),
 		want: 1,
+	}, {
+		name: "with container concurrency 10",
+		pa:   pa(WithContainerConcurrency(10)),
+		want: 10,
 	}, {
 		name: "with target annotation 1",
 		pa:   pa(WithTargetAnnotation("1")),
@@ -53,7 +75,11 @@ func TestResolveTargetConcurrency(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := ResolveTargetConcurrency(tc.pa, config); got != tc.want {
+			cfg := config
+			if tc.cfgOpt != nil {
+				cfg = tc.cfgOpt(*cfg)
+			}
+			if got := ResolveConcurrency(tc.pa, cfg); got != tc.want {
 				t.Errorf("ResolveTargetConcurrency(%v, %v) = %v, want %v", tc.pa, config, got, tc.want)
 			}
 		})


### PR DESCRIPTION
The code as it was, would multiply target currency by target utilization.
Since TU is effectively 1, this was never a problem.
But now that we're trying to lower it, it could have been that we'd have numbers <1, which after int() casting would
effectively become 0.
This fixes the problem in both places (the CFGMAP setting) and the computation (min of 1, will be ensured)>

/assign @mattmoor @markusthoemmes 

/lint

## Proposed Changes

* validate that TU*CC >=1
* enforce min=1 in the TC computation
* update tests

