### PR TITLE
Swap got and want for Diff of TestServiceDefaulting

### DIFF
--- a/pkg/apis/serving/v1beta1/service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/service_defaults_test.go
@@ -216,7 +216,7 @@ func TestServiceDefaulting(t *testing.T) {
 			got.SetDefaults(context.Background())
 			if !cmp.Equal(got, test.want, ignoreUnexportedResources) {
 				t.Errorf("SetDefaults (-want, +got) = %v",
-					cmp.Diff(got, test.want, ignoreUnexportedResources))
+					cmp.Diff(test.want, got, ignoreUnexportedResources))
 			}
 		})
 	}


### PR DESCRIPTION
This patch makes a tiny change which swaps `got` and `want` in
`TestServiceDefaulting()`.

Current diff prints oppositely, so it is confusing.

- Current output:
```
    --- FAIL: TestServiceDefaulting/run_latest_with_some_default_overrides (0.00s)
        service_defaults_test.go:218: SetDefaults (-want, +got) =   &v1beta1.Service{
              	TypeMeta:   v1.TypeMeta{},
              	ObjectMeta: v1.ObjectMeta{},
              	Spec: v1beta1.ServiceSpec{
              		ConfigurationSpec: v1beta1.ConfigurationSpec{
              			Template: v1beta1.RevisionTemplateSpec{
              				ObjectMeta: v1.ObjectMeta{},
              				Spec: v1beta1.RevisionSpec{
              					PodSpec: v1.PodSpec{
              						Volumes:        nil,
              						InitContainers: nil,
              						Containers: []v1.Container{
              							{
            - 								Name:    "",
            + 								Name:    "user-container",
              								Image:   "busybox",
              								Command: nil,
              								... // 3 identical fields
              								EnvFrom: nil,
              								Env:     nil,
              								Resources: v1.ResourceRequirements{
            - 									Limits:   nil,
            + 									Limits:   v1.ResourceList{},
            - 									Requests: nil,
            + 									Requests: v1.ResourceList{},
```


/lint

## Proposed Changes

* Swap got and want for Diff of TestServiceDefaulting

**Release Note**

```release-note
NONE
```
