### PR TITLE
Fixes to backend watcher for better testing

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -67,8 +67,7 @@ type revisionWatcher struct {
 	rev      types.NamespacedName
 	protocol networking.ProtocolType
 	updateCh chan<- *RevisionDestsUpdate
-	// Stores the podIPs we know of
-	dests []string
+
 	// Stores the state of dests (podIPs) we know about
 	healthStates map[string]bool
 	// Stores whether the service ClusterIP has been seen as healthy
@@ -111,10 +110,6 @@ type destHealth struct {
 	health bool
 }
 
-func (rw *revisionWatcher) revisionReady() bool {
-	return len(rw.dests) > 0
-}
-
 func (rw *revisionWatcher) getK8sPrivateService() (*corev1.Service, error) {
 	selector := labels.SelectorFromSet(map[string]string{
 		serving.RevisionLabelKey:  rw.rev.Name,
@@ -127,7 +122,7 @@ func (rw *revisionWatcher) getK8sPrivateService() (*corev1.Service, error) {
 
 	switch len(svcList) {
 	case 0:
-		return nil, fmt.Errorf("found no private service for revision %q", rw.rev.String())
+		return nil, fmt.Errorf("found no private services for revision %q", rw.rev.String())
 	case 1:
 		return svcList[0], nil
 	default:
@@ -165,16 +160,16 @@ func (rw *revisionWatcher) probeClusterIP(svc *corev1.Service) (bool, string, er
 	return ok, dest, err
 }
 
-func (rw *revisionWatcher) probePodIPs() (map[string]bool, error) {
+func (rw *revisionWatcher) probePodIPs(dests []string) (map[string]bool, error) {
 	// Context used for our probe requests
 	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
 
 	var probeGroup errgroup.Group
-	healthStatesCh := make(chan destHealth, len(rw.dests))
+	healthStatesCh := make(chan destHealth, len(dests))
 
-	for _, dest := range rw.dests {
-		// If the dest is already healthy then save this
+	for _, dest := range dests {
+		// If the dest is already healthy then preserve that.
 		if curHealthy, ok := rw.healthStates[dest]; ok && curHealthy {
 			healthStatesCh <- destHealth{dest, true}
 			continue
@@ -191,7 +186,7 @@ func (rw *revisionWatcher) probePodIPs() (map[string]bool, error) {
 	err := probeGroup.Wait()
 	close(healthStatesCh)
 
-	healthStates := make(map[string]bool, len(rw.dests))
+	healthStates := make(map[string]bool, len(dests))
 	for dh := range healthStatesCh {
 		healthStates[dh.dest] = dh.health
 	}
@@ -201,8 +196,8 @@ func (rw *revisionWatcher) probePodIPs() (map[string]bool, error) {
 
 // checkDests performs probing and potentially sends a dests update. It is
 // assumed this method is not called concurrently.
-func (rw *revisionWatcher) checkDests() {
-	if !rw.revisionReady() {
+func (rw *revisionWatcher) checkDests(dests []string) {
+	if len(dests) == 0 {
 		if rw.clusterIPHealthy {
 			// we have a healthy clusterIP but revision is not ready. We must have scaled down.
 			rw.clusterIPHealthy = false
@@ -237,7 +232,7 @@ func (rw *revisionWatcher) checkDests() {
 		return
 	}
 
-	healthStates, err := rw.probePodIPs()
+	healthStates, err := rw.probePodIPs(dests)
 	if err != nil {
 		rw.logger.Errorw("Failed probing", zap.Error(err))
 		// We dont want to return here as an error still affects health states
@@ -255,17 +250,18 @@ func (rw *revisionWatcher) checkDests() {
 }
 
 func (rw *revisionWatcher) runWithTickCh(tickCh <-chan time.Time) {
+	var dests []string
 	for {
 		select {
-		case dests, ok := <-rw.destsChan:
+		case x, ok := <-rw.destsChan:
 			if !ok {
 				// shutdown
 				return
 			}
-			rw.dests = dests
+			dests = x
 		case <-tickCh:
 		}
-		rw.checkDests()
+		rw.checkDests(dests)
 	}
 }
 
@@ -369,6 +365,7 @@ func (rbm *RevisionBackendsManager) getOrCreateDestsCh(rev types.NamespacedName)
 // endpointsUpdated is a handler function to be used by the Endpoints informer.
 // It updates the endpoints in the RevisionBackendsManager if the hosts changed
 func (rbm *RevisionBackendsManager) endpointsUpdated(newObj interface{}) {
+	rbm.logger.Debugf("Updating Endpoints: %+v", newObj)
 	endpoints := newObj.(*corev1.Endpoints)
 	revID := types.NamespacedName{endpoints.Namespace, endpoints.Labels[serving.RevisionLabelKey]}
 

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -259,7 +259,7 @@ func TestRevisionWatcher(t *testing.T) {
 			}
 			rt := network.RoundTripperFunc(fakeRt.RT)
 
-			updateCh := make(chan *RevisionDestsUpdate, len(tc.ticks))
+			updateCh := make(chan *RevisionDestsUpdate, len(tc.ticks)+1)
 			tickerCh := make(chan time.Time)
 			defer close(tickerCh)
 

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -250,8 +250,8 @@ func TestRevisionWatcher(t *testing.T) {
 		ticks:     []time.Time{time.Now(), time.Now()},
 		updateCnt: 3,
 	}} {
-
 		t.Run(tc.name, func(t *testing.T) {
+			defer ClearAll()
 			fakeRt := activatortest.FakeRoundTripper{
 				ExpectHost:         "test-revision",
 				ProbeHostResponses: tc.probeHostResponses,
@@ -259,8 +259,8 @@ func TestRevisionWatcher(t *testing.T) {
 			}
 			rt := network.RoundTripperFunc(fakeRt.RT)
 
-			updateCh := make(chan *RevisionDestsUpdate, 100)
-			tickerCh := make(chan time.Time, 1)
+			updateCh := make(chan *RevisionDestsUpdate, len(tc.ticks))
+			tickerCh := make(chan time.Time)
 			defer close(tickerCh)
 
 			// This gets cleaned up as part of the test
@@ -300,8 +300,8 @@ func TestRevisionWatcher(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				rw.runWithTickCh(tickerCh)
-				wg.Done()
 			}()
 
 			destsCh <- tc.dests
@@ -321,28 +321,50 @@ func TestRevisionWatcher(t *testing.T) {
 				}
 			}
 
-			// Shutdown run loop
+			// Shutdown run loop.
 			close(destsCh)
 
 			wg.Wait()
 
-			// Auto fill out Rev in expectUpdates
+			// Autofill out Rev in expectUpdates
 			for i, _ := range tc.expectUpdates {
 				tc.expectUpdates[i].Rev = revID
 			}
 
-			if diff := cmp.Diff(tc.expectUpdates, updates); diff != "" {
-				t.Errorf("Got unexpected revision dests updates (-want, +got): %v", diff)
+			if got, want := tc.expectUpdates, updates; !cmp.Equal(got, want) {
+				t.Errorf("revisionDests updates = %v, want: %v, diff (-want, +got):\n %s", got, want, cmp.Diff(want, got))
 			}
 		})
+	}
+}
 
+func ep(revL string, port int32, ips ...string) *corev1.Endpoints {
+	ss := corev1.EndpointSubset{
+		Ports: []corev1.EndpointPort{{
+			Name: networking.ServicePortNameHTTP1,
+			Port: port,
+		}},
+	}
+	for _, ip := range ips {
+		ss.Addresses = append(ss.Addresses, corev1.EndpointAddress{IP: ip})
+	}
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: revL + "-ep",
+			Labels: map[string]string{
+				serving.RevisionUID:       time.Now().Format("150415.000"),
+				networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
+				serving.RevisionLabelKey:  revL,
+			},
+		},
+		Subsets: []corev1.EndpointSubset{ss},
 	}
 }
 
 func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 	for _, tc := range []struct {
 		name               string
-		endpointsArr       []corev1.Endpoints
+		endpointsArr       []*corev1.Endpoints
 		revisions          []*v1alpha1.Revision
 		services           []*corev1.Service
 		probeResponses     []activatortest.FakeResponse
@@ -350,25 +372,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		expectDests        map[types.NamespacedName]RevisionDestsUpdate
 		updateCnt          int
 	}{{
-		name: "Add slow healthy",
-		endpointsArr: []corev1.Endpoints{{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					serving.RevisionUID:       "test",
-					networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
-					serving.RevisionLabelKey:  "test-revision",
-				},
-			},
-			Subsets: []corev1.EndpointSubset{{
-				Addresses: []corev1.EndpointAddress{{
-					IP: "128.0.0.1",
-				}},
-				Ports: []corev1.EndpointPort{{
-					Name: networking.ServicePortNameHTTP1,
-					Port: 1234,
-				}},
-			}},
-		}},
+		name:         "Add slow healthy",
+		endpointsArr: []*corev1.Endpoints{ep("test-revision", 1234, "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision"}),
 		},
@@ -398,86 +403,36 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		updateCnt: 2,
 	}, {
 		name: "Multiple revisions",
-		endpointsArr: []corev1.Endpoints{{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-ep-1",
-				Labels: map[string]string{
-					serving.RevisionUID:       "test1",
-					networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
-					serving.RevisionLabelKey:  "test-revision1",
-				},
-			},
-			Subsets: []corev1.EndpointSubset{{
-				Addresses: []corev1.EndpointAddress{{
-					IP: "128.0.0.1",
-				}},
-				Ports: []corev1.EndpointPort{{
-					Name: networking.ServicePortNameHTTP1,
-					Port: 1234,
-				}},
-			}},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-ep-2",
-				Labels: map[string]string{
-					serving.RevisionUID:       "test2",
-					networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
-					serving.RevisionLabelKey:  "test-revision2",
-				},
-			},
-			Subsets: []corev1.EndpointSubset{{
-				Addresses: []corev1.EndpointAddress{{
-					IP: "128.0.0.2",
-				}},
-				Ports: []corev1.EndpointPort{{
-					Name: networking.ServicePortNameHTTP1,
-					Port: 1234,
-				}},
-			}},
-		}},
+		endpointsArr: []*corev1.Endpoints{
+			ep("test-revision1", 1234, "128.0.0.1"),
+			ep("test-revision2", 1235, "128.1.0.2"),
+		},
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision1"}),
 			revision(types.NamespacedName{"test-namespace", "test-revision2"}),
 		},
 		services: []*corev1.Service{
 			privateSksService(types.NamespacedName{"test-namespace", "test-revision1"}, "129.0.0.1",
-				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
+				[]corev1.ServicePort{{Name: "http", Port: 2345}}),
 			privateSksService(types.NamespacedName{"test-namespace", "test-revision2"}, "129.0.0.2",
-				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
+				[]corev1.ServicePort{{Name: "http", Port: 2345}}),
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
-			"129.0.0.1:1234": []activatortest.FakeResponse{{Err: errors.New("clusterIP transport error")}},
-			"129.0.0.2:1234": []activatortest.FakeResponse{{Err: errors.New("clusterIP transport error")}},
+			"129.0.0.1:2345": []activatortest.FakeResponse{{Err: errors.New("clusterIP transport error")}},
+			"129.0.0.2:2345": []activatortest.FakeResponse{{Err: errors.New("clusterIP transport error")}},
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{
 			types.NamespacedName{Namespace: "test-namespace", Name: "test-revision1"}: RevisionDestsUpdate{
 				Dests: []string{"128.0.0.1:1234"},
 			},
 			types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}: RevisionDestsUpdate{
-				Dests: []string{"128.0.0.2:1234"},
+				Dests: []string{"128.1.0.2:1235"},
 			},
 		},
 		updateCnt: 2,
 	}, {
-		name: "slow podIP then clusterIP",
-		endpointsArr: []corev1.Endpoints{{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					serving.RevisionUID:       "test",
-					networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
-					serving.RevisionLabelKey:  "test-revision",
-				},
-			},
-			Subsets: []corev1.EndpointSubset{{
-				Addresses: []corev1.EndpointAddress{{
-					IP: "128.0.0.1",
-				}},
-				Ports: []corev1.EndpointPort{{
-					Name: networking.ServicePortNameHTTP1,
-					Port: 1234,
-				}},
-			}},
-		}},
+		name:         "slow podIP then clusterIP",
+		endpointsArr: []*corev1.Endpoints{ep("test-revision", 1234, "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision"}),
 		},
@@ -514,6 +469,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 	}} {
 
 		t.Run(tc.name, func(t *testing.T) {
+			defer ClearAll()
 			fakeRt := activatortest.FakeRoundTripper{
 				ExpectHost:         "test-revision",
 				ProbeHostResponses: tc.probeHostResponses,
@@ -531,7 +487,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			revisions := servinginformer.Serving().V1alpha1().Revisions()
 			revisionLister := revisions.Lister()
 
-			// Add the revision were testing
+			// Add the revision we're testing.
 			for _, rev := range tc.revisions {
 				servfake.ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
 				revisions.Informer().GetIndexer().Add(rev)
@@ -552,8 +508,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			defer bm.Clear()
 
 			for _, ep := range tc.endpointsArr {
-				fake.CoreV1().Endpoints("test-namespace").Create(&ep)
-				endpointsInformer.Informer().GetIndexer().Add(&ep)
+				fake.CoreV1().Endpoints("test-namespace").Create(ep)
+				endpointsInformer.Informer().GetIndexer().Add(ep)
 			}
 
 			if tc.updateCnt == 0 {
@@ -578,10 +534,9 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 				tc.expectDests[rev] = destUpdate
 			}
 
-			if diff := cmp.Diff(tc.expectDests, revDests); diff != "" {
-				t.Errorf("Got unexpected revision dests (-want, +got): %v", diff)
+			if got, want := revDests, tc.expectDests; !cmp.Equal(got, want) {
+				t.Errorf("RevisionDests = %v, want: %v, diff(-want,+got):%s\n", got, want, cmp.Diff(want, got))
 			}
 		})
-
 	}
 }

--- a/pkg/activator/testing/roundtripper.go
+++ b/pkg/activator/testing/roundtripper.go
@@ -93,8 +93,8 @@ func (rt *FakeRoundTripper) popResponse(host string) *FakeResponse {
 	rt.responseMux.Lock()
 	defer rt.responseMux.Unlock()
 
-	if _, ok := rt.ProbeHostResponses[host]; ok {
-		resp, responses := popResponseSlice(rt.ProbeHostResponses[host])
+	if v, ok := rt.ProbeHostResponses[host]; ok {
+		resp, responses := popResponseSlice(v)
 		rt.ProbeHostResponses[host] = responses
 		return resp
 	}


### PR DESCRIPTION
- This change mostly tries to avoid panics/races we have in the code right now.
- Also improve the code to generate endpoints, so that it is much shorter.
- Other testing changes, variable ports so we test helpers do what they do.
- Remove `revs` as a member. No need to have more state than we need.

/assign @greghaynes @mattmoor @markusthoemmes 