### PR TITLE
Add permissions for {networking,autoscaling}.internal.knative.dev to namespace admin role

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -19,6 +19,6 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-  - apiGroups: ["serving.knative.dev"]
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
     resources: ["*"]
     verbs: ["*"]


### PR DESCRIPTION
This PR is similar to https://github.com/knative/serving/pull/4358.

Currently even namespace's `admin` cannot access to knative resource
such as `networking.internal.knative.dev` and
`autoscaling.internal.knative.dev`.

This patch allows namespace admin to access to the resources within
their namespaces.

## Proposed Changes

* Add permissions for `{networking,autoscaling}.internal.knative.dev` to namespace `admin` role

**Release Note**

```release-note
NONE
```
