### PR TITLE
Add more validation to the PA.

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -61,7 +61,7 @@ func validateWindows(annotations map[string]string) *apis.FieldError {
 			errs = errs.Also(apis.ErrInvalidValue(v, "annotation: "+PanicThresholdPercentageAnnotationKey))
 		} else if fv < PanicThresholdPercentageMin {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("Invalid annotation value %s, must be at least %v", v, PanicThresholdPercentageMin),
+				Message: fmt.Sprintf("invalid annotation value %s, must be at least %v", v, PanicThresholdPercentageMin),
 				Paths:   []string{PanicThresholdPercentageAnnotationKey},
 			})
 		}

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -31,8 +31,8 @@ func getIntGE0(m map[string]string, k string) (int64, *apis.FieldError) {
 	i, err := strconv.ParseInt(v, 10, 32)
 	if err != nil || i < 0 {
 		return 0, &apis.FieldError{
-			Message: "invalid annotation value: must be an integer equal or greater than 0",
-			Paths:   []string{k},
+			Message: "invalid value: must be an integer equal or greater than 0",
+			Paths:   []string{annotationKey(k)},
 		}
 	}
 	return i, nil
@@ -50,19 +50,19 @@ func validateWindows(annotations map[string]string) *apis.FieldError {
 	var errs *apis.FieldError
 	if v, ok := annotations[PanicWindowPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(v, "annotation: "+PanicWindowPercentageAnnotationKey))
+			errs = errs.Also(apis.ErrInvalidValue(v, annotationKey(PanicWindowPercentageAnnotationKey)))
 		} else if fv < PanicWindowPercentageMin || fv > PanicWindowPercentageMax {
 			errs = apis.ErrOutOfBoundsValue(v, PanicWindowPercentageMin,
-				PanicWindowPercentageMax, "annotation: "+PanicWindowPercentageAnnotationKey)
+				PanicWindowPercentageMax, annotationKey(PanicWindowPercentageAnnotationKey))
 		}
 	}
 	if v, ok := annotations[PanicThresholdPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(v, "annotation: "+PanicThresholdPercentageAnnotationKey))
+			errs = errs.Also(apis.ErrInvalidValue(v, annotationKey(PanicThresholdPercentageAnnotationKey)))
 		} else if fv < PanicThresholdPercentageMin {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("invalid annotation value %s, must be at least %v", v, PanicThresholdPercentageMin),
-				Paths:   []string{PanicThresholdPercentageAnnotationKey},
+				Message: fmt.Sprintf("invalid value %s, must be at least %v", v, PanicThresholdPercentageMin),
+				Paths:   []string{annotationKey(PanicThresholdPercentageAnnotationKey)},
 			})
 		}
 	}
@@ -84,8 +84,12 @@ func validateMinMaxScale(annotations map[string]string) *apis.FieldError {
 	if max != 0 && max < min {
 		errs = errs.Also(&apis.FieldError{
 			Message: fmt.Sprintf("%s=%v is less than %s=%v", MaxScaleAnnotationKey, max, MinScaleAnnotationKey, min),
-			Paths:   []string{MaxScaleAnnotationKey, MinScaleAnnotationKey},
+			Paths:   []string{annotationKey(MaxScaleAnnotationKey), annotationKey(MinScaleAnnotationKey)},
 		})
 	}
 	return errs
+}
+
+func annotationKey(ak string) string {
+	return "annotation: " + ak
 }

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -69,17 +69,14 @@ func validateMinMaxScale(annotations map[string]string) *apis.FieldError {
 	var errs *apis.FieldError
 
 	min, err := getIntGE0(annotations, MinScaleAnnotationKey)
-	if err != nil {
-		errs = err
-	}
+	errs = errs.Also(err)
+
 	max, err := getIntGE0(annotations, MaxScaleAnnotationKey)
-	if err != nil {
-		errs = errs.Also(err)
-	}
+	errs = errs.Also(err)
 
 	if max != 0 && max < min {
 		errs = errs.Also(&apis.FieldError{
-			Message: fmt.Sprintf("%s=%v is less than %s=%v", MaxScaleAnnotationKey, max, MinScaleAnnotationKey, min),
+			Message: fmt.Sprintf("maxScale=%d is less than minScale=%d", max, min),
 			Paths:   []string{MaxScaleAnnotationKey, MinScaleAnnotationKey},
 		})
 	}

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -18,6 +18,7 @@ package autoscaling
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"knative.dev/pkg/apis"
@@ -30,10 +31,7 @@ func getIntGE0(m map[string]string, k string) (int64, *apis.FieldError) {
 	}
 	i, err := strconv.ParseInt(v, 10, 32)
 	if err != nil || i < 0 {
-		return 0, &apis.FieldError{
-			Message: "invalid value: must be an integer equal or greater than 0",
-			Paths:   []string{AnnotationErrKey(k)},
-		}
+		return 0, apis.ErrOutOfBoundsValue(v, 1, math.MaxInt32, k)
 	}
 	return i, nil
 }
