### PR TITLE
Multiscaler cleanups

### DIFF
--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -117,9 +117,8 @@ func (sr *scalerRunner) updateLatestScale(proposed, ebc int32) bool {
 	}
 
 	// If sign has changed -- then we have to update KPA
-	if !sameSign(sr.decider.Status.ExcessBurstCapacity, ebc) {
-		ret = true
-	}
+	ret = ret || !sameSign(sr.decider.Status.ExcessBurstCapacity, ebc)
+
 	// Update with the latest calculation anyway.
 	sr.decider.Status.ExcessBurstCapacity = ebc
 	return ret
@@ -246,6 +245,7 @@ func (m *MultiScaler) Inform(event string) bool {
 	}
 	return false
 }
+
 func (m *MultiScaler) updateRunner(ctx context.Context, runner *scalerRunner) {
 	runner.stopCh <- struct{}{}
 	m.runScalerTicker(ctx, runner)
@@ -277,10 +277,9 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 		return nil, err
 	}
 
-	stopCh := make(chan struct{})
 	runner := &scalerRunner{
 		scaler:  scaler,
-		stopCh:  stopCh,
+		stopCh:  make(chan struct{}),
 		decider: *decider,
 		pokeCh:  make(chan struct{}),
 	}

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -101,7 +101,7 @@ func TestMultiScalerScaling(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 
 	// Verify that we see a "tick"
@@ -139,10 +139,10 @@ func TestMultiScalerOnlyCapacityChange(t *testing.T) {
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 
-	// Verify that we see a "tick"
+	// Verify that we see a "tick".
 	if err := verifyTick(errCh); err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestMultiScalerOnlyCapacityChange(t *testing.T) {
 		t.Errorf("Delete() = %v", err)
 	}
 
-	// Verify that we stop seeing "ticks"
+	// Verify that we stop seeing "ticks".
 	if err := verifyNoTick(errCh); err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestMultiScalerTickUpdate(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 	time.Sleep(50 * time.Millisecond)
 
@@ -230,7 +230,7 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 
 	// Verify that we see a "tick"
@@ -264,7 +264,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 	metricKey := NewMetricKey(decider.Namespace, decider.Name)
 	if scaler, exists := ms.scalers[metricKey]; !exists {
@@ -312,7 +312,7 @@ func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 
 	// Verify that we get no "ticks", because the desired scale is negative
@@ -344,7 +344,7 @@ func TestMultiScalerUpdate(t *testing.T) {
 	// Create the decider and verify the Spec
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Errorf("Create() = %v", err)
+		t.Fatalf("Create() = %v", err)
 	}
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
@@ -404,7 +404,7 @@ func (u *fakeUniScaler) getScaleCount() int {
 	return u.scaleCount
 }
 
-func (u *fakeUniScaler) setScaleResult(replicas int32, surplus int32, scaled bool) {
+func (u *fakeUniScaler) setScaleResult(replicas, surplus int32, scaled bool) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 


### PR DESCRIPTION
While I was debugging a transient flake (still didn't find the reason, even though
I have -count=100 easily pass more than once); I did some clean ups around the code.

Including:

- shortcircuit eval of the return value.
- fatal when test doesn't make sense anymore
- whitespace

/assign @markusthoemmes 