### PR TITLE
Make operationsPerSecond calculate correctly irrespective of the value of reporterReportingPeriod

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -89,7 +89,8 @@ const (
 	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
 	// started as early as possible while still wanting to give the container some breathing
 	// room to get up and running.
-	aggressivePollInterval  = 25 * time.Millisecond
+	aggressivePollInterval = 25 * time.Millisecond
+	// ReporterReportingPeriod is the interval of time between reporting stats by queue proxy.
 	reporterReportingPeriod = 1 * time.Second
 )
 
@@ -328,7 +329,7 @@ func main() {
 	}
 
 	// Setup reporters and processes to handle stat reporting.
-	promStatReporter, err := queue.NewPrometheusStatsReporter(env.ServingNamespace, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+	promStatReporter, err := queue.NewPrometheusStatsReporter(env.ServingNamespace, env.ServingConfiguration, env.ServingRevision, env.ServingPod, reporterReportingPeriod)
 	if err != nil {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
@@ -345,7 +346,7 @@ func main() {
 
 	reqChan := make(chan queue.ReqEvent, requestCountingQueueLength)
 	defer close(reqChan)
-	reportTicker := time.NewTicker(queue.ReporterReportingPeriod)
+	reportTicker := time.NewTicker(reporterReportingPeriod)
 	defer reportTicker.Stop()
 	queue.NewStats(env.ServingPod, queue.Channels{
 		ReqChan:    reqChan,

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -90,8 +90,8 @@ const (
 	// started as early as possible while still wanting to give the container some breathing
 	// room to get up and running.
 	aggressivePollInterval = 25 * time.Millisecond
-	// ReporterReportingPeriod is the interval of time between reporting stats by queue proxy.
-	reporterReportingPeriod = 1 * time.Second
+	// reportingPeriod is the interval of time between reporting stats by queue proxy.
+	reportingPeriod = 1 * time.Second
 )
 
 var (
@@ -329,7 +329,7 @@ func main() {
 	}
 
 	// Setup reporters and processes to handle stat reporting.
-	promStatReporter, err := queue.NewPrometheusStatsReporter(env.ServingNamespace, env.ServingConfiguration, env.ServingRevision, env.ServingPod, reporterReportingPeriod)
+	promStatReporter, err := queue.NewPrometheusStatsReporter(env.ServingNamespace, env.ServingConfiguration, env.ServingRevision, env.ServingPod, reportingPeriod)
 	if err != nil {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
@@ -346,7 +346,7 @@ func main() {
 
 	reqChan := make(chan queue.ReqEvent, requestCountingQueueLength)
 	defer close(reqChan)
-	reportTicker := time.NewTicker(reporterReportingPeriod)
+	reportTicker := time.NewTicker(reportingPeriod)
 	defer reportTicker.Stop()
 	queue.NewStats(env.ServingPod, queue.Channels{
 		ReqChan:    reqChan,

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -89,7 +89,8 @@ const (
 	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
 	// started as early as possible while still wanting to give the container some breathing
 	// room to get up and running.
-	aggressivePollInterval = 25 * time.Millisecond
+	aggressivePollInterval  = 25 * time.Millisecond
+	reporterReportingPeriod = 1 * time.Second
 )
 
 var (

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -112,10 +112,10 @@ func (r *PrometheusStatsReporter) Report(stat *autoscaler.Stat) error {
 		return errors.New("PrometheusStatsReporter is not initialized yet")
 	}
 
-	operationsPerSecondGV.With(r.labels).Set((stat.RequestCount / (r.reporterReportingPeriod.Seconds())))
-	proxiedOperationsPerSecondGV.With(r.labels).Set((stat.ProxiedRequestCount / (r.reporterReportingPeriod.Seconds())))
-	averageConcurrentRequestsGV.With(r.labels).Set((stat.AverageConcurrentRequests / (r.reporterReportingPeriod.Seconds())))
-	averageProxiedConcurrentRequestsGV.With(r.labels).Set((stat.AverageProxiedConcurrentRequests / (r.reporterReportingPeriod.Seconds())))
+	operationsPerSecondGV.With(r.labels).Set(stat.RequestCount / (r.reporterReportingPeriod.Seconds()))
+	proxiedOperationsPerSecondGV.With(r.labels).Set(stat.ProxiedRequestCount / (r.reporterReportingPeriod.Seconds()))
+	averageConcurrentRequestsGV.With(r.labels).Set(stat.AverageConcurrentRequests / (r.reporterReportingPeriod.Seconds()))
+	averageProxiedConcurrentRequestsGV.With(r.labels).Set(stat.AverageProxiedConcurrentRequests / (r.reporterReportingPeriod.Seconds()))
 
 	return nil
 }

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -112,10 +112,10 @@ func (r *PrometheusStatsReporter) Report(stat *autoscaler.Stat) error {
 		return errors.New("PrometheusStatsReporter is not initialized yet")
 	}
 
-	operationsPerSecondGV.With(r.labels).Set(stat.RequestCount / (r.reporterReportingPeriod.Seconds()))
-	proxiedOperationsPerSecondGV.With(r.labels).Set(stat.ProxiedRequestCount / (r.reporterReportingPeriod.Seconds()))
-	averageConcurrentRequestsGV.With(r.labels).Set(stat.AverageConcurrentRequests / (r.reporterReportingPeriod.Seconds()))
-	averageProxiedConcurrentRequestsGV.With(r.labels).Set(stat.AverageProxiedConcurrentRequests / (r.reporterReportingPeriod.Seconds()))
+	operationsPerSecondGV.With(r.labels).Set(stat.RequestCount / r.reporterReportingPeriod.Seconds())
+	proxiedOperationsPerSecondGV.With(r.labels).Set(stat.ProxiedRequestCount / r.reporterReportingPeriod.Seconds())
+	averageConcurrentRequestsGV.With(r.labels).Set(stat.AverageConcurrentRequests / r.reporterReportingPeriod.Seconds())
+	averageProxiedConcurrentRequestsGV.With(r.labels).Set(stat.AverageProxiedConcurrentRequests / r.reporterReportingPeriod.Seconds())
 
 	return nil
 }

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -112,10 +112,10 @@ func (r *PrometheusStatsReporter) Report(stat *autoscaler.Stat) error {
 		return errors.New("PrometheusStatsReporter is not initialized yet")
 	}
 
-	operationsPerSecondGV.With(r.labels).Set((stat.RequestCount / (float64)(r.reporterReportingPeriod)))
-	proxiedOperationsPerSecondGV.With(r.labels).Set((stat.ProxiedRequestCount / (float64)(r.reporterReportingPeriod)))
-	averageConcurrentRequestsGV.With(r.labels).Set((stat.AverageConcurrentRequests / (float64)(r.reporterReportingPeriod)))
-	averageProxiedConcurrentRequestsGV.With(r.labels).Set((stat.AverageProxiedConcurrentRequests / (float64)(r.reporterReportingPeriod)))
+	operationsPerSecondGV.With(r.labels).Set((stat.RequestCount / (r.reporterReportingPeriod.Seconds())))
+	proxiedOperationsPerSecondGV.With(r.labels).Set((stat.ProxiedRequestCount / (r.reporterReportingPeriod.Seconds())))
+	averageConcurrentRequestsGV.With(r.labels).Set((stat.AverageConcurrentRequests / (r.reporterReportingPeriod.Seconds())))
+	averageProxiedConcurrentRequestsGV.With(r.labels).Set((stat.AverageProxiedConcurrentRequests / (r.reporterReportingPeriod.Seconds())))
 
 	return nil
 }

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -65,14 +65,14 @@ func newGV(n, h string) *prometheus.GaugeVec {
 
 // PrometheusStatsReporter structure represents a prometheus stats reporter.
 type PrometheusStatsReporter struct {
-	initialized             bool
-	labels                  prometheus.Labels
-	handler                 http.Handler
-	reporterReportingPeriod time.Duration // ReporterReportingPeriod is the interval of time between reporting stats by queue proxy.
+	initialized     bool
+	labels          prometheus.Labels
+	handler         http.Handler
+	reportingPeriod time.Duration
 }
 
 // NewPrometheusStatsReporter creates a reporter that collects and reports queue metrics.
-func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporterReportingPeriod time.Duration) (*PrometheusStatsReporter, error) {
+func NewPrometheusStatsReporter(namespace, config, revision, pod string, reportingPeriod time.Duration) (*PrometheusStatsReporter, error) {
 	if namespace == "" {
 		return nil, errors.New("namespace must not be empty")
 	}
@@ -101,8 +101,8 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporte
 			destinationRevLabel:    revision,
 			destinationPodLabel:    pod,
 		},
-		handler:                 promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
-		reporterReportingPeriod: reporterReportingPeriod,
+		handler:         promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		reportingPeriod: reportingPeriod,
 	}, nil
 }
 
@@ -112,10 +112,10 @@ func (r *PrometheusStatsReporter) Report(stat *autoscaler.Stat) error {
 		return errors.New("PrometheusStatsReporter is not initialized yet")
 	}
 
-	operationsPerSecondGV.With(r.labels).Set(stat.RequestCount / r.reporterReportingPeriod.Seconds())
-	proxiedOperationsPerSecondGV.With(r.labels).Set(stat.ProxiedRequestCount / r.reporterReportingPeriod.Seconds())
-	averageConcurrentRequestsGV.With(r.labels).Set(stat.AverageConcurrentRequests / r.reporterReportingPeriod.Seconds())
-	averageProxiedConcurrentRequestsGV.With(r.labels).Set(stat.AverageProxiedConcurrentRequests / r.reporterReportingPeriod.Seconds())
+	operationsPerSecondGV.With(r.labels).Set(stat.RequestCount / r.reportingPeriod.Seconds())
+	proxiedOperationsPerSecondGV.With(r.labels).Set(stat.ProxiedRequestCount / r.reportingPeriod.Seconds())
+	averageConcurrentRequestsGV.With(r.labels).Set(stat.AverageConcurrentRequests / r.reportingPeriod.Seconds())
+	averageProxiedConcurrentRequestsGV.With(r.labels).Set(stat.AverageProxiedConcurrentRequests / r.reportingPeriod.Seconds())
 
 	return nil
 }

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -67,11 +68,11 @@ type PrometheusStatsReporter struct {
 	initialized             bool
 	labels                  prometheus.Labels
 	handler                 http.Handler
-	reporterReportingPeriod int64 // ReporterReportingPeriod is the interval of time between reporting stats by queue proxy.
+	reporterReportingPeriod time.Duration // ReporterReportingPeriod is the interval of time between reporting stats by queue proxy.
 }
 
 // NewPrometheusStatsReporter creates a reporter that collects and reports queue metrics.
-func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporterReportingPeriod int64) (*PrometheusStatsReporter, error) {
+func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporterReportingPeriod time.Duration) (*PrometheusStatsReporter, error) {
 	if namespace == "" {
 		return nil, errors.New("namespace must not be empty")
 	}

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -158,10 +158,6 @@ func TestReporter_WithDifferentReportingPeriods(t *testing.T) {
 	}
 }
 
-func testReportWithDifferentReportingPeriods(t *testing.T, stat *autoscaler.Stat, reqCount, concurrency, proxiedCount, proxiedConcurrency float64, reporterReportingPeriods []time.Duration) {
-
-}
-
 func testReportWithProxiedRequests(t *testing.T, stat *autoscaler.Stat, reqCount, concurrency, proxiedCount, proxiedConcurrency float64, reporterReportingPeriod time.Duration) {
 	t.Helper()
 	reporter, err := NewPrometheusStatsReporter(namespace, config, revision, pod, reporterReportingPeriod)

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -101,43 +101,39 @@ func TestReporterReport(t *testing.T) {
 		expectedAverageConcurrentRequests float64
 		expectedProxiedRequestCount       float64
 		expectedProxiedConcurrency        float64
-	}{
-		{
-			name:                              "Test reporter report with no proxy",
-			reportingPeriod:                   1 * time.Second,
-			autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3},
-			expectedReqCount:                  39,
-			expectedAverageConcurrentRequests: 3,
-			expectedProxiedRequestCount:       0,
-			expectedProxiedConcurrency:        0,
-		},
-		{
-			name:                              "Test reporter report with reportingPeriod as 10s",
-			reportingPeriod:                   10 * time.Second,
-			autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
-			expectedReqCount:                  3.9,
-			expectedAverageConcurrentRequests: 0.3,
-			expectedProxiedRequestCount:       1.5,
-			expectedProxiedConcurrency:        0.2,
-		},
-		{
-			name:                              "Test reporter report with reportingPeriod as 2s",
-			reportingPeriod:                   2 * time.Second,
-			autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
-			expectedReqCount:                  19.5,
-			expectedAverageConcurrentRequests: 1.5,
-			expectedProxiedRequestCount:       7.5,
-			expectedProxiedConcurrency:        1,
-		},
-		{
-			name:                              "Test reporter report with reportingPeriod as 1s",
-			reportingPeriod:                   1 * time.Second,
-			autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
-			expectedReqCount:                  39,
-			expectedAverageConcurrentRequests: 3,
-			expectedProxiedRequestCount:       15,
-			expectedProxiedConcurrency:        2,
-		},
+	}{{
+		name:                              "no proxy requests",
+		reportingPeriod:                   1 * time.Second,
+		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3},
+		expectedReqCount:                  39,
+		expectedAverageConcurrentRequests: 3,
+		expectedProxiedRequestCount:       0,
+		expectedProxiedConcurrency:        0,
+	}, {
+		name:                              "reportingPeriod=10s",
+		reportingPeriod:                   10 * time.Second,
+		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
+		expectedReqCount:                  3.9,
+		expectedAverageConcurrentRequests: 0.3,
+		expectedProxiedRequestCount:       1.5,
+		expectedProxiedConcurrency:        0.2,
+	}, {
+		name:                              "reportingPeriod=2s",
+		reportingPeriod:                   2 * time.Second,
+		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
+		expectedReqCount:                  19.5,
+		expectedAverageConcurrentRequests: 1.5,
+		expectedProxiedRequestCount:       7.5,
+		expectedProxiedConcurrency:        1,
+	}, {
+		name:                              "reportingPeriod=1s",
+		reportingPeriod:                   1 * time.Second,
+		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
+		expectedReqCount:                  39,
+		expectedAverageConcurrentRequests: 3,
+		expectedProxiedRequestCount:       15,
+		expectedProxiedConcurrency:        2,
+	},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2524 

## Proposed Changes

* Make `operationsPerSecondGV` calculate `operations per second` irrespective of the value of `reporterReportingPeriod`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
