### PR TITLE
Prepare queue healthHandler for optional aggressive retries

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -253,8 +253,8 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.H
 // Sets up /health and /wait-for-drain endpoints.
 func createAdminHandlers() *http.ServeMux {
 	mux := http.NewServeMux()
-	// @joshrider, temporary change while waiting on other PRs to merge (See #4014)
-	mux.HandleFunc(requestQueueHealthPath, healthState.HealthHandler(probeUserContainer, true))
+	// TODO(@joshrider): temporary change while waiting on other PRs to merge (See #4014)
+	mux.HandleFunc(requestQueueHealthPath, healthState.HealthHandler(probeUserContainer, true /*isNotAggressive*/))
 	mux.HandleFunc(queue.RequestQueueDrainPath, healthState.DrainHandler())
 
 	return mux

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -186,7 +186,11 @@ func probeUserContainer() bool {
 	var err error
 	wait.PollImmediate(50*time.Millisecond, probeTimeout, func() (bool, error) {
 		logger.Debug("TCP probing the user-container.")
-		err = health.TCPProbe(userTargetAddress, 100*time.Millisecond)
+		config := health.TCPProbeConfigOptions{
+			Address:       userTargetAddress,
+			SocketTimeout: 100 * time.Millisecond,
+		}
+		err = health.TCPProbe(config)
 		return err == nil, nil
 	})
 
@@ -249,7 +253,8 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.H
 // Sets up /health and /wait-for-drain endpoints.
 func createAdminHandlers() *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.HandleFunc(requestQueueHealthPath, healthState.HealthHandler(probeUserContainer))
+	// @joshrider, temporary change while waiting on other PRs to merge (See #4014)
+	mux.HandleFunc(requestQueueHealthPath, healthState.HealthHandler(probeUserContainer, true))
 	mux.HandleFunc(queue.RequestQueueDrainPath, healthState.DrainHandler())
 
 	return mux

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -76,7 +76,7 @@ const (
 
 	// Since K8s 1.8, prober requests have
 	//   User-Agent = "kube-probe/{major-version}.{minor-version}".
-	kubeProbeUAPrefix = "kube-probe/"
+	KubeProbeUAPrefix = "kube-probe/"
 
 	// Istio with mTLS rewrites probes, but their probes pass a different
 	// user-agent.  So we augment the probes with this header.
@@ -320,7 +320,7 @@ func checkTagTemplate(t *template.Template) error {
 
 // IsKubeletProbe returns true if the request is a kubernetes probe.
 func IsKubeletProbe(r *http.Request) bool {
-	return strings.HasPrefix(r.Header.Get("User-Agent"), kubeProbeUAPrefix) ||
+	return strings.HasPrefix(r.Header.Get("User-Agent"), KubeProbeUAPrefix) ||
 		r.Header.Get(KubeletProbeHeaderName) != ""
 }
 

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -589,7 +589,7 @@ func TestIsKubeletProbe(t *testing.T) {
 	if IsKubeletProbe(req) {
 		t.Error("Not a kubelet probe but counted as such")
 	}
-	req.Header.Set("User-Agent", kubeProbeUAPrefix+"1.14")
+	req.Header.Set("User-Agent", KubeProbeUAPrefix+"1.14")
 	if !IsKubeletProbe(req) {
 		t.Error("kubelet probe but not counted as such")
 	}

--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -82,10 +82,10 @@ func (h *State) drainFinished() {
 }
 
 // HealthHandler constructs a handler that returns the current state of the
-// health server. If isAggressive is true and prober has succeeded previously,
-// will immediately return success without probing user-container again (until
+// health server. If isNotAggressive is true and prober has succeeded previously,
+// the function return success without probing user-container again (until
 // shutdown).
-func (h *State) HealthHandler(prober func() bool, isAggressive bool) func(w http.ResponseWriter, r *http.Request) {
+func (h *State) HealthHandler(prober func() bool, isNotAggressive bool) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sendAlive := func() {
 			io.WriteString(w, "alive: true")
@@ -97,7 +97,7 @@ func (h *State) HealthHandler(prober func() bool, isAggressive bool) func(w http
 		}
 
 		switch {
-		case isAggressive && h.IsAlive():
+		case isNotAggressive && h.IsAlive():
 			sendAlive()
 		case h.IsShuttingDown():
 			sendNotAlive()

--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -81,9 +81,11 @@ func (h *State) drainFinished() {
 
 }
 
-// HealthHandler constructs a handler that returns the current state of
-// the health server.
-func (h *State) HealthHandler(prober func() bool) func(w http.ResponseWriter, r *http.Request) {
+// HealthHandler constructs a handler that returns the current state of the
+// health server. If isAggressive is true and prober has succeeded previously,
+// will immediately return success without probing user-container again (until
+// shutdown).
+func (h *State) HealthHandler(prober func() bool, isAggressive bool) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sendAlive := func() {
 			io.WriteString(w, "alive: true")
@@ -95,7 +97,7 @@ func (h *State) HealthHandler(prober func() bool) func(w http.ResponseWriter, r 
 		}
 
 		switch {
-		case h.IsAlive():
+		case isAggressive && h.IsAlive():
 			sendAlive()
 		case h.IsShuttingDown():
 			sendNotAlive()

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -66,85 +66,85 @@ func TestHealthStateSetsState(t *testing.T) {
 
 func TestHealthStateHealthHandler(t *testing.T) {
 	tests := []struct {
-		name         string
-		state        *State
-		prober       func() bool
-		isAggressive bool
-		wantStatus   int
-		wantBody     string
+		name            string
+		state           *State
+		prober          func() bool
+		isNotAggressive bool
+		wantStatus      int
+		wantBody        string
 	}{{
-		name:         "alive: true, K-Probe",
-		state:        &State{alive: true},
-		isAggressive: true,
-		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		name:            "alive: true, K-Probe",
+		state:           &State{alive: true},
+		isNotAggressive: true,
+		wantStatus:      http.StatusOK,
+		wantBody:        aliveBody,
 	}, {
-		name:         "alive: false, prober: true, K-Probe",
-		state:        &State{alive: false},
-		prober:       func() bool { return true },
-		isAggressive: true,
-		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		name:            "alive: false, prober: true, K-Probe",
+		state:           &State{alive: false},
+		prober:          func() bool { return true },
+		isNotAggressive: true,
+		wantStatus:      http.StatusOK,
+		wantBody:        aliveBody,
 	}, {
-		name:         "alive: false, prober: false, K-Probe",
-		state:        &State{alive: false},
-		prober:       func() bool { return false },
-		isAggressive: true,
-		wantStatus:   http.StatusBadRequest,
-		wantBody:     notAliveBody,
+		name:            "alive: false, prober: false, K-Probe",
+		state:           &State{alive: false},
+		prober:          func() bool { return false },
+		isNotAggressive: true,
+		wantStatus:      http.StatusBadRequest,
+		wantBody:        notAliveBody,
 	}, {
-		name:         "alive: false, no prober, K-Probe",
-		state:        &State{alive: false},
-		isAggressive: true,
-		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		name:            "alive: false, no prober, K-Probe",
+		state:           &State{alive: false},
+		isNotAggressive: true,
+		wantStatus:      http.StatusOK,
+		wantBody:        aliveBody,
 	}, {
-		name:         "shuttingDown: true, K-Probe",
-		state:        &State{shuttingDown: true},
-		isAggressive: true,
-		wantStatus:   http.StatusBadRequest,
-		wantBody:     notAliveBody,
+		name:            "shuttingDown: true, K-Probe",
+		state:           &State{shuttingDown: true},
+		isNotAggressive: true,
+		wantStatus:      http.StatusBadRequest,
+		wantBody:        notAliveBody,
 	}, {
-		name:         "no prober, shuttingDown: false",
-		state:        &State{},
-		isAggressive: false,
-		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		name:            "no prober, shuttingDown: false",
+		state:           &State{},
+		isNotAggressive: false,
+		wantStatus:      http.StatusOK,
+		wantBody:        aliveBody,
 	}, {
-		name:         "prober: true, shuttingDown: true",
-		state:        &State{shuttingDown: true},
-		prober:       func() bool { return true },
-		isAggressive: false,
-		wantStatus:   http.StatusBadRequest,
-		wantBody:     notAliveBody,
+		name:            "prober: true, shuttingDown: true",
+		state:           &State{shuttingDown: true},
+		prober:          func() bool { return true },
+		isNotAggressive: false,
+		wantStatus:      http.StatusBadRequest,
+		wantBody:        notAliveBody,
 	}, {
-		name:         "prober: true, shuttingDown: false",
-		state:        &State{},
-		prober:       func() bool { return true },
-		isAggressive: false,
-		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		name:            "prober: true, shuttingDown: false",
+		state:           &State{},
+		prober:          func() bool { return true },
+		isNotAggressive: false,
+		wantStatus:      http.StatusOK,
+		wantBody:        aliveBody,
 	}, {
-		name:         "prober: false, shuttingDown: false",
-		state:        &State{},
-		prober:       func() bool { return false },
-		isAggressive: false,
-		wantStatus:   http.StatusBadRequest,
-		wantBody:     notAliveBody,
+		name:            "prober: false, shuttingDown: false",
+		state:           &State{},
+		prober:          func() bool { return false },
+		isNotAggressive: false,
+		wantStatus:      http.StatusBadRequest,
+		wantBody:        notAliveBody,
 	}, {
-		name:         "prober: false, shuttingDown: true",
-		state:        &State{},
-		prober:       func() bool { return false },
-		isAggressive: false,
-		wantStatus:   http.StatusBadRequest,
-		wantBody:     notAliveBody,
+		name:            "prober: false, shuttingDown: true",
+		state:           &State{},
+		prober:          func() bool { return false },
+		isNotAggressive: false,
+		wantStatus:      http.StatusBadRequest,
+		wantBody:        notAliveBody,
 	}, {
-		name:         "alive: true, prober: false, shuttingDown: false",
-		state:        &State{alive: true},
-		prober:       func() bool { return false },
-		isAggressive: false,
-		wantStatus:   http.StatusBadRequest,
-		wantBody:     notAliveBody,
+		name:            "alive: true, prober: false, shuttingDown: false",
+		state:           &State{alive: true},
+		prober:          func() bool { return false },
+		isNotAggressive: false,
+		wantStatus:      http.StatusBadRequest,
+		wantBody:        notAliveBody,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestHealthStateHealthHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(test.state.HealthHandler(test.prober, test.isAggressive))
+			handler := http.HandlerFunc(test.state.HealthHandler(test.prober, test.isNotAggressive))
 
 			handler.ServeHTTP(rr, req)
 

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -66,38 +66,85 @@ func TestHealthStateSetsState(t *testing.T) {
 
 func TestHealthStateHealthHandler(t *testing.T) {
 	tests := []struct {
-		name       string
-		state      *State
-		prober     func() bool
-		wantStatus int
-		wantBody   string
+		name         string
+		state        *State
+		prober       func() bool
+		isAggressive bool
+		wantStatus   int
+		wantBody     string
 	}{{
-		name:       "alive: true",
-		state:      &State{alive: true},
-		wantStatus: http.StatusOK,
-		wantBody:   aliveBody,
+		name:         "alive: true, K-Probe",
+		state:        &State{alive: true},
+		isAggressive: true,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:       "alive: false, prober: true",
-		state:      &State{alive: false},
-		prober:     func() bool { return true },
-		wantStatus: http.StatusOK,
-		wantBody:   aliveBody,
+		name:         "alive: false, prober: true, K-Probe",
+		state:        &State{alive: false},
+		prober:       func() bool { return true },
+		isAggressive: true,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:       "alive: false, prober: false",
-		state:      &State{alive: false},
-		prober:     func() bool { return false },
-		wantStatus: http.StatusBadRequest,
-		wantBody:   notAliveBody,
+		name:         "alive: false, prober: false, K-Probe",
+		state:        &State{alive: false},
+		prober:       func() bool { return false },
+		isAggressive: true,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}, {
-		name:       "alive: false, no prober",
-		state:      &State{alive: false},
-		wantStatus: http.StatusOK,
-		wantBody:   aliveBody,
+		name:         "alive: false, no prober, K-Probe",
+		state:        &State{alive: false},
+		isAggressive: true,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:       "shuttingDown: true",
-		state:      &State{shuttingDown: true},
-		wantStatus: http.StatusBadRequest,
-		wantBody:   notAliveBody,
+		name:         "shuttingDown: true, K-Probe",
+		state:        &State{shuttingDown: true},
+		isAggressive: true,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
+	}, {
+		name:         "no prober, shuttingDown: false",
+		state:        &State{},
+		isAggressive: false,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
+	}, {
+		name:         "prober: true, shuttingDown: true",
+		state:        &State{shuttingDown: true},
+		prober:       func() bool { return true },
+		isAggressive: false,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
+	}, {
+		name:         "prober: true, shuttingDown: false",
+		state:        &State{},
+		prober:       func() bool { return true },
+		isAggressive: false,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
+	}, {
+		name:         "prober: false, shuttingDown: false",
+		state:        &State{},
+		prober:       func() bool { return false },
+		isAggressive: false,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
+	}, {
+		name:         "prober: false, shuttingDown: true",
+		state:        &State{},
+		prober:       func() bool { return false },
+		isAggressive: false,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
+	}, {
+		name:         "alive: true, prober: false, shuttingDown: false",
+		state:        &State{alive: true},
+		prober:       func() bool { return false },
+		isAggressive: false,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -107,7 +154,7 @@ func TestHealthStateHealthHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(test.state.HealthHandler(test.prober))
+			handler := http.HandlerFunc(test.state.HealthHandler(test.prober, test.isAggressive))
 
 			handler.ServeHTTP(rr, req)
 

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/knative/serving/pkg/network"
-	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -34,6 +33,8 @@ import (
 type HTTPProbeConfigOptions struct {
 	Timeout time.Duration
 	*corev1.HTTPGetAction
+	KubeMajor string
+	KubeMinor string
 }
 
 // TCPProbeConfigOptions holds the TCP probe config options
@@ -75,7 +76,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 		return fmt.Errorf("error constructing probe request %v", err)
 	}
 
-	req.Header.Add(network.KubeletProbeHeaderName, queue.Name)
+	req.Header.Add("User-Agent", network.KubeProbeUAPrefix+config.KubeMajor+"/"+config.KubeMinor)
 
 	for _, header := range config.HTTPHeaders {
 		req.Header.Add(header.Name, header.Value)

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -25,6 +25,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/knative/serving/pkg/network"
+	"github.com/knative/serving/pkg/queue"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -73,6 +75,8 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 		return fmt.Errorf("error constructing probe request %v", err)
 	}
 
+	req.Header.Add(network.KubeletProbeHeaderName, queue.Name)
+
 	for _, header := range config.HTTPHeaders {
 		req.Header.Add(header.Name, header.Value)
 	}
@@ -83,7 +87,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	}
 
 	if !IsHTTPProbeReady(res) {
-		return errors.New("HTTP probe did not respond Ready")
+		return errors.New(fmt.Sprintf("HTTP probe did not respond Ready, got status code: %d", res.StatusCode))
 	}
 
 	return nil

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -17,18 +17,79 @@ limitations under the License.
 package health
 
 import (
+	"crypto/tls"
+	"errors"
+	"fmt"
 	"net"
+	"net/http"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
+
+// HTTPProbeConfigOptions holds the HTTP probe config options
+type HTTPProbeConfigOptions struct {
+	Timeout time.Duration
+	*corev1.HTTPGetAction
+}
+
+// TCPProbeConfigOptions holds the TCP probe config options
+type TCPProbeConfigOptions struct {
+	SocketTimeout time.Duration
+	Address       string
+}
 
 // TCPProbe checks that a TCP socket to the address can be opened.
 // Did not reuse k8s.io/kubernetes/pkg/probe/tcp to not create a dependency
 // on klog.
-func TCPProbe(addr string, socketTimeout time.Duration) error {
-	conn, err := net.DialTimeout("tcp", addr, socketTimeout)
+func TCPProbe(config TCPProbeConfigOptions) error {
+	conn, err := net.DialTimeout("tcp", config.Address, config.SocketTimeout)
 	if err != nil {
 		return err
 	}
 	conn.Close()
 	return nil
+}
+
+// HTTPProbe checks that HTTP connection can be established to the address.
+func HTTPProbe(config HTTPProbeConfigOptions) error {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+		Timeout: config.Timeout,
+	}
+	url := fmt.Sprintf("%s://%s:%d%s", config.Scheme, config.Host, config.Port.IntValue(), config.Path)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("Error constructing request %s", err.Error())
+	}
+
+	for _, header := range config.HTTPHeaders {
+		req.Header.Add(header.Name, header.Value)
+	}
+
+	var res *http.Response
+	res, err = httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if !IsHTTPProbeReady(res) {
+		return errors.New("http probe did not respond Ready")
+	}
+
+	return nil
+}
+
+func IsHTTPProbeReady(res *http.Response) bool {
+	if res == nil {
+		return false
+	}
+
+	// response status code between 200-399 indicates success
+	return res.StatusCode >= 200 && res.StatusCode < 400
 }

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -85,6 +85,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	return nil
 }
 
+// IsHTTPProbeReady checks whether we received a successful Response
 func IsHTTPProbeReady(res *http.Response) bool {
 	if res == nil {
 		return false

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -19,8 +19,13 @@ package health
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestTCPProbe(t *testing.T) {
@@ -28,16 +33,149 @@ func TestTCPProbe(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
-	serverAddr := server.Listener.Addr().String()
-
+	config := TCPProbeConfigOptions{
+		Address:       server.Listener.Addr().String(),
+		SocketTimeout: time.Second,
+	}
 	// Connecting to the server should work
-	if err := TCPProbe(serverAddr, 1*time.Second); err != nil {
+	if err := TCPProbe(config); err != nil {
 		t.Errorf("Expected probe to succeed but it failed with %v", err)
 	}
 
 	// Close the server so probing fails afterwards
 	server.Close()
-	if err := TCPProbe(serverAddr, 1*time.Second); err == nil {
+	if err := TCPProbe(config); err == nil {
 		t.Error("Expected probe to fail but it didn't")
+	}
+}
+
+func TestHTTPProbeSuccess(t *testing.T) {
+	var gotHeader corev1.HTTPHeader
+	expectedHeader := corev1.HTTPHeader{
+		Name:  "Testkey",
+		Value: "Testval",
+	}
+	var gotPath string
+	expectedPath := "/health"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for headerKey, headerValue := range r.Header {
+			// Flitering for expectedHeader.TestKey to avoid other HTTP probe headers
+			if expectedHeader.Name == headerKey {
+				gotHeader = corev1.HTTPHeader{Name: headerKey, Value: headerValue[0]}
+			}
+		}
+
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	httpGetAction := newHTTPGetAction(t, server.URL)
+	httpGetAction.Path = expectedPath
+	httpGetAction.HTTPHeaders = []corev1.HTTPHeader{expectedHeader}
+
+	config := HTTPProbeConfigOptions{
+		Timeout:       time.Second,
+		HTTPGetAction: httpGetAction,
+	}
+	// Connecting to the server should work
+	if err := HTTPProbe(config); err != nil {
+		t.Errorf("Expected probe to succeed but it failed with %v", err)
+	}
+	if d := cmp.Diff(gotHeader, expectedHeader); d != "" {
+		t.Errorf("Expected probe headers to match but got %s", d)
+	}
+	if !cmp.Equal(gotPath, expectedPath) {
+		t.Errorf("Expected %s path to match but got %s", expectedPath, gotPath)
+	}
+	// Close the server so probing fails afterwards
+	server.Close()
+	if err := HTTPProbe(config); err == nil {
+		t.Error("Expected probe to fail but it didn't")
+	}
+}
+
+func TestHTTPsSchemeProbeSuccess(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := HTTPProbeConfigOptions{
+		Timeout:       time.Second,
+		HTTPGetAction: newHTTPGetAction(t, server.URL),
+	}
+	// Connecting to the server should work
+	if err := HTTPProbe(config); err != nil {
+		t.Errorf("Expected probe to succeed but it failed with %v", err)
+	}
+
+	// Close the server so probing fails afterwards
+	server.Close()
+	if err := HTTPProbe(config); err == nil {
+		t.Error("Expected probe to fail but it didn't")
+	}
+}
+
+func TestHTTPProbeTimeoutFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := HTTPProbeConfigOptions{
+		Timeout:       time.Second,
+		HTTPGetAction: newHTTPGetAction(t, server.URL),
+	}
+	if err := HTTPProbe(config); err == nil {
+		t.Error("Expected probe to fail but it successded")
+	}
+}
+
+func TestHTTPProbeResponseStatusCodeFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	config := HTTPProbeConfigOptions{
+		Timeout:       time.Second,
+		HTTPGetAction: newHTTPGetAction(t, server.URL),
+	}
+	if err := HTTPProbe(config); err == nil {
+		t.Error("Expected probe to fail but it successded")
+	}
+}
+
+func TestHTTPProbeResponseErrorFailure(t *testing.T) {
+	config := HTTPProbeConfigOptions{
+		HTTPGetAction: newHTTPGetAction(t, "http://localhost:0"),
+	}
+	if err := HTTPProbe(config); err == nil {
+		t.Error("Expected probe to fail but it successded")
+	}
+}
+
+func newHTTPGetAction(t *testing.T, serverURL string) *corev1.HTTPGetAction {
+	urlParsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("Error parsing URL")
+	}
+	port := intstr.FromString(urlParsed.Port())
+
+	var uriScheme corev1.URIScheme
+	switch urlParsed.Scheme {
+	case "http":
+		uriScheme = corev1.URISchemeHTTP
+	case "https":
+		uriScheme = corev1.URISchemeHTTPS
+	default:
+		t.Fatalf("Unsupported scheme %s", urlParsed.Scheme)
+	}
+
+	return &corev1.HTTPGetAction{
+		Host:   urlParsed.Hostname(),
+		Port:   port,
+		Scheme: uriScheme,
 	}
 }


### PR DESCRIPTION
Co-authored-by: Shash Reddy <shashwathireddy@gmail.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Support #4014
One of many parts, spun out from #4600 

## Proposed Changes

* Update queue health package to include TCP and HTTP retries and pave way for user-defined readinessProbes from the queue-proxy.
* Following PRs will use this package.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
