### PR TITLE
Fix h2c bug with revisions backends manager

### DIFF
--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -26,12 +26,12 @@ import (
 
 // EndpointsToDests takes an endpoints object and a port name and returns a list
 // of l4 dests in the endpoints object which have that port
-func EndpointsToDests(endpoints *corev1.Endpoints) []string {
+func EndpointsToDests(endpoints *corev1.Endpoints, portName string) []string {
 	ret := []string{}
 
 	for _, es := range endpoints.Subsets {
 		for _, port := range es.Ports {
-			if port.Name == probePortName {
+			if port.Name == portName {
 				portStr := strconv.Itoa(int(port.Port))
 				for _, addr := range es.Addresses {
 					// Prefer IP as we can avoid a DNS lookup this way

--- a/pkg/activator/net/helpers_test.go
+++ b/pkg/activator/net/helpers_test.go
@@ -28,6 +28,7 @@ func TestEndpointsToDests(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		endpoints   corev1.Endpoints
+		protocol    networking.ProtocolType
 		expectDests []string
 	}{{
 		name:        "no endpoints",
@@ -86,9 +87,11 @@ func TestEndpointsToDests(t *testing.T) {
 		},
 		expectDests: []string{"128.0.0.1:1234"},
 	}} {
-
 		t.Run(tc.name, func(t *testing.T) {
-			dests := EndpointsToDests(&tc.endpoints)
+			if tc.protocol == "" {
+				tc.protocol = networking.ProtocolHTTP1
+			}
+			dests := EndpointsToDests(&tc.endpoints, networking.ServicePortName(tc.protocol))
 
 			if diff := cmp.Diff(tc.expectDests, dests); diff != "" {
 				t.Errorf("Got unexpected dests (-want, +got): %v", diff)


### PR DESCRIPTION
We were not taking revision port type in to account in revision backends
manager.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
