### PR TITLE
Deploy the HPA autoscaler as a separate controller.

### DIFF
--- a/cmd/autoscaler-hpa/main.go
+++ b/cmd/autoscaler-hpa/main.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	// The set of controllers this controller process runs.
+	"knative.dev/serving/pkg/reconciler/autoscaling/hpa"
+
+	// This defines the shared main for injected controllers.
+	"knative.dev/pkg/injection/sharedmain"
+)
+
+func main() {
+	sharedmain.Main("hpaautoscaler", hpa.NewController)
+}

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -39,7 +39,6 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/autoscaler/statserver"
-	"knative.dev/serving/pkg/reconciler/autoscaling/hpa"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa"
 	"knative.dev/serving/pkg/reconciler/metric"
 	"knative.dev/serving/pkg/resources"
@@ -122,7 +121,6 @@ func main() {
 
 	controllers := []*controller.Impl{
 		kpa.NewController(ctx, cmw, multiScaler),
-		hpa.NewController(ctx, cmw),
 		metric.NewController(ctx, cmw, collector),
 	}
 

--- a/config/autoscaler-hpa.yaml
+++ b/config/autoscaler-hpa.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+    autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   replicas: 1
   selector:

--- a/config/autoscaler-hpa.yaml
+++ b/config/autoscaler-hpa.yaml
@@ -1,0 +1,70 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler-hpa
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: autoscaler-hpa
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler-hpa
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: knative.dev/serving/cmd/autoscaler-hpa
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        ports:
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - name: config-logging
+          mountPath: /etc/config-logging
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This has been fairly long in the making. The HPA controller can now act as a reference implementation for a custom autoscaler based on the metrics that the Knative autoscaling system collects and exposes.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The HPA autoscaler now runs in its own container.
```

/assign @vagababov @mattmoor 
