### PR TITLE
Implementation of the target burst capacity annotation.

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -41,10 +41,10 @@ func ValidateAnnotations(anns map[string]string) *apis.FieldError {
 	if len(anns) == 0 {
 		return nil
 	}
-	return validateMinMaxScale(anns).Also(validatePercentages(anns)).Also(validateWindows(anns))
+	return validateMinMaxScale(anns).Also(validateFloats(anns)).Also(validateWindows(anns))
 }
 
-func validatePercentages(annotations map[string]string) *apis.FieldError {
+func validateFloats(annotations map[string]string) *apis.FieldError {
 	var errs *apis.FieldError
 	if v, ok := annotations[PanicWindowPercentageAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil {
@@ -68,6 +68,12 @@ func validatePercentages(annotations map[string]string) *apis.FieldError {
 			errs = errs.Also(apis.ErrInvalidValue(v, TargetUtilizationPercentageKey))
 		} else if fv < 1 || fv > 100 {
 			errs = errs.Also(apis.ErrOutOfBoundsValue(v, 1, 100, TargetUtilizationPercentageKey))
+		}
+	}
+
+	if v, ok := annotations[TargetBurstCapacityKey]; ok {
+		if fv, err := strconv.ParseFloat(v, 64); err != nil || fv < 0 && fv != -1 {
+			errs = errs.Also(apis.ErrInvalidValue(v, TargetBurstCapacityKey))
 		}
 	}
 	return errs

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -107,6 +107,23 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},
 		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicThresholdPercentage",
 	}, {
+		name:        "TBC negative",
+		annotations: map[string]string{TargetBurstCapacityKey: "-11"},
+		expectErr:   "invalid value: -11: autoscaling.knative.dev/targetBurstCapacity",
+	}, {
+		name:        "TBC 0",
+		annotations: map[string]string{TargetBurstCapacityKey: "0"},
+	}, {
+		name:        "TBC 19880709",
+		annotations: map[string]string{TargetBurstCapacityKey: "19870709"},
+	}, {
+		name:        "TBC -1",
+		annotations: map[string]string{TargetBurstCapacityKey: "-1"},
+	}, {
+		name:        "TBC invalid",
+		annotations: map[string]string{TargetBurstCapacityKey: "qarashen"},
+		expectErr:   "invalid value: qarashen: autoscaling.knative.dev/targetBurstCapacity",
+	}, {
 		name:        "TU too small",
 		annotations: map[string]string{TargetUtilizationPercentageKey: "0"},
 		expectErr:   "expected 1 <= 0 <= 100: autoscaling.knative.dev/targetUtilizationPercentage",

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -86,6 +86,14 @@ const (
 	// This annotation takes precedence over the config map value.
 	TargetUtilizationPercentageKey = GroupName + "/targetUtilizationPercentage"
 
+	// TargetBurstCapacityKey specifies the desired burst capacity for the
+	// revision. Possible values are:
+	// -1 -- infinite;
+	//  0 -- no TBC;
+	// >0 -- actual TBC.
+	// <0 && != -1 -- an error.
+	TargetBurstCapacityKey = GroupName + "/targetBurstCapacity"
+
 	// PanicWindowPercentageAnnotationKey is the annotation to
 	// specify the time interval over which to calculate the average
 	// metric during a spike. Where a spike is defined as the metric

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -107,6 +107,13 @@ func (pa *PodAutoscaler) TargetUtilization() (float64, bool) {
 	return 0, false
 }
 
+// TargetBC returns the target burst capacity,
+// if the corresponding annotation is set.
+func (pa *PodAutoscaler) TargetBC() (float64, bool) {
+	// The value is validated in the webhook.
+	return pa.annotationFloat64(autoscaling.TargetBurstCapacityKey)
+}
+
 // Window returns the window annotation value or false if not present.
 func (pa *PodAutoscaler) Window() (window time.Duration, ok bool) {
 	// The value is validated in the webhook.


### PR DESCRIPTION
THis matches the behaviour in the config map.

/assign @mattmoor

Fixes #4450


/lint


