### PR TITLE
Use per-split revision headers.

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -208,11 +208,10 @@ func makeIngressRule(domains []string, ns string, isClusterLocal bool, targets t
 				ServicePort: intstr.FromInt(int(networking.ServicePort(t.Protocol))),
 			},
 			Percent: t.Percent,
-			// TODO(nghia): Append headers per-split.
-			// AppendHeaders: map[string]string{
-			// 	activator.RevisionHeaderName:      t.TrafficTarget.RevisionName,
-			// 	activator.RevisionHeaderNamespace: ns,
-			// },
+			AppendHeaders: map[string]string{
+				activator.RevisionHeaderName:      t.TrafficTarget.RevisionName,
+				activator.RevisionHeaderNamespace: ns,
+			},
 		})
 	}
 
@@ -228,41 +227,9 @@ func makeIngressRule(domains []string, ns string, isClusterLocal bool, targets t
 			Paths: []v1alpha1.HTTPIngressPath{{
 				Splits: splits,
 				// TODO(lichuqiang): #2201, plumbing to config timeout and retries.
-				AppendHeaders: map[string]string{
-					activator.RevisionHeaderName:      maxInactive(targets),
-					activator.RevisionHeaderNamespace: ns,
-				},
 			}},
 		},
 	}
-}
-
-// maxInactive constructs Splits for the inactive targets, and add into given IngressPath.
-func maxInactive(targets traffic.RevisionTargets) string {
-	revisionName, inactiveRevisionName := "", ""
-	maxTargetPercent := 0         // There must be a non-zero target if things add to 100
-	maxInactiveTargetPercent := 0 // There must be a non-zero target if things add to 100
-
-	for _, t := range targets {
-		if t.Percent == 0 {
-			continue
-		}
-		if t.Percent >= maxTargetPercent {
-			revisionName = t.RevisionName
-			maxTargetPercent = t.Percent
-		}
-		if t.Active {
-			continue
-		}
-		if t.Percent >= maxInactiveTargetPercent {
-			inactiveRevisionName = t.RevisionName
-			maxInactiveTargetPercent = t.Percent
-		}
-	}
-	if inactiveRevisionName != "" {
-		return inactiveRevisionName
-	}
-	return revisionName
 }
 
 // GetIngressTypeName returns ingress type name: ClusterIngress or Ingress

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -135,11 +135,11 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "v2",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "v2",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -157,11 +157,11 @@ func TestMakeClusterIngressSpec_CorrectRules(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "v1",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "v1",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -449,11 +449,11 @@ func TestMakeClusterIngressRule_Vanilla(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "revision",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "revision",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -496,11 +496,11 @@ func TestMakeClusterIngressRule_ZeroPercentTarget(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "revision",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "revision",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -543,6 +543,10 @@ func TestMakeClusterIngressRule_TwoTargets(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 80,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Namespace": "test-ns",
+						"Knative-Serving-Revision":  "revision",
+					},
 				}, {
 					IngressBackend: netv1alpha1.IngressBackend{
 						ServiceNamespace: "test-ns",
@@ -550,11 +554,11 @@ func TestMakeClusterIngressRule_TwoTargets(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 20,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Namespace": "test-ns",
+						"Knative-Serving-Revision":  "new-revision",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "revision",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -592,11 +596,11 @@ func TestMakeClusterIngressRule_InactiveTarget(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "revision",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "revision",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -641,6 +645,10 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 80,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "revision",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}, {
 					IngressBackend: netv1alpha1.IngressBackend{
 						ServiceNamespace: ns,
@@ -648,11 +656,11 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 20,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "new-revision",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "revision",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -693,11 +701,11 @@ func TestMakeClusterIngressRule_ZeroPercentTargetInactive(t *testing.T) {
 						ServicePort:      intstr.FromInt(80),
 					},
 					Percent: 100,
+					AppendHeaders: map[string]string{
+						"Knative-Serving-Revision":  "revision",
+						"Knative-Serving-Namespace": "test-ns",
+					},
 				}},
-				AppendHeaders: map[string]string{
-					"Knative-Serving-Revision":  "revision",
-					"Knative-Serving-Namespace": "test-ns",
-				},
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -324,11 +324,11 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  "test-rev",
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  "test-rev",
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -429,6 +429,10 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  cfgrev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}, {
 						IngressBackend: netv1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
@@ -436,11 +440,11 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  cfgrev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -514,6 +518,10 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  cfgrev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}, {
 						IngressBackend: netv1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
@@ -521,11 +529,11 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  "test-rev",
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -623,6 +631,10 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  cfgrev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}, {
 						IngressBackend: netv1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
@@ -630,11 +642,11 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  rev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -652,11 +664,11 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  rev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -674,11 +686,11 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  rev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -753,6 +765,10 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}, {
 						IngressBackend: netv1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
@@ -760,11 +776,11 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 50,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  cfgrev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  cfgrev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -782,11 +798,11 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  cfgrev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  cfgrev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -804,11 +820,11 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
+						AppendHeaders: map[string]string{
+							"Knative-Serving-Revision":  rev.Name,
+							"Knative-Serving-Namespace": testNamespace,
+						},
 					}},
-					AppendHeaders: map[string]string{
-						"Knative-Serving-Revision":  rev.Name,
-						"Knative-Serving-Namespace": testNamespace,
-					},
 				}},
 			},
 			Visibility: netv1alpha1.IngressVisibilityExternalIP,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
Now that we plumb through per-split header for Ingress, we should make use of that in Route reconciler.

## Proposed Changes

* Use per-split revision header in Ingress.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
