### PR TITLE
Refactor network/prober

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -231,7 +231,7 @@ func main() {
 		revisionInformer.Lister(),
 		serviceInformer.Lister(),
 		sksInformer.Lister(),
-		prober.New(network.NewAutoTransport()))
+		prober.New(network.NewAutoTransport))
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -46,6 +46,7 @@ import (
 	pkghttp "github.com/knative/serving/pkg/http"
 	"github.com/knative/serving/pkg/logging"
 	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/network/prober"
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/tracing"
 	tracingconfig "github.com/knative/serving/pkg/tracing/config"
@@ -230,7 +231,7 @@ func main() {
 		revisionInformer.Lister(),
 		serviceInformer.Lister(),
 		sksInformer.Lister(),
-	)
+		prober.New(nil, network.NewAutoTransport))
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -231,7 +231,7 @@ func main() {
 		revisionInformer.Lister(),
 		serviceInformer.Lister(),
 		sksInformer.Lister(),
-		prober.New(nil, network.NewAutoTransport))
+		prober.New(network.NewAutoTransport()))
 	ah = activatorhandler.NewRequestEventHandler(reqChan, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -17,7 +17,6 @@ package handler
 import (
 	"errors"
 	"fmt"
-	"github.com/knative/serving/pkg/activator/handler"
 	"github.com/knative/serving/pkg/network/prober"
 	"io/ioutil"
 	"net/http"
@@ -326,14 +325,14 @@ func TestActivationHandler(t *testing.T) {
 				svcLister = test.svcLister
 			}
 
-			handler := handler.New(
+			handler := New(
 				TestLogger(t),
 				reporter,
 				throttler,
 				revisionLister(revision(testNamespace, testRevName)),
 				svcLister,
 				sksLister,
-				prober.New(rtFact(rt)))
+				prober.New(rtFact(rt))).(*activationHandler)
 			handler.transport = rt
 			handler.probeTimeout = test.probeTimeout
 
@@ -393,14 +392,14 @@ func TestActivationHandlerOverflow(t *testing.T) {
 		revisionLister(revision(namespace, revName)),
 		TestLogger(t))
 
-	handler := handler.New(
+	handler := New(
 		TestLogger(t),
 		reporter,
 		throttler,
 		revisionLister(revision(namespace, revName)),
 		serviceLister(service(namespace, revName, "http")),
 		sksLister(sks(namespace, revName)),
-		prober.New(rtFact(rt)))
+		prober.New(rtFact(rt))).(*activationHandler)
 	handler.transport = rt
 
 	sendRequests(requests, namespace, revName, respCh, handler)
@@ -440,14 +439,14 @@ func TestActivationHandlerOverflowSeveralRevisions(t *testing.T) {
 		},
 	}
 	rt := network.RoundTripperFunc(fakeRT.RT)
-	handler := handler.New(
+	handler := New(
 		TestLogger(t),
 		reporter,
 		throttler,
 		revClient,
 		svcClient,
 		sksClient,
-		prober.New(rtFact(rt)))
+		prober.New(rtFact(rt))).(*activationHandler)
 	handler.transport = rt
 
 	for _, revName := range revisions {
@@ -483,14 +482,14 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	}
 	probeRt := network.RoundTripperFunc(fakeRT.RT)
 
-	handler := handler.New(
+	handler := New(
 		TestLogger(t),
 		&fakeReporter{},
 		throttler,
 		revisionLister(revision(testNamespace, testRevName)),
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
-		prober.New(rtFact(probeRt)))
+		prober.New(rtFact(probeRt))).(*activationHandler)
 	handler.transport = rt
 
 	writer := httptest.NewRecorder()
@@ -548,14 +547,14 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister(revision(namespace, revName)),
 		TestLogger(t))
 
-	handler := handler.New(
+	handler := New(
 		TestLogger(t),
 		&fakeReporter{},
 		throttler,
 		revisionLister(revision(testNamespace, testRevName)),
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
-		prober.New(rtFact(rt)))
+		prober.New(rtFact(rt))).(*activationHandler)
 	handler.transport = rt
 
 	_ = sendRequest(namespace, revName, handler)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -333,7 +333,7 @@ func TestActivationHandler(t *testing.T) {
 				revisionLister(revision(testNamespace, testRevName)),
 				svcLister,
 				sksLister,
-				prober.New(nil, rtFact(rt)))
+				prober.New(rt))
 			handler.Transport = rt
 			handler.ProbeTimeout = test.probeTimeout
 
@@ -400,7 +400,7 @@ func TestActivationHandlerOverflow(t *testing.T) {
 		revisionLister(revision(namespace, revName)),
 		serviceLister(service(namespace, revName, "http")),
 		sksLister(sks(namespace, revName)),
-		prober.New(nil, rtFact(rt)))
+		prober.New(rt))
 	handler.Transport = rt
 
 	sendRequests(requests, namespace, revName, respCh, handler)
