### PR TITLE
Dump more resources to help debug e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -339,4 +339,8 @@ function dump_extra_cluster_state() {
   kubectl get configurations -o yaml --all-namespaces
   echo ">>> Revisions:"
   kubectl get revisions -o yaml --all-namespaces
+  echo ">>> PodAutoscalers:"
+  kubectl get podautoscalers -o yaml --all-namespaces
+  echo ">>> SKSs:"
+  kubectl get serverlessservices -o yaml --all-namespaces
 }


### PR DESCRIPTION
both SKS and PA are quite useful to see the networking state of the world at the time
of test failure.

/assign @mattmoor


