### PR TITLE
Add the new informational status to the SKS.

### DIFF
--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
@@ -51,6 +53,28 @@ func (sss *ServerlessServiceStatus) MarkEndpointsNotOwned(kind, name string) {
 	serverlessServiceCondSet.Manage(sss).MarkFalse(
 		ServerlessServiceConditionEndspointsPopulated, "NotOwned",
 		"Resource %s of type %s is not owned by SKS", name, kind)
+}
+
+// MarkActivatorEndpointsPopulated is setting the ActivatorEndpointsPopulated to True.
+func (sss *ServerlessServiceStatus) MarkActivatorEndpointsPopulated() {
+	serverlessServiceCondSet.Manage(sss).SetCondition(apis.Condition{
+		Type:     ActivatorEndpointsPopulated,
+		Status:   corev1.ConditionTrue,
+		Severity: apis.ConditionSeverityInfo,
+		Reason:   "ActivatorEndpointsPopulated",
+		Message:  "Revision is backed by Activator",
+	})
+}
+
+// MarkActivatorEndpointsRemoved is setting the ActivatorEndpointsPopulated to False.
+func (sss *ServerlessServiceStatus) MarkActivatorEndpointsRemoved() {
+	serverlessServiceCondSet.Manage(sss).SetCondition(apis.Condition{
+		Type:     ActivatorEndpointsPopulated,
+		Status:   corev1.ConditionFalse,
+		Severity: apis.ConditionSeverityInfo,
+		Reason:   "ActivatorEndpointsPopulated",
+		Message:  "Revision is backed by Activator",
+	})
 }
 
 // MarkEndpointsNotReady marks the ServerlessServiceStatus endpoints populated condition to unknown.

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -60,6 +60,14 @@ func TestSSTypicalFlow(t *testing.T) {
 	r.MarkEndpointsReady()
 	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionEndspointsPopulated, t)
 	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
+
+	// Verify that activator endpoints status is informational and does not
+	// affect readiness.
+	r.MarkActivatorEndpointsPopulated()
+	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
+	r.MarkActivatorEndpointsRemoved()
+	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
+
 	// Or another way to check the same condition.
 	if !r.IsReady() {
 		t.Error("IsReady=false, want: true")
@@ -67,6 +75,22 @@ func TestSSTypicalFlow(t *testing.T) {
 	r.MarkEndpointsNotReady("random")
 	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
 
+	// Verify that activator endpoints status is informational and does not
+	// affect readiness.
+	r.MarkActivatorEndpointsPopulated()
+	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
+	r.MarkActivatorEndpointsRemoved()
+	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
+
 	r.MarkEndpointsNotOwned("service", "jukebox")
 	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
+
+	// Verify that activator endpoints status is informational and does not
+	// affect readiness.
+	r.MarkActivatorEndpointsPopulated()
+	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
+	apitest.CheckConditionSucceeded(r.duck(), ActivatorEndpointsPopulated, t)
+	r.MarkActivatorEndpointsRemoved()
+	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
+	apitest.CheckConditionFailed(r.duck(), ActivatorEndpointsPopulated, t)
 }

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -126,4 +126,10 @@ const (
 	// ServerlessServiceConditionEndspointsPopulated is set when the ServerlessService's underlying
 	// Revision K8s Service has been populated with endpoints.
 	ServerlessServiceConditionEndspointsPopulated apis.ConditionType = "EndpointsPopulated"
+
+	// ActivatorEndpointsPopulated is an informational status that reports
+	// when the revision is backed by activator points. This might happen even if
+	// revision is active (no pods yet created) or even when it has healthy pods
+	// (e.g. due to target burst capacity settings).
+	ActivatorEndpointsPopulated apis.ConditionType = "ActivatorEndpointsPopulated"
 )


### PR DESCRIPTION
The status describes the dimension of the SKS which informs the user that activator endpoints are now
backing the revision.
This can happen when revision is
- active (TBC, pods not yet started, scaling to 0)
- always in proxy mode

/lint

For #4453 
/assign @jonjohnsonjr 