### PR TITLE
Update the PodAutoscaler status when desiredScale is unknown

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -236,7 +236,19 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, got int) error {
 	return nil
 }
 
-// computeActiveCondition updates the status of PA, depending on scales desired and present.
+// computeActiveCondition updates the status of a PA given the current scale (got), desired scale (want)
+// and the current status, as per the following table:
+//
+//    | Want | Got    | Status     | New status |
+//    | 0    | <any>  | <any>      | inactive   |
+//    | >0   | < min  | <any>      | activating |
+//    | >0   | >= min | <any>      | active     |
+//    | -1   | < min  | inactive   | inactive   |
+//    | -1   | < min  | activating | activating |
+//    | -1   | < min  | active     | activating |
+//    | -1   | >= min | inactive   | inactive   |
+//    | -1   | >= min | activating | active     |
+//    | -1   | >= min | active     | active     |
 func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
 	minReady := activeThreshold(pa)
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -250,11 +250,16 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
 		}
 
 	case got < minReady:
-		pa.Status.MarkActivating(
-			"Queued", "Requests to the target are being buffered as resources are provisioned.")
+		if want > 0 || !pa.Status.IsInactive() {
+			pa.Status.MarkActivating(
+				"Queued", "Requests to the target are being buffered as resources are provisioned.")
+		}
 
 	case got >= minReady:
-		pa.Status.MarkActive()
+		if want > 0 || !pa.Status.IsInactive() {
+			// SKS should already be active.
+			pa.Status.MarkActive()
+		}
 	}
 }
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -249,15 +249,12 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
 			pa.Status.MarkInactive("NoTraffic", "The target is not receiving traffic.")
 		}
 
-	case got < minReady && want > 0:
+	case got < minReady:
 		pa.Status.MarkActivating(
 			"Queued", "Requests to the target are being buffered as resources are provisioned.")
 
 	case got >= minReady:
 		pa.Status.MarkActive()
-
-	case want == scaleUnknown:
-		// We don't know what scale we want, so don't touch PA at all.
 	}
 }
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -297,14 +297,13 @@ func TestReconcileScaleUnknown(t *testing.T) {
 		fakeDeciders.Create(ctx, decider)
 
 		psFactory := presources.NewPodScalableInformerFactory(ctx)
-		fakeMetrics := newTestMetrics()
 		return &Reconciler{
 			Base: &areconciler.Base{
 				Base:              reconciler.NewBase(ctx, controllerAgentName, newConfigWatcher()),
 				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
-				Metrics:           fakeMetrics,
+				MetricLister:      listers.GetMetricLister(),
 				ConfigStore:       &testConfigStore{config: defaultConfig()},
 				PSInformerFactory: psFactory,
 			},


### PR DESCRIPTION
Currently, the PA status is left alone when the `desiredScale` is unknown and the current scale is less than the minimum (default = 1, can be changed with `minScale` annotation).

This is inaccurate in light of #4183, which introduces the possibility of the `minScale` changing during the lifetime of the PA. Tangentally, this inaccuracy is the source of some flakes in the `MinScale` test in #4884.

This change makes the following changes to how we handle the PA status _when `desiredScale` is unknown_:
* If the current scale is lower than the minimum, *and* the PA is not already inactive, mark the PA as 'activating'
* If the current scale is equal or greater than the minimum, *and* the PA is not already inactive, mark the PA as 'active'