@@ -447,7 +447,7 @@ func TestActivationHandlerOverflowSeveralRevisions(t *testing.T) {
 		revClient,
 		svcClient,
 		sksClient,
-		prober.New(nil, rtFact(rt)))
+		prober.New(rt))
 	handler.Transport = rt
 
 	for _, revName := range revisions {
@@ -490,7 +490,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 		revisionLister(revision(testNamespace, testRevName)),
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
-		prober.New(nil, rtFact(probeRt)))
+		prober.New(probeRt))
 	handler.Transport = rt
 
 	writer := httptest.NewRecorder()
@@ -555,7 +555,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister(revision(testNamespace, testRevName)),
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
-		prober.New(nil, rtFact(rt)))
+		prober.New(rt))
 	handler.Transport = rt
 
 	_ = sendRequest(namespace, revName, handler)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package handler_test
+package handler
 
 import (
 	"errors"
@@ -334,8 +334,8 @@ func TestActivationHandler(t *testing.T) {
 				svcLister,
 				sksLister,
 				prober.New(rtFact(rt)))
-			handler.Transport = rt
-			handler.ProbeTimeout = test.probeTimeout
+			handler.transport = rt
+			handler.probeTimeout = test.probeTimeout
 
 			resp := httptest.NewRecorder()
 
@@ -401,7 +401,7 @@ func TestActivationHandlerOverflow(t *testing.T) {
 		serviceLister(service(namespace, revName, "http")),
 		sksLister(sks(namespace, revName)),
 		prober.New(rtFact(rt)))
-	handler.Transport = rt
+	handler.transport = rt
 
 	sendRequests(requests, namespace, revName, respCh, handler)
 	assertResponses(wantedSuccess, wantedFailure, lockerCh, respCh, t)
@@ -448,7 +448,7 @@ func TestActivationHandlerOverflowSeveralRevisions(t *testing.T) {
 		svcClient,
 		sksClient,
 		prober.New(rtFact(rt)))
-	handler.Transport = rt
+	handler.transport = rt
 
 	for _, revName := range revisions {
 		requestCount := overallRequests / len(revisions)
@@ -491,7 +491,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
 		prober.New(rtFact(probeRt)))
-	handler.Transport = rt
+	handler.transport = rt
 
 	writer := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -556,7 +556,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
 		prober.New(rtFact(rt)))
-	handler.Transport = rt
+	handler.transport = rt
 
 	_ = sendRequest(namespace, revName, handler)
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -333,7 +333,7 @@ func TestActivationHandler(t *testing.T) {
 				revisionLister(revision(testNamespace, testRevName)),
 				svcLister,
 				sksLister,
-				prober.New(rt))
+				prober.New(rtFact(rt)))
 			handler.Transport = rt
 			handler.ProbeTimeout = test.probeTimeout
 
@@ -400,7 +400,7 @@ func TestActivationHandlerOverflow(t *testing.T) {
 		revisionLister(revision(namespace, revName)),
 		serviceLister(service(namespace, revName, "http")),
 		sksLister(sks(namespace, revName)),
-		prober.New(rt))
+		prober.New(rtFact(rt)))
 	handler.Transport = rt
 
 	sendRequests(requests, namespace, revName, respCh, handler)
@@ -447,7 +447,7 @@ func TestActivationHandlerOverflowSeveralRevisions(t *testing.T) {
 		revClient,
 		svcClient,
 		sksClient,
-		prober.New(rt))
+		prober.New(rtFact(rt)))
 	handler.Transport = rt
 
 	for _, revName := range revisions {
@@ -490,7 +490,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 		revisionLister(revision(testNamespace, testRevName)),
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
-		prober.New(probeRt))
+		prober.New(rtFact(probeRt)))
 	handler.Transport = rt
 
 	writer := httptest.NewRecorder()
@@ -555,7 +555,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister(revision(testNamespace, testRevName)),
 		serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister(sks(testNamespace, testRevName)),
-		prober.New(rt))
+		prober.New(rtFact(rt)))
 	handler.Transport = rt
 
 	_ = sendRequest(namespace, revName, handler)

