### PR TITLE
Stop printing *.internal.knative.dev resources in kubectl get all

### DIFF
--- a/config/300-certificate.yaml
+++ b/config/300-certificate.yaml
@@ -27,7 +27,6 @@ spec:
     plural: certificates
     singular: certificate
     categories:
-    - all
     - knative-internal
     - networking
     shortNames:

--- a/config/300-ingress.yaml
+++ b/config/300-ingress.yaml
@@ -27,7 +27,6 @@ spec:
     plural: ingresses
     singular: ingress
     categories:
-    - all
     - knative-internal
     - networking
     shortNames:

--- a/config/300-pa.yaml
+++ b/config/300-pa.yaml
@@ -27,7 +27,6 @@ spec:
     plural: podautoscalers
     singular: podautoscaler
     categories:
-    - all
     - knative-internal
     - autoscaling
     shortNames:

--- a/config/300-sks.yaml
+++ b/config/300-sks.yaml
@@ -27,7 +27,6 @@ spec:
     plural: serverlessservices
     singular: serverlessservice
     categories:
-    - all
     - knative-internal
     - networking
     shortNames:


### PR DESCRIPTION
Currently `kubectl get all` outputs `*.internal.knative.dev`, but it
is not necessary to examine the output in general.

This patch removes `-all` from categories to stop printing
`*.internal.knative.dev` in kubectl get all.

## Proposed Changes

* Stop printing *.internal.knative.dev resources in kubectl get all

**Release Note**

```release-note
NONE
```
