### PR TITLE
Exclude the custom-metrics API port from istio's interception.

### DIFF
--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -29,6 +29,10 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         sidecar.istio.io/inject: "true"
+        # traffic.sidecar.istio.io/excludeInboundPorts: 8443 didn't work as
+        # expected and still firewalled the given port off. Using a whitelist
+        # instead works as expected.
+        traffic.sidecar.istio.io/includeInboundPorts: "8080,9090"
       labels:
         app: autoscaler
         serving.knative.dev/release: devel


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

When a sidecar is injected, istio intercepts all application ports by default. In the case of the custom-metrics API, the Kubernetes API server will try to talk to the endpoint and fail because of SSL certificate issues.

Excluding the custom-metrics port from istio's interception helps alleviate the issue and is probably a good idea anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
