### PR TITLE
Remove `test.Options` and replace with functional options.

### DIFF
--- a/pkg/testing/v1alpha1/configuration.go
+++ b/pkg/testing/v1alpha1/configuration.go
@@ -19,7 +19,10 @@ package v1alpha1
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -102,5 +105,20 @@ func WithConfigLabel(key, value string) ConfigOption {
 			config.Labels = make(map[string]string)
 		}
 		config.Labels[key] = value
+	}
+}
+
+// WithConfigReadinessProbe sets the provided probe to be the readiness
+// probe on the configuration.
+func WithConfigReadinessProbe(p *corev1.Probe) ConfigOption {
+	return func(cfg *v1alpha1.Configuration) {
+		cfg.Spec.Template.Spec.Containers[0].ReadinessProbe = p
+	}
+}
+
+// WithConfigRevisionTimeoutSeconds sets revision timeout.
+func WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ConfigOption {
+	return func(cfg *v1alpha1.Configuration) {
+		cfg.Spec.Template.Spec.TimeoutSeconds = ptr.Int64(revisionTimeoutSeconds)
 	}
 }

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -172,6 +172,20 @@ func WithNumberedPort(number int32) ServiceOption {
 	}
 }
 
+// WithNamedPort sets the Service's port name to what's provided.
+func WithNamedPort(name string) ServiceOption {
+	return func(svc *v1alpha1.Service) {
+		c := &svc.Spec.Template.Spec.Containers[0]
+		if len(c.Ports) == 1 {
+			c.Ports[0].Name = name
+		} else {
+			c.Ports = []corev1.ContainerPort{{
+				Name: name,
+			}}
+		}
+	}
+}
+
 // WithResourceRequirements attaches resource requirements to the service
 func WithResourceRequirements(resourceRequirements corev1.ResourceRequirements) ServiceOption {
 	return func(svc *v1alpha1.Service) {
@@ -459,5 +473,13 @@ func WithSecurityContext(sc *corev1.SecurityContext) ServiceOption {
 func WithWorkingDir(wd string) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		s.Spec.Template.Spec.Containers[0].WorkingDir = wd
+	}
+}
+
+// WithReadinessProbe sets the provided probe to be the readiness
+// probe on the service.
+func WithReadinessProbe(p *corev1.Probe) ServiceOption {
+	return func(s *v1alpha1.Service) {
+		s.Spec.Template.Spec.Containers[0].ReadinessProbe = p
 	}
 }

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -66,7 +66,7 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/configuration_test.go
+++ b/test/conformance/api/v1alpha1/configuration_test.go
@@ -41,7 +41,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	t.Logf("Creating new configuration %s", names.Config)
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}); err != nil {
+	if _, err := v1a1test.CreateConfiguration(t, clients, names); err != nil {
 		t.Fatalf("Failed to create configuration %s", names.Config)
 	}
 

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -54,7 +54,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
 	t.Logf("Creating a new Configuration %s", names.Image)
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}); err != nil {
+	if _, err := v1a1test.CreateConfiguration(t, clients, names); err != nil {
 		t.Fatalf("Failed to create configuration %s", names.Config)
 	}
 	defer test.TearDown(clients, names)
@@ -162,7 +162,7 @@ func TestContainerExitingMsg(t *testing.T) {
 
 			t.Logf("Creating a new Configuration %s", names.Image)
 
-			if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}, v1a1opts.WithConfigReadinessProbe(tt.ReadinessProbe)); err != nil {
+			if _, err := v1a1test.CreateConfiguration(t, clients, names, v1a1opts.WithConfigReadinessProbe(tt.ReadinessProbe)); err != nil {
 				t.Fatalf("Failed to create configuration %s: %v", names.Config, err)
 			}
 

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ptest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -161,7 +162,7 @@ func TestContainerExitingMsg(t *testing.T) {
 
 			t.Logf("Creating a new Configuration %s", names.Image)
 
-			if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{ReadinessProbe: tt.ReadinessProbe}); err != nil {
+			if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}, v1a1opts.WithConfigReadinessProbe(tt.ReadinessProbe)); err != nil {
 				t.Fatalf("Failed to create configuration %s: %v", names.Config, err)
 			}
 

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -123,7 +123,7 @@ func TestServiceGenerateName(t *testing.T) {
 
 	// Create the service using the generate name field. If the serivce does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, setServiceGenerateName(generateName))
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)
 	}
