### PR TITLE
On every creation of the KPA we try to reconcile decider and fail.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -76,7 +76,9 @@ func New(
 	// accumulate enough data to make conscious decisions.
 	curC, err := podCounter.ReadyCount()
 	if err != nil {
-		return nil, fmt.Errorf("initial pod count failed: %v", err)
+		// This always happens on new revision creation, since decider
+		// is reconciled before SKS has even chance of creating the service/endpoints.
+		curC = 0
 	}
 	var pt *time.Time
 	if curC > 1 {

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -397,8 +397,11 @@ func TestNewFail(t *testing.T) {
 	}
 
 	podCounter := resources.NewScopedEndpointsCounter(kubeInformer.Core().V1().Endpoints().Lister(), testNamespace, deciderSpec.ServiceName)
-	_, err := New(testNamespace, testRevision, metrics, podCounter, deciderSpec, &mockReporter{})
-	if err == nil {
-		t.Error("No endpoints, but still succeeded creating the Autoscaler")
+	a, err := New(testNamespace, testRevision, metrics, podCounter, deciderSpec, &mockReporter{})
+	if err != nil {
+		t.Errorf("No endpoints should succeed, err = %v", err)
+	}
+	if got, want := int(a.maxPanicPods), 0; got != want {
+		t.Errorf("maxPanicPods = %d, want: 0", got)
 	}
 }


### PR DESCRIPTION
Since initially there is no service. Eventually it all works out,
but we fail first round for no reason.

/assign @markusthoemmes @mattmoor

