### PR TITLE
Introduce public and private loadbalancer information in ingress status

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -63,11 +63,11 @@ func (is *IngressStatus) MarkResourceNotOwned(kind, name string) {
 
 // MarkLoadBalancerReady marks the Ingress with IngressConditionLoadBalancerReady,
 // and also populate the address of the load balancer.
-func (is *IngressStatus) MarkLoadBalancerReady(lbs []LoadBalancerIngressStatus) {
-	is.LoadBalancer = &LoadBalancerStatus{
-		Ingress: []LoadBalancerIngressStatus{},
-	}
-	is.LoadBalancer.Ingress = append(is.LoadBalancer.Ingress, lbs...)
+func (is *IngressStatus) MarkLoadBalancerReady(lbs []LoadBalancerIngressStatus, publicLbs []LoadBalancerIngressStatus, privateLbs []LoadBalancerIngressStatus) {
+	is.LoadBalancer = &LoadBalancerStatus{Ingress: lbs}
+	is.PublicLoadBalancer = &LoadBalancerStatus{Ingress: publicLbs}
+	is.PrivateLoadBalancer = &LoadBalancerStatus{Ingress: privateLbs}
+
 	ingressCondSet.Manage(is).MarkTrue(IngressConditionLoadBalancerReady)
 }
 

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -81,7 +81,11 @@ func TestIngressTypicalFlow(t *testing.T) {
 	apitest.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
 
 	// Then ingress has address.
-	r.MarkLoadBalancerReady([]LoadBalancerIngressStatus{{DomainInternal: "gateway.default.svc"}})
+	r.MarkLoadBalancerReady(
+		[]LoadBalancerIngressStatus{{DomainInternal: "gateway.default.svc"}},
+		[]LoadBalancerIngressStatus{{DomainInternal: "gateway.default.svc"}},
+		[]LoadBalancerIngressStatus{{DomainInternal: "private.gateway.default.svc"}},
+	)
 	apitest.CheckConditionSucceeded(r.duck(), IngressConditionLoadBalancerReady, t)
 	apitest.CheckConditionSucceeded(r.duck(), IngressConditionReady, t)
 	if !r.IsReady() {

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -274,8 +274,17 @@ type IngressStatus struct {
 	duckv1beta1.Status `json:",inline"`
 
 	// LoadBalancer contains the current status of the load-balancer.
+	// This is to be superseded by the combination of `PublicLoadBalancer` and `PrivateLoadBalancer`
 	// +optional
 	LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
+
+	// PublicLoadBalancer contains the current status of the load-balancer.
+	// +optional
+	PublicLoadBalancer *LoadBalancerStatus `json:"publicLoadBalancer,omitempty"`
+
+	// PrivateLoadBalancer contains the current status of the load-balancer.
+	// +optional
+	PrivateLoadBalancer *LoadBalancerStatus `json:"privateLoadBalancer,omitempty"`
 }
 
 // LoadBalancerStatus represents the status of a load-balancer.

--- a/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
@@ -470,6 +470,16 @@ func (in *IngressStatus) DeepCopyInto(out *IngressStatus) {
 		*out = new(LoadBalancerStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PublicLoadBalancer != nil {
+		in, out := &in.PublicLoadBalancer, &out.PublicLoadBalancer
+		*out = new(LoadBalancerStatus)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PrivateLoadBalancer != nil {
+		in, out := &in.PrivateLoadBalancer, &out.PrivateLoadBalancer
+		*out = new(LoadBalancerStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -196,6 +196,16 @@ func TestReconcile(t *testing.T) {
 							{DomainInternal: network.GetServiceHostname("test-ingressgateway", "istio-system")},
 						},
 					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("test-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
+						},
+					},
 					Status: duckv1beta1.Status{
 						Conditions: duckv1beta1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
@@ -272,6 +282,16 @@ func TestReconcile(t *testing.T) {
 					LoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
 							{DomainInternal: network.GetServiceHostname("test-ingressgateway", "istio-system")},
+						},
+					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("test-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
 						},
 					},
 					Status: duckv1beta1.Status{
@@ -352,6 +372,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
 						},
 					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
+						},
+					},
 					Status: duckv1beta1.Status{
 						Conditions: duckv1beta1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
@@ -399,6 +429,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					LoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
 							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
 						},
 					},
 					Status: duckv1beta1.Status{
@@ -490,6 +530,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
 						},
 					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
+						},
+					},
 					Status: duckv1beta1.Status{
 						Conditions: duckv1beta1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
@@ -576,6 +626,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
 						},
 					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
+						},
+					},
 					Status: duckv1beta1.Status{
 						Conditions: duckv1beta1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
@@ -621,6 +681,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				v1alpha1.IngressStatus{
 					LoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+					},
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{MeshOnly: true},
+						},
 					},
 					Status: duckv1beta1.Status{
 						Conditions: duckv1beta1.Conditions{{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2170,9 +2170,17 @@ func readyIngressStatus() netv1alpha1.IngressStatus {
 	status := netv1alpha1.IngressStatus{}
 	status.InitializeConditions()
 	status.MarkNetworkConfigured()
-	status.MarkLoadBalancerReady([]netv1alpha1.LoadBalancerIngressStatus{
-		{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
-	})
+	status.MarkLoadBalancerReady(
+		[]netv1alpha1.LoadBalancerIngressStatus{
+			{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+		},
+		[]netv1alpha1.LoadBalancerIngressStatus{
+			{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
+		},
+		[]netv1alpha1.LoadBalancerIngressStatus{
+			{DomainInternal: network.GetServiceHostname("private-istio-ingressgateway", "istio-system")},
+		},
+	)
 
 	return status
 }


### PR DESCRIPTION
In an effort to split up my [larger PR](https://github.com/knative/serving/pull/4291).

**This depends on PR https://github.com/knative/serving/pull/4558**

Here we introduce new information in the ingress status block. Exposing both public and private loadbalancer details.



