### PR TITLE
Reduce the possible minimal grace period.

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -161,8 +161,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 }
 
 func validate(lc *Config) (*Config, error) {
-	if lc.ScaleToZeroGracePeriod < 30*time.Second {
-		return nil, fmt.Errorf("scale-to-zero-grace-period must be at least 30s, got %v", lc.ScaleToZeroGracePeriod)
+	if lc.ScaleToZeroGracePeriod < autoscaling.WindowMin {
+		return nil, fmt.Errorf("scale-to-zero-grace-period must be at least %v, got %v", autoscaling.WindowMin, lc.ScaleToZeroGracePeriod)
 	}
 	if lc.TargetBurstCapacity < 0 && lc.TargetBurstCapacity != -1 {
 		return nil, fmt.Errorf("target-burst-capacity must be non-negative, got %f", lc.TargetBurstCapacity)


### PR DESCRIPTION
With the latest changes we've done to the scale to zero behavior, especially in the face of the
Activator being in the path for TBC work, it is possible to have quite short Grace windows.
This change permits it to be as small as minimal window.
Due to the network delays, the default value is recommended to be kept as is at 30s, unless you know what you're doing.

This should help everyone who wants faster shutdowns, though.

For #4453

/assign @jonjohnsonjr 