### PR TITLE
Queue ReadinessProbe Kubelet Header e2e Test

### DIFF
--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -1,0 +1,59 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/knative/serving/test"
+	v1a1test "github.com/knative/serving/test/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/test/logstream"
+)
+
+func TestProbeRuntime(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "runtime",
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	t.Log("Creating a new Service")
+	_, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
+		RevisionTemplateAnnotations: map[string]string{},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+}


### PR DESCRIPTION
    - e2e test verifies that readiness probe receives kube-probe header

Co-authored-by: Joshua Rider <jrider@pivotal.io>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Supports #4649 

## Proposed Changes

* changes the `/_healthz` endpoint of the `runtime` test image to `/healthz`.
* changes `/healthz` path of `runtime` test image to return HTTP Status 400 if kubelet's User-Agent headers are not present
* adds an end-to-end test with a `ReadinessProbe` hitting `runtime`'s `/healthz` path to verify the queue-proxy's addition of kubelet's User-Agent header


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
