### PR TITLE
BurstCapacity computation and Decider changes

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -122,8 +123,12 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	a.reporter.ReportPanicRequestConcurrency(observedPanicConcurrency)
 	a.reporter.ReportTargetRequestConcurrency(spec.TargetConcurrency)
 
-	logger.Debugf("STABLE: Observed average %0.3f concurrency, targeting %0.3f.", observedStableConcurrency, spec.TargetConcurrency)
-	logger.Debugf("PANIC: Observed average %0.3f concurrency, targeting %0.3f.", observedPanicConcurrency, spec.TargetConcurrency)
+	logger.Debugw(fmt.Sprintf("Observed average %0.3f concurrency, targeting %0.3f.",
+		observedStableConcurrency, spec.TargetConcurrency),
+		zap.String("concurrency", "stable"))
+	logger.Debugw(fmt.Sprintf("Observed average %0.3f concurrency, targeting %0.3f.",
+		observedPanicConcurrency, spec.TargetConcurrency),
+		zap.String("concurrency", "panic"))
 
 	isOverPanicThreshold := observedPanicConcurrency/readyPodsCount >= spec.PanicThreshold
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -23,13 +23,15 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/resources"
-	"go.uber.org/zap"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// Autoscaler stores current state of an instance of an autoscaler
+// Autoscaler stores current state of an instance of an autoscaler.
 type Autoscaler struct {
 	namespace    string
 	revision     string
@@ -88,7 +90,7 @@ func (a *Autoscaler) Update(deciderSpec DeciderSpec) error {
 // Scale calculates the desired scale based on current statistics given the current time.
 // desiredPodCount is the calculated pod count the autoscaler would like to set.
 // validScale signifies whether the desiredPodCount should be applied or not.
-func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount int32, validScale bool) {
+func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount int32, excessBC int32, validScale bool) {
 	logger := logging.FromContext(ctx)
 
 	spec := a.currentSpec()
@@ -96,7 +98,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	// If the error is NotFound, then presume 0.
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Errorw("Failed to get Endpoints via K8S Lister", zap.Error(err))
-		return 0, false
+		return 0, 0, false
 	}
 	// Use 1 if there are zero current pods.
 	readyPodsCount := math.Max(1, float64(originalReadyPodsCount))
@@ -109,7 +111,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		} else {
 			logger.Errorw("Failed to obtain metrics", zap.Error(err))
 		}
-		return 0, false
+		return 0, 0, false
 	}
 
 	maxScaleUp := spec.MaxScaleUpRate * readyPodsCount
@@ -120,8 +122,8 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	a.reporter.ReportPanicRequestConcurrency(observedPanicConcurrency)
 	a.reporter.ReportTargetRequestConcurrency(spec.TargetConcurrency)
 
-	logger.Debugf("STABLE: Observed average %0.3f concurrency, targeting %v.", observedStableConcurrency, spec.TargetConcurrency)
-	logger.Debugf("PANIC: Observed average %0.3f concurrency, targeting %v.", observedPanicConcurrency, spec.TargetConcurrency)
+	logger.Debugf("STABLE: Observed average %0.3f concurrency, targeting %0.3f.", observedStableConcurrency, spec.TargetConcurrency)
+	logger.Debugf("PANIC: Observed average %0.3f concurrency, targeting %0.3f.", observedPanicConcurrency, spec.TargetConcurrency)
 
 	isOverPanicThreshold := observedPanicConcurrency/readyPodsCount >= spec.PanicThreshold
 
@@ -154,8 +156,16 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		desiredPodCount = desiredStablePodCount
 	}
 
+	// Compute the excess burst capacity based on stable concurrency for now, since we don't want to
+	// be making knee-jerk decisions about Activator in the request path. Negative EBC means
+	// that the deployment does not have enough capacity to serve the desired burst off hand.
+	// EBC = TotCapacity - Cur#ReqInFlight - TargetBurstCapacity
+	excessBC = int32(readyPodsCount*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
+		a.deciderSpec.TargetBurstCapacity)
+	logger.Debug("Excess burst capacity = ", excessBC)
+
 	a.reporter.ReportDesiredPodCount(int64(desiredPodCount))
