### PR TITLE
Report Activator request concurrency to metrics backend

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-scaling.yaml
@@ -21,1044 +21,1041 @@ metadata:
     serving.knative.dev/release: devel
 data:
   scaling-dashboard.json: |+
-      {  
-         "__inputs":[  
-            {  
-               "name":"prometheus",
-               "label":"prometheus",
-               "description":"",
-               "type":"datasource",
-               "pluginId":"prometheus",
-               "pluginName":"Prometheus"
+      {
+         "__inputs": [
+            {
+               "name": "prometheus",
+               "label": "prometheus",
+               "description": "",
+               "type": "datasource",
+               "pluginId": "prometheus",
+               "pluginName": "Prometheus"
             }
          ],
-         "__requires":[  
-            {  
-               "type":"grafana",
-               "id":"grafana",
-               "name":"Grafana",
-               "version":"5.0.3"
+         "__requires": [
+            {
+               "type": "grafana",
+               "id": "grafana",
+               "name": "Grafana",
+               "version": "5.0.3"
             },
-            {  
-               "id":"graph",
-               "name":"Graph",
-               "type":"panel",
-               "version":"5.0.0"
+            {
+               "type": "panel",
+               "id": "graph",
+               "name": "Graph",
+               "version": "5.0.0"
             },
-            {  
-               "type":"datasource",
-               "id":"prometheus",
-               "name":"Prometheus",
-               "version":"5.0.0"
+            {
+               "type": "datasource",
+               "id": "prometheus",
+               "name": "Prometheus",
+               "version": "5.0.0"
             }
          ],
-         "annotations":{  
-            "list":[  
-               {  
-                  "builtIn":1,
-                  "datasource":"-- Grafana --",
-                  "enable":true,
-                  "hide":true,
-                  "iconColor":"rgba(0, 211, 255, 1)",
-                  "name":"Annotations & Alerts",
-                  "type":"dashboard"
+         "annotations": {
+            "list": [
+               {
+               "builtIn": 1,
+               "datasource": "-- Grafana --",
+               "enable": true,
+               "hide": true,
+               "iconColor": "rgba(0, 211, 255, 1)",
+               "name": "Annotations & Alerts",
+               "type": "dashboard"
                }
             ]
          },
-         "description":"Knative Serving - Scaling Debugging",
-         "editable":false,
-         "gnetId":null,
-         "graphTooltip":0,
-         "id":null,
-         "iteration":1527886043818,
-         "links":[  
-
-         ],
-         "panels":[  
-            {  
-
-               "collapsed":true,
-               "gridPos":{  
-                  "h":1,
-                  "w":24,
-                  "x":0,
-                  "y":0
+         "description": "Knative Serving - Scaling Debugging",
+         "editable": true,
+         "gnetId": null,
+         "graphTooltip": 0,
+         "id": null,
+         "iteration": 1564079739384,
+         "links": [],
+         "panels": [
+            {
+               "collapsed": true,
+               "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 0
                },
-               "id":14,
-               "panels":[  
-                  {  
-                     "aliasColors":{  
-
-                     },
-                     "bars":false,
-                     "dashLength":10,
-                     "dashes":false,
-                     "datasource":"prometheus",
-                     "fill":1,
-                     "gridPos":{  
-                        "h":11,
-                        "w":24,
-                        "x":0,
-                        "y":1
-                     },
-                     "id":2,
-                     "legend":{  
-                        "avg":false,
-                        "current":false,
-                        "max":false,
-                        "min":false,
-                        "show":true,
-                        "total":false,
-                        "values":false
-                     },
-                     "lines":true,
-                     "linewidth":1,
-                     "links":[  
-
-                     ],
-                     "nullPointMode":"null",
-                     "percentage":false,
-                     "pointradius":5,
-                     "points":false,
-                     "renderer":"flot",
-                     "seriesOverrides":[  
-
-                     ],
-                     "spaceLength":10,
-                     "stack":false,
-                     "steppedLine":true,
-                     "targets":[  
-                        {  
-                           "expr":"sum(autoscaler_actual_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "interval":"1s",
-                           "intervalFactor":1,
-                           "legendFormat":"Actual Pods",
-                           "refId":"A"
-                        },
-                        {  
-                           "expr":"sum(autoscaler_requested_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "interval":"1s",
-                           "intervalFactor":1,
-                           "legendFormat":"Requested Pods",
-                           "refId":"C"
-                        }
-                     ],
-                     "thresholds":[  
-
-                     ],
-                     "timeFrom":null,
-                     "timeShift":null,
-                     "title":"Revision Pod Counts",
-                     "tooltip":{  
-                        "shared":true,
-                        "sort":0,
-                        "value_type":"individual"
-                     },
-                     "type":"graph",
-                     "xaxis":{  
-                        "buckets":null,
-                        "mode":"time",
-                        "name":null,
-                        "show":true,
-                        "values":[  
-
-                        ]
-                     },
-                     "yaxes":[  
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":true
-                        },
-                        {  
-                           "decimals":null,
-                           "format":"short",
-                           "label":"Concurrency",
-                           "logBase":1,
-                           "max":"1",
-                           "min":null,
-                           "show":false
-                        }
-                     ]
-                  }
-               ],
-               "title":"Revision Pod Counts",
-               "type":"row"
-            },
-            {  
-               "collapsed":true,
-               "gridPos":{  
-                  "h":1,
-                  "w":24,
-                  "x":0,
-                  "y":1
-               },
-               "id":18,
-               "panels":[  
-                  {  
-                     "aliasColors":{  
-
-                     },
-                     "bars":false,
-                     "dashLength":10,
-                     "dashes":false,
-                     "datasource":"prometheus",
-                     "fill":1,
-                     "gridPos":{  
-                        "h":9,
-                        "w":12,
-                        "x":0,
-                        "y":13
-                     },
-                     "id":4,
-                     "legend":{  
-                        "avg":false,
-                        "current":false,
-                        "max":false,
-                        "min":false,
-                        "show":true,
-                        "total":false,
-                        "values":false
-                     },
-                     "lines":true,
-                     "linewidth":1,
-                     "links":[  
-
-                     ],
-                     "nullPointMode":"null",
-                     "percentage":false,
-                     "pointradius":5,
-                     "points":false,
-                     "renderer":"flot",
-                     "seriesOverrides":[  
-
-                     ],
-                     "spaceLength":10,
-                     "stack":false,
-                     "steppedLine":false,
-                     "targets":[  
-                        {  
-                           "expr":"sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-                           "format":"time_series",
-                           "interval":"",
-                           "intervalFactor":1,
-                           "legendFormat":"Cores requested",
-                           "refId":"A"
-                        },
-                        {  
-                           "expr":"sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"}[1m]))",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Cores used",
-                           "refId":"B"
-                        },
-                        {  
-                           "expr":"sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Core limit",
-                           "refId":"C"
-                        }
-                     ],
-                     "thresholds":[  
-
-                     ],
-                     "timeFrom":null,
-                     "timeShift":null,
-                     "title":"Revision CPU Usage",
-                     "tooltip":{  
-                        "shared":true,
-                        "sort":2,
-                        "value_type":"individual"
-                     },
-                     "type":"graph",
-                     "xaxis":{  
-                        "buckets":null,
-                        "mode":"time",
-                        "name":null,
-                        "show":true,
-                        "values":[  
-
-                        ]
-                     },
-                     "yaxes":[  
-                        {  
-                           "decimals":null,
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":true
-                        },
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":false
-                        }
-                     ]
+               "id": 14,
+               "panels": [
+               {
+                  "aliasColors": {},
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "prometheus",
+                  "fill": 1,
+                  "gridPos": {
+                     "h": 11,
+                     "w": 24,
+                     "x": 0,
+                     "y": 1
                   },
-                  {  
-                     "aliasColors":{  
-
-                     },
-                     "bars":false,
-                     "dashLength":10,
-                     "dashes":false,
-                     "datasource":"prometheus",
-                     "fill":1,
-                     "gridPos":{  
-                        "h":9,
-                        "w":12,
-                        "x":12,
-                        "y":13
-                     },
-                     "id":6,
-                     "legend":{  
-                        "avg":false,
-                        "current":false,
-                        "max":false,
-                        "min":false,
-                        "show":true,
-                        "total":false,
-                        "values":false
-                     },
-                     "lines":true,
-                     "linewidth":1,
-                     "links":[  
-
-                     ],
-                     "nullPointMode":"null",
-                     "percentage":false,
-                     "pointradius":5,
-                     "points":false,
-                     "renderer":"flot",
-                     "seriesOverrides":[  
-
-                     ],
-                     "spaceLength":10,
-                     "stack":false,
-                     "steppedLine":false,
-                     "targets":[  
-                        {  
-                           "expr":"sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-                           "format":"time_series",
-                           "interval":"",
-                           "intervalFactor":1,
-                           "legendFormat":"Memory requested",
-                           "refId":"A"
-                        },
-                        {  
-                           "expr":"sum(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"})",
-                           "format":"time_series",
-                           "hide":false,
-                           "intervalFactor":1,
-                           "legendFormat":"Memory used",
-                           "refId":"B"
-                        },
-                        {  
-                           "expr":"sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "refId":"C"
-                        }
-                     ],
-                     "thresholds":[  
-
-                     ],
-                     "timeFrom":null,
-                     "timeShift":null,
-                     "title":"Pod Memory Usage",
-                     "tooltip":{  
-                        "shared":true,
-                        "sort":2,
-                        "value_type":"individual"
-                     },
-                     "type":"graph",
-                     "xaxis":{  
-                        "buckets":null,
-                        "mode":"time",
-                        "name":null,
-                        "show":true,
-                        "values":[  
-
-                        ]
-                     },
-                     "yaxes":[  
-                        {  
-                           "format":"decbytes",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":true
-                        },
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":false
-                        }
-                     ]
-                  }
-               ],
-               "title":"Resource Usages",
-               "type":"row"
-            },
-            {  
-               "collapsed":true,
-               "gridPos":{  
-                  "h":1,
-                  "w":24,
-                  "x":0,
-                  "y":2
-               },
-               "id":16,
-               "panels":[  
-                  {  
-                     "aliasColors":{  
-
-                     },
-                     "bars":false,
-                     "dashLength":10,
-                     "dashes":false,
-                     "datasource":"prometheus",
-                     "fill":1,
-                     "gridPos":{  
-                        "h":10,
-                        "w":24,
-                        "x":0,
-                        "y":3
-                     },
-                     "id":10,
-                     "legend":{  
-                        "avg":false,
-                        "current":false,
-                        "max":false,
-                        "min":false,
-                        "show":true,
-                        "total":false,
-                        "values":false
-                     },
-                     "lines":true,
-                     "linewidth":1,
-                     "links":[  
-
-                     ],
-                     "nullPointMode":"null",
-                     "percentage":false,
-                     "pointradius":5,
-                     "points":false,
-                     "renderer":"flot",
-                     "seriesOverrides":[  
-
-                     ],
-                     "spaceLength":10,
-                     "stack":false,
-                     "steppedLine":true,
-                     "targets":[  
-                        {  
-                           "expr":"sum(autoscaler_desired_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"}) ",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Desired Pods",
-                           "refId":"A"
-                        },
-                        {  
-                           "expr":"sum(autoscaler_observed_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Observed Pods",
-                           "refId":"B"
-                        }
-                     ],
-                     "thresholds":[  
-
-                     ],
-                     "timeFrom":null,
-                     "timeShift":null,
-                     "title":"Pod Counts",
-                     "tooltip":{  
-                        "shared":true,
-                        "sort":0,
-                        "value_type":"individual"
-                     },
-                     "type":"graph",
-                     "xaxis":{  
-                        "buckets":null,
-                        "mode":"time",
-                        "name":null,
-                        "show":true,
-                        "values":[  
-
-                        ]
-                     },
-                     "yaxes":[  
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":true
-                        },
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":true
-                        }
-                     ]
+                  "id": 2,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
                   },
-                  {  
-                     "aliasColors":{  
-
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": true,
+                  "targets": [
+                     {
+                     "expr": "sum(autoscaler_actual_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                     "format": "time_series",
+                     "interval": "1s",
+                     "intervalFactor": 1,
+                     "legendFormat": "Actual Pods",
+                     "refId": "A"
                      },
-                     "bars":false,
-                     "dashLength":10,
-                     "dashes":false,
-                     "datasource":"prometheus",
-                     "fill":1,
-                     "gridPos":{  
-                        "h":9,
-                        "w":24,
-                        "x":0,
-                        "y":13
-                     },
-                     "id":8,
-                     "legend":{  
-                        "avg":false,
-                        "current":false,
-                        "max":false,
-                        "min":false,
-                        "show":true,
-                        "total":false,
-                        "values":false
-                     },
-                     "lines":true,
-                     "linewidth":1,
-                     "links":[  
-
-                     ],
-                     "nullPointMode":"null",
-                     "percentage":false,
-                     "pointradius":5,
-                     "points":false,
-                     "renderer":"flot",
-                     "seriesOverrides":[  
-                        {  
-                           "alias":"Panic Mode",
-                           "color":"#ea6460",
-                           "dashes":true,
-                           "fill":2,
-                           "linewidth":2,
-                           "steppedLine":true,
-                           "yaxis":2
-                        },
-                        {  
-                           "alias":"Target Concurrency Per Pod",
-                           "color":"#0a50a1",
-                           "dashes":true,
-                           "steppedLine":false
-                        }
-                     ],
-                     "spaceLength":10,
-                     "stack":false,
-                     "steppedLine":true,
-                     "targets":[  
-                        {  
-                           "expr":"sum(autoscaler_stable_request_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "interval":"1s",
-                           "intervalFactor":1,
-                           "legendFormat":"Average Concurrency",
-                           "refId":"A"
-                        },
-                        {  
-                           "expr":"sum(autoscaler_panic_request_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "interval":"1s",
-                           "intervalFactor":1,
-                           "legendFormat":"Average Panic Concurrency",
-                           "refId":"B"
-                        },
-                        {  
-                           "expr":"sum(autoscaler_target_concurrency_per_pod{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Target Concurrency",
-                           "refId":"C"
-                        },
-                        {
-                           "expr":"sum(autoscaler_excess_burst_capacity{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Excess Burst Capacity",
-                           "refId":"D"
-                        }
-                     ],
-                     "thresholds":[  
-                     ],
-                     "timeFrom":null,
-                     "timeShift":null,
-                     "title":"Observed Concurrency",
-                     "tooltip":{  
-                        "shared":true,
-                        "sort":0,
-                        "value_type":"individual"
-                     },
-                     "type":"graph",
-                     "xaxis":{  
-                        "buckets":null,
-                        "mode":"time",
-                        "name":null,
-                        "show":true,
-                        "values":[  
-
-                        ]
-                     },
-                     "yaxes":[  
-                        {  
-                           "format":"short",
-                           "label":"",
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":true
-                        },
-                        {  
-                           "format":"short",
-                           "label":"",
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":false
-                        }
-                     ]
+                     {
+                     "expr": "sum(autoscaler_requested_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                     "format": "time_series",
+                     "interval": "1s",
+                     "intervalFactor": 1,
+                     "legendFormat": "Requested Pods",
+                     "refId": "C"
+                     }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Revision Pod Counts",
+                  "tooltip": {
+                     "shared": true,
+                     "sort": 0,
+                     "value_type": "individual"
                   },
-                  {  
-                     "aliasColors":{  
-
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": []
+                  },
+                  "yaxes": [
+                     {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
                      },
-                     "bars":false,
-                     "dashLength":10,
-                     "dashes":false,
-                     "datasource":"prometheus",
-                     "decimals":null,
-                     "fill":1,
-                     "gridPos":{  
-                        "h":9,
-                        "w":24,
-                        "x":0,
-                        "y":22
-                     },
-                     "id":12,
-                     "legend":{  
-                        "avg":false,
-                        "current":false,
-                        "hideZero":false,
-                        "max":false,
-                        "min":false,
-                        "show":false,
-                        "total":false,
-                        "values":false
-                     },
-                     "lines":true,
-                     "linewidth":1,
-                     "links":[  
-
-                     ],
-                     "nullPointMode":"null",
-                     "percentage":false,
-                     "pointradius":5,
-                     "points":false,
-                     "renderer":"flot",
-                     "seriesOverrides":[  
-                        {  
-                           "alias":"Panic Mode",
-                           "color":"#e24d42",
-                           "linewidth":2,
-                           "yaxis":2
-                        }
-                     ],
-                     "spaceLength":10,
-                     "stack":false,
-                     "steppedLine":true,
-                     "targets":[  
-                        {  
-                           "expr":"sum(autoscaler_panic_mode{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"} )",
-                           "format":"time_series",
-                           "intervalFactor":1,
-                           "legendFormat":"Panic Mode",
-                           "refId":"A"
-                        }
-                     ],
-                     "thresholds":[  
-
-                     ],
-                     "timeFrom":null,
-                     "timeShift":null,
-                     "title":"Panic Mode",
-                     "tooltip":{  
-                        "shared":true,
-                        "sort":0,
-                        "value_type":"individual"
-                     },
-                     "type":"graph",
-                     "xaxis":{  
-                        "buckets":null,
-                        "mode":"time",
-                        "name":null,
-                        "show":true,
-                        "values":[  
-
-                        ]
-                     },
-                     "yaxes":[  
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":"1.0",
-                           "min":"0",
-                           "show":true
-                        },
-                        {  
-                           "format":"short",
-                           "label":null,
-                           "logBase":1,
-                           "max":null,
-                           "min":null,
-                           "show":false
-                        }
-                     ]
-                  }
+                     {
+                     "decimals": null,
+                     "format": "short",
+                     "label": "Concurrency",
+                     "logBase": 1,
+                     "max": "1",
+                     "min": null,
+                     "show": false
+                     }
+                  ]
+               }
                ],
-               "title":"Autoscaler Metrics",
-               "type":"row"
+               "title": "Revision Pod Counts",
+               "type": "row"
             },
-            {  
-               "collapsed":true,
-               "gridPos":{  
-                  "h":1,
-                  "w":24,
-                  "x":0,
-                  "y":3
+            {
+               "collapsed": true,
+               "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 1
                },
-               "id":20,
-               "panels":[  
-                           {  
-                              "aliasColors":{  
-
-                              },
-                              "bars":false,
-                              "dashLength":10,
-                              "dashes":false,
-                              "datasource":"prometheus",
-                              "fill":1,
-                              "gridPos":{  
-                                 "h":10,
-                                 "w":24,
-                                 "x":0,
-                                 "y":12
-                              },
-                              "id":24,
-                              "legend":{  
-                                 "avg":false,
-                                 "current":false,
-                                 "max":false,
-                                 "min":false,
-                                 "show":true,
-                                 "total":false,
-                                 "values":false
-                              },
-                              "lines":true,
-                              "linewidth":1,
-                              "links":[  
-
-                              ],
-                              "nullPointMode":"null",
-                              "percentage":false,
-                              "pointradius":5,
-                              "points":false,
-                              "renderer":"flot",
-                              "seriesOverrides":[  
-
-                              ],
-                              "spaceLength":10,
-                              "stack":false,
-                              "steppedLine":false,
-                              "targets":[  
-                                 {  
-                                    "expr":"round(sum(increase(activator_request_count{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (response_code))",
-                                    "format":"time_series",
-                                    "intervalFactor":1,
-                                    "legendFormat":"{{ response_code }}",
-                                    "refId":"A"
-                                 }
-                              ],
-                              "thresholds":[  
-
-                              ],
-                              "timeFrom":null,
-                              "timeShift":null,
-                              "title":"Request Count in last minute by Response Code",
-                              "tooltip":{  
-                                 "shared":true,
-                                 "sort":0,
-                                 "value_type":"individual"
-                              },
-                              "type":"graph",
-                              "xaxis":{  
-                                 "buckets":null,
-                                 "mode":"time",
-                                 "name":null,
-                                 "show":true,
-                                 "values":[  
-
-                                 ]
-                              },
-                              "yaxes":[  
-                                 {  
-                                    "format":"none",
-                                    "label":null,
-                                    "logBase":1,
-                                    "max":null,
-                                    "min":"0",
-                                    "show":true
-                                 },
-                                 {  
-                                    "format":"short",
-                                    "label":null,
-                                    "logBase":1,
-                                    "max":null,
-                                    "min":null,
-                                    "show":true
-                                 }
-                              ]
-                           },
-                           {  
-                              "aliasColors":{  
-
-                              },
-                              "bars":false,
-                              "dashLength":10,
-                              "dashes":false,
-                              "datasource":"prometheus",
-                              "fill":1,
-                              "gridPos":{  
-                                 "h":10,
-                                 "w":24,
-                                 "x":0,
-                                 "y":32
-                              },
-                              "id":28,
-                              "legend":{  
-                                 "avg":true,
-                                 "current":false,
-                                 "max":false,
-                                 "min":false,
-                                 "show":true,
-                                 "total":false,
-                                 "values":true
-                              },
-                              "lines":true,
-                              "linewidth":1,
-                              "links":[  
-
-                              ],
-                              "nullPointMode":"null",
-                              "percentage":false,
-                              "pointradius":5,
-                              "points":false,
-                              "renderer":"flot",
-                              "seriesOverrides":[  
-
-                              ],
-                              "spaceLength":10,
-                              "stack":false,
-                              "steppedLine":false,
-                              "targets":[  
-                                 {  
-                                    "expr":"label_replace(histogram_quantile(0.50, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
-                                    "format":"time_series",
-                                    "intervalFactor":1,
-                                    "legendFormat":"{{ revision_name }} (p50)",
-                                    "refId":"A"
-                                 },
-                                 {  
-                                    "expr":"label_replace(histogram_quantile(0.90, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
-                                    "format":"time_series",
-                                    "intervalFactor":1,
-                                    "legendFormat":"{{ revision_name }} (p90)",
-                                    "refId":"B"
-                                 },
-                                 {  
-                                    "expr":"label_replace(histogram_quantile(0.95, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
-                                    "format":"time_series",
-                                    "intervalFactor":1,
-                                    "legendFormat":"{{ revision_name }} (p95)",
-                                    "refId":"C"
-                                 },
-                                 {  
-                                    "expr":"label_replace(histogram_quantile(0.99, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
-                                    "format":"time_series",
-                                    "intervalFactor":1,
-                                    "legendFormat":"{{ revision_name }} (p99)",
-                                    "refId":"D"
-                                 }
-                              ],
-                              "thresholds":[  
-
-                              ],
-                              "timeFrom":null,
-                              "timeShift":null,
-                              "title":"Response Time in last minute",
-                              "tooltip":{  
-                                 "shared":true,
-                                 "sort":0,
-                                 "value_type":"individual"
-                              },
-                              "type":"graph",
-                              "xaxis":{  
-                                 "buckets":null,
-                                 "mode":"time",
-                                 "name":null,
-                                 "show":true,
-                                 "values":[  
-
-                                 ]
-                              },
-                              "yaxes":[  
-                                 {  
-                                    "format":"ms",
-                                    "label":null,
-                                    "logBase":1,
-                                    "max":null,
-                                    "min":null,
-                                    "show":true
-                                 },
-                                 {  
-                                    "format":"short",
-                                    "label":null,
-                                    "logBase":1,
-                                    "max":null,
-                                    "min":null,
-                                    "show":true
-                                 }
-                               ]
-                             }     
+               "id": 18,
+               "panels": [
+               {
+                  "aliasColors": {},
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "prometheus",
+                  "fill": 1,
+                  "gridPos": {
+                     "h": 9,
+                     "w": 12,
+                     "x": 0,
+                     "y": 13
+                  },
+                  "id": 4,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                     "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                     "format": "time_series",
+                     "interval": "",
+                     "intervalFactor": 1,
+                     "legendFormat": "Cores requested",
+                     "refId": "A"
+                     },
+                     {
+                     "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"}[1m]))",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "Cores used",
+                     "refId": "B"
+                     },
+                     {
+                     "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "Core limit",
+                     "refId": "C"
+                     }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Revision CPU Usage",
+                  "tooltip": {
+                     "shared": true,
+                     "sort": 2,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": []
+                  },
+                  "yaxes": [
+                     {
+                     "decimals": null,
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                     },
+                     {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": {},
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "prometheus",
+                  "fill": 1,
+                  "gridPos": {
+                     "h": 9,
+                     "w": 12,
+                     "x": 12,
+                     "y": 13
+                  },
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                     "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                     "format": "time_series",
+                     "interval": "",
+                     "intervalFactor": 1,
+                     "legendFormat": "Memory requested",
+                     "refId": "A"
+                     },
+                     {
+                     "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=~\"$revision-deployment-.*\"})",
+                     "format": "time_series",
+                     "hide": false,
+                     "intervalFactor": 1,
+                     "legendFormat": "Memory used",
+                     "refId": "B"
+                     },
+                     {
+                     "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "refId": "C"
+                     }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Pod Memory Usage",
+                  "tooltip": {
+                     "shared": true,
+                     "sort": 2,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": []
+                  },
+                  "yaxes": [
+                     {
+                     "format": "decbytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                     },
+                     {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                     }
+                  ]
+               }
                ],
-               "title":"Activator Metrics",
-               "type":"row"
+               "title": "Resource Usages",
+               "type": "row"
+            },
+            {
+               "collapsed": false,
+               "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 2
+               },
+               "id": 16,
+               "panels": [],
+               "title": "Autoscaler Metrics",
+               "type": "row"
+            },
+            {
+               "aliasColors": {},
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "prometheus",
+               "fill": 1,
+               "gridPos": {
+               "h": 10,
+               "w": 24,
+               "x": 0,
+               "y": 3
+               },
+               "id": 10,
+               "legend": {
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "show": true,
+               "total": false,
+               "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": true,
+               "targets": [
+               {
+                  "expr": "sum(autoscaler_desired_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"}) ",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Desired Pods",
+                  "refId": "A"
+               },
+               {
+                  "expr": "sum(autoscaler_observed_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Observed Pods",
+                  "refId": "B"
+               }
+               ],
+               "thresholds": [],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Pod Counts",
+               "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+               },
+               "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+               ]
+            },
+            {
+               "aliasColors": {},
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "prometheus",
+               "fill": 1,
+               "gridPos": {
+               "h": 9,
+               "w": 24,
+               "x": 0,
+               "y": 13
+               },
+               "id": 8,
+               "legend": {
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "show": true,
+               "total": false,
+               "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [
+               {
+                  "alias": "Panic Mode",
+                  "color": "#ea6460",
+                  "dashes": true,
+                  "fill": 2,
+                  "linewidth": 2,
+                  "steppedLine": true,
+                  "yaxis": 2
+               },
+               {
+                  "alias": "Target Concurrency Per Pod",
+                  "color": "#0a50a1",
+                  "dashes": true,
+                  "steppedLine": false
+               }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": true,
+               "targets": [
+               {
+                  "expr": "sum(autoscaler_stable_request_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Average Concurrency",
+                  "refId": "A"
+               },
+               {
+                  "expr": "sum(autoscaler_panic_request_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Average Panic Concurrency",
+                  "refId": "B"
+               },
+               {
+                  "expr": "sum(autoscaler_target_concurrency_per_pod{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Target Concurrency",
+                  "refId": "C"
+               },
+               {
+                  "expr": "sum(autoscaler_excess_burst_capacity{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Excess Burst Capacity",
+                  "refId": "D"
+               }
+               ],
+               "thresholds": [],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Observed Concurrency",
+               "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+               },
+               "yaxes": [
+               {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+               }
+               ]
+            },
+            {
+               "aliasColors": {},
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "prometheus",
+               "decimals": null,
+               "fill": 1,
+               "gridPos": {
+               "h": 9,
+               "w": 24,
+               "x": 0,
+               "y": 22
+               },
+               "id": 12,
+               "legend": {
+               "avg": false,
+               "current": false,
+               "hideZero": false,
+               "max": false,
+               "min": false,
+               "show": false,
+               "total": false,
+               "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [
+               {
+                  "alias": "Panic Mode",
+                  "color": "#e24d42",
+                  "linewidth": 2,
+                  "yaxis": 2
+               }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": true,
+               "targets": [
+               {
+                  "expr": "sum(autoscaler_panic_mode{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"} )",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Panic Mode",
+                  "refId": "A"
+               }
+               ],
+               "thresholds": [],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Panic Mode",
+               "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+               },
+               "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": "1.0",
+                  "min": "0",
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+               }
+               ]
+            },
+            {
+               "collapsed": false,
+               "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 31
+               },
+               "id": 20,
+               "panels": [],
+               "title": "Activator Metrics",
+               "type": "row"
+            },
+            {
+               "aliasColors": {},
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "prometheus",
+               "fill": 1,
+               "gridPos": {
+               "h": 10,
+               "w": 24,
+               "x": 0,
+               "y": 32
+               },
+               "id": 24,
+               "legend": {
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "show": true,
+               "total": false,
+               "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+               {
+                  "expr": "round(sum(increase(activator_request_count{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (response_code))",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ response_code }}",
+                  "refId": "A"
+               }
+               ],
+               "thresholds": [],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Request Count in last minute by Response Code",
+               "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+               },
+               "yaxes": [
+               {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+               ]
+            },
+            {
+               "aliasColors": {},
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "prometheus",
+               "fill": 1,
+               "gridPos": {
+               "h": 10,
+               "w": 24,
+               "x": 0,
+               "y": 42
+               },
+               "id": 28,
+               "legend": {
+               "avg": true,
+               "current": false,
+               "max": false,
+               "min": false,
+               "show": true,
+               "total": false,
+               "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+               {
+                  "expr": "label_replace(histogram_quantile(0.50, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ revision_name }} (p50)",
+                  "refId": "A"
+               },
+               {
+                  "expr": "label_replace(histogram_quantile(0.90, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ revision_name }} (p90)",
+                  "refId": "B"
+               },
+               {
+                  "expr": "label_replace(histogram_quantile(0.95, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ revision_name }} (p95)",
+                  "refId": "C"
+               },
+               {
+                  "expr": "label_replace(histogram_quantile(0.99, sum(rate(activator_request_latencies_bucket{namespace_name=\"$namespace\", configuration_name=~\"$configuration\",revision_name=~\"$revision\"}[1m])) by (revision_name, le)), \"revision_name\", \"$2\", \"revision_name\", \"$configuration(-+)(.*)\")",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ revision_name }} (p99)",
+                  "refId": "D"
+               }
+               ],
+               "thresholds": [],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Response Time in last minute",
+               "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+               },
+               "yaxes": [
+               {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+               ]
+            },
+            {
+               "aliasColors": {},
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "prometheus",
+               "fill": 1,
+               "gridPos": {
+               "h": 9,
+               "w": 24,
+               "x": 0,
+               "y": 52
+               },
+               "id": 29,
+               "legend": {
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "show": true,
+               "total": false,
+               "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [
+               {
+                  "alias": "Panic Mode",
+                  "color": "#ea6460",
+                  "dashes": true,
+                  "fill": 2,
+                  "linewidth": 2,
+                  "steppedLine": true,
+                  "yaxis": 2
+               },
+               {
+                  "alias": "Target Concurrency Per Pod",
+                  "color": "#0a50a1",
+                  "dashes": true,
+                  "steppedLine": false
+               }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": true,
+               "targets": [
+               {
+                  "expr": "sum(activator_request_concurrency{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                  "format": "time_series",
+                  "interval": "1s",
+                  "intervalFactor": 1,
+                  "legendFormat": "Request Concurrency",
+                  "refId": "A"
+               }
+               ],
+               "thresholds": [],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Request Concurrency",
+               "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+               },
+               "yaxes": [
+               {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+               }
+               ]
             }
          ],
