### PR TITLE
Add simple probe cache for the activator.

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -68,12 +68,12 @@ type activationHandler struct {
 
 type probeCache struct {
 	mu     sync.RWMutex
-	probes map[activator.RevisionID]bool
+	probes map[activator.RevisionID]struct{}
 }
 
 func newProbeCache() *probeCache {
 	return &probeCache{
-		probes: map[activator.RevisionID]bool{},
+		probes: map[activator.RevisionID]struct{}{},
 	}
 }
 
@@ -89,7 +89,7 @@ func (pc *probeCache) should(revID activator.RevisionID) bool {
 func (pc *probeCache) mark(revID activator.RevisionID) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
-	pc.probes[revID] = true
+	pc.probes[revID] = struct{}{}
 }
 
 // unmark removes the probe cache entry for the revision.

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -848,7 +848,7 @@ func rtFact(rt http.RoundTripper) func() http.RoundTripper {
 
 func TestProbeCache(t *testing.T) {
 	cache := &probeCache{
-		probes: map[activator.RevisionID]bool{},
+		probes: map[activator.RevisionID]struct{}{},
 	}
 	revID := activator.RevisionID{}
 	if !cache.should(revID) {

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -33,8 +33,6 @@ import (
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
 
-	. "knative.dev/pkg/logging/testing"
-	_ "knative.dev/pkg/system/testing"
 	"github.com/knative/serving/pkg/activator"
 	activatortest "github.com/knative/serving/pkg/activator/testing"
 	nv1a1 "github.com/knative/serving/pkg/apis/networking/v1alpha1"
@@ -49,9 +47,12 @@ import (
 	"github.com/knative/serving/pkg/queue"
 	"github.com/knative/serving/pkg/tracing"
 	tracingconfig "github.com/knative/serving/pkg/tracing/config"
+	. "knative.dev/pkg/logging/testing"
+	_ "knative.dev/pkg/system/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -369,14 +370,14 @@ func TestActivationHandlerOverflow(t *testing.T) {
 	revName := testRevName
 
 	lockerCh := make(chan struct{})
-	fakeRt := activatortest.FakeRoundTripper{
+	fakeRT := activatortest.FakeRoundTripper{
 		LockerCh: lockerCh,
 		RequestResponse: &activatortest.FakeResponse{
 			Code: http.StatusOK,
 			Body: wantBody,
 		},
 	}
-	rt := network.RoundTripperFunc(fakeRt.RT)
+	rt := network.RoundTripperFunc(fakeRT.RT)
 
 	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
 	reporter := &fakeReporter{}
@@ -398,8 +399,13 @@ func TestActivationHandlerOverflow(t *testing.T) {
 	handler.transport = rt
 	handler.probeTransportFactory = rtFact(rt)
 
-	sendRequests(requests, namespace, revName, respCh, *handler)
+	sendRequests(requests, namespace, revName, respCh, handler)
 	assertResponses(wantedSuccess, wantedFailure, requests, lockerCh, respCh, t)
+	// Verify that only some of them did probe. Manual testing shows numbers in the 1-3 range
+	// but to be sure, let's presume one third.
+	if got, want := fakeRT.NumProbes, int32(requests/3); got >= want {
+		t.Errorf("num probes = %d, expect at most: %d", got, want)
+	}
 }
 
 // Make sure if one breaker is overflowed, the requests to other revisions are still served
@@ -444,9 +450,18 @@ func TestActivationHandlerOverflowSeveralRevisions(t *testing.T) {
 
 	for _, revName := range revisions {
 		requestCount := overallRequests / len(revisions)
-		sendRequests(requestCount, testNamespace, revName, respCh, *handler)
+		sendRequests(requestCount, testNamespace, revName, respCh, handler)
 	}
 	assertResponses(wantedSuccess, wantedFailure, overallRequests, lockerCh, respCh, t)
+
+	// Verify that only some of them did probe for each of revisions.
+	if got, want := fakeRT.NumProbes, int32(overallRequests/3); got >= want {
+		t.Errorf("num probes = %d, expect at most: %d", got, want)
+	}
+	// Verify cache size.
+	if got, want := len(handler.cache.probes), 2; got != want {
+		t.Errorf("ProbeCacheSize = %d, want: %d", got, want)
+	}
 }
 
 func TestActivationHandlerProxyHeader(t *testing.T) {
@@ -475,7 +490,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	}
 	probeRt := network.RoundTripperFunc(fakeRT.RT)
 
-	handler := activationHandler{
+	handler := &activationHandler{
 		transport:             rt,
 		probeTransportFactory: rtFact(probeRt),
 		logger:                TestLogger(t),
@@ -484,6 +499,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 		revisionLister:        revisionLister(revision(testNamespace, testRevName)),
 		serviceLister:         serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister:             sksLister(sks(testNamespace, testRevName)),
+		cache:                 newProbeCache(),
 	}
 
 	writer := httptest.NewRecorder()
@@ -541,7 +557,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister(revision(namespace, revName)),
 		TestLogger(t))
 
-	handler := activationHandler{
+	handler := &activationHandler{
 		transport:             rt,
 		probeTransportFactory: rtFact(rt),
 		logger:                TestLogger(t),
@@ -550,6 +566,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister:        revisionLister(revision(testNamespace, testRevName)),
 		serviceLister:         serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister:             sksLister(sks(testNamespace, testRevName)),
+		cache:                 newProbeCache(),
 	}
 	handler.transport = rt
 	handler.probeTransportFactory = rtFact(rt)
@@ -568,7 +585,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 	}
 }
 
-func sendRequest(namespace, revName string, handler activationHandler) *httptest.ResponseRecorder {
+func sendRequest(namespace, revName string, handler *activationHandler) *httptest.ResponseRecorder {
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 	req.Header.Set(activator.RevisionHeaderNamespace, namespace)
@@ -579,7 +596,7 @@ func sendRequest(namespace, revName string, handler activationHandler) *httptest
 
 // sendRequests sends `count` concurrent requests via the given handler and writes
 // the recorded responses to the `respCh`.
-func sendRequests(count int, namespace, revName string, respCh chan *httptest.ResponseRecorder, handler activationHandler) {
+func sendRequests(count int, namespace, revName string, respCh chan *httptest.ResponseRecorder, handler *activationHandler) {
 	for i := 0; i < count; i++ {
 		go func() {
 			respCh <- sendRequest(namespace, revName, handler)
@@ -827,5 +844,38 @@ func errMsg(msg string) string {
 func rtFact(rt http.RoundTripper) func() http.RoundTripper {
 	return func() http.RoundTripper {
 		return rt
+	}
+}
+
+func TestProbeCache(t *testing.T) {
+	tS := time.Now()
+	cache := &probeCache{
+		probes: map[string]time.Time{},
+		clock:  clock.NewFakeClock(tS),
+	}
+	const url = "totes.probes.svc"
+	cache.mark(url)
+
+	// Check at the same time.
+	if cache.should(url) {
+		t.Error("should returned true")
+	}
+	cache.clock = clock.NewFakeClock(tS.Add(time.Second))
+	// Now one more second passed.
+	if cache.should(url) {
+		t.Error("should returned true")
+	}
+
+	cache.clock = clock.NewFakeClock(tS.Add(-probeCacheTimout + time.Millisecond))
+	// Now timeout passed.
+	if !cache.should(url) {
+		t.Error("should returned false")
+	}
+	// Now update.
+	cache.mark(url)
+
+	// And check.
+	if cache.should(url) {
+		t.Error("should returned true")
 	}
 }

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -52,6 +52,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -848,7 +849,7 @@ func rtFact(rt http.RoundTripper) func() http.RoundTripper {
 
 func TestProbeCache(t *testing.T) {
 	cache := &probeCache{
-		probes: map[activator.RevisionID]struct{}{},
+		probes: sets.NewString(),
 	}
 	revID := activator.RevisionID{}
 	if !cache.should(revID) {

--- a/pkg/activator/testing/roundtripper.go
+++ b/pkg/activator/testing/roundtripper.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/queue"
@@ -48,6 +49,8 @@ type FakeRoundTripper struct {
 	// Response to non-probe requests
 	RequestResponse *FakeResponse
 	responseMux     sync.Mutex
+
+	NumProbes int32
 }
 
 func defaultProbeResponse() *FakeResponse {
@@ -91,6 +94,7 @@ func (rt *FakeRoundTripper) popResponse() *FakeResponse {
 // RT is a RoundTripperFunc
 func (rt *FakeRoundTripper) RT(req *http.Request) (*http.Response, error) {
 	if req.Header.Get(network.ProbeHeaderName) != "" {
+		atomic.AddInt32(&rt.NumProbes, 1)
 		resp := rt.popResponse()
 		if resp.Err != nil {
 			return nil, resp.Err

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -256,7 +256,12 @@ func TestThrottlerTry(t *testing.T) {
 				initCapacity)
 
 			if s.addCapacity {
-				throttler.UpdateCapacity(revID, 1)
+				// If we had success updating the capacity > 0, check that it's properly returned.
+				if throttler.UpdateCapacity(revID, 1) == nil {
+					if got, want := throttler.GetRevisionCapacity(revID), 1*10; got != want {
+						t.Errorf("Breaker Capacity = %d, want: %d", got, want)
+					}
+				}
 			}
 			err := throttler.Try(context.Background(), revID, func() {
 				called++


### PR DESCRIPTION
This is a simple probe cache for the activator.
With the target capacity work being introduced we are putting
a lot more traffic via Activator. When we're running the system like this
there is no reason for us to actually probe revision on every request.

The work @greghaynes is doing to make it even more generic (e.g. to listen
to the deployment size) and take it to the next level.

/assign @mattmoor @markuesthoemmes