-	return desiredPodCount, true
+	return desiredPodCount, excessBC, true
 }
 
 func (a *Autoscaler) currentSpec() DeciderSpec {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -22,16 +22,19 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/serving/pkg/resources"
 
-	. "github.com/knative/pkg/logging/testing"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	fakeK8s "k8s.io/client-go/kubernetes/fake"
 )
 
-const stableWindow = 60 * time.Second
+const (
+	stableWindow      = 60 * time.Second
+	targetUtilization = 0.75
+)
 
 var (
 	kubeClient   = fakeK8s.NewSimpleClientset()
@@ -63,141 +66,161 @@ func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
 		err: errors.New("no metrics"),
 	}
 
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 0, false)
+	a := newTestAutoscaler(10, 100, metrics)
+	a.expectScale(t, time.Now(), 0, 0, false)
 }
 
+func expectedEBC(tc, tbc, rc, np float64) int32 {
+	return int32(tc/targetUtilization*np - tbc - rc)
+}
 func TestAutoscalerNoDataAtZeroNoAutoscale(t *testing.T) {
-	a := newTestAutoscaler(10.0, &testMetricClient{})
-	a.expectScale(t, time.Now(), 0, true)
+	a := newTestAutoscaler(10, 100, &testMetricClient{})
+	// We always presume at least 1 pod, even if counter says 0.
+	a.expectScale(t, time.Now(), 0, expectedEBC(10, 100, 0, 1), true)
+}
+
+func TestAutoscalerNoDataAtZeroNoAutoscaleWithExplicitEPs(t *testing.T) {
+	a := newTestAutoscaler(10, 100, &testMetricClient{})
+	endpoints(1)
+	a.expectScale(t, time.Now(), 0, expectedEBC(10, 100, 0, 1), true)
 }
 
 func TestAutoscalerStableModeNoChange(t *testing.T) {
 	metrics := &testMetricClient{stableConcurrency: 50.0}
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 5, true)
+	a := newTestAutoscaler(10, 100, metrics)
+	a.expectScale(t, time.Now(), 5, expectedEBC(10, 100, 50, 1), true)
+}
+
+func TestAutoscalerStableModeNoChangeAlreadyScaled(t *testing.T) {
+	metrics := &testMetricClient{stableConcurrency: 50.0}
+	a := newTestAutoscaler(10, 100, metrics)
+	endpoints(5)
+	a.expectScale(t, time.Now(), 5, expectedEBC(10, 100, 50, 5), true)
 }
 
 func TestAutoscalerStableModeIncrease(t *testing.T) {
 	metrics := &testMetricClient{stableConcurrency: 50.0}
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 5, true)
+	a := newTestAutoscaler(10, 101, metrics)
+	a.expectScale(t, time.Now(), 5, expectedEBC(10, 101, 50, 1), true)
 
-	metrics.stableConcurrency = 100.0
-	a.expectScale(t, time.Now(), 10, true)
+	metrics.stableConcurrency = 100
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 101, 100, 1), true)
 }
 
 func TestAutoscalerStableModeDecrease(t *testing.T) {
 	metrics := &testMetricClient{stableConcurrency: 100.0}
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 10, true)
+	a := newTestAutoscaler(10, 98, metrics)
+	endpoints(8)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 98, 100, 8), true)
 
-	metrics.stableConcurrency = 50.0
-	a.expectScale(t, time.Now(), 5, true)
+	metrics.stableConcurrency = 50
+	a.expectScale(t, time.Now(), 5, expectedEBC(10, 98, 50, 8), true)
 }
 
