### PR TITLE
Remove -race option in command running perf tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -614,7 +614,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:148445446f896e9bcc55ca8fd05f84d6219eea8b31dd34cde61f1ba75aa1bc21"
+  digest = "1:419a22edb44208a87c204e546d197f6c5a8b08ed448fe8380bd581f1a616983f"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -634,7 +634,7 @@
     "tools/webhook-apicoverage/webhook",
   ]
   pruneopts = "UT"
-  revision = "cad8ba5b64ca151d6435a914fd29f0b8a5cdec74"
+  revision = "f9d39bd6917cd997c8e5f44a045ee20a6512778a"
 
 [[projects]]
   digest = "1:58999a98719fddbac6303cb17e8d85b945f60b72f48e3a2df6b950b97fa926f1"

--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -29,6 +29,6 @@ initialize $@ --skip-istio-addon
 
 # Run the tests
 header "Running tests"
-go_test_e2e -tags="performance" -timeout=0 ./test/performance || fail_test
+report_go_test -tags="performance" -timeout=0 ./test/performance || fail_test
 
 success

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -83,7 +83,7 @@ function go_test_e2e() {
   local go_options=""
   (( EMIT_METRICS )) && test_options="-emitmetrics"
   [[ ! " $@" == *" -tags="* ]] && go_options="-tags=e2e"
-  report_go_test -v -count=1 ${go_options} $@ ${test_options}
+  report_go_test -v -race -count=1 ${go_options} $@ ${test_options}
 }
 
 # Dump info about the test cluster. If dump_extra_cluster_info() is defined, calls it too.

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -257,7 +257,7 @@ function dump_app_logs() {
   for pod in $(get_app_pods "$1" "$2")
   do
     echo ">>> Pod: $pod"
-    kubectl -n "$2" logs "$pod" -c "$1"
+    kubectl -n "$2" logs "$pod" --all-containers
   done
 }
 
@@ -340,7 +340,7 @@ function report_go_test() {
   # Run tests in verbose mode to capture details.
   # go doesn't like repeating -v, so remove if passed.
   local args=" $@ "
-  local go_test="go test -race -v ${args/ -v / }"
+  local go_test="go test -v ${args/ -v / }"
   # Just run regular go tests if not on Prow.
   echo "Running tests with '${go_test}'"
   local report="$(mktemp)"

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -224,7 +224,7 @@ function run_unit_tests() {
 
 # Default unit test runner that runs all go tests in the repo.
 function default_unit_test_runner() {
-  report_go_test ./...
+  report_go_test -race ./...
 }
 
 # Run integration tests. If there's no `integration_tests` function, run the


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Update test-infra, and remove `-race` option from command running perf test to avoid `goroutines is exceeded` issue.
More details can be found in https://github.com/knative/test-infra/pull/1171.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```