### PR TITLE
Add reconciler/OWNERS to gc/OWNERS

### DIFF
--- a/pkg/gc/OWNERS
+++ b/pkg/gc/OWNERS
@@ -1,0 +1,10 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- serving-api-approvers
+
+reviewers:
+- serving-api-reviewers
+
+labels:
+- area/API


### PR DESCRIPTION
Not really sure why this would be different. It's basically a config map :)

/assign @mattmoor 