@@ -50,20 +48,18 @@ func validateWindows(annotations map[string]string) *apis.FieldError {
 	var errs *apis.FieldError
 	if v, ok := annotations[PanicWindowPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(v, AnnotationErrKey(PanicWindowPercentageAnnotationKey)))
+			errs = errs.Also(apis.ErrInvalidValue(v, PanicWindowPercentageAnnotationKey))
 		} else if fv < PanicWindowPercentageMin || fv > PanicWindowPercentageMax {
 			errs = apis.ErrOutOfBoundsValue(v, PanicWindowPercentageMin,
-				PanicWindowPercentageMax, AnnotationErrKey(PanicWindowPercentageAnnotationKey))
+				PanicWindowPercentageMax, PanicWindowPercentageAnnotationKey)
 		}
 	}
 	if v, ok := annotations[PanicThresholdPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(v, AnnotationErrKey(PanicThresholdPercentageAnnotationKey)))
-		} else if fv < PanicThresholdPercentageMin {
-			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("invalid value %s, must be at least %v", v, PanicThresholdPercentageMin),
-				Paths:   []string{AnnotationErrKey(PanicThresholdPercentageAnnotationKey)},
-			})
+			errs = errs.Also(apis.ErrInvalidValue(v, PanicThresholdPercentageAnnotationKey))
+		} else if fv < PanicThresholdPercentageMin || fv > PanicThresholdPercentageMax {
+			errs = errs.Also(apis.ErrOutOfBoundsValue(v, PanicThresholdPercentageMin, PanicThresholdPercentageMax,
+				PanicThresholdPercentageAnnotationKey))
 		}
 	}
 	return errs
