### PR TITLE
Do not set default values when unsupported multiple containers are defined

### DIFF
--- a/pkg/apis/serving/v1beta1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_defaults_test.go
@@ -39,13 +39,6 @@ func TestConfigurationDefaulting(t *testing.T) {
 			Spec: ConfigurationSpec{
 				Template: RevisionTemplateSpec{
 					Spec: RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Name:           config.DefaultUserContainerName,
-								Resources:      defaultResources,
-								ReadinessProbe: defaultProbe,
-							}},
-						},
 						TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 					},
 				},

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -44,10 +44,6 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 		rs.TimeoutSeconds = &ts
 	}
 
-	if len(rs.PodSpec.Containers) == 0 {
-		rs.PodSpec.Containers = make([]corev1.Container, 1)
-	}
-
 	for idx, _ := range rs.PodSpec.Containers {
 		if rs.PodSpec.Containers[idx].Name == "" {
 			rs.PodSpec.Containers[idx].Name = cfg.Defaults.UserContainerName(ctx)

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -36,13 +36,6 @@ func (rts *RevisionTemplateSpec) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
-	// More than one container is not allowed for now. Do not set default
-	// values to avoid inappropriate error happens.
-	// https://github.com/knative/serving/issues/4659
-	if len(rs.PodSpec.Containers) > 1 {
-		return
-	}
-
 	cfg := config.FromContextOrDefaults(ctx)
 
 	// Default TimeoutSeconds based on our configmap
@@ -51,58 +44,58 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 		rs.TimeoutSeconds = &ts
 	}
 
-	var container corev1.Container
-	if len(rs.PodSpec.Containers) == 1 {
-		container = rs.PodSpec.Containers[0]
-	}
-	defer func() {
-		rs.PodSpec.Containers = []corev1.Container{container}
-	}()
-
-	if container.Name == "" {
-		container.Name = cfg.Defaults.UserContainerName(ctx)
+	if len(rs.PodSpec.Containers) == 0 {
+		rs.PodSpec.Containers = make([]corev1.Container, 1)
 	}
 
-	if container.Resources.Requests == nil {
-		container.Resources.Requests = corev1.ResourceList{}
-	}
-	if _, ok := container.Resources.Requests[corev1.ResourceCPU]; !ok {
-		if rsrc := cfg.Defaults.RevisionCPURequest; rsrc != nil {
-			container.Resources.Requests[corev1.ResourceCPU] = *rsrc
+	for idx, _ := range rs.PodSpec.Containers {
+		if rs.PodSpec.Containers[idx].Name == "" {
+			rs.PodSpec.Containers[idx].Name = cfg.Defaults.UserContainerName(ctx)
 		}
-	}
-	if _, ok := container.Resources.Requests[corev1.ResourceMemory]; !ok {
-		if rsrc := cfg.Defaults.RevisionMemoryRequest; rsrc != nil {
-			container.Resources.Requests[corev1.ResourceMemory] = *rsrc
-		}
-	}
 
-	if container.Resources.Limits == nil {
-		container.Resources.Limits = corev1.ResourceList{}
-	}
-	if _, ok := container.Resources.Limits[corev1.ResourceCPU]; !ok {
-		if rsrc := cfg.Defaults.RevisionCPULimit; rsrc != nil {
-			container.Resources.Limits[corev1.ResourceCPU] = *rsrc
+		if rs.PodSpec.Containers[idx].Resources.Requests == nil {
+			rs.PodSpec.Containers[idx].Resources.Requests = corev1.ResourceList{}
 		}
-	}
-	if _, ok := container.Resources.Limits[corev1.ResourceMemory]; !ok {
-		if rsrc := cfg.Defaults.RevisionMemoryLimit; rsrc != nil {
-			container.Resources.Limits[corev1.ResourceMemory] = *rsrc
+		if _, ok := rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceCPU]; !ok {
+			if rsrc := cfg.Defaults.RevisionCPURequest; rsrc != nil {
+				rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceCPU] = *rsrc
+			}
 		}
-	}
-	if container.ReadinessProbe == nil {
-		container.ReadinessProbe = &corev1.Probe{}
-	}
-	if container.ReadinessProbe.TCPSocket == nil && container.ReadinessProbe.HTTPGet == nil && container.ReadinessProbe.Exec == nil {
-		container.ReadinessProbe.TCPSocket = &corev1.TCPSocketAction{}
-	}
+		if _, ok := rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceMemory]; !ok {
+			if rsrc := cfg.Defaults.RevisionMemoryRequest; rsrc != nil {
+				rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceMemory] = *rsrc
+			}
+		}
 
-	if container.ReadinessProbe.SuccessThreshold == 0 {
-		container.ReadinessProbe.SuccessThreshold = 1
-	}
+		if rs.PodSpec.Containers[idx].Resources.Limits == nil {
+			rs.PodSpec.Containers[idx].Resources.Limits = corev1.ResourceList{}
+		}
+		if _, ok := rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceCPU]; !ok {
+			if rsrc := cfg.Defaults.RevisionCPULimit; rsrc != nil {
+				rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceCPU] = *rsrc
+			}
+		}
+		if _, ok := rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceMemory]; !ok {
+			if rsrc := cfg.Defaults.RevisionMemoryLimit; rsrc != nil {
+				rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceMemory] = *rsrc
+			}
+		}
+		if rs.PodSpec.Containers[idx].ReadinessProbe == nil {
+			rs.PodSpec.Containers[idx].ReadinessProbe = &corev1.Probe{}
+		}
+		if rs.PodSpec.Containers[idx].ReadinessProbe.TCPSocket == nil &&
+			rs.PodSpec.Containers[idx].ReadinessProbe.HTTPGet == nil &&
+			rs.PodSpec.Containers[idx].ReadinessProbe.Exec == nil {
+			rs.PodSpec.Containers[idx].ReadinessProbe.TCPSocket = &corev1.TCPSocketAction{}
+		}
 
