### PR TITLE
Add dial with timeout function.

### DIFF
--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -65,6 +65,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, steps int, 
 		KeepAlive: 5 * time.Second,
 		DualStack: true,
 	}
+	// TODO(vagababov): use backoff.Step when we use moden k8s client.
 	for i := 0; i < steps; i++ {
 		c, err := dialer.DialContext(ctx, network, address)
 		if err != nil {

--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -68,6 +68,9 @@ func dialBackOffHelper(ctx context.Context, network, address string, steps int, 
 		c, err := dialer.DialContext(ctx, network, address)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
+				if i == steps-1 {
+					break
+				}
 				to *= factor
 				dialer.Timeout = time.Duration(to)
 				time.Sleep(time.Duration(sleep + rand.Float64()*sleep)) // Sleep with jitter.


### PR DESCRIPTION
This permits us to retry dials. It seems we fail a lot of dials
when load is high.


/lint

/assign @tcnghia @mattmoor 