### PR TITLE
Get PodScalable informer from context like all the others.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -120,10 +120,9 @@ func main() {
 	// uniScalerFactory depends endpointsInformer to be set.
 	multiScaler := autoscaler.NewMultiScaler(ctx.Done(), uniScalerFactoryFunc(endpointsInformer, collector), logger)
 
-	psInformerFactory := resources.NewPodScalableInformerFactory(ctx)
 	controllers := []*controller.Impl{
-		kpa.NewController(ctx, cmw, multiScaler, psInformerFactory),
-		hpa.NewController(ctx, cmw, psInformerFactory),
+		kpa.NewController(ctx, cmw, multiScaler),
+		hpa.NewController(ctx, cmw),
 		metric.NewController(ctx, cmw, collector),
 	}
 

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -19,7 +19,6 @@ package hpa
 import (
 	"context"
 
-	"knative.dev/pkg/apis/duck"
 	hpainformer "knative.dev/pkg/injection/informers/kubeinformers/autoscalingv2beta1/hpa"
 	serviceinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/service"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
@@ -34,6 +33,7 @@ import (
 	"knative.dev/serving/pkg/reconciler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
+	presources "knative.dev/serving/pkg/resources"
 )
 
 const (
@@ -44,7 +44,6 @@ const (
 func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
-	psInformerFactory duck.InformerFactory,
 ) *controller.Impl {
 
 	paInformer := painformer.Get(ctx)
@@ -60,7 +59,7 @@ func NewController(
 			SKSLister:         sksInformer.Lister(),
 			ServiceLister:     serviceInformer.Lister(),
 			MetricLister:      metricInformer.Lister(),
-			PSInformerFactory: psInformerFactory,
+			PSInformerFactory: presources.NewPodScalableInformerFactory(ctx),
 		},
 		hpaLister: hpaInformer.Lister(),
 	}

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -63,16 +63,13 @@ const (
 
 func TestControllerCanReconcile(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
-
-	psFactory := presources.NewPodScalableInformerFactory(ctx)
-
 	ctl := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
 			Name:      autoscaler.ConfigName,
 		},
 		Data: map[string]string{},
-	}), psFactory)
+	}))
 
 	podAutoscaler := pa(testNamespace, testRevision, WithHPAClass)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(podAutoscaler)

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -19,7 +19,6 @@ package kpa
 import (
 	"context"
 
-	"knative.dev/pkg/apis/duck"
 	endpointsinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/endpoints"
 	serviceinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/service"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
@@ -35,6 +34,7 @@ import (
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa/resources"
+	presources "knative.dev/serving/pkg/resources"
 )
 
 const controllerAgentName = "kpa-class-podautoscaler-controller"
@@ -45,7 +45,6 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	deciders resources.Deciders,
-	psInformerFactory duck.InformerFactory,
 ) *controller.Impl {
 
 	paInformer := painformer.Get(ctx)
@@ -53,6 +52,7 @@ func NewController(
 	serviceInformer := serviceinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 	metricInformer := metricinformer.Get(ctx)
+	psInformerFactory := presources.NewPodScalableInformerFactory(ctx)
 
 	c := &Reconciler{
 		Base: &areconciler.Base{

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -945,7 +945,7 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	watcher := &configmap.ManualWatcher{Namespace: system.Namespace()}
 
 	fakeDeciders := newTestDeciders()
-	ctl := NewController(ctx, watcher, fakeDeciders, presources.NewPodScalableInformerFactory(ctx))
+	ctl := NewController(ctx, watcher, fakeDeciders)
 
 	// Load default config
 	watcher.OnChange(&corev1.ConfigMap{
@@ -1015,7 +1015,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
 	fakeDeciders := newTestDeciders()
-	ctl := NewController(ctx, newConfigWatcher(), fakeDeciders, presources.NewPodScalableInformerFactory(ctx))
+	ctl := NewController(ctx, newConfigWatcher(), fakeDeciders)
 
 	rev := newTestRevision(testNamespace, testRevision)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
@@ -1082,7 +1082,7 @@ func TestUpdate(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
 	fakeDeciders := newTestDeciders()
-	ctl := NewController(ctx, newConfigWatcher(), fakeDeciders, presources.NewPodScalableInformerFactory(ctx))
+	ctl := NewController(ctx, newConfigWatcher(), fakeDeciders)
 
 	rev := newTestRevision(testNamespace, testRevision)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
@@ -1157,7 +1157,7 @@ func TestNoEndpoints(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders(), presources.NewPodScalableInformerFactory(ctx))
+	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders())
 
 	rev := newTestRevision(testNamespace, testRevision)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
@@ -1188,7 +1188,7 @@ func TestEmptyEndpoints(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders(), presources.NewPodScalableInformerFactory(ctx))
+	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders())
 
 	rev := newTestRevision(testNamespace, testRevision)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
@@ -1226,9 +1226,7 @@ func TestControllerCreateError(t *testing.T) {
 		&failingDeciders{
 			getErr:    apierrors.NewNotFound(asv1a1.Resource("Deciders"), key),
 			createErr: want,
-		},
-		presources.NewPodScalableInformerFactory(ctx),
-	)
+		})
 
 	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
@@ -1253,9 +1251,7 @@ func TestControllerUpdateError(t *testing.T) {
 		&failingDeciders{
 			getErr:    apierrors.NewNotFound(asv1a1.Resource("Deciders"), key),
 			createErr: want,
-		},
-		presources.NewPodScalableInformerFactory(ctx),
-	)
+		})
 
 	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
@@ -1279,9 +1275,7 @@ func TestControllerGetError(t *testing.T) {
 	ctl := NewController(ctx, newConfigWatcher(),
 		&failingDeciders{
 			getErr: want,
-		},
-		presources.NewPodScalableInformerFactory(ctx),
-	)
+		})
 
 	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
@@ -1299,7 +1293,7 @@ func TestScaleFailure(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders(), presources.NewPodScalableInformerFactory(ctx))
+	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders())
 
 	// Only put the KPA in the lister, which will prompt failures scaling it.
 	rev := newTestRevision(testNamespace, testRevision)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

A stepping stone towards making the HPA autoscaler a seperate container. This decouples the constructor's of both the KPA and the HPA from any shared resources, making it possible to launch the HPA via sharedmain.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
