### PR TITLE
Stop relying on timers in TimeToFirstByteTimeoutHandler's tests.

### DIFF
--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -41,7 +41,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 	}{{
 		name:    "all good",
 		timeout: longTimeout,
-		handler: func(_ *sync.Mutex, _ chan error) http.Handler {
+		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("hi"))
 			})
@@ -55,7 +55,6 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mux.Lock()
 				defer mux.Unlock()
-				w.WriteHeader(http.StatusOK)
 				_, werr := w.Write([]byte("hi"))
 				writeErrors <- werr
 			})
@@ -66,7 +65,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 	}, {
 		name:    "write then sleep",
 		timeout: 50 * time.Millisecond,
-		handler: func(mux *sync.Mutex, writeErrors chan error) http.Handler {
+		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				time.Sleep(100 * time.Millisecond) // sleep longer than the timeout.
@@ -93,7 +92,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 	}, {
 		name:    "propagate panic",
 		timeout: longTimeout,
-		handler: func(_ *sync.Mutex, _ chan error) http.Handler {
+		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic(http.ErrAbortHandler)
 			})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This test relied on timers to hit a timeout reliably. The values of these timeouts are a compromise between stability of the test and runtime of the test.

This removes the needs for these timers in almost all of the tests and instead relies on locking and waits for however long it takes for signals to propagate through the system.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
