### PR TITLE
Clean up Queue proxy and its tests

### DIFF
--- a/pkg/queue/constants.go
+++ b/pkg/queue/constants.go
@@ -20,10 +20,6 @@ const (
 	// Name is the name of the component.
 	Name = "queue"
 
-	// RequestQueueHealthPath specifies the path for health checks for
-	// queue-proxy.
-	RequestQueueHealthPath = "/health"
-
 	// RequestQueueDrainPath specifies the path to wait until the proxy
 	// server is shut down. Any subsequent calls to this endpoint after
 	// the server has finished shutting down it will return immediately.


### PR DESCRIPTION
- [x] improve probe string generation
- [x] make tests pass in 2s rather than 11s
- [x] move the constant from a shared place to local, since it's never used outside of the local place
- [x] code reflow and what not
- [x] use url.Parse() in tests, rather than manual parsing.
- [x] remove some empty lines


/lint

/assign @yanweiguo @markusthoemmes 