### PR TITLE
Fix invalid helloworld example

### DIFF
--- a/test/test_images/helloworld/helloworld.yaml
+++ b/test/test_images/helloworld/helloworld.yaml
@@ -28,7 +28,6 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 3
-          periodSeconds: 3
 ---
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route


### PR DESCRIPTION
This patch makes a tiny fix which removes invalid setting in
configuration example.

After https://github.com/knative/serving/pull/4731, `periodSeconds`
needs to be set with `failureThreshold` and `timeoutSeconds`. This
patch simply removes `periodSeconds` from the config.

#### Current error:
```
$ ko apply -f test/test_images/helloworld/helloworld.yaml 
...
2019/07/17 17:58:13 Published gcr.io/gcp-compute-engine-223401/helloworld-edca531b677458dd5cb687926757a480@sha256:88311e84da104e258959a2417f067a81009065aad93bab2240bfc79969e94056
route.serving.knative.dev/route-example configured
Error from server (InternalError): error when creating "STDIN": Internal error occurred: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: expected 1 <= 0 <= 2147483647: spec.template.spec.containers[0].readinessProbe.failureThreshold, spec.template.spec.containers[0].readinessProbe.timeoutSeconds
2019/07/17 17:58:14 error executing 'kubectl apply': exit status 1
```
## Proposed Changes
* Remove `periodSeconds` from config.

**Release Note**

```release-note
NONE
```
