### PR TITLE
Move definition of concurrency types

### DIFF
--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -32,6 +32,7 @@ import (
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/test/helpers"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -182,7 +183,7 @@ func TestThrottlerActivatorEndpoints(t *testing.T) {
 
 			throttler := getThrottler(
 				defaultMaxConcurrency,
-				revisionLister(testNamespace, testRevision, v1beta1.RevisionContainerConcurrencyType(s.revisionConcurrency)),
+				revisionLister(testNamespace, testRevision, av1alpha1.AutoscalerContainerConcurrencyType(s.revisionConcurrency)),
 				endpoints,
 				sksLister(testNamespace, testRevision),
 				TestLogger(t),
@@ -407,7 +408,7 @@ func TestHelper_ReactToEndpoints(t *testing.T) {
 	}
 }
 
-func revisionLister(namespace, name string, concurrency v1beta1.RevisionContainerConcurrencyType) servinglisters.RevisionLister {
+func revisionLister(namespace, name string, concurrency av1alpha1.AutoscalerContainerConcurrencyType) servinglisters.RevisionLister {
 	rev := &v1alpha1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -23,8 +23,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
 	net "knative.dev/serving/pkg/apis/networking"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
-	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 // +genclient
@@ -58,6 +56,32 @@ var (
 	_ kmeta.OwnerRefable = (*PodAutoscaler)(nil)
 )
 
+// AutoscalerRequestConcurrencyModelType is an enumeration of the
+// concurrency models supported by an Autoscaler.
+// DEPRECATED in favor of AutoscalerContainerConcurrencyType.
+type AutoscalerRequestConcurrencyModelType string
+
+const (
+	// AutoscalerRequestConcurrencyModelSingle guarantees that only one
+	// request will be handled at a time (concurrently) per instance
+	// of Autoscaler Container.
+	AutoscalerRequestConcurrencyModelSingle AutoscalerRequestConcurrencyModelType = "Single"
+	// AutoscalerRequestConcurrencyModelMulti allows more than one request to
+	// be handled at a time (concurrently) per instance of Autoscaler
+	// Container.
+	AutoscalerRequestConcurrencyModelMulti AutoscalerRequestConcurrencyModelType = "Multi"
+)
+
+// AutoscalerContainerConcurrencyType is an integer expressing the maximum number of
+// in-flight (concurrent) requests.
+type AutoscalerContainerConcurrencyType int64
+
+const (
+	// AutoscalerContainerConcurrencyMax is the maximum configurable
+	// container concurrency.
+	AutoscalerContainerConcurrencyMax AutoscalerContainerConcurrencyType = 1000
+)
+
 // PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).
 type PodAutoscalerSpec struct {
 	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
@@ -73,15 +97,15 @@ type PodAutoscalerSpec struct {
 
 	// DeprecatedConcurrencyModel no longer does anything, use ContainerConcurrency.
 	// +optional
-	DeprecatedConcurrencyModel servingv1alpha1.RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
+	DeprecatedConcurrencyModel AutoscalerRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
 
 	// ContainerConcurrency specifies the maximum allowed
-	// in-flight (concurrent) requests per container of the Revision.
+	// in-flight (concurrent) requests per container of the Autoscaler.
 	// Defaults to `0` which means unlimited concurrency.
 	// This field replaces ConcurrencyModel. A value of `1`
 	// is equivalent to `Single` and `0` is equivalent to `Multi`.
 	// +optional
-	ContainerConcurrency servingv1beta1.RevisionContainerConcurrencyType `json:"containerConcurrency,omitempty"`
+	ContainerConcurrency AutoscalerContainerConcurrencyType `json:"containerConcurrency,omitempty"`
 
 	// ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
 	// is responsible for quickly right-sizing.

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -38,8 +38,7 @@ func (rs *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	errs := serving.ValidateNamespacedObjectReference(&rs.ScaleTargetRef).ViaField("scaleTargetRef")
-	errs = errs.Also(rs.ContainerConcurrency.Validate(ctx).
-		ViaField("containerConcurrency"))
+	errs = errs.Also(rs.ContainerConcurrency.Validate(ctx).ViaField("containerConcurrency"))
 	return errs.Also(validateSKSFields(ctx, rs))
 }
 
@@ -70,6 +69,27 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 				metric, pa.Class()),
 			Paths: []string{"annotations[autoscaling.knative.dev/metric]"},
 		}
+	}
+	return nil
+}
+
+// Validate ensures AutoscalerRequestConcurrencyModelType is properly configured.
+func (cm AutoscalerRequestConcurrencyModelType) Validate(ctx context.Context) *apis.FieldError {
+	switch cm {
+	case AutoscalerRequestConcurrencyModelType(""),
+		AutoscalerRequestConcurrencyModelMulti,
+		AutoscalerRequestConcurrencyModelSingle:
+		return nil
+	default:
+		return apis.ErrInvalidValue(cm, apis.CurrentField)
+	}
+}
+
+// Validate implements apis.Validatable.
+func (cc AutoscalerContainerConcurrencyType) Validate(ctx context.Context) *apis.FieldError {
+	if cc < 0 || cc > AutoscalerContainerConcurrencyMax {
+		return apis.ErrOutOfBoundsValue(
+			cc, 0, AutoscalerContainerConcurrencyMax, apis.CurrentField)
 	}
 	return nil
 }

--- a/pkg/apis/serving/v1alpha1/revision_conversion.go
+++ b/pkg/apis/serving/v1alpha1/revision_conversion.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
@@ -46,7 +47,7 @@ func (source *RevisionTemplateSpec) ConvertUp(ctx context.Context, sink *v1beta1
 
 // ConvertUp helps implement apis.Convertible
 func (source *RevisionSpec) ConvertUp(ctx context.Context, sink *v1beta1.RevisionSpec) error {
-	sink.ContainerConcurrency = v1beta1.RevisionContainerConcurrencyType(
+	sink.ContainerConcurrency = av1alpha1.AutoscalerContainerConcurrencyType(
 		source.ContainerConcurrency)
 	if source.TimeoutSeconds != nil {
 		sink.TimeoutSeconds = ptr.Int64(*source.TimeoutSeconds)

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
@@ -42,7 +43,7 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 
 	// When ConcurrencyModel is specified but ContainerConcurrency
 	// is not (0), use the ConcurrencyModel value.
-	if rs.DeprecatedConcurrencyModel == RevisionRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {
+	if rs.DeprecatedConcurrencyModel == av1alpha1.AutoscalerRequestConcurrencyModelSingle && rs.ContainerConcurrency == 0 {
 		rs.ContainerConcurrency = 1
 	}
 

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -91,22 +92,6 @@ const (
 	DeprecatedRevisionServingStateRetired DeprecatedRevisionServingStateType = "Retired"
 )
 
-// RevisionRequestConcurrencyModelType is an enumeration of the
-// concurrency models supported by a Revision.
-// DEPRECATED in favor of RevisionContainerConcurrencyType.
-type RevisionRequestConcurrencyModelType string
-
-const (
-	// RevisionRequestConcurrencyModelSingle guarantees that only one
-	// request will be handled at a time (concurrently) per instance
-	// of Revision Container.
-	RevisionRequestConcurrencyModelSingle RevisionRequestConcurrencyModelType = "Single"
-	// RevisionRequestConcurencyModelMulti allows more than one request to
-	// be handled at a time (concurrently) per instance of Revision
-	// Container.
-	RevisionRequestConcurrencyModelMulti RevisionRequestConcurrencyModelType = "Multi"
-)
-
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
 	v1beta1.RevisionSpec `json:",inline"`
@@ -134,7 +119,7 @@ type RevisionSpec struct {
 	// Revision. Defaults to Multi.
 	// Deprecated in favor of ContainerConcurrency.
 	// +optional
-	DeprecatedConcurrencyModel RevisionRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
+	DeprecatedConcurrencyModel av1alpha1.AutoscalerRequestConcurrencyModelType `json:"concurrencyModel,omitempty"`
 
 	// DeprecatedBuildName optionally holds the name of the Build responsible for
 	// producing the container image for its Revision.

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -92,6 +92,18 @@ const (
 	DeprecatedRevisionServingStateRetired DeprecatedRevisionServingStateType = "Retired"
 )
 
+// RevisionRequestConcurrencyModelType is a type alias to avoid breaking clients.
+type RevisionRequestConcurrencyModelType = av1alpha1.AutoscalerRequestConcurrencyModelType
+
+const (
+	// RevisionRequestConcurrencyModelSingle redefines AutoscalerRequestConcurrencyModelSingle
+	// to avoid breaking clients.
+	RevisionRequestConcurrencyModelSingle = av1alpha1.AutoscalerRequestConcurrencyModelSingle
+	// RevisionRequestConcurrencyModelMulti redefines AutoscalerRequestConcurrencyModelMulti
+	// to avoid breaking clients.
+	RevisionRequestConcurrencyModelMulti = av1alpha1.AutoscalerRequestConcurrencyModelMulti
+)
+
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
 	v1beta1.RevisionSpec `json:",inline"`

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -167,15 +167,3 @@ func (ss DeprecatedRevisionServingStateType) Validate(ctx context.Context) *apis
 		return apis.ErrInvalidValue(ss, apis.CurrentField)
 	}
 }
-
-// Validate ensures RevisionRequestConcurrencyModelType is properly configured.
-func (cm RevisionRequestConcurrencyModelType) Validate(ctx context.Context) *apis.FieldError {
-	switch cm {
-	case RevisionRequestConcurrencyModelType(""),
-		RevisionRequestConcurrencyModelMulti,
-		RevisionRequestConcurrencyModelSingle:
-		return nil
-	default:
-		return apis.ErrInvalidValue(cm, apis.CurrentField)
-	}
-}

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -37,43 +37,6 @@ import (
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
-func TestConcurrencyModelValidation(t *testing.T) {
-	tests := []struct {
-		name string
-		cm   RevisionRequestConcurrencyModelType
-		want *apis.FieldError
-	}{{
-		name: "single",
-		cm:   RevisionRequestConcurrencyModelSingle,
-		want: nil,
-	}, {
-		name: "multi",
-		cm:   RevisionRequestConcurrencyModelMulti,
-		want: nil,
-	}, {
-		name: "empty",
-		cm:   "",
-		want: nil,
-	}, {
-		name: "bogus",
-		cm:   "bogus",
-		want: apis.ErrInvalidValue("bogus", apis.CurrentField),
-	}, {
-		name: "balderdash",
-		cm:   "balderdash",
-		want: apis.ErrInvalidValue("balderdash", apis.CurrentField),
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := test.cm.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("Validate (-want, +got) = %v", diff)
-			}
-		})
-	}
-}
-
 func TestRevisionSpecValidation(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
@@ -76,7 +77,7 @@ func TestConfigurationValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrOutOfBoundsValue(
-			-10, 0, RevisionContainerConcurrencyMax,
+			-10, 0, av1alpha1.AutoscalerContainerConcurrencyMax,
 			"spec.template.spec.containerConcurrency"),
 	}, {
 		name: "valid BYO name",

--- a/pkg/apis/serving/v1beta1/revision_types.go
+++ b/pkg/apis/serving/v1beta1/revision_types.go
@@ -68,6 +68,14 @@ type RevisionTemplateSpec struct {
 	Spec RevisionSpec `json:"spec,omitempty"`
 }
 
+// RevisionContainerConcurrencyType is a type alias to avoid breaking clients.
+type RevisionContainerConcurrencyType = av1alpha1.AutoscalerContainerConcurrencyType
+
+const (
+	// RevisionContainerConcurrencyMax redefines AutoscalerContainerConcurrencyMax to avoid breaking clients.
+	RevisionContainerConcurrencyMax RevisionContainerConcurrencyType = 1000
+)
+
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
 	corev1.PodSpec `json:",inline"`

--- a/pkg/apis/serving/v1beta1/revision_types.go
+++ b/pkg/apis/serving/v1beta1/revision_types.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 )
 
 // +genclient
@@ -67,16 +68,6 @@ type RevisionTemplateSpec struct {
 	Spec RevisionSpec `json:"spec,omitempty"`
 }
 
-// RevisionContainerConcurrencyType is an integer expressing the maximum number of
-// in-flight (concurrent) requests.
-type RevisionContainerConcurrencyType int64
-
-const (
-	// RevisionContainerConcurrencyMax is the maximum configurable
-	// container concurrency.
-	RevisionContainerConcurrencyMax RevisionContainerConcurrencyType = 1000
-)
-
 // RevisionSpec holds the desired state of the Revision (from the client).
 type RevisionSpec struct {
 	corev1.PodSpec `json:",inline"`
@@ -85,7 +76,7 @@ type RevisionSpec struct {
 	// requests per container of the Revision.  Defaults to `0` which means
 	// unlimited concurrency.
 	// +optional
-	ContainerConcurrency RevisionContainerConcurrencyType `json:"containerConcurrency,omitempty"`
+	ContainerConcurrency av1alpha1.AutoscalerContainerConcurrencyType `json:"containerConcurrency,omitempty"`
 
 	// TimeoutSeconds holds the max duration the instance is allowed for
 	// responding to a request.  If unspecified, a system default will

--- a/pkg/apis/serving/v1beta1/revision_validation.go
+++ b/pkg/apis/serving/v1beta1/revision_validation.go
@@ -122,15 +122,6 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 	return errs
 }
 
-// Validate implements apis.Validatable.
-func (cc RevisionContainerConcurrencyType) Validate(ctx context.Context) *apis.FieldError {
-	if cc < 0 || cc > RevisionContainerConcurrencyMax {
-		return apis.ErrOutOfBoundsValue(
-			cc, 0, RevisionContainerConcurrencyMax, apis.CurrentField)
-	}
-	return nil
-}
-
 // Validate implements apis.Validatable
 func (rs *RevisionStatus) Validate(ctx context.Context) *apis.FieldError {
 	return nil

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -27,6 +27,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 
@@ -71,7 +72,7 @@ func TestRevisionValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrOutOfBoundsValue(
-			-10, 0, RevisionContainerConcurrencyMax,
+			-10, 0, av1alpha1.AutoscalerContainerConcurrencyMax,
 			"spec.containerConcurrency"),
 	}}
 
@@ -245,7 +246,7 @@ func TestRevisionLabelAnnotationValidation(t *testing.T) {
 func TestContainerConcurrencyValidation(t *testing.T) {
 	tests := []struct {
 		name string
-		cc   RevisionContainerConcurrencyType
+		cc   av1alpha1.AutoscalerContainerConcurrencyType
 		want *apis.FieldError
 	}{{
 		name: "single",
@@ -262,13 +263,13 @@ func TestContainerConcurrencyValidation(t *testing.T) {
 	}, {
 		name: "invalid container concurrency (too small)",
 		cc:   -1,
-		want: apis.ErrOutOfBoundsValue(-1, 0, RevisionContainerConcurrencyMax,
+		want: apis.ErrOutOfBoundsValue(-1, 0, av1alpha1.AutoscalerContainerConcurrencyMax,
 			apis.CurrentField),
 	}, {
 		name: "invalid container concurrency (too large)",
-		cc:   RevisionContainerConcurrencyMax + 1,
-		want: apis.ErrOutOfBoundsValue(RevisionContainerConcurrencyMax+1,
-			0, RevisionContainerConcurrencyMax, apis.CurrentField),
+		cc:   av1alpha1.AutoscalerContainerConcurrencyMax + 1,
+		want: apis.ErrOutOfBoundsValue(av1alpha1.AutoscalerContainerConcurrencyMax+1,
+			0, av1alpha1.AutoscalerContainerConcurrencyMax, apis.CurrentField),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 
@@ -222,7 +223,7 @@ func TestServiceValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrOutOfBoundsValue(
-			-10, 0, RevisionContainerConcurrencyMax,
+			-10, 0, av1alpha1.AutoscalerContainerConcurrencyMax,
 			"spec.template.spec.containerConcurrency"),
 	}}
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1423,7 +1423,7 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 				Args:       []string{"hello", "world"},
 				WorkingDir: "/tmp",
 			},
-			DeprecatedConcurrencyModel: v1alpha1.RevisionRequestConcurrencyModelSingle,
+			DeprecatedConcurrencyModel: asv1a1.AutoscalerRequestConcurrencyModelSingle,
 		},
 	}
 }

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -346,7 +347,7 @@ func revision(opts ...revisionOption) *v1alpha1.Revision {
 	return revision
 }
 
-func withContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) revisionOption {
+func withContainerConcurrency(cc av1alpha1.AutoscalerContainerConcurrencyType) revisionOption {
 	return func(revision *v1alpha1.Revision) {
 		revision.Spec.ContainerConcurrency = cc
 	}

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -26,7 +26,6 @@ import (
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 // PodAutoscalerOption is an option that can be applied to a PA.
@@ -108,7 +107,7 @@ func WithKPAClass(pa *autoscalingv1alpha1.PodAutoscaler) {
 
 // WithPAContainerConcurrency returns a PodAutoscalerOption which sets
 // the PodAutoscaler containerConcurrency to the provided value.
-func WithPAContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) PodAutoscalerOption {
+func WithPAContainerConcurrency(cc autoscalingv1alpha1.AutoscalerContainerConcurrencyType) PodAutoscalerOption {
 	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Spec.ContainerConcurrency = cc
 	}

--- a/pkg/testing/v1alpha1/configuration.go
+++ b/pkg/testing/v1alpha1/configuration.go
@@ -23,8 +23,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 // ConfigOption enables further configuration of a Configuration.
@@ -42,7 +42,7 @@ func WithConfigOwnersRemoved(cfg *v1alpha1.Configuration) {
 }
 
 // WithConfigContainerConcurrency sets the given Configuration's concurrency.
-func WithConfigContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) ConfigOption {
+func WithConfigContainerConcurrency(cc av1alpha1.AutoscalerContainerConcurrencyType) ConfigOption {
 	return func(cfg *v1alpha1.Configuration) {
 		cfg.Spec.GetTemplate().Spec.ContainerConcurrency = cc
 	}

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 // RevisionOption enables further configuration of a Revision.
@@ -60,7 +60,7 @@ func MarkResourceNotOwned(kind, name string) RevisionOption {
 }
 
 // WithRevContainerConcurrency sets the given Revision's concurrency.
-func WithRevContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) RevisionOption {
+func WithRevContainerConcurrency(cc av1alpha1.AutoscalerContainerConcurrencyType) RevisionOption {
 	return func(rev *v1alpha1.Revision) {
 		rev.Spec.ContainerConcurrency = cc
 	}

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -27,6 +27,7 @@ import (
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/pkg/reconciler/route/domains"
@@ -231,10 +232,10 @@ func WithContainerConcurrency(cc int) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		if s.Spec.DeprecatedRunLatest != nil {
 			s.Spec.DeprecatedRunLatest.Configuration.GetTemplate().Spec.ContainerConcurrency =
-				v1beta1.RevisionContainerConcurrencyType(cc)
+				av1alpha1.AutoscalerContainerConcurrencyType(cc)
 		} else {
 			s.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency =
-				v1beta1.RevisionContainerConcurrencyType(cc)
+				av1alpha1.AutoscalerContainerConcurrencyType(cc)
 		}
 	}
 }

--- a/pkg/testing/v1beta1/service.go
+++ b/pkg/testing/v1beta1/service.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	presources "knative.dev/serving/pkg/resources"
 )
@@ -148,7 +149,7 @@ func WithServiceAccountName(serviceAccountName string) ServiceOption {
 }
 
 // WithContainerConcurrency sets the given Service's concurrency.
-func WithContainerConcurrency(cc v1beta1.RevisionContainerConcurrencyType) ServiceOption {
+func WithContainerConcurrency(cc av1alpha1.AutoscalerContainerConcurrencyType) ServiceOption {
 	return func(svc *v1beta1.Service) {
 		svc.Spec.Template.Spec.ContainerConcurrency = cc
 	}


### PR DESCRIPTION
This is strictly moving constants and updating references to them. I've left the original symbols as type aliases and re-definitions to avoid breaking dependents (e.g. [client](https://github.com/knative/client/blob/b7808b0fa2f578b98c2c566e806cbfff9007ebca/pkg/serving/config_changes.go#L64)).

The motivation for this change is to make it possible for
pkg/apis/serving/... to depend on pkg/apis/autoscaling.

I'd like to migrate our reconcilers to use this pattern:

```go
parent.PropagateChildStatus(child)
```

But having these constants defined in serving means that we can't do
that for the Revision -> Autoscaler relationship. Regardless, this seems
like a better place for these constants to live, since they control the
autoscaler behavior.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
