### PR TITLE
Move v1beta1 specific test into v1beta1 specific package.

### DIFF
--- a/test/conformance/api/v1beta1/migration_test.go
+++ b/test/conformance/api/v1beta1/migration_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package v1beta1
 
 import (
 	"encoding/json"
@@ -37,7 +37,7 @@ func TestV1beta1Translation(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	clients := Setup(t)
+	clients := test.Setup(t)
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
@@ -72,7 +72,7 @@ func TestV1beta1Rejection(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	clients := Setup(t)
+	clients := test.Setup(t)
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This test does not correctly work against a deployment which does not have the v1beta1 endpoints enabled.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
