### PR TITLE
Only intercept queue-proxy ports if an istio sidecar is present.

### DIFF
--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -29,6 +29,8 @@ const (
 	// TODO(mattmoor): Make this private once we remove revision_test.go
 	IstioOutboundIPRangeAnnotation = "traffic.sidecar.istio.io/includeOutboundIPRanges"
 
+	istioIncludeInboundPortsAnnotation = "traffic.sidecar.istio.io/includeInboundPorts"
+
 	// AppLabelKey is the label defining the application's name.
 	AppLabelKey = "app"
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -191,12 +191,13 @@ func makeQueueProbe(in *corev1.Probe) *corev1.Probe {
 	}
 }
 
+// queueServingPort decides which port to export from the queue-proxy based on the protocol
+// indicated given.
 func queueServingPort(protocol networking.ProtocolType) corev1.ContainerPort {
 	if protocol == networking.ProtocolH2C {
 		return queueHTTP2Port
-	} else {
-		return queueHTTPPort
 	}
+	return queueHTTPPort
 }
 
 // makeQueueContainer creates the container spec for the queue sidecar.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4277

## Proposed Changes

* Instruct Istio which port to intercept specifically for the user pods.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

This might be a bit controversial so adding a few more people to the reviewers than usual.

/assign @mattmoor 
/assign @tcnghia 
/assign @vagababov 