### PR TITLE
rename component of ingress controller binary

### DIFF
--- a/cmd/networking/istio/main.go
+++ b/cmd/networking/istio/main.go
@@ -24,6 +24,6 @@ import (
 )
 
 func main() {
-	sharedmain.Main("controller-certificate-cert-manager",
+	sharedmain.Main("controller-ingress-istio",
 		clusteringress.NewController)
 }


### PR DESCRIPTION
rename component of ingress controller binary as it is mistakenly set to the name of certificate controller binary.


