### PR TITLE
Use net.JoinHostPort instead of concatenation

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -317,7 +318,7 @@ func (a *activationHandler) serviceHostName(rev *v1alpha1.Revision, serviceName 
 
 	// Use the ClusterIP directly to elide DNS lookup, which both adds latency
 	// and hurts reliability when routing through the activator.
-	return svc.Spec.ClusterIP + ":" + strconv.Itoa(port), nil
+	return net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(port)), nil
 }
 
 func sendError(err error, w http.ResponseWriter) {

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -67,7 +67,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	}
 	url := url.URL{
 		Scheme: string(config.Scheme),
-		Host:   config.Host + ":" + config.Port.String(),
+		Host:   net.JoinHostPort(config.Host, config.Port.String()),
 		Path:   config.Path,
 	}
 	req, err := http.NewRequest(http.MethodGet, url.String(), nil)


### PR DESCRIPTION
This handles ipv6 addresses correctly.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This came to me in a dream.