### PR TITLE
Updating k8s visibility will update the specific subroute's visibility.

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -170,6 +170,11 @@ type IngressRule struct {
 	// +optional
 	Hosts []string `json:"hosts,omitempty"`
 
+	// Visibility signifies whether this rule should `ClusterLocal`. If it's not
+	// specified then it defaults to `ExternalIP`.
+	// +optional
+	Visibility IngressVisibility `json:"visibility,omitempty"`
+
 	// HTTP represents a rule to apply against incoming requests. If the
 	// rule is satisfied, the request is routed to the specified backend.
 	HTTP *HTTPIngressRuleValue `json:"http,omitempty"`

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -31,6 +31,8 @@ const (
 	// which Route it is configured as traffic target.
 	// The key can also be attached to ClusterIngress resources to indicate
 	// which Route triggered their creation.
+	// The key is also attached to k8s Service resources to indicate which Route
+	// triggered their creation.
 	RouteLabelKey = GroupName + "/route"
 
 	// RouteNamespaceLabelKey is the label key attached to a ClusterIngress

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -248,7 +248,7 @@ func (r *BaseIngressReconciler) reconcileIngress(ctx context.Context, ra Reconci
 	ia.GetStatus().InitializeConditions()
 	logger.Infof("Reconciling ingress: %#v", ia)
 
-	gatewayNames := gatewayNamesFromContext(ctx, ia)
+	gatewayNames := gatewayNamesFromContext(ctx)
 	vses := resources.MakeVirtualServices(ia, gatewayNames)
 
 	// First, create the VirtualServices.
@@ -291,7 +291,7 @@ func (r *BaseIngressReconciler) reconcileIngress(ctx context.Context, ra Reconci
 			return err
 		}
 
-		for _, gatewayName := range gatewayNames {
+		for _, gatewayName := range gatewayNames[v1alpha1.IngressVisibilityExternalIP] {
 			ns, err := resources.GatewayServiceNamespace(config.FromContext(ctx).Istio.IngressGateways, gatewayName)
 			if err != nil {
 				return err
@@ -432,12 +432,13 @@ func (r *BaseIngressReconciler) reconcileDeletion(ctx context.Context, ra Reconc
 		return nil
 	}
 
-	gatewayNames := gatewayNamesFromContext(ctx, ia)
-	logger.Infof("Cleaning up Gateway Servers for Ingress %s", ia.GetName())
-	// No desired Servers means deleting all of the existing Servers associated with the CI.
-	for _, gatewayName := range gatewayNames {
-		if err := r.reconcileGateway(ctx, ia, gatewayName, []v1alpha3.Server{}); err != nil {
-			return err
+	allGateways := gatewayNamesFromContext(ctx)
+	logger.Infof("Cleaning up Gateway Servers for ClusterIngress %s", ia.GetName())
+	for _, gatewayNames := range allGateways {
+		for _, gatewayName := range gatewayNames {
+			if err := r.reconcileGateway(ctx, ia, gatewayName, []v1alpha3.Server{}); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -525,18 +526,22 @@ func (r *BaseIngressReconciler) reconcileGateway(ctx context.Context, ia v1alpha
 }
 
 // gatewayNamesFromContext get gateway names from context
-func gatewayNamesFromContext(ctx context.Context, ia v1alpha1.IngressAccessor) []string {
-	gateways := []string{}
-	if ia.IsPublic() {
-		for _, gw := range config.FromContext(ctx).Istio.IngressGateways {
-			gateways = append(gateways, gw.GatewayName)
-		}
-	} else {
-		for _, gw := range config.FromContext(ctx).Istio.LocalGateways {
-			gateways = append(gateways, gw.GatewayName)
-		}
+func gatewayNamesFromContext(ctx context.Context) map[v1alpha1.IngressVisibility][]string {
+	var publicGateways []string
+	for _, gw := range config.FromContext(ctx).Istio.IngressGateways {
+		publicGateways = append(publicGateways, gw.GatewayName)
 	}
-	return dedup(gateways)
+	dedup(publicGateways)
+
+	var privateGateways []string
+	for _, gw := range config.FromContext(ctx).Istio.LocalGateways {
+		privateGateways = append(privateGateways, gw.GatewayName)
+	}
+
+	return map[v1alpha1.IngressVisibility][]string{
+		v1alpha1.IngressVisibilityExternalIP:   publicGateways,
+		v1alpha1.IngressVisibilityClusterLocal: privateGateways,
+	}
 }
 
 func dedup(strs []string) []string {

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -20,11 +20,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"text/template"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/route/config"
+	"github.com/knative/serving/pkg/reconciler/route/resources/labels"
 
 	"knative.dev/pkg/apis"
 )
@@ -33,15 +38,20 @@ import (
 const HTTPScheme string = "http"
 
 // GetAllDomainsAndTags returns all of the domains and tags(including subdomains) associated with a Route
-func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string) (map[string]string, error) {
+func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string, localServiceNames sets.String) (map[string]string, error) {
 	domainTagMap := make(map[string]string)
 
 	for _, name := range names {
-		hostname, err := HostnameFromTemplate(ctx, r.Name, name)
+		meta := r.ObjectMeta.DeepCopy()
+
+		hostname, err := HostnameFromTemplate(ctx, meta.Name, name)
 		if err != nil {
 			return nil, err
 		}
-		subDomain, err := DomainNameFromTemplate(ctx, r, hostname)
+
+		labels.SetVisibility(meta, localServiceNames.Has(hostname))
+
+		subDomain, err := DomainNameFromTemplate(ctx, *meta, hostname)
 		if err != nil {
 			return nil, err
 		}
@@ -52,11 +62,11 @@ func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string
 
 // DomainNameFromTemplate generates domain name base on the template specified in the `config-network` ConfigMap.
 // name is the "subdomain" which will be referred as the "name" in the template
-func DomainNameFromTemplate(ctx context.Context, r *v1alpha1.Route, name string) (string, error) {
+func DomainNameFromTemplate(ctx context.Context, r v1.ObjectMeta, name string) (string, error) {
 	domainConfig := config.FromContext(ctx).Domain
-	rLabels := r.ObjectMeta.Labels
+	rLabels := r.Labels
 	domain := domainConfig.LookupDomainForLabels(rLabels)
-	annotations := r.ObjectMeta.Annotations
+	annotations := r.Annotations
 	// These are the available properties they can choose from.
 	// We could add more over time - e.g. RevisionName if we thought that
 	// might be of interest to people.
@@ -114,4 +124,9 @@ func URL(scheme, fqdn string) *apis.URL {
 		Scheme: scheme,
 		Host:   fqdn,
 	}
+}
+
+// IsClusterLocal checks if a domain is only visible with cluster.
+func IsClusterLocal(domain string) bool {
+	return strings.HasSuffix(domain, network.GetClusterDomainName())
 }

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -134,28 +134,9 @@ func (c *Reconciler) deleteServices(namespace string, serviceNames sets.String) 
 	return nil
 }
 
-func (c *Reconciler) getServiceNameSet(route *v1alpha1.Route) (sets.String, error) {
-	currentServices, err := c.serviceLister.Services(route.Namespace).List(resources.SelectorFromRoute(route))
-	if err != nil {
-		return nil, err
-	}
-
-	serviceNames := sets.NewString()
-	for _, svc := range currentServices {
-		serviceNames.Insert(svc.Name)
-	}
-
-	return serviceNames, nil
-}
-
-func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1alpha1.Route, targets map[string]traffic.RevisionTargets) ([]*corev1.Service, error) {
+func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1alpha1.Route, targets map[string]traffic.RevisionTargets, currentServiceNames sets.String) ([]*corev1.Service, error) {
 	logger := logging.FromContext(ctx)
 	ns := route.Namespace
-
-	currentServices, err := c.getServiceNameSet(route)
-	if err != nil {
-		return nil, err
-	}
 
 	names := sets.NewString()
 	for name := range targets {
@@ -191,11 +172,11 @@ func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1
 		}
 
 		services = append(services, service)
-		delete(currentServices, desiredService.Name)
+		delete(currentServiceNames, desiredService.Name)
 	}
 
 	// Delete any current services that was no longer desired.
-	if err := c.deleteServices(ns, currentServices); err != nil {
+	if err := c.deleteServices(ns, currentServiceNames); err != nil {
 		return nil, err
 	}
 
@@ -212,7 +193,7 @@ func (c *Reconciler) updatePlaceholderServices(ctx context.Context, route *v1alp
 	for _, service := range services {
 		service := service
 		eg.Go(func() error {
-			desiredService, err := resources.MakeK8sService(ctx, route, service.Name, ingress)
+			desiredService, err := resources.MakeK8sService(ctx, route, service.Name, ingress, resources.IsClusterLocalService(service))
 			if err != nil {
 				// Loadbalancer not ready, no need to update.
 				logger.Warnf("Failed to update k8s service: %v", err)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -178,7 +179,7 @@ func newTestClusterIngress(t *testing.T, r *v1alpha1.Route, trafficOpts ...func(
 			ServerCertificate: "tls.crt",
 		},
 	}
-	ingress, err := resources.MakeClusterIngress(getContext(), r, tc, tls, "foo-ingress")
+	ingress, err := resources.MakeClusterIngress(getContext(), r, tc, tls, sets.NewString(), "foo-ingress")
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}

--- a/pkg/reconciler/route/resources/cluster_ingress.go
+++ b/pkg/reconciler/route/resources/cluster_ingress.go
@@ -19,27 +19,22 @@ package resources
 import (
 	"context"
 	"sort"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/serving/pkg/activator"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/route/domains"
+	"github.com/knative/serving/pkg/reconciler/route/resources/labels"
 	"github.com/knative/serving/pkg/reconciler/route/resources/names"
 	"github.com/knative/serving/pkg/reconciler/route/traffic"
 	"github.com/knative/serving/pkg/resources"
 )
-
-// IsClusterLocal checks if a Route is publicly visible or only visible with cluster.
-func IsClusterLocal(r *servingv1alpha1.Route) bool {
-	return r.Status.URL != nil && strings.HasSuffix(r.Status.URL.Host, network.GetClusterDomainName())
-}
 
 // MakeIngressTLS creates IngressTLS to configure the ingress TLS.
 func MakeIngressTLS(cert *v1alpha1.Certificate, hostNames []string) v1alpha1.IngressTLS {
@@ -52,8 +47,15 @@ func MakeIngressTLS(cert *v1alpha1.Certificate, hostNames []string) v1alpha1.Ing
 
 // MakeClusterIngress creates ClusterIngress to set up routing rules. Such ClusterIngress specifies
 // which Hosts that it applies to, as well as the routing rules.
-func MakeClusterIngress(ctx context.Context, r *servingv1alpha1.Route, tc *traffic.Config, tls []v1alpha1.IngressTLS, ingressClass string) (*v1alpha1.ClusterIngress, error) {
-	spec, err := makeIngressSpec(ctx, r, tls, tc.Targets)
+func MakeClusterIngress(
+	ctx context.Context,
+	r *servingv1alpha1.Route,
+	tc *traffic.Config,
+	tls []v1alpha1.IngressTLS,
+	clusterLocalServices sets.String,
+	ingressClass string,
+) (*v1alpha1.ClusterIngress, error) {
+	spec, err := makeIngressSpec(ctx, r, tls, clusterLocalServices, tc.Targets)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +76,13 @@ func MakeClusterIngress(ctx context.Context, r *servingv1alpha1.Route, tc *traff
 	}, nil
 }
 
-func makeIngressSpec(ctx context.Context, r *servingv1alpha1.Route, tls []v1alpha1.IngressTLS, targets map[string]traffic.RevisionTargets) (v1alpha1.IngressSpec, error) {
+func makeIngressSpec(
+	ctx context.Context,
+	r *servingv1alpha1.Route,
+	tls []v1alpha1.IngressTLS,
+	clusterLocalServices sets.String,
+	targets map[string]traffic.RevisionTargets,
+) (v1alpha1.IngressSpec, error) {
 	// Domain should have been specified in route status
 	// before calling this func.
 	names := make([]string, 0, len(targets))
@@ -87,16 +95,29 @@ func makeIngressSpec(ctx context.Context, r *servingv1alpha1.Route, tls []v1alph
 	// The routes are matching rule based on domain name to traffic split targets.
 	rules := make([]v1alpha1.IngressRule, 0, len(names))
 	for _, name := range names {
-		domains, err := routeDomains(ctx, name, r)
+		serviceDomain, err := domains.HostnameFromTemplate(ctx, r.Name, name)
 		if err != nil {
 			return v1alpha1.IngressSpec{}, err
 		}
+
+		isClusterLocal := clusterLocalServices.Has(serviceDomain)
+
+		routeDomains, err := routeDomains(ctx, name, r, isClusterLocal)
+		if err != nil {
+			return v1alpha1.IngressSpec{}, err
+		}
+
 		rules = append(rules, *makeIngressRule(
-			domains, r.Namespace, targets[name]))
+			routeDomains, r.Namespace, isClusterLocal, targets[name]))
+	}
+
+	defaultDomain, err := domains.HostnameFromTemplate(ctx, r.Name, "")
+	if err != nil {
+		return v1alpha1.IngressSpec{}, err
 	}
 
 	visibility := v1alpha1.IngressVisibilityExternalIP
-	if IsClusterLocal(r) {
+	if clusterLocalServices.Has(defaultDomain) {
 		visibility = v1alpha1.IngressVisibilityClusterLocal
 	}
 
@@ -107,12 +128,16 @@ func makeIngressSpec(ctx context.Context, r *servingv1alpha1.Route, tls []v1alph
 	}, nil
 }
 
-func routeDomains(ctx context.Context, targetName string, r *servingv1alpha1.Route) ([]string, error) {
+func routeDomains(ctx context.Context, targetName string, r *servingv1alpha1.Route, isClusterLocal bool) ([]string, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, r.Name, targetName)
 	if err != nil {
 		return nil, err
 	}
-	fullName, err := domains.DomainNameFromTemplate(ctx, r, hostname)
+
+	meta := r.ObjectMeta.DeepCopy()
+	labels.SetVisibility(meta, isClusterLocal)
+
+	fullName, err := domains.DomainNameFromTemplate(ctx, *meta, hostname)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +156,7 @@ func routeDomains(ctx context.Context, targetName string, r *servingv1alpha1.Rou
 	return ruleDomains, nil
 }
 
-func makeIngressRule(domains []string, ns string, targets traffic.RevisionTargets) *v1alpha1.IngressRule {
+func makeIngressRule(domains []string, ns string, isClusterLocal bool, targets traffic.RevisionTargets) *v1alpha1.IngressRule {
 	// Optimistically allocate |targets| elements.
 	splits := make([]v1alpha1.IngressBackendSplit, 0, len(targets))
 	for _, t := range targets {
@@ -156,8 +181,14 @@ func makeIngressRule(domains []string, ns string, targets traffic.RevisionTarget
 		})
 	}
 
+	visibility := v1alpha1.IngressVisibilityExternalIP
+	if isClusterLocal {
+		visibility = v1alpha1.IngressVisibilityClusterLocal
+	}
+
 	return &v1alpha1.IngressRule{
-		Hosts: domains,
+		Hosts:      domains,
+		Visibility: visibility,
 		HTTP: &v1alpha1.HTTPIngressRuleValue{
 			Paths: []v1alpha1.HTTPIngressPath{{
 				Splits: splits,

--- a/pkg/reconciler/route/resources/filters.go
+++ b/pkg/reconciler/route/resources/filters.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Filter is used for applying a function to a service
+type Filter func(service *corev1.Service) bool
+
+// FilterService applies a filter to the list of services and return the services that are accepted
+func FilterService(services []*corev1.Service, acceptFilter Filter) []*corev1.Service {
+	var filteredServices []*corev1.Service
+
+	for i := range services {
+		service := services[i]
+		if acceptFilter(service) {
+			filteredServices = append(filteredServices, service)
+		}
+	}
+
+	return filteredServices
+}
+
+// Filter functions
+
+// IsClusterLocalService returns whether a service is cluster local.
+func IsClusterLocalService(svc *corev1.Service) bool {
+	if visibility, ok := svc.GetLabels()[config.VisibilityLabelKey]; ok {
+		return config.VisibilityClusterLocal == visibility
+	}
+
+	return false
+}

--- a/pkg/reconciler/route/resources/filters_test.go
+++ b/pkg/reconciler/route/resources/filters_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resources
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilterService(t *testing.T) {
+	tests := []struct {
+		name         string
+		services     []*corev1.Service
+		acceptFilter Filter
+		want         []*corev1.Service
+	}{
+		{
+			name: "no services",
+		},
+		{
+			name: "matches services",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar-2",
+					},
+				},
+			},
+			acceptFilter: func(service *corev1.Service) bool {
+				return strings.HasPrefix(service.Name, "foo")
+			},
+			want: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo-1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if got := FilterService(tt.services, tt.acceptFilter); !cmp.Equal(got, tt.want) {
+				t.Errorf("FilterService() (-want, +got) = %v", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestIsClusterLocalService(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  *corev1.Service
+		want bool
+	}{
+		{
+			name: "Service does NOT have visibility label set",
+			svc:  &corev1.Service{},
+			want: false,
+		},
+		{
+			name: "Service has visibility label set to anything but ClusterLocal",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						config.VisibilityLabelKey: "something-unknown",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Service has visibility label set to cluster local",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsClusterLocalService(tt.svc); got != tt.want {
+				t.Errorf("IsClusterLocalService() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/route/resources/labels/doc.go
+++ b/pkg/reconciler/route/resources/labels/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package labels holds simple functions for working with ObjectMeta labels.
+package labels

--- a/pkg/reconciler/route/resources/labels/labels.go
+++ b/pkg/reconciler/route/resources/labels/labels.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsObjectLocalVisibility returns whether an ObjectMeta is of cluster-local visibility
+func IsObjectLocalVisibility(meta v1.ObjectMeta) bool {
+	return meta.Labels != nil && meta.Labels[config.VisibilityLabelKey] != ""
+}
+
+// SetVisibility sets the visibility on an ObjectMeta
+func SetVisibility(meta *v1.ObjectMeta, isClusterLocal bool) {
+	if isClusterLocal {
+		SetLabel(meta, config.VisibilityLabelKey, config.VisibilityClusterLocal)
+	} else {
+		DeleteLabel(meta, config.VisibilityLabelKey)
+	}
+}
+
+// SetLabel sets/update the label of the an ObjectMeta
+func SetLabel(meta *v1.ObjectMeta, key string, value string) {
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+
+	meta.Labels[key] = value
+}
+
+// DeleteLabel removes a label from the ObjectMeta
+func DeleteLabel(meta *v1.ObjectMeta, key string) {
+	if meta.Labels != nil {
+		delete(meta.Labels, key)
+	}
+}

--- a/pkg/reconciler/route/resources/labels/labels_test.go
+++ b/pkg/reconciler/route/resources/labels/labels_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"github.com/knative/serving/pkg/reconciler/route/config"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeleteLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     *v1.ObjectMeta
+		key      string
+		expected v1.ObjectMeta
+	}{
+		{
+			name:     "No labels in object meta",
+			meta:     &v1.ObjectMeta{},
+			key:      "key",
+			expected: v1.ObjectMeta{},
+		},
+		{
+			name: "No matching key",
+			meta: &v1.ObjectMeta{
+				Labels: map[string]string{"some label": "some value"},
+			},
+			key: "unknown",
+			expected: v1.ObjectMeta{
+				Labels: map[string]string{"some label": "some value"},
+			},
+		},
+		{
+			name: "Has matching key",
+			meta: &v1.ObjectMeta{
+				Labels: map[string]string{"some label": "some value"},
+			},
+			key: "some label",
+			expected: v1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DeleteLabel(tt.meta, tt.key)
+
+			if !cmp.Equal(tt.expected, *tt.meta) {
+				t.Errorf("DeleteLabel (-want, +got) = %v",
+					cmp.Diff(tt.expected, *tt.meta))
+			}
+		})
+	}
+}
+
+func TestSetLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		meta  *v1.ObjectMeta
+		key   string
+		value string
+
+		expected v1.ObjectMeta
+	}{
+		{
+			name:  "No labels in object meta",
+			meta:  &v1.ObjectMeta{},
+			key:   "key",
+			value: "value",
+			expected: v1.ObjectMeta{
+				Labels: map[string]string{"key": "value"},
+			},
+		},
+		{
+			name: "Empty labels",
+			meta: &v1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+			key:   "key",
+			value: "value",
+			expected: v1.ObjectMeta{
+				Labels: map[string]string{"key": "value"},
+			},
+		},
+		{
+			name: "Conflicting labels",
+			meta: &v1.ObjectMeta{
+				Labels: map[string]string{"key": "old value"},
+			},
+			key:   "key",
+			value: "new value",
+			expected: v1.ObjectMeta{
+				Labels: map[string]string{"key": "new value"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetLabel(tt.meta, tt.key, tt.value)
+
+			if !cmp.Equal(tt.expected, *tt.meta) {
+				t.Errorf("DeleteLabel (-want, +got) = %v",
+					cmp.Diff(tt.expected, *tt.meta))
+			}
+		})
+	}
+}
+
+func TestSetVisibility(t *testing.T) {
+	tests := []struct {
+		name           string
+		meta           *v1.ObjectMeta
+		isClusterLocal bool
+		expected       v1.ObjectMeta
+	}{
+		{
+			name:           "Set cluster local true",
+			meta:           &v1.ObjectMeta{},
+			isClusterLocal: true,
+			expected:       v1.ObjectMeta{Labels: map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}},
+		},
+		{
+			name:           "Set cluster local false",
+			meta:           &v1.ObjectMeta{Labels: map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}},
+			isClusterLocal: false,
+			expected:       v1.ObjectMeta{Labels: map[string]string{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetVisibility(tt.meta, tt.isClusterLocal)
+		})
+	}
+}

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -24,16 +24,29 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/serving/pkg/apis/networking"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/reconciler/route/config"
 	"github.com/knative/serving/pkg/reconciler/route/domains"
 	"knative.dev/pkg/kmeta"
 )
 
 var errLoadBalancerNotFound = errors.New("failed to fetch loadbalancer domain/IP from ingress status")
+
+// GetNames returns a set of service names.
+func GetNames(services []*corev1.Service) sets.String {
+	names := sets.NewString()
+
+	for i := range services {
+		names.Insert(services[i].Name)
+	}
+
+	return names
+}
 
 // SelectorFromRoute creates a label selector given a specific route.
 func SelectorFromRoute(route *v1alpha1.Route) labels.Selector {
@@ -51,7 +64,7 @@ func MakeK8sPlaceholderService(ctx context.Context, route *v1alpha1.Route, targe
 	if err != nil {
 		return nil, err
 	}
-	fullName, err := domains.DomainNameFromTemplate(ctx, route, hostname)
+	fullName, err := domains.DomainNameFromTemplate(ctx, route.ObjectMeta, hostname)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +85,8 @@ func MakeK8sPlaceholderService(ctx context.Context, route *v1alpha1.Route, targe
 // MakeK8sService creates a Service that redirect to the loadbalancer specified
 // in ClusterIngress status. It's owned by the provided v1alpha1.Route.
 // The purpose of this service is to provide a domain name for Istio routing.
-func MakeK8sService(ctx context.Context, route *v1alpha1.Route, targetName string, ingress *netv1alpha1.ClusterIngress) (*corev1.Service, error) {
-	svcSpec, err := makeServiceSpec(ingress)
+func MakeK8sService(ctx context.Context, route *v1alpha1.Route, targetName string, ingress *netv1alpha1.ClusterIngress, isPrivate bool) (*corev1.Service, error) {
+	svcSpec, err := makeServiceSpec(ingress, isPrivate)
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +104,15 @@ func makeK8sService(ctx context.Context, route *v1alpha1.Route, targetName strin
 	if err != nil {
 		return nil, err
 	}
+
+	svcLabels := map[string]string{
+		serving.RouteLabelKey: route.Name,
+	}
+
+	if visibility, ok := route.Labels[config.VisibilityLabelKey]; ok {
+		svcLabels[config.VisibilityLabelKey] = visibility
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      hostname,
@@ -99,23 +121,30 @@ func makeK8sService(ctx context.Context, route *v1alpha1.Route, targetName strin
 				// This service is owned by the Route.
 				*kmeta.NewControllerRef(route),
 			},
-			Labels: map[string]string{
-				serving.RouteLabelKey: route.Name,
-			},
+			Labels: svcLabels,
 		},
 	}, nil
 }
 
-func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, error) {
+func makeServiceSpec(ingress *netv1alpha1.ClusterIngress, isPrivate bool) (*corev1.ServiceSpec, error) {
 	ingressStatus := ingress.Status
-	if ingressStatus.LoadBalancer == nil || len(ingressStatus.LoadBalancer.Ingress) == 0 {
+
+	var lbStatus *netv1alpha1.LoadBalancerStatus
+
+	if isPrivate {
+		lbStatus = ingressStatus.PrivateLoadBalancer
+	} else {
+		lbStatus = ingressStatus.PublicLoadBalancer
+	}
+
+	if lbStatus == nil || len(lbStatus.Ingress) == 0 {
 		return nil, errLoadBalancerNotFound
 	}
-	if len(ingressStatus.LoadBalancer.Ingress) > 1 {
+	if len(lbStatus.Ingress) > 1 {
 		// Return error as we only support one LoadBalancer currently.
 		return nil, fmt.Errorf("more than one ingress are specified in status(LoadBalancer) of ClusterIngress %s", ingress.Name)
 	}
-	balancer := ingressStatus.LoadBalancer.Ingress[0]
+	balancer := lbStatus.Ingress[0]
 
 	// Here we decide LoadBalancer information in the order of
 	// DomainInternal > Domain > LoadBalancedIP to prioritize cluster-local,
@@ -150,4 +179,21 @@ func makeServiceSpec(ingress *netv1alpha1.ClusterIngress) (*corev1.ServiceSpec, 
 		// We'll also need ports info to make it take effect.
 	}
 	return nil, errLoadBalancerNotFound
+}
+
+// GetDesiredServiceNames returns a list of service names that we expect to create
+func GetDesiredServiceNames(ctx context.Context, route *v1alpha1.Route) (sets.String, error) {
+	traffic := route.Spec.Traffic
+
+	names := sets.String{}
+
+	for _, t := range traffic {
+		serviceName, err := domains.HostnameFromTemplate(ctx, route.Name, t.Tag)
+		if err != nil {
+			return sets.String{}, err
+		}
+		names.Insert(serviceName)
+	}
+
+	return names, nil
 }

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -21,10 +21,6 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/google/go-cmp/cmp"
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -34,6 +30,11 @@ import (
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/route/config"
 	"github.com/knative/serving/pkg/reconciler/route/traffic"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -81,6 +82,12 @@ func TestNewMakeK8SService(t *testing.T) {
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
 						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{}},
 					},
+					PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{}},
+					},
+					PrivateLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{}},
+					},
 				},
 			},
 			expectedMeta: expectedMeta,
@@ -91,6 +98,20 @@ func TestNewMakeK8SService(t *testing.T) {
 			ingress: &netv1alpha1.ClusterIngress{
 				Status: netv1alpha1.IngressStatus{
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{
+							Domain: "domain.com",
+						}, {
+							DomainInternal: "domain.com",
+						}},
+					},
+					PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{
+							Domain: "domain.com",
+						}, {
+							DomainInternal: "domain.com",
+						}},
+					},
+					PrivateLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{
 							Domain: "domain.com",
 						}, {
@@ -109,6 +130,12 @@ func TestNewMakeK8SService(t *testing.T) {
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
 						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{Domain: "domain.com"}},
 					},
+					PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{Domain: "domain.com"}},
+					},
+					PrivateLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{},
+					},
 				},
 			},
 			expectedMeta: expectedMeta,
@@ -124,6 +151,12 @@ func TestNewMakeK8SService(t *testing.T) {
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
 						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: "istio-ingressgateway.istio-system.svc.cluster.local"}},
 					},
+					PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: "istio-ingressgateway.istio-system.svc.cluster.local"}},
+					},
+					PrivateLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: "private-istio-ingressgateway.istio-system.svc.cluster.local"}},
+					},
 				},
 			},
 			expectedMeta: expectedMeta,
@@ -138,6 +171,12 @@ func TestNewMakeK8SService(t *testing.T) {
 			ingress: &netv1alpha1.ClusterIngress{
 				Status: netv1alpha1.IngressStatus{
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+					},
+					PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+					},
+					PrivateLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
 					},
 				},
@@ -157,6 +196,12 @@ func TestNewMakeK8SService(t *testing.T) {
 			ingress: &netv1alpha1.ClusterIngress{
 				Status: netv1alpha1.IngressStatus{
 					LoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+					},
+					PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
+						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+					},
+					PrivateLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 						Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
 					},
 				},
@@ -185,7 +230,7 @@ func TestNewMakeK8SService(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cfg := testConfig()
 			ctx := config.ToContext(context.Background(), cfg)
-			service, err := MakeK8sService(ctx, scenario.route, scenario.targetName, scenario.ingress)
+			service, err := MakeK8sService(ctx, scenario.route, scenario.targetName, scenario.ingress, false)
 			// Validate
 			if scenario.shouldFail && err == nil {
 				t.Errorf("Test %q failed: returned success but expected error", name)
@@ -206,42 +251,73 @@ func TestNewMakeK8SService(t *testing.T) {
 	}
 }
 
-func TestMakePlaceholderK8sService(t *testing.T) {
-	target := traffic.RevisionTarget{
-		TrafficTarget: v1beta1.TrafficTarget{
-			Tag: "foo",
+func TestMakeK8sPlaceholderService(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedSpec   corev1.ServiceSpec
+		expectedLabels map[string]string
+		wantErr        bool
+		route          *v1alpha1.Route
+	}{{
+		name:  "default public domain route",
+		route: r,
+		expectedSpec: corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeExternalName,
+			ExternalName:    "foo-test-route.test-ns.example.com",
+			SessionAffinity: corev1.ServiceAffinityNone,
 		},
-	}
-
-	cfg := testConfig()
-	ctx := config.ToContext(context.Background(), cfg)
-
-	service, err := MakeK8sPlaceholderService(ctx, r, target.Tag)
-	expectedMeta := metav1.ObjectMeta{
-		Name:      target.Tag + "-" + r.Name,
-		Namespace: r.Namespace,
-		OwnerReferences: []metav1.OwnerReference{
-			*kmeta.NewControllerRef(r),
+		expectedLabels: map[string]string{
+			serving.RouteLabelKey: "test-route",
 		},
-		Labels: map[string]string{
-			serving.RouteLabelKey: r.Name,
+		wantErr: false,
+	}, {
+		name: "cluster local route",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "test-ns",
+				Labels: map[string]string{
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
 		},
-	}
-	expectedSpec := corev1.ServiceSpec{
-		Type:            corev1.ServiceTypeExternalName,
-		ExternalName:    "foo-test-route.test-ns.example.com",
-		SessionAffinity: corev1.ServiceAffinityNone,
-	}
+		expectedSpec: corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeExternalName,
+			ExternalName:    "foo-test-route.test-ns.svc.cluster.local",
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+		expectedLabels: map[string]string{
+			serving.RouteLabelKey:     "test-route",
+			config.VisibilityLabelKey: config.VisibilityClusterLocal,
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			ctx := config.ToContext(context.Background(), cfg)
+			target := traffic.RevisionTarget{
+				TrafficTarget: v1beta1.TrafficTarget{
+					Tag: "foo",
+				},
+			}
 
-	if err != nil {
-		t.Errorf("Unexpected error %v returned", err)
-	}
+			got, err := MakeK8sPlaceholderService(ctx, tt.route, target.Tag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MakeK8sPlaceholderService() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 
-	if !cmp.Equal(expectedMeta, service.ObjectMeta) {
-		t.Errorf("Unexpected Metadata (-want +got): %s", cmp.Diff(expectedMeta, service.ObjectMeta))
-	}
-	if !cmp.Equal(expectedSpec, service.Spec) {
-		t.Errorf("Unexpected ServiceSpec (-want +got): %s", cmp.Diff(expectedSpec, service.Spec))
+			if got == nil {
+				t.Fatal("Unexpected nil service")
+			}
+
+			if !cmp.Equal(tt.expectedLabels, got.ObjectMeta.Labels) {
+				t.Errorf("Unexpected Labels (-want +got): %s", cmp.Diff(tt.expectedLabels, got.ObjectMeta.Labels))
+			}
+			if !cmp.Equal(tt.expectedSpec, got.Spec) {
+				t.Errorf("Unexpected ServiceSpec (-want +got): %s", cmp.Diff(tt.expectedSpec, got.Spec))
+			}
+		})
 	}
 }
 
@@ -270,5 +346,95 @@ func testConfig() *config.Config {
 		GC: &gc.Config{
 			StaleRevisionLastpinnedDebounce: time.Duration(1 * time.Minute),
 		},
+	}
+}
+
+func TestGetNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []*corev1.Service
+		want     sets.String
+	}{
+		{
+			name: "nil services",
+			want: sets.String{},
+		},
+		{
+			name: "multiple services",
+			services: []*corev1.Service{
+				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "svc2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "svc3"}},
+			},
+			want: sets.NewString("svc1", "svc2", "svc3"),
+		},
+		{
+			name: "duplicate services",
+			services: []*corev1.Service{
+				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
+			},
+			want: sets.NewString("svc1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetNames(tt.services); !cmp.Equal(got, tt.want) {
+				t.Errorf("GetNames() (-want, +got) = %v", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestGetDesiredServiceNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		traffic []v1alpha1.TrafficTarget
+		want    sets.String
+		wantErr bool
+	}{
+		{
+			name: "no traffic defined",
+		},
+		{
+			name:    "only default traffic",
+			traffic: []v1alpha1.TrafficTarget{{TrafficTarget: v1beta1.TrafficTarget{}}},
+			want:    sets.NewString("myroute"),
+		},
+		{
+			name: "traffic targets with tag",
+			traffic: []v1alpha1.TrafficTarget{
+				{TrafficTarget: v1beta1.TrafficTarget{}},
+				{TrafficTarget: v1beta1.TrafficTarget{Tag: "hello"}},
+				{TrafficTarget: v1beta1.TrafficTarget{Tag: "hello"}},
+				{TrafficTarget: v1beta1.TrafficTarget{Tag: "bye"}},
+			},
+			want: sets.NewString("myroute", "hello-myroute", "bye-myroute"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			ctx := config.ToContext(context.Background(), cfg)
+
+			route := &v1alpha1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myroute",
+				},
+				Spec: v1alpha1.RouteSpec{
+					Traffic: tt.traffic,
+				},
+			}
+
+			got, err := GetDesiredServiceNames(ctx, route)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDesiredServiceNames() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("GetDesiredServiceNames() (-want, +got) = %v", cmp.Diff(tt.want, got))
+			}
+		})
 	}
 }

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -40,6 +40,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/route/config"
 	"github.com/knative/serving/pkg/reconciler/route/domains"
 	"github.com/knative/serving/pkg/reconciler/route/resources"
+	"github.com/knative/serving/pkg/reconciler/route/resources/labels"
 	resourcenames "github.com/knative/serving/pkg/reconciler/route/resources/names"
 	"github.com/knative/serving/pkg/reconciler/route/traffic"
 	tr "github.com/knative/serving/pkg/reconciler/route/traffic"
@@ -145,6 +146,20 @@ func ingressClassForRoute(ctx context.Context, r *v1alpha1.Route) string {
 	return config.FromContext(ctx).Network.DefaultClusterIngressClass
 }
 
+func (c *Reconciler) getServices(route *v1alpha1.Route) ([]*corev1.Service, error) {
+	currentServices, err := c.serviceLister.Services(route.Namespace).List(resources.SelectorFromRoute(route))
+	if err != nil {
+		return nil, err
+	}
+
+	serviceCopy := make([]*corev1.Service, len(currentServices))
+	for i, svc := range currentServices {
+		serviceCopy[i] = svc.DeepCopy()
+	}
+
+	return serviceCopy, err
+}
+
 func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 	if r.GetDeletionTimestamp() != nil {
@@ -165,9 +180,38 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 
 	logger.Infof("Reconciling route: %#v", r)
 
+	// Get all services
+	existingServices, err := c.getServices(r) // This is what we use to determine whether we default or not.
+	if err != nil {
+		return err
+	}
+	existingServiceNames := resources.GetNames(existingServices)
+
+	clusterLocalServices := resources.FilterService(existingServices, resources.IsClusterLocalService)
+	clusterLocalServiceNames := resources.GetNames(clusterLocalServices)
+
+	// Any new service will follow the default route visibility. We only need to consider the case where it is "cluster-local"
+	// The alternative visibility means it should not be cluster local.
+	if labels.IsObjectLocalVisibility(r.ObjectMeta) {
+		expectedServiceNames, err := resources.GetDesiredServiceNames(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		serviceWithDefaultVisibility := expectedServiceNames.Difference(existingServiceNames)
+		clusterLocalServiceNames = clusterLocalServiceNames.Union(serviceWithDefaultVisibility)
+	}
+
+	mainRouteMeta := r.ObjectMeta.DeepCopy()
+	mainRouteServiceName, err := domains.HostnameFromTemplate(ctx, r.Name, "")
+	if err != nil {
+		return err
+	}
+	labels.SetVisibility(mainRouteMeta, clusterLocalServiceNames.Has(mainRouteServiceName))
+
 	// Update the information that makes us Addressable. This is needed to configure traffic and
 	// make the cluster ingress.
-	host, err := domains.DomainNameFromTemplate(ctx, r, r.Name)
+	host, err := domains.DomainNameFromTemplate(ctx, *mainRouteMeta, r.Name)
 	if err != nil {
 		return err
 	}
@@ -180,7 +224,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	r.Status.DeprecatedDomain = ""
 
 	// Configure traffic based on the RouteSpec.
-	traffic, err := c.configureTraffic(ctx, r)
+	traffic, err := c.configureTraffic(ctx, r, clusterLocalServiceNames)
 	if traffic == nil || err != nil {
 		// Traffic targets aren't ready, no need to configure child resources.
 		return err
@@ -213,18 +257,20 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	}
 
 	logger.Info("Creating placeholder k8s services")
-	services, err := c.reconcilePlaceholderServices(ctx, r, traffic.Targets)
+	services, err := c.reconcilePlaceholderServices(ctx, r, traffic.Targets, resources.GetNames(existingServices))
 	if err != nil {
 		return err
 	}
 
-	tls, err := c.tls(ctx, host, r, traffic)
+	clusterLocalServices = resources.FilterService(services, resources.IsClusterLocalService)
+	clusterLocalServiceNames = resources.GetNames(clusterLocalServices)
+	tls, err := c.tls(ctx, host, r, traffic, clusterLocalServiceNames)
 	if err != nil {
 		return err
 	}
 
 	logger.Info("Creating ClusterIngress.")
-	desired, err := resources.MakeClusterIngress(ctx, r, traffic, tls, ingressClassForRoute(ctx, r))
+	desired, err := resources.MakeClusterIngress(ctx, r, traffic, tls, resources.GetNames(clusterLocalServices), ingressClassForRoute(ctx, r))
 	if err != nil {
 		return err
 	}
@@ -244,16 +290,23 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	return nil
 }
 
-func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, traffic *traffic.Config) ([]netv1alpha1.IngressTLS, error) {
+func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, traffic *traffic.Config, clusterLocalServiceNames sets.String) ([]netv1alpha1.IngressTLS, error) {
 	tls := []netv1alpha1.IngressTLS{}
-	if !config.FromContext(ctx).Network.AutoTLS || resources.IsClusterLocal(r) {
+	if !config.FromContext(ctx).Network.AutoTLS {
 		return tls, nil
 	}
-	allDomainTagMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets))
+	tagToDomainMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), clusterLocalServiceNames)
 	if err != nil {
 		return nil, err
 	}
-	desiredCerts := resources.MakeCertificates(r, allDomainTagMap)
+
+	for tag, domain := range tagToDomainMap {
+		if domains.IsClusterLocal(domain) {
+			delete(tagToDomainMap, tag)
+		}
+	}
+
+	desiredCerts := resources.MakeCertificates(r, tagToDomainMap)
 	for _, desiredCert := range desiredCerts {
 
 		cert, err := c.reconcileCertificate(ctx, r, desiredCert)
@@ -316,7 +369,7 @@ func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) e
 //
 // If traffic is configured we update the RouteStatus with AllTrafficAssigned = True.  Otherwise we
 // mark AllTrafficAssigned = False, with a message referring to one of the missing target.
-func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*tr.Config, error) {
+func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, clusterLocalServices sets.String) (*tr.Config, error) {
 	logger := logging.FromContext(ctx)
 	t, err := tr.BuildTrafficConfiguration(c.configurationLister, c.revisionLister, r)
 
@@ -354,7 +407,7 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*
 
 	logger.Info("All referred targets are routable, marking AllTrafficAssigned with traffic information.")
 	// Domain should already be present
-	r.Status.Traffic, err = t.GetRevisionTrafficTargets(ctx, r)
+	r.Status.Traffic, err = t.GetRevisionTrafficTargets(ctx, r, clusterLocalServices)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -311,6 +311,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
@@ -422,6 +423,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 
@@ -506,6 +508,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
@@ -614,6 +617,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
 				"test-revision-1-test-route.test.test-domain.dev",
@@ -634,6 +638,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
 				"test-revision-2-test-route.test.test-domain.dev",
@@ -654,6 +659,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 
@@ -739,6 +745,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
 				"bar-test-route.test.test-domain.dev",
@@ -759,6 +766,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
 				"foo-test-route.test.test-domain.dev",
@@ -779,6 +787,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 					},
 				}},
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 
@@ -1047,7 +1056,7 @@ func TestRouteDomain(t *testing.T) {
 	for _, test := range tests {
 		cfg.Network.DomainTemplate = test.Template
 
-		res, err := domains.DomainNameFromTemplate(context, route, route.Name)
+		res, err := domains.DomainNameFromTemplate(context, route.ObjectMeta, route.Name)
 
 		if test.Pass != (err == nil) {
 			t.Fatalf("TestRouteDomain %q test: supposed to fail but didn't",

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientgotesting "k8s.io/client-go/testing"
 
 	netv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -197,6 +198,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				"custom-ingress-class",
+				sets.NewString(),
 			),
 			simplePlaceholderK8sService(
 				getContext(),
@@ -239,7 +241,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 		},
 		WantCreates: []runtime.Object{
-			simpleClusterIngress(
+			simpleClusterIngressWithVisibility(
 				route("default", "becomes-ready", WithConfigTarget("config"),
 					WithLocalDomain, WithRouteUID("65-23"),
 					WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
@@ -256,6 +258,7 @@ func TestReconcile(t *testing.T) {
 						}},
 					},
 				},
+				sets.NewString("becomes-ready"),
 			),
 			simplePlaceholderK8sService(
 				getContext(),
@@ -2123,7 +2126,7 @@ func simpleK8sService(r *v1alpha1.Route, so ...K8sServiceOption) *corev1.Service
 
 	// omit the error here, as we are sure the loadbalancer info is porvided.
 	// return the service instance only, so that the result can be used in TableRow.
-	svc, _ := resources.MakeK8sService(ctx, r, "", &netv1alpha1.ClusterIngress{Status: readyIngressStatus()})
+	svc, _ := resources.MakeK8sService(ctx, r, "", &netv1alpha1.ClusterIngress{Status: readyIngressStatus()}, false)
 
 	for _, opt := range so {
 		opt(svc)
@@ -2133,11 +2136,15 @@ func simpleK8sService(r *v1alpha1.Route, so ...K8sServiceOption) *corev1.Service
 }
 
 func simpleClusterIngress(r *v1alpha1.Route, tc *traffic.Config, io ...ClusterIngressOption) *netv1alpha1.ClusterIngress {
-	return ingressWithClass(r, tc, TestIngressClass, io...)
+	return simpleClusterIngressWithVisibility(r, tc, sets.NewString(), io...)
 }
 
-func ingressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, io ...ClusterIngressOption) *netv1alpha1.ClusterIngress {
-	ingress, _ := resources.MakeClusterIngress(getContext(), r, tc, nil, class)
+func simpleClusterIngressWithVisibility(r *v1alpha1.Route, tc *traffic.Config, serviceVisibility sets.String, io ...ClusterIngressOption) *netv1alpha1.ClusterIngress {
+	return ingressWithClass(r, tc, TestIngressClass, serviceVisibility, io...)
+}
+
+func ingressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, serviceVisibility sets.String, io ...ClusterIngressOption) *netv1alpha1.ClusterIngress {
+	ingress, _ := resources.MakeClusterIngress(getContext(), r, tc, nil, serviceVisibility, class)
 
 	for _, opt := range io {
 		opt(ingress)
@@ -2147,7 +2154,7 @@ func ingressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, io ..
 }
 
 func ingressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, io ...ClusterIngressOption) *netv1alpha1.ClusterIngress {
-	ingress, _ := resources.MakeClusterIngress(getContext(), r, tc, tls, TestIngressClass)
+	ingress, _ := resources.MakeClusterIngress(getContext(), r, tc, tls, sets.NewString(), TestIngressClass)
 
 	for _, opt := range io {
 		opt(ingress)

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -27,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/route/domains"
+	"github.com/knative/serving/pkg/reconciler/route/resources/labels"
 )
 
 const (
@@ -70,14 +72,14 @@ type Config struct {
 //
 // In the case that some target is missing, an error of type TargetError will be returned.
 func BuildTrafficConfiguration(configLister listers.ConfigurationLister, revLister listers.RevisionLister,
-	u *v1alpha1.Route) (*Config, error) {
-	builder := newBuilder(configLister, revLister, u.Namespace, len(u.Spec.Traffic))
-	builder.applySpecTraffic(u.Spec.Traffic)
+	r *v1alpha1.Route) (*Config, error) {
+	builder := newBuilder(configLister, revLister, r.Namespace, len(r.Spec.Traffic))
+	builder.applySpecTraffic(r.Spec.Traffic)
 	return builder.build()
 }
 
 // GetRevisionTrafficTargets returns a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.
-func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1alpha1.Route) ([]v1alpha1.TrafficTarget, error) {
+func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1alpha1.Route, clusterLocalService sets.String) ([]v1alpha1.TrafficTarget, error) {
 	results := make([]v1alpha1.TrafficTarget, len(t.revisionTargets))
 	for i, tt := range t.revisionTargets {
 		// We cannot `DeepCopy` here, since tt.TrafficTarget might contain both
@@ -91,12 +93,17 @@ func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1alpha1.Rout
 			},
 		}
 		if tt.Tag != "" {
-			hostname, err := domains.HostnameFromTemplate(ctx, r.Name, tt.Tag)
+			meta := r.ObjectMeta.DeepCopy()
+
+			hostname, err := domains.HostnameFromTemplate(ctx, meta.Name, tt.Tag)
 			if err != nil {
 				return nil, err
 			}
+
+			labels.SetVisibility(meta, clusterLocalService.Has(hostname))
+
 			// http is currently the only supported scheme
-			fullDomain, err := domains.DomainNameFromTemplate(ctx, r, hostname)
+			fullDomain, err := domains.DomainNameFromTemplate(ctx, *meta, hostname)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -958,7 +959,7 @@ func TestRoundTripping(t *testing.T) {
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, route); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else {
-		targets, err := tc.GetRevisionTrafficTargets(getContext(), route)
+		targets, err := tc.GetRevisionTrafficTargets(getContext(), route, sets.String{})
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)
 		}


### PR DESCRIPTION
In an effort to split up my [larger PR](https://github.com/knative/serving/pull/4291).

**This depends on PR https://github.com/knative/serving/pull/4559**

Updating the service's visibility label (or removing it) will propagate to the actual visibility of the subroutes.

Once the service is created, the visibility is only controlled by the service. Updating the route's visibility will only affect **new** subroute's default visibility.