### PR TITLE
Make `percent` *int

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/route_conversion_test.go
@@ -25,6 +25,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
@@ -57,7 +58,7 @@ func TestRouteConversion(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           100,
+						Percent:           ptr.Int64(100),
 					},
 				}},
 			},
@@ -73,7 +74,7 @@ func TestRouteConversion(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "foo-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}},
 					// TODO(mattmoor): Addressable
@@ -94,7 +95,7 @@ func TestRouteConversion(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo-00002",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}},
 			},
@@ -110,7 +111,7 @@ func TestRouteConversion(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "foo-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}},
 					// TODO(mattmoor): Addressable
@@ -131,20 +132,26 @@ func TestRouteConversion(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo-00001",
-						Percent:      90,
+						Percent:      ptr.Int64(90),
 						Tag:          "current",
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo-00002",
-						Percent:      10,
+						Percent:      ptr.Int64(10),
 						Tag:          "candidate",
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           0,
+						Percent:           nil,
 						Tag:               "latest",
+					},
+				}, {
+					TrafficTarget: v1beta1.TrafficTarget{
+						ConfigurationName: "foo",
+						Percent:           ptr.Int64(0),
+						Tag:               "latest2",
 					},
 				}},
 			},
@@ -160,7 +167,7 @@ func TestRouteConversion(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "foo-00001",
-							Percent:      90,
+							Percent:      ptr.Int64(90),
 							Tag:          "current",
 							URL: &apis.URL{
 								Scheme: "http",
@@ -170,7 +177,7 @@ func TestRouteConversion(t *testing.T) {
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "foo-00002",
-							Percent:      10,
+							Percent:      ptr.Int64(10),
 							Tag:          "candidate",
 							URL: &apis.URL{
 								Scheme: "http",
@@ -180,11 +187,21 @@ func TestRouteConversion(t *testing.T) {
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "foo-00003",
-							Percent:      0,
+							Percent:      nil,
 							Tag:          "latest",
 							URL: &apis.URL{
 								Scheme: "http",
 								Host:   "latest.foo.bar",
+							},
+						},
+					}, {
+						TrafficTarget: v1beta1.TrafficTarget{
+							RevisionName: "foo-00003",
+							Percent:      ptr.Int64(0),
+							Tag:          "latest2",
+							URL: &apis.URL{
+								Scheme: "http",
+								Host:   "latest2.foo.bar",
 							},
 						},
 					}},
@@ -207,7 +224,7 @@ func TestRouteConversion(t *testing.T) {
 					DeprecatedName: "candidate",
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 						Tag:          "current",
 					},
 				}},

--- a/pkg/apis/serving/v1alpha1/route_defaults.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults.go
@@ -41,7 +41,7 @@ func (rs *RouteSpec) SetDefaults(ctx context.Context) {
 	if len(rs.Traffic) == 0 && v1beta1.HasDefaultConfigurationName(ctx) {
 		rs.Traffic = []TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
-				Percent:        100,
+				Percent:        ptr.Int64(100),
 				LatestRevision: ptr.Bool(true),
 			},
 		}}

--- a/pkg/apis/serving/v1alpha1/route_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults_test.go
@@ -40,13 +40,13 @@ func TestRouteDefaulting(t *testing.T) {
 					DeprecatedName: "foo",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      50,
+						Percent:      ptr.Int64(50),
 					},
 				}},
 			},
@@ -57,14 +57,14 @@ func TestRouteDefaulting(t *testing.T) {
 					DeprecatedName: "foo",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 						LatestRevision:    ptr.Bool(true),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:            "bar",
 						RevisionName:   "foo",
-						Percent:        50,
+						Percent:        ptr.Int64(50),
 						LatestRevision: ptr.Bool(false),
 					},
 				}},
@@ -79,13 +79,13 @@ func TestRouteDefaulting(t *testing.T) {
 					DeprecatedName: "foo",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      50,
+						Percent:      ptr.Int64(50),
 					},
 				}},
 			},
@@ -96,14 +96,14 @@ func TestRouteDefaulting(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:               "foo",
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 						LatestRevision:    ptr.Bool(true),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:            "bar",
 						RevisionName:   "foo",
-						Percent:        50,
+						Percent:        ptr.Int64(50),
 						LatestRevision: ptr.Bool(false),
 					},
 				}},
@@ -118,14 +118,14 @@ func TestRouteDefaulting(t *testing.T) {
 					DeprecatedName: "foo",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, {
 					DeprecatedName: "baz",
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      50,
+						Percent:      ptr.Int64(50),
 					},
 				}},
 			},
@@ -136,7 +136,7 @@ func TestRouteDefaulting(t *testing.T) {
 					DeprecatedName: "foo",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 						LatestRevision:    ptr.Bool(true),
 					},
 				}, {
@@ -144,7 +144,7 @@ func TestRouteDefaulting(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:            "bar",
 						RevisionName:   "foo",
-						Percent:        50,
+						Percent:        ptr.Int64(50),
 						LatestRevision: ptr.Bool(false),
 					},
 				}},
@@ -159,13 +159,13 @@ func TestRouteDefaulting(t *testing.T) {
 					DeprecatedName: "bar",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      50,
+						Percent:      ptr.Int64(50),
 					},
 				}},
 			},
@@ -176,14 +176,14 @@ func TestRouteDefaulting(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:               "bar",
 						ConfigurationName: "foo",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 						LatestRevision:    ptr.Bool(true),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:            "bar",
 						RevisionName:   "foo",
-						Percent:        50,
+						Percent:        ptr.Int64(50),
 						LatestRevision: ptr.Bool(false),
 					},
 				}},

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -45,12 +45,14 @@ func (rs *RouteSpec) Validate(ctx context.Context) *apis.FieldError {
 	// Track the targets of named TrafficTarget entries (to detect duplicates).
 	trafficMap := make(map[string]diagnostic)
 
-	percentSum := 0
+	percentSum := int64(0)
 	for i, tt := range rs.Traffic {
 		// Delegate to the v1beta1 validation.
 		errs = errs.Also(tt.TrafficTarget.Validate(ctx).ViaFieldIndex("traffic", i))
 
-		percentSum += tt.Percent
+		if tt.Percent != nil {
+			percentSum += *tt.Percent
+		}
 
 		if tt.DeprecatedName != "" && tt.Tag != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("name", "tag").

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -43,7 +44,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}},
 			},
@@ -60,13 +61,13 @@ func TestRouteValidation(t *testing.T) {
 					DeprecatedName: "prod",
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo",
-						Percent:      90,
+						Percent:      ptr.Int64(90),
 					},
 				}, {
 					DeprecatedName: "experiment",
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "bar",
-						Percent:           10,
+						Percent:           ptr.Int64(10),
 					},
 				}},
 			},
@@ -82,7 +83,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					DeprecatedName: "foo",
 					TrafficTarget: v1beta1.TrafficTarget{
-						Percent: 100,
+						Percent: ptr.Int64(100),
 					},
 				}},
 			},
@@ -104,7 +105,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}},
 			},
@@ -123,7 +124,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo",
-						Percent:      90,
+						Percent:      ptr.Int64(90),
 					},
 				}},
 			},
@@ -145,7 +146,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "foo",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}},
 			},
@@ -181,7 +182,7 @@ func TestRouteSpecValidation(t *testing.T) {
 			Traffic: []TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "foo",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				},
 			}},
 		},
@@ -193,13 +194,13 @@ func TestRouteSpecValidation(t *testing.T) {
 				DeprecatedName: "prod",
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "foo",
-					Percent:      90,
+					Percent:      ptr.Int64(90),
 				},
 			}, {
 				DeprecatedName: "experiment",
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: "bar",
-					Percent:           10,
+					Percent:           ptr.Int64(10),
 				},
 			}},
 		},
@@ -214,7 +215,7 @@ func TestRouteSpecValidation(t *testing.T) {
 			Traffic: []TrafficTarget{{
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
-					Percent: 100,
+					Percent: ptr.Int64(100),
 				},
 			}},
 		},
@@ -231,7 +232,7 @@ func TestRouteSpecValidation(t *testing.T) {
 			Traffic: []TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "b@r",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				},
 			}},
 		},
@@ -246,7 +247,7 @@ func TestRouteSpecValidation(t *testing.T) {
 			Traffic: []TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: "f**",
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 			}},
 		},
@@ -262,13 +263,13 @@ func TestRouteSpecValidation(t *testing.T) {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				},
 			}, {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "baz",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				},
 			}},
 		},
@@ -280,13 +281,13 @@ func TestRouteSpecValidation(t *testing.T) {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				},
 			}, {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				},
 			}},
 		},
@@ -298,13 +299,13 @@ func TestRouteSpecValidation(t *testing.T) {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: "bar",
-					Percent:           50,
+					Percent:           ptr.Int64(50),
 				},
 			}, {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: "bar",
-					Percent:           50,
+					Percent:           ptr.Int64(50),
 				},
 			}},
 		},
@@ -315,12 +316,12 @@ func TestRouteSpecValidation(t *testing.T) {
 			Traffic: []TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "bar",
-					Percent:      99,
+					Percent:      ptr.Int64(99),
 				},
 			}, {
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "baz",
-					Percent:      99,
+					Percent:      ptr.Int64(99),
 				},
 			}},
 		},
@@ -336,7 +337,7 @@ func TestRouteSpecValidation(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					Tag:          "foo",
 					RevisionName: "bar",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				},
 			}},
 		},
@@ -348,13 +349,13 @@ func TestRouteSpecValidation(t *testing.T) {
 				DeprecatedName: "foo",
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				},
 			}, {
 				TrafficTarget: v1beta1.TrafficTarget{
 					Tag:          "foo",
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				},
 			}},
 		},
@@ -388,7 +389,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			DeprecatedName: "foo",
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "bar",
-				Percent:      12,
+				Percent:      ptr.Int64(12),
 			},
 		},
 		want: nil,
