### PR TITLE
Elide DNS lookups in the activator.

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -317,7 +317,9 @@ func (a *activationHandler) serviceHostName(rev *v1alpha1.Revision, serviceName 
 		return "", errors.New("revision needs external HTTP port")
 	}
 
-	return network.GetServiceHostname(serviceName, rev.Namespace) + ":" + strconv.Itoa(port), nil
+	// Use the ClusterIP directly to elide DNS lookup, which both adds latency
+	// and hurts reliability when routing through the activator.
+	return svc.Spec.ClusterIP + ":" + strconv.Itoa(port), nil
 }
 
 func sendError(err error, w http.ResponseWriter) {


### PR DESCRIPTION
With the activator on the data path, we see intermittent 502 errors.  When @tcnghia and I started
looking at logs it was fairly clearly correlated with failed DNS lookups talking to kube-dns.  The
errors and a surprising amount of latency were eliminated by hard-coding the Revision's ClusterIP.

It turns out, we already have a K8s Service informer in the activator, so in place of the
fully-qualified service hostname, we simply return the ClusterIP of the service.

In my experiments which fairly reliably kicked out several dozen 502s per run and fairly variable
latency this change seems to have eliminated the errors and significantly reduced the overhead of
the activator proxying the request.

With DNS lookups: https://mako.dev/run?run_key=6259862728081408&~kd=1&~qp=1&~a=1&~ae=1&~ke=1&~qe=1&scatter=1
Without DNS lookups: https://mako.dev/run?run_key=4651310234206208&~kd=1&~qp=1&~a=1&~ae=1&~ke=1&~qe=1&scatter=1

cc @markusthoemmes @vagababov @greghaynes 