### PR TITLE
Remove the inactive reviewers and old aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -56,15 +56,8 @@ aliases:
   - tcnghia
   - vagababov
   networking-reviewers:
-  - lichuqiang
   - markusthoemmes
   - mdemirhan
   - tcnghia
   - vagababov
 
-  build-approvers:
-  - imjasonh
-  - mattmoor
-  build-reviewers:
-  - imjasonh
-  - mattmoor

--- a/third_party/OWNERS
+++ b/third_party/OWNERS
@@ -5,8 +5,6 @@ approvers:
 - networking-approvers
 # Monitoring Configs
 - monitoring-approvers
-# knative/build
-- build-approvers
 
 
 reviewers:
@@ -14,5 +12,3 @@ reviewers:
 - networking-reviewers
 # Monitoring Configs
 - monitoring-reviewers
-# knative/build
-- build-reviewers


### PR DESCRIPTION
Removed lichuqiang as a reviewer, who has not reviewed or committed a PR since November.
Removed build approvers group, since there's no longer coupling between the two and there is only networking in the third-party dir now.


/assign @vaikas-google @evankanderson 