### PR TITLE
Bump the activator grace timeout to the default request timeout

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -35,6 +35,9 @@ spec:
         serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
+      # We want to give Activator quite some to exit, to process the existing requests
+      # which might be quite long running, i.e. streaming.
+      terminationGracePeriodSeconds: 300
       containers:
       - name: activator
         # This is the Go import path for the binary that is containerized


### PR DESCRIPTION
This will permit us to let activator linger longer, before K8s forcefully kills it
to process the requests that might take more time (e.g. streaming).

/assign @mattmoor

Fixes: https://github.com/knative/serving/issues/4654