### PR TITLE
Remove prober transport factory since it's no longer used anywhere

### DIFF
--- a/pkg/network/prober/prober.go
+++ b/pkg/network/prober/prober.go
@@ -28,9 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// TransportFactory is a function which returns an HTTP transport.
-type TransportFactory func() http.RoundTripper
-
 // Preparer is a way for the caller to modify the HTTP request before it goes out.
 type Preparer func(r *http.Request) *http.Request
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -80,7 +80,6 @@ type scaler struct {
 	dynamicClient     dynamic.Interface
 	logger            *zap.SugaredLogger
 	transport         http.RoundTripper
-	transportFactory  prober.TransportFactory
 
 	// For sync probes.
 	activatorProbe func(pa *pav1alpha1.PodAutoscaler, transport http.RoundTripper) (bool, error)
@@ -103,9 +102,6 @@ func newScaler(ctx context.Context, psInformerFactory duck.InformerFactory, enqu
 		dynamicClient:     dynamicclient.Get(ctx),
 		logger:            logger,
 		transport:         transport,
-		transportFactory: func() http.RoundTripper {
-			return network.NewAutoTransport()
-		},
 
 		// Production setup uses the default probe implementation.
 		activatorProbe: activatorProbe,


### PR DESCRIPTION
Subj.
We replaced that with no cache client instead.

/assign @mattmoor @dgerd 
/lint
