### PR TITLE
Remove UpdateTarget method.

### DIFF
--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -45,9 +45,6 @@ const (
 type StatsScraper interface {
 	// Scrape scrapes the Revision queue metric endpoint.
 	Scrape() (*StatMessage, error)
-
-	// UpdateTarget updates the target URL to scrape, usign K8s service name and namespace.
-	UpdateTarget(target, ns string)
 }
 
 // scrapeClient defines the interface for collecting Revision metrics for a given
@@ -128,14 +125,6 @@ func (s *ServiceScraper) target() string {
 	s.urlMu.RLock()
 	defer s.urlMu.RUnlock()
 	return s.url
-}
-
-// UpdateTarget implements StatsScraper interface.
-func (s *ServiceScraper) UpdateTarget(target, ns string) {
-	url := urlFromTarget(target, ns)
-	s.urlMu.Lock()
-	defer s.urlMu.Unlock()
-	s.url = url
 }
 
 // Scrape calls the destination service then sends it

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package autoscaler
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -202,21 +201,6 @@ func TestScrapeReportErrorIfAllFail(t *testing.T) {
 	_, err = scraper.Scrape()
 	if errors.Cause(err) != errTest {
 		t.Errorf("scraper.Scrape() = %v, want %v", err, errTest)
-	}
-}
-
-func TestUpdateTarget(t *testing.T) {
-	client := newTestScrapeClient(testStats, nil)
-	scraper, err := serviceScraperForTest(client)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
-	if got, want := scraper.target(), fmt.Sprintf("http://%s-zhudex.%s:9090/metrics", testRevision, testNamespace); got != want {
-		t.Errorf("Initial target = %s, want: %s, diff: %s", got, want, cmp.Diff(got, want))
-	}
-	scraper.UpdateTarget("last-words", "said-again")
-	if got, want := scraper.target(), "http://last-words.said-again:9090/metrics"; got != want {
-		t.Errorf("Initial target = %s, want: %s, diff: %s", got, want, cmp.Diff(got, want))
 	}
 }
 


### PR DESCRIPTION
UpdateTarget was added for random merics service name.
But since we've chosen a different path of updating the scraper as a whole and keeping it immutable.
So remove code to prevent it from rot

/assign @mattmoor @markusthoemmes 