### PR TITLE
Make sure we apply target utilization at every level.

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -45,6 +45,8 @@ data:
     # on average. A value of 70 is chosen because the Autoscaler panics
     # when concurrency exceeds 2x the desired set point. So we will panic
     # before we reach the limit.
+    # Note: this limit will be applied to container concurency set at every
+    # level (ConfigMap, Revision Spec or Annotation).
     # For legacy and backwards compatibility reasons, this value also accepts
     # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
     # Thus minimal percentage value must be greater than 1.0, or it will be

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -44,7 +44,7 @@ func TestMakeDecider(t *testing.T) {
 	}, {
 		name: "tu < 1", // See #4449 why Target=100
 		pa:   pa(),
-		want: decider(withTarget(100), withPanicThreshold(200.0), withTotal(100)),
+		want: decider(withTarget(80), withPanicThreshold(160.0), withTotal(100)),
 		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c

--- a/pkg/reconciler/autoscaling/resources/concurrency_test.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency_test.go
@@ -38,6 +38,25 @@ func TestResolveConcurrency(t *testing.T) {
 		wantTgt: 100,
 		wantTot: 100,
 	}, {
+		name: "default CC + 80% TU",
+		pa:   pa(),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.8
+			return &c
+		},
+		wantTgt: 80,
+		wantTot: 100,
+	}, {
+		name: "non-default CC and TU",
+		pa:   pa(),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.3
+			c.ContainerConcurrencyTargetDefault = 2
+			return &c
+		},
+		wantTgt: 1,
+		wantTot: 2,
+	}, {
 		name: "with container concurrency 10 and TU=80%",
 		pa:   pa(WithContainerConcurrency(10)),
 		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
@@ -58,6 +77,15 @@ func TestResolveConcurrency(t *testing.T) {
 		pa:      pa(WithContainerConcurrency(1)),
 		wantTgt: 1,
 	}, {
+		name: "with container concurrency 10 and TU=80%",
+		pa:   pa(WithContainerConcurrency(10)),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.8
+			return &c
+		},
+		wantTgt: 8,
+		wantTot: 10,
+	}, {
 		name:    "with container concurrency 10",
 		pa:      pa(WithContainerConcurrency(10)),
 		wantTgt: 10,
@@ -65,6 +93,24 @@ func TestResolveConcurrency(t *testing.T) {
 		name:    "with target annotation 1",
 		pa:      pa(WithTargetAnnotation("1")),
 		wantTgt: 1,
+	}, {
+		name: "with target annotation 1 and TU=75%",
+		pa:   pa(WithTargetAnnotation("1")),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.75
+			return &c
+		},
+		wantTgt: 1,
+		wantTot: 1,
+	}, {
+		name: "with target annotation 10 and TU=75%",
+		pa:   pa(WithTargetAnnotation("10")),
+		cfgOpt: func(c autoscaler.Config) *autoscaler.Config {
+			c.ContainerConcurrencyTargetFraction = 0.75
+			return &c
+		},
+		wantTgt: 7.5,
+		wantTot: 10,
 	}, {
 		name:    "with container concurrency greater than target annotation (ok)",
 		pa:      pa(WithContainerConcurrency(10), WithTargetAnnotation("1")),


### PR DESCRIPTION
Fixes #4449
Currently we apply TargetUtilization only if it's set on the revision Spec.
Which is not right, since we should be apply utilization targets even is CC is specified
in the annotation or generally, in the configmap.

Without this, for example, I have TU=70% and CC set on revision 15. My burst capacity is always close to 0 (at most 14), which defeats the work for the Target burst capacity.

/assign @mattmoor @markusthoemmes 


/lint
