### PR TITLE
Fix race condition in revision backends test.

### DIFF
--- a/pkg/activator/revision_backends_test.go
+++ b/pkg/activator/revision_backends_test.go
@@ -182,8 +182,6 @@ func TestRevisionWatcher(t *testing.T) {
 			rt := network.RoundTripperFunc(fakeRt.RT)
 
 			updateCh := make(chan *RevisionDestsUpdate, 100)
-			defer close(updateCh)
-
 			tickerCh := make(chan time.Time, 1)
 			defer close(tickerCh)
 
@@ -351,8 +349,6 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			controller.StartInformers(stopCh, endpointsInformer.Informer())
 
 			updateCh := make(chan *RevisionDestsUpdate, 100)
-			defer close(updateCh)
-
 			bm := NewRevisionBackendsManagerWithProbeFrequency(updateCh, rt, endpointsInformer, TestLogger(t), 50*time.Millisecond)
 			defer bm.Clear()
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Seen in https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/4962/pull-knative-serving-unit-tests/1155877920204394497

You don't actually need to close this channel though. Channels only need to be closed if the close is an actual signal. The garbage collector will take care of them otherwise.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @greghaynes 
