### PR TITLE
Short FQDN into spec.hosts of {virtualservice}-mesh if Istio sidecar injected for service only visible within cluster

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -94,7 +94,7 @@ func MakeMeshVirtualService(ia v1alpha1.IngressAccessor) *v1alpha3.VirtualServic
 		Spec: *makeVirtualServiceSpec(ia, map[v1alpha1.IngressVisibility]sets.String{
 			v1alpha1.IngressVisibilityExternalIP:   sets.NewString("mesh"),
 			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("mesh"),
-		}, keepLocalHostnames(getHosts(ia))),
+		}, expandedHosts(keepLocalHostnames(getHosts(ia)))),
 	}
 	// Populate the ClusterIngress labels.
 

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -168,8 +168,6 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Rules: []v1alpha1.IngressRule{{
 				Hosts: []string{
 					"test-route.test-ns.svc.cluster.local",
-					"test-route.test-ns.svc",
-					"test-route.test-ns",
 				},
 				HTTP: &v1alpha1.HTTPIngressRuleValue{
 					Paths: []v1alpha1.HTTPIngressPath{{


### PR DESCRIPTION
Signed-off-by: Wei Yu(Jared) <yuweiw@cn.ibm.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4597 

## Proposed Changes
Short FQDN should be added to spec.hosts in {virtualservice}-mesh when following conditions are satisfied:
* knative serving service with label serving.knative.dev/visibility: "cluster-local"
* istio automatically injection is enabled

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```