### PR TITLE
Send logs for pods in bad status

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -99,4 +99,3 @@ data:
     # flag to "true" could cause extra Stackdriver charge.
     # If metrics.backend-destination is not Stackdriver, this is ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
-  metrics.request-metrics-backend-destination: stackdriver

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -99,3 +99,4 @@ data:
     # flag to "true" could cause extra Stackdriver charge.
     # If metrics.backend-destination is not Stackdriver, this is ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
+  metrics.request-metrics-backend-destination: stackdriver

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -165,7 +165,10 @@ func (rs *RevisionStatus) MarkContainerHealthy() {
 }
 
 func (rs *RevisionStatus) MarkContainerExiting(exitCode int32, reason, message string) {
-	exitCodeString := fmt.Sprintf("ExitCode%d/%s", exitCode, reason)
+	exitCodeString := fmt.Sprintf("ExitCode%d", exitCode)
+	if reason != "" {
+		exitCodeString = fmt.Sprintf("%s/%s", exitCodeString, reason)
+	}
 	revCondSet.Manage(rs).MarkFalse(RevisionConditionContainerHealthy, exitCodeString, RevisionContainerExitingMessage(message))
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -21,12 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 const (
@@ -164,8 +164,8 @@ func (rs *RevisionStatus) MarkContainerHealthy() {
 	revCondSet.Manage(rs).MarkTrue(RevisionConditionContainerHealthy)
 }
 
-func (rs *RevisionStatus) MarkContainerExiting(exitCode int32, message string) {
-	exitCodeString := fmt.Sprintf("ExitCode%d", exitCode)
+func (rs *RevisionStatus) MarkContainerExiting(exitCode int32, reason, message string) {
+	exitCodeString := fmt.Sprintf("ExitCode%d/%s", exitCode, reason)
 	revCondSet.Manage(rs).MarkFalse(RevisionConditionContainerHealthy, exitCodeString, RevisionContainerExitingMessage(message))
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
@@ -21,15 +21,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitest "knative.dev/pkg/apis/testing"
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	apitest "knative.dev/pkg/apis/testing"
 )
 
 func TestRevisionDuckTypes(t *testing.T) {
@@ -358,6 +358,29 @@ func TestRevisionNotOwnedStuff(t *testing.T) {
 	}
 	if got := r.GetCondition(RevisionConditionReady); got == nil || got.Reason != want {
 		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+}
+
+func TestRevisionContainerExiting(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitest.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	const (
+		exitCode                = 137
+		reason, message         = "OOMKilled", "Out of memory"
+		wantReason, wantMessage = "ExitCode137/OOMKilled", "Container failed with: Out of memory"
+	)
+	r.MarkContainerExiting(exitCode, reason, message)
+	apitest.CheckConditionFailed(r.duck(), RevisionConditionContainerHealthy, t)
+	apitest.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	if got := r.GetCondition(RevisionConditionContainerHealthy); got == nil || got.Reason != wantReason {
+		t.Errorf("RevisionConditionResourcesAvailable = %v, want %v", got.Reason, wantReason)
+	}
+	if got := r.GetCondition(RevisionConditionContainerHealthy); got == nil || got.Message != wantMessage {
+		t.Errorf("RevisionConditionResourcesAvailable = %v, want %v", got.Message, wantMessage)
 	}
 }
 

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -34,16 +34,16 @@ import (
 	"knative.dev/pkg/logging/logkey"
 )
 
-// shouldSurfaceToUser is the key used to represent whether the logs should
-// surface to user
+// userFacing is the key used to represent whether the logs should be surfaced
+// to user
 // TODO: Move this to knative/pkg/logging/logkey
-const shouldSurfaceToUser = "surface"
+const userFacing = "userfacing"
 
 func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revision) error {
 	ns := rev.Namespace
 	deploymentName := resourcenames.Deployment(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.Deployment, deploymentName))
-	surfaceLogger := logger.With(zap.Bool(shouldSurfaceToUser, true))
+	surfaceLogger := logger.With(zap.Bool(userFacing, true))
 
 	deployment, err := c.deploymentLister.Deployments(ns).Get(deploymentName)
 	if apierrs.IsNotFound(err) {

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -66,34 +66,52 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 	}
 
 	// If a container keeps crashing (no active pods in the deployment although we want some)
-	if *deployment.Spec.Replicas > 0 && deployment.Status.AvailableReplicas == 0 {
+	if *deployment.Spec.Replicas > deployment.Status.AvailableReplicas {
 		pods, err := c.KubeClientSet.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(deployment.Spec.Selector)})
 		if err != nil {
 			logger.Errorf("Error getting pods: %v", err)
 		} else if len(pods.Items) > 0 {
-			// Arbitrarily grab the very first pod, as they all should be crashing
-			pod := pods.Items[0]
-
-			// Update the revision status if pod cannot be scheduled(possibly resource constraints)
-			// If pod cannot be scheduled then we expect the container status to be empty.
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
-					rev.Status.MarkResourcesUnavailable(cond.Reason, cond.Message)
-					break
-				}
-			}
-
-			for _, status := range pod.Status.ContainerStatuses {
-				if status.Name == rev.Spec.GetContainer().Name {
-					if t := status.LastTerminationState.Terminated; t != nil {
-						logger.Infof("%s marking exiting with: %d/%s: %s", rev.Name, t.ExitCode, t.Reason, t.Message)
-						logger.Infof("Container %s in pod %s of revision %s is in terminated status: %d/%s",
-							status.Name, pod.Name, rev.Name, t.ExitCode, t.Reason)
-						rev.Status.MarkContainerExiting(t.ExitCode, t.Reason, t.Message)
-					} else if w := status.State.Waiting; w != nil && hasDeploymentTimedOut(deployment) {
-						logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, w.Reason, w.Message)
-						rev.Status.MarkResourcesUnavailable(w.Reason, w.Message)
+			// Should change revision status if all pods are crashing
+			shouldMarkRev := deployment.Status.AvailableReplicas == 0
+			for _, pod := range pods.Items {
+				// Update the revision status if pod cannot be scheduled(possibly resource constraints)
+				// If pod cannot be scheduled then we expect the container status to be empty.
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
+						logger.Warnf("Pod %s of revision %s cannot be scheduled: %s/%s", pod.Name, rev.Name, cond.Reason, cond.Message)
+						if shouldMarkRev {
+							logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, cond.Reason, cond.Message)
+							rev.Status.MarkResourcesUnavailable(cond.Reason, cond.Message)
+						}
+						break
 					}
+				}
+
+				for _, status := range pod.Status.ContainerStatuses {
+					// This is based on the fact that rev.Spec.GetContainer() returns
+					// the user container.
+					if status.Name == rev.Spec.GetContainer().Name {
+						if t := status.LastTerminationState.Terminated; t != nil {
+							logger.Warnf("Container %s in pod %s of revision %s is in terminated status: %s/%s",
+								status.Name, pod.Name, rev.Name, t.Reason, t.Message)
+							if shouldMarkRev {
+								logger.Infof("%s marking exiting with: %d/%s: %s", rev.Name, t.ExitCode, t.Reason, t.Message)
+								rev.Status.MarkContainerExiting(t.ExitCode, t.Reason, t.Message)
+							}
+						} else if w := status.State.Waiting; w != nil && hasDeploymentTimedOut(deployment) {
+							logger.Warnf("Container %s in pod %s of revision %s is timeout in waiting status: %s/%s",
+								status.Name, pod.Name, rev.Name, t.Reason, t.Message)
+							if shouldMarkRev {
+								logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, w.Reason, w.Message)
+								rev.Status.MarkResourcesUnavailable(w.Reason, w.Message)
+							}
+						}
+						break
+					}
+				}
+
+				if shouldMarkRev {
+					// Arbitrarily check the very first pod, as they all should be crashing
 					break
 				}
 			}

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -34,10 +34,16 @@ import (
 	"knative.dev/pkg/logging/logkey"
 )
 
