### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -31,15 +31,15 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	cachingclient "knative.dev/caching/pkg/client/injection/client"
 	servingclient "github.com/knative/serving/pkg/client/injection/client"
+	cachingclient "knative.dev/caching/pkg/client/injection/client"
 	sharedclient "knative.dev/pkg/client/injection/client"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/injection/clients/kubeclient"
 
-	cachingclientset "knative.dev/caching/pkg/client/clientset/versioned"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	servingScheme "github.com/knative/serving/pkg/client/clientset/versioned/scheme"
+	cachingclientset "knative.dev/caching/pkg/client/clientset/versioned"
 	sharedclientset "knative.dev/pkg/client/clientset/versioned"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
-	_ "knative.dev/caching/pkg/client/injection/client/fake"
 	_ "github.com/knative/serving/pkg/client/injection/client/fake"
+	_ "knative.dev/caching/pkg/client/injection/client/fake"
 	_ "knative.dev/pkg/client/injection/client/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	_ "knative.dev/pkg/injection/clients/kubeclient/fake"

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"net/http"
 
-	imageinformer "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image"
 	painformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
 	revisioninformer "github.com/knative/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
+	imageinformer "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image"
 	"knative.dev/pkg/injection/clients/kubeclient"
 	deploymentinformer "knative.dev/pkg/injection/informers/kubeinformers/appsv1/deployment"
 	configmapinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/configmap"

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -19,7 +19,6 @@ package revision
 import (
 	"context"
 
-	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/revision/config"
@@ -27,6 +26,7 @@ import (
 	presources "github.com/knative/serving/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 )

--- a/pkg/reconciler/revision/resources/imagecache.go
+++ b/pkg/reconciler/revision/resources/imagecache.go
@@ -19,11 +19,11 @@ package resources
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/revision/resources/names"
 	"github.com/knative/serving/pkg/resources"
+	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/kmeta"
 )
 

--- a/pkg/reconciler/revision/resources/imagecache_test.go
+++ b/pkg/reconciler/revision/resources/imagecache_test.go
@@ -23,10 +23,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/ptr"
 )
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
-	cachinglisters "knative.dev/caching/pkg/client/listers/caching/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	palisters "github.com/knative/serving/pkg/client/listers/autoscaling/v1alpha1"
@@ -37,6 +36,7 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	cachinglisters "knative.dev/caching/pkg/client/listers/caching/v1alpha1"
 	"knative.dev/pkg/controller"
 	commonlogging "knative.dev/pkg/logging"
 )

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	// Inject the fakes for informers this controller relies on.
-	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
-	fakeimageinformer "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake"
 	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
 	fakepainformer "github.com/knative/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
 	fakerevisioninformer "github.com/knative/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
+	fakeimageinformer "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake"
 	fakekubeclient "knative.dev/pkg/injection/clients/kubeclient/fake"
 	fakedeploymentinformer "knative.dev/pkg/injection/informers/kubeinformers/appsv1/deployment/fake"
 	_ "knative.dev/pkg/injection/informers/kubeinformers/corev1/configmap/fake"

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	autoscalingv1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -36,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"

--- a/pkg/reconciler/testing/v1alpha1/factory.go
+++ b/pkg/reconciler/testing/v1alpha1/factory.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
 	fakecertmanagerclient "github.com/knative/serving/pkg/client/certmanager/injection/client/fake"
 	fakeservingclient "github.com/knative/serving/pkg/client/injection/client/fake"
+	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
 	fakesharedclient "knative.dev/pkg/client/injection/client/fake"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	fakekubeclient "knative.dev/pkg/injection/clients/kubeclient/fake"

--- a/pkg/reconciler/testing/v1alpha1/listers.go
+++ b/pkg/reconciler/testing/v1alpha1/listers.go
@@ -18,9 +18,6 @@ package v1alpha1
 
 import (
 	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
-	cachingv1alpha1 "knative.dev/caching/pkg/apis/caching/v1alpha1"
-	fakecachingclientset "knative.dev/caching/pkg/client/clientset/versioned/fake"
-	cachinglisters "knative.dev/caching/pkg/client/listers/caching/v1alpha1"
 	av1alpha1 "github.com/knative/serving/pkg/apis/autoscaling/v1alpha1"
 	networking "github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -38,6 +35,9 @@ import (
 	autoscalingv2beta1listers "k8s.io/client-go/listers/autoscaling/v2beta1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	cachingv1alpha1 "knative.dev/caching/pkg/apis/caching/v1alpha1"
+	fakecachingclientset "knative.dev/caching/pkg/client/clientset/versioned/fake"
+	cachinglisters "knative.dev/caching/pkg/client/listers/caching/v1alpha1"
 	istiov1alpha3 "knative.dev/pkg/apis/istio/v1alpha3"
 	fakesharedclientset "knative.dev/pkg/client/clientset/versioned/fake"
 	istiolisters "knative.dev/pkg/client/listers/istio/v1alpha3"

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -19,14 +19,15 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/knative/serving/pkg/network"
 	"github.com/knative/serving/pkg/reconciler/route/resources/labels"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/test/logstream"
-	"strings"
-	"testing"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