@@ -158,7 +158,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	defer func() { test.TearDown(clients, names) }()
 
 	t.Logf("Creating new configuration with generateName %s", generateName)
-	config, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}, setConfigurationGenerateName(generateName))
+	config, err := v1a1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create configuration with generateName %s: %v", generateName, err)
 	}

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -53,7 +54,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{ContainerResources: resources})
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -54,7 +54,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithResourceRequirements(resources))
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -41,7 +41,7 @@ import (
 // createLatestService creates a service in namespace with the name names.Service
 // that uses the image specified by names.Image
 func createLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) (*v1alpha1.Service, error) {
-	service := v1a1test.LatestService(names, &v1a1test.Options{}, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
+	service := v1a1test.LatestService(names, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
 	v1a1test.LogResourceObject(t, v1a1test.ResourceObjects{Service: service})
 	svc, err := clients.ServingAlphaClient.Services.Create(service)
 	return svc, err

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -107,7 +107,7 @@ func TestRouteCreation(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Route and Configuration")
-	config, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{})
+	config, err := v1a1test.CreateConfiguration(t, clients, names, )
 	if err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -53,7 +53,7 @@ func TestRunLatestService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -196,7 +196,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	revName := names.Service + "-byoname"
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, func(svc *v1alpha1.Service) {
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, func(svc *v1alpha1.Service) {
 		svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
 	})
 	if err != nil {
@@ -265,7 +265,7 @@ func TestReleaseService(t *testing.T) {
 	)
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -529,7 +529,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	pkgTest "knative.dev/pkg/test"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -44,9 +45,7 @@ func TestSingleConcurrency(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		ContainerConcurrency: 1,
-	})
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -45,7 +45,7 @@ func TestSingleConcurrency(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithContainerConcurrency(1))
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -89,7 +89,7 @@ func TestConfigMapVolume(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withVolume, withOptionalBadVolume); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -161,7 +161,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withVolume); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -227,7 +227,7 @@ func TestSecretVolume(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withVolume, withOptionalBadVolume); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -297,7 +297,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 	}
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withVolume, withSubpath); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume, withSubpath); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -394,7 +394,7 @@ func TestProjectedComplex(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withVolume); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 

--- a/test/conformance/api/v1beta1/migration_test.go
+++ b/test/conformance/api/v1beta1/migration_test.go
@@ -50,7 +50,7 @@ func TestV1beta1Translation(t *testing.T) {
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service.  This should perform conversion during the webhook
 	// and return back a converted service resource.
-	service, err := v1a1test.CreateLatestServiceLegacy(t, clients, names, &v1a1test.Options{})
+	service, err := v1a1test.CreateLatestServiceLegacy(t, clients, names, )
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -84,7 +84,7 @@ func TestV1beta1Rejection(t *testing.T) {
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service, but give it the TypeMeta of v1beta1.
-	service := v1a1test.LatestServiceLegacy(names, &v1a1test.Options{})
+	service := v1a1test.LatestServiceLegacy(names, )
 	service.APIVersion = v1beta1.SchemeGroupVersion.String()
 	service.Kind = "Service"
 

--- a/test/conformance/runtime/container_test.go
+++ b/test/conformance/runtime/container_test.go
@@ -108,7 +108,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 				Service: test.ObjectNameForTest(t),
 				Image:   test.Runtime,
 			}
-			if svc, err := v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{}, tc.options); err == nil {
+			if svc, err := v1a1test.CreateLatestService(t, clients, names, tc.options); err == nil {
 				t.Errorf("CreateService = %v, want: error", spew.Sdump(svc))
 			}
 		})
@@ -191,7 +191,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 				Service: test.ObjectNameForTest(t),
 				Image:   test.Runtime,
 			}
