### PR TITLE
Fix dep hanging for a very long time without mercurial.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,7 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+  source = "https://hg@bitbucket.org/ww/goautoneg"
 
 [[projects]]
   digest = "1:6db34685a5216187ec35414e36c3bd0436fa2ac291d47b39f4ab4d68cf1c55f1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,6 +66,10 @@ required = [
   revision = "4bbc89b6501cca7dd6b5557d78d70c8d2c6e8b97"
 
 [[override]]
+  name = "github.com/kelseyhightower/envconfig"
+  version = "v1.4.0"
+
+[[override]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"
   # HEAD as of 2019-02-11
   # Needed because this includes a fix to support Stackdriver built-in metrics
@@ -84,6 +88,10 @@ required = [
   name = "k8s.io/metrics"
   version = "kubernetes-1.12.9"
 
+[[override]]
+  name = "bitbucket.org/ww/goautoneg"
+  source = "https://hg@bitbucket.org/ww/goautoneg"
+
 [prune]
   go-tests = true
   unused-packages = true
@@ -97,10 +105,6 @@ required = [
 [[prune.project]]
   name = "github.com/knative/test-infra"
   non-go = false
-
-[[override]]
-  name = "github.com/kelseyhightower/envconfig"
-  version = "v1.4.0"
 
 [[prune.project]]
   name = "bitbucket.org/ww/goautoneg"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

If mercurial is not installed, `dep ensure` can hang for a very long time because it tries first to clone mercurial repos via `hg` (which fails), but in the case for bitbucket.org based repositories it'll also try to clone it via git, which eventually fails as well but has a very long timeout.

This gives dep a hint that this is actually a mercurial repository, so it won't try git at all and fail straight away, giving you the information that `hg` is not installed.

```
$ ./hack/update-deps.sh
grouped write of manifest, lock and vendor: failed to export bitbucket.org/ww/goautoneg:
	(1) hg is not installed:
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