-	vms := container.VolumeMounts
-	for i := range vms {
-		vms[i].ReadOnly = true
+		if rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold == 0 {
+			rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold = 1
+		}
+
+		vms := rs.PodSpec.Containers[idx].VolumeMounts
+		for i := range vms {
+			vms[i].ReadOnly = true
+		}
 	}
 }

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -36,6 +36,13 @@ func (rts *RevisionTemplateSpec) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
+	// More than one container is not allowed for now. Do not set default
+	// values to avoid inappropriate error happens.
+	// https://github.com/knative/serving/issues/4659
+	if len(rs.PodSpec.Containers) > 1 {
+		return
+	}
+
 	cfg := config.FromContextOrDefaults(ctx)
 
 	// Default TimeoutSeconds based on our configmap

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -241,11 +241,13 @@ func TestRevisionDefaulting(t *testing.T) {
 				TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 				PodSpec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Name:      "busybox",
-						Resources: defaultResources,
+						Name:           "busybox",
+						Resources:      defaultResources,
+						ReadinessProbe: defaultProbe,
 					}, {
-						Name:      "helloworld",
-						Resources: defaultResources,
+						Name:           "helloworld",
+						Resources:      defaultResources,
+						ReadinessProbe: defaultProbe,
 					}},
 				},
 			},

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -55,21 +55,10 @@ func TestRevisionDefaulting(t *testing.T) {
 	}{{
 		name: "empty",
 		in:   &Revision{},
-		want: &Revision{
-			Spec: RevisionSpec{
-				TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
-				PodSpec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:           config.DefaultUserContainerName,
-						Resources:      defaultResources,
-						ReadinessProbe: defaultProbe,
-					}},
-				},
-			},
-		},
+		want: &Revision{Spec: RevisionSpec{TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds)}},
 	}, {
 		name: "with context",
-		in:   &Revision{},
+		in:   &Revision{Spec: RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}}},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
@@ -209,7 +198,9 @@ func TestRevisionDefaulting(t *testing.T) {
 	}, {
 		name: "partially initialized",
 		in: &Revision{
-			Spec: RevisionSpec{},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}},
+			},
 		},
 		want: &Revision{
 			Spec: RevisionSpec{

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -223,6 +223,33 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "multiple containers",
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "busybox",
+					}, {
+						Name: "helloworld",
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:      "busybox",
+						Resources: defaultResources,
+					}, {
+						Name:      "helloworld",
+						Resources: defaultResources,
+					}},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -208,13 +208,13 @@ func TestRevisionSpecValidation(t *testing.T) {
 		},
 		want: apis.ErrDisallowedFields("containers[0].lifecycle"),
 	}, {
-		name: "missing image",
+		name: "missing container",
 		rs: &RevisionSpec{
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{},
 			},
 		},
-		want: apis.ErrMissingField("containers[0].image"),
+		want: apis.ErrMissingField("containers"),
 	}, {
 		name: "too many containers",
 		rs: &RevisionSpec{
@@ -284,7 +284,6 @@ func TestRevisionSpecValidation(t *testing.T) {
 			if test.wc != nil {
 				ctx = test.wc(ctx)
 			}
-			test.rs.SetDefaults(ctx)
 			got := test.rs.Validate(ctx)
 			if !cmp.Equal(test.want.Error(), got.Error()) {
 				t.Errorf("Validate (-want, +got) = %v",

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -208,13 +208,13 @@ func TestRevisionSpecValidation(t *testing.T) {
 		},
 		want: apis.ErrDisallowedFields("containers[0].lifecycle"),
 	}, {
-		name: "missing container",
+		name: "missing image",
 		rs: &RevisionSpec{
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{},
 			},
 		},
-		want: apis.ErrMissingField("containers"),
+		want: apis.ErrMissingField("containers[0].image"),
 	}, {
 		name: "too many containers",
 		rs: &RevisionSpec{
@@ -284,6 +284,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 			if test.wc != nil {
 				ctx = test.wc(ctx)
 			}
+			test.rs.SetDefaults(ctx)
 			got := test.rs.Validate(ctx)
 			if !cmp.Equal(test.want.Error(), got.Error()) {
 				t.Errorf("Validate (-want, +got) = %v",

--- a/pkg/apis/serving/v1beta1/service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/service_defaults_test.go
@@ -43,13 +43,6 @@ func TestServiceDefaulting(t *testing.T) {
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
 						Spec: RevisionSpec{
-							PodSpec: corev1.PodSpec{
-								Containers: []corev1.Container{{
-									Name:           config.DefaultUserContainerName,
-									Resources:      defaultResources,
-									ReadinessProbe: defaultProbe,
-								}},
-							},
 							TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 						},
 					},


### PR DESCRIPTION
## Proposed Changes

If multiple containers are defined but one container is returned after
setting default values, inappropriate error happens.

To fix it, this patch stops setting default values when unsupported
multiple containers are defined.

/lint

Fixes https://github.com/knative/serving/issues/4706

After this PR, we will get the error as:

```
$ kubectl create -f test.yaml 
Error from server (InternalError): error when creating "test.yaml": Internal error occurred: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: expected exactly one, got both: spec.template.spec.containers
```

## Proposed Changes
* Do not set default values when unsupported multiple containers are defined

**Release Note**

```release-note
NONE
```
