### PR TITLE
Enhance the 'Forwarded' header checker in conformance tests.

### DIFF
--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -128,11 +128,12 @@ type checkForwardedHeader struct {
 	expected string
 }
 
-// token as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6
-var tokenMatcher = regexp.MustCompile(`^[0-9a-zA-Z!#$%&'*+-.^_|~]+$`)
-
-// approximation of quoted-string as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6
-var quotedStringMatcher = regexp.MustCompile(`^"[^"]+"$`)
+var (
+	// token as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6
+	tokenMatcher = regexp.MustCompile(`^[0-9a-zA-Z!#$%&'*+-.^_|~]+$`)
+	// approximation of quoted-string as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6
+	quotedStringMatcher = regexp.MustCompile(`^"[^"]+"$`)
+)
 
 func isDelimiter(r rune) bool {
 	return r == ';' || r == ','


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This test uses an intricate regular-expression to verify the returned Forwarded header roughly conforms to the spec. Unfortunately, it does not account for arbitrary additions (known as extensions to the spec) and trailing delimiters. While trailing delimiters are non-standard, they are unfortunately added by some routers.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @dgerd 
