### PR TITLE
Remove endpoints lister/informer from the revision controller

### DIFF
--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -55,7 +55,6 @@ type Reconciler struct {
 	imageLister         cachinglisters.ImageLister
 	deploymentLister    appsv1listers.DeploymentLister
 	serviceLister       corev1listers.ServiceLister
-	endpointsLister     corev1listers.EndpointsLister
 	configMapLister     corev1listers.ConfigMapLister
 
 	resolver    resolver

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -562,7 +562,6 @@ func TestReconcile(t *testing.T) {
 			imageLister:         listers.GetImageLister(),
 			deploymentLister:    listers.GetDeploymentLister(),
 			serviceLister:       listers.GetK8sServiceLister(),
-			endpointsLister:     listers.GetEndpointsLister(),
 			configMapLister:     listers.GetConfigMapLister(),
 			resolver:            &nopResolver{},
 			configStore:         &testConfigStore{config: ReconcilerTestConfig()},


### PR DESCRIPTION
It's no longer used for anything

/assign @mattmoor 