### PR TITLE
Remove 404 retry logic in E2E tests

### DIFF
--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -74,10 +73,6 @@ func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, 
 // - 404 until the route is propagated to the proxy
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
-		if resp.StatusCode == http.StatusNotFound {
-			return false, nil
-		}
-
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -120,10 +119,6 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
 // - 404 until the route is propagated to the proxy
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
-		if resp.StatusCode == http.StatusNotFound {
-			return false, nil
-		}
-
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3312.

## Proposed Changes
Since https://github.com/knative/serving/pull/4734, there is no need to ignore the HTTP 404 coming from the VirtualService not being applied yet.
 
* Remove 404 check in RetryingRouteInconsistency
* Keep RetryingRouteInconsistency around in case it is needed in the future

Some tests started failing allowing us to find a bug in Route controller #5056.

