### PR TITLE
Remove clusteringress from kubectl get all

### DIFF
--- a/config/300-clusteringress.yaml
+++ b/config/300-clusteringress.yaml
@@ -27,7 +27,6 @@ spec:
     plural: clusteringresses
     singular: clusteringress
     categories:
-    - all
     - knative-internal
     - networking
   scope: Cluster


### PR DESCRIPTION
Currently namespace admin cannot access to
`clusteringress.networking.internal.knative.dev` as it is not
a namespace scope resource. Hence, when `kubectl get all` was executed by
namespace admin, we always get a permission error.

This patch changes to remove
`clusteringress.networking.internal.knative.dev` from `kubectl get all`.

## Proposed Changes

* Remove clusteringress from kubectl get all

**Release Note**

```release-note
NONE
```