@@ -84,13 +80,8 @@ func validateMinMaxScale(annotations map[string]string) *apis.FieldError {
 	if max != 0 && max < min {
 		errs = errs.Also(&apis.FieldError{
 			Message: fmt.Sprintf("%s=%v is less than %s=%v", MaxScaleAnnotationKey, max, MinScaleAnnotationKey, min),
-			Paths:   []string{AnnotationErrKey(MaxScaleAnnotationKey), AnnotationErrKey(MinScaleAnnotationKey)},
+			Paths:   []string{MaxScaleAnnotationKey, MinScaleAnnotationKey},
 		})
 	}
 	return errs
-}
-
-// AnnotationErrKey formats the annotation key for error reporting.
-func AnnotationErrKey(ak string) string {
-	return "annotation: " + ak
 }

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -31,7 +31,7 @@ func getIntGE0(m map[string]string, k string) (int64, *apis.FieldError) {
 	i, err := strconv.ParseInt(v, 10, 32)
 	if err != nil || i < 0 {
 		return 0, &apis.FieldError{
-			Message: fmt.Sprintf("Invalid %s annotation value: must be an integer equal or greater than 0", k),
+			Message: "invalid annotation value: must be an integer equal or greater than 0",
 			Paths:   []string{k},
 		}
 	}

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -50,28 +50,18 @@ func validateWindows(annotations map[string]string) *apis.FieldError {
 	var errs *apis.FieldError
 	if v, ok := annotations[PanicWindowPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = &apis.FieldError{
-				Message: fmt.Sprintf("Invalid annatation value %s=%s, not a valid number",
-					PanicWindowPercentageAnnotationKey, v),
-				Paths: []string{PanicWindowPercentageAnnotationKey},
-			}
+			errs = errs.Also(apis.ErrInvalidValue(v, "annotation: "+PanicWindowPercentageAnnotationKey))
 		} else if fv < PanicWindowPercentageMin || fv > PanicWindowPercentageMax {
-			errs = &apis.FieldError{
-				Message: fmt.Sprintf("Invalid annatation value %s=%s, not a valid percentage ",
-					PanicWindowPercentageAnnotationKey, v),
-				Paths: []string{PanicWindowPercentageAnnotationKey},
-			}
+			errs = apis.ErrOutOfBoundsValue(v, PanicWindowPercentageMin,
+				PanicWindowPercentageMax, "annotation: "+PanicWindowPercentageAnnotationKey)
 		}
 	}
 	if v, ok := annotations[PanicThresholdPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("Invalid annatation value %s=%s, not a valid number", PanicThresholdPercentageAnnotationKey, v),
-				Paths:   []string{PanicThresholdPercentageAnnotationKey},
-			})
+			errs = errs.Also(apis.ErrInvalidValue(v, "annotation: "+PanicThresholdPercentageAnnotationKey))
 		} else if fv < PanicThresholdPercentageMin {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("Invalid annatation value %s=%s, must be at least 110", PanicThresholdPercentageAnnotationKey, v),
+				Message: fmt.Sprintf("Invalid annotation value %s, must be at least %v", v, PanicThresholdPercentageMin),
 				Paths:   []string{PanicThresholdPercentageAnnotationKey},
 			})
 		}

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -32,7 +32,7 @@ func getIntGE0(m map[string]string, k string) (int64, *apis.FieldError) {
 	if err != nil || i < 0 {
 		return 0, &apis.FieldError{
 			Message: "invalid value: must be an integer equal or greater than 0",
-			Paths:   []string{annotationKey(k)},
+			Paths:   []string{AnnotationErrKey(k)},
 		}
 	}
 	return i, nil
@@ -50,19 +50,19 @@ func validateWindows(annotations map[string]string) *apis.FieldError {
 	var errs *apis.FieldError
 	if v, ok := annotations[PanicWindowPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(v, annotationKey(PanicWindowPercentageAnnotationKey)))
+			errs = errs.Also(apis.ErrInvalidValue(v, AnnotationErrKey(PanicWindowPercentageAnnotationKey)))
 		} else if fv < PanicWindowPercentageMin || fv > PanicWindowPercentageMax {
 			errs = apis.ErrOutOfBoundsValue(v, PanicWindowPercentageMin,
-				PanicWindowPercentageMax, annotationKey(PanicWindowPercentageAnnotationKey))
+				PanicWindowPercentageMax, AnnotationErrKey(PanicWindowPercentageAnnotationKey))
 		}
 	}
 	if v, ok := annotations[PanicThresholdPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(v, annotationKey(PanicThresholdPercentageAnnotationKey)))
+			errs = errs.Also(apis.ErrInvalidValue(v, AnnotationErrKey(PanicThresholdPercentageAnnotationKey)))
 		} else if fv < PanicThresholdPercentageMin {
 			errs = errs.Also(&apis.FieldError{
 				Message: fmt.Sprintf("invalid value %s, must be at least %v", v, PanicThresholdPercentageMin),
-				Paths:   []string{annotationKey(PanicThresholdPercentageAnnotationKey)},
+				Paths:   []string{AnnotationErrKey(PanicThresholdPercentageAnnotationKey)},
 			})
 		}
 	}
@@ -84,12 +84,13 @@ func validateMinMaxScale(annotations map[string]string) *apis.FieldError {
 	if max != 0 && max < min {
 		errs = errs.Also(&apis.FieldError{
 			Message: fmt.Sprintf("%s=%v is less than %s=%v", MaxScaleAnnotationKey, max, MinScaleAnnotationKey, min),
-			Paths:   []string{annotationKey(MaxScaleAnnotationKey), annotationKey(MinScaleAnnotationKey)},
+			Paths:   []string{AnnotationErrKey(MaxScaleAnnotationKey), AnnotationErrKey(MinScaleAnnotationKey)},
 		})
 	}
 	return errs
 }
 
