### PR TITLE
Use route inconsistency retry helper throughout all tests.

### DIFF
--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -20,15 +20,14 @@ package v1alpha1
 
 import (
 	"fmt"
-	"net/http"
 	"regexp"
 	"testing"
 
-	pkgTest "knative.dev/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	rtesting "github.com/knative/serving/pkg/testing/v1alpha1"
 	"github.com/knative/serving/test"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
+	pkgTest "knative.dev/pkg/test"
 )
 
 func setServiceGenerateName(generateName string) rtesting.ServiceOption {
@@ -96,7 +95,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1alpha1.Route
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText)), http.StatusNotFound),
+		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -20,15 +20,14 @@ package v1beta1
 
 import (
 	"fmt"
-	"net/http"
 	"regexp"
 	"testing"
 
-	pkgTest "knative.dev/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	rtesting "github.com/knative/serving/pkg/testing/v1beta1"
 	"github.com/knative/serving/test"
 	v1b1test "github.com/knative/serving/test/v1beta1"
+	pkgTest "knative.dev/pkg/test"
 )
 
 func setServiceGenerateName(generateName string) rtesting.ServiceOption {
@@ -96,7 +95,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1beta1.Route)
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText)), http.StatusNotFound),
+		v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/knative/serving/test"
+	v1a1test "github.com/knative/serving/test/v1alpha1"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
-	"github.com/knative/serving/test"
-	v1a1test "github.com/knative/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -98,7 +98,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 		clients.KubeClient,
 		t.Logf,
 		domain,
-		pkgTest.Retrying(pkgTest.IsStatusOK, http.StatusNotFound),
+		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"HTTPProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Use the `RetryRouteInconsistency` helper throughout all tests to centrally manage the status codes we need to return.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