-			if svc, err := v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{}, tc.options); err == nil {
+			if svc, err := v1a1test.CreateLatestService(t, clients, names, tc.options); err == nil {
 				t.Errorf("CreateLatestService = %v, want: error", spew.Sdump(svc))
 			}
 		})

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -44,7 +44,7 @@ func TestProbeRuntime(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	_, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithReadinessProbe(
+	_, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithReadinessProbe(
 		&corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/test/logstream"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -43,16 +44,14 @@ func TestProbeRuntime(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	_, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		RevisionTemplateAnnotations: map[string]string{},
-		ReadinessProbe: &corev1.Probe{
+	_, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithReadinessProbe(
+		&corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: "/healthz",
 				},
 			},
-		},
-	})
+		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -54,7 +54,7 @@ func fetchRuntimeInfo(
 		svc.Spec.Template.Spec.Containers[0].ImagePullPolicy = "Always"
 	})
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, &v1a1test.Options{}, serviceOpts...)
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, serviceOpts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -58,7 +58,7 @@ func TestActivatorOverload(t *testing.T) {
 	t.Log("Creating a service with run latest configuration.")
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, func(service *v1alpha1.Service) {
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, func(service *v1alpha1.Service) {
 		service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = 1
 		service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 	})

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -124,7 +124,7 @@ func generateTraffic(ctx *testContext, concurrency int, duration time.Duration, 
 	return nil
 }
 
-func setup(t *testing.T, class string, metric string, opts *v1a1test.Options, fopts ...rtesting.ServiceOption) *testContext {
+func setup(t *testing.T, class string, metric string, fopts ...rtesting.ServiceOption) *testContext {
 	t.Helper()
 	clients := Setup(t)
 
@@ -134,7 +134,7 @@ func setup(t *testing.T, class string, metric string, opts *v1a1test.Options, fo
 		Image:   "autoscale",
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, opts,
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		append(fopts, rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:  class,
 			autoscaling.MetricAnnotationKey: metric,
@@ -295,7 +295,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, &v1a1test.Options{},
+	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency,
 		rtesting.WithContainerConcurrency(containerConcurrency))
 	defer test.TearDown(ctx.clients, ctx.names)
 
@@ -319,7 +319,7 @@ func TestAutoscaleUpCountPods(t *testing.T) {
 			cancel := logstream.Start(t)
 			defer cancel()
 
-			ctx := setup(tt, class, autoscaling.Concurrency, &v1a1test.Options{},
+			ctx := setup(tt, class, autoscaling.Concurrency,
 				rtesting.WithContainerConcurrency(containerConcurrency))
 			defer test.TearDown(ctx.clients, ctx.names)
 
@@ -346,7 +346,7 @@ func TestAutoscaleSustaining(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, &v1a1test.Options{},
+	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency,
 		rtesting.WithContainerConcurrency(containerConcurrency))
 	defer test.TearDown(ctx.clients, ctx.names)
 
@@ -363,7 +363,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, &v1a1test.Options{},
+	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetAnnotationKey:                   "10",
 			autoscaling.TargetUtilizationPercentageKey:        "70",
@@ -445,7 +445,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, &v1a1test.Options{},
+	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetAnnotationKey:            "10",
 			autoscaling.TargetUtilizationPercentageKey: "70",

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -61,7 +61,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		Image:  "timeout",
 	}
 
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}, v1a1opts.WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds)); err != nil {
+	if _, err := v1a1test.CreateConfiguration(t, clients, names, v1a1opts.WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds)); err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
 	if _, err := v1a1test.CreateRoute(t, clients, names); err != nil {
@@ -169,7 +169,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
+	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -14,7 +14,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
 // Setup creates the client objects needed in the e2e tests.
@@ -38,23 +37,6 @@ func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
 		t.Fatalf("Couldn't initialize clients: %v", err)
 	}
 	return clients
-}
-
-// CreateRouteAndConfig will create Route and Config objects using clients.
-// The Config object will serve requests to a container started from the image at imagePath.
-func CreateRouteAndConfig(t *testing.T, clients *test.Clients, image string, options *v1a1test.Options) (test.ResourceNames, error) {
-	svcName := test.ObjectNameForTest(t)
-	names := test.ResourceNames{
-		Config: svcName,
-		Route:  svcName,
-		Image:  image,
-	}
-
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, options); err != nil {
-		return test.ResourceNames{}, err
-	}
-	_, err := v1a1test.CreateRoute(t, clients, names)
-	return names, err
 }
 
 // autoscalerCM returns the current autoscaler config map deployed to the

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 
@@ -48,7 +49,7 @@ func TestEgressTraffic(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{EnvVars: envVars})
+	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithEnv(envVars...))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -49,7 +49,7 @@ func TestEgressTraffic(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, v1a1opts.WithEnv(envVars...))
+	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithEnv(envVars...))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -175,7 +175,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, fopts...)
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/system"
@@ -172,13 +171,11 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		Image:   "grpc-ping",
 	}
 
