### PR TITLE
Separately release our CRDs.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -211,7 +211,10 @@ when you use Minikube or Docker Desktop as the Kubernetes environment.
 Next, run:
 
 ```shell
-ko apply -f config/
+# There are some issues with multi-versioned CRDs before Kubernetes 1.14, so
+# depending on how you plan to use knative you may need to switch this to
+# v1alpha1, see also: https://github.com/knative/serving/issues/4533
+ko apply -f config/ -f config/v1beta1
 
 # Optional steps
 

--- a/config/v1alpha1/300-configuration.yaml
+++ b/config/v1alpha1/300-configuration.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: revisions.serving.knative.dev
+  name: configurations.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
@@ -25,29 +25,27 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  - name: v1beta1
-    served: true
-    storage: false
   names:
-    kind: Revision
-    plural: revisions
-    singular: revision
+    kind: Configuration
+    plural: configurations
+    singular: configuration
     categories:
     - all
     - knative
     - serving
     shortNames:
-    - rev
+    - config
+    - cfg
   scope: Namespaced
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Service Name
+  - name: LatestCreated
     type: string
-    JSONPath: .status.serviceName
-  - name: Generation
-    type: string # int in string form :(
-    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
   - name: Ready
     type: string
     JSONPath: ".status.conditions[?(@.type=='Ready')].status"

--- a/config/v1alpha1/300-revision.yaml
+++ b/config/v1alpha1/300-revision.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: services.serving.knative.dev
+  name: revisions.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
@@ -25,33 +25,26 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  - name: v1beta1
-    served: true
-    storage: false
   names:
-    kind: Service
-    plural: services
-    singular: service
+    kind: Revision
+    plural: revisions
+    singular: revision
     categories:
     - all
     - knative
     - serving
     shortNames:
-    - kservice
-    - ksvc
+    - rev
   scope: Namespaced
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: URL
+  - name: Service Name
     type: string
-    JSONPath: .status.url
-  - name: LatestCreated
-    type: string
-    JSONPath: .status.latestCreatedRevisionName
-  - name: LatestReady
-    type: string
-    JSONPath: .status.latestReadyRevisionName
+    JSONPath: .status.serviceName
+  - name: Generation
+    type: string # int in string form :(
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
   - name: Ready
     type: string
     JSONPath: ".status.conditions[?(@.type=='Ready')].status"

--- a/config/v1alpha1/300-route.yaml
+++ b/config/v1alpha1/300-route.yaml
@@ -1,0 +1,50 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rt
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"

--- a/config/v1alpha1/300-service.yaml
+++ b/config/v1alpha1/300-service.yaml
@@ -1,0 +1,57 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - kservice
+    - ksvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"

--- a/config/v1beta1/300-configuration.yaml
+++ b/config/v1beta1/300-configuration.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/v1beta1/300-revision.yaml
+++ b/config/v1beta1/300-revision.yaml
@@ -1,0 +1,56 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rev
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Service Name
+    type: string
+    JSONPath: .status.serviceName
+  - name: Generation
+    type: string # int in string form :(
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"

--- a/config/v1beta1/300-route.yaml
+++ b/config/v1beta1/300-route.yaml
@@ -1,0 +1,53 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rt
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"

--- a/config/v1beta1/300-service.yaml
+++ b/config/v1beta1/300-service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: routes.serving.knative.dev
+  name: services.serving.knative.dev
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
@@ -29,15 +29,16 @@ spec:
     served: true
     storage: false
   names:
-    kind: Route
-    plural: routes
-    singular: route
+    kind: Service
+    plural: services
+    singular: service
     categories:
     - all
     - knative
     - serving
     shortNames:
-    - rt
+    - kservice
+    - ksvc
   scope: Namespaced
   subresources:
     status: {}
@@ -45,6 +46,12 @@ spec:
   - name: URL
     type: string
     JSONPath: .status.url
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
   - name: Ready
     type: string
     JSONPath: ".status.conditions[?(@.type=='Ready')].status"

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -49,6 +49,11 @@ rm -fr ${YAML_OUTPUT_DIR}/*.yaml
 
 # Generated Knative component YAML files
 readonly SERVING_YAML=${YAML_OUTPUT_DIR}/serving.yaml
+readonly SERVING_CRD_ALPHA_YAML=${YAML_OUTPUT_DIR}/serving-alpha-crds.yaml
+readonly SERVING_ALPHA_YAML=${YAML_OUTPUT_DIR}/serving-pre-1.14.yaml
+readonly SERVING_CRD_BETA_YAML=${YAML_OUTPUT_DIR}/serving-beta-crds.yaml
+readonly SERVING_BETA_YAML=${YAML_OUTPUT_DIR}/serving-post-1.14.yaml
+
 readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
 readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
 readonly MONITORING_TRACE_ZIPKIN_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin.yaml
@@ -75,6 +80,21 @@ cd "${YAML_REPO_ROOT}"
 
 echo "Building Knative Serving"
 ko resolve ${KO_YAML_FLAGS} -f config/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_YAML}"
+# These don't have images, but ko will concatenate them for us.
+ko resolve ${KO_YAML_FLAGS} -f config/v1alpha1 | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_ALPHA_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/v1beta1 | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_BETA_YAML}"
+
+# Create the full alpha install.
+cat "${SERVING_YAML}" > "${SERVING_ALPHA_YAML}"
+cat "${SERVING_CRD_ALPHA_YAML}" >> "${SERVING_ALPHA_YAML}"
+
+# Create the full beta install.
+cat "${SERVING_YAML}" > "${SERVING_BETA_YAML}"
+cat "${SERVING_CRD_BETA_YAML}" >> "${SERVING_BETA_YAML}"
+
+# Our ${SERVING_YAML} should be a complete install, so bias towards the most
+# broadly compatible by default.
+cat "${SERVING_ALPHA_YAML}" > "${SERVING_YAML}"
 
 echo "Building Monitoring & Logging"
 # Use ko to concatenate them all together.
@@ -112,4 +132,8 @@ echo "All manifests generated"
 # List generated YAML files, with serving.yaml first.
 
 ls -1 ${SERVING_YAML} > ${YAML_LIST_FILE}
+ls -1 ${SERVING_CRD_ALPHA_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${SERVING_ALPHA_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${SERVING_CRD_BETA_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${SERVING_BETA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${SERVING_YAML} >> ${YAML_LIST_FILE}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -24,6 +24,12 @@ fi
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
 
+
+# Clone the v1beta1 types to v1alpha1 sans v1beta1.
+for x in $(ls "${REPO_ROOT_DIR}/config/v1beta1"); do
+  sed -e '28,30d' "${REPO_ROOT_DIR}/config/v1beta1/$x" > "${REPO_ROOT_DIR}/config/v1alpha1/$x"
+done
+
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -39,7 +39,7 @@ func CleanupOnInterrupt(cleanup func()) {
 // TearDown will delete created names using clients.
 func TearDown(clients *Clients, names ResourceNames) {
 	if clients != nil && clients.ServingBetaClient != nil {
-		clients.ServingBetaClient.Delete(
+		clients.ServingAlphaClient.Delete(
 			[]string{names.Route},
 			[]string{names.Config},
 			[]string{names.Service},

--- a/test/clients.go
+++ b/test/clients.go
@@ -19,7 +19,6 @@ limitations under the License.
 package test
 
 import (
-	"knative.dev/pkg/test"
 	"github.com/knative/serving/pkg/client/clientset/versioned"
 	servingv1alpha1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	servingv1beta1 "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1beta1"
@@ -28,6 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"knative.dev/pkg/test"
 )
 
 // Clients holds instances of interfaces for making requests to Knative Serving.
@@ -125,7 +125,7 @@ func newServingBetaClients(cfg *rest.Config, namespace string) (*ServingBetaClie
 
 // Delete will delete all Routes and Configs with the names routes and configs, if clients
 // has been successfully initialized.
-func (clients *ServingBetaClients) Delete(routes []string, configs []string, services []string) error {
+func (clients *ServingAlphaClients) Delete(routes []string, configs []string, services []string) error {
 	deletions := []struct {
 		client interface {
 			Delete(name string, options *v1.DeleteOptions) error

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -35,6 +35,8 @@ INSTALL_MONITORING_YAML=""
 
 INSTALL_MONITORING=0
 
+INSTALL_BETA=1
+
 # List of custom YAMLs to install, if specified (space-separated).
 INSTALL_CUSTOM_YAMLS=""
 
@@ -61,6 +63,14 @@ function parse_flags() {
       ;;
     --install-monitoring)
       readonly INSTALL_MONITORING=1
+      return 1
+      ;;
+    --install-alpha)
+      readonly INSTALL_BETA=0
+      return 1
+      ;;
+    --install-beta)
+      readonly INSTALL_BETA=1
       return 1
       ;;
     --custom-yamls)
@@ -122,7 +132,11 @@ function install_knative_serving_standard() {
   if [[ -z "$1" ]]; then
     # install_knative_serving_standard was called with no arg.
     build_knative_from_source
-    INSTALL_RELEASE_YAML="${SERVING_YAML}"
+    if (( INSTALL_BETA )); then
+      INSTALL_RELEASE_YAML="${SERVING_BETA_YAML}"
+    else
+      INSTALL_RELEASE_YAML="${SERVING_ALPHA_YAML}"
+    fi
     if (( INSTALL_MONITORING )); then
       INSTALL_MONITORING_YAML="${MONITORING_YAML}"
     fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -44,12 +44,21 @@ header "Running tests"
 failed=0
 
 # Run conformance and e2e tests.
-go_test_e2e -timeout=30m \
-  ./test/conformance/api/v1alpha1 \
-  ./test/conformance/api/v1beta1 \
-  ./test/conformance/runtime \
-  ./test/e2e \
-  "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+if (( INSTALL_BETA )); then
+  # When beta is installed, include our beta tests.
+  go_test_e2e -timeout=30m \
+    ./test/conformance/api/v1alpha1 \
+    ./test/conformance/api/v1beta1 \
+    ./test/conformance/runtime \
+    ./test/e2e \
+    "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+else
+  go_test_e2e -timeout=30m \
+    ./test/conformance/api/v1alpha1 \
+    ./test/conformance/runtime \
+    ./test/e2e \
+    "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+fi
 
 # Dump cluster state after e2e tests to prevent logs being truncated.
 (( failed )) && dump_cluster_state


### PR DESCRIPTION
This change has two main parts:
1. Create separate release artifacts for our CRDs,
1. Create two versions of our CRD definitions, with and without v1beta1.

The `v1alpha1` CRDs are generated during `./hack/update-codegen.sh` from the
`v1beta1` CRDs, so we still have a single source of truth (e.g. for columns
and whatnot).

For now, `config/` contains symlinks of the `v1alpha1` CRDs, which are the most
broadly compatible, but we symlink the `v1beta1` CRDs into `test/config` so they
are available to run the `./test/conformance/api/v1beta1` tests.  We can explore
more exotic variations in the future, but this seemed the simplest short-term
change.

Related to: https://github.com/knative/serving/issues/4533

/hold