-         "refresh":false,
-         "schemaVersion":16,
-         "style":"dark",
-         "tags":[  
-
-         ],
-         "templating":{  
-            "list":[  
-               {  
-                  "allValue":null,
-                  "current":{  
-
-                  },
-                  "datasource":"prometheus",
-                  "hide":0,
-                  "includeAll":false,
-                  "label":"Namespace",
-                  "multi":false,
-                  "name":"namespace",
-                  "options":[  
-
-                  ],
-                  "query":"label_values(autoscaler_desired_pods, namespace_name)",
-                  "refresh":1,
-                  "regex":"",
-                  "sort":1,
-                  "tagValuesQuery":"",
-                  "tags":[  
-
-                  ],
-                  "tagsQuery":"",
-                  "type":"query",
-                  "useTags":false
+         "refresh": false,
+         "schemaVersion": 16,
+         "style": "dark",
+         "tags": [],
+         "templating": {
+            "list": [
+               {
+               "allValue": null,
+               "current": {},
+               "datasource": "prometheus",
+               "hide": 0,
+               "includeAll": false,
+               "label": "Namespace",
+               "multi": false,
+               "name": "namespace",
+               "options": [],
+               "query": "label_values(autoscaler_desired_pods, namespace_name)",
+               "refresh": 1,
+               "regex": "",
+               "sort": 1,
+               "tagValuesQuery": "",
+               "tags": [],
+               "tagsQuery": "",
+               "type": "query",
+               "useTags": false
                },
-               {  
-                  "allValue":null,
-                  "current":{  
-
-                  },
-                  "datasource":"prometheus",
-                  "hide":0,
-                  "includeAll":false,
-                  "label":"Configuration",
-                  "multi":false,
-                  "name":"configuration",
-                  "options":[  
-
-                  ],
-                  "query":"label_values(autoscaler_desired_pods{namespace_name=\"$namespace\"}, configuration_name)",
-                  "refresh":1,
-                  "regex":"",
-                  "sort":1,
-                  "tagValuesQuery":"",
-                  "tags":[  
-
-                  ],
-                  "tagsQuery":"",
-                  "type":"query",
-                  "useTags":false
+               {
+               "allValue": null,
+               "current": {},
+               "datasource": "prometheus",
+               "hide": 0,
+               "includeAll": false,
+               "label": "Configuration",
+               "multi": false,
+               "name": "configuration",
+               "options": [],
+               "query": "label_values(autoscaler_desired_pods{namespace_name=\"$namespace\"}, configuration_name)",
+               "refresh": 1,
+               "regex": "",
+               "sort": 1,
+               "tagValuesQuery": "",
+               "tags": [],
+               "tagsQuery": "",
+               "type": "query",
+               "useTags": false
                },
-               {  
-                  "allValue":null,
-                  "current":{  
-
-                  },
-                  "datasource":"prometheus",
-                  "hide":0,
-                  "includeAll":false,
-                  "label":"Revision",
-                  "multi":false,
-                  "name":"revision",
-                  "options":[  
-
-                  ],
-                  "query":"label_values(autoscaler_desired_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\"}, revision_name)",
-                  "refresh":1,
-                  "regex":"",
-                  "sort":2,
-                  "tagValuesQuery":"",
-                  "tags":[  
-
-                  ],
-                  "tagsQuery":"",
-                  "type":"query",
-                  "useTags":false
+               {
+               "allValue": null,
+               "current": {},
+               "datasource": "prometheus",
+               "hide": 0,
+               "includeAll": false,
+               "label": "Revision",
+               "multi": false,
+               "name": "revision",
+               "options": [],
+               "query": "label_values(autoscaler_desired_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\"}, revision_name)",
+               "refresh": 1,
+               "regex": "",
+               "sort": 2,
+               "tagValuesQuery": "",
+               "tags": [],
+               "tagsQuery": "",
+               "type": "query",
+               "useTags": false
                }
             ]
          },
-         "time":{  
-            "from":"now-15m",
-            "to":"now"
+         "time": {
+            "from": "now-15m",
+            "to": "now"
          },
-         "timepicker":{  
-            "refresh_intervals":[  
+         "timepicker": {
+            "refresh_intervals": [
                "5s",
                "10s",
                "30s",
@@ -1070,7 +1067,7 @@ data:
                "2h",
                "1d"
             ],
-            "time_options":[  
+            "time_options": [
                "5m",
                "15m",
                "1h",
@@ -1082,8 +1079,8 @@ data:
                "30d"
             ]
          },
-         "timezone":"",
-         "title":"Knative Serving - Scaling Debugging",
-         "uid":"u_-9SIMiz",
-         "version":2
-      }
+         "timezone": "",
+         "title": "Knative Serving - Scaling Debugging",
+         "uid": "u_-9SIMiz",
+         "version": 2
+         }

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -670,6 +670,21 @@ type fakeReporter struct {
 	mux   sync.Mutex
 }
 
+func (f *fakeReporter) ReportRequestConcurrency(ns, service, config, rev string, v int64) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	f.calls = append(f.calls, reporterCall{
+		Op:        "ReportRequestCount",
+		Namespace: ns,
+		Service:   service,
+		Config:    config,
+		Revision:  rev,
+		Value:     v,
+	})
+
+	return nil
+}
+
 func (f *fakeReporter) ReportRequestCount(ns, service, config, rev string, responseCode, numTries int, v int64) error {
 	f.mux.Lock()
 	defer f.mux.Unlock()

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -674,7 +674,7 @@ func (f *fakeReporter) ReportRequestConcurrency(ns, service, config, rev string,
 	f.mux.Lock()
 	defer f.mux.Unlock()
 	f.calls = append(f.calls, reporterCall{
-		Op:        "ReportRequestCount",
+		Op:        "ReportRequestConcurrency",
 		Namespace: ns,
 		Service:   service,
 		Config:    config,

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -47,6 +47,22 @@ func TestActivatorReporter(t *testing.T) {
 	// we get an error about view already being registered.
 	defer unregister()
 
+	// test ReportResponseConcurrency
+	wantTags1 := map[string]string{
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       "testsvc",
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+	}
+	expectSuccess(t, func() error {
+		return r.ReportRequestConcurrency("testns", "testsvc", "testconfig", "testrev", 100)
+	})
+	metricstest.CheckLastValueData(t, "request_concurrency", wantTags1, 100)
+	expectSuccess(t, func() error {
+		return r.ReportRequestConcurrency("testns", "testsvc", "testconfig", "testrev", 200)
+	})
+	metricstest.CheckLastValueData(t, "request_concurrency", wantTags1, 200)
+
 	// test ReportRequestCount
 	wantTags2 := map[string]string{
 		metricskey.LabelNamespaceName:     "testns",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Report Activator request concurrency to metrics backend as well.
* Add a Grafana dashboard for this metric.

We can use this metric to check whether the activator is overloaded.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Report Activator request concurrency to metrics backend.
```
