### PR TITLE
Some flyby fixes in parsing

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -239,10 +239,11 @@ func (a *activationHandler) serviceHostName(rev *v1alpha1.Revision, serviceName 
 		return "", err
 	}
 
-	// Search for the appropriate port
+	// Search for the appropriate port.
 	port := -1
+	wantName := networking.ServicePortName(rev.GetProtocol())
 	for _, p := range svc.Spec.Ports {
-		if p.Name == networking.ServicePortName(rev.GetProtocol()) {
+		if p.Name == wantName {
 			port = int(p.Port)
 			break
 		}

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package activator
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ func unregister() {
 func TestActivatorReporter(t *testing.T) {
 	r := &Reporter{}
 
-	if err := r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 1, 1); err == nil {
+	if err := r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 1, 1); err == nil {
 		t.Error("Reporter expected an error for Report call before init. Got success.")
 	}
 
@@ -57,8 +58,12 @@ func TestActivatorReporter(t *testing.T) {
 		"response_code_class":             "2xx",
 		"num_tries":                       "6",
 	}
-	expectSuccess(t, func() error { return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 1) })
-	expectSuccess(t, func() error { return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", 200, 6, 3) })
+	expectSuccess(t, func() error {
+		return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 6, 1)
+	})
+	expectSuccess(t, func() error {
+		return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 6, 3)
+	})
 	metricstest.CheckSumData(t, "request_count", wantTags2, 4)
 
 	// test ReportResponseTime
@@ -71,10 +76,10 @@ func TestActivatorReporter(t *testing.T) {
 		"response_code_class":             "2xx",
 	}
 	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", 200, 1100*time.Millisecond)
+		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 1100*time.Millisecond)
 	})
 	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", 200, 9100*time.Millisecond)
+		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 9100*time.Millisecond)
 	})
 	metricstest.CheckDistributionData(t, "request_latencies", wantTags3, 2, 1100.0, 9100.0)
 }
@@ -93,7 +98,7 @@ func TestReportRequestCount_EmptyServiceName(t *testing.T) {
 		"num_tries":                       "6",
 	}
 	expectSuccess(t, func() error {
-		return r.ReportRequestCount("testns" /*service=*/, "", "testconfig", "testrev", 200, 6, 10)
+		return r.ReportRequestCount("testns" /*service=*/, "", "testconfig", "testrev", http.StatusOK, 6, 10)
 	})
 	metricstest.CheckSumData(t, "request_count", wantTags, 10)
 }
@@ -111,10 +116,10 @@ func TestReportResponseTimeEmptyServiceName(t *testing.T) {
 		"response_code_class":             "2xx",
 	}
 	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns" /*service=*/, "", "testconfig", "testrev", 200, 7100*time.Millisecond)
+		return r.ReportResponseTime("testns" /*service=*/, "", "testconfig", "testrev", http.StatusOK, 7100*time.Millisecond)
 	})
 	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns" /*service=*/, "", "testconfig", "testrev", 200, 5100*time.Millisecond)
