### PR TITLE
Relax 'TestMultiScalerTickUpdate' to make it more stable.

### DIFF
--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -152,14 +152,14 @@ func TestMultiScalerTickUpdate(t *testing.T) {
 		t.Fatalf("Expected count to be 0 but got %d", count)
 	}
 
-	decider.Spec.TickInterval = time.Millisecond
+	decider.Spec.TickInterval = tickInterval
 
 	if _, err = ms.Update(ctx, decider); err != nil {
 		t.Errorf("Update() = %v", err)
 	}
 
-	if err := wait.PollImmediate(time.Millisecond, 10*time.Millisecond, func() (bool, error) {
-		// Expected count to be greater than 1 as the tick interval is updated to be 1ms
+	if err := wait.PollImmediate(tickInterval, tickTimeout, func() (bool, error) {
+		// Expected count to be greater than 1 as the tick interval is updated to be 5ms
 		if uniScaler.getScaleCount() >= 1 {
 			return true, nil
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/4492/pull-knative-serving-unit-tests/1142871983030013952/

## Proposed Changes

This test had a very narrow timeout setting (poll once per millisecond for 10 milliseconds), which is usually fine but gets hairy on non-dedicated test machines.

It now uses the same timeout parameters all the other tests in this package use as well, so they can be adjusted more globally in the future. The diluted timeout settings do not compromise the value of the test.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
