### PR TITLE
Add Record() to Collector interface

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -84,6 +84,8 @@ type Collector interface {
 	// CreateOrUpdate either creates a collection for the given metric or update it, should
 	// it already exist.
 	CreateOrUpdate(*av1alpha1.Metric) error
+	// Record allows stats to be captured that came from outside the Collector.
+	Record(key types.NamespacedName, stat Stat)
 	// Delete deletes a Metric and halts collection.
 	Delete(context.Context, string, string) error
 }

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -18,6 +18,8 @@ package metric
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/serving/pkg/autoscaler"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -145,6 +147,8 @@ type testCollector struct {
 	createOrUpdateCalls int
 	createOrUpdateError error
 
+	recordCalls int
+
 	deleteCalls int
 	deleteError error
 }
@@ -152,6 +156,10 @@ type testCollector struct {
 func (c *testCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
 	c.createOrUpdateCalls++
 	return c.createOrUpdateError
+}
+
+func (c *testCollector) Record(key types.NamespacedName, stat autoscaler.Stat) {
+	c.recordCalls++
 }
 
 func (c *testCollector) Delete(ctx context.Context, namespace, name string) error {


### PR DESCRIPTION
Previously, this method was attached to the MetricCollector struct, making it impossible to mock/fake or consume downstream.

/lint

**Release Note**

```release-note
NONE
```