-func annotationKey(ak string) string {
+// AnnotationErrKey formats the annotation key for error reporting.
+func AnnotationErrKey(ak string) string {
 	return "annotation: " + ak
 }

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -43,23 +43,23 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is -1",
 		annotations: map[string]string{MinScaleAnnotationKey: "-1"},
-		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/minScale",
+		expectErr:   "expected 1 <= -1 <= 2147483647: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "maxScale is -1",
 		annotations: map[string]string{MaxScaleAnnotationKey: "-1"},
-		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale",
+		expectErr:   "expected 1 <= -1 <= 2147483647: autoscaling.knative.dev/maxScale",
 	}, {
 		name:        "minScale is foo",
 		annotations: map[string]string{MinScaleAnnotationKey: "foo"},
-		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/minScale",
+		expectErr:   "expected 1 <= foo <= 2147483647: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "maxScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar"},
-		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale",
+		expectErr:   "expected 1 <= bar <= 2147483647: autoscaling.knative.dev/maxScale",
 	}, {
 		name:        "max/minScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar", MinScaleAnnotationKey: "bar"},
-		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale, annotation: autoscaling.knative.dev/minScale",
+		expectErr:   "expected 1 <= bar <= 2147483647: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
 	}, {
 		name:        "minScale is 5",
 		annotations: map[string]string{MinScaleAnnotationKey: "5"},
@@ -72,7 +72,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is 5, maxScale is 2",
 		annotations: map[string]string{MinScaleAnnotationKey: "5", MaxScaleAnnotationKey: "2"},
-		expectErr:   "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5: annotation: autoscaling.knative.dev/maxScale, annotation: autoscaling.knative.dev/minScale",
+		expectErr:   "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
 	}, {
 		name: "minScale is 0, maxScale is 0",
 		annotations: map[string]string{
@@ -82,26 +82,30 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "panic window percentange bad",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "-1"},
-		expectErr:   "expected 1 <= -1 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "expected 1 <= -1 <= 100: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
 		name:        "panic window percentange bad2",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "202"},
-		expectErr:   "expected 1 <= 202 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "expected 1 <= 202 <= 100: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
 		name:        "panic window percentange bad3",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "fifty"},
-		expectErr:   "invalid value: fifty: annotation: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
 		name:        "panic threshold percentange good",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "210"},
 	}, {
 		name:        "panic threshold percentange bad2",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "109"},
-		expectErr:   "invalid value 109, must be at least 110: annotation: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "expected 110 <= 109 <= 1000: autoscaling.knative.dev/panicThresholdPercentage",
+	}, {
+		name:        "panic threshold percentange bad2.5",
+		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "10009"},
+		expectErr:   "expected 110 <= 10009 <= 1000: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name:        "panic threshold percentange bad3",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},
-		expectErr:   "invalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name: "all together now fail",
 		annotations: map[string]string{
@@ -110,7 +114,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MinScaleAnnotationKey:                 "-4",
 			MaxScaleAnnotationKey:                 "never",
 		},
-		expectErr: "expected 1 <= -11 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage\ninvalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage\ninvalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale, annotation: autoscaling.knative.dev/minScale",
+		expectErr: "expected 1 <= -11 <= 100: autoscaling.knative.dev/panicWindowPercentage\nexpected 1 <= -4 <= 2147483647: autoscaling.knative.dev/minScale\nexpected 1 <= never <= 2147483647: autoscaling.knative.dev/maxScale\ninvalid value: fifty: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name: "all together now, succeed",
 		annotations: map[string]string{

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -72,7 +72,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is 5, maxScale is 2",
 		annotations: map[string]string{MinScaleAnnotationKey: "5", MaxScaleAnnotationKey: "2"},
-		expectErr:   "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
+		expectErr:   "maxScale=2 is less than minScale=5: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
 	}, {
 		name: "minScale is 0, maxScale is 0",
 		annotations: map[string]string{
@@ -92,7 +92,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "fifty"},
 		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
-		name:        "panic threshold percentange good",
+		name:        "panic window percentange good",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "210"},
 	}, {
 		name:        "panic threshold percentange bad2",

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -43,23 +43,23 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is -1",
 		annotations: map[string]string{MinScaleAnnotationKey: "-1"},
-		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
+		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "maxScale is -1",
 		annotations: map[string]string{MaxScaleAnnotationKey: "-1"},
-		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale",
+		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale",
 	}, {
 		name:        "minScale is foo",
 		annotations: map[string]string{MinScaleAnnotationKey: "foo"},
-		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
+		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "maxScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar"},
-		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale",
+		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale",
 	}, {
 		name:        "max/minScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar", MinScaleAnnotationKey: "bar"},
