### PR TITLE
Remove /devstats hack from update-deps.sh

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -31,7 +31,6 @@ sed -n '11,41p' vendor/bitbucket.org/ww/goautoneg/README.txt > vendor/bitbucket.
 
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')
-rm -rf vendor/github.com/knative/test-infra/devstats
 
 update_licenses third_party/VENDOR-LICENSE "./cmd/*"
 remove_broken_symlinks ./vendor


### PR DESCRIPTION
It's not necessary anymore.