+	fopts = append(fopts, rtesting.WithNamedPort("h2c"))
+
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		ContainerPorts: []corev1.ContainerPort{{
-			Name: "h2c",
-		}},
-	}, fopts...)
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -29,6 +29,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -49,9 +50,7 @@ func TestHelloWorld(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		RevisionTemplateAnnotations: map[string]string{},
-	})
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -100,11 +99,8 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		RevisionTemplateAnnotations: map[string]string{
-			serving.QueueSideCarResourcePercentageAnnotation: "0.2",
-		},
-		ContainerResources: corev1.ResourceRequirements{
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName("cpu"):    resource.MustParse("50m"),
 				corev1.ResourceName("memory"): resource.MustParse("128Mi"),
@@ -113,8 +109,9 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 				corev1.ResourceName("cpu"):    resource.MustParse("100m"),
 				corev1.ResourceName("memory"): resource.MustParse("258Mi"),
 			},
-		},
-	})
+		}), v1a1opts.WithConfigAnnotations(map[string]string{
+			serving.QueueSideCarResourcePercentageAnnotation: "0.2",
+		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -50,7 +50,7 @@ func TestHelloWorld(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -99,7 +99,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName("cpu"):    resource.MustParse("50m"),

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -100,7 +100,7 @@ func TestImagePullError(t *testing.T) {
 // Wrote our own thing so that we can pass in an image by digest.
 // knative/pkg/test.ImagePath currently assumes there's a tag, which fails to parse.
 func createLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames) (*v1alpha1.Service, error) {
-	opt := v1alpha1testing.WithInlineConfigSpec(*v1a1test.ConfigurationSpec(names.Image, &v1a1test.Options{}))
+	opt := v1alpha1testing.WithInlineConfigSpec(*v1a1test.ConfigurationSpec(names.Image, ))
 	service := v1alpha1testing.ServiceWithoutNamespace(names.Service, opt)
 	v1a1test.LogResourceObject(t, v1a1test.ResourceObjects{Service: service})
 	return clients.ServingAlphaClient.Services.Create(service)

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -44,7 +44,7 @@ func TestMinScale(t *testing.T) {
 		Image:  "helloworld",
 	}
 
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, &v1a1test.Options{}, func(cfg *v1alpha1.Configuration) {
+	if _, err := v1a1test.CreateConfiguration(t, clients, names, func(cfg *v1alpha1.Configuration) {
 		if cfg.Spec.Template.Annotations == nil {
 			cfg.Spec.Template.Annotations = make(map[string]string)
 		}

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -63,7 +63,7 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources, &v1a1test.Options{}); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources, ); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
 
@@ -73,7 +73,7 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources, &v1a1test.Options{}); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources, ); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
 
@@ -125,7 +125,7 @@ func TestConflictingRouteService(t *testing.T) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, ); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
 }

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -65,7 +65,7 @@ func TestPodScheduleError(t *testing.T) {
 		svc *v1alpha1.Service
 		err error
 	)
-	if svc, err = v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{}, v1a1opts.WithResourceRequirements(resources)); err != nil {
+	if svc, err = v1a1test.CreateLatestService(t, clients, names, v1a1opts.WithResourceRequirements(resources)); err != nil {
 		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 	}
 

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -64,7 +65,7 @@ func TestPodScheduleError(t *testing.T) {
 		svc *v1alpha1.Service
 		err error
 	)
-	if svc, err = v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{ContainerResources: resources}); err != nil {
+	if svc, err = v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{}, v1a1opts.WithResourceRequirements(resources)); err != nil {
 		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 	}
 

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -79,25 +79,12 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				Image:   "helloworld",
 			}
 
