### PR TITLE
Some minor optimizations to how we format host:port strings.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/knative/serving/cmd/util"
@@ -81,7 +82,7 @@ const (
 	breakerMaxConcurrency = 1000
 
 	// The port on which autoscaler WebSocket server listens.
-	autoscalerPort = 8080
+	autoscalerPort = ":8080"
 
 	defaultResyncInterval = 10 * time.Hour
 )
@@ -203,8 +204,8 @@ func main() {
 	configStore := activatorconfig.NewStore(createdLogger, tracerUpdater)
 	configStore.WatchConfigs(configMapWatcher)
 
-	// Open a websocket connection to the autoscaler
-	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.%s:%d", "autoscaler", system.Namespace(), network.GetClusterDomainName(), autoscalerPort)
+	// Open a WebSocket connection to the autoscaler.
+	autoscalerEndpoint := fmt.Sprintf("ws://%s.%s.svc.%s%s", "autoscaler", system.Namespace(), network.GetClusterDomainName(), autoscalerPort)
 	logger.Info("Connecting to autoscaler at", autoscalerEndpoint)
 	statSink := websocket.NewDurableSendingConnection(autoscalerEndpoint, logger)
 	go statReporter(statSink, stopCh, statChan, logger)
@@ -250,8 +251,8 @@ func main() {
 	}
 
 	servers := map[string]*http.Server{
-		"http1": network.NewServer(fmt.Sprintf(":%d", networking.BackendHTTPPort), ah),
-		"h2c":   network.NewServer(fmt.Sprintf(":%d", networking.BackendHTTP2Port), ah),
+		"http1": network.NewServer(":"+strconv.Itoa(networking.BackendHTTPPort), ah),
+		"h2c":   network.NewServer(":"+strconv.Itoa(networking.BackendHTTP2Port), ah),
 	}
 
 	errCh := make(chan error, len(servers))

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -144,7 +144,7 @@ func initEnv() {
 	servingRevision = util.GetRequiredEnvOrFatal("SERVING_REVISION", logger)
 	servingService = os.Getenv("SERVING_SERVICE") // KService is optional
 	userTargetPort = util.MustParseIntEnvOrFatal("USER_PORT", logger)
-	userTargetAddress = fmt.Sprintf("127.0.0.1:%d", userTargetPort)
+	userTargetAddress = "127.0.0.1:" + strconv.Itoa(userTargetPort)
 	userContainerName = util.GetRequiredEnvOrFatal("USER_CONTAINER_NAME", logger)
 
 	enableVarLogCollection, _ = strconv.ParseBool(os.Getenv("ENABLE_VAR_LOG_COLLECTION")) // Optional, default is false
@@ -354,7 +354,7 @@ func main() {
 	}, time.Now())
 
 	adminServer := &http.Server{
-		Addr:    fmt.Sprintf(":%d", networking.QueueAdminPort),
+		Addr:    ":" + strconv.Itoa(networking.QueueAdminPort),
 		Handler: createAdminHandlers(),
 	}
 
@@ -384,8 +384,9 @@ func main() {
 	if metricsSupported {
 		composedHandler = pushRequestMetricHandler(composedHandler, requestCountM, responseTimeInMsecM)
 	}
-	logger.Infof("Queue-proxy will listen on port %d", queueServingPort)
-	server := network.NewServer(fmt.Sprintf(":%d", queueServingPort), composedHandler)
+	qSP := strconv.Itoa(queueServingPort)
+	logger.Info("Queue-proxy will listen on port ", qSP)
+	server := network.NewServer(":"+qSP, composedHandler)
 
 	errChan := make(chan error, 2)
 	defer close(errChan)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
@@ -316,9 +317,7 @@ func (a *activationHandler) serviceHostName(rev *v1alpha1.Revision, serviceName 
 		return "", errors.New("revision needs external HTTP port")
 	}
 
-	serviceFQDN := network.GetServiceHostname(serviceName, rev.Namespace)
-
-	return fmt.Sprintf("%s:%d", serviceFQDN, port), nil
+	return network.GetServiceHostname(serviceName, rev.Namespace) + ":" + strconv.Itoa(port), nil
 }
 
 func sendError(err error, w http.ResponseWriter) {


### PR DESCRIPTION
In most cases we can avoid sprintf, which only for the means of formatting integer runs 4x slower than atoi,
pile in additional memory for parsing the request string, etc.

So do just that.

Also some ports were always used as strings, so define the constant as string, rather than as number.

/assign @tcnghia 