### PR TITLE
Use actual pod count for the TBC calculation.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -165,7 +165,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	// be making knee-jerk decisions about Activator in the request path. Negative EBC means
 	// that the deployment does not have enough capacity to serve the desired burst off hand.
 	// EBC = TotCapacity - Cur#ReqInFlight - TargetBurstCapacity
-	excessBC = int32(readyPodsCount*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
+	excessBC = int32(float64(originalReadyPodsCount)*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
 		a.deciderSpec.TargetBurstCapacity)
 	logger.Debug("Excess burst capacity = ", excessBC)
 

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -194,14 +194,14 @@ func TestAutoscalerUseOnePodAsMinimumIfEndpointsNotFound(t *testing.T) {
 	endpoints(0)
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no read pods are there from K8S API.
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 1), true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), true)
 
 	ep, _ := kubeClient.CoreV1().Endpoints(testNamespace).Get(testService, metav1.GetOptions{})
 	kubeClient.CoreV1().Endpoints(testNamespace).Delete(testService, nil)
 	kubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Delete(ep)
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no Endpoints object is there from K8S API.
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 1), true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), true)
 }
 
 func TestAutoscalerUpdateTarget(t *testing.T) {


### PR DESCRIPTION
Since we don't do division, we can use the actual number
reported by the endpoints to count BC.


This seems to be a more precise way of doing this.

/assign @mattmoor 