### PR TITLE
Make sure we check the same constants throughout the code

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/knative/serving/pkg/apis/autoscaling"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -175,7 +177,7 @@ func validate(lc *Config) (*Config, error) {
 	}
 
 	// We can't permit stable window be less than our aggregation window for correctness.
-	if lc.StableWindow < BucketSize {
+	if lc.StableWindow < autoscaling.WindowMin {
 		return nil, fmt.Errorf("stable-window = %v, must be at least %v", lc.StableWindow, BucketSize)
 	}
 

--- a/pkg/reconciler/autoscaling/resources/metric.go
+++ b/pkg/reconciler/autoscaling/resources/metric.go
@@ -52,8 +52,8 @@ func StableWindow(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) time.Du
 // MakeMetric constructs a Metric resource from a PodAutoscaler
 func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, metricSvc string,
 	config *autoscaler.Config) *autoscaler.Metric {
-
 	stableWindow := StableWindow(pa, config)
+
 	// Look for a panic window percentage annotation.
 	panicWindowPercentage, ok := pa.PanicWindowPercentage()
 	if !ok {
@@ -61,6 +61,9 @@ func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, metricSvc strin
 		panicWindowPercentage = config.PanicWindowPercentage
 	}
 	panicWindow := time.Duration(float64(stableWindow) * panicWindowPercentage / 100.0)
+	if panicWindow < autoscaler.BucketSize {
+		panicWindow = autoscaler.BucketSize
+	}
 	return &autoscaler.Metric{
 		ObjectMeta: pa.ObjectMeta,
 		Spec: autoscaler.MetricSpec{

--- a/pkg/reconciler/autoscaling/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/resources/metric_test.go
@@ -42,11 +42,18 @@ func TestMakeMetric(t *testing.T) {
 		msn:  "ik",
 		want: metric(withScarapeTarget("ik")),
 	}, {
+		name: "with too short panic window",
+		pa:   pa(WithWindowAnnotation("10s"), WithPanicWindowPercentageAnnotation("10")),
+		msn:  "wil",
+		want: metric(withScarapeTarget("wil"), withWindowAnnotation("10s"),
+			withStableWindow(10*time.Second), withPanicWindow(autoscaler.BucketSize),
+			withPanicWindowPercentageAnnotation("10")),
+	}, {
 		name: "with longer stable window, no panic window percentage, defaults to 10%",
 		pa:   pa(WithWindowAnnotation("10m")),
-		msn:  "wil",
+		msn:  "nu",
 		want: metric(
-			withScarapeTarget("wil"),
+			withScarapeTarget("nu"),
 			withStableWindow(10*time.Minute), withPanicWindow(time.Minute),
 			withWindowAnnotation("10m")),
 	}, {


### PR DESCRIPTION
Currently the values that we were checking against not the same everywhere.
And also we didn't enforce reasonable minimum for panic window.
Now they are all the same (I kept panic threshold lower).

/assign @markusthoemmes 