@@ -398,7 +399,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			DeprecatedName: "baz",
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: "blah",
-				Percent:           37,
+				Percent:           ptr.Int64(37),
 			},
 		},
 		want: nil,
@@ -416,7 +417,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: "booga",
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			},
 		},
 		want: nil,
@@ -437,7 +438,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			DeprecatedName: "foo",
 			TrafficTarget: v1beta1.TrafficTarget{
-				Percent: 100,
+				Percent: ptr.Int64(100),
 			},
 		},
 		want: &apis.FieldError{
@@ -449,7 +450,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "foo",
-				Percent:      -5,
+				Percent:      ptr.Int64(-5),
 			},
 		},
 		want: apis.ErrOutOfBoundsValue(-5, 0, 100, "percent"),
@@ -458,7 +459,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "foo",
-				Percent:      101,
+				Percent:      ptr.Int64(101),
 			},
 		},
 		want: apis.ErrOutOfBoundsValue(101, 0, 100, "percent"),
@@ -467,7 +468,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: "foo",
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 				URL: &apis.URL{
 					Host: "should.not.be.set",
 				},

--- a/pkg/apis/serving/v1alpha1/service_conversion.go
+++ b/pkg/apis/serving/v1alpha1/service_conversion.go
@@ -45,7 +45,7 @@ func (source *ServiceSpec) ConvertUp(ctx context.Context, sink *v1beta1.ServiceS
 	case source.DeprecatedRunLatest != nil:
 		sink.RouteSpec = v1beta1.RouteSpec{
 			Traffic: []v1beta1.TrafficTarget{{
-				Percent:        100,
+				Percent:        ptr.Int64(100),
 				LatestRevision: ptr.Bool(true),
 			}},
 		}
@@ -56,14 +56,14 @@ func (source *ServiceSpec) ConvertUp(ctx context.Context, sink *v1beta1.ServiceS
 			sink.RouteSpec = v1beta1.RouteSpec{
 				Traffic: []v1beta1.TrafficTarget{{
 					RevisionName: source.DeprecatedRelease.Revisions[0],
-					Percent:      100 - source.DeprecatedRelease.RolloutPercent,
+					Percent:      ptr.Int64(int64(100 - source.DeprecatedRelease.RolloutPercent)),
 					Tag:          "current",
 				}, {
 					RevisionName: source.DeprecatedRelease.Revisions[1],
-					Percent:      source.DeprecatedRelease.RolloutPercent,
+					Percent:      ptr.Int64(int64(source.DeprecatedRelease.RolloutPercent)),
 					Tag:          "candidate",
 				}, {
-					Percent:        0,
+					Percent:        nil,
 					Tag:            "latest",
 					LatestRevision: ptr.Bool(true),
 				}},
@@ -72,10 +72,10 @@ func (source *ServiceSpec) ConvertUp(ctx context.Context, sink *v1beta1.ServiceS
 			sink.RouteSpec = v1beta1.RouteSpec{
 				Traffic: []v1beta1.TrafficTarget{{
 					RevisionName: source.DeprecatedRelease.Revisions[0],
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 					Tag:          "current",
 				}, {
-					Percent:        0,
+					Percent:        nil,
 					Tag:            "latest",
 					LatestRevision: ptr.Bool(true),
 				}},
@@ -93,7 +93,7 @@ func (source *ServiceSpec) ConvertUp(ctx context.Context, sink *v1beta1.ServiceS
 		sink.RouteSpec = v1beta1.RouteSpec{
 			Traffic: []v1beta1.TrafficTarget{{
 				RevisionName: source.DeprecatedPinned.RevisionName,
-				Percent:      100,
+				Percent:      ptr.Int64(100),
 			}},
 		}
 		return source.DeprecatedPinned.Configuration.ConvertUp(ctx, &sink.ConfigurationSpec)

--- a/pkg/apis/serving/v1alpha1/service_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/service_conversion_test.go
@@ -87,7 +87,7 @@ func TestServiceConversion(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					}},
@@ -109,7 +109,7 @@ func TestServiceConversion(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							RevisionName:   "foo-00001",
 							LatestRevision: ptr.Bool(true),
 						},
@@ -154,7 +154,7 @@ func TestServiceConversionFromDeprecated(t *testing.T) {
 		RouteStatusFields: RouteStatusFields{
 			Traffic: []TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 					RevisionName: "foo-00001",
 				},
 			}},
@@ -248,7 +248,7 @@ func TestServiceConversionFromDeprecated(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					}},
@@ -341,13 +341,13 @@ func TestServiceConversionFromDeprecated(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "current",
 							RevisionName: "foo-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
 							LatestRevision: ptr.Bool(true),
-							Percent:        0,
+							Percent:        nil,
 						},
 					}},
 				},
@@ -440,19 +440,19 @@ func TestServiceConversionFromDeprecated(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "current",
 							RevisionName: "foo-00001",
-							Percent:      78,
+							Percent:      ptr.Int64(78),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "candidate",
 							RevisionName: "foo-00002",
-							Percent:      22,
+							Percent:      ptr.Int64(22),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
 							LatestRevision: ptr.Bool(true),
-							Percent:        0,
+							Percent:        nil,
 						},
 					}},
 				},
@@ -545,19 +545,19 @@ func TestServiceConversionFromDeprecated(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "current",
 							RevisionName: "foo-00001",
-							Percent:      63,
+							Percent:      ptr.Int64(63),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "candidate",
 							LatestRevision: ptr.Bool(true),
-							Percent:        37,
+							Percent:        ptr.Int64(37),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
 							LatestRevision: ptr.Bool(true),
-							Percent:        0,
+							Percent:        nil,
 						},
 					}},
 				},
@@ -648,7 +648,7 @@ func TestServiceConversionFromDeprecated(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "foo-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}},
 				},

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -47,7 +47,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -142,7 +142,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -265,7 +265,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "asdf",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(false),
 						},
 					}},
@@ -391,21 +391,21 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "current",
-							Percent:        57,
+							Percent:        ptr.Int64(57),
 							RevisionName:   "foo",
 							LatestRevision: ptr.Bool(false),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "candidate",
-							Percent:        43,
+							Percent:        ptr.Int64(43),
 							RevisionName:   "bar",
 							LatestRevision: ptr.Bool(false),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
-							Percent:        0,
+							Percent:        nil,
 							LatestRevision: ptr.Bool(true),
 						},
 					}},
@@ -452,20 +452,20 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "current",
-							Percent:        57,
+							Percent:        ptr.Int64(57),
 							RevisionName:   "foo",
 							LatestRevision: ptr.Bool(false),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "candidate",
-							Percent:        43,
+							Percent:        ptr.Int64(43),
 							LatestRevision: ptr.Bool(true),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
-							Percent:        0,
+							Percent:        nil,
 							LatestRevision: ptr.Bool(true),
 						},
 					}},
@@ -511,14 +511,14 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "current",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							RevisionName:   "foo",
 							LatestRevision: ptr.Bool(false),
 						},
 					}, {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "latest",
-							Percent:        0,
+							Percent:        nil,
 							LatestRevision: ptr.Bool(true),
 						},
 					}},
@@ -608,7 +608,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -644,7 +644,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -696,7 +696,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -722,7 +722,7 @@ func TestServiceDefaulting(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
-							Percent: 100,
+							Percent: ptr.Int64(100),
 						},
 					}},
 				},
@@ -751,7 +751,7 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},

--- a/pkg/apis/serving/v1alpha1/service_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/service_lifecycle_test.go
@@ -26,6 +26,7 @@ import (
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	apitesting "knative.dev/pkg/apis/testing"
+	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -577,12 +578,12 @@ func TestRouteStatusPropagation(t *testing.T) {
 		},
 		Traffic: []TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
-				Percent:      100,
+				Percent:      ptr.Int64(100),
 				RevisionName: "newstuff",
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
-				Percent:      0,
+				Percent:      nil,
 				RevisionName: "oldstuff",
 			},
 		}},

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -1248,7 +1248,7 @@ func getServiceSpec(image string) ServiceSpec {
 			Traffic: []TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
 					LatestRevision: ptr.Bool(true),
-					Percent:        100},
+					Percent:        ptr.Int64(100)},
 			}},
 		},
 	}

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -565,7 +565,7 @@ func TestServiceValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -596,7 +596,7 @@ func TestServiceValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "valid-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}},
 				},
@@ -628,7 +628,7 @@ func TestServiceValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "valid-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}},
 				},
@@ -659,7 +659,7 @@ func TestServiceValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
 							LatestRevision: ptr.Bool(true),
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 						},
 					}},
 				},
@@ -691,7 +691,7 @@ func TestServiceValidation(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						TrafficTarget: v1beta1.TrafficTarget{
-							Percent: 100,
+							Percent: ptr.Int64(100),
 						},
 					}},
 				},

