### PR TITLE
Limit the diagnose.go noise

### DIFF
--- a/test/e2e/diagnose.go
+++ b/test/e2e/diagnose.go
@@ -1,10 +1,27 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package e2e
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/knative/pkg/test/helpers"
 	rnames "github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/test"
 
@@ -69,7 +86,11 @@ func checkCurrentPodCount(t *testing.T, clients *test.Clients) {
 		t.Logf("%v: could not check current pod count: %v", time.Now(), err)
 		return
 	}
+	prefix := helpers.ObjectPrefixForTest(t)
 	for _, r := range revs.Items {
+		if !strings.HasPrefix(r.Name, prefix) {
+			continue
+		}
 		deploymentName := rnames.Deployment(&r)
 		dep, err := clients.KubeClient.Kube.AppsV1().Deployments(test.ServingNamespace).Get(deploymentName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
This uses a similar trick to the logstream to limit the noise we get in test logs with `t.Parallel()`.