### PR TITLE
Replace timeout propagation with context propagation in breaker.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -235,7 +235,7 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.H
 
 		// Enforce queuing and concurrency limits.
 		if breaker != nil {
-			if !breaker.Maybe(0 /* Infinite timeout */, func() {
+			if !breaker.Maybe(r.Context(), func() {
 				handler.ServeHTTP(w, r)
 			}) {
 				http.Error(w, "overload", http.StatusServiceUnavailable)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -170,8 +170,13 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	_, ttSpan := trace.StartSpan(r.Context(), "throttler_try")
 	ttStart := time.Now()
-	tryContext, cancel := context.WithTimeout(r.Context(), a.endpointTimeout)
-	defer cancel()
+
+	tryContext := r.Context()
+	if a.endpointTimeout > 0 {
+		var cancel context.CancelFunc
+		tryContext, cancel = context.WithTimeout(r.Context(), a.endpointTimeout)
+		defer cancel()
+	}
 	err = a.throttler.Try(tryContext, revID, func() {
 		var (
 			httpStatus int

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -17,10 +17,10 @@ limitations under the License.
 package queue
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 )
 
 var (
@@ -68,10 +68,8 @@ func NewBreaker(params BreakerParams) *Breaker {
 // Maybe conditionally executes thunk based on the Breaker concurrency
 // and queue parameters. If the concurrency limit and queue capacity are
 // already consumed, Maybe returns immediately without calling thunk. If
-// the thunk was executed, Maybe returns true, else false. Timeout is the
-// time before this function returns false without calling thunk. A 0
-// timeout value is infinite timeout.
-func (b *Breaker) Maybe(timeout time.Duration, thunk func()) bool {
+// the thunk was executed, Maybe returns true, else false.
+func (b *Breaker) Maybe(ctx context.Context, thunk func()) bool {
 	select {
 	default:
 		// Pending request queue is full.  Report failure.
@@ -79,7 +77,7 @@ func (b *Breaker) Maybe(timeout time.Duration, thunk func()) bool {
 	case b.pendingRequests <- struct{}{}:
 		// Pending request has capacity.
 		// Wait for capacity in the active queue.
-		if !b.sem.acquire(timeout) {
+		if !b.sem.acquire(ctx) {
 			return false
 		}
 		// Defer releasing capacity in the active and pending request queue.
@@ -135,17 +133,11 @@ type semaphore struct {
 }
 
 // acquire receives the token from the semaphore, potentially blocking.
-func (s *semaphore) acquire(timeout time.Duration) bool {
-	tt := &time.Timer{}
-	if timeout != 0 {
-		tt = time.NewTimer(timeout)
-		defer tt.Stop()
-	}
-
+func (s *semaphore) acquire(ctx context.Context) bool {
 	select {
 	case <-s.queue:
 		return true
-	case <-tt.C:
+	case <-ctx.Done():
 		return false
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The use-case of potentially aborting a long-running function like the breaker's `Maybe` seems like a perfect fit for the use of Contexts. This has the added benefit that the tests are no longer timing based and that an abortion of the outer HTTP request actually aborts trying to obtain a semaphore.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
