### PR TITLE
Harden our scraper logic against skewed scrapes.

### DIFF
--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -80,7 +80,7 @@ func extractData(body io.Reader) (*Stat, error) {
 		if stat.PodName == "" {
 			stat.PodName = prometheusLabel(pm.Label, "destination_pod")
 			if stat.PodName == "" {
-				return nil, fmt.Errorf("could not find pod name in metric labels")
+				return nil, errors.New("could not find pod name in metric labels")
 			}
 		}
 	}

--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -76,6 +76,13 @@ func extractData(body io.Reader) (*Stat, error) {
 			return nil, fmt.Errorf("could not find value for %s in response", m)
 		}
 		*pv = *pm.Gauge.Value
+
+		if stat.PodName == "" {
+			stat.PodName = prometheusLabel(pm.Label, "destination_pod")
+			if stat.PodName == "" {
+				return nil, fmt.Errorf("could not find pod name in metric labels")
+			}
+		}
 	}
 	return &stat, nil
 }
@@ -89,4 +96,16 @@ func prometheusMetric(metricFamilies map[string]*dto.MetricFamily, key string) *
 	}
 
 	return nil
+}
+
+// prometheusLabels returns the value of the label with the given key from the
+// given slice of labels. Returns an empty string if the label cannot be found.
+func prometheusLabel(labels []*dto.LabelPair, key string) string {
+	for _, label := range labels {
+		if *label.Name == key {
+			return *label.Value
+		}
+	}
+
+	return ""
 }

--- a/pkg/autoscaler/http_scrape_client_test.go
+++ b/pkg/autoscaler/http_scrape_client_test.go
@@ -96,6 +96,9 @@ func TestHTTPScrapeClient_Scrape_HappyCase(t *testing.T) {
 	if stat.ProxiedRequestCount != 4 {
 		t.Errorf("stat.ProxiedCount = %v, want 4", stat.ProxiedRequestCount)
 	}
+	if stat.PodName != "test-revision-1234" {
+		t.Errorf("stat.PodName = %s, want test-revision-1234", stat.PodName)
+	}
 }
 
 func TestHTTPScrapeClient_Scrape_ErrorCases(t *testing.T) {

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -145,8 +145,8 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 		})
 	}
 
-	// Return the inner error if all of the scrape calls failed.
-	if err := grp.Wait(); err != nil && len(statCh) == 0 {
+	// Return the inner error, if any.
+	if err := grp.Wait(); err != nil {
 		return nil, errors.Wrapf(err, "fail to get a successful scrape for %d tries", sampleSize)
 	}
 	close(statCh)

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -164,32 +164,9 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 	}
 }
 
-func TestScrapeReportStatWhenAtLeastOneCallSucceeds(t *testing.T) {
+func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 	errTest := errors.New("test")
-	client := newTestScrapeClient(testStats, []error{nil, errTest, errTest})
-	scraper, err := serviceScraperForTest(client)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
-
-	// Make an Endpoints with 3 pods.
-	endpoints(3)
-
-	got, err := scraper.Scrape()
-	if err != nil {
-		t.Fatalf("unexpected error from scraper.Scrape(): %v", err)
-	}
-	// Only first sample.
-	// 3.0 * 3
-	if got.Stat.AverageConcurrentRequests != 9.0 {
-		t.Errorf("StatMessage.Stat.AverageConcurrentRequests=%v, want %v",
-			got.Stat.AverageConcurrentRequests, 9.0)
-	}
-}
-
-func TestScrapeReportErrorIfAllFail(t *testing.T) {
-	errTest := errors.New("test")
-	client := newTestScrapeClient(testStats, []error{errTest, errTest})
+	client := newTestScrapeClient(testStats, []error{nil, errTest})
 	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Return an error if any of the scrapes fail.
* Only return a metric if we actually scraped only distinct pods.

These two changes basically make sure that we reach the confidence we want to reach when computing the `sampleSize`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adjusted the stats scraping implementation to be more robust and actually reach the wanted confidence on every scrape.
```

/assign @mattmoor @vagababov @yanweiguo 
