### PR TITLE
Fix config tests to run more than once

### DIFF
--- a/pkg/apis/networking/v1alpha1/clusteringress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_defaults_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestClusterIngressDefaulting(t *testing.T) {
+	defer logtesting.ClearAll()
 	tests := []struct {
 		name string
 		in   *ClusterIngress

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestRevisionDefaulting(t *testing.T) {
+	defer logtesting.ClearAll()
 	tests := []struct {
 		name string
 		in   *Revision

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -40,6 +40,7 @@ var (
 )
 
 func TestRevisionDefaulting(t *testing.T) {
+	defer logtesting.ClearAll()
 	tests := []struct {
 		name string
 		in   *Revision

--- a/pkg/gc/config_test.go
+++ b/pkg/gc/config_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestOurConfig(t *testing.T) {
+	defer logtesting.ClearAll()
+
 	actual, example := ConfigMapsFromTestFile(t, "config-gc")
 	for _, tt := range []struct {
 		name string

--- a/pkg/reconciler/certificate/config/store_test.go
+++ b/pkg/reconciler/certificate/config/store_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestStoreLoadWithContext(t *testing.T) {
+	defer ClearAll()
 	store := NewStore(TestLogger(t))
 
 	certManagerConfig := ConfigMapFromTestFile(t, CertManagerConfigName)
@@ -39,16 +40,14 @@ func TestStoreLoadWithContext(t *testing.T) {
 }
 
 func TestStoreImmutableConfig(t *testing.T) {
+	defer ClearAll()
+
 	store := NewStore(TestLogger(t))
-
 	store.OnConfigChanged(ConfigMapFromTestFile(t, CertManagerConfigName))
-
 	config := store.Load()
 
 	config.CertManager.IssuerRef.Kind = "newKind"
-
 	newConfig := store.Load()
-
 	if newConfig.CertManager.IssuerRef.Kind == "newKind" {
 		t.Error("CertManager config is not immutable")
 	}


### PR DESCRIPTION
This makes go test ./... -count=2 work for `serving/pkg`.
/lint

/assign @mattmoor @jonjohnsonjr 