### PR TITLE
Set k8s normal default when assuming non aggressive probe is used

### DIFF
--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -77,30 +77,31 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 			}
 		}
 
-		if rs.PodSpec.Containers[idx].ReadinessProbe == nil {
-			rs.PodSpec.Containers[idx].ReadinessProbe = &corev1.Probe{}
+		readinessProbe := &rs.PodSpec.Containers[idx].ReadinessProbe
+		if *readinessProbe == nil {
+			*readinessProbe = &corev1.Probe{}
 		}
-		if rs.PodSpec.Containers[idx].ReadinessProbe.TCPSocket == nil &&
-			rs.PodSpec.Containers[idx].ReadinessProbe.HTTPGet == nil &&
-			rs.PodSpec.Containers[idx].ReadinessProbe.Exec == nil {
-			rs.PodSpec.Containers[idx].ReadinessProbe.TCPSocket = &corev1.TCPSocketAction{}
+		if (*readinessProbe).TCPSocket == nil &&
+			(*readinessProbe).HTTPGet == nil &&
+			(*readinessProbe).Exec == nil {
+			(*readinessProbe).TCPSocket = &corev1.TCPSocketAction{}
 		}
-		if rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold == 0 {
-			rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold = 1
+		if (*readinessProbe).SuccessThreshold == 0 {
+			(*readinessProbe).SuccessThreshold = 1
 		}
 		// If any of FailureThreshold, TimeoutSeconds or PeriodSeconds are greater than 0,
 		// standard k8s-style would be used so setting normal k8s default values.
-		if rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold > 0 ||
-			rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds > 0 ||
-			rs.PodSpec.Containers[idx].ReadinessProbe.PeriodSeconds > 0 {
-			if rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold == 0 {
-				rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold = 3
+		if (*readinessProbe).FailureThreshold > 0 ||
+			(*readinessProbe).TimeoutSeconds > 0 ||
+			(*readinessProbe).PeriodSeconds > 0 {
+			if (*readinessProbe).FailureThreshold == 0 {
+				(*readinessProbe).FailureThreshold = 3
 			}
-			if rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds == 0 {
-				rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds = 1
+			if (*readinessProbe).TimeoutSeconds == 0 {
+				(*readinessProbe).TimeoutSeconds = 1
 			}
-			if rs.PodSpec.Containers[idx].ReadinessProbe.PeriodSeconds == 0 {
-				rs.PodSpec.Containers[idx].ReadinessProbe.PeriodSeconds = 10
+			if (*readinessProbe).PeriodSeconds == 0 {
+				(*readinessProbe).PeriodSeconds = 10
 			}
 		}
 

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -76,6 +76,7 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 				rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceMemory] = *rsrc
 			}
 		}
+
 		if rs.PodSpec.Containers[idx].ReadinessProbe == nil {
 			rs.PodSpec.Containers[idx].ReadinessProbe = &corev1.Probe{}
 		}
@@ -84,9 +85,23 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 			rs.PodSpec.Containers[idx].ReadinessProbe.Exec == nil {
 			rs.PodSpec.Containers[idx].ReadinessProbe.TCPSocket = &corev1.TCPSocketAction{}
 		}
-
 		if rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold == 0 {
 			rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold = 1
+		}
+		// If any of FailureThreshold, TimeoutSeconds or PeriodSeconds are greater than 0,
+		// standard k8s-style would be used so setting normal k8s default values.
+		if rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold > 0 ||
+			rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds > 0 ||
+			rs.PodSpec.Containers[idx].ReadinessProbe.PeriodSeconds > 0 {
+			if rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold == 0 {
+				rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold = 3
+			}
+			if rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds == 0 {
+				rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds = 1
+			}
+			if rs.PodSpec.Containers[idx].ReadinessProbe.PeriodSeconds == 0 {
+				rs.PodSpec.Containers[idx].ReadinessProbe.PeriodSeconds = 10
+			}
 		}
 
 		vms := rs.PodSpec.Containers[idx].VolumeMounts

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -45,67 +45,68 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	}
 
 	for idx := range rs.PodSpec.Containers {
-		if rs.PodSpec.Containers[idx].Name == "" {
-			rs.PodSpec.Containers[idx].Name = cfg.Defaults.UserContainerName(ctx)
+		ctr := &rs.PodSpec.Containers[idx]
+
+		if ctr.Name == "" {
+			ctr.Name = cfg.Defaults.UserContainerName(ctx)
 		}
 
-		if rs.PodSpec.Containers[idx].Resources.Requests == nil {
-			rs.PodSpec.Containers[idx].Resources.Requests = corev1.ResourceList{}
+		if ctr.Resources.Requests == nil {
+			ctr.Resources.Requests = corev1.ResourceList{}
 		}
-		if _, ok := rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceCPU]; !ok {
+		if _, ok := ctr.Resources.Requests[corev1.ResourceCPU]; !ok {
 			if rsrc := cfg.Defaults.RevisionCPURequest; rsrc != nil {
-				rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceCPU] = *rsrc
+				ctr.Resources.Requests[corev1.ResourceCPU] = *rsrc
 			}
 		}
-		if _, ok := rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceMemory]; !ok {
+		if _, ok := ctr.Resources.Requests[corev1.ResourceMemory]; !ok {
 			if rsrc := cfg.Defaults.RevisionMemoryRequest; rsrc != nil {
-				rs.PodSpec.Containers[idx].Resources.Requests[corev1.ResourceMemory] = *rsrc
+				ctr.Resources.Requests[corev1.ResourceMemory] = *rsrc
 			}
 		}
 
-		if rs.PodSpec.Containers[idx].Resources.Limits == nil {
-			rs.PodSpec.Containers[idx].Resources.Limits = corev1.ResourceList{}
+		if ctr.Resources.Limits == nil {
+			ctr.Resources.Limits = corev1.ResourceList{}
 		}
-		if _, ok := rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceCPU]; !ok {
+		if _, ok := ctr.Resources.Limits[corev1.ResourceCPU]; !ok {
 			if rsrc := cfg.Defaults.RevisionCPULimit; rsrc != nil {
-				rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceCPU] = *rsrc
+				ctr.Resources.Limits[corev1.ResourceCPU] = *rsrc
 			}
 		}
-		if _, ok := rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceMemory]; !ok {
+		if _, ok := ctr.Resources.Limits[corev1.ResourceMemory]; !ok {
 			if rsrc := cfg.Defaults.RevisionMemoryLimit; rsrc != nil {
-				rs.PodSpec.Containers[idx].Resources.Limits[corev1.ResourceMemory] = *rsrc
+				ctr.Resources.Limits[corev1.ResourceMemory] = *rsrc
 			}
 		}
 
-		readinessProbe := &rs.PodSpec.Containers[idx].ReadinessProbe
-		if *readinessProbe == nil {
-			*readinessProbe = &corev1.Probe{}
+		if ctr.ReadinessProbe == nil {
+			ctr.ReadinessProbe = &corev1.Probe{}
 		}
-		if (*readinessProbe).TCPSocket == nil &&
-			(*readinessProbe).HTTPGet == nil &&
-			(*readinessProbe).Exec == nil {
-			(*readinessProbe).TCPSocket = &corev1.TCPSocketAction{}
+		if ctr.ReadinessProbe.TCPSocket == nil &&
+			ctr.ReadinessProbe.HTTPGet == nil &&
+			ctr.ReadinessProbe.Exec == nil {
+			ctr.ReadinessProbe.TCPSocket = &corev1.TCPSocketAction{}
 		}
-		if (*readinessProbe).SuccessThreshold == 0 {
-			(*readinessProbe).SuccessThreshold = 1
+		if ctr.ReadinessProbe.SuccessThreshold == 0 {
+			ctr.ReadinessProbe.SuccessThreshold = 1
 		}
 		// If any of FailureThreshold, TimeoutSeconds or PeriodSeconds are greater than 0,
 		// standard k8s-style would be used so setting normal k8s default values.
-		if (*readinessProbe).FailureThreshold > 0 ||
-			(*readinessProbe).TimeoutSeconds > 0 ||
-			(*readinessProbe).PeriodSeconds > 0 {
-			if (*readinessProbe).FailureThreshold == 0 {
-				(*readinessProbe).FailureThreshold = 3
+		if ctr.ReadinessProbe.FailureThreshold > 0 ||
+			ctr.ReadinessProbe.TimeoutSeconds > 0 ||
+			ctr.ReadinessProbe.PeriodSeconds > 0 {
+			if ctr.ReadinessProbe.FailureThreshold == 0 {
+				ctr.ReadinessProbe.FailureThreshold = 3
 			}
-			if (*readinessProbe).TimeoutSeconds == 0 {
-				(*readinessProbe).TimeoutSeconds = 1
+			if ctr.ReadinessProbe.TimeoutSeconds == 0 {
+				ctr.ReadinessProbe.TimeoutSeconds = 1
 			}
-			if (*readinessProbe).PeriodSeconds == 0 {
-				(*readinessProbe).PeriodSeconds = 10
+			if ctr.ReadinessProbe.PeriodSeconds == 0 {
+				ctr.ReadinessProbe.PeriodSeconds = 10
 			}
 		}
 
-		vms := rs.PodSpec.Containers[idx].VolumeMounts
+		vms := ctr.VolumeMounts
 		for i := range vms {
 			vms[i].ReadOnly = true
 		}

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -243,6 +243,40 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "defaluting non aggressive probe",
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: config.DefaultUserContainerName,
+						ReadinessProbe: &corev1.Probe{
+							FailureThreshold: 3,
+						},
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:      config.DefaultUserContainerName,
+						Resources: defaultResources,
+						ReadinessProbe: &corev1.Probe{
+							TimeoutSeconds:   1,
+							PeriodSeconds:    10,
+							FailureThreshold: 3,
+							SuccessThreshold: 1,
+							Handler: corev1.Handler{
+								TCPSocket: &corev1.TCPSocketAction{},
+							},
+						},
+					}},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -244,7 +244,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			},
 		},
 	}, {
-		name: "defaluting non aggressive probe",
+		name: "defaulting non aggressive probe",
 		in: &Revision{
 			Spec: RevisionSpec{
 				PodSpec: corev1.PodSpec{


### PR DESCRIPTION
Currently we have to set all periodSeconds, timeoutSeconds and
failureThreshold greater than 0, when we would like to use k8s style
readiness probe.

However, it could be assume that the user would like to use non
aggressive readiness probe when setting one of these values.
Hence, this patch sets k8s's normal default values for such  case.

/lint

Ref https://github.com/knative/serving/pull/4780#issuecomment-512288314

## Proposed Changes
* Set k8s normal default when assuming non aggressive probe is used


**Release Note**

```release-note
NONE
```