--- a/pkg/apis/serving/v1beta1/route_defaults.go
+++ b/pkg/apis/serving/v1beta1/route_defaults.go
@@ -32,7 +32,7 @@ func (r *Route) SetDefaults(ctx context.Context) {
 func (rs *RouteSpec) SetDefaults(ctx context.Context) {
 	if len(rs.Traffic) == 0 && HasDefaultConfigurationName(ctx) {
 		rs.Traffic = []TrafficTarget{{
-			Percent:        100,
+			Percent:        ptr.Int64(100),
 			LatestRevision: ptr.Bool(true),
 		}}
 	}

--- a/pkg/apis/serving/v1beta1/route_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/route_defaults_test.go
@@ -40,8 +40,61 @@ func TestRouteDefaulting(t *testing.T) {
 		want: &Route{
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
-					Percent:        100,
+					Percent:        ptr.Int64(100),
 					LatestRevision: ptr.Bool(true),
+				}},
+			},
+		},
+		wc: WithDefaultConfigurationName,
+	}, {
+		// Make sure it keeps a 'nil' as a 'nil' and not 'zero'
+		name: "implied zero percent",
+		in: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Percent:        ptr.Int64(100),
+					LatestRevision: ptr.Bool(true),
+				}, {
+					RevisionName: "bar",
+				}},
+			},
+		},
+		want: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Percent:        ptr.Int64(100),
+					LatestRevision: ptr.Bool(true),
+				}, {
+					RevisionName:   "bar",
+					Percent:        nil,
+					LatestRevision: ptr.Bool(false),
+				}},
+			},
+		},
+		wc: WithDefaultConfigurationName,
+	}, {
+		// Just to make sure it doesn't convert a 'zero' into a 'nil'
+		name: "explicit zero percent",
+		in: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Percent:        ptr.Int64(100),
+					LatestRevision: ptr.Bool(true),
+				}, {
+					RevisionName: "bar",
+					Percent:      ptr.Int64(0),
+				}},
+			},
+		},
+		want: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Percent:        ptr.Int64(100),
+					LatestRevision: ptr.Bool(true),
+				}, {
+					RevisionName:   "bar",
+					Percent:        ptr.Int64(0),
+					LatestRevision: ptr.Bool(false),
 				}},
 			},
 		},
@@ -52,13 +105,13 @@ func TestRouteDefaulting(t *testing.T) {
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
 					RevisionName: "foo",
-					Percent:      12,
+					Percent:      ptr.Int64(12),
 				}, {
 					RevisionName: "bar",
-					Percent:      34,
+					Percent:      ptr.Int64(34),
 				}, {
 					ConfigurationName: "baz",
-					Percent:           54,
+					Percent:           ptr.Int64(54),
 				}},
 			},
 		},
@@ -66,15 +119,15 @@ func TestRouteDefaulting(t *testing.T) {
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
 					RevisionName:   "foo",
-					Percent:        12,
+					Percent:        ptr.Int64(12),
 					LatestRevision: ptr.Bool(false),
 				}, {
 					RevisionName:   "bar",
-					Percent:        34,
+					Percent:        ptr.Int64(34),
 					LatestRevision: ptr.Bool(false),
 				}, {
 					ConfigurationName: "baz",
-					Percent:           54,
+					Percent:           ptr.Int64(54),
 					LatestRevision:    ptr.Bool(true),
 				}},
 			},

--- a/pkg/apis/serving/v1beta1/route_types.go
+++ b/pkg/apis/serving/v1beta1/route_types.go
@@ -89,10 +89,17 @@ type TrafficTarget struct {
 	// +optional
 	LatestRevision *bool `json:"latestRevision,omitempty"`
 
-	// Percent specifies percent of the traffic to this Revision or Configuration.
-	// This defaults to zero if unspecified.
+	// Percent indicates that percentage based routing should be used and
+	// the value indicates the percent of traffic that is be routed to this
+	// Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+	// traffic.
+	// If "percent" appears on one or more Traffic Targets then the sum of
+	// all those percent values must equal 100.
+	// If "percent", nor any other routing mechanism is specified, then
+	// the default is that no traffic will be sent to this Revision or
+	// Configuration.
 	// +optional
-	Percent int `json:"percent"`
+	Percent *int64 `json:"percent,omitempty"`
 
 	// URL displays the URL for accessing named traffic targets. URL is displayed in
 	// status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and

--- a/pkg/apis/serving/v1beta1/route_types.go
+++ b/pkg/apis/serving/v1beta1/route_types.go
@@ -97,8 +97,6 @@ type TrafficTarget struct {
 	// - the sum of all percent values must equal 100
 	// - when not specified, the implied value for `percent` is zero for
 	//   that particular Revision or Configuration
-	// If some other routing mechanism is being used then that mechanism
-	// must define its processing rules.
 	// +optional
 	Percent *int64 `json:"percent,omitempty"`
 

--- a/pkg/apis/serving/v1beta1/route_types.go
+++ b/pkg/apis/serving/v1beta1/route_types.go
@@ -93,11 +93,12 @@ type TrafficTarget struct {
 	// the value indicates the percent of traffic that is be routed to this
 	// Revision or Configuration. `0` (zero) mean no traffic, `100` means all
 	// traffic.
-	// If "percent" appears on one or more Traffic Targets then the sum of
-	// all those percent values must equal 100.
-	// If "percent", nor any other routing mechanism is specified, then
-	// the default is that no traffic will be sent to this Revision or
-	// Configuration.
+	// When percentage based routing is being used the follow rules apply:
+	// - the sum of all percent values must equal zero
+	// - when not specified, the implied value for `percent` is zero for
+	//   that particular Revision or Configuration
+	// If some other routing mechanism is being used then that mechanism
+	// must define its processing rules.
 	// +optional
 	Percent *int64 `json:"percent,omitempty"`
 

--- a/pkg/apis/serving/v1beta1/route_types.go
+++ b/pkg/apis/serving/v1beta1/route_types.go
@@ -94,7 +94,7 @@ type TrafficTarget struct {
 	// Revision or Configuration. `0` (zero) mean no traffic, `100` means all
 	// traffic.
 	// When percentage based routing is being used the follow rules apply:
-	// - the sum of all percent values must equal zero
+	// - the sum of all percent values must equal 100
 	// - when not specified, the implied value for `percent` is zero for
 	//   that particular Revision or Configuration
 	// If some other routing mechanism is being used then that mechanism

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -42,7 +42,7 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 	// Track the targets of named TrafficTarget entries (to detect duplicates).
 	trafficMap := make(map[string]int)
 
-	sum := 0
+	sum := int64(0)
 	for i, tt := range traffic {
 		errs = errs.Also(tt.Validate(ctx).ViaIndex(i))
 
@@ -59,7 +59,9 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 		} else {
 			trafficMap[tt.Tag] = i
 		}
-		sum += tt.Percent
+		if tt.Percent != nil {
+			sum += *tt.Percent
+		}
 	}
 
 	if sum != 100 {
@@ -130,9 +132,9 @@ func (tt *TrafficTarget) validateRevisionAndConfiguration(ctx context.Context, e
 
 func (tt *TrafficTarget) validateTrafficPercentage(errs *apis.FieldError) *apis.FieldError {
 	// Check that the traffic Percentage is within bounds.
-	if tt.Percent < 0 || tt.Percent > 100 {
+	if tt.Percent != nil && (*tt.Percent < 0 || *tt.Percent > 100) {
 		errs = errs.Also(apis.ErrOutOfBoundsValue(
-			tt.Percent, 0, 100, "percent"))
+			*tt.Percent, 0, 100, "percent"))
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -39,7 +39,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "valid with revisionName",
 		tt: &TrafficTarget{
 			RevisionName: "bar",
-			Percent:      12,
+			Percent:      ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
 		want: nil,
@@ -48,7 +48,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			Tag:          "foo",
 			RevisionName: "bar",
-			Percent:      12,
+			Percent:      ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
 		want: nil,
@@ -57,7 +57,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			Tag:          "foo",
 			RevisionName: "bar",
-			Percent:      12,
+			Percent:      ptr.Int64(12),
 			URL: &apis.URL{
 				Scheme: "http",
 				Host:   "foo.bar.com",
@@ -70,7 +70,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			Tag:          "foo",
 			RevisionName: "bar",
-			Percent:      12,
+			Percent:      ptr.Int64(12),
 		},
 		wc:   apis.WithinStatus,
 		want: apis.ErrMissingField("url"),
@@ -78,7 +78,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "invalid with bad revisionName",
 		tt: &TrafficTarget{
 			RevisionName: "b ar",
-			Percent:      12,
+			Percent:      ptr.Int64(12),
 		},
 		wc: apis.WithinSpec,
 		want: apis.ErrInvalidKeyName(
@@ -88,7 +88,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			RevisionName:   "bar",
 			LatestRevision: ptr.Bool(false),
-			Percent:        12,
+			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
 		want: nil,
@@ -97,7 +97,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			RevisionName:   "bar",
 			LatestRevision: ptr.Bool(true),
-			Percent:        12,
+			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
 		want: apis.ErrInvalidValue(true, "latestRevision"),
@@ -106,7 +106,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			RevisionName:   "bar",
 			LatestRevision: ptr.Bool(true),
-			Percent:        12,
+			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinStatus,
 		want: nil,
@@ -114,7 +114,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "valid with configurationName",
 		tt: &TrafficTarget{
 			ConfigurationName: "bar",
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
 		want: nil,
@@ -123,7 +123,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			Tag:               "foo",
 			ConfigurationName: "bar",
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
 		want: nil,
@@ -131,7 +131,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "invalid with bad configurationName",
 		tt: &TrafficTarget{
 			ConfigurationName: "b ar",
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc: apis.WithinSpec,
 		want: apis.ErrInvalidKeyName(
@@ -141,7 +141,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			ConfigurationName: "blah",
 			LatestRevision:    ptr.Bool(true),
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
 		want: nil,
@@ -150,7 +150,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		tt: &TrafficTarget{
 			ConfigurationName: "blah",
 			LatestRevision:    ptr.Bool(false),
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
 		want: apis.ErrInvalidValue(false, "latestRevision"),
@@ -158,14 +158,14 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "invalid with configurationName and default configurationName",
 		tt: &TrafficTarget{
 			ConfigurationName: "blah",
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc:   WithDefaultConfigurationName,
 		want: apis.ErrDisallowedFields("configurationName"),
 	}, {
 		name: "valid with only default configurationName",
 		tt: &TrafficTarget{
-			Percent: 37,
+			Percent: ptr.Int64(37),
 		},
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
@@ -175,7 +175,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "valid with default configurationName and latestRevision",
 		tt: &TrafficTarget{
 			LatestRevision: ptr.Bool(true),
-			Percent:        37,
+			Percent:        ptr.Int64(37),
 		},
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
@@ -185,7 +185,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "invalid with default configurationName and latestRevision",
 		tt: &TrafficTarget{
 			LatestRevision: ptr.Bool(false),
-			Percent:        37,
+			Percent:        ptr.Int64(37),
 		},
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
@@ -195,7 +195,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "invalid without revisionName in status",
 		tt: &TrafficTarget{
 			ConfigurationName: "blah",
-			Percent:           37,
+			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinStatus,
 		want: apis.ErrMissingField("revisionName"),
@@ -203,7 +203,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "valid with revisionName and default configurationName",
 		tt: &TrafficTarget{
 			RevisionName: "bar",
-			Percent:      12,
+			Percent:      ptr.Int64(12),
 		},
 		wc:   WithDefaultConfigurationName,
 		want: nil,
@@ -214,10 +214,24 @@ func TestTrafficTargetValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "valid with nil percent",
+		tt: &TrafficTarget{
+			ConfigurationName: "booga",
+			Percent:           nil,
+		},
+		want: nil,
+	}, {
+		name: "valid with zero percent",
+		tt: &TrafficTarget{
+			ConfigurationName: "booga",
+			Percent:           ptr.Int64(0),
+		},
+		want: nil,
+	}, {
 		name: "valid with no name",
 		tt: &TrafficTarget{
 			ConfigurationName: "booga",
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 		},
 		want: nil,
 	}, {
@@ -233,7 +247,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 	}, {
 		name: "invalid with neither",
 		tt: &TrafficTarget{
-			Percent: 100,
+			Percent: ptr.Int64(100),
 		},
 		want: &apis.FieldError{
 			Message: "expected exactly one, got neither",
@@ -243,21 +257,21 @@ func TestTrafficTargetValidation(t *testing.T) {
 		name: "invalid percent too low",
 		tt: &TrafficTarget{
 			RevisionName: "foo",
-			Percent:      -5,
+			Percent:      ptr.Int64(-5),
 		},
 		want: apis.ErrOutOfBoundsValue("-5", "0", "100", "percent"),
 	}, {
 		name: "invalid percent too high",
 		tt: &TrafficTarget{
 			RevisionName: "foo",
-			Percent:      101,
+			Percent:      ptr.Int64(101),
 		},
 		want: apis.ErrOutOfBoundsValue("101", "0", "100", "percent"),
 	}, {
 		name: "disallowed url set",
 		tt: &TrafficTarget{
 			ConfigurationName: "foo",
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 			URL: &apis.URL{
 				Host: "should.not.be.set",
 			},
@@ -296,7 +310,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					Tag:          "bar",
 					RevisionName: "foo",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				}},
 			},
 			Status: RouteStatus{
@@ -304,7 +318,7 @@ func TestRouteValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 						URL: &apis.URL{
 							Scheme: "http",
 							Host:   "bar.blah.com",
@@ -324,11 +338,11 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					Tag:          "prod",
 					RevisionName: "foo",
-					Percent:      90,
+					Percent:      ptr.Int64(90),
 				}, {
 					Tag:               "experiment",
 					ConfigurationName: "bar",
-					Percent:           10,
+					Percent:           ptr.Int64(10),
 				}},
 			},
 		},
@@ -343,7 +357,7 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					Tag:          "bar",
 					RevisionName: "foo",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				}},
 			},
 			Status: RouteStatus{
@@ -351,7 +365,7 @@ func TestRouteValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					}},
 				},
 			},
@@ -371,7 +385,7 @@ func TestRouteValidation(t *testing.T) {
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
 					Tag:     "foo",
-					Percent: 100,
+					Percent: ptr.Int64(100),
 				}},
 			},
 		},
@@ -392,11 +406,11 @@ func TestRouteValidation(t *testing.T) {
 				Traffic: []TrafficTarget{{
 					Tag:          "foo",
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				}, {
 					Tag:          "foo",
 					RevisionName: "bar",
-					Percent:      50,
+					Percent:      ptr.Int64(50),
 				}},
 			},
 		},
@@ -416,7 +430,7 @@ func TestRouteValidation(t *testing.T) {
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
 					RevisionName: "foo",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				}},
 			},
 		},
