### PR TITLE
Reduce waiting time before scale to 0.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/serving/pkg/activator"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
+	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/network/prober"
@@ -141,7 +142,7 @@ func applyBounds(min, max, x int32) int32 {
 	return x
 }
 
-func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale int32, config *autoscaler.Config) (int32, bool) {
+func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, sks *nv1a1.ServerlessService, desiredScale int32, config *autoscaler.Config) (int32, bool) {
 	if desiredScale != 0 {
 		return desiredScale, true
 	}
@@ -181,13 +182,31 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, desiredScale i
 		r, err := ks.activatorProbe(pa, ks.transport)
 		ks.logger.Infof("%s probing activator = %v, err = %v", pa.Name, r, err)
 		if r {
-			// Make sure we've been inactive for enough time.
+			// This enforces that the revision has been backed by the activator for at least
+			// ScaleToZeroGracePeriod time.
+			// Note: SKS will always be present when scaling to zero, so nil checks are just
+			// defensive programming.
+
+			// Most conservative check, if it passes we're good.
 			if pa.Status.CanScaleToZero(config.ScaleToZeroGracePeriod) {
 				return desiredScale, true
 			}
-			// Re-enqeue the PA for reconciliation after grace period.
-			// In istio-lean this can be close to 0.
-			ks.enqueueCB(pa, config.ScaleToZeroGracePeriod)
+
+			// Otherwise check how long SKS was in proxy mode.
+			to := config.ScaleToZeroGracePeriod
+			if sks != nil {
+				// Compute the difference between time we've been proxying with the timeout.
+				// If it's positive, that's the time we need to sleep, if negative -- we
+				// can scale to zero.
+				to -= sks.Status.ProxyFor()
+				if to <= 0 {
+					return desiredScale, true
+				}
+			}
+
+			// Re-enqeue the PA for reconciliation with timeout of `to` to make sure we wait
+			// long enough.
+			ks.enqueueCB(pa, to)
 			return desiredScale, false
 		}
 
@@ -234,7 +253,7 @@ func (ks *scaler) applyScale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, 
 }
 
 // Scale attempts to scale the given PA's target reference to the desired scale.
