### PR TITLE
Make tests run much faster.

### DIFF
--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -23,7 +23,6 @@ import (
 
 	perrors "github.com/pkg/errors"
 
-	"github.com/knative/pkg/kmp"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
@@ -90,7 +89,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, d
 		if !equality.Semantic.DeepEqual(tmpl.Spec, sks.Spec) {
 			want := sks.DeepCopy()
 			want.Spec = tmpl.Spec
-			logger.Infof("SKS %s changed; reconciling, diff: %s, %v", sksName, kmp.SafeDiff(want.Spec, tmpl.Spec))
+			logger.Infof("SKS %s changed; reconciling, want mode: %v", sksName, want.Spec.Mode)
 			if sks, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
 				return nil, perrors.Wrapf(err, "error updating SKS %s", sksName)
 			}

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
 	perrors "github.com/pkg/errors"
 
+	"github.com/knative/pkg/kmp"
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	pav1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
@@ -90,7 +90,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, d
 		if !equality.Semantic.DeepEqual(tmpl.Spec, sks.Spec) {
 			want := sks.DeepCopy()
 			want.Spec = tmpl.Spec
-			logger.Infof("SKS %s changed; reconciling, diff: %s", sksName, cmp.Diff(want.Spec, tmpl.Spec))
+			logger.Infof("SKS %s changed; reconciling, diff: %s, %v", sksName, kmp.SafeDiff(want.Spec, tmpl.Spec))
 			if sks, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
 				return nil, perrors.Wrapf(err, "error updating SKS %s", sksName)
 			}

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	perrors "github.com/pkg/errors"
 
 	"github.com/knative/serving/pkg/apis/autoscaling"
@@ -89,7 +90,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, d
 		if !equality.Semantic.DeepEqual(tmpl.Spec, sks.Spec) {
 			want := sks.DeepCopy()
 			want.Spec = tmpl.Spec
-			logger.Info("SKS changed; reconciling:", sksName)
+			logger.Infof("SKS %s changed; reconciling, diff: %s", sksName, cmp.Diff(want.Spec, tmpl.Spec))
 			if sks, err = c.ServingClientSet.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
 				return nil, perrors.Wrapf(err, "error updating SKS %s", sksName)
 			}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -90,7 +90,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
 		EnvVars: envVars,
 		RevisionTemplateAnnotations: map[string]string{
-			autoscaling.WindowAnnotationKey: "6s", // shortest permitted.
+			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		},
 	})
 	if err != nil {
@@ -215,7 +215,7 @@ func TestServiceToServiceCallFromZero(t *testing.T) {
 	helloWorld, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
 		&v1a1test.Options{
 			RevisionTemplateAnnotations: map[string]string{
-				autoscaling.WindowAnnotationKey: "7s",
+				autoscaling.WindowAnnotationKey: "6s", // shortest permitted.
 			},
 		}, withInternalVisibility)
 	if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -90,7 +90,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
 		EnvVars: envVars,
 		RevisionTemplateAnnotations: map[string]string{
-			autoscaling.WindowAnnotationKey: "7s",
+			autoscaling.WindowAnnotationKey: "6s", // shortest permitted.
 		},
 	})
 	if err != nil {
@@ -162,7 +162,7 @@ func TestServiceToServiceCall(t *testing.T) {
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
 		RevisionTemplateAnnotations: map[string]string{
-			autoscaling.WindowAnnotationKey: "7s",
+			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		},
 	}, withInternalVisibility)
 	if err != nil {


### PR DESCRIPTION
With this simple change the tests with -count=5 ran in 363 seconds for both of them
while before single invocation of single test was ~125 seconds, thus yielding ~3.5 time
improvement in execution time.
Also log difference in the SKS.

/assign @dgerd @mattmoor

