### PR TITLE
Remove the usage of the extensions API for deployments.

### DIFF
--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -74,7 +74,7 @@ func TestMinScale(t *testing.T) {
 		t.Fatalf("The Revision %q did not become ready: %v", revName, err)
 	}
 
-	deployment, err := clients.KubeClient.Kube.ExtensionsV1beta1().Deployments(test.ServingNamespace).Get(revName+"-deployment", metav1.GetOptions{})
+	deployment, err := clients.KubeClient.Kube.AppsV1().Deployments(test.ServingNamespace).Get(revName+"-deployment", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Deployment for Revision %s, err: %v", revName, err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We already comply with this mostly, this is the last offender. [1.11 already supports `apps/v1`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#deployment-v1-apps) so there's little reason to use the extensions API still.

Also see: https://groups.google.com/forum/#!topic/kubernetes-dev/je0rjyfTVyc/discussion

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
