### PR TITLE
Print error message from WaitForRevisionState in TestMinScale

### DIFF
--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -71,7 +71,7 @@ func TestMinScale(t *testing.T) {
 	revName := config.Status.LatestCreatedRevisionName
 
 	if err = v1a1test.WaitForRevisionState(clients.ServingAlphaClient, revName, v1a1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatal("Revision did not become ready.")
+		t.Fatalf("The Revision %q did not become ready: %v", revName, err)
 	}
 
 	deployment, err := clients.KubeClient.Kube.ExtensionsV1beta1().Deployments(test.ServingNamespace).Get(revName+"-deployment", metav1.GetOptions{})


### PR DESCRIPTION
This patch makes a tiny change which prints error message from
`WaitForRevisionState()`.

Currently `TestMinScale()` is missing the output so it is difficult to
find the reason why test was failed.

/lint

## Proposed Changes

* Print error message from WaitForRevisionState in TestMinScale.

**Release Note**

```release-note
NONE
```
