### PR TITLE
Separate cert-manager related yaml from serving.yaml

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -49,11 +49,13 @@ rm -fr ${YAML_OUTPUT_DIR}/*.yaml
 
 # Generated Knative component YAML files
 readonly SERVING_YAML=${YAML_OUTPUT_DIR}/serving.yaml
+readonly SERVING_CORE_YAML=${YAML_OUTPUT_DIR}/serving-core.yaml
 readonly SERVING_CRD_ALPHA_YAML=${YAML_OUTPUT_DIR}/serving-alpha-crds.yaml
 readonly SERVING_ALPHA_YAML=${YAML_OUTPUT_DIR}/serving-pre-1.14.yaml
 readonly SERVING_CRD_BETA_YAML=${YAML_OUTPUT_DIR}/serving-beta-crds.yaml
 readonly SERVING_BETA_YAML=${YAML_OUTPUT_DIR}/serving-post-1.14.yaml
-readonly SERVING_TLS_CERT_MANAGER_YAML=${YAML_OUTPUT_DIR}/serving-tls-cert-manager.yaml
+readonly SERVING_CERT_MANAGER_YAML=${YAML_OUTPUT_DIR}/serving-cert-manager.yaml
+readonly SERVING_ISTIO_YAML=${YAML_OUTPUT_DIR}/serving-istio.yaml
 
 readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
 readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
@@ -81,11 +83,14 @@ cd "${YAML_REPO_ROOT}"
 
 echo "Building Knative Serving"
 ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/certificate-provider!=cert-manager | "${LABEL_YAML_CMD[@]}" > "${SERVING_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/certificate-provider!=cert-manager,networking.knative.dev/ingress-provider!=istio | "${LABEL_YAML_CMD[@]}" > "${SERVING_CORE_YAML}"
 # These don't have images, but ko will concatenate them for us.
 ko resolve ${KO_YAML_FLAGS} -f config/v1alpha1 | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_ALPHA_YAML}"
 ko resolve ${KO_YAML_FLAGS} -f config/v1beta1 | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_BETA_YAML}"
 # Create cert-manager related yaml
-ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/certificate-provider=cert-manager | "${LABEL_YAML_CMD[@]}" > "${SERVING_TLS_CERT_MANAGER_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/certificate-provider=cert-manager | "${LABEL_YAML_CMD[@]}" > "${SERVING_CERT_MANAGER_YAML}"
+# Create Istio related yaml
+ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/ingress-provider=istio | "${LABEL_YAML_CMD[@]}" > "${SERVING_ISTIO_YAML}"
 
 # Create the full alpha install.
 cat "${SERVING_YAML}" > "${SERVING_ALPHA_YAML}"
@@ -98,6 +103,7 @@ cat "${SERVING_CRD_BETA_YAML}" >> "${SERVING_BETA_YAML}"
 # Our ${SERVING_YAML} should be a complete install, so bias towards the most
 # broadly compatible by default.
 cat "${SERVING_ALPHA_YAML}" > "${SERVING_YAML}"
+cat "${SERVING_CRD_ALPHA_YAML}" >> "${SERVING_CORE_YAML}"
 
 echo "Building Monitoring & Logging"
 # Use ko to concatenate them all together.
@@ -135,9 +141,11 @@ echo "All manifests generated"
 # List generated YAML files, with serving.yaml first.
 
 ls -1 ${SERVING_YAML} > ${YAML_LIST_FILE}
+ls -1 ${SERVING_CORE_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_CRD_ALPHA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_ALPHA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_CRD_BETA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_BETA_YAML} >> ${YAML_LIST_FILE}
-ls -1 ${SERVING_TLS_CERT_MANAGER_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${SERVING_CERT_MANAGER_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${SERVING_ISTIO_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${SERVING_YAML} >> ${YAML_LIST_FILE}

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -53,6 +53,7 @@ readonly SERVING_CRD_ALPHA_YAML=${YAML_OUTPUT_DIR}/serving-alpha-crds.yaml
 readonly SERVING_ALPHA_YAML=${YAML_OUTPUT_DIR}/serving-pre-1.14.yaml
 readonly SERVING_CRD_BETA_YAML=${YAML_OUTPUT_DIR}/serving-beta-crds.yaml
 readonly SERVING_BETA_YAML=${YAML_OUTPUT_DIR}/serving-post-1.14.yaml
+readonly SERVING_TLS_CERT_MANAGER_YAML=${YAML_OUTPUT_DIR}/serving-tls-cert-manager.yaml
 
 readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
 readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
@@ -79,10 +80,12 @@ export KO_DOCKER_REPO
 cd "${YAML_REPO_ROOT}"
 
 echo "Building Knative Serving"
-ko resolve ${KO_YAML_FLAGS} -f config/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/certificate-provider!=cert-manager | "${LABEL_YAML_CMD[@]}" > "${SERVING_YAML}"
 # These don't have images, but ko will concatenate them for us.
 ko resolve ${KO_YAML_FLAGS} -f config/v1alpha1 | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_ALPHA_YAML}"
 ko resolve ${KO_YAML_FLAGS} -f config/v1beta1 | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_BETA_YAML}"
+# Create cert-manager related yaml
+ko resolve ${KO_YAML_FLAGS} -f config/ --selector networking.knative.dev/certificate-provider=cert-manager | "${LABEL_YAML_CMD[@]}" > "${SERVING_TLS_CERT_MANAGER_YAML}"
 
 # Create the full alpha install.
 cat "${SERVING_YAML}" > "${SERVING_ALPHA_YAML}"
@@ -136,4 +139,5 @@ ls -1 ${SERVING_CRD_ALPHA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_ALPHA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_CRD_BETA_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${SERVING_BETA_YAML} >> ${YAML_LIST_FILE}
+ls -1 ${SERVING_TLS_CERT_MANAGER_YAML} >> ${YAML_LIST_FILE}
 ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${SERVING_YAML} >> ${YAML_LIST_FILE}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
https://github.com/knative/serving/issues/4120

## Proposed Changes

*  Separate cert-manager related yaml from serving.yaml when generating release yaml


