### PR TITLE
Run the metrics controller and make metric creations via API. 

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/serving/pkg/autoscaler/statserver"
 	"knative.dev/serving/pkg/reconciler/autoscaling/hpa"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa"
+	"knative.dev/serving/pkg/reconciler/metric"
 	"knative.dev/serving/pkg/resources"
 
 	basecmd "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd"
@@ -121,8 +122,9 @@ func main() {
 
 	psInformerFactory := resources.NewPodScalableInformerFactory(ctx)
 	controllers := []*controller.Impl{
-		kpa.NewController(ctx, cmw, multiScaler, collector, psInformerFactory),
-		hpa.NewController(ctx, cmw, collector, psInformerFactory),
+		kpa.NewController(ctx, cmw, multiScaler, psInformerFactory),
+		hpa.NewController(ctx, cmw, psInformerFactory),
+		metric.NewController(ctx, cmw, collector),
 	}
 
 	// Set up a statserver.

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -62,9 +62,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := c.PALister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		logger.Debug("PA no longer exists")
-		if err := c.Metrics.Delete(ctx, namespace, name); err != nil {
-			return err
-		}
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -75,9 +75,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		if err := c.deciders.Delete(ctx, namespace, name); err != nil {
 			return err
 		}
-		if err := c.Metrics.Delete(ctx, namespace, name); err != nil {
-			return err
-		}
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/autoscaling/resources/metric.go
+++ b/pkg/reconciler/autoscaling/resources/metric.go
@@ -27,21 +27,6 @@ import (
 	"knative.dev/serving/pkg/resources"
 )
 
-// Metrics is an interface for notifying the presence or absence of metric collection.
-type Metrics interface {
-	// Get accesses the Metric resource for this key, returning any errors.
-	Get(ctx context.Context, namespace, name string) (*v1alpha1.Metric, error)
-
-	// Create adds a Metric resource for a given key, returning any errors.
-	Create(ctx context.Context, metric *v1alpha1.Metric) (*v1alpha1.Metric, error)
-
-	// Delete removes the Metric resource for a given key, returning any errors.
-	Delete(ctx context.Context, namespace, name string) error
-
-	// Update update the Metric resource, return the new Metric or any errors.
-	Update(ctx context.Context, metric *v1alpha1.Metric) (*v1alpha1.Metric, error)
-}
-
 // StableWindow returns the stable window for the revision from PA, if set, or
 // systemwide default.
 func StableWindow(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) time.Duration {

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -55,7 +55,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 
 	metric, err := r.metricLister.Metrics(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
-		return r.collector.Delete(ctx, namespace, name)
+		return r.collector.Delete(namespace, name)
 	} else if err != nil {
 		return errors.Wrapf(err, "failed to fetch metric %q", key)
 	}

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -154,7 +154,7 @@ func (c *testCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
 	return c.createOrUpdateError
 }
 
-func (c *testCollector) Delete(ctx context.Context, namespace, name string) error {
+func (c *testCollector) Delete(namespace, name string) error {
 	c.deleteCalls++
 	return c.deleteError
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4403 
Depends on #4923 

## Proposed Changes

This is the last step to realize the Metric API.

1. The metrics controller runs as part of the autoscaler.
2. All in-memory metric creations are replaced with actual API calls.
3. The collector API is stripped to only the needed functionality.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
/hold

Holding until #4923 merges.
