### PR TITLE
Remove deprecated field `DeprecatedAppendHeaders`

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -214,12 +214,8 @@ func makeVirtualServiceRoute(hosts []string, http *v1alpha1.HTTPIngressPath, gat
 			Attempts:      http.Retries.Attempts,
 			PerTryTimeout: http.Retries.PerTryTimeout.Duration.String(),
 		},
-		// TODO(mattmoor): Remove AppendHeaders when 1.1 is a hard dependency.
-		// AppendHeaders is deprecated in Istio 1.1 in favor of Headers,
-		// however, 1.0.x doesn't support Headers.
-		DeprecatedAppendHeaders: http.AppendHeaders,
-		Headers:                 h,
-		WebsocketUpgrade:        true,
+		Headers:          h,
+		WebsocketUpgrade: true,
 	}
 }
 

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -251,9 +251,6 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 				},
 			},
 		},
-		DeprecatedAppendHeaders: map[string]string{
-			"foo": "bar",
-		},
 		Timeout: defaultMaxRevisionTimeout.String(),
 		Retries: &v1alpha3.HTTPRetry{
 			Attempts:      networking.DefaultRetryCount,
@@ -387,9 +384,6 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 				},
 			},
 		},
-		DeprecatedAppendHeaders: map[string]string{
-			"foo": "bar",
-		},
 		Timeout: defaultMaxRevisionTimeout.String(),
 		Retries: &v1alpha3.HTTPRetry{
 			Attempts:      networking.DefaultRetryCount,
@@ -414,9 +408,6 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 					"foo": "baz",
 				},
 			},
-		},
-		DeprecatedAppendHeaders: map[string]string{
-			"foo": "baz",
 		},
 		Timeout: defaultMaxRevisionTimeout.String(),
 		Retries: &v1alpha3.HTTPRetry{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Remove usage of DeprecateAppendHeader, now that we dropped Istio 1.0 support.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
