### PR TITLE
Fix memory-leak in TimeoutToFirstByteHandler.

### DIFF
--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -89,14 +89,15 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handler.ServeHTTP(tw, r.WithContext(ctx))
 	}()
 
-	timeout := time.After(h.dt)
+	timeout := time.NewTimer(h.dt)
+	defer timeout.Stop()
 	for {
 		select {
 		case p := <-panicChan:
 			panic(p)
 		case <-done:
 			return
-		case <-timeout:
+		case <-timeout.C:
 			if tw.TimeoutAndWriteError(h.errorBody()) {
 				return
 			}

--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -23,6 +23,9 @@ import (
 )
 
 func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
+	failingTimeout := 10 * time.Millisecond
+	sleepToFail := 100 * time.Millisecond
+
 	tests := []struct {
 		name           string
 		timeout        time.Duration
@@ -44,10 +47,10 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:   "hi",
 	}, {
 		name:    "timeout",
-		timeout: 50 * time.Millisecond,
+		timeout: failingTimeout,
 		handler: func(writeErrors chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(sleepToFail)
 				w.WriteHeader(http.StatusOK)
 				_, werr := w.Write([]byte("hi"))
 				writeErrors <- werr
@@ -58,11 +61,11 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantWriteError: true,
 	}, {
 		name:    "write then sleep",
-		timeout: 10 * time.Millisecond,
+		timeout: failingTimeout,
 		handler: func(writeErrors chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				time.Sleep(50 * time.Millisecond)
+				time.Sleep(sleepToFail)
 				w.Write([]byte("hi"))
 			})
 		},
@@ -70,10 +73,10 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:   "hi",
 	}, {
 		name:    "custom timeout message",
-		timeout: 50 * time.Millisecond,
+		timeout: failingTimeout,
 		handler: func(writeErrors chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(sleepToFail)
 				_, werr := w.Write([]byte("hi"))
 				writeErrors <- werr
 			})
@@ -84,7 +87,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantWriteError: true,
 	}, {
 		name:    "propagate panic",
-		timeout: 50 * time.Millisecond,
+		timeout: 10 * time.Second,
 		handler: func(writeErrors chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic(http.ErrAbortHandler)

--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -23,8 +23,10 @@ import (
 )
 
 func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
-	failingTimeout := 10 * time.Millisecond
-	sleepToFail := 100 * time.Millisecond
+	const (
+		failingTimeout = 10 * time.Millisecond
+		sleepToFail    = 100 * time.Millisecond
+	)
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/4464/pull-knative-serving-unit-tests/1142847947994566656/

## Proposed Changes

- `time.After` famously only free up memory once the timer actually fires. That should not be the common case in this handler, so we're now freeing the timers explicitly.
- Widened the timeout values in tests to make them more resilient.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
