### PR TITLE
Update comment httpProtocol is valid when reconcileExternalGateway is enabled

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -128,9 +128,9 @@ data:
     autoTLS: "Disabled"
 
     # Controls the behavior of the HTTP endpoint for the Knative ingress.
-    # It requires autoTLS to be enabled.
+    # It requires autoTLS to be enabled or reconcileExternalGateway in config-istio to be true.
     # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
-    # 2. Disabled: The Knative ingress ter will reject HTTP traffic.
+    # 2. Disabled: The Knative ingress will reject HTTP traffic.
     # 3. Redirected: The Knative ingress will send a 302 redirect for all
     # http connections, asking the clients to use HTTPS
     httpProtocol: "Enabled"


### PR DESCRIPTION
This patch makes a small change in config-network confimap.

Currently `httpProtocol` param is valid not only when `autoTLS` but also
`reconcileExternalGateway` in `config-istio` is enabled.

This patch updates the comment.

**Release Note**

```release-note
NONE
```
