### PR TITLE
Fail activation if we exceed a timeout

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -22,9 +22,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/knative/serving/pkg/apis/autoscaling"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/knative/serving/pkg/apis/autoscaling"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
@@ -200,6 +201,12 @@ func (pas *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
 // for at least the specified idle period.
 func (pas *PodAutoscalerStatus) CanMarkInactive(idlePeriod time.Duration) bool {
 	return pas.inStatusFor(corev1.ConditionTrue, idlePeriod)
+}
+
+// CanFailActivation checks whether the pod autoscaler has been activating
+// for at least the specified idle period.
+func (pas *PodAutoscalerStatus) CanFailActivation(idlePeriod time.Duration) bool {
+	return pas.inStatusFor(corev1.ConditionUnknown, idlePeriod)
 }
 
 // inStatusFor returns true if the PodAutoscalerStatus's Active condition has stayed in

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -234,6 +234,7 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 	case want == 0:
 		ret = !pa.Status.IsInactive() // Any state but inactive should change SKS.
 		if pa.Status.IsActivating() {
+			// We only ever scale to zero while activating if we fail to activate within the progress deadline.
 			pa.Status.MarkInactive("TimedOut", "The target could not be activated.")
 		} else {
 			pa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -233,7 +233,11 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 	switch {
 	case want == 0:
 		ret = !pa.Status.IsInactive() // Any state but inactive should change SKS.
-		pa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")
+		if pa.Status.IsActivating() {
+			pa.Status.MarkInactive("TimedOut", "The target could not be activated.")
+		} else {
+			pa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")
+		}
 
 	case got < minReady && want > 0:
 		ret = pa.Status.IsInactive() // If we were inactive and became activating.

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -387,7 +387,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
 		},
 	}, {
-		Name: "activing failure",
+		Name: "activation failure",
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActivating, markOld,

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -148,6 +148,7 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 	}
 
 	if pa.Status.IsActivating() { // Active=Unknown
+		// If we are stuck activating for longer than our progress deadline, presume we cannot succeed and scale to 0.
 		if pa.Status.CanFailActivation(activationTimeout) {
 			ks.logger.Infof("%s activation has timed out after %v.", pa.Name, activationTimeout)
 			return 0, true

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -59,7 +59,7 @@ const (
 	// however, after ProgressDeadlineSeconds, the Deployment itself updates its status, which causes
 	// the Revision to re-reconcile and diagnose pod failures. If we use the same timeout here, we will
 	// race the Revision reconciler and scale down the pods before it can actually surface the pod errors.
-	// We should instead ddo pod failure diagnostics here immediately before scaling down the Deployment.
+	// We should instead do pod failure diagnostics here immediately before scaling down the Deployment.
 	activationTimeoutBuffer = 10 * time.Second
 	activationTimeout       = time.Duration(rresources.ProgressDeadlineSeconds)*time.Second + activationTimeoutBuffer
 )

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -149,7 +149,7 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 
 	if pa.Status.IsActivating() { // Active=Unknown
 		if pa.Status.CanFailActivation(activationTimeout) {
-			ks.logger.Infof("%s activation has timed out after %s.", pa.Name, activationTimeout)
+			ks.logger.Infof("%s activation has timed out after %v.", pa.Name, activationTimeout)
 			return 0, true
 		}
 		ks.enqueueCB(pa, activationTimeout)

--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -31,13 +31,13 @@ const (
 
 	// AppLabelKey is the label defining the application's name.
 	AppLabelKey = "app"
-)
 
-var (
 	// ProgressDeadlineSeconds is the time in seconds we wait for the deployment to
 	// be ready before considering it failed.
 	ProgressDeadlineSeconds = int32(120)
+)
 
+var (
 	// See https://github.com/knative/serving/pull/1124#issuecomment-397120430
 	// for how CPU and memory values were calculated.
 	queueContainerCPU = resource.MustParse("25m")

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -228,7 +228,7 @@ func MakeDeployment(rev *v1alpha1.Revision,
 		Spec: appsv1.DeploymentSpec{
 			Replicas:                ptr.Int32(1),
 			Selector:                makeSelector(rev),
-			ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
+			ProgressDeadlineSeconds: ptr.Int32(ProgressDeadlineSeconds),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      makeLabels(rev),

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -172,7 +172,7 @@ var (
 					serving.RevisionUID: "1234",
 				},
 			},
-			ProgressDeadlineSeconds: &ProgressDeadlineSeconds,
+			ProgressDeadlineSeconds: ptr.Int32(ProgressDeadlineSeconds),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


This partially addresses https://github.com/knative/serving/issues/3456

The KPA reconciler will consider activation to have TimedOut if it is activating (Active=Unknown) for [ProgressDeadlineSeconds](https://github.com/knative/serving/blob/94be2a6a068e41dd6e0144ebb773b98993f52574/pkg/reconciler/revision/resources/constants.go#L37-L39) (this is currently a hardcoded constant, but we might want to make it configurable in the future if we revive https://github.com/knative/serving/issues/810) and scale the deployment to zero, since we don't expect activation to ever succeed.

The Revision reconciler gets triggered after ProgressDeadlineSeconds because the Deployment that it watches will have it status update with Progressing=False,Reason=ProgressDeadlineExceeded. The Revision reconciler currently does pod failure diagnosis, which breaks if the pods get scaled down to zero. To avoid breaking that, the KPA reconciler will wait for ProgressDeadlineSeconds + 10 seconds before scaling to zero, to give the Revision reconciler an opportunity to look at the pod status. In the future we can make the KPA responsible for [pod failure diagnosis](https://github.com/knative/serving/issues/4557) to remove this race (and the 10 second buffer).

This PR is a continuation of https://github.com/knative/serving/pull/4094, but I've split apart the not-scaling-to-zero part from the lifecycle changes to make the PR smaller.