### PR TITLE
Make error message for invalid panic-window-percentage accurate

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -187,7 +187,7 @@ func validate(lc *Config) (*Config, error) {
 
 	effPW := time.Duration(lc.PanicWindowPercentage / 100 * float64(lc.StableWindow))
 	if effPW < BucketSize || effPW > lc.StableWindow {
-		return nil, fmt.Errorf("panic-window = %v, must be in [%v, %v] interval", lc.PanicWindow, BucketSize, lc.StableWindow)
+		return nil, fmt.Errorf("panic-window-percentage = %v, must be in [%v, 100] interval", lc.PanicWindow, 100*float64(BucketSize)/float64(lc.StableWindow))
 	}
 
 	return lc, nil


### PR DESCRIPTION
When an invalid `panic-window-percentage` is used, the error message says what value `panic-window` should use, which doesn't tell the root cause.