### PR TITLE
Mark LB status ready after Gateway is successfully reconciled

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -426,33 +426,18 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Object: ingressWithTLSAndStatus("reconciling-clusteringress", 1234,
 				ingressTLS,
 				v1alpha1.IngressStatus{
-					LoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
-						},
-					},
-					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: network.GetServiceHostname("istio-ingressgateway", "istio-system")},
-						},
-					},
-					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{MeshOnly: true},
-						},
-					},
 					Status: duckv1beta1.Status{
 						Conditions: duckv1beta1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
-							Status:   corev1.ConditionTrue,
+							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
 						}, {
 							Type:     v1alpha1.IngressConditionNetworkConfigured,
-							Status:   corev1.ConditionTrue,
+							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
 						}, {
 							Type:     v1alpha1.IngressConditionReady,
-							Status:   corev1.ConditionTrue,
+							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
 						}},
 					},

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -258,24 +258,8 @@ func (r *BaseIngressReconciler) reconcileIngress(ctx context.Context, ra Reconci
 		// when error reconciling VirtualService?
 		return err
 	}
-	// As underlying network programming (VirtualService now) is stateless,
-	// here we simply mark the ingress as ready if the VirtualService
-	// is successfully synced.
-	ia.GetStatus().MarkNetworkConfigured()
 
-	lbs := getLBStatus(gatewayServiceURLFromContext(ctx, ia))
-	publicLbs := getLBStatus(publicGatewayServiceURLFromContext(ctx))
-	privateLbs := getLBStatus(privateGatewayServiceURLFromContext(ctx))
-
-	ia.GetStatus().MarkLoadBalancerReady(lbs, publicLbs, privateLbs)
-	ia.GetStatus().ObservedGeneration = ia.GetGeneration()
-
-	if enableReconcileGateway(ctx) {
-		if !ia.IsPublic() {
-			logger.Infof("Ingress %s is not public. So no need to configure TLS.", ia.GetName())
-			return nil
-		}
-
+	if enableReconcileGateway(ctx) && ia.IsPublic() {
 		// Add the finalizer before adding `Servers` into Gateway so that we can be sure
 		// the `Servers` get cleaned up from Gateway.
 		if err := r.ensureFinalizer(ra, ia); err != nil {
@@ -308,6 +292,18 @@ func (r *BaseIngressReconciler) reconcileIngress(ctx context.Context, ra Reconci
 			}
 		}
 	}
+
+	// As underlying network programming (VirtualService now) is stateless,
+	// here we simply mark the ingress as ready if the VirtualService
+	// is successfully synced.
+	ia.GetStatus().MarkNetworkConfigured()
+
+	lbs := getLBStatus(gatewayServiceURLFromContext(ctx, ia))
+	publicLbs := getLBStatus(publicGatewayServiceURLFromContext(ctx))
+	privateLbs := getLBStatus(privateGatewayServiceURLFromContext(ctx))
+
+	ia.GetStatus().MarkLoadBalancerReady(lbs, publicLbs, privateLbs)
+	ia.GetStatus().ObservedGeneration = ia.GetGeneration()
 
 	// TODO(zhiminx): Mark Route status to indicate that Gateway is configured.
 	logger.Info("ClusterIngress successfully synced")


### PR DESCRIPTION

## Proposed Changes

* Mark LB status ready after Gateway is successfully reconciled

Currently we mark LB status as ready after VS is reconciled which is not accurate. We should not consider LB as ready if the Gateway is failed to reconcile.
