### PR TITLE
Assorted linting fixes.

### DIFF
--- a/pkg/activator/config/store.go
+++ b/pkg/activator/config/store.go
@@ -90,14 +90,3 @@ func (s *Store) HTTPMiddleware(next http.Handler) http.Handler {
 		next:  next,
 	}
 }
-
-// TracingEnabledForContext returns true if tracing is enabled in the Configuration and ok if configuration
-// was able to be found in context
-func TracingEnabledForContext(ctx context.Context) (bool, bool) {
-	cfg := FromContext(ctx)
-	if cfg == nil {
-		return false, false
-	}
-
-	return cfg.Tracing.Enable, true
-}

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -222,7 +222,3 @@ type testScraper struct {
 func (s *testScraper) Scrape() (*StatMessage, error) {
 	return s.s()
 }
-
-func (s *testScraper) UpdateTarget(sv, ns string) {
-	s.url = urlFromTarget(sv, ns)
-}

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -384,7 +384,6 @@ type fakeUniScaler struct {
 	replicas   int32
 	surplus    int32
 	scaled     bool
-	lastStat   Stat
 	scaleCount int
 }
 
@@ -412,13 +411,6 @@ func (u *fakeUniScaler) setScaleResult(replicas int32, surplus int32, scaled boo
 	u.surplus = surplus
 	u.replicas = replicas
 	u.scaled = scaled
-}
-
-func (u *fakeUniScaler) Record(ctx context.Context, stat Stat) {
-	u.mutex.Lock()
-	defer u.mutex.Unlock()
-
-	u.lastStat = stat
 }
 
 func (u *fakeUniScaler) Update(DeciderSpec) error {

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -20,28 +20,12 @@ import (
 	"strings"
 	"text/template"
 
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/metrics"
 )
 
 const (
 	defaultLogURLTemplate = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
 )
-
-// UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
-// when a config map is updated
-func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
-	return func(configMap *corev1.ConfigMap) {
-		if err := metrics.UpdateExporter(metrics.ExporterOptions{
-			Domain:    metrics.Domain(),
-			Component: component,
-			ConfigMap: configMap.Data,
-		}, logger); err != nil {
-			logger.Errorw("Error updating metrics exporter", zap.Error(err))
-		}
-	}
-}
 
 // ObservabilityConfig contains the configuration defined in the observability ConfigMap.
 type ObservabilityConfig struct {

--- a/pkg/network/h2c.go
+++ b/pkg/network/h2c.go
@@ -35,12 +35,6 @@ func NewServer(addr string, h http.Handler) *http.Server {
 	return h1s
 }
 
-// ListenAndServe starts a new server and listens on the `addr`.
-func ListenAndServe(addr string, h http.Handler) error {
-	s := NewServer(addr, h)
-	return s.ListenAndServe()
-}
-
 // NewH2CTransport constructs a new H2C transport.
 // That transport will reroute all HTTPS traffic to HTTP. This is
 // to explicitly allow h2c (http2 without TLS) transport.
@@ -58,6 +52,3 @@ func NewH2CTransport() http.RoundTripper {
 		},
 	}
 }
-
-// DefaultH2CTransport is a singleton instance of H2C transport.
-var DefaultH2CTransport http.RoundTripper = NewH2CTransport()

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -18,7 +18,6 @@ package health
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -88,7 +87,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	}
 
 	if !IsHTTPProbeReady(res) {
-		return errors.New(fmt.Sprintf("HTTP probe did not respond Ready, got status code: %d", res.StatusCode))
+		return fmt.Errorf("HTTP probe did not respond Ready, got status code: %d", res.StatusCode)
 	}
 
 	return nil

--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -78,7 +78,7 @@ func (p *Probe) ProbeContainer() bool {
 
 	if err != nil {
 		// Using Fprintf for a concise error message in the event log.
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
 		return false
 	}
 

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -36,9 +36,6 @@ const (
 
 	// LocalGatewayKeyPrefix is the prefix of all keys to configure Istio gateways for public & private ClusterIngresses.
 	LocalGatewayKeyPrefix = "local-gateway."
-
-	// MeshGatewayName is the name of the special 'mesh' Istio Gateway.
-	MeshGatewayName = "mesh"
 )
 
 var (

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -27,8 +27,6 @@ import (
 	"knative.dev/pkg/metrics"
 )
 
-type Measurement int
-
 const (
 	// ServiceReadyCountN is the number of services that have become ready.
 	ServiceReadyCountN = "service_ready_count"

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -98,14 +98,6 @@ func WithHPAClass(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.Annotations[autoscaling.ClassAnnotationKey] = autoscaling.HPA
 }
 
-// WithKPAClass updates the PA to add the kpa class annotation.
-func WithKPAClass(pa *autoscalingv1alpha1.PodAutoscaler) {
-	if pa.Annotations == nil {
-		pa.Annotations = make(map[string]string)
-	}
-	pa.Annotations[autoscaling.ClassAnnotationKey] = autoscaling.KPA
-}
-
 // WithContainerConcurrency returns a PodAutoscalerOption which sets
 // the PodAutoscaler containerConcurrency to the provided value.
 func WithContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) PodAutoscalerOption {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Produced with `staticcheck -unused.whole-program ./cmd/... ./pkg/...`.

I played around with `staticcheck` a bit more, because I want it to actually lint the tests for me as well (it doesn't yet sadly 😢), but I found `-unused.whole-program` which finds unused exported values as well!

I left some of the findings alone though, namely:

- `pkg/activator/config/store.go:35:6: func FromContext is unused (U1001)` I'd keep that for uniformity between the Store implementations.
- `pkg/apis/networking/v1alpha1/certificate_lifecycle.go:61:30: func (*CertificateStatus).GetCondition is unused (U1001)` same comment, leaving for uniformity.
- `pkg/apis` and `pkg/testing`, I'd leave that alone as long as we're transitioning to v1beta1. We can clean up once that completes.
- `pkg/reconciler/ingress` not yet done, so leaving that alone as well.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
