### PR TITLE
Update the benchmark to probe in two dimensions.

### DIFF
--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -18,10 +18,12 @@ package activator
 
 import (
 	"context"
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"go.uber.org/zap"
@@ -56,9 +58,7 @@ const (
 	initCapacity          = 0
 )
 
-var (
-	revID = RevisionID{testNamespace, testRevision}
-)
+var revID = RevisionID{testNamespace, testRevision}
 
 func TestThrottlerUpdateCapacity(t *testing.T) {
 	samples := []struct {
@@ -565,27 +565,61 @@ func TestInfiniteBreaker(t *testing.T) {
 	}
 }
 
+func revisionListerN(namespace, name string, count int) servinglisters.RevisionLister {
+	revs := make([]runtime.Object, count)
+	for i := 0; i < count; i++ {
+		revs[i] = &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + strconv.Itoa(i),
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1beta1.RevisionSpec{
+					ContainerConcurrency: 0,
+				},
+			},
+		}
+	}
+	fake := servingfake.NewSimpleClientset(revs...)
+	informer := servinginformers.NewSharedInformerFactory(fake, 0)
+	revisions := informer.Serving().V1alpha1().Revisions()
+	for i := 0; i < count; i++ {
+		revisions.Informer().GetIndexer().Add(revs[i])
+	}
+	return revisions.Lister()
+}
+
 func BenchmarkThrottler(b *testing.B) {
+	const numRevs = 10000
 	throttler := getThrottler(
 		defaultMaxConcurrency,
-		revisionLister(testNamespace, testRevision, 0),
+		revisionListerN(testNamespace, testRevision, numRevs),
 		endpointsInformer(testNamespace, testRevision, 0),
 		sksLister(testNamespace, testRevision),
 		nil,
 		initCapacity)
 
-	throttler.UpdateCapacity(revID, 1)
+	rIDs := make([]RevisionID, numRevs)
+	for i := 0; i < numRevs; i++ {
+		rID := RevisionID{testNamespace, testRevision + strconv.Itoa(i)}
+		rIDs[i] = rID
+		throttler.UpdateCapacity(rID, 1)
+	}
 
+	rand.Seed(time.Now().Unix())
 	for _, parallelism := range []int{1, 10, 100, 1000, 10000} {
-		b.Run(strconv.Itoa(parallelism), func(b *testing.B) {
-			b.SetParallelism(parallelism)
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					if err := throttler.Try(context.Background(), revID, func() {}); err != nil {
-						b.Errorf("Try() unexpectedly returned an error: %v", err)
+		for _, numRevs := range []int{1, 10, 100, 1000, 10000} {
+			b.Run(strconv.Itoa(parallelism)+"-"+strconv.Itoa(numRevs), func(b *testing.B) {
+				b.SetParallelism(parallelism)
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						revID := rIDs[rand.Intn(numRevs)]
+						if err := throttler.Try(context.Background(), revID, func() {}); err != nil {
+							b.Errorf("Try() unexpectedly returned an error: %v", err)
+						}
 					}
-				}
+				})
 			})
-		})
+		}
 	}
 }


### PR DESCRIPTION
Change the throttler benchmark to scale in both number of threads (read parallel requests)
as well as number of objects they try to acquire.

Results are pretty good, though rather than staying constant they grow with number of revisions in question,
so perhaps sharded map can improve the performance.

Somehow at 1000 goroutines we get worst results, but that might be because at 10000k goroutines
scheduling starts to play a role, so they interfere less...

```
BenchmarkThrottlerMultiple/1-1-8                 5000000               251 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1-10-8                5000000               254 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1-100-8               5000000               256 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1-1000-8              5000000               281 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1-10000-8             5000000               348 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10-1-8                5000000               340 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10-10-8               5000000               332 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10-100-8              5000000               338 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10-1000-8             5000000               358 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10-10000-8            3000000               409 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/100-1-8               5000000               266 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/100-10-8              5000000               278 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/100-100-8             5000000               284 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/100-1000-8            5000000               309 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/100-10000-8           3000000               405 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1000-1-8             10000000               936 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1000-10-8             5000000               914 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1000-100-8            3000000               971 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1000-1000-8          10000000              1247 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/1000-10000-8          2000000              1315 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10000-1-8             3000000               469 ns/op               5 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10000-10-8            3000000               426 ns/op               5 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10000-100-8           5000000               459 ns/op               0 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10000-1000-8          2000000               685 ns/op               2 B/op          0 allocs/op
BenchmarkThrottlerMultiple/10000-10000-8         2000000               730 ns/op               2 B/op          0 allocs/op
```

/assign @yanweiguo @markusthoemmes 
