### PR TITLE
Make breaker tests deterministic again.

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -86,12 +86,10 @@ func (b *Breaker) Maybe(ctx context.Context, thunk func()) bool {
 			return false
 		}
 		// Defer releasing capacity in the active.
-		defer func() {
-			// It's safe to ignore the error returned by release since we
-			// make sure the semaphore is only manipulated here and acquire
-			// + release calls are equally paired.
-			b.sem.release()
-		}()
+		// It's safe to ignore the error returned by release since we
+		// make sure the semaphore is only manipulated here and acquire
+		// + release calls are equally paired.
+		defer b.sem.release()
 
 		// Do the thing.
 		thunk()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We currently have a test regression where the unit tests fail due to a timeout because the breaker tests never finish.

It's very important in these tests to assert failing requests to make sure the breaker's state is consistent. The change caused the "to be canceled" request to race the "supposed to be successful" request before it to the semaphore. If the "to be canceled" request won, it'd get capacity immediately and the cancel is defunct. The "supposed to be successful" request before it gets put into the queue and the `expectFailure` call hangs forever.

I didn't spot that in the review. Concurrency is hard 😢 

One occurrence is here: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/4763/pull-knative-serving-unit-tests/1151424068474376192

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
