### PR TITLE
Anticipate zero values for stable-window and scale-to-zero-grace-period to support 'scale down each instance as soon as possible'

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -91,7 +91,7 @@ func validateWindows(annotations map[string]string) *apis.FieldError {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			errs = apis.ErrInvalidValue(v, WindowAnnotationKey)
-		} else if d < WindowMin || d > WindowMax {
+		} else if (d < WindowMin || d > WindowMax) && d != 0 { // We allow StableWindow and ScaleToZeroGracePeriod to be zero to "scale down each instance as soon as possible" (see issue #4589)
 			errs = apis.ErrOutOfBoundsValue(v, WindowMin, WindowMax, WindowAnnotationKey)
 		}
 	}

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -70,6 +70,9 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		name:        "minScale is 2, maxScale is 5",
 		annotations: map[string]string{MinScaleAnnotationKey: "2", MaxScaleAnnotationKey: "5"},
 	}, {
+		name:        "window is zero",
+		annotations: map[string]string{WindowAnnotationKey: "0s"},
+	}, {
 		name:        "minScale is 5, maxScale is 2",
 		annotations: map[string]string{MinScaleAnnotationKey: "5", MaxScaleAnnotationKey: "2"},
 		expectErr:   "maxScale=2 is less than minScale=5: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -23,7 +23,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/serving/pkg/apis/autoscaling"


### PR DESCRIPTION
/lint

Fixes #4589. 

## Proposed Changes

* Currently, we don't allow zero values for `stable-window` and `scale-to-zero-grace-period`. This PR lifts up those restrictions, so that users can use zero values to indicate "I want to scale down as soon as possible".

**Release Note**
```release-note
NONE
```

/cc @greghaynes 