### PR TITLE
Add queue readiness probe package

### DIFF
--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -41,7 +41,7 @@ func TestTCPProbe(t *testing.T) {
 	}
 	// Connecting to the server should work
 	if err := TCPProbe(config); err != nil {
-		t.Errorf("Expected probe to succeed but failed with error %v", err)
+		t.Errorf("Probe failed with: %v", err)
 	}
 
 	// Close the server so probing fails afterwards

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -41,7 +41,7 @@ func TestTCPProbe(t *testing.T) {
 	}
 	// Connecting to the server should work
 	if err := TCPProbe(config); err != nil {
-		t.Errorf("Expected probe to succeed but it failed with %v", err)
+		t.Errorf("Expected probe to succeed but failed with error %v", err)
 	}
 
 	// Close the server so probing fails afterwards
@@ -116,7 +116,7 @@ func TestHTTPsSchemeProbeSuccess(t *testing.T) {
 	}
 	// Connecting to the server should work
 	if err := HTTPProbe(config); err != nil {
-		t.Errorf("Expected probe to succeed but it failed with %v", err)
+		t.Errorf("Expected probe to succeed but failed with error %v", err)
 	}
 
 	// Close the server so probing fails afterwards
@@ -138,7 +138,7 @@ func TestHTTPProbeTimeoutFailure(t *testing.T) {
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
 	}
 	if err := HTTPProbe(config); err == nil {
-		t.Error("Expected probe to fail but it successded")
+		t.Error("Expected probe to fail but it succeeded")
 	}
 }
 
@@ -153,7 +153,7 @@ func TestHTTPProbeResponseStatusCodeFailure(t *testing.T) {
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
 	}
 	if err := HTTPProbe(config); err == nil {
-		t.Error("Expected probe to fail but it successded")
+		t.Error("Expected probe to fail but it succeeded")
 	}
 }
 
@@ -162,7 +162,7 @@ func TestHTTPProbeResponseErrorFailure(t *testing.T) {
 		HTTPGetAction: newHTTPGetAction(t, "http://localhost:0"),
 	}
 	if err := HTTPProbe(config); err == nil {
-		t.Error("Expected probe to fail but it successded")
+		t.Error("Expected probe to fail but it succeeded")
 	}
 }
 

--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	aggressiveProbeTimeout = 100 * time.Millisecond
-	// Set equal to the queue-proxy's ExecProbe timeout to take
+	// PollTimeout is set equal to the queue-proxy's ExecProbe timeout to take
 	// advantage of the full window
 	PollTimeout   = 10 * time.Second
 	retryInterval = 50 * time.Millisecond

