### PR TITLE
golang format tools

### DIFF
--- a/pkg/activator/revision_backends_test.go
+++ b/pkg/activator/revision_backends_test.go
@@ -281,7 +281,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			Body: queue.Name,
 		}},
 		expectDests: map[RevisionID][]string{
-			RevisionID{Namespace: "test-namespace", Name: "test-revision"}: []string{"128.0.0.1:1234"},
+			{Namespace: "test-namespace", Name: "test-revision"}: {"128.0.0.1:1234"},
 		},
 		updateCnt: 2,
 	}, {
@@ -329,8 +329,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			Body: queue.Name,
 		}},
 		expectDests: map[RevisionID][]string{
-			RevisionID{Namespace: "test-namespace", Name: "test-revision1"}: []string{"128.0.0.1:1234"},
-			RevisionID{Namespace: "test-namespace", Name: "test-revision2"}: []string{"128.0.0.2:1234"},
+			{Namespace: "test-namespace", Name: "test-revision1"}: {"128.0.0.1:1234"},
+			{Namespace: "test-namespace", Name: "test-revision2"}: {"128.0.0.2:1234"},
 		},
 		updateCnt: 2,
 	}} {

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -18,9 +18,10 @@ package metric
 
 import (
 	"context"
+	"testing"
+
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/serving/pkg/autoscaler"
-	"testing"
 
 	"github.com/pkg/errors"
 

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -19,6 +19,7 @@ package route
 import (
 	"context"
 	"encoding/json"
+
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/test/e2e/route_service_test.go
+++ b/test/e2e/route_service_test.go
@@ -21,13 +21,13 @@ package e2e
 import (
 	"testing"
 
+	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
-	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
-	"knative.dev/pkg/test/logstream"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	. "knative.dev/serving/pkg/testing/v1alpha1"
+	"knative.dev/serving/test"
+	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
 // TestRoutesNotReady tests the scenario that when Route's status is
@@ -52,7 +52,7 @@ func TestRoutesNotReady(t *testing.T) {
 		Traffic: []v1alpha1.TrafficTarget{
 			{
 				TrafficTarget: v1beta1.TrafficTarget{
-					RevisionName: "foobar",  // Invalid revision name. This allows Revision creation to succeed and Route configuration to fail
+					RevisionName: "foobar", // Invalid revision name. This allows Revision creation to succeed and Route configuration to fail
 					Percent:      100,
 				},
 			},

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/mattbaird/jsonpatch"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,7 +34,6 @@ import (
 	"knative.dev/pkg/test/logging"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
-	corev1 "k8s.io/api/core/v1"
 
 	ptest "knative.dev/pkg/test"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
