### PR TITLE
Use vegeta in benchmarks test

### DIFF
--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -121,11 +121,10 @@ func runTest(t *testing.T, pacer vegeta.Pacer, saveMetrics bool) {
 func TestBenchmarkSteadyTraffic(t *testing.T) {
 	for _, load := range loads {
 		t.Run(fmt.Sprintf("N%d", load), func(t *testing.T) {
-			zeroToNSteadyPacer := vegeta.SinePacer{
-				Period:  4 * duration,
-				Mean:    vegeta.Rate{Freq: load, Per: time.Second},
-				Amp:     vegeta.Rate{Freq: load - 1, Per: time.Second},
-				StartAt: vegeta.Trough,
+			zeroToNSteadyPacer := SteadyUpPacer{
+				Min:        vegeta.Rate{Freq: 1, Per: time.Second},
+				Max:        vegeta.Rate{Freq: load, Per: time.Second},
+				UpDuration: 0.5 * duration,
 			}
 			runTest(t, zeroToNSteadyPacer, true)
 		})
@@ -147,11 +146,10 @@ func TestBenchmarkBurstNto2N(t *testing.T) {
 	for _, load := range loads {
 		t.Run(fmt.Sprintf("N%d", load), func(t *testing.T) {
 			// Steady ramp up from 0 to N, then burst to 2N
-			zeroToNSteadyPacer := vegeta.SinePacer{
-				Period:  4 * duration,
-				Mean:    vegeta.Rate{Freq: load, Per: time.Second},
-				Amp:     vegeta.Rate{Freq: load - 1, Per: time.Second},
-				StartAt: vegeta.Trough,
+			zeroToNSteadyPacer := SteadyUpPacer{
+				Min:        vegeta.Rate{Freq: 1, Per: time.Second},
+				Max:        vegeta.Rate{Freq: load, Per: time.Second},
+				UpDuration: duration,
 			}
 			runTest(t, zeroToNSteadyPacer, false)
 

--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -65,7 +65,7 @@ func runTest(t *testing.T, pacer vegeta.Pacer, saveMetrics bool) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, &v1a1test.Options{})
+	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -105,9 +105,9 @@ func runTest(t *testing.T, pacer vegeta.Pacer, saveMetrics bool) {
 
 	var tc []junit.TestCase
 	// Add latency metrics
-	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.P50)*1000, "p50(ms)", tName))
-	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.Quantile(0.90))*1000, "p90(ms)", tName))
-	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.P99)*1000, "p99(ms)", tName))
+	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.P50.Seconds()*1000), "p50(ms)", tName))
+	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.Quantile(0.90).Seconds()*1000), "p90(ms)", tName))
+	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.P99.Seconds()*1000), "p99(ms)", tName))
 
 	// Add errorsPercentage metrics
 	tc = append(tc, perf.CreatePerfTestCase(float32(1-metrics.Success), "errorsPercentage", tName))

