### PR TITLE
Remove duplicated imports under different names.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -33,7 +33,6 @@ import (
 	endpointsinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/endpoints"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
-	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/serving"
@@ -195,5 +194,5 @@ func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) func
 
 func flush(logger *zap.SugaredLogger) {
 	logger.Sync()
-	pkgmetrics.FlushExporter()
+	metrics.FlushExporter()
 }

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -41,7 +41,6 @@ import (
 	"knative.dev/serving/pkg/queue"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -491,11 +490,11 @@ func breakerCount(t *Throttler) int {
 	return len(t.breakers)
 }
 
-func endpointsSubset(hostsPerSubset, subsets int) []v1.EndpointSubset {
-	resp := []v1.EndpointSubset{}
+func endpointsSubset(hostsPerSubset, subsets int) []corev1.EndpointSubset {
+	resp := []corev1.EndpointSubset{}
 	if hostsPerSubset > 0 {
-		addresses := make([]v1.EndpointAddress, hostsPerSubset)
-		subset := v1.EndpointSubset{Addresses: addresses}
+		addresses := make([]corev1.EndpointAddress, hostsPerSubset)
+		subset := corev1.EndpointSubset{Addresses: addresses}
 		for s := 0; s < subsets; s++ {
 			resp = append(resp, subset)
 		}

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -42,7 +42,6 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
@@ -403,13 +402,13 @@ func key(name, namespace string) string {
 	return namespace + "/" + name
 }
 
-func pa(name, namespace string, options ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {
-	pa := &autoscalingv1alpha1.PodAutoscaler{
+func pa(name, namespace string, options ...PodAutoscalerOption) *asv1a1.PodAutoscaler {
+	pa := &asv1a1.PodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+		Spec: asv1a1.PodAutoscalerSpec{
 			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
@@ -430,7 +429,7 @@ func withHPAOwnersRemoved(hpa *autoscalingv2beta1.HorizontalPodAutoscaler) {
 	hpa.OwnerReferences = nil
 }
 
-func hpa(name, namespace string, pa *autoscalingv1alpha1.PodAutoscaler, options ...hpaOption) *autoscalingv2beta1.HorizontalPodAutoscaler {
+func hpa(name, namespace string, pa *asv1a1.PodAutoscaler, options ...hpaOption) *autoscalingv2beta1.HorizontalPodAutoscaler {
 	h := resources.MakeHPA(pa, defaultConfig().Autoscaler)
 	for _, o := range options {
 		o(h)

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -56,7 +56,6 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
-	rpkg "knative.dev/serving/pkg/reconciler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa/resources"
@@ -262,7 +261,7 @@ func TestReconcileNegativeBurstCapacity(t *testing.T) {
 		scaler.activatorProbe = func(*asv1a1.PodAutoscaler, http.RoundTripper) (bool, error) { return true, nil }
 		return &Reconciler{
 			Base: &areconciler.Base{
-				Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),
+				Base:              reconciler.NewBase(ctx, controllerAgentName, newConfigWatcher()),
 				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
@@ -433,7 +432,7 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 		scaler.activatorProbe = func(*asv1a1.PodAutoscaler, http.RoundTripper) (bool, error) { return true, nil }
 		return &Reconciler{
 			Base: &areconciler.Base{
-				Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),
+				Base:              reconciler.NewBase(ctx, controllerAgentName, newConfigWatcher()),
 				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
@@ -905,7 +904,7 @@ func TestReconcile(t *testing.T) {
 		fakeMetrics := newTestMetrics()
 		return &Reconciler{
 			Base: &areconciler.Base{
-				Base:              rpkg.NewBase(ctx, controllerAgentName, newConfigWatcher()),
+				Base:              reconciler.NewBase(ctx, controllerAgentName, newConfigWatcher()),
 				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),

--- a/pkg/reconciler/autoscaling/resources/service.go
+++ b/pkg/reconciler/autoscaling/resources/service.go
@@ -21,7 +21,6 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	sv1a1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/resources"
 
@@ -45,12 +44,12 @@ func MakeMetricsService(pa *pav1alpha1.PodAutoscaler, selector map[string]string
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       v1alpha1.ServiceQueueMetricsPortName,
+				Name:       sv1a1.ServiceQueueMetricsPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.AutoscalingQueueMetricsPort,
 				TargetPort: intstr.FromString(sv1a1.AutoscalingQueueMetricsPortName),
 			}, {
-				Name:       v1alpha1.UserQueueMetricsPortName,
+				Name:       sv1a1.UserQueueMetricsPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.UserQueueMetricsPort,
 				TargetPort: intstr.FromString(sv1a1.UserQueueMetricsPortName),

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -50,7 +50,6 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
 	resourcenames "knative.dev/serving/pkg/reconciler/route/resources/names"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
-	tr "knative.dev/serving/pkg/reconciler/route/traffic"
 )
 
 // routeFinalizer is the name that we put into the resource finalizer list, e.g.
@@ -369,9 +368,9 @@ func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) e
 //
 // If traffic is configured we update the RouteStatus with AllTrafficAssigned = True.  Otherwise we
 // mark AllTrafficAssigned = False, with a message referring to one of the missing target.
-func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, clusterLocalServices sets.String) (*tr.Config, error) {
+func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, clusterLocalServices sets.String) (*traffic.Config, error) {
 	logger := logging.FromContext(ctx)
-	t, err := tr.BuildTrafficConfiguration(c.configurationLister, c.revisionLister, r)
+	t, err := traffic.BuildTrafficConfiguration(c.configurationLister, c.revisionLister, r)
 
 	if t != nil {
 		// Tell our trackers to reconcile Route whenever the things referred to by our
@@ -391,7 +390,7 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, cl
 		}
 	}
 
-	badTarget, isTargetError := err.(tr.TargetError)
+	badTarget, isTargetError := err.(traffic.TargetError)
 	if err != nil && !isTargetError {
 		// An error that's not due to missing traffic target should
 		// make us fail fast.

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -44,7 +44,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	ctrl "knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/system"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -165,14 +164,14 @@ func newTestReconciler(t *testing.T, configs ...*corev1.ConfigMap) (
 func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 	ctx context.Context,
 	informers []controller.Informer,
-	controller *ctrl.Impl,
+	ctrl *controller.Impl,
 	reconciler *Reconciler,
 	configMapWatcher *configmap.ManualWatcher) {
 
 	ctx, informers = SetupFakeContext(t)
 	configMapWatcher = &configmap.ManualWatcher{Namespace: system.Namespace()}
-	controller = NewController(ctx, configMapWatcher)
-	reconciler = controller.Reconciler.(*Reconciler)
+	ctrl = NewController(ctx, configMapWatcher)
+	reconciler = ctrl.Reconciler.(*Reconciler)
 
 	cms := append([]*corev1.ConfigMap{{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -31,7 +31,6 @@ import (
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	rbase "knative.dev/serving/pkg/reconciler"
 	presources "knative.dev/serving/pkg/resources"
 )
 
@@ -50,7 +49,7 @@ func NewController(
 	sksInformer := sksinformer.Get(ctx)
 
 	c := &reconciler{
-		Base:              rbase.NewBase(ctx, controllerAgentName, cmw),
+		Base:              pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
 		endpointsLister:   endpointsInformer.Lister(),
 		serviceLister:     serviceInformer.Lister(),
 		sksLister:         sksInformer.Lister(),
@@ -84,9 +83,9 @@ func NewController(
 	}
 	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		// Accept only ActivatorService K8s service objects.
-		FilterFunc: rbase.ChainFilterFuncs(
-			rbase.NamespaceFilterFunc(system.Namespace()),
-			rbase.NameFilterFunc(activator.K8sServiceName)),
+		FilterFunc: pkgreconciler.ChainFilterFuncs(
+			pkgreconciler.NamespaceFilterFunc(system.Namespace()),
+			pkgreconciler.NameFilterFunc(activator.K8sServiceName)),
 		Handler: controller.HandleAll(grCb),
 	})
 

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -79,7 +78,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger.Debugf("Reconciling SKS resource: %s", key)
 	// Get the current SKS resource.
 	original, err := r.sksLister.ServerlessServices(namespace).Get(name)
-	if apierrs.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
 		logger.Errorf("SKS resource %q in work queue no longer exists", key)
 		return nil
@@ -286,7 +285,7 @@ func (r *reconciler) privateService(sks *netv1alpha1.ServerlessService) (*corev1
 	}
 	switch l := len(svcs); l {
 	case 0:
-		return nil, apierrs.NewNotFound(corev1.Resource("Services"), sks.Name)
+		return nil, errors.NewNotFound(corev1.Resource("Services"), sks.Name)
 	case 1:
 		return svcs[0], nil
 	default:

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
@@ -75,7 +74,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Get the Service resource with this namespace/name
 	original, err := c.serviceLister.Services(namespace).Get(name)
-	if apierrs.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
 		logger.Errorf("service %q in work queue no longer exists", key)
 		return nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

I found quite a bit of satisfaction in working on static analysis tools and it turns out my beloved `staticcheck` was [missing a duplicate import check](https://github.com/dominikh/go-tools/pull/537). And duplicated imports really are not pretty! Open-Source rocks 🚀 .

## Proposed Changes

* Remove duplicated 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 