### PR TITLE
Simple refactor for ResolveConcurrency

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -39,7 +39,7 @@ import (
 
 const controllerAgentName = "kpa-class-podautoscaler-controller"
 
-// NewController returns a new HPA reconcile controller.
+// NewController returns a new KPA reconcile controller.
 // TODO(mattmoor): Fix the signature to adhere to the injection type.
 func NewController(
 	ctx context.Context,

--- a/pkg/reconciler/autoscaling/resources/concurrency.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency.go
@@ -30,7 +30,7 @@ import (
 func ResolveConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) (target float64, total float64) {
 	total = float64(pa.Spec.ContainerConcurrency)
 	// If containerConcurrency is 0 we'll always target the default.
-	if pa.Spec.ContainerConcurrency == 0 {
+	if total == 0 {
 		total = config.ContainerConcurrencyTargetDefault
 	}
 

--- a/pkg/reconciler/autoscaling/resources/concurrency.go
+++ b/pkg/reconciler/autoscaling/resources/concurrency.go
@@ -29,17 +29,16 @@ import (
 // `total` is the maximum possible concurrency that is permitted on the pod.
 func ResolveConcurrency(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) (target float64, total float64) {
 	total = float64(pa.Spec.ContainerConcurrency)
+	// If containerConcurrency is 0 we'll always target the default.
+	if pa.Spec.ContainerConcurrency == 0 {
+		total = config.ContainerConcurrencyTargetDefault
+	}
+
 	tu := config.ContainerConcurrencyTargetFraction
 	if v, ok := pa.TargetUtilization(); ok {
 		tu = v
 	}
 	target = math.Max(1, total*tu)
-
-	// If containerConcurrency is 0 we'll always target the default.
-	if pa.Spec.ContainerConcurrency == 0 {
-		total = config.ContainerConcurrencyTargetDefault
-		target = math.Max(1, total*tu)
-	}
 
 	// Use the target provided via annotation, if applicable.
 	if annotationTarget, ok := pa.Target(); ok {


### PR DESCRIPTION
## Proposed Changes

* Move `Spec.ContainerConcurrency` check ahead. No need to call `target = math.Max(1, total*tu)` twice.
* Typo fix.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