--- a/test/performance/pacers.go
+++ b/test/performance/pacers.go
@@ -47,15 +47,14 @@ type steadyUpPacer struct {
 
 // NewSteadyUpPacer returns a new SteadyUpPacer with the given config.
 func NewSteadyUpPacer(min vegeta.Rate, max vegeta.Rate, upDuration time.Duration) vegeta.Pacer {
-	pacer := &steadyUpPacer{
-		Min:        min,
-		Max:        max,
-		UpDuration: upDuration,
+	return &steadyUpPacer{
+		Min:          min,
+		Max:          max,
+		UpDuration:   upDuration,
+		slope:        (hitsPerNs(max) - hitsPerNs(min)) / float64(upDuration),
+		minHitsPerNs: hitsPerNs(min),
+		maxHitsPerNs: hitsPerNs(max),
 	}
-	pacer.slope = (hitsPerNs(max) - hitsPerNs(min)) / float64(upDuration)
-	pacer.minHitsPerNs = hitsPerNs(pacer.Min)
-	pacer.maxHitsPerNs = hitsPerNs(pacer.Max)
-	return pacer
 }
 
 // steadyUpPacer satisfies the Pacer interface.

--- a/test/performance/pacers.go
+++ b/test/performance/pacers.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package performance
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+// SteadyUpPacer is a Pacer that describes attack request rates that increases in the beginning then becomes steady.
+//  Max  |     ,----------------
+//       |    /
+//       |   /
+//       |  /
+//       | /
+//  Min -+------------------------------> t
+//       |<-Up->|
+type SteadyUpPacer struct {
+	// UpDuration is the duration that attack request rates increase from Min to Max.
+	UpDuration time.Duration
+	// Min is the attack request rates from the beginning.
+	Min vegeta.Rate
+	// Max is the maximum and final steady attack request rates.
+	Max vegeta.Rate
+}
+
+// SteadyUpPacer satisfies the Pacer interface.
+var _ vegeta.Pacer = SteadyUpPacer{}
+
+// String returns a pretty-printed description of the SteadyUpPacer's behaviour.
+func (sup SteadyUpPacer) String() string {
+	return fmt.Sprintf("Up{%s + %s / %s}, then Steady{%s}", sup.Min, sup.Max, sup.UpDuration, sup.Max)
+}
+
+// invalid tests the constraints documented in the SteadyUpPacer struct definition.
+func (sup SteadyUpPacer) invalid() bool {
+	return sup.UpDuration <= 0 || hitsPerNs(sup.Min) <= 0 || hitsPerNs(sup.Max) <= hitsPerNs(sup.Min)
+}
+
+// Pace determines the length of time to sleep until the next hit is sent.
+func (sup SteadyUpPacer) Pace(elapsedTime time.Duration, elapsedHits uint64) (time.Duration, bool) {
+	if sup.invalid() {
+		// If pacer configuration is invalid, stop the attack.
+		return 0, true
+	}
+
+	expectedHits := sup.hits(elapsedTime)
+	if elapsedHits < uint64(expectedHits) {
+		// Running behind, send next hit immediately.
+		return 0, false
+	}
+
+	// Re-arranging our hits equation to provide a duration given the number of
+	// requests sent is non-trivial, so we must solve for the duration numerically.
+	// math.Round() added here because we have to coerce to int64 nanoseconds
+	// at some point and it corrects a bunch of off-by-one problems.
+	nsPerHit := 1 / sup.hitsPerNs(elapsedTime)
+	hitsToWait := float64(elapsedHits+1) - expectedHits
+	nextHitIn := time.Duration(nsPerHit * hitsToWait)
+
+	// If we can't converge to an error of <1e-3 within 10 iterations, bail.
+	// This rarely even loops for any large Period if hitsToWait is small.
+	for i := 0; i < 10; i++ {
+		hitsAtGuess := sup.hits(elapsedTime + nextHitIn)
+		err := float64(elapsedHits+1) - hitsAtGuess
+		if math.Abs(err) < 1e-3 {
+			return nextHitIn, false
+		}
+		nextHitIn = time.Duration(float64(nextHitIn) / (hitsAtGuess - float64(elapsedHits)))
+	}
+
+	return nextHitIn, false
+}
+
+// hits returns the number of expected hits for this pacer during the given time.
+func (sup SteadyUpPacer) hits(t time.Duration) float64 {
+	if t <= 0 || sup.invalid() {
+		return 0
+	}
+
+	// If t is smaller than the UpDuration, calculate the hits as a triangle.
+	if t <= sup.UpDuration {
+		curtHitsPerNs := sup.hitsPerNs(t)
+		return (curtHitsPerNs + hitsPerNs(sup.Min)) / 2.0 * float64(t)
+	}
+
+	// If t is larger than the UpDuration, calculate the hits as a triangle + a rectangle.
+	upHits := (hitsPerNs(sup.Max) + hitsPerNs(sup.Min)) / 2.0 * float64(sup.UpDuration)
+	steadyHits := hitsPerNs(sup.Max) * float64(t-sup.UpDuration)
+	return upHits + steadyHits
+}
+
+// slope returns slope of the up line.
+func (sup SteadyUpPacer) slope() float64 {
+	return (hitsPerNs(sup.Max) - hitsPerNs(sup.Min)) / float64(sup.UpDuration)
+}
+
+// hitsPerNs returns the attack rate for this pacer at a given time.
+func (sup SteadyUpPacer) hitsPerNs(t time.Duration) float64 {
+	if t <= sup.UpDuration {
+		return hitsPerNs(sup.Min) + float64(t)*sup.slope()
+	}
+
+	return hitsPerNs(sup.Max)
+}
+
+// hitsPerNs returns the attack rate this ConstantPacer represents, in
+// fractional hits per nanosecond.
+func hitsPerNs(cp vegeta.ConstantPacer) float64 {
+	return float64(cp.Freq) / float64(cp.Per)
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Use vegeta in benchmarks test.
- Ramping up to 1 qps or bursting up to 1 qps are basically the same thing, and it has already been covered in other tests, so I removed it from the loads in this test.
- Add a new `SteadyUpPacer` for vegeta
- Use `ConstantPacer` for burst traffic and `SteadyUpPacer` for steady up traffic control

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @srinivashegde86 
/cc @vagababov 