### PR TITLE
Fix component names containing invalid (for Prometheus) characters

### DIFF
--- a/cmd/networking/certmanager/main.go
+++ b/cmd/networking/certmanager/main.go
@@ -24,6 +24,6 @@ import (
 )
 
 func main() {
-	sharedmain.Main("controller-certificate-cert-manager",
+	sharedmain.Main("certcontroller",
 		certificate.NewController)
 }

--- a/cmd/networking/istio/main.go
+++ b/cmd/networking/istio/main.go
@@ -24,6 +24,6 @@ import (
 )
 
 func main() {
-	sharedmain.Main("controller-ingress-istio",
+	sharedmain.Main("istiocontroller",
 		clusteringress.NewController)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4716 

## Proposed Changes
* Remove `-`
* Use single word namespace as recommended

