### PR TITLE
Deep copy gateway slice in qualifyGateways func

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -142,7 +142,12 @@ func makeVirtualServiceSpec(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.I
 
 // qualifyGateways modifies the provided gateway list to add namespace
 // information into gateway names that don't already have them.
-func qualifyGateways(gws []string) []string {
+func qualifyGateways(gwsOrg []string) []string {
+	if len(gwsOrg) == 0 {
+		return nil
+	}
+	gws := make([]string, len(gwsOrg))
+	copy(gws, gwsOrg)
 	for i, gw := range gws {
 		if !(strings.Contains(gw, "/") || strings.Contains(gw, ".") || gw == "mesh") { // unqualified
 			gws[i] = system.Namespace() + "/" + gw

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -142,18 +142,19 @@ func makeVirtualServiceSpec(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.I
 
 // qualifyGateways modifies the provided gateway list to add namespace
 // information into gateway names that don't already have them.
-func qualifyGateways(gwsOrg []string) []string {
-	if len(gwsOrg) == 0 {
+func qualifyGateways(gws []string) []string {
+	if len(gws) == 0 {
 		return nil
 	}
-	gws := make([]string, len(gwsOrg))
-	copy(gws, gwsOrg)
+	gwsQualify := make([]string, len(gws))
 	for i, gw := range gws {
 		if !(strings.Contains(gw, "/") || strings.Contains(gw, ".") || gw == "mesh") { // unqualified
-			gws[i] = system.Namespace() + "/" + gw
+			gwsQualify[i] = system.Namespace() + "/" + gw
+		} else {
+			gwsQualify[i] = gw
 		}
 	}
-	return gws
+	return gwsQualify
 }
 
 func makePortSelector(ios intstr.IntOrString) v1alpha3.PortSelector {


### PR DESCRIPTION
After https://github.com/knative/serving/pull/4828,
MakeVirtualServices() function modifies gatewayNames list to
`NAMESPACE/GATEWAYFORMAT` format. Due to this, following logic to find a
particular gateway was broken and Reconcile Gateway stopped working.

To solve it, this patch copy gateway slice in qualifyGateways func.

/lint

Fixes https://github.com/knative/serving/issues/4859

## Proposed Changes

* Deep copy gateway slice in qualifyGateways func

**Release Note**

```release-note
NONE
```
