### PR TITLE
Enable resolvable domain and ingressendpoint in perf tests

### DIFF
--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -84,13 +84,12 @@ func runTest(t *testing.T, pacer vegeta.Pacer, saveMetrics bool) {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
-	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, domain, test.ServingFlags.ResolvableDomain,
+	url, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, domain, test.ServingFlags.ResolvableDomain,
 		pkgTest.Flags.IngressEndpoint)
 	if err != nil {
 		t.Fatalf("Cannot resolve service endpoint: %v", err)
 	}
 
-	url := endpoint
 	if !strings.HasPrefix(url, httpPrefix) {
 		url = httpPrefix + url
 	}

--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -91,7 +91,7 @@ func runTest(t *testing.T, pacer vegeta.Pacer, saveMetrics bool) {
 
 	url := endpoint
 	if !strings.HasPrefix(url, httpPrefix) {
-		url = fmt.Sprintf("%s%s", httpPrefix, url)
+		url = httpPrefix + url
 	}
 
 	headers := make(map[string][]string)

--- a/test/performance/benchmarks_test.go
+++ b/test/performance/benchmarks_test.go
@@ -29,6 +29,7 @@ import (
 	perf "github.com/knative/test-infra/shared/performance"
 	"github.com/knative/test-infra/shared/testgrid"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 
@@ -83,7 +84,7 @@ func runTest(t *testing.T, pacer vegeta.Pacer, saveMetrics bool) {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
-	endpoint, err := resolveEndpoint(clients.KubeClient, domain, test.ServingFlags.ResolvableDomain,
+	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, domain, test.ServingFlags.ResolvableDomain,
 		pkgTest.Flags.IngressEndpoint)
 	if err != nil {
 		t.Fatalf("Cannot resolve service endpoint: %v", err)

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -30,6 +30,7 @@ import (
 	perf "github.com/knative/test-infra/shared/performance"
 	"github.com/knative/test-infra/shared/testgrid"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -76,7 +77,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
-	endpoint, err := resolveEndpoint(clients.KubeClient, domain, test.ServingFlags.ResolvableDomain,
+	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, domain, test.ServingFlags.ResolvableDomain,
 		pkgTest.Flags.IngressEndpoint)
 	if err != nil {
 		t.Fatalf("Cannot resolve service endpoint: %v", err)

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -30,7 +30,6 @@ import (
 	perf "github.com/knative/test-infra/shared/performance"
 	"github.com/knative/test-infra/shared/testgrid"
 	pkgTest "knative.dev/pkg/test"
-	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
@@ -66,10 +65,6 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	}
 
 	domain := objs.Route.Status.URL.Host
-	endpoint, err := ingress.GetIngressEndpoint(clients.KubeClient.Kube)
-	if err != nil {
-		t.Fatalf("Cannot get service endpoint: %v", err)
-	}
 
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
@@ -81,17 +76,28 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		t.Fatalf("Error probing domain %s: %v", domain, err)
 	}
 
+	endpoint, err := resolveEndpoint(clients.KubeClient, domain, test.ServingFlags.ResolvableDomain,
+		pkgTest.Flags.IngressEndpoint)
+	if err != nil {
+		t.Fatalf("Cannot resolve service endpoint: %v", err)
+	}
+
 	opts := loadgenerator.GeneratorOptions{
 		Duration:       duration,
 		NumThreads:     1,
 		NumConnections: 5,
 		Domain:         domain,
-		URL:            fmt.Sprintf("http://%s/?%s", *endpoint, query),
+		URL:            fmt.Sprintf("%s/?%s", endpoint, query),
 		RequestTimeout: reqTimeout,
 		LoadFactors:    []float64{1},
 		FileNamePrefix: tName,
 	}
-	resp, err := opts.RunLoadTest(loadgenerator.AddHostHeader)
+	var flags []int
+	if !test.ServingFlags.ResolvableDomain {
+		flags = append(flags, loadgenerator.AddHostHeader)
+	}
+
+	resp, err := opts.RunLoadTest(flags...)
 	if err != nil {
 		t.Fatalf("Generating traffic via fortio failed: %v", err)
 	}

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -27,7 +27,6 @@ import (
 	"github.com/knative/test-infra/shared/prometheus"
 	"github.com/knative/test-infra/shared/prow"
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/zipkin"
 	"knative.dev/serving/test"
@@ -133,20 +132,4 @@ func AddTrace(logf logging.FormatLogger, tName string, traceID string) {
 	if _, err := traceFile.WriteString(fmt.Sprintf("%s,\n", trace)); err != nil {
 		logf("Cannot write to trace file: %v", err)
 	}
-}
-
-func resolveEndpoint(kubeClientset *pkgTest.KubeClient, domain string, resolvable bool, endpointOverride string) (string, error) {
-	endpoint := domain
-	if !resolvable {
-		e := &endpointOverride
-		if endpointOverride == "" {
-			var err error
-			e, err = ingress.GetIngressEndpoint(kubeClientset.Kube)
-			if err != nil {
-				return "", err
-			}
-		}
-		endpoint = *e
-	}
-	return endpoint, nil
 }

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -136,7 +136,7 @@ func AddTrace(logf logging.FormatLogger, tName string, traceID string) {
 }
 
 func resolveEndpoint(kubeClientset *pkgTest.KubeClient, domain string, resolvable bool, endpointOverride string) (string, error) {
-	var endpoint string
+	endpoint := domain
 	if !resolvable {
 		e := &endpointOverride
 		if endpointOverride == "" {
@@ -147,9 +147,6 @@ func resolveEndpoint(kubeClientset *pkgTest.KubeClient, domain string, resolvabl
 			}
 		}
 		endpoint = *e
-	} else {
-		// If the domain is resolvable, we can use it directly when we make requests.
-		endpoint = domain
 	}
 	return endpoint, nil
 }

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/resources"
 	testingv1alpha1 "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
@@ -145,7 +146,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	})
 	controller.StartInformers(stopCh, endpointsInformer)
 
-	endpoint, err := resolveEndpoint(clients.KubeClient, domain, test.ServingFlags.ResolvableDomain,
+	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, domain, test.ServingFlags.ResolvableDomain,
 		pkgTest.Flags.IngressEndpoint)
 	if err != nil {
 		t.Fatalf("Cannot resolve service endpoint: %v", err)

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
 	pkgTest "knative.dev/pkg/test"
-	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/serving/pkg/resources"
 	testingv1alpha1 "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
@@ -102,10 +101,6 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	}
 
 	domain := objs.Route.Status.URL.Host
-	endpoint, err := ingress.GetIngressEndpoint(clients.KubeClient.Kube)
-	if err != nil {
-		t.Fatalf("Cannot get service endpoint: %v", err)
-	}
 
 	// Make sure we are ready to serve.
 	st := time.Now()
@@ -150,19 +145,30 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	})
 	controller.StartInformers(stopCh, endpointsInformer)
 
+	endpoint, err := resolveEndpoint(clients.KubeClient, domain, test.ServingFlags.ResolvableDomain,
+		pkgTest.Flags.IngressEndpoint)
+	if err != nil {
+		t.Fatalf("Cannot resolve service endpoint: %v", err)
+	}
+
 	opts := loadgenerator.GeneratorOptions{
 		Duration:       iterationDuration,
 		NumThreads:     numClients,
 		NumConnections: numClients,
 		Domain:         domain,
 		BaseQPS:        qpsPerClient * float64(numClients),
-		URL:            fmt.Sprintf("http://%s/?timeout=%d", *endpoint, processingTimeMillis),
+		URL:            fmt.Sprintf("%s/?timeout=%d", endpoint, processingTimeMillis),
 		LoadFactors:    []float64{1},
 		FileNamePrefix: strings.Replace(t.Name(), "/", "_", -1),
 	}
 
+	var flags []int
+	if !test.ServingFlags.ResolvableDomain {
+		flags = append(flags, loadgenerator.AddHostHeader)
+	}
+
 	t.Logf("Starting test with %d clients at %s", numClients, time.Now())
-	resp, err := opts.RunLoadTest(loadgenerator.AddHostHeader)
+	resp, err := opts.RunLoadTest(flags...)
 	if err != nil {
 		t.Fatalf("Generating traffic via fortio failed: %v", err)
 	}


### PR DESCRIPTION
Make it possible to specify --resolvabledomain and/or --ingressendpoint in perf tests

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes the following problems:
* not being able to pass ingressendpoint to the test
* not being able to use the domain directly without the Host header
* failing tests when my ingress gateway is not of type LoadBalancer (and hence can't be acquired via svc.Status.LoadBalancer.Ingress which used to be called every time no matter if I used resolvable domain or not)

## Proposed Changes


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
