### PR TITLE
Revert "Add simple probe cache for the activator. (#4618)"

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -52,7 +52,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -358,58 +357,6 @@ func TestActivationHandler(t *testing.T) {
 	}
 }
 
-func TestActivationHandlerProbeCaching(t *testing.T) {
-	namespace := testNamespace
-	revName := testRevName
-	revID := activator.RevisionID{Namespace: namespace, Name: revName}
-
-	fakeRT := activatortest.FakeRoundTripper{}
-	rt := network.RoundTripperFunc(fakeRT.RT)
-
-	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
-	reporter := &fakeReporter{}
-
-	throttler := activator.NewThrottler(
-		breakerParams,
-		endpointsInformer(endpoints(namespace, revName, breakerParams.InitialCapacity)),
-		sksLister(sks(namespace, revName)),
-		revisionLister(revision(namespace, revName)),
-		TestLogger(t))
-
-	handler := (New(TestLogger(t), reporter, throttler,
-		revisionLister(revision(namespace, revName)),
-		serviceLister(service(namespace, revName, "http")),
-		sksLister(sks(namespace, revName)),
-	)).(*activationHandler)
-
-	// Setup transports.
-	handler.transport = rt
-	handler.probeTransport = rt
-
-	sendRequest(namespace, revName, handler)
-	if fakeRT.NumProbes != 1 {
-		t.Errorf("NumProbes = %d, want: %d", fakeRT.NumProbes, 1)
-	}
-
-	sendRequest(namespace, revName, handler)
-	// Assert that we didn't reprobe
-	if fakeRT.NumProbes != 1 {
-		t.Errorf("NumProbes = %d, want: %d", fakeRT.NumProbes, 1)
-	}
-
-	// Dropping the capacity to 0 causes the next request to probe again.
-	throttler.UpdateCapacity(revID, 0)
-	time.AfterFunc(100*time.Millisecond, func() {
-		// Asynchronously updating the capacity to let the request through.
-		throttler.UpdateCapacity(revID, 1)
-	})
-
-	sendRequest(namespace, revName, handler)
-	if fakeRT.NumProbes != 2 {
-		t.Errorf("NumProbes = %d, want: %d", fakeRT.NumProbes, 2)
-	}
-}
-
 // Make sure we return http internal server error when the Breaker is overflowed
 func TestActivationHandlerOverflow(t *testing.T) {
 	const (
@@ -422,14 +369,14 @@ func TestActivationHandlerOverflow(t *testing.T) {
 	revName := testRevName
 
 	lockerCh := make(chan struct{})
-	fakeRT := activatortest.FakeRoundTripper{
+	fakeRt := activatortest.FakeRoundTripper{
 		LockerCh: lockerCh,
 		RequestResponse: &activatortest.FakeResponse{
 			Code: http.StatusOK,
 			Body: wantBody,
 		},
 	}
-	rt := network.RoundTripperFunc(fakeRT.RT)
+	rt := network.RoundTripperFunc(fakeRt.RT)
 
 	breakerParams := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
 	reporter := &fakeReporter{}
@@ -451,7 +398,7 @@ func TestActivationHandlerOverflow(t *testing.T) {
 	handler.transport = rt
 	handler.probeTransport = rt
 
-	sendRequests(requests, namespace, revName, respCh, handler)
+	sendRequests(requests, namespace, revName, respCh, *handler)
 	assertResponses(wantedSuccess, wantedFailure, requests, lockerCh, respCh, t)
 }
 
@@ -497,14 +444,9 @@ func TestActivationHandlerOverflowSeveralRevisions(t *testing.T) {
 
 	for _, revName := range revisions {
 		requestCount := overallRequests / len(revisions)
-		sendRequests(requestCount, testNamespace, revName, respCh, handler)
+		sendRequests(requestCount, testNamespace, revName, respCh, *handler)
 	}
 	assertResponses(wantedSuccess, wantedFailure, overallRequests, lockerCh, respCh, t)
-
-	// Verify cache size.
-	if got, want := len(handler.cache.probes), 2; got != want {
-		t.Errorf("ProbeCacheSize = %d, want: %d", got, want)
-	}
 }
 
 func TestActivationHandlerProxyHeader(t *testing.T) {
@@ -533,7 +475,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	}
 	probeRt := network.RoundTripperFunc(fakeRT.RT)
 
-	handler := &activationHandler{
+	handler := activationHandler{
 		transport:      rt,
 		probeTransport: probeRt,
 		logger:         TestLogger(t),
@@ -542,7 +484,6 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 		revisionLister: revisionLister(revision(testNamespace, testRevName)),
 		serviceLister:  serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister:      sksLister(sks(testNamespace, testRevName)),
-		cache:          newProbeCache(),
 	}
 
 	writer := httptest.NewRecorder()
@@ -600,7 +541,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister(revision(namespace, revName)),
 		TestLogger(t))
 
-	handler := &activationHandler{
+	handler := activationHandler{
 		transport:      rt,
 		probeTransport: rt,
 		logger:         TestLogger(t),
@@ -609,7 +550,6 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		revisionLister: revisionLister(revision(testNamespace, testRevName)),
 		serviceLister:  serviceLister(service(testNamespace, testRevName, "http")),
 		sksLister:      sksLister(sks(testNamespace, testRevName)),
-		cache:          newProbeCache(),
 	}
 	handler.transport = rt
 	handler.probeTransport = rt
@@ -628,7 +568,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 	}
 }
 
-func sendRequest(namespace, revName string, handler *activationHandler) *httptest.ResponseRecorder {
+func sendRequest(namespace, revName string, handler activationHandler) *httptest.ResponseRecorder {
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 	req.Header.Set(activator.RevisionHeaderNamespace, namespace)
@@ -639,7 +579,7 @@ func sendRequest(namespace, revName string, handler *activationHandler) *httptes
 
 // sendRequests sends `count` concurrent requests via the given handler and writes
 // the recorded responses to the `respCh`.
-func sendRequests(count int, namespace, revName string, respCh chan *httptest.ResponseRecorder, handler *activationHandler) {
+func sendRequests(count int, namespace, revName string, respCh chan *httptest.ResponseRecorder, handler activationHandler) {
 	for i := 0; i < count; i++ {
 		go func() {
 			respCh <- sendRequest(namespace, revName, handler)
@@ -882,22 +822,4 @@ func endpointsInformer(eps ...*corev1.Endpoints) corev1informers.EndpointsInform
 
 func errMsg(msg string) string {
 	return fmt.Sprintf("Error getting active endpoint: %v\n", msg)
-}
-
-func TestProbeCache(t *testing.T) {
-	cache := &probeCache{
-		probes: sets.NewString(),
-	}
-	revID := activator.RevisionID{}
-	if !cache.should(revID) {
-		t.Error("should returned true")
-	}
-	cache.mark(revID)
-	if cache.should(revID) {
-		t.Error("should returned false")
-	}
-	cache.unmark(revID)
-	if !cache.should(revID) {
-		t.Error("should returned true")
-	}
 }

--- a/pkg/activator/testing/roundtripper.go
+++ b/pkg/activator/testing/roundtripper.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
 
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -49,8 +48,6 @@ type FakeRoundTripper struct {
 	// Response to non-probe requests
 	RequestResponse *FakeResponse
 	responseMux     sync.Mutex
-
-	NumProbes int32
 }
 
 func defaultProbeResponse() *FakeResponse {
@@ -94,7 +91,6 @@ func (rt *FakeRoundTripper) popResponse() *FakeResponse {
 // RT is a RoundTripperFunc
 func (rt *FakeRoundTripper) RT(req *http.Request) (*http.Response, error) {
 	if req.Header.Get(network.ProbeHeaderName) != "" {
-		atomic.AddInt32(&rt.NumProbes, 1)
 		resp := rt.popResponse()
 		if resp.Err != nil {
 			return nil, resp.Err

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -50,7 +50,7 @@ var ErrActivatorOverload = errors.New("activator overload")
 // It enables the use case to start with max concurrency set to 0 (no requests are sent because no endpoints are available)
 // and gradually increase its value depending on the external condition (e.g. new endpoints become available)
 type Throttler struct {
-	breakersMux sync.RWMutex
+	breakersMux sync.Mutex
 	breakers    map[RevisionID]*queue.Breaker
 
 	breakerParams   queue.BreakerParams
@@ -197,17 +197,6 @@ func (t *Throttler) getOrCreateBreaker(rev RevisionID) (*queue.Breaker, bool) {
 		t.breakers[rev] = breaker
 	}
 	return breaker, ok
-}
-
-// GetRevisionCapacity returns the capacity for the revision.
-func (t *Throttler) GetRevisionCapacity(rev RevisionID) int {
-	t.breakersMux.RLock()
-	defer t.breakersMux.RUnlock()
-	b, ok := t.breakers[rev]
-	if !ok {
-		return 0
-	}
-	return b.Capacity()
 }
 
 // forceUpdateCapacity fetches the endpoints and updates the capacity of the newly created breaker.


### PR DESCRIPTION
I have the funny feeling that the prober cache somehow causes our 503s. Gonna ask Dr. Empirical before trying to convince myself fully 😂 .

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
