### PR TITLE
Raise the channel size to be huge.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -79,7 +80,9 @@ const (
 
 	// The upper bound for concurrent requests sent to the revision.
 	// As new endpoints show up, the Breakers concurrency increases up to this value.
-	breakerMaxConcurrency = 1000
+	// NB: current implementation of Breaker uses a `chan struct{}` which consumes 0 additional
+	// memory per entry, hence it's free.
+	breakerMaxConcurrency = int(math.MaxInt32 - 1)
 
 	// The port on which autoscaler WebSocket server listens.
 	autoscalerPort = ":8080"


### PR DESCRIPTION
The chan struct{} requires no additional memory beyond initial buffer, since sizeof struct{} is 0.
See an example program: https://play.golang.org/p/WQd_1Dwh5aj
Rather than doing infinity breaker, let's just do this.

/assign @mattmoor @markusthoemmes

