### PR TITLE
Add conformance test for valid service account name

### DIFF
--- a/pkg/testing/v1beta1/service.go
+++ b/pkg/testing/v1beta1/service.go
@@ -140,6 +140,13 @@ func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 	}
 }
 
+// WithServiceAccountName sets revision service account name
+func WithServiceAccountName(sericeAccountName string) ServiceOption {
+	return func(service *v1beta1.Service) {
+		service.Spec.Template.Spec.ServiceAccountName = sericeAccountName
+	}
+}
+
 // WithContainerConcurrency sets the given Service's concurrency.
 func WithContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) ServiceOption {
 	return func(svc *v1beta1.Service) {

--- a/pkg/testing/v1beta1/service.go
+++ b/pkg/testing/v1beta1/service.go
@@ -141,9 +141,9 @@ func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 }
 
 // WithServiceAccountName sets revision service account name
-func WithServiceAccountName(sericeAccountName string) ServiceOption {
+func WithServiceAccountName(serviceAccountName string) ServiceOption {
 	return func(service *v1beta1.Service) {
-		service.Spec.Template.Spec.ServiceAccountName = sericeAccountName
+		service.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 	}
 }
 

--- a/test/conformance/api/v1beta1/service_account_test.go
+++ b/test/conformance/api/v1beta1/service_account_test.go
@@ -1,0 +1,58 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+
+	. "knative.dev/serving/pkg/testing/v1beta1"
+	"knative.dev/serving/test"
+	v1b1test "knative.dev/serving/test/v1beta1"
+)
+
+const (
+	invalidServiceAccountName = "foo@bar.baz"
+)
+
+func TestServiceAccountValidation(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.PizzaPlanet1,
+	}
+
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+
+	t.Logf("Creating a new Service %s", names.Service)
+	service := v1b1test.Service(names, WithServiceAccountName(invalidServiceAccountName))
+	v1b1test.LogResourceObject(t, v1b1test.ResourceObjects{Service: service})
+
+	_, err := clients.ServingBetaClient.Services.Create(service)
+	if err == nil {
+		t.Fatal("Expected Service creation to fail")
+	}
+
+	if !strings.Contains(err.Error(), "serviceAccountName: spec.template.spec."+invalidServiceAccountName) {
+		t.Fatalf("Expected service creation failure to contain fieldpath: %s", err.Error())
+	}
+}

--- a/test/conformance/api/v1beta1/service_account_test.go
+++ b/test/conformance/api/v1beta1/service_account_test.go
@@ -51,8 +51,7 @@ func TestServiceAccountValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected Service creation to fail")
 	}
-
-	if !strings.Contains(err.Error(), "serviceAccountName: spec.template.spec."+invalidServiceAccountName) {
-		t.Fatalf("Expected service creation failure to contain fieldpath: %s", err.Error())
+	if got, want := err.Error(), "serviceAccountName: spec.template.spec."+invalidServiceAccountName; !strings.Contains(got, want) {
+		t.Errorf("Error = %q, want to contain = %q", got, want)
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4647 

## Proposed Changes

* Add conformance test as this is API spec related change
* For context https://github.com/knative/serving/issues/4647#issuecomment-513394252 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

cc @steren 

**Question** : I am validating the error msg to check if it failed for correct reason. I could not find any pattern for similar sort of assertion in other e2e tests so if anybody has objections to what I have done/ have better way to assert the error, please leave a comment. I appreciate it.
