### PR TITLE
Add a proxy for method

### DIFF
--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -91,4 +93,14 @@ func (sss *ServerlessServiceStatus) IsReady() bool {
 
 func (sss *ServerlessServiceStatus) duck() *duckv1beta1.Status {
 	return &sss.Status
+}
+
+// ProxyFor returns how long it has been since Activator was moved
+// to the request path.
+func (sss *ServerlessServiceStatus) ProxyFor() time.Duration {
+	cond := sss.GetCondition(ActivatorEndpointsPopulated)
+	if cond == nil || cond.Status != corev1.ConditionTrue {
+		return 0
+	}
+	return time.Since(cond.LastTransitionTime.Inner.Time)
 }

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -17,6 +17,7 @@ package v1alpha1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
@@ -90,7 +91,17 @@ func TestSSTypicalFlow(t *testing.T) {
 	r.MarkActivatorEndpointsPopulated()
 	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
 	apitest.CheckConditionSucceeded(r.duck(), ActivatorEndpointsPopulated, t)
+
+	time.Sleep(time.Millisecond * 1)
+	if got, want := r.ProxyFor(), time.Duration(0); got == want {
+		t.Error("ProxyFor returned duration of 0")
+	}
+
 	r.MarkActivatorEndpointsRemoved()
 	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
 	apitest.CheckConditionFailed(r.duck(), ActivatorEndpointsPopulated, t)
+
+	if got, want := r.ProxyFor(), time.Duration(0); got != want {
+		t.Errorf("ProxyFor = %v, want: %v", got, want)
+	}
 }


### PR DESCRIPTION
This method returns the duration of how long has Activator been in the request
path, i.e. how long the requests have been proxied.

For #4453

/assign @jonjohnsonjr 