-			options := &v1a1test.Options{
-				// Give each request 10 seconds to respond.
-				// This is mostly to work around #2897
-				RevisionTimeoutSeconds: 10,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/",
-						},
-					},
-				},
-			}
-
 			// Start the clock for various waypoints towards Service readiness.
 			start := time.Now()
 			// Record the overall completion time regardless of success/failure.
 			defer latencies.Add("time-to-done", start)
 
-			svc, err := v1a1test.CreateLatestService(t, clients, names, options,
+			svc, err := v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{},
 				WithResourceRequirements(corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -110,7 +97,15 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				}),
 				WithConfigAnnotations(map[string]string{
 					"autoscaling.knative.dev/maxScale": "1",
-				}))
+				}),
+				WithReadinessProbe(&corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/",
+						},
+					},
+				}),
+				WithRevisionTimeoutSeconds(10))
 
 			if err != nil {
 				t.Errorf("CreateLatestService() = %v", err)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -84,7 +84,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 			// Record the overall completion time regardless of success/failure.
 			defer latencies.Add("time-to-done", start)
 
-			svc, err := v1a1test.CreateLatestService(t, clients, names, &v1a1test.Options{},
+			svc, err := v1a1test.CreateLatestService(t, clients, names,
 				WithResourceRequirements(corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -109,7 +109,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -182,7 +182,7 @@ func TestServiceToServiceCall(t *testing.T) {
 
 	withInternalVisibility := WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		withInternalVisibility,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -228,7 +228,6 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	defer test.TearDown(clients, testNames)
 
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
-		&v1a1test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -109,13 +109,12 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		EnvVars: envVars,
-		RevisionTemplateAnnotations: map[string]string{
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+		rtesting.WithEnv(envVars...),
+		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 			"sidecar.istio.io/inject":       strconv.FormatBool(inject),
-		},
-	})
+		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -183,11 +182,11 @@ func TestServiceToServiceCall(t *testing.T) {
 
 	withInternalVisibility := WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		RevisionTemplateAnnotations: map[string]string{
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+		withInternalVisibility,
+		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
-		},
-	}, withInternalVisibility)
+		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -232,7 +231,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 		&v1a1test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
-			"sidecar.istio.io/inject": strconv.FormatBool(injectB),
+			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
 		}), withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
@@ -276,4 +275,3 @@ func TestServiceToServiceCallViaActivator(t *testing.T) {
 		})
 	}
 }
-

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -74,7 +74,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 		},
 	})
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withInternalVisibility, withTrafficSpec)
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -121,7 +121,7 @@ func TestSubrouteVisibilityChange(t *testing.T) {
 			},
 		},
 	})
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}, withInternalVisibility, withTrafficSpec)
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -128,7 +128,7 @@ func TestWebSocket(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{}); err != nil {
+	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{},
+	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}),

--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -64,7 +64,7 @@ func runTest(t *testing.T, img string, baseQPS float64, loadFactors []float64) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -60,7 +60,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -37,6 +37,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
+	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -152,15 +153,14 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		ContainerConcurrency: 1,
-		ContainerResources: corev1.ResourceRequirements{
+	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("20Mi"),
 			},
