### PR TITLE
Make containerPort number optional

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -400,9 +400,9 @@ func validateContainerPorts(ports []corev1.ContainerPort) *apis.FieldError {
 		errs = errs.Also(apis.ErrInvalidValue(userPort.ContainerPort, "containerPort"))
 	}
 
-	if userPort.ContainerPort < 1 || userPort.ContainerPort > 65535 {
+	if userPort.ContainerPort < 0 || userPort.ContainerPort > 65535 {
 		errs = errs.Also(apis.ErrOutOfBoundsValue(userPort.ContainerPort,
-			1, 65535, "containerPort"))
+			0, 65535, "containerPort"))
 	}
 
 	if !validPortNames.Has(userPort.Name) {

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -241,6 +241,15 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "has valid unnamed user port",
+		c: corev1.Container{
+			Image: "foo",
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 8181,
+			}},
+		},
+		want: nil,
+	}, {
 		name: "has valid user port http1",
 		c: corev1.Container{
 			Image: "foo",

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -245,8 +245,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Name:          "http1",
-				ContainerPort: 8081,
+				Name: "http1",
 			}},
 		},
 		want: nil,
@@ -255,8 +254,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Name:          "h2c",
-				ContainerPort: 8081,
+				Name: "h2c",
 			}},
 		},
 		want: nil,
@@ -265,11 +263,9 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Name:          "h2c",
-				ContainerPort: 8080,
+				Name: "h2c",
 			}, {
-				Name:          "http1",
-				ContainerPort: 8181,
+				Name: "http1",
 			}},
 		},
 		want: &apis.FieldError{
@@ -285,14 +281,14 @@ func TestContainerValidation(t *testing.T) {
 				ContainerPort: 65536,
 			}},
 		},
-		want: apis.ErrOutOfBoundsValue(65536, 1, 65535, "ports.containerPort"),
+		want: apis.ErrOutOfBoundsValue(65536, 0, 65535, "ports.containerPort"),
 	}, {
 		name: "has an empty port set",
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{}},
 		},
-		want: apis.ErrOutOfBoundsValue(0, 1, 65535, "ports.containerPort"),
+		want: nil,
 	}, {
 		name: "has more than one unnamed port",
 		c: corev1.Container{
@@ -313,8 +309,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Protocol:      corev1.ProtocolTCP,
-				ContainerPort: 8080,
+				Protocol: corev1.ProtocolTCP,
 			}},
 		},
 		want: nil,
@@ -323,8 +318,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Protocol:      "tdp",
-				ContainerPort: 8080,
+				Protocol: "tdp",
 			}},
 		},
 		want: apis.ErrInvalidValue("tdp", "ports.protocol"),
@@ -333,8 +327,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				HostPort:      80,
-				ContainerPort: 8080,
+				HostPort: 80,
 			}},
 		},
 		want: apis.ErrDisallowedFields("ports.hostPort"),
@@ -343,8 +336,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				HostIP:        "127.0.0.1",
-				ContainerPort: 8080,
+				HostIP: "127.0.0.1",
 			}},
 		},
 		want: apis.ErrDisallowedFields("ports.hostIP"),
@@ -389,8 +381,7 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			Ports: []corev1.ContainerPort{{
-				Name:          "foobar",
-				ContainerPort: 8080,
+				Name: "foobar",
 			}},
 		},
 		want: &apis.FieldError{

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -157,8 +157,10 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, observab
 }
 
 func getUserPort(rev *v1alpha1.Revision) int32 {
-	if len(rev.Spec.GetContainer().Ports) == 1 {
-		return rev.Spec.GetContainer().Ports[0].ContainerPort
+	ports := rev.Spec.GetContainer().Ports
+
+	if len(ports) > 0 && ports[0].ContainerPort != 0 {
+		return ports[0].ContainerPort
 	}
 
 	//TODO(#2258): Use container EXPOSE metadata from image before falling back to default value

--- a/pkg/testing/v1beta1/service.go
+++ b/pkg/testing/v1beta1/service.go
@@ -72,11 +72,9 @@ func WithNamedPort(name string) ServiceOption {
 		c := &svc.Spec.Template.Spec.Containers[0]
 		if len(c.Ports) == 1 {
 			c.Ports[0].Name = name
-			c.Ports[0].ContainerPort = 8080
 		} else {
 			c.Ports = []corev1.ContainerPort{{
-				Name:          name,
-				ContainerPort: 8080,
+				Name: name,
 			}}
 		}
 	}

--- a/test/conformance/api/v1alpha1/protocol_test.go
+++ b/test/conformance/api/v1alpha1/protocol_test.go
@@ -106,7 +106,7 @@ func portOption(portname string) *v1a1test.Options {
 	options := &v1a1test.Options{}
 
 	if portname != "" {
-		options.ContainerPorts = []corev1.ContainerPort{{Name: portname, ContainerPort: 8080}}
+		options.ContainerPorts = []corev1.ContainerPort{{Name: portname}}
 	}
 
 	return options

--- a/test/conformance/runtime/container_test.go
+++ b/test/conformance/runtime/container_test.go
@@ -43,8 +43,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		name: "TestArbitraryPortName",
 		options: func(s *v1alpha1.Service) {
 			s.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
-				Name:          "arbitrary",
-				ContainerPort: 8080,
+				Name: "arbitrary",
 			}}
 		},
 	}, {
@@ -157,8 +156,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 		name: "TestHostPort",
 		options: func(s *v1alpha1.Service) {
 			s.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
-				ContainerPort: 8081,
-				HostPort:      80,
+				HostPort: 80,
 			}}
 		},
 	}, {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -169,8 +169,7 @@ func testGRPC(t *testing.T, f grpcTest) {
 	defer test.TearDown(clients, names)
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
 		ContainerPorts: []corev1.ContainerPort{{
-			Name:          "h2c",
-			ContainerPort: 8080,
+			Name: "h2c",
 		}},
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4364

## Proposed Changes

* Port number no longer needs to be specified when providing a `ContainerPort`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Container ports can now be specified without a port number.
```