@@ -433,7 +447,7 @@ func TestRouteValidation(t *testing.T) {
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
 					RevisionName: "foo",
-					Percent:      90,
+					Percent:      ptr.Int64(90),
 				}},
 			},
 		},
@@ -453,7 +467,7 @@ func TestRouteValidation(t *testing.T) {
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
 					RevisionName: "foo",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				}},
 			},
 		},
@@ -479,7 +493,7 @@ func TestRouteLabelValidation(t *testing.T) {
 		Traffic: []TrafficTarget{{
 			Tag:          "bar",
 			RevisionName: "foo",
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		}},
 	}
 	tests := []struct {

--- a/pkg/apis/serving/v1beta1/service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/service_defaults_test.go
@@ -49,7 +49,7 @@ func TestServiceDefaulting(t *testing.T) {
 				},
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					}},
 				},
@@ -91,7 +91,7 @@ func TestServiceDefaulting(t *testing.T) {
 				},
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					}},
 				},
@@ -134,7 +134,7 @@ func TestServiceDefaulting(t *testing.T) {
 				},
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					}},
 				},
@@ -159,11 +159,11 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						Tag:          "current",
 						RevisionName: "foo",
-						Percent:      90,
+						Percent:      ptr.Int64(90),
 					}, {
 						Tag:          "candidate",
 						RevisionName: "bar",
-						Percent:      10,
+						Percent:      ptr.Int64(10),
 					}, {
 						Tag: "latest",
 					}},
@@ -191,12 +191,12 @@ func TestServiceDefaulting(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						Tag:            "current",
 						RevisionName:   "foo",
-						Percent:        90,
+						Percent:        ptr.Int64(90),
 						LatestRevision: ptr.Bool(false),
 					}, {
 						Tag:            "candidate",
 						RevisionName:   "bar",
-						Percent:        10,
+						Percent:        ptr.Int64(10),
 						LatestRevision: ptr.Bool(false),
 					}, {
 						Tag:            "latest",

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -46,7 +46,7 @@ func TestServiceValidation(t *testing.T) {
 	goodRouteSpec := RouteSpec{
 		Traffic: []TrafficTarget{{
 			LatestRevision: ptr.Bool(true),
-			Percent:        100,
+			Percent:        ptr.Int64(100),
 		}},
 	}
 
@@ -65,7 +65,7 @@ func TestServiceValidation(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -144,16 +144,16 @@ func TestServiceValidation(t *testing.T) {
 						Tag:            "current",
 						LatestRevision: ptr.Bool(false),
 						RevisionName:   "valid-00001",
-						Percent:        98,
+						Percent:        ptr.Int64(98),
 					}, {
 						Tag:            "candidate",
 						LatestRevision: ptr.Bool(false),
 						RevisionName:   "valid-00002",
-						Percent:        2,
+						Percent:        ptr.Int64(2),
 					}, {
 						Tag:            "latest",
 						LatestRevision: ptr.Bool(true),
-						Percent:        0,
+						Percent:        nil,
 					}},
 				},
 			},
@@ -171,7 +171,7 @@ func TestServiceValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						ConfigurationName: "valid",
 						LatestRevision:    ptr.Bool(true),
-						Percent:           100,
+						Percent:           ptr.Int64(100),
 					}},
 				},
 			},
@@ -189,7 +189,7 @@ func TestServiceValidation(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						RevisionName:   "valid",
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -217,7 +217,7 @@ func TestServiceValidation(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -268,7 +268,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -292,7 +292,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -322,7 +322,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						RevisionName: "byo-name-foo", // Used it!
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					}},
 				},
 			},
@@ -349,7 +349,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						RevisionName: "byo-name-bar", // Used it!
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					}},
 				},
 			},
@@ -379,7 +379,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						RevisionName: "byo-name-bar", // Leave old.
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					}},
 				},
 			},
@@ -406,7 +406,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						RevisionName: "byo-name-bar", // Used it!
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					}},
 				},
 			},
@@ -436,7 +436,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -463,7 +463,7 @@ func TestImmutableServiceFields(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -516,7 +516,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -545,7 +545,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -574,7 +574,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -583,7 +583,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 					Traffic: []TrafficTarget{{
 						Tag:          "bar",
 						RevisionName: "foo",
-						Percent:      50, URL: &apis.URL{
+						Percent:      ptr.Int64(50), URL: &apis.URL{
 							Scheme: "http",
 							Host:   "foo.bar.com",
 						},
@@ -618,7 +618,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},
@@ -647,7 +647,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 				RouteSpec: RouteSpec{
 					Traffic: []TrafficTarget{{
 						LatestRevision: ptr.Bool(true),
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 					}},
 				},
 			},

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -688,7 +688,7 @@ func getServiceSpec(image string) ServiceSpec {
 		RouteSpec: RouteSpec{
 			Traffic: []TrafficTarget{{
 				LatestRevision: ptr.Bool(true),
-				Percent:        100,
+				Percent:        ptr.Int64(100),
 			}},
 		},
 	}

--- a/pkg/apis/serving/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1beta1/zz_generated.deepcopy.go
@@ -497,6 +497,11 @@ func (in *TrafficTarget) DeepCopyInto(out *TrafficTarget) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Percent != nil {
+		in, out := &in.Percent, &out.Percent
+		*out = new(int64)
+		**out = **in
+	}
 	if in.URL != nil {
 		in, out := &in.URL, &out.URL
 		*out = new(apis.URL)

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/pkg/reconciler"
@@ -226,7 +227,7 @@ func simpleRunLatest(namespace, name, config string) *v1alpha1.Route {
 	return routeWithTraffic(namespace, name, v1alpha1.TrafficTarget{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: config + "-dbnfd",
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	})
 }

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -52,7 +53,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 		[]v1alpha1.TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "test-rev",
-				Percent:      100,
+				Percent:      ptr.Int64(100),
 			},
 		}},
 	)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -93,10 +94,10 @@ func TestReconcileClusterIngress_Update(t *testing.T) {
 	fakeciinformer.Get(ctx).Informer().GetIndexer().Add(updated)
 
 	ci2 := newTestClusterIngress(t, r, func(tc *traffic.Config) {
-		tc.Targets[traffic.DefaultTarget][0].TrafficTarget.Percent = 50
+		tc.Targets[traffic.DefaultTarget][0].TrafficTarget.Percent = ptr.Int64(50)
 		tc.Targets[traffic.DefaultTarget] = append(tc.Targets[traffic.DefaultTarget], traffic.RevisionTarget{
 			TrafficTarget: v1beta1.TrafficTarget{
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 				RevisionName: "revision2",
 			},
 		})
@@ -137,7 +138,7 @@ func TestReconcileTargetRevisions(t *testing.T) {
 			traffic.DefaultTarget: {{
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "revision",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				},
 				Active: true,
 			}}}},
@@ -147,7 +148,7 @@ func TestReconcileTargetRevisions(t *testing.T) {
 			traffic.DefaultTarget: {{
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "inal-revision",
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				},
 				Active: true,
 			}}}},