-		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
+		expectErr:   "invalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale, annotation: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "minScale is 5",
 		annotations: map[string]string{MinScaleAnnotationKey: "5"},
@@ -72,7 +72,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is 5, maxScale is 2",
 		annotations: map[string]string{MinScaleAnnotationKey: "5", MaxScaleAnnotationKey: "2"},
-		expectErr:   "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
+		expectErr:   "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5: annotation: autoscaling.knative.dev/maxScale, annotation: autoscaling.knative.dev/minScale",
 	}, {
 		name: "minScale is 0, maxScale is 0",
 		annotations: map[string]string{
@@ -97,7 +97,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "panic threshold percentange bad2",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "109"},
-		expectErr:   "invalid annotation value 109, must be at least 110: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "invalid value 109, must be at least 110: annotation: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name:        "panic threshold percentange bad3",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},
@@ -110,7 +110,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MinScaleAnnotationKey:                 "-4",
 			MaxScaleAnnotationKey:                 "never",
 		},
-		expectErr: "expected 1 <= -11 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage\ninvalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale\ninvalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr: "expected 1 <= -11 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage\ninvalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage\ninvalid value: must be an integer equal or greater than 0: annotation: autoscaling.knative.dev/maxScale, annotation: autoscaling.knative.dev/minScale",
 	}, {
 		name: "all together now, succeed",
 		annotations: map[string]string{

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -43,23 +43,23 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is -1",
 		annotations: map[string]string{MinScaleAnnotationKey: "-1"},
-		expectErr:   "Invalid autoscaling.knative.dev/minScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
+		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "maxScale is -1",
 		annotations: map[string]string{MaxScaleAnnotationKey: "-1"},
-		expectErr:   "Invalid autoscaling.knative.dev/maxScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale",
+		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale",
 	}, {
 		name:        "minScale is foo",
 		annotations: map[string]string{MinScaleAnnotationKey: "foo"},
-		expectErr:   "Invalid autoscaling.knative.dev/minScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
+		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
 	}, {
 		name:        "maxScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar"},
-		expectErr:   "Invalid autoscaling.knative.dev/maxScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale",
+		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale",
 	}, {
 		name:        "max/minScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar", MinScaleAnnotationKey: "bar"},
-		expectErr:   "Invalid autoscaling.knative.dev/maxScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale\nInvalid autoscaling.knative.dev/minScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
+		expectErr:   "invalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
 	}, {
 		name:        "minScale is 5",
 		annotations: map[string]string{MinScaleAnnotationKey: "5"},
@@ -110,7 +110,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MinScaleAnnotationKey:                 "-4",
 			MaxScaleAnnotationKey:                 "never",
 		},
-		expectErr: "Invalid autoscaling.knative.dev/maxScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale\nInvalid autoscaling.knative.dev/minScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale\nexpected 1 <= -11 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage\ninvalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr: "expected 1 <= -11 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage\ninvalid annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale\ninvalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name: "all together now, succeed",
 		annotations: map[string]string{

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,28 +80,28 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MaxScaleAnnotationKey: "0",
 		},
 	}, {
-		name:        "panic window  percentange bad",
+		name:        "panic window percentange bad",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "-1"},
-		expectErr:   "Invalid annatation value autoscaling.knative.dev/panicWindowPercentage=-1, not a valid percentage : autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "expected 1 <= -1 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
 		name:        "panic window percentange bad2",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "202"},
-		expectErr:   "Invalid annatation value autoscaling.knative.dev/panicWindowPercentage=202, not a valid percentage : autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "expected 1 <= 202 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
 		name:        "panic window percentange bad3",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "fifty"},
