### PR TITLE
Swap got and want for Diff of TestConfigurationDefaulting

### DIFF
--- a/pkg/apis/serving/v1beta1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_defaults_test.go
@@ -124,7 +124,7 @@ func TestConfigurationDefaulting(t *testing.T) {
 			got.SetDefaults(context.Background())
 			if !cmp.Equal(got, test.want, ignoreUnexportedResources) {
 				t.Errorf("SetDefaults (-want, +got) = %v",
-					cmp.Diff(got, test.want, ignoreUnexportedResources))
+					cmp.Diff(test.want, got, ignoreUnexportedResources))
 			}
 		})
 	}


### PR DESCRIPTION
This patch makes a tiny change which swaps `got` and `want` in
`TestConfigurationDefaulting()`.

This is same fix with https://github.com/knative/serving/pull/4742, but another test code.

/lint

## Proposed Changes

* Swap got and want for Diff of TestConfigurationDefaulting

**Release Note**

```release-note
NONE
```
