### PR TITLE
Qualify the gateway names, regardless of VirtualService namespace.

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -140,16 +140,15 @@ func makeVirtualServiceSpec(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.I
 	return &spec
 }
 
+// qualifyGateways modifies the provided gateway list to add namespace
+// information into gateway names that don't already have them.
 func qualifyGateways(gws []string) []string {
-	var q []string
-	for _, gw := range gws {
-		if strings.Contains(gw, "/") || strings.Contains(gw, ".") || gw == "mesh" { // qualified gateway name
-			q = append(q, gw)
-		} else {
-			q = append(q, system.Namespace()+"/"+gw)
+	for i, gw := range gws {
+		if !(strings.Contains(gw, "/") || strings.Contains(gw, ".") || gw == "mesh") { // unqualified
+			gws[i] = system.Namespace() + "/" + gw
 		}
 	}
-	return q
+	return gws
 }
 
 func makePortSelector(ios intstr.IntOrString) v1alpha3.PortSelector {

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -279,7 +279,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectGateways(t *testing.T) {
 		},
 		Spec: v1alpha1.IngressSpec{},
 	}
-	expected := []string{"gateway-one", "gateway-two"}
+	expected := []string{"knative-testing/gateway-one", "knative-testing/gateway-two"}
 	gateways := MakeIngressVirtualService(ci, makeGatewayMap([]string{"gateway-one", "gateway-two"}, nil)).Spec.Gateways
 	if diff := cmp.Diff(expected, gateways); diff != "" {
 		t.Errorf("Unexpected gateways (-want +got): %v", diff)
@@ -454,10 +454,10 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath, []string{"gateway-1"})
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Gateways:  []string{"gateway-1"},
+			Gateways:  []string{"knative-testing/gateway-1"},
 			Authority: &istiov1alpha1.StringMatch{Regex: `^a\.com(?::\d{1,5})?$`},
 		}, {
-			Gateways:  []string{"gateway-1"},
+			Gateways:  []string{"knative-testing/gateway-1"},
 			Authority: &istiov1alpha1.StringMatch{Regex: `^b\.org(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.HTTPRouteDestination{{
@@ -507,7 +507,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 	route := makeVirtualServiceRoute(hosts, ingressPath, []string{"gateway-1"})
 	expected := v1alpha3.HTTPRoute{
 		Match: []v1alpha3.HTTPMatchRequest{{
-			Gateways:  []string{"gateway-1"},
+			Gateways:  []string{"knative-testing/gateway-1"},
 			Authority: &istiov1alpha1.StringMatch{Regex: `^test\.org(?::\d{1,5})?$`},
 		}},
 		Route: []v1alpha3.HTTPRouteDestination{{

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -86,9 +86,9 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 
 	h := NewHooks()
 
-	// Check for ClusterIngress created as a signal that syncHandler ran
-	h.OnCreate(&servingClient.Fake, "clusteringresses", func(obj runtime.Object) HookResult {
-		ci := obj.(*netv1alpha1.ClusterIngress)
+	// Check for Ingress created as a signal that syncHandler ran
+	h.OnCreate(&servingClient.Fake, "ingresses", func(obj runtime.Object) HookResult {
+		ci := obj.(*netv1alpha1.Ingress)
 		t.Logf("ingress created: %q", ci.Name)
 
 		return HookComplete

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -65,10 +65,13 @@ func (c *Reconciler) deleteIngressesForRoute(route *v1alpha1.Route) error {
 }
 
 func (c *Reconciler) reconcileIngress(
-	ctx context.Context, ira IngressResourceAccessors, r *v1alpha1.Route, desired netv1alpha1.IngressAccessor) (netv1alpha1.IngressAccessor, error) {
+	ctx context.Context, ira IngressResourceAccessors, r *v1alpha1.Route, desired netv1alpha1.IngressAccessor, optional bool) (netv1alpha1.IngressAccessor, error) {
 	logger := logging.FromContext(ctx)
 	ingress, err := ira.getIngressForRoute(r)
 	if apierrs.IsNotFound(err) {
+		if optional {
+			return nil, nil
+		}
 		ingress, err = ira.createIngress(desired)
 		if err != nil {
 			logger.Errorw("Failed to create Ingress", zap.Error(err))

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -58,12 +58,12 @@ func TestReconcileClusterIngress_Insert(t *testing.T) {
 		clusterIngressLister: reconciler.clusterIngressLister,
 	}
 
-	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), ira, r, ci); err != nil {
+	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), ira, r, ci, true /* optional*/); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	created := getRouteClusterIngressFromClient(ctx, t, r)
-	if diff := cmp.Diff(ci, created); diff != "" {
-		t.Errorf("Unexpected diff (-want +got): %v", diff)
+	if created != nil {
+		t.Errorf("Unexpected ClusterIngress creation")
 	}
 }
 
@@ -85,7 +85,7 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 	}
 
 	ci := newTestClusterIngress(t, r)
-	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), ira, r, ci); err != nil {
+	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), ira, r, ci, false /*optional*/); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -101,7 +101,7 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 			},
 		})
 	})
-	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), ira, r, ci2); err != nil {
+	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), ira, r, ci2, true /*optional*/); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -284,6 +284,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 			},
 			clusterIngressLister: c.clusterIngressLister,
 		},
+		true, /* optional */
 	)
 
 	if err != nil {
@@ -298,6 +299,7 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 			},
 			ingressLister: c.ingressLister,
 		},
+		false, /*optional*/
 	)
 
 	if err != nil {
@@ -317,14 +319,14 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 }
 
 func (c *Reconciler) reconcileIngressResources(ctx context.Context, r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS,
-	clusterLocalServices sets.String, ingressClass string, ira IngressResourceAccessors) (netv1alpha1.IngressAccessor, error) {
+	clusterLocalServices sets.String, ingressClass string, ira IngressResourceAccessors, optional bool) (netv1alpha1.IngressAccessor, error) {
 
 	desired, err := ira.makeIngress(ctx, r, tc, tls, clusterLocalServices, ingressClass)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterIngress, err := c.reconcileIngress(ctx, ira, r, desired)
+	clusterIngress, err := c.reconcileIngress(ctx, ira, r, desired, optional)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

@JRBANCEL found during his testing of #4734 that in case of namespaced Ingress we should qualify the Gateways, since the Route/Ingress/VirtualServices don't live in the same namespaces.

## Proposed Changes

* Always qualify the Gateways in VirtualServices.
* Only reconcile existing ClusterIngress - avoid creating new ones.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