--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/knative/serving/pkg/queue/health"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	aggressiveProbeTimeout = 100 * time.Millisecond
+	// Set equal to the queue-proxy's ExecProbe timeout to take
+	// advantage of the full window
+	PollTimeout   = 10 * time.Second
+	retryInterval = 50 * time.Millisecond
+)
+
+// Probe wraps a corev1.Probe along with a logger and a count of consecutive, successful probes
+type Probe struct {
+	*corev1.Probe
+	count  int32
+	logger *zap.SugaredLogger
+}
+
+// NewProbe returns a pointer a new Probe
+func NewProbe(v1p *corev1.Probe, logger *zap.SugaredLogger) *Probe {
+	return &Probe{
+		Probe:  v1p,
+		logger: logger,
+	}
+}
+
+// IsAggressive indicates whether the Knative probe with aggressive retries should be used.
+func (p *Probe) IsAggressive() bool {
+	return p.PeriodSeconds == 0
+}
+
+// ProbeContainer executes the defined Probe against the user-container
+func (p *Probe) ProbeContainer() bool {
+	var err error
+
+	if p.HTTPGet != nil {
+		err = p.httpProbe()
+	} else if p.TCPSocket != nil {
+		err = p.tcpProbe()
+	} else if p.Exec != nil {
+		// Assumes the true readinessProbe is being executed directly on user container. See (#4086).
+		return true
+	} else {
+		// using Fprintf for a concise error message in the event log
+		fmt.Fprint(os.Stderr, "no probe found")
+		return false
+	}
+
+	if err != nil {
+		p.logger.Errorw("User-container could not be probed successfully.", zap.Error(err))
+		return false
+	}
+
+	p.logger.Info("User-container successfully probed.")
+	return true
+}
+
+// tcpProbe function executes TCP probe once if its standard probe
+// otherwise TCP probe polls condition function which returns true
+// if the probe count is greater than success threshold and false if TCP probe fails
+func (p *Probe) tcpProbe() error {
+	config := health.TCPProbeConfigOptions{
+		Address:       fmt.Sprintf("%s:%d", p.TCPSocket.Host, p.TCPSocket.Port.IntValue()),
+		SocketTimeout: time.Duration(p.TimeoutSeconds) * time.Second,
+	}
+
+	if p.IsAggressive() {
+		// timeout quickly so we can aggressively retry
+		config.SocketTimeout = aggressiveProbeTimeout
+
+		return wait.PollImmediate(retryInterval, PollTimeout, func() (bool, error) {
+			if tcpErr := health.TCPProbe(config); tcpErr != nil {
+				// reset count of consecutive successes to zero
+				p.count = 0
+				return false, nil
+			}
+
+			p.count++
+
+			// return success if count of consecutive successes is equal to or greater
+			// than the probe's SuccessThreshold.
+			return p.Count() >= p.SuccessThreshold, nil
+		})
+	}
+
+	return health.TCPProbe(config)
+}
+
+// httpProbe function executes HTTP probe once if its standard probe
+// otherwise HTTP probe polls condition function which returns true
+// if the probe count is greater than success threshold and false if HTTP probe fails
+func (p *Probe) httpProbe() error {
+	config := health.HTTPProbeConfigOptions{
+		HTTPGetAction: p.HTTPGet,
+		Timeout:       time.Duration(p.TimeoutSeconds) * time.Second,
+	}
+
+	if p.IsAggressive() {
+		// timeout quickly so we can aggressively retry
+		config.Timeout = aggressiveProbeTimeout
+
+		return wait.PollImmediate(retryInterval, PollTimeout, func() (bool, error) {
+			if err := health.HTTPProbe(config); err != nil {
+				// reset count of consecutive successes to zero
+				p.count = 0
+				return false, nil
+			}
+
+			p.count++
+
+			// return success if count of consecutive successes is equal to or greater
+			// than the probe's SuccessThreshold.
+			return p.Count() >= p.SuccessThreshold, nil
+		})
+	}
+
+	return health.HTTPProbe(config)
+}
+
+// Count function fetches current probe count
+func (p *Probe) Count() int32 {
+	return p.count
+}

--- a/pkg/queue/readiness/probe_encoding.go
+++ b/pkg/queue/readiness/probe_encoding.go
@@ -31,11 +31,11 @@ func DecodeProbe(jsonProbe string) (*corev1.Probe, error) {
 	return p, nil
 }
 
-// EncodeProbe takes *corev1.Probe object and returns marshalled Probe JSON string.
-func EncodeProbe(rp *corev1.Probe) string {
+// EncodeProbe takes *corev1.Probe object and returns marshalled Probe JSON string and an error.
+func EncodeProbe(rp *corev1.Probe) (string, error) {
 	probeJSON, err := json.Marshal(rp)
 	if err != nil {
-		probeJSON = []byte{}
+		return "", err
 	}
-	return string(probeJSON)
+	return string(probeJSON), nil
 }

--- a/pkg/queue/readiness/probe_encoding.go
+++ b/pkg/queue/readiness/probe_encoding.go
@@ -31,7 +31,7 @@ func DecodeProbe(jsonProbe string) (*corev1.Probe, error) {
 	return p, nil
 }
 
-// EncodeProbe takes *corev1.Probe object and returns marshalled Probe byte array
+// EncodeProbe takes *corev1.Probe object and returns marshalled Probe JSON string.
 func EncodeProbe(rp *corev1.Probe) string {
 	probeJSON, err := json.Marshal(rp)
 	if err != nil {

--- a/pkg/queue/readiness/probe_encoding.go
+++ b/pkg/queue/readiness/probe_encoding.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DecodeProbe takes a json serialised *corev1.Probe and returns a Probe or an error.
+func DecodeProbe(jsonProbe string) (*corev1.Probe, error) {
+	p := &corev1.Probe{}
+	if err := json.Unmarshal([]byte(jsonProbe), p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// EncodeProbe takes *corev1.Probe object and returns marshalled Probe byte array
+func EncodeProbe(rp *corev1.Probe) string {
+	probeJSON, err := json.Marshal(rp)
+	if err != nil {
+		probeJSON = []byte{}
+	}
+	return string(probeJSON)
+}

--- a/pkg/queue/readiness/probe_encoding_test.go
+++ b/pkg/queue/readiness/probe_encoding_test.go
@@ -72,7 +72,12 @@ func TestEncodeProbe(t *testing.T) {
 		},
 	}
 
-	jsonProbe := EncodeProbe(probe)
+	jsonProbe, err := EncodeProbe(probe)
+
+	if err != nil {
+		t.Fatalf("Expected no errer, got: %#v", err)
+	}
+
 	wantProbe := `{"tcpSocket":{"port":"8080","host":"127.0.0.1"},"successThreshold":1}`
 
 	if diff := cmp.Diff(jsonProbe, wantProbe); diff != "" {

--- a/pkg/queue/readiness/probe_encoding_test.go
+++ b/pkg/queue/readiness/probe_encoding_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package readiness
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestParseProbeSuccess(t *testing.T) {
+	expectedProbe := &corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString("8080"),
+			},
+		},
+	}
+	probeBytes, err := json.Marshal(expectedProbe)
+	if err != nil {
+		t.Fatalf("Failed to decode probe %#v", err)
+	}
+	gotProbe, err := DecodeProbe(string(probeBytes))
+	if err != nil {
+		t.Fatalf("Failed DecodeProbe() %#v", err)
+	}
+	if d := cmp.Diff(gotProbe, expectedProbe); d != "" {
+		t.Errorf("Probe diff %s; got %v, want %v", d, gotProbe, expectedProbe)
+	}
+}
+
+func TestParseProbeFailure(t *testing.T) {
+	probeBytes, err := json.Marshal("wrongProbeObject")
+	if err != nil {
+		t.Fatalf("Failed to decode probe %#v", err)
+	}
+	_, err = DecodeProbe(string(probeBytes))
+	if err == nil {
+		t.Fatal("Expected DecodeProbe() to fail")
+	}
+}
+
+func TestEncodeProbe(t *testing.T) {
+	probe := &corev1.Probe{
+		SuccessThreshold: 1,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString("8080"),
+			},
+		},
+	}
+
+	jsonProbe := EncodeProbe(probe)
+	wantProbe := `{"tcpSocket":{"port":"8080","host":"127.0.0.1"},"successThreshold":1}`
+
+	if diff := cmp.Diff(jsonProbe, wantProbe); diff != "" {
+		t.Errorf("Probe diff: %s; got %v, want %v", diff, jsonProbe, wantProbe)
+	}
+}

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -103,8 +103,8 @@ func TestExecHandler(t *testing.T) {
 			}},
 	}, t)
 
