### PR TITLE
Validate window annotation in the webhook.

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -107,6 +107,18 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},
 		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
+		name:        "window invalid",
+		annotations: map[string]string{WindowAnnotationKey: "jerry-was-a-racecar-driver"},
+		expectErr:   "invalid value: jerry-was-a-racecar-driver: autoscaling.knative.dev/window",
+	}, {
+		name:        "window too short",
+		annotations: map[string]string{WindowAnnotationKey: "1s"},
+		expectErr:   "expected 6s <= 1s <= 1h0m0s: autoscaling.knative.dev/window",
+	}, {
+		name:        "window too long",
+		annotations: map[string]string{WindowAnnotationKey: "365h"},
+		expectErr:   "expected 6s <= 365h <= 1h0m0s: autoscaling.knative.dev/window",
+	}, {
 		name: "all together now fail",
 		annotations: map[string]string{
 			PanicThresholdPercentageAnnotationKey: "fifty",
@@ -122,6 +134,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			PanicWindowPercentageAnnotationKey:    "75",
 			MinScaleAnnotationKey:                 "5",
 			MaxScaleAnnotationKey:                 "8",
+			WindowAnnotationKey:                   "1984s",
 		},
 	}}
 

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -77,6 +77,10 @@ const (
 	// isn't going to work well.
 	WindowMin = 6 * time.Second
 
+	// WindowMax is the maximum permitted stable autoscaling window.
+	// This keeps the event horizon to a resonable enough limit.
+	WindowMax = 1 * time.Hour
+
 	// PanicWindowPercentageAnnotationKey is the annotation to
 	// specify the time interval over which to calculate the average
 	// metric during a spike. Where a spike is defined as the metric

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -101,13 +101,8 @@ func (pa *PodAutoscaler) Target() (float64, bool) {
 // Window returns the window annotation value or false if not present.
 func (pa *PodAutoscaler) Window() (window time.Duration, ok bool) {
 	if s, ok := pa.Annotations[autoscaling.WindowAnnotationKey]; ok {
-		d, err := time.ParseDuration(s)
-		if err != nil {
-			return 0, false
-		}
-		if d < autoscaling.WindowMin {
-			return 0, false
-		}
+		// The value is already validated in the webhook.
+		d, _ := time.ParseDuration(s)
 		return d, true
 	}
 	return 0, false
@@ -115,20 +110,15 @@ func (pa *PodAutoscaler) Window() (window time.Duration, ok bool) {
 
 // PanicWindowPercentage returns panic window annotation value or false if not present.
 func (pa *PodAutoscaler) PanicWindowPercentage() (percentage float64, ok bool) {
+	// The value is validated in the webhook.
 	percentage, ok = pa.annotationFloat64(autoscaling.PanicWindowPercentageAnnotationKey)
-	if !ok || percentage > autoscaling.PanicWindowPercentageMax ||
-		percentage < autoscaling.PanicWindowPercentageMin {
-		return 0, false
-	}
 	return percentage, ok
 }
 
 // PanicThresholdPercentage return the panic target annotation value or false if not present.
 func (pa *PodAutoscaler) PanicThresholdPercentage() (percentage float64, ok bool) {
+	// The value is validated in the webhook.
 	percentage, ok = pa.annotationFloat64(autoscaling.PanicThresholdPercentageAnnotationKey)
-	if !ok || percentage < autoscaling.PanicThresholdPercentageMin {
-		return 0, false
-	}
 	return percentage, ok
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -102,8 +102,8 @@ func (pa *PodAutoscaler) Target() (float64, bool) {
 func (pa *PodAutoscaler) Window() (window time.Duration, ok bool) {
 	if s, ok := pa.Annotations[autoscaling.WindowAnnotationKey]; ok {
 		// The value is already validated in the webhook.
-		d, _ := time.ParseDuration(s)
-		return d, true
+		d, err := time.ParseDuration(s)
+		return d, err == nil
 	}
 	return 0, false
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -623,6 +623,13 @@ func TestWindowAnnotation(t *testing.T) {
 		}),
 		wantWindow: time.Second * 120,
 		wantOk:     true,
+	}, {
+		name: "invalid",
+		pa: pa(map[string]string{
+			autoscaling.WindowAnnotationKey: "365d",
+		}),
+		wantWindow: 0,
+		wantOk:     false,
 	}}
 
 	for _, tc := range cases {

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -386,6 +386,13 @@ func TestTargetAnnotation(t *testing.T) {
 		wantTarget: 1,
 		wantOk:     true,
 	}, {
+		name: "present float",
+		pa: pa(map[string]string{
+			autoscaling.TargetAnnotationKey: "19.82",
+		}),
+		wantTarget: 19.82,
+		wantOk:     true,
+	}, {
 		name: "invalid zero",
 		pa: pa(map[string]string{
 			autoscaling.TargetAnnotationKey: "0",
@@ -616,20 +623,6 @@ func TestWindowAnnotation(t *testing.T) {
 		}),
 		wantWindow: time.Second * 120,
 		wantOk:     true,
-	}, {
-		name: "invalid too small",
-		pa: pa(map[string]string{
-			autoscaling.WindowAnnotationKey: "1s",
-		}),
-		wantWindow: 0,
-		wantOk:     false,
-	}, {
-		name: "invalid format",
-		pa: pa(map[string]string{
-			autoscaling.WindowAnnotationKey: "sandwich",
-		}),
-		wantWindow: 0,
-		wantOk:     false,
 	}}
 
 	for _, tc := range cases {
@@ -663,20 +656,6 @@ func TestPanicWindowPercentageAnnotation(t *testing.T) {
 		}),
 		wantPercentage: 10.0,
 		wantOk:         true,
-	}, {
-		name: "too large",
-		pa: pa(map[string]string{
-			autoscaling.PanicWindowPercentageAnnotationKey: "150.0",
-		}),
-		wantPercentage: 0.0,
-		wantOk:         false,
-	}, {
-		name: "too small",
-		pa: pa(map[string]string{
-			autoscaling.PanicWindowPercentageAnnotationKey: "0.0",
-		}),
-		wantPercentage: 0.0,
-		wantOk:         false,
 	}, {
 		name: "malformed",
 		pa: pa(map[string]string{
@@ -717,13 +696,6 @@ func TestPanicThresholdPercentage(t *testing.T) {
 		}),
 		wantPercentage: 300.0,
 		wantOk:         true,
-	}, {
-		name: "too small",
-		pa: pa(map[string]string{
-			autoscaling.PanicThresholdPercentageAnnotationKey: "100.0",
-		}),
-		wantPercentage: 0.0,
-		wantOk:         false,
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
1. make window annotation happen in the webhook, which will prohibit setting invlid things in the first place (and then silently overriding them with the defaults/configmap)
2. also remove validation from the lifecycle code, since we can be sure that values are already validated at this point.

/assign @dgerd @mattmoor 