### PR TITLE
Fix race condition in the activator endpoint updates.

### DIFF
--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -58,7 +58,9 @@ type Throttler struct {
 	endpointsLister corev1listers.EndpointsLister
 	revisionLister  servinglisters.RevisionLister
 	sksLister       netlisters.ServerlessServiceLister
-	numActivators   int
+
+	numActivatorsMux sync.RWMutex
+	numActivators    int
 }
 
 // NewThrottler creates a new Throttler.
@@ -125,7 +127,7 @@ func (t *Throttler) UpdateCapacity(rev RevisionID, size int) error {
 		return err
 	}
 	breaker, _ := t.getOrCreateBreaker(rev)
-	return t.updateCapacity(breaker, int(revision.Spec.ContainerConcurrency), size, minOneOrValue(t.numActivators))
+	return t.updateCapacity(breaker, int(revision.Spec.ContainerConcurrency), size, t.activatorCount())
 }
 
 // Try potentially registers a new breaker in our bookkeeping
@@ -136,10 +138,9 @@ func (t *Throttler) UpdateCapacity(rev RevisionID, size int) error {
 // timeout is infinite.
 func (t *Throttler) Try(timeout time.Duration, rev RevisionID, function func()) error {
 	breaker, existed := t.getOrCreateBreaker(rev)
-	activatorCount := minOneOrValue(t.numActivators)
 	if !existed {
 		// Need to fetch the latest endpoints state, in case we missed the update.
-		if err := t.forceUpdateCapacity(rev, breaker, activatorCount); err != nil {
+		if err := t.forceUpdateCapacity(rev, breaker, t.activatorCount()); err != nil {
 			return err
 		}
 	}
@@ -149,10 +150,19 @@ func (t *Throttler) Try(timeout time.Duration, rev RevisionID, function func()) 
 	return nil
 }
 
+func (t *Throttler) activatorCount() int {
+	t.numActivatorsMux.RLock()
+	defer t.numActivatorsMux.RUnlock()
+	return t.numActivators
+}
+
 func (t *Throttler) activatorEndpointsUpdated(newObj interface{}) {
 	endpoints := newObj.(*corev1.Endpoints)
+
+	t.numActivatorsMux.Lock()
+	defer t.numActivatorsMux.Unlock()
 	t.numActivators = resources.ReadyAddressCount(endpoints)
-	t.updateAllBreakerCapacity()
+	t.updateAllBreakerCapacity(t.numActivators)
 }
 
 // minOneOrValue function returns num if its greater than 1
@@ -172,7 +182,7 @@ func (t *Throttler) updateCapacity(breaker *queue.Breaker, cc, size, activatorCo
 		// The concurrency is unlimited, thus hand out as many tokens as we can in this breaker.
 		targetCapacity = t.breakerParams.MaxConcurrency
 	} else if targetCapacity > 0 {
-		targetCapacity = minOneOrValue(targetCapacity / activatorCount)
+		targetCapacity = minOneOrValue(targetCapacity / minOneOrValue(activatorCount))
 	}
 	return breaker.UpdateConcurrency(targetCapacity)
 }
@@ -219,10 +229,9 @@ func (t *Throttler) forceUpdateCapacity(rev RevisionID, breaker *queue.Breaker, 
 }
 
 // updateAllBreakerCapacity updates the capacity of all breakers.
-func (t *Throttler) updateAllBreakerCapacity() {
+func (t *Throttler) updateAllBreakerCapacity(activatorCount int) {
 	t.breakersMux.Lock()
 	defer t.breakersMux.Unlock()
-	activatorCount := minOneOrValue(t.numActivators)
 	for revID, breaker := range t.breakers {
 		if err := t.forceUpdateCapacity(revID, breaker, activatorCount); err != nil {
 			t.logger.With(zap.String(logkey.Key, revID.String())).Errorw("updating capacity failed", zap.Error(err))

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -136,6 +136,22 @@ func TestThrottlerActivatorEndpoints(t *testing.T) {
 		updatePollTimeout  = 3 * time.Second
 	)
 
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRevision,
+			Namespace: testNamespace,
+		},
+		Subsets: endpointsSubset(1, 1),
+	}
+	fake := kubefake.NewSimpleClientset(ep)
+	informer := kubeinformers.NewSharedInformerFactory(fake, 0)
+	endpoints := informer.Core().V1().Endpoints()
+	endpoints.Informer().GetIndexer().Add(ep)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	controller.StartInformers(stopCh, endpoints.Informer())
+
 	scenarios := []struct {
 		name                string
 		activatorCount      int
@@ -155,13 +171,6 @@ func TestThrottlerActivatorEndpoints(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
-			ep := &corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testRevision,
-					Namespace: testNamespace,
-				},
-				Subsets: endpointsSubset(1, 1),
-			}
 			activatorEp := &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      K8sServiceName,
@@ -169,11 +178,6 @@ func TestThrottlerActivatorEndpoints(t *testing.T) {
 				},
 				Subsets: endpointsSubset(1, s.activatorCount),
 			}
-
-			fake := kubefake.NewSimpleClientset(ep)
-			informer := kubeinformers.NewSharedInformerFactory(fake, 0)
-			endpoints := informer.Core().V1().Endpoints()
-			endpoints.Informer().GetIndexer().Add(ep)
 
 			throttler := getThrottler(
 				defaultMaxConcurrency,
@@ -185,10 +189,8 @@ func TestThrottlerActivatorEndpoints(t *testing.T) {
 			)
 			throttler.UpdateCapacity(revID, 1) // This sets the initial breaker
 
-			stopCh := make(chan struct{})
-			defer close(stopCh)
-			controller.StartInformers(stopCh, endpoints.Informer())
 			fake.CoreV1().Endpoints(activatorEp.Namespace).Create(activatorEp)
+			endpoints.Informer().GetIndexer().Add(activatorEp)
 
 			breaker := throttler.breakers[RevisionID{Name: testRevision, Namespace: testNamespace}]
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- Fixes a race condition around updating the activator count and reading it.
- Consolidates common test setup to make the test quicker.
- Consolidates usages of `minValueOrOne` to the point where it's actually needed.
- Consolidates reads of the activatorCount to a minimum.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
