### PR TITLE
Fix flaky unit test

### DIFF
--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -114,6 +115,12 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 
 	if _, err := servingClient.ServingV1alpha1().Revisions(rev.Namespace).Create(rev); err != nil {
 		t.Errorf("Unexpected error creating revision: %v", err)
+	}
+
+	for i, informer := range informers {
+		if ok := cache.WaitForCacheSync(ctx.Done(), informer.HasSynced); !ok {
+			t.Fatalf("failed to wait for cache at index %d to sync", i)
+		}
 	}
 
 	if _, err := servingClient.ServingV1alpha1().Routes(route.Namespace).Create(route); err != nil {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -407,6 +407,7 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, cl
 		return nil, err
 	}
 	if badTarget != nil && isTargetError {
+		logger.Infof("Marking bad traffic target: %v", badTarget)
 		badTarget.MarkBadTrafficTarget(&r.Status)
 
 		// Traffic targets aren't ready, no need to configure Route.


### PR DESCRIPTION
This waits for informer caches to sync after creating the revision and
before creating the route. By doing this, we can ensure that the
informer will be populated with the revision when we reconcile the
route. If the revision doesn't exist when we reconcile the route, we
currently don't bother tracking the revision via the tracker, so we
never re-reconcile the route once the informer syncs. This feels like
dropping updates, but I'm not sure if this race condition ever happens
in practice.

I also added the log line that helped uncover what was happening.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
