### PR TITLE
Update the tests to just go via activator rather than wait for scale to 0

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -20,18 +20,25 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
-	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	"knative.dev/serving/pkg/activator"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	ping "knative.dev/serving/test/test_images/grpc-ping/proto"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -149,7 +156,7 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
 	}
 }
 
-func testGRPC(t *testing.T, f grpcTest) {
+func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Helper()
 	t.Parallel()
 	cancel := logstream.Start(t)
@@ -171,7 +178,7 @@ func testGRPC(t *testing.T, f grpcTest) {
 		ContainerPorts: []corev1.ContainerPort{{
 			Name: "h2c",
 		}},
-	})
+	}, fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -209,22 +216,48 @@ func TestGRPCStreamingPing(t *testing.T) {
 	testGRPC(t, streamTest)
 }
 
-func TestGRPCUnaryPingFromZero(t *testing.T) {
-	testGRPC(t, func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, host, domain string) {
-		if err := WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
-			t.Fatalf("Could not scale to zero: %v", err)
-		}
+func waitForActivatorEPS(resources *v1a1test.ResourceObjects, clients *test.Clients) error {
+	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
+		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting activator endpoints: %v", err)
+	}
 
-		unaryTest(t, resources, clients, host, domain)
+	// Wait for the endpoints to equalize.
+	return wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+		svcEps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
+			resources.Revision.Status.ServiceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return cmp.Equal(svcEps.Subsets, aeps.Subsets), nil
 	})
 }
 
-func TestGRPCStreamingPingFromZero(t *testing.T) {
-	testGRPC(t, func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, host, domain string) {
-		if err := WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
-			t.Fatalf("Could not scale to zero: %v", err)
-		}
+func TestGRPCUnaryPingViaActivator(t *testing.T) {
+	testGRPC(t,
+		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, host, domain string) {
+			if err := waitForActivatorEPS(resources, clients); err != nil {
+				t.Fatal("Never got Activator endpoints in the service")
+			}
+			unaryTest(t, resources, clients, host, domain)
+		},
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetBurstCapacityKey: "-1",
+		}),
+	)
+}
 
-		streamTest(t, resources, clients, host, domain)
-	})
+func TestGRPCStreamingPingViaActivator(t *testing.T) {
+	testGRPC(t,
+		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, host, domain string) {
+			if err := waitForActivatorEPS(resources, clients); err != nil {
+				t.Fatal("Never got Activator endpoints in the service")
+			}
+			streamTest(t, resources, clients, host, domain)
+		},
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetBurstCapacityKey: "-1",
+		}),
+	)
 }

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -22,17 +22,23 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/activator"
+	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	. "knative.dev/serving/pkg/testing/v1alpha1"
@@ -192,7 +198,7 @@ func TestServiceToServiceCall(t *testing.T) {
 
 // Same test as TestServiceToServiceCall but before sending requests
 // we're waiting for target app to be scaled to zero
-func TestServiceToServiceCallFromZero(t *testing.T) {
+func TestServiceToServiceCallViaActivator(t *testing.T) {
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()
@@ -212,22 +218,34 @@ func TestServiceToServiceCallFromZero(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, testNames) })
 	defer test.TearDown(clients, testNames)
 
-	helloWorld, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
-		&v1a1test.Options{
-			RevisionTemplateAnnotations: map[string]string{
-				autoscaling.WindowAnnotationKey: "6s", // shortest permitted.
-			},
-		}, withInternalVisibility)
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
+		&v1a1test.Options{},
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetBurstCapacityKey: "-1",
+		}), withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}
 
-	// Wait for service to be scaled to zero
-	deploymentName := names.Deployment(helloWorld.Revision)
-	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
-		t.Fatalf("Could not scale to zero: %v", err)
+	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
+		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting activator endpoints: %v", err)
+	}
+	t.Logf("Activator endpoints: %v", aeps)
+
+	// Wait for the endpoints to equalize.
+	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+		svcEps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
+			resources.Revision.Status.ServiceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return cmp.Equal(svcEps.Subsets, aeps.Subsets), nil
+	}); err != nil {
+		t.Fatalf("Initial state never achieved: %v", err)
 	}
 
 	// Send request to helloworld app via httpproxy service
-	testProxyToHelloworld(t, clients, helloWorld.Route.Status.URL.Host)
+	testProxyToHelloworld(t, clients, resources.Route.Status.URL.Host)
 }

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -23,12 +23,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/websocket"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
-	rnames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	"knative.dev/serving/pkg/activator"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -133,11 +138,9 @@ func TestWebSocket(t *testing.T) {
 	}
 }
 
-// TestWebSocketFromZero (1) creates a service based on the `wsserver` image,
-// (2) waits for the service to be scaled down to zero replicas
-// (3) connects to the service using websocket, (4) sends a message, and
-// (5) verifies that we receive back the same message.
-func TestWebSocketFromZero(t *testing.T) {
+// TestWebSocketViaActivator (1) creates a service based on the `wsserver` image,
+// and with -1 as target burst capacity and then validates that we can still serve.
+func TestWebSocketViaActivator(t *testing.T) {
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()
@@ -153,17 +156,33 @@ func TestWebSocketFromZero(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetBurstCapacityKey: "-1",
+		}),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
-	deploymentName := rnames.Deployment(resources.Revision)
-
-	if err := WaitForScaleToZero(t, deploymentName, clients); err != nil {
-		t.Fatalf("Could not scale to zero: %v", err)
+	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
+		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting activator endpoints: %v", err)
 	}
+	t.Logf("Activator endpoints: %v", aeps)
 
+	// Wait for the endpoints to equalize.
+	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+		svcEps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
+			resources.Revision.Status.ServiceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return cmp.Equal(svcEps.Subsets, aeps.Subsets), nil
+	}); err != nil {
+		t.Fatalf("Initial state never achieved: %v", err)
+	}
 	if err := validateWebSocketConnection(t, clients, names); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Since we just want to verify the behaviour of request transit
via the Activator, rather than the actual scale to/from 0, then
we can use TBC=-1 to transit the traffic through Activator always.

This requires verifying that endpoints match that of Activator
since due to the autoscaler lag we do the transition back and forth for some time.

Also improve reliability of the TBC test, since sometimes the scale is not high enough to cause activator.

Finally add TBC=-1 specific e2e test.

/assign @mattmoor @markusthoemmes

Fixes #4744 