+		return r.ReportResponseTime("testns" /*service=*/, "", "testconfig", "testrev", http.StatusOK, 5100*time.Millisecond)
 	})
 	metricstest.CheckDistributionData(t, "request_latencies", wantTags, 2, 5100.0, 7100.0)
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -68,9 +68,8 @@ func (pa *PodAutoscaler) annotationInt32(key string) int32 {
 
 func (pa *PodAutoscaler) annotationFloat64(key string) (float64, bool) {
 	if s, ok := pa.Annotations[key]; ok {
-		if f, err := strconv.ParseFloat(s, 64); err == nil {
-			return f, true
-		}
+		f, err := strconv.ParseFloat(s, 64)
+		return f, err == nil
 	}
 	return 0.0, false
 }

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -79,7 +79,7 @@ func createQueueResources(annotations map[string]string, userContainer *corev1.C
 		resourcePercentage                               float32
 	)
 
-	if ok, resourcePercentage = createResourcePercentageFromAnnotations(annotations, serving.QueueSideCarResourcePercentageAnnotation); ok {
+	if ok, resourcePercentage = fractionFromPercentage(annotations, serving.QueueSideCarResourcePercentageAnnotation); ok {
 		if ok, requestCPU = computeResourceRequirements(userContainer.Resources.Requests.Cpu(), resourcePercentage, queueContainerRequestCPU); ok {
 			resourceRequests[corev1.ResourceCPU] = requestCPU
 		}
@@ -134,16 +134,13 @@ func computeResourceRequirements(resourceQuantity *resource.Quantity, percentage
 	return true, newquantity
 }
 
-func createResourcePercentageFromAnnotations(m map[string]string, k string) (bool, float32) {
+func fractionFromPercentage(m map[string]string, k string) (bool, float32) {
 	v, ok := m[k]
 	if !ok {
 		return false, 0
 	}
 	value, err := strconv.ParseFloat(v, 32)
-	if err != nil {
-		return false, 0
-	}
-	return true, float32(value / 100)
+	return err == nil, float32(value / 100)
 }
 
 func makeQueueProbe(in *corev1.Probe) *corev1.Probe {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -73,26 +73,22 @@ var (
 func createQueueResources(annotations map[string]string, userContainer *corev1.Container) corev1.ResourceRequirements {
 	resourceRequests := corev1.ResourceList{corev1.ResourceCPU: queueContainerCPU}
 	resourceLimits := corev1.ResourceList{}
-	var (
-		ok                                               bool
-		requestCPU, limitCPU, requestMemory, limitMemory resource.Quantity
-		resourcePercentage                               float32
-	)
+	var requestCPU, limitCPU, requestMemory, limitMemory resource.Quantity
 
-	if ok, resourcePercentage = fractionFromPercentage(annotations, serving.QueueSideCarResourcePercentageAnnotation); ok {
-		if ok, requestCPU = computeResourceRequirements(userContainer.Resources.Requests.Cpu(), resourcePercentage, queueContainerRequestCPU); ok {
+	if resourceFraction, ok := fractionFromPercentage(annotations, serving.QueueSideCarResourcePercentageAnnotation); ok {
+		if ok, requestCPU = computeResourceRequirements(userContainer.Resources.Requests.Cpu(), resourceFraction, queueContainerRequestCPU); ok {
 			resourceRequests[corev1.ResourceCPU] = requestCPU
 		}
 
-		if ok, limitCPU = computeResourceRequirements(userContainer.Resources.Limits.Cpu(), resourcePercentage, queueContainerLimitCPU); ok {
+		if ok, limitCPU = computeResourceRequirements(userContainer.Resources.Limits.Cpu(), resourceFraction, queueContainerLimitCPU); ok {
 			resourceLimits[corev1.ResourceCPU] = limitCPU
 		}
 
-		if ok, requestMemory = computeResourceRequirements(userContainer.Resources.Requests.Memory(), resourcePercentage, queueContainerRequestMemory); ok {
+		if ok, requestMemory = computeResourceRequirements(userContainer.Resources.Requests.Memory(), resourceFraction, queueContainerRequestMemory); ok {
 			resourceRequests[corev1.ResourceMemory] = requestMemory
 		}
 
-		if ok, limitMemory = computeResourceRequirements(userContainer.Resources.Limits.Memory(), resourcePercentage, queueContainerLimitMemory); ok {
+		if ok, limitMemory = computeResourceRequirements(userContainer.Resources.Limits.Memory(), resourceFraction, queueContainerLimitMemory); ok {
 			resourceLimits[corev1.ResourceMemory] = limitMemory
 		}
 	}
@@ -107,12 +103,12 @@ func createQueueResources(annotations map[string]string, userContainer *corev1.C
 	return resources
 }
 
-func computeResourceRequirements(resourceQuantity *resource.Quantity, percentage float32, boundary resourceBoundary) (bool, resource.Quantity) {
+func computeResourceRequirements(resourceQuantity *resource.Quantity, fraction float64, boundary resourceBoundary) (bool, resource.Quantity) {
 	if resourceQuantity.IsZero() {
 		return false, resource.Quantity{}
 	}
 
-	// Incase the resourceQuantity MilliValue overflow in we use MaxInt64
+	// In case the resourceQuantity MilliValue overflows int64 we use MaxInt64
 	// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
 	scaledValue := resourceQuantity.Value()
 	scaledMilliValue := int64(math.MaxInt64 - 1)
@@ -121,26 +117,19 @@ func computeResourceRequirements(resourceQuantity *resource.Quantity, percentage
 	}
 
 	// float64(math.MaxInt64) > math.MaxInt64, to avoid overflow
-	percentageValue := float64(scaledMilliValue) * float64(percentage)
-	var newValue int64
-	if percentageValue >= math.MaxInt64 {
-		newValue = math.MaxInt64
-	} else {
+	percentageValue := float64(scaledMilliValue) * fraction
+	newValue := int64(math.MaxInt64)
+	if percentageValue < math.MaxInt64 {
 		newValue = int64(percentageValue)
 	}
 
-	newquantity := *resource.NewMilliQuantity(newValue, resource.BinarySI)
-	newquantity = boundary.applyBoundary(newquantity)
+	newquantity := boundary.applyBoundary(*resource.NewMilliQuantity(newValue, resource.BinarySI))
 	return true, newquantity
 }
 
-func fractionFromPercentage(m map[string]string, k string) (bool, float32) {
-	v, ok := m[k]
-	if !ok {
-		return false, 0
-	}
-	value, err := strconv.ParseFloat(v, 32)
-	return err == nil, float32(value / 100)
+func fractionFromPercentage(m map[string]string, k string) (float64, bool) {
+	value, err := strconv.ParseFloat(m[k], 64)
+	return float64(value / 100), err == nil
 }
 
 func makeQueueProbe(in *corev1.Probe) *corev1.Probe {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -440,8 +440,8 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 					corev1.ResourceName("cpu"): resource.MustParse("25m"),
 				},
 				Limits: corev1.ResourceList{
+					corev1.ResourceName("memory"): *resource.NewMilliQuantity(429496729600, resource.BinarySI),
 					corev1.ResourceName("cpu"):    *resource.NewMilliQuantity(400, resource.BinarySI),
-					corev1.ResourceName("memory"): *resource.NewQuantity(429496736, resource.BinarySI),
 				},
 			},
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
@@ -631,16 +631,16 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 				t.Errorf("makeQueueContainerWithPercentageAnnotation (-want, +got) = %v", diff)
 			}
 			if test.want.Resources.Limits.Memory().Cmp(*got.Resources.Limits.Memory()) != 0 {
-				t.Errorf("Expected Resources.Limits.Memory %v got %v ", test.want.Resources.Limits.Memory(), got.Resources.Limits.Memory())
+				t.Errorf("Resources.Limits.Memory = %v, want: %v", got.Resources.Limits.Memory(), test.want.Resources.Limits.Memory())
 			}
 			if test.want.Resources.Requests.Cpu().Cmp(*got.Resources.Requests.Cpu()) != 0 {
-				t.Errorf("Expected Resources.Request.Cpu %v got %v ", test.want.Resources.Requests.Cpu(), got.Resources.Requests.Cpu())
+				t.Errorf("Resources.Request.CPU = %v, want: %v", got.Resources.Requests.Cpu(), test.want.Resources.Requests.Cpu())
 			}
 			if test.want.Resources.Requests.Memory().Cmp(*got.Resources.Requests.Memory()) != 0 {
-				t.Errorf("Expected Resources.Requests.Memory %v got %v ", test.want.Resources.Requests.Memory(), got.Resources.Requests.Memory())
+				t.Errorf("Resources.Requests.Memory = %v, want: %v", got.Resources.Requests.Memory(), test.want.Resources.Requests.Memory())
 			}
 			if test.want.Resources.Limits.Cpu().Cmp(*got.Resources.Limits.Cpu()) != 0 {
-				t.Errorf("Expected Resources.Limits.Cpu %v got %v ", test.want.Resources.Limits.Cpu(), got.Resources.Limits.Cpu())
+				t.Errorf("Resources.Limits.CPU  = %v, want: %v", got.Resources.Limits.Cpu(), test.want.Resources.Limits.Cpu())
 			}
 		})
 	}


### PR DESCRIPTION
- pull computations out of the loop
- replace 200 with StatusOK
- rename function to a shorter and more correct name
- simplify `ParseFloat` handling. We do check return errors, so no need to do an `if`.

/assign @markusthoemmes  @dgerd 