### PR TITLE
Add the metric to report excess burst capacity.

### DIFF
--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -272,6 +272,11 @@ func (r *mockReporter) ReportPanic(v int64) error {
 	return nil
 }
 
+// ReportExcessBurstCapacity retports excess burst capacity.
+func (r *mockReporter) ReportExcessBurstCapacity(v float64) error {
+	return nil
+}
+
 func newTestAutoscaler(targetConcurrency, targetBurstCapacity float64, metrics MetricClient) *Autoscaler {
 	deciderSpec := DeciderSpec{
 		TargetConcurrency:   targetConcurrency,

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -41,6 +41,10 @@ var (
 		"actual_pods",
 		"Number of pods that are allocated currently",
 		stats.UnitDimensionless)
+	excessBurstCapacityM = stats.Float64(
+		"excess_burst_capacity",
+		"Excess burst capacity overserved in each stable window (default 60 seconds)",
+		stats.UnitDimensionless)
 	stableRequestConcurrencyM = stats.Float64(
 		"stable_request_concurrency",
 		"Average of requests count per observed pod in each stable window (default 60 seconds)",
@@ -120,6 +124,12 @@ func register() {
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
+			Description: "Current excess burst capacity over average request count in each 60 second stable window",
+			Measure:     excessBurstCapacityM,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+		},
+		&view.View{
 			Description: "Average of requests count in each 6 second panic window",
 			Measure:     panicRequestConcurrencyM,
 			Aggregation: view.LastValue(),
@@ -151,6 +161,7 @@ type StatsReporter interface {
 	ReportStableRequestConcurrency(v float64) error
 	ReportPanicRequestConcurrency(v float64) error
 	ReportTargetRequestConcurrency(v float64) error
+	ReportExcessBurstCapacity(v float64) error
 	ReportPanic(v int64) error
 }
 
@@ -169,7 +180,6 @@ func valueOrUnknown(v string) string {
 
 // NewStatsReporter creates a reporter that collects and reports autoscaler metrics
 func NewStatsReporter(podNamespace string, service string, config string, revision string) (*Reporter, error) {
-
 	r := &Reporter{}
 
 	// Our tags are static. So, we can get away with creating a single context
@@ -203,6 +213,11 @@ func (r *Reporter) ReportRequestedPodCount(v int64) error {
 // ReportActualPodCount captures value v for actual pod count measure.
 func (r *Reporter) ReportActualPodCount(v int64) error {
 	return r.report(actualPodCountM.M(v))
+}
+
+// ReportExcessBurstCapacity captures value v for excess target burst capacity.
+func (r *Reporter) ReportExcessBurstCapacity(v float64) error {
+	return r.report(excessBurstCapacityM.M(v))
 }
 
 // ReportStableRequestConcurrency captures value v for stable request concurrency measure.

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -43,15 +43,15 @@ var (
 		stats.UnitDimensionless)
 	excessBurstCapacityM = stats.Float64(
 		"excess_burst_capacity",
-		"Excess burst capacity overserved in each stable window",
+		"Excess burst capacity overserved over the stable window",
 		stats.UnitDimensionless)
 	stableRequestConcurrencyM = stats.Float64(
 		"stable_request_concurrency",
-		"Average of requests count per observed pod in each stable window",
+		"Average of requests count per observed pod over the stable window",
 		stats.UnitDimensionless)
 	panicRequestConcurrencyM = stats.Float64(
 		"panic_request_concurrency",
-		"Average of requests count per observed pod in each panic window",
+		"Average of requests count per observed pod over the panic window",
 		stats.UnitDimensionless)
 	targetRequestConcurrencyM = stats.Float64(
 		"target_concurrency_per_pod",
@@ -118,7 +118,7 @@ func register() {
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
-			Description: "Average of requests count over the table window",
+			Description: "Average of requests count over the stable window",
 			Measure:     stableRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
@@ -130,7 +130,7 @@ func register() {
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
-			Description: "Average of requests count over the second panic window",
+			Description: "Average of requests count over the panic window",
 			Measure:     panicRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -43,15 +43,15 @@ var (
 		stats.UnitDimensionless)
 	excessBurstCapacityM = stats.Float64(
 		"excess_burst_capacity",
-		"Excess burst capacity overserved in each stable window (default 60 seconds)",
+		"Excess burst capacity overserved in each stable window",
 		stats.UnitDimensionless)
 	stableRequestConcurrencyM = stats.Float64(
 		"stable_request_concurrency",
-		"Average of requests count per observed pod in each stable window (default 60 seconds)",
+		"Average of requests count per observed pod in each stable window",
 		stats.UnitDimensionless)
 	panicRequestConcurrencyM = stats.Float64(
 		"panic_request_concurrency",
-		"Average of requests count per observed pod in each panic window (default 6 seconds)",
+		"Average of requests count per observed pod in each panic window",
 		stats.UnitDimensionless)
 	targetRequestConcurrencyM = stats.Float64(
 		"target_concurrency_per_pod",
@@ -118,19 +118,19 @@ func register() {
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
-			Description: "Average of requests count in each 60 second stable window",
+			Description: "Average of requests count over the table window",
 			Measure:     stableRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
-			Description: "Current excess burst capacity over average request count in each 60 second stable window",
+			Description: "Current excess burst capacity over average request count over the stable window",
 			Measure:     excessBurstCapacityM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
 		},
 		&view.View{
-			Description: "Average of requests count in each 6 second panic window",
+			Description: "Average of requests count over the second panic window",
 			Measure:     panicRequestConcurrencyM,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -59,7 +59,7 @@ var (
 	}
 )
 
-func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
+func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	client := newTestScrapeClient(testStats, []error{nil})
 	if scraper, err := serviceScraperForTest(client); err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
@@ -73,7 +73,7 @@ func TestNewServiceScraperWithClient_HappyCase(t *testing.T) {
 	}
 }
 
-func TestNewServiceScraperWithClient_ErrorCases(t *testing.T) {
+func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
 	metric := testMetric()
 	invalidMetric := testMetric()
 	invalidMetric.Labels = map[string]string{}


### PR DESCRIPTION
This reports excess burst capacity from the autoscaler.
Next change will contain the Graphana config changes
so we can plot those by default.

/assign @markusthoemmes  @yanweiguo 

/lint
