### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -18,8 +18,15 @@ package ingress
 
 import (
 	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
 	"go.uber.org/zap/zaptest"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -27,12 +34,6 @@ import (
 	istiolisters "knative.dev/pkg/client/listers/istio/v1alpha3"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/ingress/resources"
-	"log"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"testing"
-	"time"
 )
 
 func TestIsReadyFailures(t *testing.T) {

--- a/test/apicoverage/image/webhook/webhook_server.go
+++ b/test/apicoverage/image/webhook/webhook_server.go
@@ -21,11 +21,11 @@ import (
 	"log"
 	"net/http"
 
-	"knative.dev/test-infra/tools/webhook-apicoverage/resourcetree"
-	"knative.dev/test-infra/tools/webhook-apicoverage/webhook"
 	"knative.dev/pkg/signals"
 	"knative.dev/serving/test/apicoverage/image/common"
 	"knative.dev/serving/test/apicoverage/image/rules"
+	"knative.dev/test-infra/tools/webhook-apicoverage/resourcetree"
+	"knative.dev/test-infra/tools/webhook-apicoverage/webhook"
 )
 
 // SetupWebhookServer builds the necessary webhook configuration, HTTPServer and starts the webhook.

--- a/test/apicoverage/tools/main.go
+++ b/test/apicoverage/tools/main.go
@@ -23,10 +23,10 @@ import (
 	"path"
 	"strings"
 
-	"knative.dev/test-infra/shared/prow"
-	"knative.dev/test-infra/tools/webhook-apicoverage/tools"
 	"knative.dev/serving/test/apicoverage/image/common"
 	"knative.dev/serving/test/apicoverage/image/rules"
+	"knative.dev/test-infra/shared/prow"
+	"knative.dev/test-infra/tools/webhook-apicoverage/tools"
 )
 
 func main() {

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -31,15 +31,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"knative.dev/test-infra/shared/junit"
-	perf "knative.dev/test-infra/shared/performance"
-	"knative.dev/test-infra/shared/testgrid"
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
+	"knative.dev/test-infra/shared/junit"
+	perf "knative.dev/test-infra/shared/performance"
+	"knative.dev/test-infra/shared/testgrid"
 )
 
 // generateTraffic loads the given endpoint with the given concurrency for the given duration.

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -26,15 +26,15 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"knative.dev/test-infra/shared/junit"
-	perf "knative.dev/test-infra/shared/performance"
-	"knative.dev/test-infra/shared/testgrid"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 	ktest "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1a1test "knative.dev/serving/test/v1alpha1"
+	"knative.dev/test-infra/shared/junit"
+	perf "knative.dev/test-infra/shared/performance"
+	"knative.dev/test-infra/shared/testgrid"
 
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/zipkin"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
