### PR TITLE
Add a job to Prometheus scrape_configs to scrape annotated services

### DIFF
--- a/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
+++ b/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
@@ -379,3 +379,29 @@ data:
         target_label: pod
       - source_labels: [__meta_kubernetes_service_name]
         target_label: service
+
+    - job_name: kubernetes-service-endpoints
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+      - action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: kubernetes_namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: kubernetes_name


### PR DESCRIPTION
Fixes #4616

## Proposed Changes

* Add a general job in Prometheus scrape_configs to scrape all services with an annotation `prometheus.io/scrape: "true"`

**Release Note**

```release-note
NONE
```
