### PR TITLE
golang format tools

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path"
-        "strconv"
+	"strconv"
 	"strings"
 	"time"
 

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -85,8 +85,8 @@ func MakeMeshVirtualService(ia v1alpha1.IngressAccessor) *v1alpha3.VirtualServic
 			Annotations:     ia.GetAnnotations(),
 		},
 		Spec: *makeVirtualServiceSpec(ia, map[v1alpha1.IngressVisibility][]string{
-			v1alpha1.IngressVisibilityExternalIP:   []string{"mesh"},
-			v1alpha1.IngressVisibilityClusterLocal: []string{"mesh"},
+			v1alpha1.IngressVisibilityExternalIP:   {"mesh"},
+			v1alpha1.IngressVisibilityClusterLocal: {"mesh"},
 		}, retainLocals(getHosts(ia))),
 	}
 	// Populate the ClusterIngress labels.

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -57,7 +57,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			},
 			Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
 				Visibility: v1alpha1.IngressVisibilityExternalIP,
-				HTTP: &v1alpha1.HTTPIngressRuleValue{},
+				HTTP:       &v1alpha1.HTTPIngressRuleValue{},
 			}}},
 		},
 		expected: []metav1.ObjectMeta{{

--- a/pkg/reconciler/route/resources/filters_test.go
+++ b/pkg/reconciler/route/resources/filters_test.go
@@ -16,10 +16,11 @@ limitations under the License.
 package resources
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/knative/serving/pkg/reconciler/route/config"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/serving/pkg/reconciler/route/config"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/reconciler/route/resources/labels/labels_test.go
+++ b/pkg/reconciler/route/resources/labels/labels_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package labels
 
 import (
-	"github.com/knative/serving/pkg/reconciler/route/config"
 	"testing"
+
+	"github.com/knative/serving/pkg/reconciler/route/config"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
