### PR TITLE
Some small fixes for the metric collector.

### DIFF
--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -55,15 +54,15 @@ func TestMetricCollectorCRUD(t *testing.T) {
 	ctx := context.Background()
 
 	scraper := &testScraper{
-		s: (func() (*StatMessage, error) {
+		s: func() (*StatMessage, error) {
 			return nil, nil
-		}),
+		},
 		url: "just-right",
 	}
 	scraper2 := &testScraper{
-		s: (func() (*StatMessage, error) {
+		s: func() (*StatMessage, error) {
 			return nil, nil
-		}),
+		},
 		url: "slightly-off",
 	}
 	factory := scraperFactory(scraper, nil)
@@ -168,8 +167,8 @@ func TestMetricCollectorScraper(t *testing.T) {
 
 	coll.Delete(ctx, defaultNamespace, defaultName)
 	_, _, err := coll.StableAndPanicConcurrency(metricKey)
-	if !k8serrors.IsNotFound(err) {
-		t.Errorf("StableAndPanicConcurrency() = %v, want a not found error", err)
+	if err != ErrNotScraping {
+		t.Errorf("StableAndPanicConcurrency() = %v, want %v", err, ErrNotScraping)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- Don't allocate an object to check its interface.
- Add a missing mutex section.
- Report a more canonical error if no scraper is set up for a specific resource.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
