### PR TITLE
Make scale down to 0 even faster in some cases.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -186,27 +186,29 @@ func (pas *PodAutoscalerStatus) MarkResourceFailedCreation(kind, name string) {
 // CanScaleToZero checks whether the pod autoscaler has been in an inactive state
 // for at least the specified grace period.
 func (pas *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
-	return pas.inStatusFor(corev1.ConditionFalse, gracePeriod)
+	return pas.inStatusFor(corev1.ConditionFalse, gracePeriod) > 0
 }
 
-// CanMarkInactive checks whether the pod autoscaler has been in an active state
-// for at least the specified idle period.
-func (pas *PodAutoscalerStatus) CanMarkInactive(idlePeriod time.Duration) bool {
-	return pas.inStatusFor(corev1.ConditionTrue, idlePeriod)
+// ActiveFor returns the time PA spent being active.
+func (pas *PodAutoscalerStatus) ActiveFor() time.Duration {
+	return pas.inStatusFor(corev1.ConditionTrue, 0)
 }
 
 // CanFailActivation checks whether the pod autoscaler has been activating
 // for at least the specified idle period.
 func (pas *PodAutoscalerStatus) CanFailActivation(idlePeriod time.Duration) bool {
-	return pas.inStatusFor(corev1.ConditionUnknown, idlePeriod)
+	return pas.inStatusFor(corev1.ConditionUnknown, idlePeriod) > 0
 }
 
-// inStatusFor returns true if the PodAutoscalerStatus's Active condition has stayed in
-// the specified status for at least the specified duration. Otherwise it returns false,
+// inStatusFor returns positive duration if the PodAutoscalerStatus's Active condition has stayed in
+// the specified status for at least the specified duration. Otherwise it returns negative duration,
 // including when the status is undetermined (Active condition is not found.)
-func (pas *PodAutoscalerStatus) inStatusFor(status corev1.ConditionStatus, dur time.Duration) bool {
+func (pas *PodAutoscalerStatus) inStatusFor(status corev1.ConditionStatus, dur time.Duration) time.Duration {
 	cond := pas.GetCondition(PodAutoscalerConditionActive)
-	return cond != nil && cond.Status == status && time.Now().After(cond.LastTransitionTime.Inner.Add(dur))
+	if cond == nil || cond.Status != status {
+		return -1
+	}
+	return time.Now().Sub(cond.LastTransitionTime.Inner.Add(dur))
 }
 
 func (pas *PodAutoscalerStatus) duck() *duckv1beta1.Status {


### PR DESCRIPTION
For the single request activation it might happen that we end up
here earlier than stable period. In that case, e.g. with window of 60 seconds,
which is the default, we'd wait another whole minute.
This way we'll wait on the remaining time (usually under a second).

/assign @jonjohnsonjr 

For #4453 