@@ -176,7 +177,7 @@ func newTestClusterIngress(t *testing.T, r *v1alpha1.Route, trafficOpts ...func(
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "revision",
-				Percent:      100,
+				Percent:      ptr.Int64(100),
 			},
 			Active: true,
 		}}}}

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -194,7 +194,7 @@ func makeIngressRule(domains []string, ns string, isClusterLocal bool, targets t
 	// Optimistically allocate |targets| elements.
 	splits := make([]v1alpha1.IngressBackendSplit, 0, len(targets))
 	for _, t := range targets {
-		if t.Percent == 0 {
+		if t.Percent == nil || *t.Percent == 0 {
 			continue
 		}
 
@@ -206,7 +206,7 @@ func makeIngressRule(domains []string, ns string, isClusterLocal bool, targets t
 				// Otherwise, the serverless services can't guarantee seamless positive handoff.
 				ServicePort: intstr.FromInt(int(networking.ServicePort(t.Protocol))),
 			},
-			Percent: t.Percent,
+			Percent: int(*t.Percent),
 			AppendHeaders: map[string]string{
 				activator.RevisionHeaderName:      t.TrafficTarget.RevisionName,
 				activator.RevisionHeaderNamespace: ns,

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -46,6 +46,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -290,7 +291,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName:      "test-rev",
 				ConfigurationName: "test-config",
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			},
 		}},
 	)
@@ -400,12 +401,12 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		[]v1alpha1.TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: config.Name,
-				Percent:           90,
+				Percent:           ptr.Int64(90),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: rev.Name,
-				Percent:      10,
+				Percent:      ptr.Int64(10),
 			},
 		}},
 	)
@@ -488,13 +489,13 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 		[]v1alpha1.TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: config.Name,
-				Percent:           90,
+				Percent:           ptr.Int64(90),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName:      rev.Name,
 				ConfigurationName: "test-config",
-				Percent:           10,
+				Percent:           ptr.Int64(10),
 			},
 		}},
 	)
@@ -574,40 +575,40 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		[]v1alpha1.TrafficTarget{{
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: "test-config",
-				Percent:           30,
+				Percent:           ptr.Int64(30),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: "test-config",
-				Percent:           20,
+				Percent:           ptr.Int64(20),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "test-rev",
-				Percent:      10,
+				Percent:      ptr.Int64(10),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				RevisionName: "test-rev",
-				Percent:      5,
-			},
-		}, {
-			TrafficTarget: v1beta1.TrafficTarget{
-				Tag:          "test-revision-1",
-				RevisionName: "test-rev",
-				Percent:      10,
+				Percent:      ptr.Int64(5),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "test-revision-1",
 				RevisionName: "test-rev",
-				Percent:      10,
+				Percent:      ptr.Int64(10),
+			},
+		}, {
+			TrafficTarget: v1beta1.TrafficTarget{
+				Tag:          "test-revision-1",
+				RevisionName: "test-rev",
+				Percent:      ptr.Int64(10),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "test-revision-2",
 				RevisionName: "test-rev",
-				Percent:      15,
+				Percent:      ptr.Int64(15),
 			},
 		}},
 	)
@@ -734,13 +735,13 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "foo",
 				RevisionName: "test-rev",
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:               "bar",
 				ConfigurationName: "test-config",
-				Percent:           50,
+				Percent:           ptr.Int64(50),
 			},
 		}},
 	)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -137,7 +137,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "mcd",
 							Active:      true,
@@ -162,7 +162,7 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				})),
@@ -192,7 +192,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "bk",
 							Active:      true,
@@ -220,7 +220,7 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				})),
@@ -253,7 +253,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "tb",
 							Active:      true,
@@ -282,7 +282,7 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				})),
@@ -309,7 +309,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -324,7 +324,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -349,7 +349,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -378,7 +378,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -399,7 +399,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -434,7 +434,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "astrid",
 							Active:      true,
@@ -458,7 +458,7 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				})),
@@ -481,7 +481,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -499,7 +499,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -514,7 +514,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -534,7 +534,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 			cfg("default", "config",
@@ -551,7 +551,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -568,7 +568,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					}),
@@ -591,7 +591,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteFinalizer, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				}), WithRouteLabel("app", "prod")),
@@ -610,7 +610,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active:      true,
 							ServiceName: "my-service",
@@ -627,7 +627,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active:      true,
 							ServiceName: "my-service",
@@ -647,7 +647,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active:      true,
 							ServiceName: "my-service",
@@ -671,7 +671,7 @@ func TestReconcile(t *testing.T) {
 								TrafficTarget: v1beta1.TrafficTarget{
 									// Use the Revision name from the config.
 									RevisionName: "config-00001",
-									Percent:      100,
+									Percent:      ptr.Int64(100),
 								},
 								Active:      true,
 								ServiceName: "my-service",
@@ -696,7 +696,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -715,7 +715,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "daisy",
 							Active:      true,
@@ -731,7 +731,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "daisy",
 							Active:      true,
@@ -752,7 +752,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 			cfg("default", "config",
@@ -771,7 +771,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "magnolia",
 							Active:      true,
@@ -787,7 +787,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "magnolia",
 							Active:      true,
@@ -807,7 +807,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// This is the new config we're making become ready.
 								RevisionName: "config-00002",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "belltown",
 							Active:      true,
@@ -825,7 +825,7 @@ func TestReconcile(t *testing.T) {
 								TrafficTarget: v1beta1.TrafficTarget{
 									// This is the new config we're making become ready.
 									RevisionName: "config-00002",
-									Percent:      100,
+									Percent:      ptr.Int64(100),
 								},
 								ServiceName: "belltown",
 								Active:      true,
@@ -842,7 +842,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00002",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -863,7 +863,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 			cfg("default", "config",
@@ -882,7 +882,7 @@ func TestReconcile(t *testing.T) {
 							// Use the Revision name from the config.
 							TrafficTarget: v1beta1.TrafficTarget{
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "fremont",
 							Active:      true,
@@ -901,7 +901,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// This is the new config we're making become ready.
 								RevisionName: "config-00002",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "wallingford",
 							Active:      true,
@@ -917,7 +917,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00002",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -936,7 +936,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -954,7 +954,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -969,7 +969,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -997,7 +997,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1015,7 +1015,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1030,7 +1030,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1059,7 +1059,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1077,7 +1077,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1092,7 +1092,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1116,7 +1116,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1134,7 +1134,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1149,7 +1149,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1172,7 +1172,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1190,7 +1190,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "magnusson-park",
 							Active:      true,
@@ -1206,7 +1206,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "magnusson-park",
 							Active:      true,
@@ -1225,7 +1225,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "windemere",
 							Active:      true,
@@ -1243,7 +1243,7 @@ func TestReconcile(t *testing.T) {
 								TrafficTarget: v1beta1.TrafficTarget{
 									// Use the Revision name from the config.
 									RevisionName: "config-00001",
-									Percent:      100,
+									Percent:      ptr.Int64(100),
 								},
 								ServiceName: "windemere",
 								Active:      true,
@@ -1265,7 +1265,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "oldconfig-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 			// Both configs exist, but only "oldconfig" is labelled.
@@ -1286,7 +1286,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "oldconfig-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "greenwood",
 							Active:      true,
@@ -1302,7 +1302,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "oldconfig-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "greenwood",
 							Active:      true,
@@ -1322,7 +1322,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "newconfig-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "broadview",
 							Active:      true,
@@ -1341,7 +1341,7 @@ func TestReconcile(t *testing.T) {
 								TrafficTarget: v1beta1.TrafficTarget{
 									// Use the Revision name from the config.
 									RevisionName: "newconfig-00001",
-									Percent:      100,
+									Percent:      ptr.Int64(100),
 								},
 								ServiceName: "broadview",
 								Active:      true,
@@ -1359,7 +1359,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "newconfig-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1419,7 +1419,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1435,7 +1435,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1452,7 +1452,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(false),
 						},
 					})),
@@ -1466,12 +1466,12 @@ func TestReconcile(t *testing.T) {
 				v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "blue",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "green",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}), WithRouteUID("34-78"), WithRouteFinalizer),
 			cfg("default", "blue",
@@ -1487,12 +1487,12 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "green",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}), WithRouteUID("34-78")),
 				&traffic.Config{
@@ -1501,7 +1501,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "blue-00001",
-								Percent:      50,
+								Percent:      ptr.Int64(50),
 							},
 							ServiceName: "blue-ridge",
 							Active:      true,
@@ -1509,7 +1509,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "green-00001",
-								Percent:      50,
+								Percent:      ptr.Int64(50),
 							},
 							ServiceName: "green-lake",
 							Active:      true,
@@ -1523,12 +1523,12 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "green",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}), WithRouteUID("34-78"), WithRouteFinalizer),
 				"",
