### PR TITLE
Fix wrong output for validation of MaxConcurrency

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -53,7 +53,7 @@ func NewBreaker(params BreakerParams) *Breaker {
 		panic(fmt.Sprintf("Queue depth must be greater than 0. Got %v.", params.QueueDepth))
 	}
 	if params.MaxConcurrency < 0 {
-		panic(fmt.Sprintf("Max concurrency must be 0 or greater. Got %v.", params.QueueDepth))
+		panic(fmt.Sprintf("Max concurrency must be 0 or greater. Got %v.", params.MaxConcurrency))
 	}
 	if params.InitialCapacity < 0 || params.InitialCapacity > params.MaxConcurrency {
 		panic(fmt.Sprintf("Initial capacity must be between 0 and max concurrency. Got %v.", params.InitialCapacity))


### PR DESCRIPTION
This patch makes a tiny fix which outputs the value of
`MaxConcurrency` instead of `QueueDepth` when validation of
`MaxConcurrency` failed.

/lint

## Proposed Changes

* Fix wrong value for the validation of `MaxConcurrency`.

**Release Note**

```release-note
NONE
```
