### PR TITLE
Trim trailing dots from resolv.conf search line.

### DIFF
--- a/pkg/network/domain.go
+++ b/pkg/network/domain.go
@@ -66,7 +66,7 @@ func getClusterDomainName(r io.Reader) string {
 		}
 		for i := 1; i < len(elements)-1; i++ {
 			if strings.HasPrefix(elements[i], "svc.") {
-				return elements[i][4:]
+				return strings.TrimSuffix(elements[i][4:], ".")
 			}
 		}
 	}

--- a/pkg/network/domain_test.go
+++ b/pkg/network/domain_test.go
@@ -37,6 +37,15 @@ options ndots:5
 			want: "abc.com",
 		},
 		{
+			name: "all good with trailing dot",
+			resolvConf: `
+nameserver 1.1.1.1
+search default.svc.abc.com. svc.abc.com. abc.com.
+options ndots:5
+`,
+			want: "abc.com",
+		},
+		{
 			name: "missing search line",
 			resolvConf: `
 nameserver 1.1.1.1


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4407 

## Proposed Changes

* Trim the trailing dot from resolv.conf search line.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix issue in detecting cluster suffix logic to allow for trailing `.` in the search line.
```
