### PR TITLE
Don't run the 'DestroyPodTimely' test in parallel with the others.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -144,7 +144,8 @@ func TestDestroyPodInflight(t *testing.T) {
 const revisionTimeout = 5 * time.Minute
 
 func TestDestroyPodTimely(t *testing.T) {
-	t.Parallel()
+	// Not running in parallel on purpose.
+
 	cancel := logstream.Start(t)
 	defer cancel()
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Just trying to make the thing more stable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