-func TestAutoscaler_StableModeNoTrafficScaleToZero(t *testing.T) {
-	metrics := &testMetricClient{stableConcurrency: 1.0}
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 1, true)
+func TestAutoscalerStableModeNoTrafficScaleToZero(t *testing.T) {
+	metrics := &testMetricClient{stableConcurrency: 1}
+	a := newTestAutoscaler(10, 75, metrics)
+	a.expectScale(t, time.Now(), 1, expectedEBC(10, 75, 1, 1), true)
 
 	metrics.stableConcurrency = 0.0
-	a.expectScale(t, time.Now(), 0, true)
+	a.expectScale(t, time.Now(), 0, expectedEBC(10, 75, 0, 1), true)
 }
 
 func TestAutoscalerPanicModeDoublePodCount(t *testing.T) {
-	metrics := &testMetricClient{stableConcurrency: 50.0, panicConcurrency: 100.0}
-	a := newTestAutoscaler(10.0, metrics)
+	metrics := &testMetricClient{stableConcurrency: 50, panicConcurrency: 100}
+	a := newTestAutoscaler(10, 84, metrics)
 
 	// PanicConcurrency takes precedence.
-	a.expectScale(t, time.Now(), 10, true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 84, 50, 1), true)
 }
 
 // QPS is increasing exponentially. Each scaling event bring concurrency
 // back to the target level (1.0) but then traffic continues to increase.
 // At 1296 QPS traffic stablizes.
 func TestAutoscalerPanicModeExponentialTrackAndStablize(t *testing.T) {
-	metrics := &testMetricClient{panicConcurrency: 6.0}
-	a := newTestAutoscaler(1.0, metrics)
-	a.expectScale(t, time.Now(), 6, true)
+	metrics := &testMetricClient{stableConcurrency: 6, panicConcurrency: 6}
+	a := newTestAutoscaler(1, 101, metrics)
+	a.expectScale(t, time.Now(), 6, expectedEBC(1, 101, 6, 1), true)
+
 	endpoints(6)
+	metrics.panicConcurrency, metrics.stableConcurrency = 36, 36
+	a.expectScale(t, time.Now(), 36, expectedEBC(1, 101, 36, 6), true)
 
-	metrics.panicConcurrency = 36.0
-	a.expectScale(t, time.Now(), 36, true)
 	endpoints(36)
+	metrics.panicConcurrency, metrics.stableConcurrency = 216, 216
+	a.expectScale(t, time.Now(), 216, expectedEBC(1, 101, 216, 36), true)
 
-	metrics.panicConcurrency = 216.0
-	a.expectScale(t, time.Now(), 216, true)
 	endpoints(216)
-
-	metrics.panicConcurrency = 1296.0
-	a.expectScale(t, time.Now(), 1296, true)
+	metrics.panicConcurrency, metrics.stableConcurrency = 1296, 1296
+	a.expectScale(t, time.Now(), 1296, expectedEBC(1, 101, 1296, 216), true)
 	endpoints(1296)
+	a.expectScale(t, time.Now(), 1296, expectedEBC(1, 101, 1296, 1296), true)
 }
 
 func TestAutoscalerPanicThenUnPanicScaleDown(t *testing.T) {
-	metrics := &testMetricClient{stableConcurrency: 100.0, panicConcurrency: 100.0}
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 10, true)
+	metrics := &testMetricClient{stableConcurrency: 100, panicConcurrency: 100}
+	a := newTestAutoscaler(10, 93, metrics)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 93, 100, 1), true)
 	endpoints(10)
 
 	panicTime := time.Now()
-	metrics.panicConcurrency = 1000.0
-	a.expectScale(t, panicTime, 100, true)
+	metrics.panicConcurrency = 1000
+	a.expectScale(t, panicTime, 100, expectedEBC(10, 93, 100, 10), true)
 
 	// Traffic dropped off, scale stays as we're still in panic.
