### PR TITLE
Release pending requests count of breaker if the request is timeout

### DIFF
--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -131,15 +131,21 @@ func TestBreakerCancel(t *testing.T) {
 	cancel1()
 	reqs.expectFailure(t)
 
-	// Let through a request with capacity and cache a request.
+	// Let through a request with capacity.
 	b.UpdateConcurrency(1)
 	reqs.request()
-	reqs.request()
 
-	// This request cannot get capacity.
+	// This request fails due to canceled.
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	reqs.requestWithContext(ctx2)
 	cancel2()
+	reqs.expectFailure(t)
+
+	// This request is cached
+	reqs.request()
+
+	// This request fails due to overflows.
+	reqs.request()
 	reqs.expectFailure(t)
 
 	// The requests that were put in earlier should succeed.

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -131,14 +131,10 @@ func TestBreakerCancel(t *testing.T) {
 	cancel1()
 	reqs.expectFailure(t)
 
-	// Let through a request with capacity then timeout following request
+	// Let through a request with capacity and cache a request.
 	b.UpdateConcurrency(1)
 	reqs.request()
-
-	// Exceed capacity and assert failure. This makes sure the Breaker is consistently
-	// at capacity.
 	reqs.request()
-	reqs.expectFailure(t)
 
 	// This request cannot get capacity.
 	ctx2, cancel2 := context.WithCancel(context.Background())
@@ -146,7 +142,8 @@ func TestBreakerCancel(t *testing.T) {
 	cancel2()
 	reqs.expectFailure(t)
 
-	// The request that was put in earlier should succeed.
+	// The requests that were put in earlier should succeed.
+	reqs.processSuccessfully(t)
 	reqs.processSuccessfully(t)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Always release pending requests count of breaker. Otherwise, if timeout requests count exceeds `pendingRequests` cap, the channel will be full.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