-		expectErr:   "Invalid annatation value autoscaling.knative.dev/panicWindowPercentage=fifty, not a valid number: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "invalid value: fifty: annotation: autoscaling.knative.dev/panicWindowPercentage",
 	}, {
-		name:        "panic threshold percentange bad2",
+		name:        "panic threshold percentange good",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "210"},
 	}, {
 		name:        "panic threshold percentange bad2",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "109"},
-		expectErr:   "Invalid annatation value autoscaling.knative.dev/panicThresholdPercentage=109, must be at least 110: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "Invalid annotation value 109, must be at least 110: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name:        "panic threshold percentange bad3",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},
-		expectErr:   "Invalid annatation value autoscaling.knative.dev/panicThresholdPercentage=fifty, not a valid number: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "invalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name: "all together now fail",
 		annotations: map[string]string{
@@ -110,7 +110,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MinScaleAnnotationKey:                 "-4",
 			MaxScaleAnnotationKey:                 "never",
 		},
-		expectErr: "Invalid annatation value autoscaling.knative.dev/panicThresholdPercentage=fifty, not a valid number: autoscaling.knative.dev/panicThresholdPercentage\nInvalid annatation value autoscaling.knative.dev/panicWindowPercentage=-11, not a valid percentage : autoscaling.knative.dev/panicWindowPercentage\nInvalid autoscaling.knative.dev/maxScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale\nInvalid autoscaling.knative.dev/minScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale",
+		expectErr: "Invalid autoscaling.knative.dev/maxScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/maxScale\nInvalid autoscaling.knative.dev/minScale annotation value: must be an integer equal or greater than 0: autoscaling.knative.dev/minScale\nexpected 1 <= -11 <= 100: annotation: autoscaling.knative.dev/panicWindowPercentage\ninvalid value: fifty: annotation: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name: "all together now, succeed",
 		annotations: map[string]string{

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -97,7 +97,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "panic threshold percentange bad2",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "109"},
-		expectErr:   "Invalid annotation value 109, must be at least 110: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "invalid annotation value 109, must be at least 110: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
 		name:        "panic threshold percentange bad3",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -129,6 +129,10 @@ const (
 	// smallest useful value.
 	PanicThresholdPercentageMin = 110.0
 
+	// PanicThresholdPercentageMax is the counterpart to the PanicThresholdPercentageMin
+	// but bounding from above.
+	PanicThresholdPercentageMax = 1000.0
+
 	// KPALabelKey is the label key attached to a K8s Service to hint to the KPA
 	// which services/endpoints should trigger reconciles.
 	KPALabelKey = GroupName + "/kpa"

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -197,10 +198,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 				},
 			},
 		},
