### PR TITLE
Change scale-to-zero period for rolling upgrade tests

### DIFF
--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -21,7 +21,9 @@ package upgrade
 import (
 	"testing"
 
+	"knative.dev/serving/pkg/apis/autoscaling"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -35,7 +37,11 @@ func TestRunLatestServicePreUpgrade(t *testing.T) {
 	names.Service = serviceName
 	names.Image = test.PizzaPlanet1
 
-	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names)
+	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names,
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.MinScaleAnnotationKey: "1", //make sure we don't scale to zero during the test
+		}),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
@@ -51,7 +57,11 @@ func TestRunLatestServicePreUpgradeAndScaleToZero(t *testing.T) {
 	names.Service = scaleToZeroServiceName
 	names.Image = test.PizzaPlanet1
 
-	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names)
+	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names,
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.WindowAnnotationKey: autoscaling.WindowMin.String(), //make sure we scale to zero quickly
+		}),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}


### PR DESCRIPTION
* make sure that during rolling upgrade only the expected services are
scaled to zero

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes  a problem with pre-upgrade tests where waiting in the TestRunLatestServicePreUpgradeAndScaleToZero test finally causes also the other service from TestRunLatestServicePreUpgrade to scale to zero. And the rolling upgrade is performed with all services scaled to zero.

## Proposed Changes

* Set long scale-to-zero period for the ScaleToZero test service and long period for the other service

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