-func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desiredScale int32) (int32, error) {
+func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, sks *nv1a1.ServerlessService, desiredScale int32) (int32, error) {
 	logger := logging.FromContext(ctx)
 
 	if desiredScale < 0 && !pa.Status.IsActivating() {
@@ -248,7 +267,7 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, desir
 		desiredScale = newScale
 	}
 
-	desiredScale, shouldApplyScale := ks.handleScaleToZero(pa, desiredScale, config.FromContext(ctx).Autoscaler)
+	desiredScale, shouldApplyScale := ks.handleScaleToZero(pa, sks, desiredScale, config.FromContext(ctx).Autoscaler)
 	if !shouldApplyScale {
 		return desiredScale, nil
 	}

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -200,6 +200,7 @@ func (ks *scaler) handleScaleToZero(pa *pav1alpha1.PodAutoscaler, sks *nv1a1.Ser
 				// can scale to zero.
 				to -= sks.Status.ProxyFor()
 				if to <= 0 {
+					ks.logger.Infof("Fast path scaling to 0, in proxy mode for: %v", sks.Status.ProxyFor())
 					return desiredScale, true
 				}
 			}

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -38,6 +38,7 @@ import (
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
@@ -75,6 +76,7 @@ func TestScaler(t *testing.T) {
 		maxScale            int32
 		wantReplicas        int32
 		wantScaling         bool
+		sks                 SKSOption
 		paMutation          func(*pav1alpha1.PodAutoscaler)
 		proberfunc          func(*pav1alpha1.PodAutoscaler, http.RoundTripper) (bool, error)
 		wantCBCount         int
@@ -159,6 +161,31 @@ func TestScaler(t *testing.T) {
 			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
 		},
 		wantCBCount: 1,
+	}, {
+		label:         "waits to scale to zero (just before grace period, sks short)",
+		startReplicas: 1,
+		scaleTo:       0,
+		wantReplicas:  0,
+		wantScaling:   false,
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(time.Second))
+		},
+		sks: func(s *nv1a1.ServerlessService) {
+			markSKSInProxyFor(s, gracePeriod-time.Second)
+		},
+		wantCBCount: 1,
+	}, {
+		label:         "waits to scale to zero (just before grace period, sks in proxy long)",
+		startReplicas: 1,
+		scaleTo:       0,
+		wantReplicas:  0,
+		wantScaling:   true,
+		paMutation: func(k *pav1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
+		},
+		sks: func(s *nv1a1.ServerlessService) {
+			markSKSInProxyFor(s, gracePeriod)
+		},
 	}, {
 		label:         "scale to zero after grace period, but fail prober",
 		startReplicas: 1,
@@ -314,8 +341,13 @@ func TestScaler(t *testing.T) {
 				test.paMutation(pa)
 			}
 
+			sks := sks("ns", "name")
+			if test.sks != nil {
+				test.sks(sks)
+			}
+
 			ctx = config.ToContext(ctx, defaultConfig())
-			desiredScale, err := revisionScaler.Scale(ctx, pa, test.scaleTo)
+			desiredScale, err := revisionScaler.Scale(ctx, pa, sks, test.scaleTo)
 			if err != nil {
 				t.Error("Scale got an unexpected error: ", err)
 			}
@@ -401,7 +433,7 @@ func TestDisableScaleToZero(t *testing.T) {
 			conf := defaultConfig()
 			conf.Autoscaler.EnableScaleToZero = false
 			ctx = config.ToContext(ctx, conf)
-			desiredScale, err := revisionScaler.Scale(ctx, pa, test.scaleTo)
+			desiredScale, err := revisionScaler.Scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
 
 			if err != nil {
 				t.Error("Scale got an unexpected error: ", err)
@@ -609,4 +641,10 @@ type countingProber struct {
 func (c *countingProber) Offer(ctx context.Context, target string, arg interface{}, period, timeout time.Duration, ops ...interface{}) bool {
 	c.count++
 	return true
+}
+
+func markSKSInProxyFor(sks *nv1a1.ServerlessService, d time.Duration) {
+	sks.Status.MarkActivatorEndpointsPopulated()
+	// This works because the conditions are sorted alphabetically
+	sks.Status.Conditions[0].LastTransitionTime = apis.VolatileTime{Inner: metav1.NewTime(time.Now().Add(-d))}
 }

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -158,7 +158,7 @@ func TestScaler(t *testing.T) {
 		wantReplicas:  0,
 		wantScaling:   false,
 		paMutation: func(k *pav1alpha1.PodAutoscaler) {
-			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
+			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(time.Second))
 		},
 		wantCBCount: 1,
 	}, {
@@ -181,7 +181,7 @@ func TestScaler(t *testing.T) {
 		wantReplicas:  0,
 		wantScaling:   true,
 		paMutation: func(k *pav1alpha1.PodAutoscaler) {
-			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(1*time.Second))
+			paMarkInactive(k, time.Now().Add(-gracePeriod).Add(time.Second))
 		},
 		sks: func(s *nv1a1.ServerlessService) {
 			markSKSInProxyFor(s, gracePeriod)


### PR DESCRIPTION
With this change the Scaler will take into account the time SKS has been in proxy mode.
If the time in proxy mode was at least as large as grace period, then we scale down
immediately, otherwise we try to reconcile again after remaining period elapses.

In theory with tbc=-1 we can scale down right after 0 requests were received
during the stable window.

For the final fix, I am going to add an integration tests that verifies the scale to 0 performance.

The nasty part is that we need to query SKS, but oh well, the lengths we'd go for performance.

/assign @jonjohnsonjr 

For #4453.