### PR TITLE
Check route is not ready when underlying revision is not healthy in TestContainerErrorMsg

### DIFF
--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -69,6 +69,11 @@ func TestContainerErrorMsg(t *testing.T) {
 	manifestUnknown := string(transport.ManifestUnknownErrorCode)
 	t.Log("When the imagepath is invalid, the Configuration should have error status.")
 
+	// Wait for ServiceState becomes NotReady. It also waits for the creation of Configuration.
+	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceNotReady, "ServiceIsNotReady"); err != nil {
+		t.Fatalf("The Service %s was unexpected state: %v", names.Service, err)
+	}
+
 	// Checking for "Container image not present in repository" scenario defined in error condition spec
 	err = v1a1test.WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(r *v1alpha1.Configuration) (bool, error) {
 		cond := r.Status.GetCondition(v1alpha1.ConfigurationConditionReady)

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -71,6 +71,11 @@ func TestContainerErrorMsg(t *testing.T) {
 	manifestUnknown := string(transport.ManifestUnknownErrorCode)
 	t.Log("When the imagepath is invalid, the Configuration should have error status.")
 
+	// Wait for ServiceState becomes NotReady. It also waits for the creation of Configuration.
+	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceNotReady, "ServiceIsNotReady"); err != nil {
+		t.Fatalf("The Service %s was unexpected state: %v", names.Service, err)
+	}
+
 	// Checking for "Container image not present in repository" scenario defined in error condition spec
 	err = v1b1test.WaitForConfigurationState(clients.ServingBetaClient, names.Config, func(r *v1beta1.Configuration) (bool, error) {
 		cond := r.Status.GetCondition(v1beta1.ConfigurationConditionReady)

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -129,6 +129,12 @@ func IsRouteReady(r *v1alpha1.Route) (bool, error) {
 	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
+// IsRouteNotReady will check the status conditions of the route and return true if the route is
+// not ready.
+func IsRouteNotReady(r *v1alpha1.Route) (bool, error) {
+	return !r.Status.IsReady(), nil
+}
+
 // AllRouteTrafficAtRevision will check the revision that route r is routing
 // traffic to and return true if 100% of the traffic is routing to revisionName.
 func AllRouteTrafficAtRevision(names test.ResourceNames) func(r *v1alpha1.Route) (bool, error) {

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -345,3 +345,9 @@ func CheckServiceState(client *test.ServingAlphaClients, name string, inState fu
 func IsServiceReady(s *v1alpha1.Service) (bool, error) {
 	return s.Generation == s.Status.ObservedGeneration && s.Status.IsReady(), nil
 }
+
+// IsServiceNotReady will check the status conditions of the service and return true if the service is
+// not ready.
+func IsServiceNotReady(s *v1alpha1.Service) (bool, error) {
+	return s.Generation == s.Status.ObservedGeneration && !s.Status.IsReady(), nil
+}

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -110,6 +110,12 @@ func IsRouteReady(r *v1beta1.Route) (bool, error) {
 	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
+// IsRouteNotReady will check the status conditions of the route and return true if the route is
+// not ready.
+func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
+	return !r.Status.IsReady(), nil
+}
+
 // RetryingRouteInconsistency retries common requests seen when creating a new route
 // - 404 until the route is propagated to the proxy
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {

--- a/test/v1beta1/service.go
+++ b/test/v1beta1/service.go
@@ -244,3 +244,9 @@ func CheckServiceState(client *test.ServingBetaClients, name string, inState fun
 func IsServiceReady(s *v1beta1.Service) (bool, error) {
 	return s.Generation == s.Status.ObservedGeneration && s.Status.IsReady(), nil
 }
+
+// IsServiceNotReady will check the status conditions of the service and return true if the service is
+// not ready.
+func IsServiceNotReady(s *v1beta1.Service) (bool, error) {
+	return s.Generation == s.Status.ObservedGeneration && !s.Status.IsReady(), nil
+}


### PR DESCRIPTION
This PR fixes following TODO comment

https://github.com/knative/serving/blob/aac25fb74e06abe9ceb12cc755c049d0ae961b6b/test/conformance/api/v1alpha1/errorcondition_test.go#L114

## Proposed Changes

This patch changes TestContainerErrorMsg to:
- create new service instead of configuration.
- make sure route state is not ready when revision is not healthy.

/lint

**Release Note**

```release-note
NONE
```