@@ -1539,12 +1539,12 @@ func TestReconcile(t *testing.T) {
 				WithSpecTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "blue",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						ConfigurationName: "green",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}), WithRouteUID("34-78"),
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -1552,13 +1552,13 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "blue-00001",
-							Percent:        50,
+							Percent:        ptr.Int64(50),
 							LatestRevision: ptr.Bool(true),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "green-00001",
-							Percent:        50,
+							Percent:        ptr.Int64(50),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1577,13 +1577,13 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:               "gray",
 						ConfigurationName: "gray",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          "also-gray",
 						RevisionName: "gray-00001",
-						Percent:      50,
+						Percent:      ptr.Int64(50),
 					},
 				}), WithRouteUID("1-2"), WithRouteFinalizer),
 			cfg("default", "gray",
@@ -1597,13 +1597,13 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:               "gray",
 							ConfigurationName: "gray",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "also-gray",
 							RevisionName: "gray-00001",
-							Percent:      50,
+							Percent:      ptr.Int64(50),
 						},
 					}), WithRouteUID("1-2")),
 				&traffic.Config{
@@ -1612,7 +1612,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "gray-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "shades",
 							Active:      true,
@@ -1621,7 +1621,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "gray-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "shades",
 							Active:      true,
@@ -1630,7 +1630,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "gray-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "shades",
 							Active:      true,
@@ -1645,13 +1645,13 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:               "gray",
 							ConfigurationName: "gray",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "also-gray",
 							RevisionName: "gray-00001",
-							Percent:      50,
+							Percent:      ptr.Int64(50),
 						},
 					}), WithRouteUID("1-2"), WithRouteFinalizer),
 				"",
@@ -1663,13 +1663,13 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:               "gray",
 							ConfigurationName: "gray",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "also-gray",
 							RevisionName: "gray-00001",
-							Percent:      50,
+							Percent:      ptr.Int64(50),
 						},
 					}), WithRouteUID("1-2"), WithRouteFinalizer),
 				"also-gray",
@@ -1681,13 +1681,13 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:               "gray",
 							ConfigurationName: "gray",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "also-gray",
 							RevisionName: "gray-00001",
-							Percent:      50,
+							Percent:      ptr.Int64(50),
 						},
 					}), WithRouteUID("1-2"), WithRouteFinalizer),
 				"gray",
@@ -1699,13 +1699,13 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:               "gray",
 						ConfigurationName: "gray",
-						Percent:           50,
+						Percent:           ptr.Int64(50),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          "also-gray",
 						RevisionName: "gray-00001",
-						Percent:      50,
+						Percent:      ptr.Int64(50),
 					},
 				}), WithRouteUID("1-2"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -1714,7 +1714,7 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "gray",
 							RevisionName:   "gray-00001",
-							Percent:        50,
+							Percent:        ptr.Int64(50),
 							LatestRevision: ptr.Bool(true),
 							URL: &apis.URL{
 								Scheme: "http",
@@ -1725,7 +1725,7 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:            "also-gray",
 							RevisionName:   "gray-00001",
-							Percent:        50,
+							Percent:        ptr.Int64(50),
 							LatestRevision: ptr.Bool(false),
 							URL: &apis.URL{
 								Scheme: "http",
@@ -1753,7 +1753,7 @@ func TestReconcile(t *testing.T) {
 						TrafficTarget: v1beta1.TrafficTarget{
 							Tag:          "blue",
 							RevisionName: "blue-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					}), WithRouteFinalizer),
 			cfg("default", "blue",
@@ -1773,7 +1773,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "blue-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "alki-beach",
 							Active:      true,
@@ -1789,7 +1789,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "blue-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "alki-beach",
 							Active:      true,
@@ -1808,7 +1808,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "green-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "rainier-beach",
 							Active:      true,
@@ -1826,7 +1826,7 @@ func TestReconcile(t *testing.T) {
 								TrafficTarget: v1beta1.TrafficTarget{
 									// Use the Revision name from the config.
 									RevisionName: "green-00001",
-									Percent:      100,
+									Percent:      ptr.Int64(100),
 								},
 								ServiceName: "rainier-beach",
 								Active:      true,
@@ -1843,7 +1843,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "green-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					}), WithRouteFinalizer),
@@ -1861,19 +1861,19 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "green",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}),
 				WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
-							Percent:           100,
+							Percent:           ptr.Int64(100),
 							LatestRevision:    ptr.Bool(true),
 						},
 					},
@@ -1892,7 +1892,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "blue-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1909,19 +1909,19 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}, v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "green",
-							Percent:           50,
+							Percent:           ptr.Int64(50),
 						},
 					}),
 				WithStatusTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							ConfigurationName: "blue",
-							Percent:           100,
+							Percent:           ptr.Int64(100),
 							LatestRevision:    ptr.Bool(true),
 						},
 					})),
@@ -1937,7 +1937,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -1957,7 +1957,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1972,7 +1972,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -1994,7 +1994,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -2014,7 +2014,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -2029,7 +2029,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -2048,7 +2048,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 		},
@@ -2063,7 +2063,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 		},
@@ -2078,7 +2078,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 		},
@@ -2110,7 +2110,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName: "config-00001",
-							Percent:      100,
+							Percent:      ptr.Int64(100),
 						},
 					})),
 		}},
@@ -2126,7 +2126,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -2144,7 +2144,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -2159,7 +2159,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -2196,7 +2196,7 @@ func TestReconcile(t *testing.T) {
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1beta1.TrafficTarget{
 							RevisionName:   "config-00001",
-							Percent:        100,
+							Percent:        ptr.Int64(100),
 							LatestRevision: ptr.Bool(true),
 						},
 					})),
@@ -2214,7 +2214,7 @@ func TestReconcile(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							Active: true,
 						}},
@@ -2286,7 +2286,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "mcd",
 							Active:      true,
@@ -2315,7 +2315,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				}), MarkCertificateNotReady),
@@ -2362,7 +2362,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							TrafficTarget: v1beta1.TrafficTarget{
 								// Use the Revision name from the config.
 								RevisionName: "config-00001",
-								Percent:      100,
+								Percent:      ptr.Int64(100),
 							},
 							ServiceName: "mcd",
 							Active:      true,
@@ -2397,7 +2397,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        100,
+						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
 				}), MarkCertificateReady,

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"knative.dev/pkg/ptr"
 	net "knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -127,7 +128,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: goodConfig.Name,
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 		},
 	}}
 
@@ -137,7 +138,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -147,7 +148,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -170,7 +171,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodNewRev.Name,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	}}
 	expected := &Config{
@@ -179,7 +180,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName:      goodNewRev.Name,
 					ConfigurationName: goodConfig.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -189,7 +190,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -209,7 +210,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: inactiveConfig.Name,
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 		},
 	}}
 	expected := &Config{
@@ -218,7 +219,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: inactiveConfig.Name,
 					RevisionName:      inactiveRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   false,
 				Protocol: net.ProtocolHTTP1,
@@ -228,7 +229,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: inactiveConfig.Name,
 				RevisionName:      inactiveRev.Name,
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			},
 			Active:   false,
 			Protocol: net.ProtocolHTTP1,
@@ -252,12 +253,12 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: niceConfig.Name,
-			Percent:           90,
+			Percent:           ptr.Int64(90),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: goodConfig.Name,
-			Percent:           10,
+			Percent:           ptr.Int64(10),
 		},
 	}}
 	expected := &Config{
@@ -266,7 +267,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
-					Percent:           90,
+					Percent:           ptr.Int64(90),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -274,7 +275,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           10,
+					Percent:           ptr.Int64(10),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -284,7 +285,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
 				RevisionName:      niceNewRev.Name,
-				Percent:           90,
+				Percent:           ptr.Int64(90),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -292,7 +293,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           10,
+				Percent:           ptr.Int64(10),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -318,12 +319,12 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodOldRev.Name,
-			Percent:      90,
+			Percent:      ptr.Int64(90),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: goodConfig.Name,
-			Percent:           10,
+			Percent:           ptr.Int64(10),
 		},
 	}}
 	expected := &Config{
@@ -332,7 +333,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
-					Percent:           90,
+					Percent:           ptr.Int64(90),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -340,7 +341,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           10,
+					Percent:           ptr.Int64(10),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -350,7 +351,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
-				Percent:           90,
+				Percent:           ptr.Int64(90),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -358,7 +359,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           10,
+				Percent:           ptr.Int64(10),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -384,19 +385,19 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:          "one",
 			RevisionName: goodOldRev.Name,
-			Percent:      49,
+			Percent:      ptr.Int64(49),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:          "two",
 			RevisionName: goodNewRev.Name,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:               "also-two",
 			ConfigurationName: goodConfig.Name,
-			Percent:           1,
+			Percent:           ptr.Int64(1),
 		},
 	}}
 	expected := &Config{
@@ -406,7 +407,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Tag:               "one",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
-					Percent:           49,
+					Percent:           ptr.Int64(49),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -415,7 +416,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Tag:               "two",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           51,
+					Percent:           ptr.Int64(51),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -425,7 +426,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Tag:               "one",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -435,7 +436,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Tag:               "two",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -445,7 +446,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					Tag:               "also-two",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -456,7 +457,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Tag:               "one",
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
-				Percent:           49,
+				Percent:           ptr.Int64(49),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -465,7 +466,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Tag:               "two",
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           50,
+				Percent:           ptr.Int64(50),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -474,7 +475,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				Tag:               "also-two",
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           1,
+				Percent:           ptr.Int64(1),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -499,12 +500,12 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodOldRev.Name,
-			Percent:      90,
+			Percent:      ptr.Int64(90),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodNewRev.Name,
-			Percent:      10,
+			Percent:      ptr.Int64(10),
 		},
 	}}
 	expected := &Config{
@@ -513,7 +514,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
-					Percent:           90,
+					Percent:           ptr.Int64(90),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -521,7 +522,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           10,
+					Percent:           ptr.Int64(10),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -531,7 +532,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
-				Percent:           90,
+				Percent:           ptr.Int64(90),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -539,7 +540,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           10,
+				Percent:           ptr.Int64(10),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -564,12 +565,12 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodNewRev.Name,
-			Percent:      40,
+			Percent:      ptr.Int64(40),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: niceNewRev.Name,
-			Percent:      60,
+			Percent:      ptr.Int64(60),
 		},
 	}}
 	expected := &Config{
@@ -578,7 +579,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           40,
+					Percent:           ptr.Int64(40),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -586,7 +587,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
-					Percent:           60,
+					Percent:           ptr.Int64(60),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -596,7 +597,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
-				Percent:           40,
+				Percent:           ptr.Int64(40),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -604,7 +605,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
 				RevisionName:      niceNewRev.Name,
-				Percent:           60,
+				Percent:           ptr.Int64(60),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -630,7 +631,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodOldRev.Name,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
@@ -649,7 +650,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				TrafficTarget: v1beta1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -675,7 +676,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Tag:               "beta",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -685,7 +686,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Tag:               "alpha",
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -695,7 +696,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -737,7 +738,7 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodOldRev.Name,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
@@ -773,7 +774,7 @@ func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: unreadyRev.Name,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	}}
 	expected := &Config{
@@ -794,7 +795,7 @@ func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: unreadyConfig.Name,
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 		},
 	}}
 	expected := &Config{
@@ -815,7 +816,7 @@ func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: emptyConfig.Name,
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 		},
 	}}
 
