### PR TITLE
Move from deprecated field in CRDs

### DIFF
--- a/config/300-clusteringress.yaml
+++ b/config/300-clusteringress.yaml
@@ -21,7 +21,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: ClusterIngress
     plural: clusteringresses

--- a/config/300-ingress.yaml
+++ b/config/300-ingress.yaml
@@ -21,7 +21,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: Ingress
     plural: ingresses

--- a/config/300-pa.yaml
+++ b/config/300-pa.yaml
@@ -21,7 +21,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: PodAutoscaler
     plural: podautoscalers

--- a/config/300-sks.yaml
+++ b/config/300-sks.yaml
@@ -21,7 +21,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: ServerlessService
     plural: serverlessservices


### PR DESCRIPTION
Move from using `version` in CRDs to `versions`

Fixes #4827

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
