### PR TITLE
Do some reconciliation of approvers

### DIFF
--- a/cmd/webhook/OWNERS
+++ b/cmd/webhook/OWNERS
@@ -1,0 +1,10 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- serving-api-approvers
+
+reviewers:
+- serving-api-reviewers
+
+labels:
+- area/API

--- a/pkg/http/OWNERS
+++ b/pkg/http/OWNERS
@@ -1,0 +1,10 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- networking-approvers
+
+reviewers:
+- networking-reviewers
+
+labels:
+- area/networking

--- a/pkg/testing/OWNERS
+++ b/pkg/testing/OWNERS
@@ -3,10 +3,14 @@
 approvers:
 - productivity-approvers
 - serving-api-approvers
+- networking-approvers
+- autoscaling-approvers
 
 reviewers:
 - productivity-reviewers
 - serving-api-approvers
+- networking-approvers
+- autoscaling-approvers
 
 labels:
 - area/test-and-release


### PR DESCRIPTION
1. Add serving to the cmd/webhook. This is just main file.
2. HTTP is network protocol, so network approvers (I can also consider move to pkg/network/http)
3. Expand testing to include autoscaling and network approvers/reviewers. Test helper changes really shouldn't require cross group approvals.

/assign @mattmoor