-	if !pb.ProbeContainer() {
-		t.Error("Probe failed. Expected Exec probe to always pass.")
+	if pb.ProbeContainer() {
+		t.Error("Expected ExecProbe to always fail")
 	}
 }
 

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -1,0 +1,575 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestNewProbe(t *testing.T) {
+	v1p := &corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   1,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromInt(12345),
+			},
+		},
+	}
+
+	logger := logtesting.TestLogger(t)
+
+	p := NewProbe(v1p, logger)
+
+	if diff := cmp.Diff(p.Probe, v1p); diff != "" {
+		t.Errorf("NewProbe (-want, +got) = %v", diff)
+	}
+
+	if c := p.Count(); c != 0 {
+		t.Errorf("Expected Probe.Count == 0, got: %d", c)
+	}
+}
+
+func TestTCPFailure(t *testing.T) {
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   1,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromInt(12345),
+			},
+		},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Reported success when no server was available for connection")
+	}
+}
+
+func TestEmptyHandler(t *testing.T) {
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   1,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler:          corev1.Handler{},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Reported success when no handler was configured.")
+	}
+}
+
+func TestExecHandler(t *testing.T) {
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   1,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"echo", "hello"},
+			}},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Probe failed. Expected Exec probe to always pass.")
+	}
+}
+
+func TestTCPSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString(port),
+			},
+		},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Probe report failure. Expected success.")
+	}
+}
+
+func TestHTTPFailureToConnect(t *testing.T) {
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromInt(12345),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Reported success when no server was available for connection")
+	}
+}
+
+func TestHTTPBadResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   5,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromString(port),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Reported success when server replied with Bad Request")
+	}
+}
+
+func TestHTTPSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   5,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromString(port),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Probe failed. Expected success.")
+	}
+}
+
+func TestHTTPTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString(port),
+			},
+		},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Probe succeeded. Expected failure due to timeout.")
+	}
+}
+
+func TestHTTPSuccessWithDelay(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromString(port),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Probe failed. Wanted success.")
+	}
+}
+
+func TestKnHTTPSuccessWithRetry(t *testing.T) {
+	attempted := false
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !attempted {
+			w.WriteHeader(http.StatusBadRequest)
+			attempted = true
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: 1,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromString(port),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Probe failed. Expected success after retry.")
+	}
+}
+
+func TestKnHTTPSuccessWithThreshold(t *testing.T) {
+	var count int32
+	var threshold int32 = 3
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: threshold,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromString(port),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Expected success after second attempt.")
+	}
+
+	if count != threshold {
+		t.Errorf("Expected %d requests before reporting success", threshold)
+	}
+}
+
+func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
+	var count int32
+	var threshold int32 = 3
+	var requestFailure int32 = 2
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+
+		if count == requestFailure {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: threshold,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString(port),
+				HTTPHeaders: []corev1.HTTPHeader{{
+					Name:  "Test-key",
+					Value: "Test-value",
+				}},
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if !pb.ProbeContainer() {
+		t.Error("Expected success.")
+	}
+
+	if count != threshold+requestFailure {
+		t.Errorf("Wanted %d requests before reporting success, got=%d", threshold+requestFailure, count)
+	}
+}
+
+func TestKnHTTPTimeoutFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: 1,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Host:   "127.0.0.1",
+				Port:   intstr.FromString(port),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Probe succeeded. Expected failure due to timeout.")
+	}
+}
+
+func TestKnTCPProbeSuccess(t *testing.T) {
+	port := freePort(t)
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: 1,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromInt(port),
+			},
+		},
+	}, t)
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		t.Fatalf("Error setting up tcp listener: %s", err.Error())
+	}
+	defer listener.Close()
+
+	if !pb.ProbeContainer() {
+		t.Error("Got probe error. Wanted success.")
+	}
+}
+
+func TestKnUnimplementedProbe(t *testing.T) {
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: 1,
+		FailureThreshold: 0,
+		Handler:          corev1.Handler{},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Got probe success. Wanted failure.")
+	}
+}
+func TestKnTCPProbeFailure(t *testing.T) {
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: 1,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromInt(12345),
+			},
+		},
+	}, t)
+
+	if pb.ProbeContainer() {
+		t.Error("Got probe success. Wanted failure.")
+	}
+}
+
+func TestKnTCPProbeSuccessWithThreshold(t *testing.T) {
+	port := freePort(t)
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: 3,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromInt(port),
+			},
+		},
+	}, t)
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		t.Fatalf("Error setting up tcp listener: %s", err.Error())
+	}
+	defer listener.Close()
+
+	if !pb.ProbeContainer() {
+		t.Error("Got probe error. Wanted success.")
+	}
+
+	if pb.Count() != 3 {
+		t.Errorf("Expected count to be 3, go %d", pb.Count())
+	}
+}
+
+func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
+	var successThreshold int32 = 3
+	port := freePort(t)
+	pb := newProbe(&corev1.Probe{
+		PeriodSeconds:    0,
+		TimeoutSeconds:   0,
+		SuccessThreshold: successThreshold,
+		FailureThreshold: 0,
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromInt(port),
+			},
+		},
+	}, t)
+
+	connCount := 0
+	desiredConnCount := 4 // 1 conn from 1st server, 3 from 2nd server
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		t.Fatalf("Error setting up tcp listener: %s", err.Error())
+	}
+
+	errChan := make(chan bool, 1)
+	go func(errChan chan bool) {
+		errChan <- pb.ProbeContainer()
+	}(errChan)
+
+	if _, err = listener.Accept(); err != nil {
+		t.Fatalf("Failed to accept TCP conn: %s", err.Error())
+	}
+	connCount++
+
+	// Close server and sleep to give probe time to fail a few times
+	// and reset count
+	listener.Close()
+	time.Sleep(500 * time.Millisecond)
+
+	listener2, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		t.Fatalf("Error setting up tcp listener: %s", err.Error())
+	}
+
+	for {
+		if connCount < desiredConnCount {
+			if _, err = listener2.Accept(); err != nil {
+				t.Fatalf("Failed to accept TCP conn: %s", err.Error())
+			}
+			connCount++
+		} else {
+			listener2.Close()
+			break
+		}
+	}
+
+	if probeErr := <-errChan; !probeErr {
+		t.Error("Wanted ProbeContainer() successed but got error")
+	}
+	if pb.Count() != successThreshold {
+		t.Errorf("Expected count to be %d but got %d", successThreshold, pb.Count())
+	}
+}
+
+func freePort(t *testing.T) int {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Error setting up tcp listener: %s", err.Error())
+	}
+	listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func newProbe(pb *corev1.Probe, t *testing.T) Probe {
+	return Probe{
+		Probe:  pb,
+		count:  0,
+		logger: logtesting.TestLogger(t),
+	}
+}


### PR DESCRIPTION

Co-authored-by: Shash Reddy <shashwathireddy@gmail.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Supports #4014 

## Proposed Changes

* Package to support addition of user-defined ReadinessProbes executed by the queue-proxy against the user-container
* Will be used in PRs to follow
* See #4600 for reference

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
