### PR TITLE
Introduce the metric controller.

### DIFF
--- a/pkg/reconciler/metric/controller.go
+++ b/pkg/reconciler/metric/controller.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+
+	"knative.dev/serving/pkg/autoscaler"
+	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
+	pkgreconciler "knative.dev/serving/pkg/reconciler"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+)
+
+const (
+	controllerAgentName = "metric-controller"
+)
+
+// NewController initializes the controller and is called by the generated code.
+// Registers eventhandlers to enqueue events.
+func NewController(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	collector autoscaler.Collector,
+) *controller.Impl {
+	metricInformer := metricinformer.Get(ctx)
+
+	c := &reconciler{
+		Base:         pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
+		collector:    collector,
+		metricLister: metricInformer.Lister(),
+	}
+	impl := controller.NewImpl(c, c.Logger, reconcilerName)
+
+	c.Logger.Info("Setting up event handlers")
+
+	// Watch all the Metric objects.
+	metricInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	return impl
+}

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"knative.dev/serving/pkg/autoscaler"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	listers "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
+	rbase "knative.dev/serving/pkg/reconciler"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+)
+
+const reconcilerName = "Metrics"
+
+// reconciler implements controller.Reconciler for Metric resources.
+type reconciler struct {
+	*rbase.Base
+	collector    autoscaler.Collector
+	metricLister listers.MetricLister
+}
+
+// Check that our Reconciler implements controller.Reconciler
+var _ controller.Reconciler = (*reconciler)(nil)
+
+// Reconcile compares the actual state with the desired, and attempts to
+// converge the two.
+func (r *reconciler) Reconcile(ctx context.Context, key string) error {
+	logger := logging.FromContext(ctx)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if namespace == "" || err != nil {
+		logger.Errorf("Invalid resource key: %s", key)
+		return nil
+	}
+
+	metric, err := r.metricLister.Metrics(namespace).Get(name)
+	if apierrs.IsNotFound(err) {
+		return r.collector.Delete(ctx, namespace, name)
+	} else if err != nil {
+		return errors.Wrapf(err, "failed to fetch metric %q", key)
+	}
+
+	if err := r.collector.CreateOrUpdate(metric); err != nil {
+		return errors.Wrapf(err, "failed to initiate or update scraping")
+	}
+	return nil
+}

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	logtesting "knative.dev/pkg/logging/testing"
+	. "knative.dev/pkg/reconciler/testing"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	rpkg "knative.dev/serving/pkg/reconciler"
+	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
+)
+
+func TestNewController(t *testing.T) {
+	defer logtesting.ClearAll()
+	ctx, _ := SetupFakeContext(t)
+	c := NewController(ctx, configmap.NewStaticWatcher(), &testCollector{})
+	if c == nil {
+		t.Fatal("Expected NewController to return a non-nil value")
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	table := TableTest{{
+		Name:                    "bad workqueue key, Part I",
+		Key:                     "too/many/parts",
+		SkipNamespaceValidation: true,
+	}, {
+		Name:                    "bad workqueue key, Part II",
+		Key:                     "too-few-parts",
+		SkipNamespaceValidation: true,
+	}}
+
+	defer logtesting.ClearAll()
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		return &reconciler{
+			Base:         rpkg.NewBase(ctx, controllerAgentName, cmw),
+			metricLister: listers.GetMetricLister(),
+		}
+	}))
+}
+
+func TestReconcileWithCollector(t *testing.T) {
+	updateError := errors.New("update error")
+	deleteError := errors.New("delete error")
+
+	tests := []struct {
+		name                string
+		key                 string
+		metric              *av1alpha1.Metric
+		collector           *testCollector
+		createOrUpdateCalls int
+		deleteCalls         int
+		expectErr           error
+	}{{
+		name:                "new",
+		key:                 "new/metric",
+		metric:              metric("new", "metric"),
+		collector:           &testCollector{},
+		createOrUpdateCalls: 1,
+	}, {
+		name:        "delete",
+		key:         "old/metric",
+		metric:      metric("new", "metric"),
+		collector:   &testCollector{},
+		deleteCalls: 1,
+	}, {
+		name:                "error on create",
+		key:                 "new/metric",
+		metric:              metric("new", "metric"),
+		collector:           &testCollector{createOrUpdateError: updateError},
+		createOrUpdateCalls: 1,
+		expectErr:           updateError,
+	}, {
+		name:        "error on delete",
+		key:         "old/metric",
+		metric:      metric("new", "metric"),
+		collector:   &testCollector{deleteError: deleteError},
+		deleteCalls: 1,
+		expectErr:   deleteError,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := SetupFakeContext(t)
+			metricInformer := metricinformer.Get(ctx)
+
+			r := &reconciler{
+				Base:         rpkg.NewBase(ctx, controllerAgentName, configmap.NewStaticWatcher()),
+				collector:    tt.collector,
+				metricLister: metricInformer.Lister(),
+			}
+
+			// Make sure the provided metric is available via the fake clients/informers.
+			r.ServingClientSet.AutoscalingV1alpha1().Metrics(tt.metric.Namespace).Create(tt.metric)
+			metricInformer.Informer().GetIndexer().Add(tt.metric)
+
+			if err := r.Reconcile(ctx, tt.key); errors.Cause(err) != tt.expectErr {
+				t.Errorf("Reconcile() = %v, wanted %v", errors.Cause(err), tt.expectErr)
+			}
+
+			if tt.createOrUpdateCalls != tt.collector.createOrUpdateCalls {
+				t.Errorf("CreateOrUpdate() called %d times, want %d times", tt.collector.createOrUpdateCalls, tt.createOrUpdateCalls)
+			}
+			if tt.deleteCalls != tt.collector.deleteCalls {
+				t.Errorf("Delete() called %d times, want %d times", tt.collector.deleteCalls, tt.deleteCalls)
+			}
+		})
+	}
+}
+
+func metric(namespace, name string) *av1alpha1.Metric {
+	return &av1alpha1.Metric{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+type testCollector struct {
+	createOrUpdateCalls int
+	createOrUpdateError error
+
+	deleteCalls int
+	deleteError error
+}
+
+func (c *testCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
+	c.createOrUpdateCalls++
+	return c.createOrUpdateError
+}
+
+func (c *testCollector) Delete(ctx context.Context, namespace, name string) error {
+	c.deleteCalls++
+	return c.deleteError
+}

--- a/pkg/reconciler/testing/v1alpha1/listers.go
+++ b/pkg/reconciler/testing/v1alpha1/listers.go
@@ -133,6 +133,11 @@ func (l *Listers) GetPodAutoscalerLister() palisters.PodAutoscalerLister {
 	return palisters.NewPodAutoscalerLister(l.IndexerFor(&av1alpha1.PodAutoscaler{}))
 }
 
+// GetMetricLister returns a lister for the Metric objects.
+func (l *Listers) GetMetricLister() palisters.MetricLister {
+	return palisters.NewMetricLister(l.IndexerFor(&av1alpha1.Metric{}))
+}
+
 // GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.
 func (l *Listers) GetHorizontalPodAutoscalerLister() autoscalingv2beta1listers.HorizontalPodAutoscalerLister {
 	return autoscalingv2beta1listers.NewHorizontalPodAutoscalerLister(l.IndexerFor(&autoscalingv2beta1.HorizontalPodAutoscaler{}))


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Ref #4403

## Proposed Changes

The metric controller reacts on the lifecycle of metric objects and currently makes sure that metric collecting is started when a metric is created and stopped if one is deleted. As updating is not really a distinct use-case we want to handle differently, this also introduces a 'CreateOrUpdate' function to the collector, which appropriately acts if the collection was already running or not.

This is a stepping stone towards removing the in-memory handling of metric entities. The controller is not yet hooked up though.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