@@ -840,12 +841,12 @@ func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: emptyConfig.Name,
-			Percent:           50,
+			Percent:           ptr.Int64(50),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: failedConfig.Name,
-			Percent:           50,
+			Percent:           ptr.Int64(50),
 		},
 	}}
 	expected := &Config{
@@ -869,12 +870,12 @@ func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: failedConfig.Name,
-			Percent:           50,
+			Percent:           ptr.Int64(50),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: emptyConfig.Name,
-			Percent:           50,
+			Percent:           ptr.Int64(50),
 		},
 	}}
 	expected := &Config{
@@ -898,12 +899,12 @@ func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: missingRev.Name,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodNewRev.Name,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		},
 	}}
 	expected := &Config{
@@ -924,7 +925,7 @@ func TestRoundTripping(t *testing.T) {
 	tts := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodOldRev.Name,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
@@ -940,7 +941,7 @@ func TestRoundTripping(t *testing.T) {
 	expected := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: goodOldRev.Name,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{

--- a/pkg/reconciler/service/resources/route_test.go
+++ b/pkg/reconciler/service/resources/route_test.go
@@ -52,7 +52,7 @@ func TestRouteRunLatest(t *testing.T) {
 	}
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 			ConfigurationName: testConfigName,
 			LatestRevision:    ptr.Bool(true),
 		},
@@ -95,7 +95,7 @@ func TestRoutePinned(t *testing.T) {
 	}
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
-			Percent:        100,
+			Percent:        ptr.Int64(100),
 			RevisionName:   testRevisionName,
 			LatestRevision: ptr.Bool(false),
 		},
@@ -131,7 +131,7 @@ func TestRouteReleaseSingleRevision(t *testing.T) {
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:            v1alpha1.CurrentTrafficTarget,
-			Percent:        100,
+			Percent:        ptr.Int64(100),
 			RevisionName:   testRevisionName,
 			LatestRevision: ptr.Bool(false),
 		},
@@ -176,14 +176,14 @@ func TestRouteLatestRevisionSplit(t *testing.T) {
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:               v1alpha1.CurrentTrafficTarget,
-			Percent:           currentPercent,
+			Percent:           ptr.Int64(currentPercent),
 			ConfigurationName: testConfigName,
 			LatestRevision:    ptr.Bool(true),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:            v1alpha1.CandidateTrafficTarget,
-			Percent:        rolloutPercent,
+			Percent:        ptr.Int64(rolloutPercent),
 			RevisionName:   "juicy-revision",
 			LatestRevision: ptr.Bool(false),
 		},
@@ -228,14 +228,14 @@ func TestRouteLatestRevisionSplitCandidate(t *testing.T) {
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:            v1alpha1.CurrentTrafficTarget,
-			Percent:        currentPercent,
+			Percent:        ptr.Int64(currentPercent),
 			RevisionName:   "squishy-revision",
 			LatestRevision: ptr.Bool(false),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:               v1alpha1.CandidateTrafficTarget,
-			Percent:           rolloutPercent,
+			Percent:           ptr.Int64(rolloutPercent),
 			ConfigurationName: testConfigName,
 			LatestRevision:    ptr.Bool(true),
 		},
@@ -278,7 +278,7 @@ func TestRouteLatestRevisionNoSplit(t *testing.T) {
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:               v1alpha1.CurrentTrafficTarget,
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 			ConfigurationName: testConfigName,
 			LatestRevision:    ptr.Bool(true),
 		},
@@ -324,14 +324,14 @@ func TestRouteReleaseTwoRevisions(t *testing.T) {
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:            v1alpha1.CurrentTrafficTarget,
-			Percent:        currentPercent,
+			Percent:        ptr.Int64(currentPercent),
 			RevisionName:   testRevisionName,
 			LatestRevision: ptr.Bool(false),
 		},
 	}, {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:            v1alpha1.CandidateTrafficTarget,
-			Percent:        100 - currentPercent,
+			Percent:        ptr.Int64(100 - currentPercent),
 			RevisionName:   testCandidateRevisionName,
 			LatestRevision: ptr.Bool(false),
 		},
@@ -373,7 +373,7 @@ func TestInlineRouteSpec(t *testing.T) {
 	}
 	wantT := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1beta1.TrafficTarget{
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 			ConfigurationName: testConfigName,
 			LatestRevision:    ptr.Bool(true),
 		},

--- a/pkg/reconciler/service/resources/shared_test.go
+++ b/pkg/reconciler/service/resources/shared_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 
@@ -82,7 +83,7 @@ func createServiceInline() *v1alpha1.Service {
 		WithInlineRouteSpec(v1alpha1.RouteSpec{
 			Traffic: []v1alpha1.TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
-					Percent: 100,
+					Percent: ptr.Int64(100),
 				},
 			}},
 		}))

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/pkg/reconciler"
@@ -180,13 +181,13 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "pinned3-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "pinned3-00001",
-						Percent:      0,
+						Percent:      nil,
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 		},
@@ -205,13 +206,13 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "pinned3-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "pinned3-00001",
-						Percent:      0,
+						Percent:      nil,
 					},
 				})),
 		}},
@@ -294,7 +295,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 		},
@@ -307,7 +308,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				})),
 		}},
@@ -333,7 +334,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 		},
@@ -346,7 +347,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				})),
 		}},
@@ -375,12 +376,12 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts-00001",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts-00002",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 		},
@@ -393,12 +394,12 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts-00001",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts-00002",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				})),
 		}},
@@ -428,12 +429,12 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts2-00002",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts2-00003",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 		},
@@ -446,12 +447,12 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts2-00002",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "release-nr-ts2-00003",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				})),
 		}},
@@ -477,7 +478,7 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
@@ -503,7 +504,7 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
@@ -540,13 +541,13 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-lr-00002",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
@@ -573,13 +574,13 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-lr-00001",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-lr-00002",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				}, {
 					TrafficTarget: v1beta1.TrafficTarget{
@@ -616,19 +617,19 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-00001",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-00002",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-00002",
-						Percent:      0,
+						Percent:      nil,
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 			config("release-ready", "foo", WithRunLatestRollout,
@@ -649,19 +650,19 @@ func TestReconcile(t *testing.T) {
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CurrentTrafficTarget,
 						RevisionName: "release-ready-00001",
-						Percent:      42,
+						Percent:      ptr.Int64(42),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.CandidateTrafficTarget,
 						RevisionName: "release-ready-00002",
-						Percent:      58,
+						Percent:      ptr.Int64(58),
 					},
 				}, v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						Tag:          v1alpha1.LatestTrafficTarget,
 						RevisionName: "release-ready-00002",
-						Percent:      0,
+						Percent:      nil,
 					},
 				}),
 			),
@@ -1046,7 +1047,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "all-ready-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 			config("all-ready", "foo", WithRunLatestRollout,
@@ -1063,7 +1064,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "all-ready-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				})),
 		}},
@@ -1091,7 +1092,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "all-ready-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 			config("all-ready", "foo", WithRunLatestRollout,
@@ -1109,7 +1110,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "all-ready-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				})),
 		}},
@@ -1134,7 +1135,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "config-only-ready-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 			config("config-only-ready", "foo", WithRunLatestRollout,
@@ -1150,7 +1151,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "config-only-ready-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				})),
 		}},
@@ -1176,7 +1177,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "config-fails-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 			config("config-fails", "foo", WithRunLatestRollout, WithGeneration(2),
@@ -1190,7 +1191,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "config-fails-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}),
 				WithFailedConfig("config-fails-00002", "RevisionFailed", "blah"),
@@ -1307,7 +1308,7 @@ func TestReconcile(t *testing.T) {
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "new-owner-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				}), MarkTrafficAssigned, MarkIngressReady),
 			config("new-owner", "foo", WithRunLatestRollout, WithGeneration(1), WithObservedGen,
@@ -1323,7 +1324,7 @@ func TestReconcile(t *testing.T) {
 				WithSvcStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1beta1.TrafficTarget{
 						RevisionName: "new-owner-00001",
-						Percent:      100,
+						Percent:      ptr.Int64(100),
 					},
 				})),
 		}},

--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -70,7 +71,7 @@ func WithConfigTarget(config string) RouteOption {
 	return WithSpecTraffic(v1alpha1.TrafficTarget{
 		TrafficTarget: v1beta1.TrafficTarget{
 			ConfigurationName: config,
-			Percent:           100,
+			Percent:           ptr.Int64(100),
 		},
 	})
 }