-		},
-	})
+		}),
+		v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -30,7 +30,6 @@ import (
 	perf "github.com/knative/test-infra/shared/performance"
 	"github.com/knative/test-infra/shared/testgrid"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 	ktest "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
@@ -118,30 +117,26 @@ func createServices(t *testing.T, pc *Client, count int) ([]*v1a1test.ResourceOb
 	}()
 	sos := []ktest.ServiceOption{
 		// We set a small resource alloc so that we can pack more pods into the cluster.
-		func(svc *v1alpha1.Service) {
-			svc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("50m"),
-					corev1.ResourceMemory: resource.MustParse("50Mi"),
-				},
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("20Mi"),
-				},
-			}
-		},
+		ktest.WithResourceRequirements(corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		}),
+		ktest.WithConfigAnnotations(map[string]string{
+			autoscaling.WindowAnnotationKey: "7s",
+		}),
 	}
 	g := errgroup.Group{}
 	for i := 0; i < count; i++ {
 		ndx := i
 		g.Go(func() error {
 			var err error
-			if objs[ndx], err = v1a1test.CreateRunLatestServiceReady(
-				t, pc.E2EClients, testNames[ndx], &v1a1test.Options{
-					RevisionTemplateAnnotations: map[string]string{
-						autoscaling.WindowAnnotationKey: "7s",
-					},
-				}, sos...); err != nil {
+			if objs[ndx], err = v1a1test.CreateRunLatestServiceReady(t, pc.E2EClients, testNames[ndx], sos...); err != nil {
 				return fmt.Errorf("%02d: failed to create Ready service: %v", ndx, err)
 			}
 			return nil

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -88,13 +88,13 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{
-		ContainerResources: corev1.ResourceRequirements{
+	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		testingv1alpha1.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
 				corev1.ResourceMemory: resource.MustParse("20Mi"),
 			},
-		}},
+		}),
 		testingv1alpha1.WithConfigAnnotations(map[string]string{"autoscaling.knative.dev/target": strconv.Itoa(targetConcurrency)}),
 	)
 	if err != nil {

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -51,7 +51,7 @@ func TestProbe(t *testing.T) {
 	}
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names, &v1a1test.Options{})
+	objects, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names, )
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -35,7 +35,7 @@ func TestRunLatestServicePreUpgrade(t *testing.T) {
 	names.Service = serviceName
 	names.Image = test.PizzaPlanet1
 
-	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names, &v1a1test.Options{})
+	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestRunLatestServicePreUpgradeAndScaleToZero(t *testing.T) {
 	names.Service = scaleToZeroServiceName
 	names.Image = test.PizzaPlanet1
 
-	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names, &v1a1test.Options{})
+	resources, err := v1a1test.CreateRunLatestServiceLegacyReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,7 +33,6 @@ import (
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 
-	"knative.dev/pkg/ptr"
 	ptest "knative.dev/pkg/test"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	v1alpha1testing "knative.dev/serving/pkg/testing/v1alpha1"
@@ -46,22 +44,10 @@ const (
 	timeout  = 10 * time.Minute
 )
 
-// Options are test setup parameters.
-type Options struct {
-	EnvVars                     []corev1.EnvVar
-	ContainerPorts              []corev1.ContainerPort
-	ContainerConcurrency        int
-	RevisionTimeoutSeconds      int64
-	ContainerResources          corev1.ResourceRequirements
-	ReadinessProbe              *corev1.Probe
-	SecurityContext             *corev1.SecurityContext
-	RevisionTemplateAnnotations map[string]string
-}
-
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by names.Image.
-func CreateConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, options *Options, fopt ...rtesting.ConfigOption) (*v1alpha1.Configuration, error) {
-	config := Configuration(names, options, fopt...)
+func CreateConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ConfigOption) (*v1alpha1.Configuration, error) {
+	config := Configuration(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Config: config})
 	return clients.ServingAlphaClient.Configs.Create(config)
 }
@@ -101,101 +87,45 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 
 // ConfigurationSpec returns the spec of a configuration to be used throughout different
 // CRD helpers.