-	metrics.panicConcurrency = 1.0
-	metrics.stableConcurrency = 1.0
-	a.expectScale(t, panicTime.Add(30*time.Second), 100, true)
+	metrics.panicConcurrency = 1
+	metrics.stableConcurrency = 1
+	a.expectScale(t, panicTime.Add(30*time.Second), 100, expectedEBC(10, 93, 1, 10), true)
 
 	// Scale down after the StableWindow
-	a.expectScale(t, panicTime.Add(61*time.Second), 1, true)
+	a.expectScale(t, panicTime.Add(61*time.Second), 1, expectedEBC(10, 93, 1, 10), true)
 }
 
 func TestAutoscalerRateLimitScaleUp(t *testing.T) {
-	metrics := &testMetricClient{stableConcurrency: 1000.0}
-	a := newTestAutoscaler(10.0, metrics)
-	endpoints(1)
+	metrics := &testMetricClient{stableConcurrency: 1000}
+	a := newTestAutoscaler(10, 61, metrics)
 
 	// Need 100 pods but only scale x10
-	a.expectScale(t, time.Now(), 10, true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 61, 1000, 1), true)
 
 	endpoints(10)
 	// Scale x10 again
-	a.expectScale(t, time.Now(), 100, true)
+	a.expectScale(t, time.Now(), 100, expectedEBC(10, 61, 1000, 10), true)
 }
 
 func TestAutoscalerUseOnePodAsMinimumIfEndpointsNotFound(t *testing.T) {
-	metrics := &testMetricClient{stableConcurrency: 1000.0}
-	a := newTestAutoscaler(10.0, metrics)
+	metrics := &testMetricClient{stableConcurrency: 1000}
+	a := newTestAutoscaler(10, 81, metrics)
 
 	endpoints(0)
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no read pods are there from K8S API.
-	a.expectScale(t, time.Now(), 10, true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 1), true)
 
 	ep, _ := kubeClient.CoreV1().Endpoints(testNamespace).Get(testService, metav1.GetOptions{})
 	kubeClient.CoreV1().Endpoints(testNamespace).Delete(testService, nil)
 	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Delete(ep)
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no Endpoints object is there from K8S API.
-	a.expectScale(t, time.Now(), 10, true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 1), true)
 }
 
 func TestAutoscalerUpdateTarget(t *testing.T) {
-	metrics := &testMetricClient{stableConcurrency: 100.0}
-	a := newTestAutoscaler(10.0, metrics)
-	a.expectScale(t, time.Now(), 10, true)
-	endpoints(10)
+	metrics := &testMetricClient{stableConcurrency: 100}
+	a := newTestAutoscaler(10, 77, metrics)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 77, 100, 1), true)
 
+	endpoints(10)
 	a.Update(DeciderSpec{
-		TargetConcurrency: 1.0,
-		PanicThreshold:    2.0,
-		MaxScaleUpRate:    10.0,
-		StableWindow:      stableWindow,
-		ServiceName:       testService,
+		TargetConcurrency:   1,
+		TotalConcurrency:    1 / targetUtilization,
+		TargetBurstCapacity: 71,
+		PanicThreshold:      2,
+		MaxScaleUpRate:      10,
+		StableWindow:        stableWindow,
+		ServiceName:         testService,
 	})
-	a.expectScale(t, time.Now(), 100, true)
+	a.expectScale(t, time.Now(), 100, expectedEBC(1, 71, 100, 10), true)
 }
 
 type mockReporter struct{}
@@ -237,28 +260,34 @@ func (r *mockReporter) ReportPanic(v int64) error {
 	return nil
 }
 
