### PR TITLE
Increase MaxIdleConns and MaxIdleConnsPerHost of the transport

### DIFF
--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -89,7 +89,8 @@ func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.Ro
 	return &http.Transport{
 		// Those match net/http/transport.go
 		Proxy:                 http.ProxyFromEnvironment,
-		MaxIdleConns:          100,
+		MaxIdleConns:          1000,
+		MaxIdleConnsPerHost:   100,
 		IdleConnTimeout:       5 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #4773 

## Proposed Changes

For the transport used in Activator and queue-proxy:
* Increase MaxIdleConns from 100 to 1000.
* Increase MaxIdleConnsPerHost from default value 2 to 100.

When activator is used as a meet shield, the following response error happens frequently when the concurrency/QPS is high:

```
connection reset by peer
```

In my testing case,  I sent traffic to activator directly via
```
echo 'GET http://<activator loadbalancer service IP>' |  vegeta attack  -rate 1000 -duration 10m -header "Knative-Serving-Revision: helloworld-go-9pxdr" -header "Knative-Serving-Namespace: default" | vegeta report
```

Apparently the default value of `MaxIdleConnsPerHost`, i.e. 2, is too small for rate 1000. The server connections will often be closed after a request, only to be immediately opened again. This slows down the process.

After this change, I no longer see the same error at rate 1000.

In theory, it may increase performance. In my load tests of rate 500, the client side P95 latency decreased from 28.9 ms to 24.6 ms after this change. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
