### PR TITLE
Add queue-metrics to container ports of scrape lists

### DIFF
--- a/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
+++ b/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
@@ -91,7 +91,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_pod_label_serving_knative_dev_revision, __meta_kubernetes_pod_container_port_name]
         action: keep
-        regex: .+;user-metrics
+        regex: .+;(user-metrics|queue-metrics)
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace


### PR DESCRIPTION
Currently there are no `queue_*` in query of Prometheus. This patch
adds queue-metrics to the regex and scrape it.

Fixes https://github.com/knative/serving/issues/4638

## Proposed Changes
* Add queue-metrics to container ports of scrape lists

**Release Note**

```release-note
NONE
```
