### PR TITLE
[WIP][DO NOT MERGE] test flaky-test-retryer

### DIFF
--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -45,6 +45,7 @@ const (
 // Also, traffic that targets revisions *directly* will be routed to the correct
 // revision 100% of the time.
 func TestBlueGreenRoute(t *testing.T) {
+	t.Fatalf("force failure to test retryer")
 	t.Parallel()
 	clients := test.Setup(t)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes
flaky-test-retryer is a new bot that will automatically rerun integration tests that failed due to flakiness. This PR breaks a flaky test to see how it responds.
*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