--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -112,7 +112,7 @@ func TestDoAsync(t *testing.T) {
 	tests := []struct {
 		name        string
 		headerValue string
-		callback Callback
+		callback    Callback
 	}{{
 		name:        "ok",
 		headerValue: systemName,

--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -68,9 +68,10 @@ func TestDoServing(t *testing.T) {
 		headerValue: "",
 		want:        false,
 	}}
+	prober := New(func(arg interface{}, success bool, err error) {}, network.NewAutoTransport)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, test.headerValue)
+			got, err := prober.Do(context.Background(), ts.URL, test.headerValue)
 			if want := test.want; got != want {
 				t.Errorf("Got = %v, want: %v", got, want)
 			}
@@ -82,7 +83,8 @@ func TestDoServing(t *testing.T) {
 }
 
 func TestBlackHole(t *testing.T) {
-	got, err := Do(context.Background(), network.NewAutoTransport(), "http://gone.fishing.svc.custer.local:8080", systemName)
+	prober := New(func(arg interface{}, success bool, err error) {}, network.NewAutoTransport)
+	got, err := prober.Do(context.Background(), "http://gone.fishing.svc.custer.local:8080", systemName)
 	if want := false; got != want {
 		t.Errorf("Got = %v, want: %v", got, want)
 	}
@@ -92,7 +94,8 @@ func TestBlackHole(t *testing.T) {
 }
 
 func TestBadURL(t *testing.T) {
-	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo", systemName)
+	prober := New(func(arg interface{}, success bool, err error) {}, network.NewAutoTransport)
+	_, err := prober.Do(context.Background(), ":foo", systemName)
 	if err == nil {
 		t.Error("Do did not return an error")
 	}

--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -68,7 +68,7 @@ func TestDoServing(t *testing.T) {
 		headerValue: "",
 		want:        false,
 	}}
-	prober := New(network.NewAutoTransport())
+	prober := New(network.NewAutoTransport)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := prober.Do(context.Background(), ts.URL, test.headerValue)
@@ -83,7 +83,7 @@ func TestDoServing(t *testing.T) {
 }
 
 func TestBlackHole(t *testing.T) {
-	prober := New(network.NewAutoTransport())
+	prober := New(network.NewAutoTransport)
 	got, err := prober.Do(context.Background(), "http://gone.fishing.svc.custer.local:8080", systemName)
 	if want := false; got != want {
 		t.Errorf("Got = %v, want: %v", got, want)
@@ -94,7 +94,7 @@ func TestBlackHole(t *testing.T) {
 }
 
 func TestBadURL(t *testing.T) {
-	prober := New(network.NewAutoTransport())
+	prober := New(network.NewAutoTransport)
 	_, err := prober.Do(context.Background(), ":foo", systemName)
 	if err == nil {
 		t.Error("Do did not return an error")
@@ -149,7 +149,7 @@ func TestDoAsync(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			prober := New(network.NewAutoTransport())
+			prober := New(network.NewAutoTransport)
 			prober.Offer(context.Background(), ts.URL, test.headerValue, test.callback, 50*time.Millisecond, 2*time.Second)
 			<-wch
 		})
@@ -186,7 +186,7 @@ func TestDoAsyncRepeat(t *testing.T) {
 		}
 		wch <- 42
 	}
-	m := New(network.NewAutoTransport())
+	m := New(network.NewAutoTransport)
 	m.Offer(context.Background(), ts.URL, systemName, cb, 50*time.Millisecond, 3*time.Second)
 	<-wch
 	if got, want := c.calls, 3; got != want {
@@ -209,7 +209,7 @@ func TestDoAsyncTimeout(t *testing.T) {
 		}
 		wch <- 2009
 	}
-	m := New(network.NewAutoTransport())
+	m := New(network.NewAutoTransport)
 	m.Offer(context.Background(), ts.URL, systemName, cb, 10*time.Millisecond, 200*time.Millisecond)
 	<-wch
 }
@@ -224,7 +224,7 @@ func TestAsyncMultiple(t *testing.T) {
 		<-wch
 		wch <- 2006
 	}
-	m := New(network.NewAutoTransport())
+	m := New(network.NewAutoTransport)
 	if !m.Offer(context.Background(), ts.URL, systemName, cb, 100*time.Millisecond, 1*time.Second) {
 		t.Error("First call to offer returned false")
 	}

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -24,6 +24,8 @@ import (
 	serviceinformer "github.com/knative/pkg/injection/informers/kubeinformers/corev1/service"
 	kpainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
 	sksinformer "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/network/prober"
 
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
@@ -67,7 +69,8 @@ func NewController(
 		deciders:        deciders,
 	}
 	impl := controller.NewImpl(c, c.Logger, "KPA-Class Autoscaling")
-	c.scaler = newScaler(ctx, psInformerFactory, impl.EnqueueAfter)
+	prober := prober.New(network.NewAutoTransport())
+	c.scaler = newScaler(ctx, psInformerFactory, prober, impl.EnqueueAfter)
 
 	c.Logger.Info("Setting up KPA-Class event handlers")
 	// Handle PodAutoscalers missing the class annotation for backward compatibility.

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -69,7 +69,7 @@ func NewController(
 		deciders:        deciders,
 	}
 	impl := controller.NewImpl(c, c.Logger, "KPA-Class Autoscaling")
-	prober := prober.New(network.NewAutoTransport())
+	prober := prober.New(network.NewAutoTransport)
 	c.scaler = newScaler(ctx, psInformerFactory, prober, impl.EnqueueAfter)
 
 	c.Logger.Info("Setting up KPA-Class event handlers")

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -304,7 +304,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		fakeMetrics := newTestMetrics()
 		psFactory := presources.NewPodScalableInformerFactory(ctx)
 		prober := &fakeProber{
-			DoOver: func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (b bool, e error) {
+			FakeDo: func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (b bool, e error) {
 				return true, nil
 			},
 		}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -783,7 +783,7 @@ func TestReconcile(t *testing.T) {
 
 		psFactory := presources.NewPodScalableInformerFactory(ctx)
 		fakeMetrics := newTestMetrics()
-		prober := prober.New(network.NewAutoTransport())
+		prober := prober.New(network.NewAutoTransport)
 		enqueueFunc := func(interface{}, time.Duration) {}
 		return &Reconciler{
 			Base: &areconciler.Base{

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -19,7 +19,7 @@ package kpa
 import (
 	"context"
 	"fmt"
-	"net/http"
+	"github.com/knative/serving/pkg/network/prober"
 	"strconv"
 	"sync"
 	"testing"
@@ -303,7 +303,11 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		fakeMetrics := newTestMetrics()
 		psFactory := presources.NewPodScalableInformerFactory(ctx)
 		scaler := newScaler(ctx, psFactory, func(interface{}, time.Duration) {})
-		scaler.activatorProbe = func(*asv1a1.PodAutoscaler, http.RoundTripper) (bool, error) { return true, nil }
+		scaler.prober = &fakeProber{
+			DoOver: func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (b bool, e error) {
+				return true, nil
+			},
+		}
 		return &Reconciler{
 			Base: &areconciler.Base{
 				Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -240,11 +240,11 @@ func TestScaler(t *testing.T) {
 
 			var fakeDo func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (b bool, e error)
 			if test.proberfunc != nil {
-				fakeDo = func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (b bool, e error){
+				fakeDo = func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (b bool, e error) {
 					return test.proberfunc(nil, nil)
 				}
 			} else {
-				fakeDo = func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (bool, error){
+				fakeDo = func(ctx context.Context, target, headerValue string, pos ...prober.ProbeOption) (bool, error) {
 					return true, nil
 				}
 			}
@@ -546,7 +546,7 @@ func TestActivatorProbe(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			prober := prober.New(func() http.RoundTripper {return  test.rt})
+			prober := prober.New(func() http.RoundTripper { return test.rt })
 			enqueueFunc := func(interface{}, time.Duration) {}
 			scaler := newScaler(ctx, presources.NewPodScalableInformerFactory(ctx), prober, enqueueFunc)
 			res, err := scaler.activatorProbe(pa)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -250,7 +250,7 @@ func TestScaler(t *testing.T) {
 			}
 			prober := &countingProber{
 				Prober: &fakeProber{
-					Prober: prober.New(network.NewAutoTransport()),
+					Prober: prober.New(network.NewAutoTransport),
 					FakeDo: fakeDo,
 				},
 			}
@@ -546,7 +546,7 @@ func TestActivatorProbe(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			prober := prober.New(test.rt)
+			prober := prober.New(func() http.RoundTripper {return  test.rt})
 			enqueueFunc := func(interface{}, time.Duration) {}
 			scaler := newScaler(ctx, presources.NewPodScalableInformerFactory(ctx), prober, enqueueFunc)
 			res, err := scaler.activatorProbe(pa)


### PR DESCRIPTION
The prober needs to be made more generic in order to be reused for #3312. This is the first pass.

Originally, I just wanted to make Do a method and not a function since some of its parameters (TransportFactory e.g.) are available as fields. Plus it makes sense for testing/mocking. But, unfortunately this code was highly coupled to various tests so I had to bite the bullet and make the dependency injection and mocking cleaner in other places. They was an excessive amount of mutating private fields.

## Proposed Changes
* Make Do a method, not a function
* Replace the global callback by a callback passed per invocation (removes the need to use interface{}) and it's more flexible
* ~~TransportFactory is useless, just accept a RoundTripper in .ctor~~ See https://github.com/knative/serving/pull/4509
* Put the handler tests in package handler_tests to prevent using private field/functions
* Removed some useless parameters

## Next
Remove the activator assumptions (special header and response body) from prober by making it more generic.

Alternatively, ignore those changes and not reuse this prober.
