### PR TITLE
Reconcile SKS once in KPA 

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/hpa/resources"
@@ -148,8 +149,7 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 		}
 	}
 
-	// HPA has its own deciders.
-	sks, err := c.ReconcileSKS(ctx, pa, nil /* decider */)
+	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe)
 	if err != nil {
 		return perrors.Wrap(err, "error reconciling SKS")
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
@@ -137,16 +138,25 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		return perrors.Wrap(err, "error reconciling metric")
 	}
 
-	sks, err := c.ReconcileSKS(ctx, pa, decider)
-	if err != nil {
-		return perrors.Wrap(err, "error reconciling SKS")
-	}
-
 	// Get the appropriate current scale from the metric, and right size
 	// the scaleTargetRef based on it.
 	want, err := c.scaler.Scale(ctx, pa, decider.Status.DesiredScale)
 	if err != nil {
 		return perrors.Wrap(err, "error scaling target")
+	}
+
+	mode := nv1alpha1.SKSOperationModeServe
+	// We put activator in the serving path in two cases:
+	// 1. The revision is scaled to 0.
+	// 2. The excess burst capacity is negative.
+	if want == 0 || decider.Status.ExcessBurstCapacity < 0 {
+		logger.Debugf("SKS %s is in proxy mode: want = %d, ebc = %d", pa.Name, want, decider.Status.ExcessBurstCapacity)
+		mode = nv1alpha1.SKSOperationModeProxy
+	}
+
+	sks, err := c.ReconcileSKS(ctx, pa, mode)
+	if err != nil {
+		return perrors.Wrap(err, "error reconciling SKS")
 	}
 
 	// Compare the desired and observed resources to determine our situation.
@@ -170,14 +180,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		return perrors.Wrap(err, "error reporting metrics")
 	}
 
-	// computeActiveCondition decides if we need to change the SKS mode,
-	// and returns true if the status has changed.
-	if changed := computeActiveCondition(pa, want, got); changed {
-		_, err := c.ReconcileSKS(ctx, pa, decider)
-		if err != nil {
-			return perrors.Wrap(err, "error re-reconciling SKS")
-		}
-	}
+	computeActiveCondition(pa, want, got)
+
+	pa.Status.ObservedGeneration = pa.Generation
 	return nil
 }
 
@@ -226,13 +231,11 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, got int) error {
 }
 
 // computeActiveCondition updates the status of PA, depending on scales desired and present.
-// computeActiveCondition returns true if it thinks SKS needs an update.
-func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (ret bool) {
+func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
 	minReady := activeThreshold(pa)
 
 	switch {
 	case want == 0:
-		ret = !pa.Status.IsInactive() // Any state but inactive should change SKS.
 		if pa.Status.IsActivating() {
 			// We only ever scale to zero while activating if we fail to activate within the progress deadline.
 			pa.Status.MarkInactive("TimedOut", "The target could not be activated.")
@@ -241,7 +244,6 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 		}
 
 	case got < minReady && want > 0:
-		ret = pa.Status.IsInactive() // If we were inactive and became activating.
 		pa.Status.MarkActivating(
 			"Queued", "Requests to the target are being buffered as resources are provisioned.")
 
@@ -252,9 +254,6 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) (
 	case want == scaleUnknown:
 		// We don't know what scale we want, so don't touch PA at all.
 	}
-
-	pa.Status.ObservedGeneration = pa.Generation
-	return
 }
 
 // activeThreshold returns the scale required for the pa to be marked Active

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -346,35 +346,6 @@ func TestReconcileAndScaleToZero(t *testing.T) {
 				WithDeployRef(deployName), WithProxyMode),
 		}},
 	}, {
-		Name: "from serving to proxy, sks update fail :-(",
-		Key:  key,
-		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, markActive, markOld,
-				WithPAStatusService(testRevision), withMSvcStatus("they-give-you-this")),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
-			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
-				withMSvcName("they-give-you-this")),
-			deploy(testNamespace, testRevision),
-			makeSKSPrivateEndpoints(1, testNamespace, testRevision),
-		},
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("update", "serverlessservices"),
-		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError",
-				"error re-reconciling SKS: error updating SKS test-revision: inducing failure for update serverlessservices"),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: kpa(testNamespace, testRevision,
-				WithNoTraffic("NoTraffic", "The target is not receiving traffic."),
-				WithPAStatusService(testRevision), withMSvcStatus("they-give-you-this")),
-		}},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: sks(testNamespace, testRevision, WithSKSReady,
-				WithDeployRef(deployName), WithProxyMode),
-		}},
-	}, {
 		Name: "scaling to 0, but not stable for long enough, so no-op",
 		Key:  key,
 		Objects: []runtime.Object{

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -29,7 +29,6 @@ import (
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/autoscaler"
 	listers "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
 	nlisters "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
 	"knative.dev/serving/pkg/reconciler"
@@ -58,17 +57,9 @@ type Base struct {
 }
 
 // ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.
-func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, d *autoscaler.Decider) (*nv1alpha1.ServerlessService, error) {
+func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, mode nv1alpha1.ServerlessServiceOperationMode) (*nv1alpha1.ServerlessService, error) {
 	logger := logging.FromContext(ctx)
 
-	mode := nv1alpha1.SKSOperationModeServe
-	// We put activator in the serving path in two cases:
-	// 1. The revision is scaled to 0.
-	// 2. The excess burst capacity is negative.
-	if pa.Status.IsInactive() || (d != nil && d.Status.ExcessBurstCapacity < 0) {
-		logger.Debugf("SKS %s is in proxy mode: pa.IsInactive = %v, ebc = %d", pa.Name, pa.Status.IsInactive(), d.Status.ExcessBurstCapacity)
-		mode = nv1alpha1.SKSOperationModeProxy
-	}
 	sksName := anames.SKS(pa.Name)
 	sks, err := c.SKSLister.ServerlessServices(pa.Namespace).Get(sksName)
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The SKS Mode is only truly dependent on the desired replicas and the ExcessBurstCapacity. Before this change, the mode was computed based on the KPA condition being set to Inactive, which introduced a false dependency on the count of the actual replicas. This change breaks that dependency and the cycle that forced us to reconcile the SKS twice.

This also makes the hpa call site for ReconcileSKS more reasonable (being explicit about the mode instead of passing in a nil decider).

Before (cycle in red, false dependency in blue):
![image](https://user-images.githubusercontent.com/17863526/61735523-0202f480-ad39-11e9-9b26-8f6a3d6f8e22.png)

After (no more cycle, true dependency in blue):
![image](https://user-images.githubusercontent.com/17863526/61735536-07603f00-ad39-11e9-8624-33e1a64be473.png)
