### PR TITLE
Replace a prober factory with a prober with no caching.

### DIFF
--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -149,7 +149,7 @@ func TestDoAsync(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := New(test.cb, network.NewAutoTransport)
+			m := New(test.cb, network.NewProberTransport())
 			m.Offer(context.Background(), ts.URL, test.name, 50*time.Millisecond, 2*time.Second, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue))
 			<-wch
 		})
@@ -186,7 +186,7 @@ func TestDoAsyncRepeat(t *testing.T) {
 		}
 		wch <- arg
 	}
-	m := New(cb, network.NewAutoTransport)
+	m := New(cb, network.NewProberTransport())
 	m.Offer(context.Background(), ts.URL, 42, 50*time.Millisecond, 3*time.Second, WithHeader(network.ProbeHeaderName, systemName), ExpectsBody(systemName))
 	<-wch
 	if got, want := c.calls, 3; got != want {
@@ -209,7 +209,7 @@ func TestDoAsyncTimeout(t *testing.T) {
 		}
 		wch <- arg
 	}
-	m := New(cb, network.NewAutoTransport)
+	m := New(cb, network.NewProberTransport())
 	m.Offer(context.Background(), ts.URL, 2009, 10*time.Millisecond, 200*time.Millisecond)
 	<-wch
 }
@@ -224,7 +224,7 @@ func TestAsyncMultiple(t *testing.T) {
 		<-wch
 		wch <- 2006
 	}
-	m := New(cb, network.NewAutoTransport)
+	m := New(cb, network.NewProberTransport())
 	if !m.Offer(context.Background(), ts.URL, 1984, 100*time.Millisecond, 1*time.Second) {
 		t.Error("First call to offer returned false")
 	}

--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -85,7 +85,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, steps int, 
 	return nil, errDialTimeout
 }
 
-func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
+func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.RoundTripper {
 	return &http.Transport{
 		// Those match net/http/transport.go
 		Proxy:                 http.ProxyFromEnvironment,
@@ -93,16 +93,23 @@ func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
 		IdleConnTimeout:       5 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		DisableKeepAlives:     disableKeepAlives,
 
 		// This is bespoke.
 		DialContext: dialWithBackOff,
 	}
 }
 
+// NewProberTransport creates a RoundTripper that is useful for probing,
+// since it will not cache connections.
+func NewProberTransport() http.RoundTripper {
+	return newAutoTransport(newHTTPTransport(DefaultConnTimeout, true /*disable keep-alives*/), NewH2CTransport())
+}
+
 // NewAutoTransport creates a RoundTripper that can use appropriate transport
 // based on the request's HTTP version.
 func NewAutoTransport() http.RoundTripper {
-	return newAutoTransport(newHTTPTransport(DefaultConnTimeout), NewH2CTransport())
+	return newAutoTransport(newHTTPTransport(DefaultConnTimeout, false /*disable keep-alives*/), NewH2CTransport())
 }
 
 // AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -79,6 +79,7 @@ type scaler struct {
 	psInformerFactory duck.InformerFactory
 	dynamicClient     dynamic.Interface
 	logger            *zap.SugaredLogger
+	transport         http.RoundTripper
 	transportFactory  prober.TransportFactory
 
 	// For sync probes.
@@ -89,15 +90,19 @@ type scaler struct {
 	enqueueCB    func(interface{}, time.Duration)
 }
 
+var transport = network.NewProberTransport()
+
 // newScaler creates a scaler.
 func newScaler(ctx context.Context, psInformerFactory duck.InformerFactory, enqueueCB func(interface{}, time.Duration)) *scaler {
 	logger := logging.FromContext(ctx)
+	transport := network.NewProberTransport()
 	ks := &scaler{
 		// Wrap it in a cache, so that we don't stamp out a new
 		// informer/lister each time.
 		psInformerFactory: psInformerFactory,
 		dynamicClient:     dynamicclient.Get(ctx),
 		logger:            logger,
+		transport:         transport,
 		transportFactory: func() http.RoundTripper {
 			return network.NewAutoTransport()
 		},
@@ -108,7 +113,7 @@ func newScaler(ctx context.Context, psInformerFactory duck.InformerFactory, enqu
 			logger.Infof("Async prober is done for %v: success?: %v error: %v", arg, success, err)
 			// Re-enqeue the PA in any case. If the probe timed out to retry again, if succeeded to scale to 0.
 			enqueueCB(arg, reenqeuePeriod)
-		}, network.NewAutoTransport),
+		}, transport),
 		enqueueCB: enqueueCB,
 	}
 	return ks
@@ -179,7 +184,7 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 		ks.enqueueCB(pa, sw)
 		desiredScale = 1
 	} else { // Active=False
-		r, err := ks.activatorProbe(pa, ks.transportFactory())
+		r, err := ks.activatorProbe(pa, ks.transport)
 		ks.logger.Infof("%s probing activator = %v, err = %v", pa.Name, r, err)
 		if r {
 			// Make sure we've been inactive for enough time.

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -30,6 +30,11 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -41,12 +46,6 @@ import (
 	revisionresources "knative.dev/serving/pkg/reconciler/revision/resources"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 	presources "knative.dev/serving/pkg/resources"
-
-	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck"
-	"knative.dev/pkg/logging"
-	logtesting "knative.dev/pkg/logging/testing"
-	_ "knative.dev/pkg/system/testing"
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
If we use a transport that has disablekeepalives , then the connection should only
be used once and solve the problem that factory was solving, i.e. making new TCP connection
each time we send a request.

This also noted by Dave earlier in a comment.


/lint

## Proposed Changes

* Add a new transport factory method that returns transports useful for probing
* Update the rest of the code.


/assign @tcnghia @mattmoor 