### PR TITLE
Enable local routing for public subroutes

### DIFF
--- a/pkg/reconciler/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/route/resources/cluster_ingress_test.go
@@ -122,8 +122,8 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
-			"test-route.test-ns.example.com",
 			"test-route.test-ns.svc.cluster.local",
+			"test-route.test-ns.example.com",
 		},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
 			Paths: []netv1alpha1.HTTPIngressPath{{
@@ -144,6 +144,7 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}, {
 		Hosts: []string{
+			"v1-test-route.test-ns.svc.cluster.local",
 			"v1-test-route.test-ns.example.com",
 		},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
@@ -345,8 +346,8 @@ func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
 		},
 	}
 	expected := []string{
-		"test-route.test-ns.example.com",
 		"test-route.test-ns.svc.cluster.local",
+		"test-route.test-ns.example.com",
 	}
 	domains, err := routeDomains(getContext(), "", r, false)
 	if err != nil {
@@ -374,8 +375,8 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 		},
 	}
 	expected := []string{
-		"test-route.test-ns.example.com",
 		"test-route.test-ns.svc.cluster.local",
+		"test-route.test-ns.example.com",
 	}
 	domains, err := routeDomains(getContext(), "", r, false)
 	if err != nil {
@@ -407,6 +408,7 @@ func TestGetRouteDomains_NamedTarget(t *testing.T) {
 		},
 	}
 	expected := []string{
+		"v1-test-route.test-ns.svc.cluster.local",
 		"v1-test-route.test-ns.example.com",
 	}
 	domains, err := routeDomains(getContext(), name, r, false)

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -292,8 +292,8 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		TLS:        []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
-				domain,
 				"test-route.test.svc.cluster.local",
+				domain,
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
 				Paths: []netv1alpha1.HTTPIngressPath{{
@@ -397,8 +397,8 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		TLS:        []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
-				domain,
 				"test-route.test.svc.cluster.local",
+				domain,
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
 				Paths: []netv1alpha1.HTTPIngressPath{{
@@ -482,8 +482,8 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 		TLS:        []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
-				domain,
 				"test-route.test.svc.cluster.local",
+				domain,
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
 				Paths: []netv1alpha1.HTTPIngressPath{{
@@ -591,8 +591,8 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		TLS:        []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
-				domain,
 				"test-route.test.svc.cluster.local",
+				domain,
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
 				Paths: []netv1alpha1.HTTPIngressPath{{
@@ -620,6 +620,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
+				"test-revision-1-test-route.test.svc.cluster.local",
 				"test-revision-1-test-route.test.test-domain.dev",
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
@@ -641,6 +642,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
+				"test-revision-2-test-route.test.svc.cluster.local",
 				"test-revision-2-test-route.test.test-domain.dev",
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
@@ -719,8 +721,8 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		TLS:        []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
-				domain,
 				"test-route.test.svc.cluster.local",
+				domain,
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
 				Paths: []netv1alpha1.HTTPIngressPath{{
@@ -748,6 +750,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
+				"bar-test-route.test.svc.cluster.local",
 				"bar-test-route.test.test-domain.dev",
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
@@ -769,6 +772,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
+				"foo-test-route.test.svc.cluster.local",
 				"foo-test-route.test.test-domain.dev",
 			},
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -607,8 +607,8 @@ func TestReconcile(t *testing.T) {
 				},
 				WithHosts(
 					0,
-					"different-domain.default.another-example.com",
 					"different-domain.default.svc.cluster.local",
+					"different-domain.default.another-example.com",
 				),
 			),
 		}},

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -1,0 +1,87 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"knative.dev/pkg/test/logstream"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	routeconfig "github.com/knative/serving/pkg/reconciler/route/config"
+	"github.com/knative/serving/test"
+	v1a1test "github.com/knative/serving/test/v1alpha1"
+
+	. "github.com/knative/serving/pkg/testing/v1alpha1"
+)
+
+// In this test, we set up two apps: helloworld and httpproxy.
+// helloworld is a simple app that displays a plaintext string with private visibility.
+// httpproxy is a proxy that redirects request to internal service of helloworld app
+// with {tag}-{route}.{namespace}.svc.cluster.local, or {tag}-{route}.{namespace}.svc, or {tag}-{route}.{namespace}.
+// The expected result is that the request sent to httpproxy app is successfully redirected
+// to helloworld app when trying to communicate via local address only.
+func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descriptive name because routes will fail DNS checks. (Max 64 characters)
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+
+	t.Log("Creating a Service for the helloworld test app.")
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	tag := "current"
+
+	withInternalVisibility := WithServiceLabel(routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
+	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
+		Traffic: []v1alpha1.TrafficTarget{
+			{
+				TrafficTarget: v1beta1.TrafficTarget{
+					Tag:            tag,
+					Percent:        100,
+				},
+			},
+		},
+	})
+
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withInternalVisibility, withTrafficSpec)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	t.Logf("helloworld internal domain is %s.", resources.Route.Status.URL.Host)
+
+	// helloworld app and its route are ready. Running the test cases now.
+	for _, tc := range testCases {
+		domain := fmt.Sprintf("%s-%s", tag, resources.Route.Status.Address.URL.Host)
+		helloworldDomain := strings.TrimSuffix(domain, tc.suffix)
+		t.Run(tc.name, func(t *testing.T) {
+			testProxyToHelloworld(t, clients, helloworldDomain)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4622

This adds local routes to clusteringress when subroutes are publicly visible.