### PR TITLE
Fix the bug where with TBC=0 we could get Activator.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -166,9 +166,12 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	// that the deployment does not have enough capacity to serve the desired burst off hand.
 	// EBC = TotCapacity - Cur#ReqInFlight - TargetBurstCapacity
 	excessBC = int32(-1)
-	if a.deciderSpec.TargetBurstCapacity >= 0 {
-		excessBC = int32(float64(originalReadyPodsCount)*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
-			a.deciderSpec.TargetBurstCapacity)
+	switch {
+	case a.deciderSpec.TargetBurstCapacity == 0:
+		excessBC = 0
+	case a.deciderSpec.TargetBurstCapacity >= 0:
+		excessBC = int32(math.Floor(float64(originalReadyPodsCount)*a.deciderSpec.TotalConcurrency - observedStableConcurrency -
+			a.deciderSpec.TargetBurstCapacity))
 		logger.Debugf("PodCount=%v TotalConc=%v ObservedStableConc=%v TargetBC=%v ExcessBC=%v",
 			originalReadyPodsCount,
 			a.deciderSpec.TotalConcurrency,

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -70,7 +71,7 @@ func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
 }
 
 func expectedEBC(tc, tbc, rc, np float64) int32 {
-	return int32(tc/targetUtilization*np - tbc - rc)
+	return int32(math.Floor(tc/targetUtilization*np - tbc - rc))
 }
 func TestAutoscalerNoDataAtZeroNoAutoscale(t *testing.T) {
 	a := newTestAutoscaler(10, 100, &testMetricClient{})
@@ -88,6 +89,12 @@ func TestAutoscalerStableModeUnlimitedTBC(t *testing.T) {
 	metrics := &testMetricClient{stableConcurrency: 21.0}
 	a := newTestAutoscaler(181, -1, metrics)
 	a.expectScale(t, time.Now(), 1, -1, true)
+}
+
+func TestAutoscaler0TBC(t *testing.T) {
+	metrics := &testMetricClient{stableConcurrency: 50.0}
+	a := newTestAutoscaler(10, 0, metrics)
+	a.expectScale(t, time.Now(), 5, 0, true)
 }
 
 func TestAutoscalerStableModeNoChange(t *testing.T) {


### PR DESCRIPTION
When we are behind the scaling Activator would be put in the path even
if the operator set TBC=0.

So explicitly call out that case.

/assign @mattmoor

For 
#1409