### PR TITLE
Adjust metric creation to be akin to other reconciled entities.

### DIFF
--- a/pkg/reconciler/autoscaling/resources/metric.go
+++ b/pkg/reconciler/autoscaling/resources/metric.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
+	"knative.dev/serving/pkg/resources"
 )
 
 // Metrics is an interface for notifying the presence or absence of metric collection.
@@ -65,7 +68,13 @@ func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, metricSvc strin
 		panicWindow = autoscaler.BucketSize
 	}
 	return &v1alpha1.Metric{
-		ObjectMeta: pa.ObjectMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       pa.Namespace,
+			Name:            pa.Name,
+			Annotations:     resources.CopyMap(pa.Annotations),
+			Labels:          resources.CopyMap(pa.Labels),
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pa)},
+		},
 		Spec: v1alpha1.MetricSpec{
 			StableWindow: stableWindow,
 			PanicWindow:  panicWindow,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
- Adjust the reconcile method to act as if the reconciliation was actually backed by an API. It needs to base the update entity on the actual entity it got earlier to be able to successfully update once we have the Metric entities backed by an API.
- Adjust the Metric's metadata to only pick the needed values from PA's metadata. resourceVersion and friends are not to be copied over. Also add an owner reference.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