-func ConfigurationSpec(imagePath string, options *Options) *v1alpha1.ConfigurationSpec {
-	if options.ContainerResources.Limits == nil && options.ContainerResources.Requests == nil {
-		options.ContainerResources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse(defaultRequestCPU),
-			},
-		}
-	}
-
-	spec := &v1alpha1.ConfigurationSpec{
+func ConfigurationSpec(imagePath string) *v1alpha1.ConfigurationSpec {
+	return &v1alpha1.ConfigurationSpec{
 		Template: &v1alpha1.RevisionTemplateSpec{
 			Spec: v1alpha1.RevisionSpec{
 				RevisionSpec: v1beta1.RevisionSpec{
 					PodSpec: corev1.PodSpec{
 						Containers: []corev1.Container{{
-							Image:           imagePath,
-							Resources:       options.ContainerResources,
-							ReadinessProbe:  options.ReadinessProbe,
-							Ports:           options.ContainerPorts,
-							SecurityContext: options.SecurityContext,
+							Image: imagePath,
 						}},
 					},
-					ContainerConcurrency: v1beta1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
 				},
 			},
 		},
 	}
-
-	if options.RevisionTimeoutSeconds > 0 {
-		spec.GetTemplate().Spec.TimeoutSeconds = ptr.Int64(options.RevisionTimeoutSeconds)
-	}
-
-	if options.EnvVars != nil {
-		spec.GetTemplate().Spec.GetContainer().Env = options.EnvVars
-	}
-
-	if len(options.RevisionTemplateAnnotations) != 0 {
-		spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Annotations: options.RevisionTemplateAnnotations,
-		}
-	}
-
-	return spec
 }
 
 // LegacyConfigurationSpec returns the spec of a configuration to be used throughout different
 // CRD helpers.
-func LegacyConfigurationSpec(imagePath string, options *Options) *v1alpha1.ConfigurationSpec {
-	if options.ContainerResources.Limits == nil && options.ContainerResources.Requests == nil {
-		options.ContainerResources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse(defaultRequestCPU),
-			},
-		}
-	}
-
-	spec := &v1alpha1.ConfigurationSpec{
+func LegacyConfigurationSpec(imagePath string) *v1alpha1.ConfigurationSpec {
+	return &v1alpha1.ConfigurationSpec{
 		DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
 			Spec: v1alpha1.RevisionSpec{
 				DeprecatedContainer: &corev1.Container{
-					Image:           imagePath,
-					Resources:       options.ContainerResources,
-					ReadinessProbe:  options.ReadinessProbe,
-					Ports:           options.ContainerPorts,
-					SecurityContext: options.SecurityContext,
+					Image: imagePath,
 				},
-				RevisionSpec: v1beta1.RevisionSpec{
-					ContainerConcurrency: v1beta1.RevisionContainerConcurrencyType(options.ContainerConcurrency),
-				},
+				RevisionSpec: v1beta1.RevisionSpec{},
 			},
 		},
 	}
-
-	if options.RevisionTimeoutSeconds > 0 {
-		spec.GetTemplate().Spec.TimeoutSeconds = ptr.Int64(options.RevisionTimeoutSeconds)
-	}
-
-	if options.EnvVars != nil {
-		spec.GetTemplate().Spec.GetContainer().Env = options.EnvVars
-	}
-
-	return spec
 }
 
 // Configuration returns a Configuration object in namespace with the name names.Config
 // that uses the image specified by names.Image
