### PR TITLE
Inject time into StableAndPanicConcurrency()

### DIFF
--- a/cmd/autoscaler/main_test.go
+++ b/cmd/autoscaler/main_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	time "time"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/autoscaler/main_test.go
+++ b/cmd/autoscaler/main_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	time "time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,6 +151,6 @@ func getTestUniScalerFactory() func(decider *autoscaler.Decider) (autoscaler.Uni
 
 type testMetricClient struct{}
 
-func (t *testMetricClient) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
+func (t *testMetricClient) StableAndPanicConcurrency(key types.NamespacedName, now time.Time) (float64, float64, error) {
 	return 1.0, 1.0, nil
 }

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -126,7 +126,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	readyPodsCount := math.Max(1, float64(originalReadyPodsCount))
 
 	metricKey := types.NamespacedName{Namespace: a.namespace, Name: a.revision}
-	observedStableConcurrency, observedPanicConcurrency, err := a.metricClient.StableAndPanicConcurrency(metricKey)
+	observedStableConcurrency, observedPanicConcurrency, err := a.metricClient.StableAndPanicConcurrency(metricKey, now)
 	if err != nil {
 		if err == ErrNoData {
 			logger.Debug("No data to scale on yet")

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -325,7 +325,7 @@ type testMetricClient struct {
 	err               error
 }
 
-func (t *testMetricClient) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
+func (t *testMetricClient) StableAndPanicConcurrency(key types.NamespacedName, now time.Time) (float64, float64, error) {
 	return t.stableConcurrency, t.panicConcurrency, t.err
 }
 

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -81,8 +81,9 @@ type StatMessage struct {
 
 // MetricClient surfaces the metrics that can be obtained via the collector.
 type MetricClient interface {
-	// StableAndPanicConcurrency returns both the stable and the panic concurrency.
-	StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error)
+	// StableAndPanicConcurrency returns both the stable and the panic concurrency
+	// for the given replica as of the given time.
+	StableAndPanicConcurrency(key types.NamespacedName, now time.Time) (float64, float64, error)
 }
 
 // MetricCollector manages collection of metrics for many entities.
@@ -190,7 +191,8 @@ func (c *MetricCollector) Record(key types.NamespacedName, stat Stat) {
 }
 
 // StableAndPanicConcurrency returns both the stable and the panic concurrency.
-func (c *MetricCollector) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
+// It may truncate metric buckets as a side-effect.
+func (c *MetricCollector) StableAndPanicConcurrency(key types.NamespacedName, now time.Time) (float64, float64, error) {
 	c.collectionsMutex.RLock()
 	defer c.collectionsMutex.RUnlock()
 
@@ -199,7 +201,7 @@ func (c *MetricCollector) StableAndPanicConcurrency(key types.NamespacedName) (f
 		return 0, 0, ErrNotScraping
 	}
 
-	return collection.stableAndPanicConcurrency(time.Now())
+	return collection.stableAndPanicConcurrency(now)
 }
 
 // collection represents the collection of metrics for one specific entity.

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -134,7 +134,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 	logger := TestLogger(t)
 	ctx := context.Background()
 
-	now := time.Unix(0, 0)
+	now := time.Now()
 	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	want := 10.0
 	stat := &StatMessage{
@@ -167,7 +167,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 
 	// injecting times inside the window should not change the calculation result
 	wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
-		got, _, _ = coll.StableAndPanicConcurrency(metricKey, now.Add(stableWindow).Add(-1*time.Second))
+		got, _, _ = coll.StableAndPanicConcurrency(metricKey, now.Add(stableWindow).Add(-5*time.Second))
 		return got == want, nil
 	})
 	if got != want {

--- a/pkg/autoscaler/metrics_provider.go
+++ b/pkg/autoscaler/metrics_provider.go
@@ -63,7 +63,8 @@ func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provide
 		return nil, errMetricNotSupported
 	}
 
-	concurrency, _, err := p.metricClient.StableAndPanicConcurrency(name)
+	now := time.Now()
+	concurrency, _, err := p.metricClient.StableAndPanicConcurrency(name, now)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +74,7 @@ func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provide
 		Metric: cmetrics.MetricIdentifier{
 			Name: info.Metric,
 		},
-		Timestamp: metav1.Time{Time: time.Now()},
+		Timestamp: metav1.Time{Time: now},
 		Value:     value,
 	}, nil
 }

--- a/pkg/autoscaler/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics_provider_test.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	"knative.dev/pkg/kmp"
@@ -110,7 +111,7 @@ func TestListAllMetrics(t *testing.T) {
 
 type staticConcurrency float64
 
-func (s staticConcurrency) StableAndPanicConcurrency(key types.NamespacedName) (float64, float64, error) {
+func (s staticConcurrency) StableAndPanicConcurrency(key types.NamespacedName, now time.Time) (float64, float64, error) {
 	if key.Namespace == existingNamespace {
 		return (float64)(s), 0.0, nil
 	}


### PR DESCRIPTION
This enables the use of fake times in tests or in downstream consumers of the API.

<!--
Request Prow to automatically lint any go code in this PR:
/lint
-->

**Release Note**

```release-note
NONE
```
