### PR TITLE
Possibility to add unique value to route URLs (#3689)

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -102,6 +102,11 @@ data:
     # We strongly recommend keeping namespace part of the template to avoid domain name clashes
     # Example '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
     # and you have an annotation {"sub":"foo"}, then the generated template would be {Name}-{Namespace}.foo.{Domain}
+    # {{.Unique}} variable can be used as an another option to avoid domain name clashes.
+    # Unique value (12 symbols) will be generated as a part of domain name, so user don't have to
+    # worry about collisions with other routes in the system. It can be used with or without {{.Namespace}} variable.
+    # Example '{{.Name}}-{{.Unique}}.{{.Domain}}' results in {Name}-123456789abc.{Domain}.
+    # Example '{{.Name}}-{{.Unique}}.{{.Namespace}}.{{.Domain}}' results in {Name}-123456789abc.{Namespace}.{Domain}.
     domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
 
     # tagTemplate specifies the golang text template string to use

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -122,6 +122,7 @@ type DomainTemplateValues struct {
 	Name        string
 	Namespace   string
 	Domain      string
+	Unique      string
 	Annotations map[string]string
 }
 
@@ -280,6 +281,7 @@ func checkDomainTemplate(t *template.Template) error {
 		Name:        "foo",
 		Namespace:   "bar",
 		Domain:      "baz.com",
+		Unique:      "uniq",
 		Annotations: nil,
 	}
 	buf := bytes.Buffer{}

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -19,6 +19,7 @@ package domains
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 
 	"knative.dev/pkg/apis"
@@ -54,6 +55,11 @@ func DomainNameFromTemplate(ctx context.Context, r *v1alpha1.Route, name string)
 	domainConfig := config.FromContext(ctx).Domain
 	domain := domainConfig.LookupDomainForLabels(r.ObjectMeta.Labels)
 	annotations := r.ObjectMeta.Annotations
+
+	// Generates an unique string that can be used as part of domain name
+	// The unique string is SHA256 generated from KnRoute's UID and shortened to 12 symbols
+	unique := fmt.Sprintf("%x", sha256.Sum256([]byte(r.UID)))[:12]
+
 	// These are the available properties they can choose from.
 	// We could add more over time - e.g. RevisionName if we thought that
 	// might be of interest to people.
@@ -61,6 +67,7 @@ func DomainNameFromTemplate(ctx context.Context, r *v1alpha1.Route, name string)
 		Name:        name,
 		Namespace:   r.Namespace,
 		Domain:      domain,
+		Unique:      unique,
 		Annotations: annotations,
 	}
 

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -60,9 +60,11 @@ import (
 )
 
 const (
-	testNamespace       = "test"
-	defaultDomainSuffix = "test-domain.dev"
-	prodDomainSuffix    = "prod-domain.com"
+	testNamespace                     = "test"
+	defaultDomainSuffix               = "test-domain.dev"
+	prodDomainSuffix                  = "prod-domain.com"
+	exampleRouteUID                   = "example-uid-for-testing-unique-value-in-domain"
+	uniqueValueBasedOnExampleRouteUID = "78e273dd728c"
 )
 
 func getTestRouteWithTrafficTargets(traffic []v1alpha1.TrafficTarget) *v1alpha1.Route {
@@ -1002,6 +1004,7 @@ func TestRouteDomain(t *testing.T) {
 			Annotations: map[string]string{
 				"sub": "mysub",
 			},
+			UID: exampleRouteUID,
 		},
 	}
 
@@ -1039,6 +1042,21 @@ func TestRouteDomain(t *testing.T) {
 		Template: `{{.Name}}.{{ index .Annotations "sub"}}.{{.Domain}}`,
 		Pass:     true,
 		Expected: "myapp.mysub.example.com",
+	}, {
+		Name:     "UniqueValue",
+		Template: "{{.Name}}.{{.Unique}}.{{.Domain}}",
+		Pass:     true,
+		Expected: "myapp." + uniqueValueBasedOnExampleRouteUID + ".example.com",
+	}, {
+		Name:     "UniqueValueNamespace",
+		Template: "{{.Name}}.{{.Unique}}.{{.Namespace}}.{{.Domain}}",
+		Pass:     true,
+		Expected: "myapp." + uniqueValueBasedOnExampleRouteUID + ".default.example.com",
+	}, {
+		Name:     "UniqueValueDash",
+		Template: "{{.Name}}-{{.Unique}}.{{.Domain}}",
+		Pass:     true,
+		Expected: "myapp-" + uniqueValueBasedOnExampleRouteUID + ".example.com",
 	}, {
 		// This cannot get through our validation, but verify we handle errors.
 		Name:     "BadVarName",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:


-->
/lint

Fixes #3689

## Proposed Changes
* Unique value (12 symbols) will be generated as a part of domain name, so user don't have to  worry about collisions with other routes in the system.
* With this approach we generate an unique value from KnRoute UID and not just use a random number, since it would be regenerated with each change in the deployment and it that will cause changes in the domain name all the time.
* Example '{{.Name}}-{{.Unique}}.{{.Domain}}' results in {Name}-123456789abc.{Domain}

