### PR TITLE
Deeply replace the 'MetricKey' with 'NamespacedName'.

### DIFF
--- a/cmd/autoscaler/main_test.go
+++ b/cmd/autoscaler/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	fakeK8s "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/serving/pkg/apis/serving"
@@ -149,6 +150,6 @@ func getTestUniScalerFactory() func(decider *autoscaler.Decider) (autoscaler.Uni
 
 type testMetricClient struct{}
 
-func (t *testMetricClient) StableAndPanicConcurrency(key string) (float64, float64, error) {
+func (t *testMetricClient) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
 	return 1.0, 1.0, nil
 }

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/stats"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/metrics"
@@ -86,11 +87,10 @@ const (
 )
 
 var (
-	servingRevisionKey string
-	userTargetAddress  string
-	reqChan            = make(chan queue.ReqEvent, requestCountingQueueLength)
-	logger             *zap.SugaredLogger
-	breaker            *queue.Breaker
+	userTargetAddress string
+	reqChan           = make(chan queue.ReqEvent, requestCountingQueueLength)
+	logger            *zap.SugaredLogger
+	breaker           *queue.Breaker
 
 	httpProxy *httputil.ReverseProxy
 
@@ -148,8 +148,6 @@ func initConfig(env config) {
 		logger.Fatal("INTERNAL_VOLUME_PATH must be specified when ENABLE_VAR_LOG_COLLECTION is true")
 	}
 
-	// TODO(mattmoor): Move this key to be in terms of the KPA.
-	servingRevisionKey = autoscaler.NewMetricKey(env.ServingNamespace, env.ServingRevision)
 	_psr, err := queue.NewPrometheusStatsReporter(env.ServingNamespace, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
 	if err != nil {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
@@ -299,7 +297,7 @@ func main() {
 
 	initConfig(env)
 	logger = logger.With(
-		zap.String(logkey.Key, servingRevisionKey),
+		zap.String(logkey.Key, types.NamespacedName{Namespace: env.ServingNamespace, Name: env.ServingRevision}.String()),
 		zap.String(logkey.Pod, env.ServingPod))
 
 	target, err := url.Parse("http://" + userTargetAddress)

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/autoscaler"
 )
@@ -55,7 +56,7 @@ func NewConcurrencyReporterWithClock(podName string, reqChan chan ReqEvent, repo
 	}
 }
 
-func (cr *ConcurrencyReporter) report(key string, concurrency, requestCount int32) {
+func (cr *ConcurrencyReporter) report(key types.NamespacedName, concurrency, requestCount int32) {
 	stat := autoscaler.Stat{
 		PodName:                   cr.podName,
 		AverageConcurrentRequests: float64(concurrency),
@@ -73,10 +74,10 @@ func (cr *ConcurrencyReporter) report(key string, concurrency, requestCount int3
 // Run runs until stopCh is closed and processes events on all incoming channels
 func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
 	// Contains the number of in-flight requests per-key
-	outstandingRequestsPerKey := make(map[string]int32)
+	outstandingRequestsPerKey := make(map[types.NamespacedName]int32)
 	// Contains the number of incoming requests in the current
 	// reporting period, per key.
-	incomingRequestsPerKey := make(map[string]int32)
+	incomingRequestsPerKey := make(map[types.NamespacedName]int32)
 
 	for {
 		select {
@@ -102,7 +103,7 @@ func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
 				}
 			}
 
-			incomingRequestsPerKey = make(map[string]int32)
+			incomingRequestsPerKey = make(map[types.NamespacedName]int32)
 		case <-stopCh:
 			return
 		}

--- a/pkg/activator/handler/requestevent_handler.go
+++ b/pkg/activator/handler/requestevent_handler.go
@@ -17,12 +17,13 @@ import (
 	"net/http"
 
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/autoscaler"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ReqEvent represents an incoming/finished request with a given key
 type ReqEvent struct {
-	Key       string
+	Key       types.NamespacedName
 	EventType ReqEventType
 }
 
@@ -57,9 +58,11 @@ func (h *RequestEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
 	name := r.Header.Get(activator.RevisionHeaderName)
 
-	revisionKey := autoscaler.NewMetricKey(namespace, name)
+	revisionKey := types.NamespacedName{Namespace: namespace, Name: name}
 
 	h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqIn}
-	defer func() { h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqOut} }()
+	defer func() {
+		h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqOut}
+	}()
 	h.nextHandler.ServeHTTP(w, r)
 }

--- a/pkg/activator/handler/requestevent_handler_test.go
+++ b/pkg/activator/handler/requestevent_handler_test.go
@@ -14,12 +14,12 @@ package handler
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/serving/pkg/activator"
 )
 
@@ -43,7 +43,7 @@ func TestRequestEventHandler(t *testing.T) {
 
 	in := <-handler.ReqChan
 	wantIn := ReqEvent{
-		Key:       fmt.Sprintf("%s/%s", namespace, revision),
+		Key:       types.NamespacedName{Namespace: namespace, Name: revision},
 		EventType: ReqIn,
 	}
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/serving/pkg/resources"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Autoscaler stores current state of an instance of an autoscaler.
@@ -124,7 +125,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	// Use 1 if there are zero current pods.
 	readyPodsCount := math.Max(1, float64(originalReadyPodsCount))
 
-	metricKey := NewMetricKey(a.namespace, a.revision)
+	metricKey := types.NamespacedName{Namespace: a.namespace, Name: a.revision}
 	observedStableConcurrency, observedPanicConcurrency, err := a.metricClient.StableAndPanicConcurrency(metricKey)
 	if err != nil {
 		if err == ErrNoData {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	fakeK8s "k8s.io/client-go/kubernetes/fake"
 	. "knative.dev/pkg/logging/testing"
@@ -324,7 +325,7 @@ type testMetricClient struct {
 	err               error
 }
 
-func (t *testMetricClient) StableAndPanicConcurrency(key string) (float64, float64, error) {
+func (t *testMetricClient) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
 	return t.stableConcurrency, t.panicConcurrency, t.err
 }
 

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -26,6 +26,7 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	. "knative.dev/pkg/logging/testing"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -106,7 +107,7 @@ func TestMetricCollectorCRUD(t *testing.T) {
 		if !cmp.Equal(defaultMetric, got) {
 			t.Errorf("Get() didn't return the same metric: %v", cmp.Diff(defaultMetric, got))
 		}
-		key := NewMetricKey(defaultMetric.Namespace, defaultMetric.Name)
+		key := types.NamespacedName{Namespace: defaultMetric.Namespace, Name: defaultMetric.Name}
 
 		defaultMetric.Spec.ScrapeTarget = "new-target"
 		coll.statsScraperFactory = scraperFactory(scraper2, nil)
@@ -135,7 +136,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now()
-	metricKey := NewMetricKey(defaultNamespace, defaultName)
+	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	want := 10.0
 	stat := &StatMessage{
 		Key: metricKey,
@@ -179,7 +180,7 @@ func TestMetricCollectorRecord(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now()
-	metricKey := NewMetricKey(defaultNamespace, defaultName)
+	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	want := 10.0
 	stat := Stat{
 		Time:                             &now,

--- a/pkg/autoscaler/metrics_provider.go
+++ b/pkg/autoscaler/metrics_provider.go
@@ -63,7 +63,7 @@ func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provide
 		return nil, errMetricNotSupported
 	}
 
-	concurrency, _, err := p.metricClient.StableAndPanicConcurrency(name.String())
+	concurrency, _, err := p.metricClient.StableAndPanicConcurrency(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autoscaler/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics_provider_test.go
@@ -18,7 +18,6 @@ package autoscaler
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
@@ -111,8 +110,8 @@ func TestListAllMetrics(t *testing.T) {
 
 type staticConcurrency float64
 
-func (s staticConcurrency) StableAndPanicConcurrency(key string) (float64, float64, error) {
-	if strings.HasPrefix(key, existingNamespace) {
+func (s staticConcurrency) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
+	if key.Namespace == existingNamespace {
 		return (float64)(s), 0.0, nil
 	}
 	return 0.0, 0.0, errors.New("doesn't exist")

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -266,7 +267,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() = %v", err)
 	}
-	metricKey := NewMetricKey(decider.Namespace, decider.Name)
+	metricKey := types.NamespacedName{Namespace: decider.Namespace, Name: decider.Name}
 	if scaler, exists := ms.scalers[metricKey]; !exists {
 		t.Errorf("Failed to get scaler for metric %s", metricKey)
 	} else if !scaler.updateLatestScale(0, 10) {

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/pkg/errors"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -78,7 +79,7 @@ type ServiceScraper struct {
 	sClient   scrapeClient
 	counter   resources.ReadyPodCounter
 	namespace string
-	metricKey string
+	metricKey types.NamespacedName
 	url       string
 }
 
@@ -114,7 +115,7 @@ func newServiceScraperWithClient(
 		sClient:   sClient,
 		counter:   counter,
 		url:       urlFromTarget(metric.Spec.ScrapeTarget, metric.ObjectMeta.Namespace),
-		metricKey: NewMetricKey(metric.Namespace, metric.Name),
+		metricKey: types.NamespacedName{Namespace: metric.Namespace, Name: metric.Name},
 		namespace: metric.Namespace,
 	}, nil
 }

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/resources"
@@ -33,10 +34,10 @@ const (
 	testRevision  = "test-revision"
 	testService   = "test-revision-metrics"
 	testNamespace = "test-namespace"
-	testPAKey     = "test-namespace/test-revision"
 )
 
 var (
+	testPAKey = types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}
 	testStats = []*Stat{
 		{
 			PodName:                          "pod-1",

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -32,6 +32,8 @@ import (
 	"golang.org/x/sync/errgroup"
 	"knative.dev/serving/pkg/autoscaler"
 	stats "knative.dev/serving/pkg/autoscaler/statserver"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestServerLifecycle(t *testing.T) {
@@ -82,8 +84,8 @@ func TestStatsReceived(t *testing.T) {
 
 	statSink := dialOk(server.ListenAddr(), t)
 
-	assertReceivedOk(newStatMessage("test-namespace/test-revision", "activator1", 2.1, 51), statSink, statsCh, t)
-	assertReceivedOk(newStatMessage("test-namespace/test-revision2", "activator2", 2.2, 30), statSink, statsCh, t)
+	assertReceivedOk(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, t)
+	assertReceivedOk(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), statSink, statsCh, t)
 
 	closeSink(statSink, t)
 }
@@ -97,14 +99,14 @@ func TestServerShutdown(t *testing.T) {
 	listenAddr := server.ListenAddr()
 	statSink := dialOk(listenAddr, t)
 
-	assertReceivedOk(newStatMessage("test-namespace/test-revision", "activator1", 2.1, 51), statSink, statsCh, t)
+	assertReceivedOk(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, t)
 
 	server.Shutdown(time.Second)
 	// We own the channel.
 	close(statsCh)
 
 	// Send a statistic to the server
-	send(statSink, newStatMessage("test-namespace/test-revision2", "activator2", 2.2, 30), t)
+	send(statSink, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), t)
 
 	// Check the statistic was not received
 	_, ok := <-statsCh
@@ -144,7 +146,7 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	listenAddr := server.ListenAddr()
 	statSink := dialOk(listenAddr, t)
 
-	assertReceivedOk(newStatMessage("test-namespace/test-revision", "activator1", 2.1, 51), statSink, statsCh, t)
+	assertReceivedOk(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, t)
 
 	closeSink(statSink, t)
 
@@ -163,7 +165,7 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	server.Shutdown(time.Second)
 }
 
-func newStatMessage(revKey string, podName string, averageConcurrentRequests float64, requestCount float64) *autoscaler.StatMessage {
+func newStatMessage(revKey types.NamespacedName, podName string, averageConcurrentRequests float64, requestCount float64) *autoscaler.StatMessage {
 	return &autoscaler.StatMessage{
 		Key: revKey,
 		Stat: autoscaler.Stat{

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -35,6 +35,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ktesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -490,7 +491,7 @@ type testMetrics struct {
 
 func (km *testMetrics) Get(ctx context.Context, namespace, name string) (*asv1a1.Metric, error) {
 	if km.metric == nil {
-		return nil, apierrors.NewNotFound(asv1a1.Resource("Metric"), autoscaler.NewMetricKey(namespace, name))
+		return nil, apierrors.NewNotFound(asv1a1.Resource("Metric"), types.NamespacedName{Namespace: namespace, Name: name}.String())
 	}
 	return km.metric, nil
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/serving/pkg/reconciler"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/google/go-cmp/cmp"
@@ -1351,7 +1352,7 @@ func (km *testDeciders) Get(ctx context.Context, namespace, name string) (*autos
 	defer km.mutex.Unlock()
 
 	if km.decider == nil {
-		return nil, apierrors.NewNotFound(asv1a1.Resource("Deciders"), autoscaler.NewMetricKey(namespace, name))
+		return nil, apierrors.NewNotFound(asv1a1.Resource("Deciders"), types.NamespacedName{Namespace: namespace, Name: name}.String())
 	}
 	return km.decider, nil
 }
@@ -1432,7 +1433,7 @@ type testMetrics struct {
 
 func (km *testMetrics) Get(ctx context.Context, namespace, name string) (*asv1a1.Metric, error) {
 	if km.metric == nil {
-		return nil, apierrors.NewNotFound(asv1a1.Resource("Metric"), autoscaler.NewMetricKey(namespace, name))
+		return nil, apierrors.NewNotFound(asv1a1.Resource("Metric"), types.NamespacedName{Namespace: namespace, Name: name}.String())
 	}
 	return km.metric, nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Today is 🐇  🕳  day 🙂 . This has been something I wanted to do a loooong time ago but now that we're scraping metrics in the autoscaler I think it's even a non-breaking change 🤔.

## Proposed Changes

The metric keys are currently a concatenated version of namespace/name. However, working with strings all throughout the codebase is kinda brittle as in the end, anything could be in them.

A much more typesafe method is to use 'NamespacedName' from k8s apimachinery. As it is only a struct with two strings, it is comparable via == and thus can even be used as keys for maps.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
