### PR TITLE
Redo breaker tests to ensure consistency and to not rely on polling.

### DIFF
--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -421,7 +421,7 @@ func (r *requestor) expectFailure(t *testing.T) {
 }
 
 // processSuccessfully allows a request to pass the barrier, waits for it to
-// be finished and asserts it to succeeed.
+// be finished and asserts it to succeed.
 func (r *requestor) processSuccessfully(t *testing.T) {
 	t.Helper()
 	r.barrierCh <- struct{}{}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The breaker tests used to rely on a mechnism to poll the internal state of the breaker to eventually become consistent. In a concurrent setting, this is prone to errors and subtle bugs.

This is a complete overhaul of these tests. It relies on the fact that failed requests terminate immediately and that this failure can be used as a mechnism to detect whether the internal state is consistent or not. Essentially, if a request fails it is safe to say that the breaker is at capacity.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 

I hope you'll appreciate this 🙂 
