### PR TITLE
Allow empty strings for forwarded header's value in TestMustHaveHeadersSet

### DIFF
--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -132,7 +132,7 @@ var (
 	// token as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6
 	tokenMatcher = regexp.MustCompile(`^[0-9a-zA-Z!#$%&'*+-.^_|~]+$`)
 	// approximation of quoted-string as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6
-	quotedStringMatcher = regexp.MustCompile(`^"[^"]+"$`)
+	quotedStringMatcher = regexp.MustCompile(`^"[^"]*"$`)
 )
 
 func isDelimiter(r rune) bool {


### PR DESCRIPTION
Currently `TestMustHaveHeadersSet` does not allow empty strings in
forwarded header's value, so some value like `proto-version=""` failed
to pass the test.

This patch changes regex check to pass empty strings.

/lint
## Proposed Changes

* Allow empty strings for forwarded header's value in `TestMustHaveHeadersSet`

**Release Note**

```release-note
NONE
```

cc @markusthoemmes 
