### PR TITLE
Increase Istio resource quotas in *-lean scenarios.

### DIFF
--- a/third_party/istio-1.1.7/istio-lean.yaml
+++ b/third_party/istio-1.1.7/istio-lean.yaml
@@ -731,11 +731,11 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 2000m
-              memory: 1024Mi
+              cpu: 3000m
+              memory: 2048Mi
             requests:
-              cpu: 100m
-              memory: 128Mi
+              cpu: 3000m
+              memory: 2048Mi
 
           env:
           - name: POD_NAME
@@ -915,8 +915,8 @@ spec:
             value: "1"
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 3000m
+              memory: 2048Mi
 
           volumeMounts:
           - name: config-volume

--- a/third_party/istio-1.1.7/values-lean.yaml
+++ b/third_party/istio-1.1.7/values-lean.yaml
@@ -20,6 +20,13 @@ gateways:
       enabled: true
     autoscaleMin: 1
     autoscaleMax: 1
+    resources:
+      limits:
+        cpu: 3000m
+        memory: 2048Mi
+      requests:
+        cpu: 3000m
+        memory: 2048Mi
     ports:
     - name: status-port
       port: 15020
@@ -77,8 +84,8 @@ pilot:
   sidecar: false
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 3000m
+      memory: 2048Mi
 
 galley:
   enabled: false

--- a/third_party/istio-1.2.0/istio-lean.yaml
+++ b/third_party/istio-1.2.0/istio-lean.yaml
@@ -672,11 +672,11 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 2000m
-              memory: 1024Mi
+              cpu: 3000m
+              memory: 2048Mi
             requests:
-              cpu: 100m
-              memory: 128Mi
+              cpu: 3000m
+              memory: 2048Mi
 
           env:
           - name: NODE_NAME
@@ -861,8 +861,8 @@ spec:
             value: "1"
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 3000m
+              memory: 2048Mi
 
           volumeMounts:
           - name: config-volume

--- a/third_party/istio-1.2.0/values-lean.yaml
+++ b/third_party/istio-1.2.0/values-lean.yaml
@@ -21,6 +21,13 @@ gateways:
       enabled: true
     autoscaleMin: 1
     autoscaleMax: 1
+    resources:
+      limits:
+        cpu: 3000m
+        memory: 2048Mi
+      requests:
+        cpu: 3000m
+        memory: 2048Mi
     ports:
     - name: status-port
       port: 15020
@@ -78,8 +85,8 @@ pilot:
   sidecar: false
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 3000m
+      memory: 2048Mi
 
 galley:
   enabled: false


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This was originally part of https://github.com/knative/serving/pull/4927 and later removed when it was though to not be needed anymore because of https://github.com/knative/serving/pull/4950. But 503 are still happening in the *-lean scenarios.

## Proposed Changes
* Increase Istio resource quotas in *-lean scenarios

/assign tcnghia