### PR TITLE
Added test cases for service call without sidecar

### DIFF
--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -20,6 +20,7 @@ package e2e
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -63,6 +64,20 @@ var testCases = []struct {
 	{"shortest", ".svc.cluster.local"},
 }
 
+// testcases for table-driven testing.
+var testInjection = []struct {
+	name string
+	// injectA indicates whether istio sidecar injection is enabled for httpproxy service
+	// injectB indicates whether istio sidecar injection is enabled for helloworld service
+	injectA bool
+	injectB bool
+}{
+	{"both-disabled", false, false},
+	{"a-disabled", false, true},
+	{"b-disabled", true, false},
+	{"both-enabled", true, true},
+}
+
 func sendRequest(t *testing.T, clients *test.Clients, resolvableDomain bool, domain string) (*spoof.Response, error) {
 	t.Logf("The domain of request is %s.", domain)
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, resolvableDomain)
@@ -77,7 +92,7 @@ func sendRequest(t *testing.T, clients *test.Clients, resolvableDomain bool, dom
 	return client.Do(req)
 }
 
-func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain string) {
+func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain string, inject bool) {
 	// Create envVars to be used in httpproxy app.
 	envVars := []corev1.EnvVar{{
 		Name:  targetHostEnv,
@@ -93,10 +108,12 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
+
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
 		EnvVars: envVars,
 		RevisionTemplateAnnotations: map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
+			"sidecar.istio.io/inject":       strconv.FormatBool(inject),
 		},
 	})
 	if err != nil {
@@ -191,19 +208,12 @@ func TestServiceToServiceCall(t *testing.T) {
 	for _, tc := range testCases {
 		helloworldDomain := strings.TrimSuffix(resources.Route.Status.URL.Host, tc.suffix)
 		t.Run(tc.name, func(t *testing.T) {
-			testProxyToHelloworld(t, clients, helloworldDomain)
+			testProxyToHelloworld(t, clients, helloworldDomain, true)
 		})
 	}
 }
 
-// Same test as TestServiceToServiceCall but before sending requests
-// we're waiting for target app to be scaled to zero
-func TestServiceToServiceCallViaActivator(t *testing.T) {
-	t.Parallel()
-	cancel := logstream.Start(t)
-	defer cancel()
-
-	clients := Setup(t)
+func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA bool, injectB bool) {
 
 	t.Log("Creating helloworld Service")
 
@@ -222,6 +232,7 @@ func TestServiceToServiceCallViaActivator(t *testing.T) {
 		&v1a1test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
+			"sidecar.istio.io/inject": strconv.FormatBool(injectB),
 		}), withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
@@ -247,5 +258,22 @@ func TestServiceToServiceCallViaActivator(t *testing.T) {
 	}
 
 	// Send request to helloworld app via httpproxy service
-	testProxyToHelloworld(t, clients, resources.Route.Status.URL.Host)
+	testProxyToHelloworld(t, clients, resources.Route.Status.URL.Host, injectA)
 }
+
+// Same test as TestServiceToServiceCall but before sending requests
+// we're waiting for target app to be scaled to zero
+func TestServiceToServiceCallViaActivator(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+
+	for _, tc := range testInjection {
+		t.Run(tc.name, func(t *testing.T) {
+			testSvcToSvcCallViaActivator(t, clients, tc.injectA, tc.injectB)
+		})
+	}
+}
+

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -86,7 +86,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 		domain := fmt.Sprintf("%s-%s", tag, resources.Route.Status.Address.URL.Host)
 		helloworldDomain := strings.TrimSuffix(domain, tc.suffix)
 		t.Run(tc.name, func(t *testing.T) {
-			testProxyToHelloworld(t, clients, helloworldDomain)
+			testProxyToHelloworld(t, clients, helloworldDomain, true)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Wei Yu(Jared) <yuweiw@cn.ibm.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4028

## Proposed Changes
Following tests added:
* Service call scale from zero without side car
* Service A without side car call service B with side car
* Service A with side car call Service B without side car

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```