-		want: (&apis.FieldError{
-			Message: "invalid value: must be an integer equal or greater than 0",
-			Paths:   []string{autoscaling.AnnotationErrKey(autoscaling.MinScaleAnnotationKey)},
-		}).ViaField("annotations").ViaField("metadata"),
+		want: apis.ErrOutOfBoundsValue("FOO", 1, math.MaxInt32, autoscaling.MinScaleAnnotationKey).ViaField("metadata", "annotations"),
 	}, {
 		name: "empty spec",
 		r: &PodAutoscaler{
@@ -232,7 +230,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.r.Validate(context.Background())
 			if got, want := got.Error(), test.want.Error(); !cmp.Equal(got, want) {
-				t.Errorf("Got = %v, want: %v, diff: %s", got, want, cmp.Diff(got, want))
+				t.Errorf("Got: %q, want: %q, diff: %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -18,17 +18,16 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/pkg/apis"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	net "github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"knative.dev/pkg/apis"
 )
 
 func TestPodAutoscalerSpecValidation(t *testing.T) {
@@ -199,8 +198,8 @@ func TestPodAutoscalerValidation(t *testing.T) {
 			},
 		},
 		want: (&apis.FieldError{
-			Message: fmt.Sprintf("Invalid %s annotation value: must be an integer equal or greater than 0", autoscaling.MinScaleAnnotationKey),
-			Paths:   []string{autoscaling.MinScaleAnnotationKey},
+			Message: "invalid value: must be an integer equal or greater than 0",
+			Paths:   []string{autoscaling.AnnotationErrKey(autoscaling.MinScaleAnnotationKey)},
 		}).ViaField("annotations").ViaField("metadata"),
 	}, {
 		name: "empty spec",
@@ -232,8 +231,8 @@ func TestPodAutoscalerValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.r.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("Validate (-want, +got) = %v", diff)
+			if got, want := got.Error(), test.want.Error(); !cmp.Equal(got, want) {
+				t.Errorf("Got = %v, want: %v, diff: %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -452,7 +452,7 @@ func TestRevisionValidation(t *testing.T) {
 			},
 		},
 		want: (&apis.FieldError{
-			Message: "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5",
+			Message: "maxScale=2 is less than minScale=5",
 			Paths:   []string{autoscaling.MaxScaleAnnotationKey, autoscaling.MinScaleAnnotationKey},
 		}).ViaField("annotations").ViaField("metadata"),
 	}}
@@ -461,7 +461,7 @@ func TestRevisionValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.r.Validate(context.Background())
 			if got, want := got.Error(), test.want.Error(); got != want {
-				t.Errorf("Validate got: %s, want: %s, diff:(-want, +got)=\n%v", got, want, cmp.Diff(got, want))
+				t.Errorf("Validate got:\n%s, want:\n%s, diff:(-want, +got)=\n%v", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -453,7 +453,7 @@ func TestRevisionValidation(t *testing.T) {
 		},
 		want: (&apis.FieldError{
 			Message: "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5",
-			Paths:   []string{autoscaling.AnnotationErrKey(autoscaling.MaxScaleAnnotationKey), autoscaling.AnnotationErrKey(autoscaling.MinScaleAnnotationKey)},
+			Paths:   []string{autoscaling.MaxScaleAnnotationKey, autoscaling.MinScaleAnnotationKey},
 		}).ViaField("annotations").ViaField("metadata"),
 	}}
 

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -23,9 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/apis"
-	logtesting "knative.dev/pkg/logging/testing"
-	"knative.dev/pkg/ptr"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/config"
 	net "github.com/knative/serving/pkg/apis/networking"
@@ -33,6 +30,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 )
@@ -452,16 +452,16 @@ func TestRevisionValidation(t *testing.T) {
 			},
 		},
 		want: (&apis.FieldError{
-			Message: fmt.Sprintf("%s=%v is less than %s=%v", autoscaling.MaxScaleAnnotationKey, 2, autoscaling.MinScaleAnnotationKey, 5),
-			Paths:   []string{autoscaling.MaxScaleAnnotationKey, autoscaling.MinScaleAnnotationKey},
+			Message: "autoscaling.knative.dev/maxScale=2 is less than autoscaling.knative.dev/minScale=5",
+			Paths:   []string{autoscaling.AnnotationErrKey(autoscaling.MaxScaleAnnotationKey), autoscaling.AnnotationErrKey(autoscaling.MinScaleAnnotationKey)},
 		}).ViaField("annotations").ViaField("metadata"),
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.r.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("Validate (-want, +got) = %v", diff)
+			if got, want := got.Error(), test.want.Error(); got != want {
+				t.Errorf("Validate got: %s, want: %s, diff:(-want, +got)=\n%v", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/knative/serving/pkg/apis/config"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/apis"
-	logtesting "knative.dev/pkg/logging/testing"
-	"knative.dev/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 )
 
 func TestRevisionValidation(t *testing.T) {
@@ -566,9 +566,8 @@ func TestImmutableFields(t *testing.T) {
 				ctx = test.wc(ctx)
 			}
 			got := test.new.Validate(ctx)
-			if !cmp.Equal(test.want.Error(), got.Error()) {
-				t.Errorf("Validate (-want, +got) = %v",
-					cmp.Diff(test.want.Error(), got.Error()))
+			if got, want := got.Error(), test.want.Error(); got != want {
+				t.Errorf("Validate got: %s, want: %s, diff:(-want, +got)=\n%v", got, want, cmp.Diff(got, want))
 			}
 		})
 	}


### PR DESCRIPTION
This moves the checks we can execute earlier to the validation, so that invalid values will not
even propagate to the PA.

Also replace the objects with strings, the same way we actually test in FieldErrors.


/lint

/assign @mattmoor @markusthoemmes 