### PR TITLE
Use sets.String in hosts and gateways & reduce number of matches in VirtualServices

### DIFF
--- a/pkg/reconciler/ingress/config/store_test.go
+++ b/pkg/reconciler/ingress/config/store_test.go
@@ -57,12 +57,12 @@ func TestStoreImmutableConfig(t *testing.T) {
 
 	config := store.Load()
 
-	config.Istio.IngressGateways = []Gateway{{GatewayName: "mutated", ServiceURL: "mutated"}}
+	config.Istio.IngressGateways = []Gateway{{Name: "mutated", ServiceURL: "mutated"}}
 	config.Network.HTTPProtocol = network.HTTPRedirected
 
 	newConfig := store.Load()
 
-	if newConfig.Istio.IngressGateways[0].GatewayName == "mutated" {
+	if newConfig.Istio.IngressGateways[0].Name == "mutated" {
 		t.Error("Istio config is not immutable")
 	}
 	if newConfig.Network.HTTPProtocol == network.HTTPRedirected {

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -217,24 +217,17 @@ func MakeHTTPServer(httpProtocol network.HTTPProtocol, hosts []string) *v1alpha3
 	return server
 }
 
-// GatewayServiceNamespace returns the namespace of the gateway service that the `Gateway` object
-// with name `gatewayName` is associated with.
-func GatewayServiceNamespace(ingressGateways []config.Gateway, gatewayName string) (string, error) {
-	for _, gw := range ingressGateways {
-		if gw.GatewayName != gatewayName {
-			continue
-		}
-		// serviceURL should be of the form serviceName.namespace.<domain>, for example
-		// serviceName.namespace.svc.cluster.local.
-		parts := strings.SplitN(gw.ServiceURL, ".", 3)
-		if len(parts) != 3 {
-			return "", fmt.Errorf("unexpected service URL form: %s", gw.ServiceURL)
-		}
-		return parts[1], nil
+// ServiceNamespaceFromURL extracts the namespace part from the service URL.
+// TODO(nghia):  Remove this by parsing at config parsing time.
+func ServiceNamespaceFromURL(svc string) (string, error) {
+	parts := strings.SplitN(svc, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("unexpected service URL form: %s", svc)
 	}
-	return "", fmt.Errorf("no Gateway configuration is found for gateway %s", gatewayName)
+	return parts[1], nil
 }
 
+// TODO(nghia):  Remove this by parsing at config parsing time.
 func getIngressGatewaySvcNameNamespaces(ctx context.Context) ([]metav1.ObjectMeta, error) {
 	cfg := config.FromContext(ctx).Istio
 	nameNamespaces := make([]metav1.ObjectMeta, len(cfg.IngressGateways))

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -270,45 +270,6 @@ func TestMakeHTTPServer(t *testing.T) {
 	}
 }
 
-func TestGatewayServiceNamespace(t *testing.T) {
-	cases := []struct {
-		name            string
-		ingressGateways []config.Gateway
-		gatewayName     string
-		expected        string
-		wantErr         bool
-	}{{
-		name: "Gateway service exists.",
-		ingressGateways: []config.Gateway{{
-			GatewayName: "test-gateway",
-			ServiceURL:  "istio-ingressgateway.istio-system.svc.cluster.local",
-		}},
-		gatewayName: "test-gateway",
-		expected:    "istio-system",
-		wantErr:     false,
-	}, {
-		name: "Gateway service does not exists.",
-		ingressGateways: []config.Gateway{{
-			GatewayName: "test-gateway",
-			ServiceURL:  "istio-ingressgateway.istio-system.svc.cluster.local",
-		}},
-		gatewayName: "non-exist-gateway",
-		wantErr:     true,
-	}}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			gatewayServiceNamespace, err := GatewayServiceNamespace(c.ingressGateways, c.gatewayName)
-			if (err != nil) != c.wantErr {
-				t.Fatalf("Test: %s; GatewayServiceNamespace error = %v, WantErr %v", c.name, err, c.wantErr)
-			}
-
-			if diff := cmp.Diff(c.expected, gatewayServiceNamespace); diff != "" {
-				t.Errorf("Unexpected gateway service namespace (-want, +got): %v", diff)
-			}
-		})
-	}
-}
-
 func TestUpdateGateway(t *testing.T) {
 	cases := []struct {
 		name            string
@@ -613,8 +574,8 @@ func TestMakeIngressGateways(t *testing.T) {
 		ctx := config.ToContext(context.Background(), &config.Config{
 			Istio: &config.Istio{
 				IngressGateways: []config.Gateway{{
-					GatewayName: "knative-ingress-gateway",
-					ServiceURL:  fmt.Sprintf("%s.%s.svc.cluster.local", c.gatewayService.Name, c.gatewayService.Namespace),
+					Name:       "knative-ingress-gateway",
+					ServiceURL: fmt.Sprintf("%s.%s.svc.cluster.local", c.gatewayService.Name, c.gatewayService.Namespace),
 				}},
 			},
 			Network: &network.Config{

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -110,7 +110,7 @@ func TestMakeSecrets(t *testing.T) {
 	ctx = config.ToContext(ctx, &config.Config{
 		Istio: &config.Istio{
 			IngressGateways: []config.Gateway{{
-				GatewayName: "test-gateway",
+				Name: "test-gateway",
 				// The namespace of Istio gateway service is istio-system.
 				ServiceURL: "istio-ingressgateway.istio-system.svc.cluster.local",
 			}},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Attempt to make sure VirtualServices have deterministic values in `gateways` and `host` which are currently `[]string`, as well as reducing the foot-print of Envoy routes.

## Proposed Changes

* Use sets.String for `hosts` and `gateways` for consistent ordering.
* Use a single regexp match for `.svc.cluster.local` VirtualService rule.
* Remove some stutters and dead code.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