+// shouldSurfaceToUser is the key used to represent whether the logs should
+// surface to user
+// TODO: Move this to knative/pkg/logging/logkey
+const shouldSurfaceToUser = "surface"
+
 func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revision) error {
 	ns := rev.Namespace
 	deploymentName := resourcenames.Deployment(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.Deployment, deploymentName))
+	surfaceLogger := logger.With(zap.Bool(shouldSurfaceToUser, true))
 
 	deployment, err := c.deploymentLister.Deployments(ns).Get(deploymentName)
 	if apierrs.IsNotFound(err) {
@@ -78,7 +84,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 				// If pod cannot be scheduled then we expect the container status to be empty.
 				for _, cond := range pod.Status.Conditions {
 					if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
-						logger.Warnf("Pod %s of revision %s cannot be scheduled: %s/%s", pod.Name, rev.Name, cond.Reason, cond.Message)
+						surfaceLogger.Warnf("Pod %s of revision %s cannot be scheduled: %s/%s", pod.Name, rev.Name, cond.Reason, cond.Message)
 						if shouldMarkRev {
 							logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, cond.Reason, cond.Message)
 							rev.Status.MarkResourcesUnavailable(cond.Reason, cond.Message)
@@ -92,14 +98,14 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 					// the user container.
 					if status.Name == rev.Spec.GetContainer().Name {
 						if t := status.LastTerminationState.Terminated; t != nil {
-							logger.Warnf("Container %s in pod %s of revision %s is in terminated status: %s/%s",
+							surfaceLogger.Warnf("Container %s in pod %s of revision %s is in terminated status: %s/%s",
 								status.Name, pod.Name, rev.Name, t.Reason, t.Message)
 							if shouldMarkRev {
 								logger.Infof("%s marking exiting with: %d/%s: %s", rev.Name, t.ExitCode, t.Reason, t.Message)
 								rev.Status.MarkContainerExiting(t.ExitCode, t.Reason, t.Message)
 							}
 						} else if w := status.State.Waiting; w != nil && hasDeploymentTimedOut(deployment) {
-							logger.Warnf("Container %s in pod %s of revision %s is timeout in waiting status: %s/%s",
+							surfaceLogger.Warnf("Container %s in pod %s of revision %s is timeout in waiting status: %s/%s",
 								status.Name, pod.Name, rev.Name, w.Reason, w.Message)
 							if shouldMarkRev {
 								logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, w.Reason, w.Message)

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -100,7 +100,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 							}
 						} else if w := status.State.Waiting; w != nil && hasDeploymentTimedOut(deployment) {
 							logger.Warnf("Container %s in pod %s of revision %s is timeout in waiting status: %s/%s",
-								status.Name, pod.Name, rev.Name, t.Reason, t.Message)
+								status.Name, pod.Name, rev.Name, w.Reason, w.Message)
 							if shouldMarkRev {
 								logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, w.Reason, w.Message)
 								rev.Status.MarkResourcesUnavailable(w.Reason, w.Message)

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -21,10 +21,6 @@ import (
 	"testing"
 
 	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
-	logtesting "knative.dev/pkg/logging/testing"
 	autoscalingv1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -40,11 +36,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
 
-	. "knative.dev/pkg/reconciler/testing"
 	. "github.com/knative/serving/pkg/reconciler/testing/v1alpha1"
 	. "github.com/knative/serving/pkg/testing"
 	. "github.com/knative/serving/pkg/testing/v1alpha1"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
@@ -437,13 +437,13 @@ func TestReconcile(t *testing.T) {
 			rev("foo", "pod-error",
 				withK8sServiceName("a-pod-error"), WithLogURL, AllUnknownConditions, MarkActive),
 			kpa("foo", "pod-error"), // PA can't be ready, since no traffic.
-			pod("foo", "pod-error", WithFailingContainer("user-container", 5, "I failed man!")),
+			pod("foo", "pod-error", WithFailingContainer("user-container", 5, "Failed", "I failed man!")),
 			deploy("foo", "pod-error"),
 			image("foo", "pod-error"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rev("foo", "pod-error",
-				WithLogURL, AllUnknownConditions, MarkContainerExiting(5, "I failed man!")),
+				WithLogURL, AllUnknownConditions, MarkContainerExiting(5, "Failed", "I failed man!")),
 		}},
 		Key: "foo/pod-error",
 	}, {

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -246,13 +246,14 @@ type PodOption func(*corev1.Pod)
 
 // WithFailingContainer sets the .Status.ContainerStatuses on the pod to
 // include a container named accordingly to fail with the given state.
-func WithFailingContainer(name string, exitCode int, message string) PodOption {
+func WithFailingContainer(name string, exitCode int, reason, message string) PodOption {
 	return func(pod *corev1.Pod) {
 		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
 			Name: name,
 			LastTerminationState: corev1.ContainerState{
 				Terminated: &corev1.ContainerStateTerminated{
 					ExitCode: int32(exitCode),
+					Reason:   reason,
 					Message:  message,
 				},
 			},

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -133,9 +133,9 @@ func MarkContainerMissing(rev *v1alpha1.Revision) {
 }
 
 // MarkContainerExiting calls .Status.MarkContainerExiting on the Revision.
-func MarkContainerExiting(exitCode int32, message string) RevisionOption {
+func MarkContainerExiting(exitCode int32, reason, message string) RevisionOption {
 	return func(r *v1alpha1.Revision) {
-		r.Status.MarkContainerExiting(exitCode, message)
+		r.Status.MarkContainerExiting(exitCode, reason, message)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4534
Part of #4557

## Proposed Changes

* Check every pod when reconciling revision instead of one single pod.
* If not all pods of a revision are unavailable, only send warning logs.
* Also propagate reason of container in terminated status to revision when all pods of a revision are unavailable.
*  Add a key to some controller logs indicating that they are helpful to be surfaced to users. It can be used as logs query filter.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The reason for crashing pods are now propagated to the revision combined with existing exit code to ease debuggability.
```
