### PR TITLE
Rename all occurrences of 'KPA' to 'PA' where applicable.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,6 +25,13 @@ import (
 
 	"go.uber.org/zap"
 
+	autoscalingv1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	apiconfig "github.com/knative/serving/pkg/apis/config"
+	net "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
@@ -32,13 +39,6 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/version"
 	"knative.dev/pkg/webhook"
-	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
-	apiconfig "github.com/knative/serving/pkg/apis/config"
-	net "github.com/knative/serving/pkg/apis/networking/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -106,18 +106,18 @@ func main() {
 		Client:  kubeClient,
 		Options: options,
 		Handlers: map[schema.GroupVersionKind]webhook.GenericCRD{
-			v1alpha1.SchemeGroupVersion.WithKind("Revision"):      &v1alpha1.Revision{},
-			v1alpha1.SchemeGroupVersion.WithKind("Configuration"): &v1alpha1.Configuration{},
-			v1alpha1.SchemeGroupVersion.WithKind("Route"):         &v1alpha1.Route{},
-			v1alpha1.SchemeGroupVersion.WithKind("Service"):       &v1alpha1.Service{},
-			v1beta1.SchemeGroupVersion.WithKind("Revision"):       &v1beta1.Revision{},
-			v1beta1.SchemeGroupVersion.WithKind("Configuration"):  &v1beta1.Configuration{},
-			v1beta1.SchemeGroupVersion.WithKind("Route"):          &v1beta1.Route{},
-			v1beta1.SchemeGroupVersion.WithKind("Service"):        &v1beta1.Service{},
-			kpa.SchemeGroupVersion.WithKind("PodAutoscaler"):      &kpa.PodAutoscaler{},
-			net.SchemeGroupVersion.WithKind("Certificate"):        &net.Certificate{},
-			net.SchemeGroupVersion.WithKind("ClusterIngress"):     &net.ClusterIngress{},
-			net.SchemeGroupVersion.WithKind("ServerlessService"):  &net.ServerlessService{},
+			v1alpha1.SchemeGroupVersion.WithKind("Revision"):                 &v1alpha1.Revision{},
+			v1alpha1.SchemeGroupVersion.WithKind("Configuration"):            &v1alpha1.Configuration{},
+			v1alpha1.SchemeGroupVersion.WithKind("Route"):                    &v1alpha1.Route{},
+			v1alpha1.SchemeGroupVersion.WithKind("Service"):                  &v1alpha1.Service{},
+			v1beta1.SchemeGroupVersion.WithKind("Revision"):                  &v1beta1.Revision{},
+			v1beta1.SchemeGroupVersion.WithKind("Configuration"):             &v1beta1.Configuration{},
+			v1beta1.SchemeGroupVersion.WithKind("Route"):                     &v1beta1.Route{},
+			v1beta1.SchemeGroupVersion.WithKind("Service"):                   &v1beta1.Service{},
+			autoscalingv1alpha1.SchemeGroupVersion.WithKind("PodAutoscaler"): &autoscalingv1alpha1.PodAutoscaler{},
+			net.SchemeGroupVersion.WithKind("Certificate"):                   &net.Certificate{},
+			net.SchemeGroupVersion.WithKind("ClusterIngress"):                &net.ClusterIngress{},
+			net.SchemeGroupVersion.WithKind("ServerlessService"):             &net.ServerlessService{},
 		},
 		Logger:                logger,
 		DisallowUnknownFields: true,

--- a/config/300-pa.yaml
+++ b/config/300-pa.yaml
@@ -32,6 +32,7 @@ spec:
     - autoscaling
     shortNames:
     - kpa
+    - pa
   scope: Namespaced
   subresources:
     status: {}

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/knative/serving/pkg/autoscaler/aggregation"
 
-	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,7 +135,7 @@ func (c *MetricCollector) Get(ctx context.Context, namespace, name string) (*Met
 	key := NewMetricKey(namespace, name)
 	collector, ok := c.collections[key]
 	if !ok {
-		return nil, k8serrors.NewNotFound(kpa.Resource("Metrics"), key)
+		return nil, k8serrors.NewNotFound(av1alpha1.Resource("Metrics"), key)
 	}
 
 	return collector.metric.DeepCopy(), nil
@@ -179,7 +179,7 @@ func (c *MetricCollector) Update(ctx context.Context, metric *Metric) (*Metric, 
 		collection.updateMetric(metric)
 		return metric.DeepCopy(), nil
 	}
-	return nil, k8serrors.NewNotFound(kpa.Resource("Metrics"), key)
+	return nil, k8serrors.NewNotFound(av1alpha1.Resource("Metrics"), key)
 }
 
 // Delete deletes a Metric and halts collection.
@@ -211,7 +211,7 @@ func (c *MetricCollector) Record(key string, stat Stat) {
 func (c *MetricCollector) StableAndPanicConcurrency(key string) (float64, float64, error) {
 	collection, exists := c.collections[key]
 	if !exists {
-		return 0, 0, k8serrors.NewNotFound(kpa.Resource("Metrics"), key)
+		return 0, 0, k8serrors.NewNotFound(av1alpha1.Resource("Metrics"), key)
 	}
 
 	return collection.stableAndPanicConcurrency(time.Now())

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,7 +166,7 @@ func (m *MultiScaler) Get(ctx context.Context, namespace, name string) (*Decider
 	scaler, exists := m.scalers[key]
 	if !exists {
 		// This GroupResource is a lie, but unfortunately this interface requires one.
-		return nil, errors.NewNotFound(kpa.Resource("Deciders"), key)
+		return nil, errors.NewNotFound(av1alpha1.Resource("Deciders"), key)
 	}
 	scaler.mux.RLock()
 	defer scaler.mux.RUnlock()
@@ -209,7 +209,7 @@ func (m *MultiScaler) Update(ctx context.Context, decider *Decider) (*Decider, e
 		return decider, nil
 	}
 	// This GroupResource is a lie, but unfortunately this interface requires one.
-	return nil, errors.NewNotFound(kpa.Resource("Deciders"), key)
+	return nil, errors.NewNotFound(av1alpha1.Resource("Deciders"), key)
 }
 
 // Delete stops and removes a Decider.

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -26,9 +26,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	. "knative.dev/pkg/logging/testing"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "knative.dev/pkg/logging/testing"
 )
 
 const (
@@ -280,7 +280,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 		AverageConcurrentRequests: 1,
 		RequestCount:              1,
 	}
-	ms.Poke(testKPAKey, testStat)
+	ms.Poke(testPAKey, testStat)
 
 	// Verify that we see a "tick"
 	if err := verifyTick(errCh); err != nil {

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -32,7 +32,7 @@ const (
 	testRevision  = "test-revision"
 	testService   = "test-revision-metrics"
 	testNamespace = "test-namespace"
-	testKPAKey    = "test-namespace/test-revision"
+	testPAKey     = "test-namespace/test-revision"
 )
 
 var (
@@ -67,8 +67,8 @@ func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
 		if scraper.url != testURL {
 			t.Errorf("scraper.url=%v, want %v", scraper.url, testURL)
 		}
-		if scraper.metricKey != testKPAKey {
-			t.Errorf("scraper.metricKey=%v, want %v", scraper.metricKey, testKPAKey)
+		if scraper.metricKey != testPAKey {
+			t.Errorf("scraper.metricKey=%v, want %v", scraper.metricKey, testPAKey)
 		}
 	}
 }
@@ -143,8 +143,8 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 		t.Fatalf("unexpected error from scraper.Scrape(): %v", err)
 	}
 
-	if got.Key != testKPAKey {
-		t.Errorf("StatMessage.Key=%v, want %v", got.Key, testKPAKey)
+	if got.Key != testPAKey {
+		t.Errorf("StatMessage.Key=%v, want %v", got.Key, testPAKey)
 	}
 	if got.Stat.Time.Before(now) {
 		t.Errorf("stat.Time=%v, want bigger than %v", got.Stat.Time, now)

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -19,14 +19,12 @@ package hpa
 import (
 	"context"
 
+	painformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
+	sksinformer "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	"knative.dev/pkg/apis/duck"
 	hpainformer "knative.dev/pkg/injection/informers/kubeinformers/autoscalingv2beta1/hpa"
 	serviceinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/service"
-	kpainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
-	sksinformer "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/reconciler"
@@ -34,6 +32,8 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	aresources "github.com/knative/serving/pkg/reconciler/autoscaling/resources"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
 )
 
 const (
@@ -48,7 +48,7 @@ func NewController(
 	psInformerFactory duck.InformerFactory,
 ) *controller.Impl {
 
-	paInformer := kpainformer.Get(ctx)
+	paInformer := painformer.Get(ctx)
 	sksInformer := sksinformer.Get(ctx)
 	hpaInformer := hpainformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -21,17 +21,13 @@ import (
 	"testing"
 
 	// Inject our fake informers
+	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
+	fakepainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
+	_ "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice/fake"
 	fakekubeclient "knative.dev/pkg/injection/clients/kubeclient/fake"
 	_ "knative.dev/pkg/injection/informers/kubeinformers/autoscalingv2beta1/hpa/fake"
 	_ "knative.dev/pkg/injection/informers/kubeinformers/corev1/service/fake"
-	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
-	fakekpainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
-	_ "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice/fake"
 
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
-	"knative.dev/pkg/system"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	asv1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	autoscalingv1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
@@ -52,10 +48,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/system"
 
-	. "knative.dev/pkg/reconciler/testing"
 	. "github.com/knative/serving/pkg/reconciler/testing/v1alpha1"
 	. "github.com/knative/serving/pkg/testing"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 const (
@@ -79,7 +79,7 @@ func TestControllerCanReconcile(t *testing.T) {
 
 	podAutoscaler := pa(testRevision, testNamespace, WithHPAClass)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(podAutoscaler)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(podAutoscaler)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(podAutoscaler)
 
 	err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision)
 	if err != nil {

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -22,7 +22,7 @@ import (
 	"knative.dev/pkg/apis/duck"
 	endpointsinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/endpoints"
 	serviceinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/service"
-	kpainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
+	painformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
 	sksinformer "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 
 	"knative.dev/pkg/configmap"
@@ -49,7 +49,7 @@ func NewController(
 	psInformerFactory duck.InformerFactory,
 ) *controller.Impl {
 
-	paInformer := kpainformer.Get(ctx)
+	paInformer := painformer.Get(ctx)
 	sksInformer := sksinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -93,7 +93,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 	} else if _, err = c.UpdateStatus(pa); err != nil {
-		logger.Warnw("Failed to update kpa status", zap.Error(err))
+		logger.Warnw("Failed to update pa status", zap.Error(err))
 		c.Recorder.Eventf(pa, corev1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for PA %q: %v", pa.Name, err)
 		return err
@@ -252,7 +252,7 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 	return
 }
 
-// activeThreshold returns the scale required for the kpa to be marked Active
+// activeThreshold returns the scale required for the pa to be marked Active
 func activeThreshold(pa *pav1alpha1.PodAutoscaler) int {
 	if min, ok := pa.Annotations[autoscaling.MinScaleAnnotationKey]; ok {
 		if ms, err := strconv.Atoi(min); err == nil {

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -27,7 +27,7 @@ import (
 
 	// These are the fake informers we want setup.
 	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
-	fakekpainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
+	fakepainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
 	fakesksinformer "github.com/knative/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice/fake"
 	fakerevisioninformer "github.com/knative/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
 	"github.com/knative/serving/pkg/reconciler"
@@ -166,7 +166,7 @@ func withMSvcStatus(s string) PodAutoscalerOption {
 
 func kpa(ns, n string, opts ...PodAutoscalerOption) *asv1a1.PodAutoscaler {
 	rev := newTestRevision(ns, n)
-	kpa := revisionresources.MakeKPA(rev)
+	kpa := revisionresources.MakePA(rev)
 	kpa.Annotations["autoscaling.knative.dev/class"] = "kpa.autoscaling.knative.dev"
 	kpa.Annotations["autoscaling.knative.dev/metric"] = "concurrency"
 	for _, opt := range opts {
@@ -955,9 +955,9 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	rev := newTestRevision(testNamespace, testRevision)
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
-	kpa := revisionresources.MakeKPA(rev)
+	kpa := revisionresources.MakePA(rev)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	// Wait for decider to be created.
 	if decider, err := pollDeciders(fakeDeciders, testNamespace, testRevision, nil); err != nil {
@@ -1006,9 +1006,9 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
-	kpa := revisionresources.MakeKPA(rev)
+	kpa := revisionresources.MakePA(rev)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	sks := sks(testNamespace, testRevision, WithDeployRef(kpa.Spec.ScaleTargetRef.Name),
 		WithSKSReady)
@@ -1042,7 +1042,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Delete(testRevision, nil)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Delete(rev)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Delete(testRevision, nil)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Delete(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Delete(kpa)
 	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {
 		t.Errorf("Reconcile() = %v", err)
 	}
@@ -1080,10 +1080,10 @@ func TestUpdate(t *testing.T) {
 	fakekubeclient.Get(ctx).CoreV1().Endpoints(testNamespace).Create(ep)
 	fakeendpointsinformer.Get(ctx).Informer().GetIndexer().Add(ep)
 
-	kpa := revisionresources.MakeKPA(rev)
+	kpa := revisionresources.MakePA(rev)
 	kpa.SetDefaults(context.Background())
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	msvc := aresources.MakeMetricsService(kpa, map[string]string{
 		serving.RevisionLabelKey: rev.Name,
@@ -1127,7 +1127,7 @@ func TestUpdate(t *testing.T) {
 	// Update the KPA container concurrency.
 	kpa.Spec.ContainerConcurrency = 2
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Update(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Update(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Update(kpa)
 
 	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {
 		t.Errorf("Reconcile() = %v", err)
@@ -1148,9 +1148,9 @@ func TestNoEndpoints(t *testing.T) {
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
-	kpa := revisionresources.MakeKPA(rev)
+	kpa := revisionresources.MakePA(rev)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
@@ -1181,9 +1181,9 @@ func TestEmptyEndpoints(t *testing.T) {
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
-	kpa := revisionresources.MakeKPA(rev)
+	kpa := revisionresources.MakePA(rev)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	// Wait for the Reconcile to complete.
 	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {
@@ -1216,9 +1216,9 @@ func TestControllerCreateError(t *testing.T) {
 		presources.NewPodScalableInformerFactory(ctx),
 	)
 
-	kpa := revisionresources.MakeKPA(newTestRevision(testNamespace, testRevision))
+	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
@@ -1244,9 +1244,9 @@ func TestControllerUpdateError(t *testing.T) {
 		presources.NewPodScalableInformerFactory(ctx),
 	)
 
-	kpa := revisionresources.MakeKPA(newTestRevision(testNamespace, testRevision))
+	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
@@ -1271,9 +1271,9 @@ func TestControllerGetError(t *testing.T) {
 		presources.NewPodScalableInformerFactory(ctx),
 	)
 
-	kpa := revisionresources.MakeKPA(newTestRevision(testNamespace, testRevision))
+	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
@@ -1291,8 +1291,8 @@ func TestScaleFailure(t *testing.T) {
 
 	// Only put the KPA in the lister, which will prompt failures scaling it.
 	rev := newTestRevision(testNamespace, testRevision)
-	kpa := revisionresources.MakeKPA(rev)
-	fakekpainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+	kpa := revisionresources.MakePA(rev)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -24,7 +24,7 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/resources"
 )
 
-// Deciders is an interface for notifying the presence or absence of KPAs.
+// Deciders is an interface for notifying the presence or absence of autoscaling deciders.
 type Deciders interface {
 	// Get accesses the Decider resource for this key, returning any errors.
 	Get(ctx context.Context, namespace, name string) (*autoscaler.Decider, error)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -76,7 +76,7 @@ func TestScaler(t *testing.T) {
 		maxScale            int32
 		wantReplicas        int32
 		wantScaling         bool
-		kpaMutation         func(*pav1alpha1.PodAutoscaler)
+		paMutation          func(*pav1alpha1.PodAutoscaler)
 		proberfunc          func(*pav1alpha1.PodAutoscaler, http.RoundTripper) (bool, error)
 		wantCBCount         int
 		wantAsyncProbeCount int
@@ -86,8 +86,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  1,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
 		},
 		wantCBCount: 1,
 	}, {
@@ -97,9 +97,9 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  1,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
 			WithWindowAnnotation(paStableWindow.String())(k)
-			kpaMarkActive(k, time.Now().Add(-paStableWindow).Add(1*time.Second))
+			paMarkActive(k, time.Now().Add(-paStableWindow).Add(1*time.Second))
 		},
 		wantCBCount: 1,
 	}, {
@@ -108,9 +108,9 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
 			WithWindowAnnotation(paStableWindow.String())(k)
-			kpaMarkActive(k, time.Now().Add(-stableWindow))
+			paMarkActive(k, time.Now().Add(-stableWindow))
 		},
 	}, {
 		label:         "scale to 1 waiting for idle expires",
@@ -118,8 +118,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  1,
 		wantScaling:   true,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkActive(k, time.Now().Add(-stableWindow).Add(1*time.Second))
 		},
 		wantCBCount: 1,
 	}, {
@@ -128,8 +128,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkActive(k, time.Now().Add(-stableWindow))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkActive(k, time.Now().Add(-stableWindow))
 		},
 	}, {
 		label:         "waits to scale to zero after idle period (custom PA window)",
@@ -137,9 +137,9 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
 			WithWindowAnnotation(paStableWindow.String())(k)
-			kpaMarkActive(k, time.Now().Add(-paStableWindow))
+			paMarkActive(k, time.Now().Add(-paStableWindow))
 		},
 	}, {
 		label:         "scale to zero after grace period",
@@ -147,8 +147,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   true,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 	}, {
 		label:         "waits to scale to zero (just before grace period)",
@@ -156,8 +156,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
 		},
 		wantCBCount: 1,
 	}, {
@@ -166,8 +166,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 		proberfunc: func(*pav1alpha1.PodAutoscaler, http.RoundTripper) (bool, error) {
 			return false, errors.New("hell or high water")
@@ -179,8 +179,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 		proberfunc:          func(*pav1alpha1.PodAutoscaler, http.RoundTripper) (bool, error) { return false, nil },
 		wantAsyncProbeCount: 1,
@@ -190,7 +190,7 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  -1,
 		wantScaling:   false,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
 			k.Status.MarkActivating("", "")
 		},
 	}, {
@@ -200,8 +200,8 @@ func TestScaler(t *testing.T) {
 		minScale:      2,
 		wantReplicas:  2,
 		wantScaling:   true,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod+time.Second))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod+time.Second))
 		},
 	}, {
 		label:         "scale down to minScale after grace period",
@@ -210,8 +210,8 @@ func TestScaler(t *testing.T) {
 		minScale:      2,
 		wantReplicas:  2,
 		wantScaling:   true,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
 	}, {
 		label:         "scales up",
@@ -232,8 +232,8 @@ func TestScaler(t *testing.T) {
 		scaleTo:       10,
 		wantReplicas:  10,
 		wantScaling:   true,
-		kpaMutation: func(k *pav1alpha1.PodAutoscaler) {
-			kpaMarkInactive(k, time.Now().Add(-gracePeriod/2))
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod/2))
 		},
 	}, {
 		label:         "does not scale up from zero with no metrics",
@@ -295,8 +295,8 @@ func TestScaler(t *testing.T) {
 				})
 
 			pa := newKPA(t, fakeservingclient.Get(ctx), revision)
-			if test.kpaMutation != nil {
-				test.kpaMutation(pa)
+			if test.paMutation != nil {
+				test.paMutation(pa)
 			}
 
 			ctx = config.ToContext(ctx, defaultConfig())
@@ -404,7 +404,7 @@ func TestDisableScaleToZero(t *testing.T) {
 }
 
 func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1alpha1.Revision) *pav1alpha1.PodAutoscaler {
-	pa := revisionresources.MakeKPA(revision)
+	pa := revisionresources.MakePA(revision)
 	pa.Status.InitializeConditions()
 	_, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(pa)
 	if err != nil {
@@ -481,14 +481,14 @@ func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, r
 	return deployment
 }
 
-func kpaMarkActive(pa *pav1alpha1.PodAutoscaler, ltt time.Time) {
+func paMarkActive(pa *pav1alpha1.PodAutoscaler, ltt time.Time) {
 	pa.Status.MarkActive()
 
 	// This works because the conditions are sorted alphabetically
 	pa.Status.Conditions[0].LastTransitionTime = apis.VolatileTime{Inner: metav1.NewTime(ltt)}
 }
 
-func kpaMarkInactive(pa *pav1alpha1.PodAutoscaler, ltt time.Time) {
+func paMarkInactive(pa *pav1alpha1.PodAutoscaler, ltt time.Time) {
 	pa.Status.MarkInactive("", "")
 
 	// This works because the conditions are sorted alphabetically

--- a/pkg/reconciler/autoscaling/resources/service_test.go
+++ b/pkg/reconciler/autoscaling/resources/service_test.go
@@ -21,12 +21,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"knative.dev/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestMakeService(t *testing.T) {
@@ -35,7 +35,7 @@ func TestMakeService(t *testing.T) {
 			Namespace: "here",
 			Name:      "with-you",
 			UID:       "2006",
-			// Those labels are propagated from the Revision->KPA.
+			// Those labels are propagated from the Revision->PA.
 			Labels: map[string]string{
 				serving.RevisionLabelKey: "with-you",
 				serving.RevisionUID:      "2009",

--- a/pkg/reconciler/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/autoscaling/resources/sks_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/ptr"
 	pav1a1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 )
 
 // MakeSKS makes an SKS resource from the PA, selector and operation mode.
@@ -36,7 +36,7 @@ func TestMakeSKS(t *testing.T) {
 			Namespace: "here",
 			Name:      "with-you",
 			UID:       "2006",
-			// Those labels are propagated from the Revision->KPA.
+			// Those labels are propagated from the Revision->PA.
 			Labels: map[string]string{
 				serving.RevisionLabelKey: "with-you",
 				serving.RevisionUID:      "2009",

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -20,15 +20,15 @@ import (
 	"context"
 
 	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
-	"knative.dev/pkg/kmp"
-	"knative.dev/pkg/logging"
-	kpav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/revision/config"
 	"github.com/knative/serving/pkg/reconciler/revision/resources"
 	presources "github.com/knative/serving/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/logging"
 )
 
 func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revision) (*appsv1.Deployment, error) {
@@ -104,8 +104,8 @@ func (c *Reconciler) createImageCache(ctx context.Context, rev *v1alpha1.Revisio
 	return c.CachingClientSet.CachingV1alpha1().Images(image.Namespace).Create(image)
 }
 
-func (c *Reconciler) createKPA(ctx context.Context, rev *v1alpha1.Revision) (*kpav1alpha1.PodAutoscaler, error) {
-	kpa := resources.MakeKPA(rev)
+func (c *Reconciler) createPA(ctx context.Context, rev *v1alpha1.Revision) (*av1alpha1.PodAutoscaler, error) {
+	pa := resources.MakePA(rev)
 
-	return c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(kpa.Namespace).Create(kpa)
+	return c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).Create(pa)
 }

--- a/pkg/reconciler/revision/resources/names/names.go
+++ b/pkg/reconciler/revision/resources/names/names.go
@@ -28,9 +28,7 @@ func ImageCache(rev kmeta.Accessor) string {
 	return kmeta.ChildName(rev.GetName(), "-cache")
 }
 
-// KPA returns the PA name for the revision.
-func KPA(rev kmeta.Accessor) string {
-	// We want the KPA's "key" to match the revision,
-	// to simplify the transition to the KPA.
+// PA returns the PA name for the revision.
+func PA(rev kmeta.Accessor) string {
 	return rev.GetName()
 }

--- a/pkg/reconciler/revision/resources/names/names_test.go
+++ b/pkg/reconciler/revision/resources/names/names_test.go
@@ -22,8 +22,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/pkg/kmeta"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/pkg/kmeta"
 )
 
 func TestNamer(t *testing.T) {
@@ -87,13 +87,13 @@ func TestNamer(t *testing.T) {
 		f:    ImageCache,
 		want: "foo-cache",
 	}, {
-		name: "KPA",
+		name: "PA",
 		rev: &v1alpha1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "baz",
 			},
 		},
-		f:    KPA,
+		f:    PA,
 		want: "baz",
 	}}
 

--- a/pkg/reconciler/revision/resources/pa.go
+++ b/pkg/reconciler/revision/resources/pa.go
@@ -20,19 +20,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/pkg/kmeta"
-	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/pkg/resources"
+	"knative.dev/pkg/kmeta"
 )
 
-// MakeKPA makes a Knative Pod Autoscaler resource from a revision.
-func MakeKPA(rev *v1alpha1.Revision) *kpa.PodAutoscaler {
-	return &kpa.PodAutoscaler{
+// MakePA makes a Knative Pod Autoscaler resource from a revision.
+func MakePA(rev *v1alpha1.Revision) *av1alpha1.PodAutoscaler {
+	return &av1alpha1.PodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.KPA(rev),
+			Name:      names.PA(rev),
 			Namespace: rev.Namespace,
 			Labels:    makeLabels(rev),
 			Annotations: resources.FilterMap(rev.GetAnnotations(), func(k string) bool {
@@ -41,7 +41,7 @@ func MakeKPA(rev *v1alpha1.Revision) *kpa.PodAutoscaler {
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(rev)},
 		},
-		Spec: kpa.PodAutoscalerSpec{
+		Spec: av1alpha1.PodAutoscalerSpec{
 			ContainerConcurrency: rev.Spec.ContainerConcurrency,
 			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",

--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -25,19 +25,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/pkg/ptr"
-	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"knative.dev/pkg/ptr"
 )
 
-func TestMakeKPA(t *testing.T) {
+func TestMakePA(t *testing.T) {
 	tests := []struct {
 		name string
 		rev  *v1alpha1.Revision
-		want *kpa.PodAutoscaler
+		want *av1alpha1.PodAutoscaler
 	}{{
 		name: "name is bar (Concurrency=1)",
 		rev: &v1alpha1.Revision{
@@ -56,7 +56,7 @@ func TestMakeKPA(t *testing.T) {
 				},
 			},
 		},
-		want: &kpa.PodAutoscaler{
+		want: &av1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -77,7 +77,7 @@ func TestMakeKPA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: kpa.PodAutoscalerSpec{
+			Spec: av1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 1,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -107,7 +107,7 @@ func TestMakeKPA(t *testing.T) {
 				},
 			},
 		},
-		want: &kpa.PodAutoscaler{
+		want: &av1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
 				Name:      "baz",
@@ -126,7 +126,7 @@ func TestMakeKPA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: kpa.PodAutoscalerSpec{
+			Spec: av1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 0,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -139,7 +139,7 @@ func TestMakeKPA(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := MakeKPA(test.rev)
+			got := MakePA(test.rev)
 			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
 				t.Errorf("MakeK8sService (-want, +got) = %v", diff)
 			}

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -23,11 +23,9 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	cachinglisters "github.com/knative/caching/pkg/client/listers/caching/v1alpha1"
-	"knative.dev/pkg/controller"
-	commonlogging "knative.dev/pkg/logging"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
-	kpalisters "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
+	palisters "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
 	listers "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
 	"github.com/knative/serving/pkg/reconciler/revision/config"
@@ -39,6 +37,8 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	commonlogging "knative.dev/pkg/logging"
 )
 
 type resolver interface {
@@ -51,7 +51,7 @@ type Reconciler struct {
 
 	// lister indexes properties about Revision
 	revisionLister      listers.RevisionLister
-	podAutoscalerLister kpalisters.PodAutoscalerLister
+	podAutoscalerLister palisters.PodAutoscalerLister
 	imageLister         cachinglisters.ImageLister
 	deploymentLister    appsv1listers.DeploymentLister
 	serviceLister       corev1listers.ServiceLister
@@ -187,8 +187,8 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 		name: "image cache",
 		f:    c.reconcileImageCache,
 	}, {
-		name: "KPA",
-		f:    c.reconcileKPA,
+		name: "PA",
+		f:    c.reconcilePA,
 	}}
 
 	for _, phase := range phases {

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -24,10 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"knative.dev/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
+	"knative.dev/pkg/ptr"
 )
 
 var (
@@ -48,7 +48,7 @@ func TestMakePublicService(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie",
 				UID:       "1982",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "collie",
 					serving.RevisionUID:      "1982",
@@ -96,7 +96,7 @@ func TestMakePublicService(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie",
 				UID:       "1982",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "collie",
 					serving.RevisionUID:      "1982",
@@ -144,7 +144,7 @@ func TestMakePublicService(t *testing.T) {
 				Namespace: "siamese",
 				Name:      "dream",
 				UID:       "1988",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "dream",
 					serving.RevisionUID:      "1988",
@@ -197,7 +197,7 @@ func TestMakePublicService(t *testing.T) {
 				Namespace: "siamese",
 				Name:      "dream",
 				UID:       "1988",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "dream",
 					serving.RevisionUID:      "1988",
@@ -250,7 +250,7 @@ func TestMakePublicService(t *testing.T) {
 				Namespace: "siamese",
 				Name:      "dream",
 				UID:       "1988",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "dream",
 					serving.RevisionUID:      "1988",
@@ -321,7 +321,7 @@ func TestMakeEndpoints(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie",
 				UID:       "1982",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "collie",
 					serving.RevisionUID:      "1982",
@@ -366,7 +366,7 @@ func TestMakeEndpoints(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie",
 				UID:       "1982",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey:  "collie",
 					serving.RevisionUID:       "1982",
@@ -458,7 +458,7 @@ func TestMakePrivateService(t *testing.T) {
 				Namespace: "melon",
 				Name:      "collie",
 				UID:       "1982",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "collie",
 					serving.RevisionUID:      "1982",
@@ -513,7 +513,7 @@ func TestMakePrivateService(t *testing.T) {
 				Namespace: "siamese",
 				Name:      "dream",
 				UID:       "1988",
-				// Those labels are propagated from the Revision->KPA.
+				// Those labels are propagated from the Revision->PA.
 				Labels: map[string]string{
 					serving.RevisionLabelKey: "dream",
 					serving.RevisionUID:      "1988",

--- a/pkg/reconciler/testing/v1alpha1/listers.go
+++ b/pkg/reconciler/testing/v1alpha1/listers.go
@@ -25,12 +25,12 @@ import (
 	fakesharedclientset "knative.dev/pkg/client/clientset/versioned/fake"
 	istiolisters "knative.dev/pkg/client/listers/istio/v1alpha3"
 	"knative.dev/pkg/reconciler/testing"
-	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
+	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	networking "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	certmanagerlisters "github.com/knative/serving/pkg/client/certmanager/listers/certmanager/v1alpha1"
 	fakeservingclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
-	kpalisters "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
+	palisters "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
 	networkinglisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -129,8 +129,8 @@ func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
 	return servinglisters.NewRevisionLister(l.IndexerFor(&v1alpha1.Revision{}))
 }
 
-func (l *Listers) GetPodAutoscalerLister() kpalisters.PodAutoscalerLister {
-	return kpalisters.NewPodAutoscalerLister(l.IndexerFor(&kpa.PodAutoscaler{}))
+func (l *Listers) GetPodAutoscalerLister() palisters.PodAutoscalerLister {
+	return palisters.NewPodAutoscalerLister(l.IndexerFor(&av1alpha1.PodAutoscaler{}))
 }
 
 // GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

As we support arbitrary autoscalers controlled by the 'PodAutoscaler' CRD, this removes inappropriate specification of that PA object as 'KPA'.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