-func newTestAutoscaler(containerConcurrency int, metrics MetricClient) *Autoscaler {
+func newTestAutoscaler(targetConcurrency, targetBurstCapacity float64, metrics MetricClient) *Autoscaler {
 	deciderSpec := DeciderSpec{
-		TargetConcurrency: float64(containerConcurrency),
-		PanicThreshold:    2 * float64(containerConcurrency),
-		MaxScaleUpRate:    10.0,
-		StableWindow:      stableWindow,
-		ServiceName:       testService,
+		TargetConcurrency:   targetConcurrency,
+		TotalConcurrency:    targetConcurrency / targetUtilization, // For UTs presume 75% utilization
+		TargetBurstCapacity: targetBurstCapacity,
+		PanicThreshold:      2 * targetConcurrency,
+		MaxScaleUpRate:      10.0,
+		StableWindow:        stableWindow,
+		ServiceName:         testService,
 	}
 
 	podCounter := resources.NewScopedEndpointsCounter(kubeInformer.Core().V1().Endpoints().Lister(), testNamespace, deciderSpec.ServiceName)
 	a, _ := New(testNamespace, testRevision, metrics, podCounter, deciderSpec, &mockReporter{})
+	endpoints(1)
 	return a
 }
 
-func (a *Autoscaler) expectScale(t *testing.T, now time.Time, expectScale int32, expectOk bool) {
+func (a *Autoscaler) expectScale(t *testing.T, now time.Time, expectScale, expectEBC int32, expectOk bool) {
 	t.Helper()
-	scale, ok := a.Scale(TestContextWithLogger(t), now)
+	scale, ebc, ok := a.Scale(TestContextWithLogger(t), now)
 	if ok != expectOk {
 		t.Errorf("Unexpected autoscale decision. Expected %v. Got %v.", expectOk, ok)
 	}
-	if scale != expectScale {
-		t.Errorf("Unexpected scale. Expected %v. Got %v.", expectScale, scale)
+	if got, want := scale, expectScale; got != want {
+		t.Errorf("Scale %d, want: %d", got, want)
+	}
+	if got, want := ebc, expectEBC; got != want {
+		t.Errorf("ExcessBurstCapacity = %d, want: %d", got, want)
 	}
 }
 

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -218,7 +218,7 @@ func TestNewConfig(t *testing.T) {
 		name: "invalid target burst capacity",
 		input: map[string]string{
 			"max-scale-up-rate":                       "1.0",
-			"container-concurrency-target-percentage": "42",
+			"container-concurrency-target-percentage": "80",
 			"container-concurrency-target-default":    "10.0",
 			"target-burst-capacity":                   "-1",
 			"stable-window":                           "3s",

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -218,7 +218,7 @@ func TestNewConfig(t *testing.T) {
 		name: "invalid target burst capacity",
 		input: map[string]string{
 			"max-scale-up-rate":                       "1.0",
-			"container-concurrency-target-percentage": "80",
+			"container-concurrency-target-percentage": "42",
 			"container-concurrency-target-default":    "10.0",
 			"target-burst-capacity":                   "-1",
 			"stable-window":                           "3s",
@@ -329,6 +329,19 @@ func TestNewConfig(t *testing.T) {
 			"panic-window":                            "3s",
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "110",
+			"panic-threshold-percentage":              "200",
+		},
+		wantErr: true,
+	}, {
+		name: "TU*CC < 1",
+		input: map[string]string{
+			"max-scale-up-rate":                       "1.0",
+			"container-concurrency-target-percentage": "5",
+			"container-concurrency-target-default":    "10.0",
+			"stable-window":                           "62s",
+			"panic-window":                            "12s",
+			"tick-interval":                           "2s",
+			"panic-window-percentage":                 "50",
 			"panic-threshold-percentage":              "200",
 		},
 		wantErr: true,

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -88,7 +88,7 @@ func TestMultiScalerScaling(t *testing.T) {
 	defer close(statCh)
 
 	decider := newDecider()
-	uniScaler.setScaleResult(1, true)
+	uniScaler.setScaleResult(1, 1, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -125,6 +125,47 @@ func TestMultiScalerScaling(t *testing.T) {
 	}
 }
 
+func TestMultiScalerOnlyCapacityChange(t *testing.T) {
+	ctx := context.Background()
+	ms, stopCh, statCh, uniScaler := createMultiScaler(t)
+	defer close(stopCh)
+	defer close(statCh)
+
+	decider := newDecider()
+	uniScaler.setScaleResult(1, 1, true)
+
+	errCh := make(chan error)
+	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
+
+	_, err := ms.Create(ctx, decider)
+	if err != nil {
+		t.Errorf("Create() = %v", err)
+	}
+
+	// Verify that we see a "tick"
+	if err := verifyTick(errCh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change the sign of the excess capacity.
+	uniScaler.setScaleResult(1, -1, true)
+
+	// Verify that subsequent "ticks" don't trigger a callback, since
+	// the desired scale has not changed.
+	if err := verifyTick(errCh); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ms.Delete(ctx, decider.Namespace, decider.Name); err != nil {
+		t.Errorf("Delete() = %v", err)
+	}
+
+	// Verify that we stop seeing "ticks"
+	if err := verifyNoTick(errCh); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMultiScalerTickUpdate(t *testing.T) {
 	ctx := context.Background()
 	ms, stopCh, statCh, uniScaler := createMultiScaler(t)
@@ -133,7 +174,7 @@ func TestMultiScalerTickUpdate(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TickInterval = 10 * time.Second
-	uniScaler.setScaleResult(1, true)
+	uniScaler.setScaleResult(1, 1, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -176,7 +217,7 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 	defer close(statCh)
 
 	decider := newDecider()
-	uniScaler.setScaleResult(0, true)
+	uniScaler.setScaleResult(0, 1, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -216,7 +257,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TickInterval = 60 * time.Second
-	uniScaler.setScaleResult(1, true)
+	uniScaler.setScaleResult(1, 1, true)
 
 	errCh := make(chan error)
 	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
@@ -228,7 +269,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	metricKey := NewMetricKey(decider.Namespace, decider.Name)
 	if scaler, exists := ms.scalers[metricKey]; !exists {
 		t.Errorf("Failed to get scaler for metric %s", metricKey)
-	} else if !scaler.updateLatestScale(0) {
+	} else if !scaler.updateLatestScale(0, 10) {
 		t.Error("Failed to set scale for metric to 0")
 	}
 
@@ -255,7 +296,7 @@ func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 
 	decider := newDecider()
 
-	uniScaler.setScaleResult(-1, true)
+	uniScaler.setScaleResult(-1, 10, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -298,7 +339,7 @@ func TestMultiScalerUpdate(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TargetConcurrency = 1.0
-	uniScaler.setScaleResult(0, true)
+	uniScaler.setScaleResult(0, 100, true)
 
 	// Create the decider and verify the Spec
 	_, err := ms.Create(ctx, decider)
@@ -341,6 +382,7 @@ func createMultiScaler(t *testing.T) (*MultiScaler, chan<- struct{}, chan *StatM
 type fakeUniScaler struct {
 	mutex      sync.RWMutex
 	replicas   int32
+	surplus    int32
 	scaled     bool
 	lastStat   Stat
 	scaleCount int
@@ -350,11 +392,11 @@ func (u *fakeUniScaler) fakeUniScalerFactory(*Decider) (UniScaler, error) {
 	return u, nil
 }
 
-func (u *fakeUniScaler) Scale(context.Context, time.Time) (int32, bool) {
+func (u *fakeUniScaler) Scale(context.Context, time.Time) (int32, int32, bool) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	u.scaleCount++
-	return u.replicas, u.scaled
+	return u.replicas, u.surplus, u.scaled
 }
 
 func (u *fakeUniScaler) getScaleCount() int {
@@ -363,10 +405,11 @@ func (u *fakeUniScaler) getScaleCount() int {
 	return u.scaleCount
 }
 
-func (u *fakeUniScaler) setScaleResult(replicas int32, scaled bool) {
+func (u *fakeUniScaler) setScaleResult(replicas int32, surplus int32, scaled bool) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
+	u.surplus = surplus
 	u.replicas = replicas
 	u.scaled = scaled
 }
@@ -393,5 +436,22 @@ func newDecider() *Decider {
 			TargetConcurrency: 1,
 		},
 		Status: DeciderStatus{},
+	}
+}
+
+func TestSameSign(t *testing.T) {
+	tests := []struct {
+		а, b int32
+		want bool
+	}{{1982, 1984, true},
+		{-1984, -1988, true},
+		{-1988, 2006, false},
+		{-2006, 2009, false},
+		{0, 1, true}, // 0 is considered positive for our needs
+		{0, -42, false}}
+	for _, test := range tests {
+		if got, want := sameSign(test.а, test.b), test.want; got != want {
+			t.Errorf("%d <=> %d: got: %v, want: %v", test.а, test.b, got, want)
+		}
 	}
 }

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -71,7 +71,8 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 			}}
 		}
 	case autoscaling.Concurrency:
-		target := int64(math.Ceil(aresources.ResolveConcurrency(pa, config)))
+		t, _ := aresources.ResolveConcurrency(pa, config)
+		target := int64(math.Ceil(t))
 		hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
 			Type: autoscalingv2beta1.ObjectMetricSourceType,
 			Object: &autoscalingv2beta1.ObjectMetricSource{

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -56,18 +56,20 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 		stableWindow = config.StableWindow
 	}
 
-	target := resources.ResolveConcurrency(pa, config)
+	target, total := resources.ResolveConcurrency(pa, config)
 	panicThreshold := target * panicThresholdPercentage / 100.0
 
 	return &autoscaler.Decider{
 		ObjectMeta: *pa.ObjectMeta.DeepCopy(),
 		Spec: autoscaler.DeciderSpec{
-			TickInterval:      config.TickInterval,
-			MaxScaleUpRate:    config.MaxScaleUpRate,
-			TargetConcurrency: target,
-			PanicThreshold:    panicThreshold,
-			StableWindow:      stableWindow,
-			ServiceName:       svc,
+			TickInterval:        config.TickInterval,
+			MaxScaleUpRate:      config.MaxScaleUpRate,
+			TargetConcurrency:   target,
+			TotalConcurrency:    total,
+			TargetBurstCapacity: config.TargetBurstCapacity,
+			PanicThreshold:      panicThreshold,
+			StableWindow:        stableWindow,
+			ServiceName:         svc,
 		},
 	}
 }

--- a/pkg/reconciler/autoscaling/resources/concurrency.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
@@ -31,7 +30,6 @@ import (
 func ResolveConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) (target float64, total float64) {
 	total = float64(pa.Spec.ContainerConcurrency)
 	target = math.Max(1, total*config.ContainerConcurrencyTargetFraction)
-	fmt.Printf("###3 total: %f target: %f frac: %f\n", total, target, config.ContainerConcurrencyTargetFraction)
 
 	// If containerConcurrency is 0 we'll always target the default.
 	if pa.Spec.ContainerConcurrency == 0 {


### PR DESCRIPTION
This PR propagates target burst capacity and total pod capacity to the autoscaler, and autoscaler pushes down the excess burst capacity.

Acting on it in the KPA is the next change
(config map changes are to be ignored, since they are reviewed in the previous PR).

/lint

Part of #1846, #1409

## Proposed Changes

* Update Decider Spec to contain `TotalConcurrency` and `TargetBurstCapacity` as fields that are required to compute burst capacity and decide whether it's enough (i.e. excess is positive)
* Update Decider Status to contain the `ExcessBurstCapacity` which describes the amount of capacity we have above `TargetBurstCapacity`. If this number is non-negative we can serve the configured burst without scaling
* Update Autoscaler to compute these values (BC and EBC)
* Update the tests to verify EBC
* Update the tests to be closer to life.

/assign @mattmoor @markusthoemmes 
