### PR TITLE
Fix the test termination race with logger

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -199,10 +199,12 @@ func TestStats(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			closeCh := make(chan struct{})
+			defer ClearAll()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
 			s, cr := newTestStats(t, fakeClock{})
 			go func() {
-				cr.Run(closeCh)
+				cr.Run(stopCh)
 			}()
 
 			// Apply request operations


### PR DESCRIPTION
Need to clean the test logger.
I've seen this fail in: https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/4965/pull-knative-serving-unit-tests/1155972938344697862/build-log.txt

/assign @mattmoor @markusthoemmes
