### PR TITLE
Fix one benchmark and add the errorrate metric

### DIFF
--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -86,9 +86,12 @@ func runTest(t *testing.T, img string, baseQPS float64, loadFactors []float64) {
 	}
 
 	opts := loadgenerator.GeneratorOptions{
-		Duration:       duration,
-		NumThreads:     1,
-		NumConnections: 5,
+		Duration: duration,
+		// Use the same number of threads as the QPS to send the requests
+		NumThreads: int(baseQPS),
+		// Use the same number of connections as the QPS to avoid TIME_OUT state sockets, see
+		// http://tleyden.github.io/blog/2016/11/21/tuning-the-go-http-client-library-for-load-testing/
+		NumConnections: int(baseQPS),
 		Domain:         domain,
 		URL:            fmt.Sprintf("http://%s", *endpoint),
 		RequestTimeout: reqTimeout,
@@ -108,17 +111,15 @@ func runTest(t *testing.T, img string, baseQPS float64, loadFactors []float64) {
 		t.Fatal("No result found for the load test")
 	}
 
-	if resp.ErrorsPercentage(0) > 0 {
-		t.Fatal("Found non 200 response")
-	}
-
-	// Add latency metrics
 	var tc []junit.TestCase
+	// Add latency metrics
 	for _, p := range resp.Result[0].DurationHistogram.Percentiles {
 		val := float32(p.Value) * 1000
 		name := fmt.Sprintf("p%d(ms)", int(p.Percentile))
 		tc = append(tc, perf.CreatePerfTestCase(val, name, tName))
 	}
+	// Add errorsPercentage metrics
+	tc = append(tc, perf.CreatePerfTestCase(float32(resp.ErrorsPercentageOverall()), "errorsPercentage", tName))
 
 	if err = testgrid.CreateXMLOutput(tc, filename(tName)); err != nil {
 		t.Fatalf("Cannot create output xml: %v", err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
The reason that we are not getting non-200 responses in this test is because we are only using one thread to generate the load, and this thread will always send the requests in parallel, so in this way we are not generating enough load.

The PR makes the following changes:
1. Change `NumThreads` and `NumConnections` to be the same as `baseQPS` to ensure generating the load more reliably.
2. Add `errorsPercentage` metrics in the test result.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @srinivashegde86 
/cc @vagababov 
