### PR TITLE
Fix race condition and relax test condition of multiscaler tests.

### DIFF
--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	tickInterval = 5 * time.Millisecond
-	tickTimeout  = 50 * time.Millisecond
+	tickTimeout  = 100 * time.Millisecond
 )
 
 // watchFunc generates a function to assert the changes happening in the multiscaler.
@@ -97,7 +97,6 @@ func TestMultiScalerScaling(t *testing.T) {
 	}
 
 	errCh := make(chan error)
-	defer close(errCh)
 	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
 
 	_, err = ms.Create(ctx, decider)
@@ -186,7 +185,6 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 	}
 
 	errCh := make(chan error)
-	defer close(errCh)
 	ms.Watch(watchFunc(ctx, ms, decider, 0, errCh))
 
 	_, err = ms.Create(ctx, decider)
@@ -221,7 +219,6 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	uniScaler.setScaleResult(1, true)
 
 	errCh := make(chan error)
-	defer close(errCh)
 	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
 
 	_, err := ms.Create(ctx, decider)
@@ -267,7 +264,6 @@ func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 	}
 
 	errCh := make(chan error)
-	defer close(errCh)
 	ms.Watch(func(key string) {
 		// Let the main process know when this is called.
 		errCh <- nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/4458/pull-knative-serving-unit-tests/1142584841712177153/

## Proposed Changes

- Closing the errCh can cause a race condition where the watchFunc tries to write to it after the test has already finished and the channel is closed. The channel doesn't need to be closed explicitly anyway so just stopping to do that should fix the condition.
- Relaxing the `tickTimeout` a bit as it seems busy machines can still fail intermittently.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
