### PR TITLE
This change fixes the panic in the conformance tests.

### DIFF
--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -21,10 +21,10 @@ package v1alpha1
 import (
 	"testing"
 
-	pkgTest "knative.dev/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/test"
 	v1a1test "github.com/knative/serving/test/v1alpha1"
+	pkgTest "knative.dev/pkg/test"
 )
 
 func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, domain string, expectedGeneration, expectedText string) {
@@ -79,12 +79,14 @@ func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, er
 		clients.ServingAlphaClient,
 		names.Route,
 		func(r *v1alpha1.Route) (bool, error) {
+			if r.Status.URL == nil {
+				return false, nil
+			}
 			domain = r.Status.URL.Host
 			return domain != "", nil
 		},
 		"RouteDomain",
 	)
-
 	return domain, err
 }
 

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -21,10 +21,10 @@ package v1beta1
 import (
 	"testing"
 
-	pkgTest "knative.dev/pkg/test"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"github.com/knative/serving/test"
 	v1b1test "github.com/knative/serving/test/v1beta1"
+	pkgTest "knative.dev/pkg/test"
 
 	rtesting "github.com/knative/serving/pkg/testing/v1beta1"
 )
@@ -81,6 +81,9 @@ func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, er
 		clients.ServingBetaClient,
 		names.Route,
 		func(r *v1beta1.Route) (bool, error) {
+			if r.Status.URL == nil {
+				return false, nil
+			}
 			domain = r.Status.URL.Host
 			return domain != "", nil
 		},


### PR DESCRIPTION
This is an example run: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/4604/pull-knative-serving-integration-tests/1146296878313246721
which caused lots of tests to panic here, because knative was serving route without a status (probably took some time
to reconcile).

/assign @dgerd

