### PR TITLE
Remove duplicated class check on the PodAutoscaler reconcilers.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -69,11 +69,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	if original.Class() != autoscaling.HPA {
-		logger.Warn("Ignoring non-hpa-class PA")
-		return nil
-	}
-
 	// Don't modify the informer's copy.
 	pa := original.DeepCopy()
 	// Reconcile this copy of the pa and then write back any status

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -280,12 +280,6 @@ func TestReconcile(t *testing.T) {
 				`PodAutoscaler: "test-revision" does not own HPA: "test-revision"`),
 		},
 	}, {
-		Name: "do not create hpa when non-hpa-class pod autoscaler",
-		Objects: []runtime.Object{
-			pa(testRevision, testNamespace, WithKPAClass),
-		},
-		Key: key(testRevision, testNamespace),
-	}, {
 		Name: "nop deletion reconcile",
 		// Test that with a DeletionTimestamp we do nothing.
 		Objects: []runtime.Object{

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -71,7 +71,7 @@ func NewController(
 
 	c.Logger.Info("Setting up KPA-Class event handlers")
 	// Handle PodAutoscalers missing the class annotation for backward compatibility.
-	onlyKpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.KPA, true)
+	onlyKpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.KPA, false)
 	paHandler := cache.FilteringResourceEventHandler{
 		FilterFunc: onlyKpaClass,
 		Handler:    controller.HandleAll(impl.Enqueue),

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -81,11 +81,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	if original.Class() != autoscaling.KPA {
-		logger.Warn("Ignoring non-kpa-class PA")
-		return nil
-	}
-
 	// Don't modify the informer's copy.
 	pa := original.DeepCopy()
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3731

## Proposed Changes

* Title says it all. We no longer need these checks as all PAs meanwhile have these annotations through defaulting.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
