### PR TITLE
Remove the check which is redundant and _s.

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -110,9 +110,6 @@ func (b *Breaker) Capacity() int {
 // in the rotation. Attempting to add more capacity then the max will result in error.
 // Initial capacity is the initial number of free tokens.
 func newSemaphore(maxCapacity, initialCapacity int) *semaphore {
-	if initialCapacity < 0 || initialCapacity > maxCapacity {
-		panic(fmt.Sprintf("Initial capacity must be between 0 and maximal capacity. Got %v.", initialCapacity))
-	}
 	queue := make(chan struct{}, maxCapacity)
 	sem := &semaphore{queue: queue}
 	if initialCapacity > 0 {

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -177,7 +177,7 @@ func TestBreakerUpdateConcurrencyOverlow(t *testing.T) {
 }
 
 // Test empty semaphore, token cannot be acquired
-func TestSemaphore_acquire_HasNoCapacity(t *testing.T) {
+func TestSemaphoreAcquireHasNoCapacity(t *testing.T) {
 	gotChan := make(chan struct{}, 1)
 
 	sem := newSemaphore(1, 0)
@@ -192,7 +192,7 @@ func TestSemaphore_acquire_HasNoCapacity(t *testing.T) {
 }
 
 // Test empty semaphore, add capacity, token can be acquired
-func TestSemaphore_acquire_HasCapacity(t *testing.T) {
+func TestSemaphoreAcquireHasCapacity(t *testing.T) {
 	gotChan := make(chan struct{}, 1)
 	want := 1
 
@@ -217,7 +217,7 @@ func TestSemaphore_acquire_HasCapacity(t *testing.T) {
 	}
 }
 
-func TestSemaphore_release(t *testing.T) {
+func TestSemaphoreRelease(t *testing.T) {
 	sem := newSemaphore(1, 1)
 	sem.acquire(context.Background())
 	if err := sem.release(); err != nil {
@@ -228,7 +228,7 @@ func TestSemaphore_release(t *testing.T) {
 	}
 }
 
-func TestSemaphore_releasesSeveralReducers(t *testing.T) {
+func TestSemaphoreReleasesSeveralReducers(t *testing.T) {
 	const wantAfterFirstrelease = 1
 	const wantAfterSecondrelease = 0
 	sem := newSemaphore(2, 2)
@@ -252,7 +252,7 @@ func TestSemaphore_releasesSeveralReducers(t *testing.T) {
 	}
 }
 
-func TestSemaphore_updateCapacity(t *testing.T) {
+func TestSemaphoreUpdateCapacity(t *testing.T) {
 	const initialCapacity = 1
 	sem := newSemaphore(3, initialCapacity)
 	if got, want := sem.Capacity(), 1; got != want {
@@ -266,7 +266,7 @@ func TestSemaphore_updateCapacity(t *testing.T) {
 }
 
 // Test the case when we add more capacity then the number of waiting reducers
-func TestSemaphore_updateCapacity_LessThenReducers(t *testing.T) {
+func TestSemaphoreUpdateCapacityLessThenReducers(t *testing.T) {
 	const initialCapacity = 2
 	sem := newSemaphore(2, initialCapacity)
 	sem.acquire(context.Background())
@@ -283,7 +283,7 @@ func TestSemaphore_updateCapacity_LessThenReducers(t *testing.T) {
 	}
 }
 
-func TestSemaphore_updateCapacity_ConsumingReducers(t *testing.T) {
+func TestSemaphoreUpdateCapacityConsumingReducers(t *testing.T) {
 	const initialCapacity = 2
 	sem := newSemaphore(2, initialCapacity)
 	sem.acquire(context.Background())
@@ -299,14 +299,14 @@ func TestSemaphore_updateCapacity_ConsumingReducers(t *testing.T) {
 	}
 }
 
-func TestSemaphore_updateCapacity_Overflow(t *testing.T) {
+func TestSemaphoreUpdateCapacityOverflow(t *testing.T) {
 	sem := newSemaphore(2, 0)
 	if err := sem.updateCapacity(3); err != ErrUpdateCapacity {
 		t.Errorf("updateCapacity = %v, want: %v", err, ErrUpdateCapacity)
 	}
 }
 
-func TestSemaphore_updateCapacity_OutOfBound(t *testing.T) {
+func TestSemaphoreUpdateCapacityOutOfBound(t *testing.T) {
 	sem := newSemaphore(1, 1)
 	sem.acquire(context.Background())
 	if err := sem.updateCapacity(-1); err != ErrUpdateCapacity {
@@ -314,7 +314,7 @@ func TestSemaphore_updateCapacity_OutOfBound(t *testing.T) {
 	}
 }
 
-func TestSemaphore_updateCapacity_BrokenState(t *testing.T) {
+func TestSemaphoreUpdateCapacityBrokenState(t *testing.T) {
 	sem := newSemaphore(1, 0)
 	sem.release() // This Release is not paired with an acquire
 	if err := sem.updateCapacity(1); err != ErrUpdateCapacity {
@@ -322,20 +322,11 @@ func TestSemaphore_updateCapacity_BrokenState(t *testing.T) {
 	}
 }
 
-func TestSemaphore_updateCapacity_DoNothing(t *testing.T) {
+func TestSemaphoreUpdateCapacityDoNothing(t *testing.T) {
 	sem := newSemaphore(1, 1)
 	if err := sem.updateCapacity(1); err != nil {
 		t.Errorf("updateCapacity = %v, want: %v", err, nil)
 	}
-}
-
-func TestSemaphore_WrongInitialCapacity(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("The code did not panic")
-		}
-	}()
-	newSemaphore(1, 2)
 }
 
 func tryAcquire(sem *semaphore, gotChan chan struct{}) {


### PR DESCRIPTION
We need not check the validity of the parameter passed to the semaphore
since it is an internal object and its params have already been validated in the NewBreaker. Also the test for that is gone.

Also remove the '_' from the test names.

/assign @markusthoemmes.

/lint