@@ -80,7 +81,7 @@ func WithRevTarget(revision string) RouteOption {
 	return WithSpecTraffic(v1alpha1.TrafficTarget{
 		TrafficTarget: v1beta1.TrafficTarget{
 			RevisionName: revision,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		},
 	})
 }

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -107,7 +107,7 @@ func WithInlineRollout(s *v1alpha1.Service) {
 		RouteSpec: v1alpha1.RouteSpec{
 			Traffic: []v1alpha1.TrafficTarget{{
 				TrafficTarget: v1beta1.TrafficTarget{
-					Percent: 100,
+					Percent: ptr.Int64(100),
 				},
 			}},
 		},

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -93,13 +94,13 @@ func TestBlueGreenRoute(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          blue.TrafficTarget,
 				RevisionName: blue.Revision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          green.TrafficTarget,
 				RevisionName: green.Revision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}},
 	}); err != nil {

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -166,13 +167,13 @@ func TestRevisionTimeout(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          rev2s.TrafficTarget,
 				RevisionName: rev2s.Revision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          rev5s.TrafficTarget,
 				RevisionName: rev5s.Revision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}},
 	}); err != nil {

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -286,12 +286,12 @@ func TestReleaseService(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "current",
 				RevisionName: firstRevision,
-				Percent:      100,
+				Percent:      ptr.Int64(100),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:     "latest",
-				Percent: 0,
+				Percent: nil,
 			},
 		}},
 	})
@@ -304,7 +304,7 @@ func TestReleaseService(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:            "current",
 				RevisionName:   objects.Config.Status.LatestReadyRevisionName,
-				Percent:        100,
+				Percent:        ptr.Int64(100),
 				LatestRevision: ptr.Bool(false),
 			},
 		},
@@ -371,18 +371,18 @@ func TestReleaseService(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "current",
 				RevisionName: firstRevision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "candidate",
 				RevisionName: secondRevision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:     "latest",
-				Percent: 0,
+				Percent: nil,
 			},
 		}},
 	})
@@ -395,7 +395,7 @@ func TestReleaseService(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:            "current",
 				RevisionName:   firstRevision,
-				Percent:        50,
+				Percent:        ptr.Int64(50),
 				LatestRevision: ptr.Bool(false),
 			},
 		},
@@ -403,7 +403,7 @@ func TestReleaseService(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:            "candidate",
 				RevisionName:   secondRevision,
-				Percent:        50,
+				Percent:        ptr.Int64(50),
 				LatestRevision: ptr.Bool(false),
 			},
 		},
@@ -469,17 +469,17 @@ func TestReleaseService(t *testing.T) {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:          "current",
 				RevisionName: firstRevision,
-				Percent:      50,
+				Percent:      ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:     "candidate",
-				Percent: 50,
+				Percent: ptr.Int64(50),
 			},
 		}, {
 			TrafficTarget: v1beta1.TrafficTarget{
 				Tag:     "latest",
-				Percent: 0,
+				Percent: nil,
 			},
 		}},
 	})
@@ -497,7 +497,7 @@ func TestReleaseService(t *testing.T) {
 		TrafficTarget: v1beta1.TrafficTarget{
 			Tag:            "candidate",
 			RevisionName:   thirdRevision,
-			Percent:        50,
+			Percent:        ptr.Int64(50),
 			LatestRevision: ptr.Bool(true),
 		},
 	}

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/test"
@@ -92,11 +93,11 @@ func TestBlueGreenRoute(t *testing.T) {
 		Traffic: []v1beta1.TrafficTarget{{
 			Tag:          blue.TrafficTarget,
 			RevisionName: blue.Revision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}, {
 			Tag:          green.TrafficTarget,
 			RevisionName: green.Revision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
 		t.Fatalf("Failed to update Service: %v", err)

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
@@ -164,11 +165,11 @@ func TestRevisionTimeout(t *testing.T) {
 		Traffic: []v1beta1.TrafficTarget{{
 			Tag:          rev2s.TrafficTarget,
 			RevisionName: rev2s.Revision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}, {
 			Tag:          rev5s.TrafficTarget,
 			RevisionName: rev5s.Revision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
 		t.Fatalf("Failed to update Service: %v", err)

--- a/test/conformance/api/v1beta1/service_test.go
+++ b/test/conformance/api/v1beta1/service_test.go
@@ -285,10 +285,10 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Traffic: []v1beta1.TrafficTarget{{
 			Tag:          "current",
 			RevisionName: firstRevision,
-			Percent:      100,
+			Percent:      ptr.Int64(100),
 		}, {
 			Tag:     "latest",
-			Percent: 0,
+			Percent: nil,
 		}},
 	})
 	if err != nil {
@@ -299,7 +299,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		"current": {
 			Tag:            "current",
 			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
-			Percent:        100,
+			Percent:        ptr.Int64(100),
 			LatestRevision: ptr.Bool(false),
 		},
 		"latest": {
@@ -360,14 +360,14 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Traffic: []v1beta1.TrafficTarget{{
 			Tag:          "current",
 			RevisionName: firstRevision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}, {
 			Tag:          "candidate",
 			RevisionName: secondRevision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}, {
 			Tag:     "latest",
-			Percent: 0,
+			Percent: nil,
 		}},
 	})
 	if err != nil {
@@ -378,13 +378,13 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		"current": {
 			Tag:            "current",
 			RevisionName:   firstRevision,
-			Percent:        50,
+			Percent:        ptr.Int64(50),
 			LatestRevision: ptr.Bool(false),
 		},
 		"candidate": {
 			Tag:            "candidate",
 			RevisionName:   secondRevision,
-			Percent:        50,
+			Percent:        ptr.Int64(50),
 			LatestRevision: ptr.Bool(false),
 		},
 		"latest": {
@@ -444,13 +444,13 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Traffic: []v1beta1.TrafficTarget{{
 			Tag:          "current",
 			RevisionName: firstRevision,
-			Percent:      50,
+			Percent:      ptr.Int64(50),
 		}, {
 			Tag:     "candidate",
-			Percent: 50,
+			Percent: ptr.Int64(50),
 		}, {
 			Tag:     "latest",
-			Percent: 0,
+			Percent: nil,
 		}},
 	})
 	if err != nil {
@@ -466,7 +466,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	desiredTrafficShape["candidate"] = v1beta1.TrafficTarget{
 		Tag:            "candidate",
 		RevisionName:   thirdRevision,
-		Percent:        50,
+		Percent:        ptr.Int64(50),
 		LatestRevision: ptr.Bool(true),
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")

--- a/test/e2e/route_service_test.go
+++ b/test/e2e/route_service_test.go
@@ -21,6 +21,7 @@ package e2e
 import (
 	"testing"
 
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -53,7 +54,7 @@ func TestRoutesNotReady(t *testing.T) {
 			{
 				TrafficTarget: v1beta1.TrafficTarget{
 					RevisionName: "foobar", // Invalid revision name. This allows Revision creation to succeed and Route configuration to fail
-					Percent:      100,
+					Percent:      ptr.Int64(100),
 				},
 			},
 		},

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
@@ -68,7 +69,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 			{
 				TrafficTarget: v1beta1.TrafficTarget{
 					Tag:     tag,
-					Percent: 100,
+					Percent: ptr.Int64(100),
 				},
 			},
 		},
@@ -116,7 +117,7 @@ func TestSubrouteVisibilityChange(t *testing.T) {
 			{
 				TrafficTarget: v1beta1.TrafficTarget{
 					Tag:     tag,
-					Percent: 100,
+					Percent: ptr.Int64(100),
 				},
 			},
 		},

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -49,7 +50,7 @@ func Route(names test.ResourceNames, fopt ...v1alpha1testing.RouteOption) *v1alp
 				TrafficTarget: v1beta1.TrafficTarget{
 					Tag:               names.TrafficTarget,
 					ConfigurationName: names.Config,
-					Percent:           100,
+					Percent:           ptr.Int64(100),
 				},
 			}},
 		},
@@ -134,7 +135,7 @@ func IsRouteNotReady(r *v1alpha1.Route) (bool, error) {
 func AllRouteTrafficAtRevision(names test.ResourceNames) func(r *v1alpha1.Route) (bool, error) {
 	return func(r *v1alpha1.Route) (bool, error) {
 		for _, tt := range r.Status.Traffic {
-			if tt.Percent == 100 {
+			if tt.Percent != nil && *tt.Percent == 100 {
 				if tt.RevisionName != names.Revision {
 					return true, fmt.Errorf("expected traffic revision name to be %s but actually is %s: %s", names.Revision, tt.RevisionName, spew.Sprint(r))
 				}

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -44,7 +45,7 @@ func Route(names test.ResourceNames, fopt ...rtesting.RouteOption) *v1beta1.Rout
 			Traffic: []v1beta1.TrafficTarget{{
 				Tag:               names.TrafficTarget,
 				ConfigurationName: names.Config,
-				Percent:           100,
+				Percent:           ptr.Int64(100),
 			}},
 		},
 	}
@@ -128,7 +129,7 @@ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.Response
 func AllRouteTrafficAtRevision(names test.ResourceNames) func(r *v1beta1.Route) (bool, error) {
 	return func(r *v1beta1.Route) (bool, error) {
 		for _, tt := range r.Status.Traffic {
-			if tt.Percent == 100 {
+			if tt.Percent != nil && *tt.Percent == 100 {
 				if tt.RevisionName != names.Revision {
 					return true, fmt.Errorf("expected traffic revision name to be %s but actually is %s: %s", names.Revision, tt.RevisionName, spew.Sprint(r))
 				}


### PR DESCRIPTION
So we can distinguish between 'zero' and 'not specified'.
Needed to enable other routing mechanisms.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint

## Proposed Changes

* Allow for us to distinguish between percent=0 and no percent at all
* Allow for extension routing mechanisms to be used

**Release Note**

```release-note
The definition of `TrafficTarget.percent` has been modified to allow for
future routing mechanisms to be used w/o conflicting with `percent`.

```
