### PR TITLE
Implementation of the burst capacity in the KPA

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -22,16 +22,6 @@ import (
 	"log"
 	"time"
 
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/injection"
-	"knative.dev/pkg/injection/clients/kubeclient"
-	endpointsinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/endpoints"
-	"knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics"
-	pkgmetrics "knative.dev/pkg/metrics"
-	"knative.dev/pkg/signals"
-	"knative.dev/pkg/system"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/autoscaler/statserver"
@@ -42,6 +32,16 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/clients/kubeclient"
+	endpointsinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/endpoints"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	pkgmetrics "knative.dev/pkg/metrics"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/system"
 
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -179,7 +179,7 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer, m
 			return nil, err
 		}
 
-		podCounter := resources.NewScopedEndpointsCounter(endpointsInformer.Lister(), decider.Namespace, decider.Name)
+		podCounter := resources.NewScopedEndpointsCounter(endpointsInformer.Lister(), decider.Namespace, decider.Spec.ServiceName)
 		return autoscaler.New(decider.Namespace, decider.Name, metricClient, podCounter, decider.Spec, reporter)
 	}
 }

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -22,16 +22,17 @@ import (
 	"log"
 	"time"
 
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/autoscaler"
 	"github.com/knative/serving/pkg/autoscaler/statserver"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/hpa"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/kpa"
 	"github.com/knative/serving/pkg/resources"
-	basecmd "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd"
-	"github.com/spf13/pflag"
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
+
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -43,6 +44,7 @@ import (
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 
+	basecmd "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -167,8 +167,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	// EBC = TotCapacity - Cur#ReqInFlight - TargetBurstCapacity
 	excessBC = int32(float64(originalReadyPodsCount)*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
 		a.deciderSpec.TargetBurstCapacity)
-	logger.Debug("Excess burst capacity = ", excessBC)
-	fmt.Printf("### PO=%v TC=%v OSC=%v TBC=%v EBC=%v\n",
+	logger.Debugf("PodCount=%v TotalConc=%v ObservedStableConc=%v TargetBC=%v ExcessBC=%v",
 		originalReadyPodsCount,
 		a.deciderSpec.TotalConcurrency,
 		observedStableConcurrency, a.deciderSpec.TargetBurstCapacity, excessBC)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -168,6 +168,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	excessBC = int32(float64(originalReadyPodsCount)*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
 		a.deciderSpec.TargetBurstCapacity)
 	logger.Debug("Excess burst capacity = ", excessBC)
+	fmt.Printf("### PO=%v TC=%v OSC=%v TBC=%v EBC=%v\n",
+		originalReadyPodsCount,
+		a.deciderSpec.TotalConcurrency,
+		observedStableConcurrency, a.deciderSpec.TargetBurstCapacity, excessBC)
 
 	a.reporter.ReportDesiredPodCount(int64(desiredPodCount))
 	return desiredPodCount, excessBC, true

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -61,7 +61,7 @@ type DeciderSpec struct {
 // DeciderStatus is the current scale recommendation.
 type DeciderStatus struct {
 	// DesiredScale is the target number of instances that autoscaler
-	// thiks revision needs.
+	// this revision needs.
 	DesiredScale int32
 
 	// ExcessBurstCapacity is the difference between spare capacity

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -23,11 +23,11 @@ import (
 	"sync"
 	"time"
 
-	"knative.dev/pkg/logging"
 	kpa "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
 )
 
 // Decider is a resource which observes the request load of a Revision and
@@ -60,12 +60,15 @@ type DeciderSpec struct {
 
 // DeciderStatus is the current scale recommendation.
 type DeciderStatus struct {
+	// DesiredScale is the target number of instances that autoscaler
+	// thiks revision needs.
 	DesiredScale int32
+
 	// ExcessBurstCapacity is the difference between spare capacity
 	// (how many more concurrent requests the pods in the revision
 	// deployment can serve) and the configured target burst capacity.
 	// If this number is negative: Activator will be threaded in
-	// by the PodAutoscaler controller.
+	// the request path by the PodAutoscaler controller.
 	ExcessBurstCapacity int32
 }
 

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -23,8 +23,6 @@ import (
 	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	areconciler "github.com/knative/serving/pkg/reconciler/autoscaling"
@@ -37,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv2beta1listers "k8s.io/client-go/listers/autoscaling/v2beta1"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 )
 
 // Reconciler implements the control loop for the HPA resources.
@@ -148,7 +148,8 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 		}
 	}
 
-	sks, err := c.ReconcileSKS(ctx, pa)
+	// HPA has its own deciders.
+	sks, err := c.ReconcileSKS(ctx, pa, nil /* decider */)
 	if err != nil {
 		return perrors.Wrap(err, "error reconciling SKS")
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -24,8 +24,6 @@ import (
 	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
@@ -34,6 +32,8 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/config"
 	"github.com/knative/serving/pkg/reconciler/autoscaling/kpa/resources"
 	resourceutil "github.com/knative/serving/pkg/resources"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -125,11 +125,6 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		return perrors.Wrap(err, "error reconciling metrics service")
 	}
 
-	sks, err := c.ReconcileSKS(ctx, pa)
-	if err != nil {
-		return perrors.Wrap(err, "error reconciling SKS")
-	}
-
 	// Since metricSvc is what is being scraped for metrics
 	// it should be the correct representation of the pods in the deployment
 	// for autoscaling decisions.
@@ -140,6 +135,11 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 
 	if err := c.ReconcileMetric(ctx, pa, metricSvc); err != nil {
 		return perrors.Wrap(err, "error reconciling metric")
+	}
+
+	sks, err := c.ReconcileSKS(ctx, pa, decider)
+	if err != nil {
+		return perrors.Wrap(err, "error reconciling SKS")
 	}
 
 	// Get the appropriate current scale from the metric, and right size
@@ -153,6 +153,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	// We fetch private endpoints here, since for scaling we're interested in the actual
 	// state of the deployment.
 	got := 0
+
 	// Propagate service name.
 	pa.Status.ServiceName = sks.Status.ServiceName
 	if sks.Status.IsReady() {
@@ -172,7 +173,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	// computeActiveCondition decides if we need to change the SKS mode,
 	// and returns true if the status has changed.
 	if changed := computeActiveCondition(pa, want, got); changed {
-		_, err := c.ReconcileSKS(ctx, pa)
+		_, err := c.ReconcileSKS(ctx, pa, decider)
 		if err != nil {
 			return perrors.Wrap(err, "error re-reconciling SKS")
 		}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -182,8 +182,8 @@ func markResourceNotOwned(rType, name string) PodAutoscalerOption {
 }
 
 func TestReconcileNegativeBurstCapacity(t *testing.T) {
-	// This test suite uses special decider that will
-	// force KPA to scale to 0.
+	// This suite plays with different values for the excess burst capacity
+	// and checks that SKS gets reconciled correctly inside KPA.
 	const (
 		key          = testNamespace + "/" + testRevision
 		deployName   = testRevision + "-deployment"

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -66,7 +66,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, d
 	// 1. The revision is scaled to 0.
 	// 2. The excess burst capacity is negative.
 	if pa.Status.IsInactive() || (d != nil && d.Status.ExcessBurstCapacity < 0) {
-		logger.Infof("SKS %s is in proxy mode: pa.IsInactive = %v, ebc = %d", pa.Name, pa.Status.IsInactive(), d.Status.ExcessBurstCapacity)
+		logger.Debugf("SKS %s is in proxy mode: pa.IsInactive = %v, ebc = %d", pa.Name, pa.Status.IsInactive(), d.Status.ExcessBurstCapacity)
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 	sksName := anames.SKS(pa.Name)

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -23,12 +23,11 @@ import (
 
 	perrors "github.com/pkg/errors"
 
-	"knative.dev/pkg/apis/duck"
-	"knative.dev/pkg/logging"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	nv1alpha1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"github.com/knative/serving/pkg/autoscaler"
 	listers "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
 	nlisters "github.com/knative/serving/pkg/client/listers/networking/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler"
@@ -36,6 +35,8 @@ import (
 	"github.com/knative/serving/pkg/reconciler/autoscaling/resources"
 	anames "github.com/knative/serving/pkg/reconciler/autoscaling/resources/names"
 	resourceutil "github.com/knative/serving/pkg/resources"
+	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/logging"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -57,11 +58,15 @@ type Base struct {
 }
 
 // ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.
-func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (*nv1alpha1.ServerlessService, error) {
+func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, d *autoscaler.Decider) (*nv1alpha1.ServerlessService, error) {
 	logger := logging.FromContext(ctx)
 
 	mode := nv1alpha1.SKSOperationModeServe
-	if pa.Status.IsInactive() {
+	// We put activator in the serving path in two cases:
+	// 1. The revision is scaled to 0.
+	// 2. The excess burst capacity is negative.
+	if pa.Status.IsInactive() || (d != nil && d.Status.ExcessBurstCapacity < 0) {
+		logger.Infof("SKS %s is in proxy mode: pa.IsInactive = %v, ebc = %d", pa.Name, pa.Status.IsInactive(), d.Status.ExcessBurstCapacity)
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 	sksName := anames.SKS(pa.Name)

--- a/pkg/reconciler/autoscaling/resources/metric.go
+++ b/pkg/reconciler/autoscaling/resources/metric.go
@@ -57,7 +57,7 @@ func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, metricSvc strin
 	// Look for a panic window percentage annotation.
 	panicWindowPercentage, ok := pa.PanicWindowPercentage()
 	if !ok {
-		// Fall back on cluster config.
+		// Fall back to cluster config.
 		panicWindowPercentage = config.PanicWindowPercentage
 	}
 	panicWindow := time.Duration(float64(stableWindow) * panicWindowPercentage / 100.0)

--- a/pkg/reconciler/testing/v1alpha1/factory.go
+++ b/pkg/reconciler/testing/v1alpha1/factory.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 
 	fakecachingclient "github.com/knative/caching/pkg/client/injection/client/fake"
+	fakecertmanagerclient "github.com/knative/serving/pkg/client/certmanager/injection/client/fake"
+	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
 	fakesharedclient "knative.dev/pkg/client/injection/client/fake"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	fakekubeclient "knative.dev/pkg/injection/clients/kubeclient/fake"
-	fakecertmanagerclient "github.com/knative/serving/pkg/client/certmanager/injection/client/fake"
-	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -39,8 +39,8 @@ import (
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 
-	. "knative.dev/pkg/reconciler/testing"
 	"github.com/knative/serving/pkg/reconciler"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 const (
@@ -57,7 +57,10 @@ func MakeFactory(ctor Ctor) Factory {
 	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList, *FakeStatsReporter) {
 		ls := NewListers(r.Objects)
 
-		ctx := context.Background()
+		ctx := r.Ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		logger := logtesting.TestLogger(t)
 		ctx = logging.WithLogger(ctx, logger)
 


### PR DESCRIPTION
This implements the pre-final step of burst capacity in the Knative. 
Final step being a meticulously carved integration test to verify this behavior.

In this PR we:

- apply the SKS in proxy mode if EBC is negative
- update unit tests

Part of #1409  and #1625



/lint
/assign @mattmoor @markusthoemmes 