### PR TITLE
Skip the istio addon in the smoke test

### DIFF
--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -35,7 +35,7 @@ function knative_setup() {
 
 # Script entry point.
 
-initialize $@
+initialize $@ --skip-istio-addon
 
 # Ensure Knative Serving can be uninstalled/reinstalled cleanly
 subheader "Uninstalling Knative Serving"


### PR DESCRIPTION
The other tests pass this, and several of our recent unattributed failures were due to the sidecars not coming up.