### PR TITLE
Remove duplicated log collection

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -333,12 +333,4 @@ function dump_extra_cluster_state() {
   kubectl get configurations -o yaml --all-namespaces
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
-
-  echo ">>> Knative logs:"
-  for app in controller webhook autoscaler activator networking-certmanager networking-istio; do
-    dump_app_logs ${app} knative-serving
-  done
-
-  echo ">>> Istio logs:"
-  dump_app_logs istio-ingressgateway istio-system
 }


### PR DESCRIPTION
This is no longer needed as we capture ALL logs since #4906.
This results in duplicated logs.