### PR TITLE
Filter probe requests for revision metrics and logs

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -133,18 +133,10 @@ type config struct {
 	ServingReadinessProbe        string `split_words:"true" required:"true"`
 }
 
-func knativeProbeHeader(r *http.Request) string {
-	return r.Header.Get(network.ProbeHeaderName)
-}
-
-func knativeProxyHeader(r *http.Request) string {
-	return r.Header.Get(network.ProxyHeaderName)
-}
-
 // Make handler a closure for testing.
 func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.Handler, prober func() bool) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ph := knativeProbeHeader(r)
+		ph := network.KnativeProbeHeader(r)
 		switch {
 		case ph != "":
 			if ph != queue.Name {
@@ -171,7 +163,7 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.H
 
 		// Metrics for autoscaling.
 		in, out := queue.ReqIn, queue.ReqOut
-		if activator.Name == knativeProxyHeader(r) {
+		if activator.Name == network.KnativeProxyHeader(r) {
 			in, out = queue.ProxiedIn, queue.ProxiedOut
 		}
 		reqChan <- queue.ReqEvent{Time: time.Now(), EventType: in}

--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -135,17 +135,16 @@ func (h *RequestLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rr := NewResponseRecorder(w, http.StatusOK)
-
-	// Filter probe requests for request logs.
-	// TODO(yanweiguo): Add probe request logs with a way to distinguish external
-	// requests and probe requests.
-	if network.IsProbe(r) {
-		h.handler.ServeHTTP(rr, r)
-		return
-	}
-
 	startTime := time.Now()
+
 	defer func() {
+		// Filter probe requests for request logs.
+		// TODO(yanweiguo): Add probe request logs with a way to distinguish external
+		// requests and probe requests.
+		if network.IsProbe(r) {
+			return
+		}
+
 		// If ServeHTTP panics, recover, record the failure and panic again.
 		err := recover()
 		latency := time.Since(startTime).Seconds()
@@ -164,6 +163,7 @@ func (h *RequestLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}))
 		}
 	}()
+
 	h.handler.ServeHTTP(rr, r)
 }
 

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -334,10 +334,26 @@ func checkTagTemplate(t *template.Template) error {
 	return t.Execute(ioutil.Discard, data)
 }
 
-// IsKubeletProbe returns true if the request is a kubernetes probe.
+// IsKubeletProbe returns true if the request is a Kubernetes probe.
 func IsKubeletProbe(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get("User-Agent"), KubeProbeUAPrefix) ||
 		r.Header.Get(KubeletProbeHeaderName) != ""
+}
+
+// KnativeProbeHeader returns the value for key ProbeHeaderName in request headers.
+func KnativeProbeHeader(r *http.Request) string {
+	return r.Header.Get(ProbeHeaderName)
+}
+
+// KnativeProxyHeader returns the value for key ProxyHeaderName in request headers.
+func KnativeProxyHeader(r *http.Request) string {
+	return r.Header.Get(ProxyHeaderName)
+}
+
+// IsProbe returns true if the request is a Kubernetes probe or a Knative probe,
+// i.e. non-empty ProbeHeaderName header.
+func IsProbe(r *http.Request) bool {
+	return IsKubeletProbe(r) || KnativeProbeHeader(r) != ""
 }
 
 // RewriteHostIn removes the `Host` header from the inbound (server) request


### PR DESCRIPTION
Filter probe requests for revision metrics and logs. Otherwise if the request is from activator, we count twice to request count and sent two request logs, one for probe request and another for external request.

We may consider adding request logs and metrics for probe requests separated from external requests.