### PR TITLE
Use a local buffer to store request logs template expansion

### DIFF
--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -31,6 +31,7 @@ import (
 type RequestLogHandler struct {
 	handler     http.Handler
 	inputGetter RequestLogTemplateInputGetter
+	writerMux   sync.Mutex
 	writer      io.Writer
 	templateMux sync.RWMutex
 	templateStr string
@@ -156,6 +157,8 @@ func (h *RequestLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *RequestLogHandler) write(t *template.Template, in *RequestLogTemplateInput) {
+	h.writerMux.Lock()
+	defer h.writerMux.Unlock()
 	if err := t.Execute(h.writer, in); err != nil {
 		// Template execution failed. Write an error message with some basic information about the request.
 		fmt.Fprintf(h.writer, "Invalid request log template: method: %v, response code: %v, latency: %v, url: %v\n",

--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -171,7 +171,7 @@ func (h *RequestLogHandler) write(t *template.Template, in *RequestLogTemplateIn
 	}
 }
 
-// InMemoryWriter is an io.Writer that is backed by an byte slice in memory.
+// InMemoryWriter is an io.Writer that is backed by a byte slice in memory.
 // It is not safe to be used in parallel.
 // TODO(yanweiguo): Move this to knative/pkg repository.
 type InMemoryWriter struct {

--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -161,13 +161,10 @@ func (h *RequestLogHandler) write(t *template.Template, in *RequestLogTemplateIn
 	// is used directly, parallel template executions may result in interleaved
 	// output.
 	w := &bytes.Buffer{}
-	err := t.Execute(w, in)
-	if err == nil {
-		_, err = h.writer.Write(w.Bytes())
-	}
-	if err != nil {
+	if err := t.Execute(w, in); err != nil {
 		// Template execution failed. Write an error message with some basic information about the request.
 		fmt.Fprintf(h.writer, "Invalid request log template: method: %v, response code: %v, latency: %v, url: %v\n",
 			in.Request.Method, in.Response.Code, in.Response.Latency, in.Request.URL)
 	}
+	h.writer.Write(w.Bytes())
 }


### PR DESCRIPTION
There exist interleaved request logs from queue-proxy. For example:

```
{"httpRequest": {"requestMethod": "GET", "requestUrl": "/", "requestSize": "0", "status": 200, "responseSize": "{"httpRequest": {"requestMethod": "GET", "requestUrl": "20", "userAgent": "hey/0.0.1", "remoteIp": "/", "requestSize": "0", "status": 200, "responseSize": "20", "userAgent": "10.32.0.2:56020", "serverIp": "hey/0.0.1", "remoteIp": "10.32.0.2:56168", "serverIp": "10.32.0.44", "referer": "", "latency": "0.00110783s", "protocol": "HTTP/1.1"}, "traceId": "[ae4cabd9089711eba555f824ecd9ed50]"}
10.32.0.44", "referer": "", "latency": "0.001027144s", "protocol": "HTTP/1.1"}, "traceId": "[d379fc1a0330a7776fa5300aa7563bd5]"}
```

From golang template lib:
```
// A template may be executed safely in parallel, although if parallel
// executions share a Writer the output may be interleaved.
```

So we can't use the writer in parallel.