### PR TITLE
Give probe timeout test a lot more time to timeout.

### DIFF
--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -114,12 +114,12 @@ func TestTCPSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
 
-	t.Log("Port", tsUrl.Port())
+	t.Log("Port", tsURL.Port())
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -128,8 +128,8 @@ func TestTCPSuccess(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			TCPSocket: &corev1.TCPSocketAction{
-				Host: tsUrl.Hostname(),
-				Port: intstr.FromString(tsUrl.Port()),
+				Host: tsURL.Hostname(),
+				Port: intstr.FromString(tsURL.Port()),
 			},
 		},
 	}, t)
@@ -165,7 +165,7 @@ func TestHTTPBadResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -177,8 +177,8 @@ func TestHTTPBadResponse(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   tsUrl.Hostname(),
-				Port:   intstr.FromString(tsUrl.Port()),
+				Host:   tsURL.Hostname(),
+				Port:   intstr.FromString(tsURL.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -195,7 +195,7 @@ func TestHTTPSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -207,8 +207,8 @@ func TestHTTPSuccess(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   tsUrl.Hostname(),
-				Port:   intstr.FromString(tsUrl.Port()),
+				Host:   tsURL.Hostname(),
+				Port:   intstr.FromString(tsURL.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -226,7 +226,7 @@ func TestHTTPTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -238,8 +238,8 @@ func TestHTTPTimeout(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host: tsUrl.Hostname(),
-				Port: intstr.FromString(tsUrl.Port()),
+				Host: tsURL.Hostname(),
+				Port: intstr.FromString(tsURL.Port()),
 			},
 		},
 	}, t)
@@ -256,7 +256,7 @@ func TestHTTPSuccessWithDelay(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -268,8 +268,8 @@ func TestHTTPSuccessWithDelay(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   tsUrl.Hostname(),
-				Port:   intstr.FromString(tsUrl.Port()),
+				Host:   tsURL.Hostname(),
+				Port:   intstr.FromString(tsURL.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -293,7 +293,7 @@ func TestKnHTTPSuccessWithRetry(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -305,8 +305,8 @@ func TestKnHTTPSuccessWithRetry(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   tsUrl.Hostname(),
-				Port:   intstr.FromString(tsUrl.Port()),
+				Host:   tsURL.Hostname(),
+				Port:   intstr.FromString(tsURL.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -327,7 +327,7 @@ func TestKnHTTPSuccessWithThreshold(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -339,8 +339,8 @@ func TestKnHTTPSuccessWithThreshold(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   tsUrl.Hostname(),
-				Port:   intstr.FromString(tsUrl.Port()),
+				Host:   tsURL.Hostname(),
+				Port:   intstr.FromString(tsURL.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -372,7 +372,7 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -384,8 +384,8 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host: tsUrl.Hostname(),
-				Port: intstr.FromString(tsUrl.Port()),
+				Host: tsURL.Hostname(),
+				Port: intstr.FromString(tsURL.Port()),
 				HTTPHeaders: []corev1.HTTPHeader{{
 					Name:  "Test-key",
 					Value: "Test-value",
@@ -411,7 +411,7 @@ func TestKnHTTPTimeoutFailure(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tsUrl, err := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
 	}
@@ -423,8 +423,8 @@ func TestKnHTTPTimeoutFailure(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   tsUrl.Hostname(),
-				Port:   intstr.FromString(tsUrl.Port()),
+				Host:   tsURL.Hostname(),
+				Port:   intstr.FromString(tsURL.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"net/url"
 	"testing"
 	"time"
 
@@ -114,7 +114,12 @@ func TestTCPSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
+
+	t.Log("Port", tsUrl.Port())
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -123,8 +128,8 @@ func TestTCPSuccess(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			TCPSocket: &corev1.TCPSocketAction{
-				Host: "127.0.0.1",
-				Port: intstr.FromString(port),
+				Host: tsUrl.Hostname(),
+				Port: intstr.FromString(tsUrl.Port()),
 			},
 		},
 	}, t)
@@ -160,7 +165,10 @@ func TestHTTPBadResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -169,8 +177,8 @@ func TestHTTPBadResponse(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   "127.0.0.1",
-				Port:   intstr.FromString(port),
+				Host:   tsUrl.Hostname(),
+				Port:   intstr.FromString(tsUrl.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -187,7 +195,10 @@ func TestHTTPSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -196,8 +207,8 @@ func TestHTTPSuccess(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   "127.0.0.1",
-				Port:   intstr.FromString(port),
+				Host:   tsUrl.Hostname(),
+				Port:   intstr.FromString(tsUrl.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -215,7 +226,10 @@ func TestHTTPTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -224,8 +238,8 @@ func TestHTTPTimeout(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host: "127.0.0.1",
-				Port: intstr.FromString(port),
+				Host: tsUrl.Hostname(),
+				Port: intstr.FromString(tsUrl.Port()),
 			},
 		},
 	}, t)
@@ -242,7 +256,10 @@ func TestHTTPSuccessWithDelay(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -251,8 +268,8 @@ func TestHTTPSuccessWithDelay(t *testing.T) {
 		FailureThreshold: 1,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   "127.0.0.1",
-				Port:   intstr.FromString(port),
+				Host:   tsUrl.Hostname(),
+				Port:   intstr.FromString(tsUrl.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -276,7 +293,10 @@ func TestKnHTTPSuccessWithRetry(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -285,8 +305,8 @@ func TestKnHTTPSuccessWithRetry(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   "127.0.0.1",
-				Port:   intstr.FromString(port),
+				Host:   tsUrl.Hostname(),
+				Port:   intstr.FromString(tsUrl.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -307,7 +327,10 @@ func TestKnHTTPSuccessWithThreshold(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -316,8 +339,8 @@ func TestKnHTTPSuccessWithThreshold(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   "127.0.0.1",
-				Port:   intstr.FromString(port),
+				Host:   tsUrl.Hostname(),
+				Port:   intstr.FromString(tsUrl.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -349,7 +372,10 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -358,8 +384,8 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host: "127.0.0.1",
-				Port: intstr.FromString(port),
+				Host: tsUrl.Hostname(),
+				Port: intstr.FromString(tsUrl.Port()),
 				HTTPHeaders: []corev1.HTTPHeader{{
 					Name:  "Test-key",
 					Value: "Test-value",
@@ -380,12 +406,15 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 
 func TestKnHTTPTimeoutFailure(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 
-	port := strings.TrimPrefix(ts.URL, "http://127.0.0.1:")
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
+	}
 
 	pb := newProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -394,8 +423,8 @@ func TestKnHTTPTimeoutFailure(t *testing.T) {
 		FailureThreshold: 0,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Host:   "127.0.0.1",
-				Port:   intstr.FromString(port),
+				Host:   tsUrl.Hostname(),
+				Port:   intstr.FromString(tsUrl.Port()),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- Bump the timeout for the timeout test a lot to make it less prone to flakes on slow hardware.
- Actually parse URLs and extract Hostname and Port that way.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
