### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -242,9 +242,9 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice-extra",
 					Namespace: system.Namespace(),
 					Labels: map[string]string{
-						networking.ClusterIngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteLabelKey:          "test-route",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.ClusterIngressLabelKey: "reconcile-virtualservice",
+						serving.RouteLabelKey:             "test-route",
+						serving.RouteNamespaceLabelKey:    "test-ns",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
 				},


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