-func Configuration(names test.ResourceNames, options *Options, fopt ...v1alpha1testing.ConfigOption) *v1alpha1.Configuration {
+func Configuration(names test.ResourceNames, fopt ...v1alpha1testing.ConfigOption) *v1alpha1.Configuration {
 	config := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: names.Config,
 		},
-		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image), options),
-	}
-	if options.ContainerPorts != nil && len(options.ContainerPorts) > 0 {
-		config.Spec.GetTemplate().Spec.GetContainer().Ports = options.ContainerPorts
+		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image)),
 	}
 
 	for _, opt := range fopt {

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -104,13 +104,13 @@ func GetResourceObjects(clients *test.Clients, names test.ResourceNames) (*Resou
 // CreateRunLatestServiceReady creates a new Service in state 'Ready'. This function expects Service and Image name passed in through 'names'.
 // Names is updated with the Route and Configuration created by the Service and ResourceObjects is returned with the Service, Route, and Configuration objects.
 // Returns error if the service does not come up correctly.
-func CreateRunLatestServiceReady(t *testing.T, clients *test.Clients, names *test.ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
+func CreateRunLatestServiceReady(t *testing.T, clients *test.Clients, names *test.ResourceNames, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
 	if names.Image == "" {
 		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
 	}
 
 	t.Logf("Creating a new Service %s.", names.Service)
-	svc, err := CreateLatestService(t, clients, *names, options, fopt...)
+	svc, err := CreateLatestService(t, clients, *names, fopt...)
 	if err != nil {
 		return nil, err
 	}
@@ -146,13 +146,13 @@ func CreateRunLatestServiceReady(t *testing.T, clients *test.Clients, names *tes
 // CreateRunLatestServiceLegacyReady creates a new Service in state 'Ready'. This function expects Service and Image name passed in through 'names'.
 // Names is updated with the Route and Configuration created by the Service and ResourceObjects is returned with the Service, Route, and Configuration objects.
 // Returns error if the service does not come up correctly.
-func CreateRunLatestServiceLegacyReady(t *testing.T, clients *test.Clients, names *test.ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
+func CreateRunLatestServiceLegacyReady(t *testing.T, clients *test.Clients, names *test.ResourceNames, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
 	if names.Image == "" {
 		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
 	}
 
 	t.Logf("Creating a new Service %s.", names.Service)
-	svc, err := CreateLatestServiceLegacy(t, clients, *names, options, fopt...)
+	svc, err := CreateLatestServiceLegacy(t, clients, *names, fopt...)
 	if err != nil {
 		return nil, err
 	}
@@ -186,16 +186,16 @@ func CreateRunLatestServiceLegacyReady(t *testing.T, clients *test.Clients, name
 }
 
 // CreateLatestService creates a service in namespace with the name names.Service and names.Image
-func CreateLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
-	service := LatestService(names, options, fopt...)
+func CreateLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
+	service := LatestService(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Service: service})
 	svc, err := clients.ServingAlphaClient.Services.Create(service)
 	return svc, err
 }
 
 // CreateLatestServiceLegacy creates a service in namespace with the name names.Service and names.Image
-func CreateLatestServiceLegacy(t *testing.T, clients *test.Clients, names test.ResourceNames, options *Options, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
-	service := LatestServiceLegacy(names, options, fopt...)
+func CreateLatestServiceLegacy(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ServiceOption) (*v1alpha1.Service, error) {
+	service := LatestServiceLegacy(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Service: service})
 	svc, err := clients.ServingAlphaClient.Services.Create(service)
 	return svc, err
@@ -281,18 +281,18 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 
 // LatestService returns a Service object in namespace with the name names.Service
 // that uses the image specified by names.Image.
-func LatestService(names test.ResourceNames, options *Options, fopt ...rtesting.ServiceOption) *v1alpha1.Service {
+func LatestService(names test.ResourceNames, fopt ...rtesting.ServiceOption) *v1alpha1.Service {
 	a := append([]rtesting.ServiceOption{
-		rtesting.WithInlineConfigSpec(*ConfigurationSpec(ptest.ImagePath(names.Image), options)),
+		rtesting.WithInlineConfigSpec(*ConfigurationSpec(ptest.ImagePath(names.Image))),
 	}, fopt...)
 	return rtesting.ServiceWithoutNamespace(names.Service, a...)
 }
 
 // LatestServiceLegacy returns a DeprecatedRunLatest Service object in namespace with the name names.Service
 // that uses the image specified by names.Image.
-func LatestServiceLegacy(names test.ResourceNames, options *Options, fopt ...rtesting.ServiceOption) *v1alpha1.Service {
+func LatestServiceLegacy(names test.ResourceNames, fopt ...rtesting.ServiceOption) *v1alpha1.Service {
 	a := append([]rtesting.ServiceOption{
-		rtesting.WithRunLatestConfigSpec(*LegacyConfigurationSpec(ptest.ImagePath(names.Image), options)),
+		rtesting.WithRunLatestConfigSpec(*LegacyConfigurationSpec(ptest.ImagePath(names.Image))),
 	}, fopt...)
 	svc := rtesting.ServiceWithoutNamespace(names.Service, a...)
 	// Clear the name, which is put there by defaulting.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Remove the `test.Options` struct and replace it with functional options everywhere.

Having both in place is confusing to contributors, so cleaning all of that up.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
