### PR TITLE
Increase Activator CPU requests and limits

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -78,7 +78,7 @@ spec:
           # The numbers are based on performance test results from
           # https://github.com/knative/serving/issues/1625#issuecomment-511930023
           requests:
-            cpu: 800m
+            cpu: 300m
             memory: 60Mi
           limits:
             cpu: 1000m
@@ -129,5 +129,5 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        # Percentage of the requested CPU
-        targetAverageUtilization: 100
+        # Percentage of the requested CPU, i.e. 250%*300 = 750. 75% of the limit.
+        targetAverageUtilization: 250

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -78,10 +78,10 @@ spec:
           # The numbers are based on performance test results from
           # https://github.com/knative/serving/issues/1625#issuecomment-511930023
           requests:
-            cpu: 300m
+            cpu: 800m
             memory: 60Mi
           limits:
-            cpu: 400m
+            cpu: 1000m
             memory: 600Mi
         env:
           - name: POD_NAME

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -129,5 +129,5 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        # Percentage of the requested CPU, i.e. 250%*300 = 750. 75% of the limit.
-        targetAverageUtilization: 250
+        # Percentage of the requested CPU
+        targetAverageUtilization: 100


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Per https://github.com/knative/serving/issues/4773#issuecomment-514382171, increase activator CPU usage. With current setting, I will get lots errors when the RPS is 500 for single activator pod.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
