### PR TITLE
Remove /dev/log from Runtime Contract

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -409,7 +409,6 @@ MUST be provided:
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/tmp`     | MUST be Read-write.<p>SHOULD be backed by tmpfs if disk load is a concern.                                                                                       |
 | `/var/log` | MUST be a directory with write permissions for logs storage. Implementations MAY permit the creation of additional subdirectories and log rotation and renaming. |
-| `/dev/log` | MUST be a writable socket to syslog                                                                                                                              |
 
 In addition, the following files may be overridden by the runtime environment to
 enable DNS resolution:

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -45,9 +45,6 @@ var MustFiles = map[string]FileInfo{
 	"/dev/full": {
 		IsDir: ptr.Bool(false),
 	},
-	// TODO(#822): Add conformance tests for "/dev/log" once implemented
-	//"/dev/log": {
-	//},
 	"/dev/null": {
 		IsDir: ptr.Bool(false),
 	},


### PR DESCRIPTION
This change removes reference to /dev/log as a requirement of the
runtime contract, and removes a TODO referencing it in the tests.

See #822 for more info.

Fixes #822

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->