### PR TITLE
Stop relying on naming conventions in the activator's throttler logic.

### DIFF
--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -356,6 +356,7 @@ func TestHelper_ReactToEndpoints(t *testing.T) {
 			Labels: map[string]string{
 				serving.RevisionUID:       "test",
 				networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
+				serving.RevisionLabelKey:  testRevision,
 			},
 		},
 		Subsets: endpointsSubset(0, 1),

--- a/pkg/resources/endpoints.go
+++ b/pkg/resources/endpoints.go
@@ -17,24 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
-
-// ParentResourceFromService returns the parent resource name from
-// endpoints or k8s service resource.
-// The function is based upon knowledge that all knative built services
-// have `parent-resource-<svc-unique-suffix` format.
-func ParentResourceFromService(name string) string {
-	li := strings.LastIndex(name, "-")
-	if li == -1 {
-		// Presume same.
-		return name
-	}
-	return name[:li]
-}
 
 // ReadyAddressCount returns the total number of addresses ready for the given endpoint.
 func ReadyAddressCount(endpoints *corev1.Endpoints) int {

--- a/pkg/resources/endpoints_test.go
+++ b/pkg/resources/endpoints_test.go
@@ -125,18 +125,3 @@ func endpoints(ipCount int) *corev1.Endpoints {
 	}}
 	return ep
 }
-
-func TestParentResourceFromService(t *testing.T) {
-	tests := map[string]string{
-		"":      "",
-		"a":     "a",
-		"a-":    "a",
-		"a-b":   "a",
-		"a-b-c": "a-b",
-	}
-	for in, want := range tests {
-		if got := ParentResourceFromService(in); got != want {
-			t.Errorf("%s => got: %s, want: %s", in, got, want)
-		}
-	}
-}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The throttler code needs to get the revision's name based on endpoints floating in to update it's internal capacity counts which are per revision. That lookup is based on a naming convention currently. The throttler assumes that the endpoint's name is the revision's name appended with a random string delimited by a dash. A typical generateName schema.

generateName however is [smart enough](https://github.com/kubernetes/kubernetes/blob/7f23a743e8c23ac6489340bbb34fa6f1d392db9d/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L42-L54) to know that some resources have a limit of 63 characters. It makes sure that this limit is not surpassed thus breaking the assumption taken above for very long names (as is the case for the service-to-service tests for example).

This drops that assumption and instead relies on a label that's already propagated through to the endpoints.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a bug where revisions that are scaled to zero might behave weirdly if they have very long names (approximately 59 characters).
```

/assign @vagababov 
/assign @mattmoor 
