### PR TITLE
Have the labeling reconciler label Revisions.

### DIFF
--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -57,9 +56,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	route, err := c.routeLister.Routes(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		logger.Infof("Clearing labels for deleted Route: %q", key)
-		return c.deleteLabelForOutsideOfGivenConfigurations(
-			ctx, namespace, name, sets.NewString(),
-		)
+		return c.clearLabels(ctx, namespace, name)
 	} else if err != nil {
 		return err
 	}

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -58,10 +58,10 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "first-reconcile", "the-config"),
 			simpleConfig("default", "the-config"),
-			simpleRevision("default", "the-config"),
+			rev("default", "the-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", simpleRevision("default", "the-config").Name,
+			patchAddLabel("default", rev("default", "the-config").Name,
 				"serving.knative.dev/route", "first-reconcile", "v1"),
 			patchAddLabel("default", "the-config", "serving.knative.dev/route", "first-reconcile", "v1"),
 		},
@@ -72,7 +72,7 @@ func TestReconcile(t *testing.T) {
 			simpleRunLatest("default", "steady-state", "the-config"),
 			simpleConfig("default", "the-config",
 				WithConfigLabel("serving.knative.dev/route", "steady-state")),
-			simpleRevision("default", "the-config",
+			rev("default", "the-config",
 				WithRevisionLabel("serving.knative.dev/route", "steady-state")),
 		},
 		Key: "default/steady-state",
@@ -86,10 +86,10 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "add-label-failure", "the-config"),
 			simpleConfig("default", "the-config"),
-			simpleRevision("default", "the-config"),
+			rev("default", "the-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			patchAddLabel("default", simpleRevision("default", "the-config").Name,
+			patchAddLabel("default", rev("default", "the-config").Name,
 				"serving.knative.dev/route", "add-label-failure", "v1"),
 		},
 		Key: "default/add-label-failure",
@@ -103,7 +103,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "add-label-failure", "the-config"),
 			simpleConfig("default", "the-config"),
-			simpleRevision("default", "the-config",
+			rev("default", "the-config",
 				WithRevisionLabel("serving.knative.dev/route", "add-label-failure")),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
@@ -117,7 +117,7 @@ func TestReconcile(t *testing.T) {
 			simpleRunLatest("default", "the-route", "the-config"),
 			simpleConfig("default", "the-config",
 				WithConfigLabel("serving.knative.dev/route", "another-route")),
-			simpleRevision("default", "the-config",
+			rev("default", "the-config",
 				WithRevisionLabel("serving.knative.dev/route", "another-route")),
 		},
 		Key: "default/the-route",
@@ -127,15 +127,15 @@ func TestReconcile(t *testing.T) {
 			simpleRunLatest("default", "config-change", "new-config"),
 			simpleConfig("default", "old-config",
 				WithConfigLabel("serving.knative.dev/route", "config-change")),
-			simpleRevision("default", "old-config",
+			rev("default", "old-config",
 				WithRevisionLabel("serving.knative.dev/route", "config-change")),
 			simpleConfig("default", "new-config"),
-			simpleRevision("default", "new-config"),
+			rev("default", "new-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			patchRemoveLabel("default", simpleRevision("default", "old-config").Name,
+			patchRemoveLabel("default", rev("default", "old-config").Name,
 				"serving.knative.dev/route", "v1"),
-			patchAddLabel("default", simpleRevision("default", "new-config").Name,
+			patchAddLabel("default", rev("default", "new-config").Name,
 				"serving.knative.dev/route", "config-change", "v1"),
 			patchRemoveLabel("default", "old-config", "serving.knative.dev/route", "v1"),
 			patchAddLabel("default", "new-config", "serving.knative.dev/route", "config-change", "v1"),
@@ -164,9 +164,9 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
 			simpleConfig("default", "new-config",
 				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
-			simpleRevision("default", "new-config",
+			rev("default", "new-config",
 				WithRevisionLabel("serving.knative.dev/route", "delete-label-failure")),
-			simpleRevision("default", "old-config"),
+			rev("default", "old-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveLabel("default", "old-config", "serving.knative.dev/route", "v1"),
@@ -185,13 +185,13 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
 			simpleConfig("default", "new-config",
 				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
-			simpleRevision("default", "new-config",
+			rev("default", "new-config",
 				WithRevisionLabel("serving.knative.dev/route", "delete-label-failure")),
-			simpleRevision("default", "old-config",
+			rev("default", "old-config",
 				WithRevisionLabel("serving.knative.dev/route", "delete-label-failure")),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			patchRemoveLabel("default", simpleRevision("default", "old-config").Name,
+			patchRemoveLabel("default", rev("default", "old-config").Name,
 				"serving.knative.dev/route", "v1"),
 		},
 		Key: "default/delete-label-failure",
@@ -249,7 +249,7 @@ func simpleConfig(namespace, name string, opts ...ConfigOption) *v1alpha1.Config
 	return cfg
 }
 
-func simpleRevision(namespace, name string, opts ...RevisionOption) *v1alpha1.Revision {
+func rev(namespace, name string, opts ...RevisionOption) *v1alpha1.Revision {
 	cfg := simpleConfig(namespace, name)
 	rev := &v1alpha1.Revision{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -40,6 +40,7 @@ import (
 
 	. "knative.dev/pkg/reconciler/testing"
 	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
@@ -60,6 +61,8 @@ func TestReconcile(t *testing.T) {
 			simpleRevision("default", "the-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("default", simpleRevision("default", "the-config").Name,
+				"serving.knative.dev/route", "first-reconcile", "v1"),
 			patchAddLabel("default", "the-config", "serving.knative.dev/route", "first-reconcile", "v1"),
 		},
 		Key: "default/first-reconcile",
@@ -67,12 +70,31 @@ func TestReconcile(t *testing.T) {
 		Name: "steady state",
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "steady-state", "the-config"),
-			routeLabel(simpleConfig("default", "the-config"), "steady-state"),
-			simpleRevision("default", "the-config"),
+			simpleConfig("default", "the-config",
+				WithConfigLabel("serving.knative.dev/route", "steady-state")),
+			simpleRevision("default", "the-config",
+				WithRevisionLabel("serving.knative.dev/route", "steady-state")),
 		},
 		Key: "default/steady-state",
 	}, {
-		Name: "failure adding label",
+		Name: "failure adding label (revision)",
+		// Induce a failure during patching
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("patch", "revisions"),
+		},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "add-label-failure", "the-config"),
+			simpleConfig("default", "the-config"),
+			simpleRevision("default", "the-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("default", simpleRevision("default", "the-config").Name,
+				"serving.knative.dev/route", "add-label-failure", "v1"),
+		},
+		Key: "default/add-label-failure",
+	}, {
+		Name: "failure adding label (configuration)",
 		// Induce a failure during patching
 		WantErr: true,
 		WithReactors: []clientgotesting.ReactionFunc{
@@ -81,7 +103,8 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "add-label-failure", "the-config"),
 			simpleConfig("default", "the-config"),
-			simpleRevision("default", "the-config"),
+			simpleRevision("default", "the-config",
+				WithRevisionLabel("serving.knative.dev/route", "add-label-failure")),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddLabel("default", "the-config", "serving.knative.dev/route", "add-label-failure", "v1"),
@@ -92,19 +115,28 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "the-route", "the-config"),
-			routeLabel(simpleConfig("default", "the-config"), "another-route"),
-			simpleRevision("default", "the-config"),
+			simpleConfig("default", "the-config",
+				WithConfigLabel("serving.knative.dev/route", "another-route")),
+			simpleRevision("default", "the-config",
+				WithRevisionLabel("serving.knative.dev/route", "another-route")),
 		},
 		Key: "default/the-route",
 	}, {
 		Name: "change configurations",
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "config-change", "new-config"),
-			routeLabel(simpleConfig("default", "old-config"), "config-change"),
+			simpleConfig("default", "old-config",
+				WithConfigLabel("serving.knative.dev/route", "config-change")),
+			simpleRevision("default", "old-config",
+				WithRevisionLabel("serving.knative.dev/route", "config-change")),
 			simpleConfig("default", "new-config"),
 			simpleRevision("default", "new-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
+			patchRemoveLabel("default", simpleRevision("default", "old-config").Name,
+				"serving.knative.dev/route", "v1"),
+			patchAddLabel("default", simpleRevision("default", "new-config").Name,
+				"serving.knative.dev/route", "config-change", "v1"),
 			patchRemoveLabel("default", "old-config", "serving.knative.dev/route", "v1"),
 			patchAddLabel("default", "new-config", "serving.knative.dev/route", "config-change", "v1"),
 		},
@@ -112,14 +144,15 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "delete route",
 		Objects: []runtime.Object{
-			routeLabel(simpleConfig("default", "the-config"), "delete-route"),
+			simpleConfig("default", "the-config",
+				WithConfigLabel("serving.knative.dev/route", "delete-route")),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveLabel("default", "the-config", "serving.knative.dev/route", "v1"),
 		},
 		Key: "default/delete-route",
 	}, {
-		Name: "failure while removing an annotation should return an error",
+		Name: "failure while removing a cfg annotation should return an error",
 		// Induce a failure during patching
 		WantErr: true,
 		WithReactors: []clientgotesting.ReactionFunc{
@@ -127,12 +160,39 @@ func TestReconcile(t *testing.T) {
 		},
 		Objects: []runtime.Object{
 			simpleRunLatest("default", "delete-label-failure", "new-config"),
-			routeLabel(simpleConfig("default", "old-config"), "delete-label-failure"),
-			routeLabel(simpleConfig("default", "new-config"), "delete-label-failure"),
-			simpleRevision("default", "new-config"),
+			simpleConfig("default", "old-config",
+				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
+			simpleConfig("default", "new-config",
+				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
+			simpleRevision("default", "new-config",
+				WithRevisionLabel("serving.knative.dev/route", "delete-label-failure")),
+			simpleRevision("default", "old-config"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveLabel("default", "old-config", "serving.knative.dev/route", "v1"),
+		},
+		Key: "default/delete-label-failure",
+	}, {
+		Name: "failure while removing a rev annotation should return an error",
+		// Induce a failure during patching
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("patch", "revisions"),
+		},
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "delete-label-failure", "new-config"),
+			simpleConfig("default", "old-config",
+				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
+			simpleConfig("default", "new-config",
+				WithConfigLabel("serving.knative.dev/route", "delete-label-failure")),
+			simpleRevision("default", "new-config",
+				WithRevisionLabel("serving.knative.dev/route", "delete-label-failure")),
+			simpleRevision("default", "old-config",
+				WithRevisionLabel("serving.knative.dev/route", "delete-label-failure")),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchRemoveLabel("default", simpleRevision("default", "old-config").Name,
+				"serving.knative.dev/route", "v1"),
 		},
 		Key: "default/delete-label-failure",
 	}}
@@ -171,15 +231,7 @@ func simpleRunLatest(namespace, name, config string) *v1alpha1.Route {
 	})
 }
 
-func routeLabel(cfg *v1alpha1.Configuration, route string) *v1alpha1.Configuration {
-	if cfg.Labels == nil {
-		cfg.Labels = make(map[string]string)
-	}
-	cfg.Labels["serving.knative.dev/route"] = route
-	return cfg
-}
-
-func simpleConfig(namespace, name string) *v1alpha1.Configuration {
+func simpleConfig(namespace, name string, opts ...ConfigOption) *v1alpha1.Configuration {
 	cfg := &v1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       namespace,
@@ -190,18 +242,28 @@ func simpleConfig(namespace, name string) *v1alpha1.Configuration {
 	cfg.Status.InitializeConditions()
 	cfg.Status.SetLatestCreatedRevisionName(name + "-dbnfd")
 	cfg.Status.SetLatestReadyRevisionName(name + "-dbnfd")
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
 	return cfg
 }
 
-func simpleRevision(namespace, name string) *v1alpha1.Revision {
+func simpleRevision(namespace, name string, opts ...RevisionOption) *v1alpha1.Revision {
 	cfg := simpleConfig(namespace, name)
-	return &v1alpha1.Revision{
+	rev := &v1alpha1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       namespace,
 			Name:            cfg.Status.LatestCreatedRevisionName,
+			ResourceVersion: "v1",
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(cfg)},
 		},
 	}
+
+	for _, opt := range opts {
+		opt(rev)
+	}
+	return rev
 }
 
 func patchRemoveLabel(namespace, name, key, version string) clientgotesting.PatchActionImpl {

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -20,19 +20,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	servingv1alpha1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 )
 
+// accessor defines an abstraction for manipulating labeled entity
+// (Configuration, Revision) with shared logic.
+type accessor interface {
+	get(ns, name string) (kmeta.Accessor, error)
+	list(ns, name string) ([]kmeta.Accessor, error)
+	patch(ns, name string, pt types.PatchType, p []byte) error
+}
+
+// syncLabels makes sure that the revisions and configurations referenced from
+// a Route are labeled with route labels.
 func (c *Reconciler) syncLabels(ctx context.Context, r *v1alpha1.Route) error {
 	revisions := sets.NewString()
 	configs := sets.NewString()
@@ -51,63 +60,67 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1alpha1.Route) error {
 		}
 	}
 
-	if err := c.deleteLabelForOutsideOfGivenRevisions(ctx, r.Namespace, r.Name, revisions); err != nil {
+	// Use a revision accessor to manipulate the revisions.
+	racc := &revision{r: c}
+	if err := deleteLabelForNotListed(ctx, r.Namespace, r.Name, racc, revisions); err != nil {
 		return err
 	}
-	if err := c.setLabelForGivenRevisions(ctx, r, revisions); err != nil {
+	if err := setLabelForListed(ctx, r, racc, revisions); err != nil {
 		return err
 	}
 
-	if err := c.deleteLabelForOutsideOfGivenConfigurations(ctx, r.Namespace, r.Name, configs); err != nil {
+	// Use a config access to manipulate the configs.
+	cacc := &configuration{r: c}
+	if err := deleteLabelForNotListed(ctx, r.Namespace, r.Name, cacc, configs); err != nil {
 		return err
 	}
-	return c.setLabelForGivenConfigurations(ctx, r, configs)
+	return setLabelForListed(ctx, r, cacc, configs)
 }
 
-func (c *Reconciler) setLabelForGivenConfigurations(
-	ctx context.Context,
-	route *v1alpha1.Route,
-	configs sets.String) error {
-	logger := logging.FromContext(ctx)
+// clearLabels removes any labels for a named route from configurations and revisions.
+func (c *Reconciler) clearLabels(ctx context.Context, ns, name string) error {
+	racc := &revision{r: c}
+	if err := deleteLabelForNotListed(ctx, ns, name, racc, sets.NewString()); err != nil {
+		return err
+	}
+	cacc := &configuration{r: c}
+	return deleteLabelForNotListed(ctx, ns, name, cacc, sets.NewString())
+}
 
-	// The ordered collection of Configurations to which we
-	// should patch our Route label.
-	configurationOrder := []string{}
-	configMap := make(map[string]*v1alpha1.Configuration)
+// setLabelForListed uses the accessor to attach the label for this route to every element
+// listed within "names" in the same namespace.
+func setLabelForListed(ctx context.Context, route *v1alpha1.Route, acc accessor, names sets.String) error {
+	nameToAccessor := make(map[string]kmeta.Accessor)
 
-	// Lookup Configurations that are missing our Route label.
-	for name := range configs {
-		configurationOrder = append(configurationOrder, name)
-
-		config, err := c.configurationLister.Configurations(route.Namespace).Get(name)
+	// Lookup names that are missing our Route label.
+	for name := range names {
+		elt, err := acc.get(route.Namespace, name)
 		if err != nil {
 			return err
 		}
-		configMap[name] = config
-		routeName, ok := config.Labels[serving.RouteLabelKey]
+		nameToAccessor[name] = elt
+		routeName, ok := elt.GetLabels()[serving.RouteLabelKey]
 		if !ok {
 			continue
 		}
 		if routeName != route.Name {
-			return fmt.Errorf("configuration %q is already in use by %q, and cannot be used by %q",
-				config.Name, routeName, route.Name)
+			return fmt.Errorf("%s %q is already in use by %q, and cannot be used by %q",
+				elt.GroupVersionKind(), elt.GetName(), routeName, route.Name)
 		}
 	}
-	// Sort the names to give things a deterministic ordering.
-	sort.Strings(configurationOrder)
 
-	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(route.Namespace)
-	// Set label for newly added configurations as traffic target.
-	for _, configName := range configurationOrder {
-		config := configMap[configName]
-		if config.Labels == nil {
-			config.Labels = make(map[string]string)
-		} else if _, ok := config.Labels[serving.RouteLabelKey]; ok {
+	// Set label for newly added names as traffic target.
+	for _, name := range names.List() {
+		elt := nameToAccessor[name]
+		if elt.GetLabels() == nil {
+			elt.SetLabels(make(map[string]string))
+		} else if _, ok := elt.GetLabels()[serving.RouteLabelKey]; ok {
 			continue
 		}
 
-		if err := setRouteLabelForConfiguration(configClient, config.Name, config.ResourceVersion, &route.Name); err != nil {
-			logger.Errorf("Failed to add route label to configuration %q: %s", config.Name, err)
+		if err := setRouteLabel(acc, elt, &route.Name); err != nil {
+			logging.FromContext(ctx).Errorf("Failed to add route label to %s %q: %s",
+				elt.GroupVersionKind(), elt.GetName(), err)
 			return err
 		}
 	}
@@ -115,31 +128,24 @@ func (c *Reconciler) setLabelForGivenConfigurations(
 	return nil
 }
 
-func (c *Reconciler) deleteLabelForOutsideOfGivenConfigurations(
-	ctx context.Context,
-	routeNamespace, routeName string,
-	configs sets.String,
-) error {
-
-	logger := logging.FromContext(ctx)
-
-	// Get Configurations set as traffic target before this sync.
-	selector := labels.SelectorFromSet(labels.Set{serving.RouteLabelKey: routeName})
-
-	oldConfigsList, err := c.configurationLister.Configurations(routeNamespace).List(selector)
+// deleteLabelForNotListed uses the accessor to delete the label from any listable entity that is
+// not named within our list.  Unlike setLabelForListed, this function takes ns/name instead of a
+// Route so that it can clean things up when a Route ceases to exist.
+func deleteLabelForNotListed(ctx context.Context, ns, name string, acc accessor, names sets.String) error {
+	oldList, err := acc.list(ns, name)
 	if err != nil {
 		return err
 	}
 
-	// Delete label for newly removed configurations as traffic target.
-	configClient := c.ServingClientSet.ServingV1alpha1().Configurations(routeNamespace)
-	for _, config := range oldConfigsList {
-		if configs.Has(config.Name) {
+	// Delete label for newly removed traffic targets.
+	for _, elt := range oldList {
+		if names.Has(elt.GetName()) {
 			continue
 		}
 
-		if err := setRouteLabelForConfiguration(configClient, config.Name, config.ResourceVersion, nil); err != nil {
-			logger.Errorf("Failed to remove route label to configuration %q: %s", config.Name, err)
+		if err := setRouteLabel(acc, elt, nil); err != nil {
+			logging.FromContext(ctx).Errorf("Failed to remove route label from %s %q: %s",
+				elt.GroupVersionKind(), elt.GetName(), err)
 			return err
 		}
 	}
@@ -147,19 +153,16 @@ func (c *Reconciler) deleteLabelForOutsideOfGivenConfigurations(
 	return nil
 }
 
-func setRouteLabelForConfiguration(
-	configClient servingv1alpha1.ConfigurationInterface,
-	configName string,
-	configVersion string,
-	routeName *string, // a nil route name will cause the route label to be deleted
-) error {
-
+// setRouteLabel toggles the route label on the specified element through the provided accessor.
+// a nil route name will cause the route label to be deleted, and a non-nil route will cause
+// that route name to be attached to the element.
+func setRouteLabel(acc accessor, elt kmeta.Accessor, routeName *string) error {
 	mergePatch := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"labels": map[string]interface{}{
 				serving.RouteLabelKey: routeName,
 			},
-			"resourceVersion": configVersion,
+			"resourceVersion": elt.GetResourceVersion(),
 		},
 	}
 
@@ -168,114 +171,75 @@ func setRouteLabelForConfiguration(
 		return err
 	}
 
-	_, err = configClient.Patch(configName, types.MergePatchType, patch)
+	return acc.patch(elt.GetNamespace(), elt.GetName(), types.MergePatchType, patch)
+}
+
+// revision is an implementation of accessor for Revisions
+type revision struct {
+	r *Reconciler
+}
+
+// revision implements accessor
+var _ accessor = (*revision)(nil)
+
+// get implements accessor
+func (r *revision) get(ns, name string) (kmeta.Accessor, error) {
+	return r.r.revisionLister.Revisions(ns).Get(name)
+}
+
+// list implements accessor
+func (r *revision) list(ns, name string) ([]kmeta.Accessor, error) {
+	rl, err := r.r.revisionLister.Revisions(ns).List(labels.SelectorFromSet(labels.Set{
+		serving.RouteLabelKey: name,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	// Need a copy to change types in Go
+	kl := make([]kmeta.Accessor, 0, len(rl))
+	for _, r := range rl {
+		kl = append(kl, r)
+	}
+	return kl, err
+}
+
+// patch implements accessor
+func (r *revision) patch(ns, name string, pt types.PatchType, p []byte) error {
+	_, err := r.r.ServingClientSet.ServingV1alpha1().Revisions(ns).Patch(name, pt, p)
 	return err
 }
 
-func (c *Reconciler) setLabelForGivenRevisions(
-	ctx context.Context,
-	route *v1alpha1.Route,
-	revisions sets.String) error {
-	logger := logging.FromContext(ctx)
-
-	// The ordered collection of Revisions to which we
-	// should patch our Route label.
-	revisionOrder := []string{}
-	revisionMap := make(map[string]*v1alpha1.Revision)
-
-	// Lookup Revisions that are missing our Route label.
-	for name := range revisions {
-		revisionOrder = append(revisionOrder, name)
-
-		revision, err := c.revisionLister.Revisions(route.Namespace).Get(name)
-		if err != nil {
-			return err
-		}
-		revisionMap[name] = revision
-		routeName, ok := revision.Labels[serving.RouteLabelKey]
-		if !ok {
-			continue
-		}
-		if routeName != route.Name {
-			return fmt.Errorf("revision %q is already in use by %q, and cannot be used by %q",
-				revision.Name, routeName, route.Name)
-		}
-	}
-	// Sort the names to give things a deterministic ordering.
-	sort.Strings(revisionOrder)
-
-	revisionClient := c.ServingClientSet.ServingV1alpha1().Revisions(route.Namespace)
-	// Set label for newly added revisions as traffic target.
-	for _, revisionName := range revisionOrder {
-		revision := revisionMap[revisionName]
-		if revision.Labels == nil {
-			revision.Labels = make(map[string]string)
-		} else if _, ok := revision.Labels[serving.RouteLabelKey]; ok {
-			continue
-		}
-
-		if err := setRouteLabelForRevision(revisionClient, revision.Name, revision.ResourceVersion, &route.Name); err != nil {
-			logger.Errorf("Failed to add route label to revision %q: %s", revision.Name, err)
-			return err
-		}
-	}
-
-	return nil
+// configuration is an implementation of accessor for Configurations
+type configuration struct {
+	r *Reconciler
 }
 
-func (c *Reconciler) deleteLabelForOutsideOfGivenRevisions(
-	ctx context.Context,
-	routeNamespace, routeName string,
-	revisions sets.String,
-) error {
+// configuration implements accessor
+var _ accessor = (*configuration)(nil)
 
-	logger := logging.FromContext(ctx)
-
-	// Get Revisions set as traffic target before this sync.
-	selector := labels.SelectorFromSet(labels.Set{serving.RouteLabelKey: routeName})
-
-	oldRevisionsList, err := c.revisionLister.Revisions(routeNamespace).List(selector)
-	if err != nil {
-		return err
-	}
-
-	// Delete label for newly removed revisions as traffic target.
-	revisionClient := c.ServingClientSet.ServingV1alpha1().Revisions(routeNamespace)
-	for _, revision := range oldRevisionsList {
-		if revisions.Has(revision.Name) {
-			continue
-		}
-
-		if err := setRouteLabelForRevision(revisionClient, revision.Name, revision.ResourceVersion, nil); err != nil {
-			logger.Errorf("Failed to remove route label to revision %q: %s", revision.Name, err)
-			return err
-		}
-	}
-
-	return nil
+// get implements accessor
+func (c *configuration) get(ns, name string) (kmeta.Accessor, error) {
+	return c.r.configurationLister.Configurations(ns).Get(name)
 }
 
-func setRouteLabelForRevision(
-	revisionClient servingv1alpha1.RevisionInterface,
-	revisionName string,
-	revisionVersion string,
-	routeName *string, // a nil route name will cause the route label to be deleted
-) error {
-
-	mergePatch := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				serving.RouteLabelKey: routeName,
-			},
-			"resourceVersion": revisionVersion,
-		},
-	}
-
-	patch, err := json.Marshal(mergePatch)
+// list implements accessor
+func (c *configuration) list(ns, name string) ([]kmeta.Accessor, error) {
+	rl, err := c.r.configurationLister.Configurations(ns).List(labels.SelectorFromSet(labels.Set{
+		serving.RouteLabelKey: name,
+	}))
 	if err != nil {
-		return err
+		return nil, err
 	}
+	// Need a copy to change types in Go
+	kl := make([]kmeta.Accessor, 0, len(rl))
+	for _, r := range rl {
+		kl = append(kl, r)
+	}
+	return kl, err
+}
 
-	_, err = revisionClient.Patch(revisionName, types.MergePatchType, patch)
+// patch implements accessor
+func (c *configuration) patch(ns, name string, pt types.PatchType, p []byte) error {
+	_, err := c.r.ServingClientSet.ServingV1alpha1().Configurations(ns).Patch(name, pt, p)
 	return err
 }

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -153,3 +153,13 @@ func MarkRevisionReady(r *v1alpha1.Revision) {
 	r.Status.MarkResourcesAvailable()
 	r.Status.MarkContainerHealthy()
 }
+
+// WithRevisionLabel attaches a particular label to the revision.
+func WithRevisionLabel(key, value string) RevisionOption {
+	return func(config *v1alpha1.Revision) {
+		if config.Labels == nil {
+			config.Labels = make(map[string]string)
+		}
+		config.Labels[key] = value
+	}
+}


### PR DESCRIPTION
I have broken this PR into two commits to make it more reviewable.
1. The first commit does the naive change: copy/paste the configuration logic, `s/configuration/revision/`, and fix up tests.
2. Refactor the code to go through an `accessor` abstraction that allows us to recombine the copied logic, and verify the (unchanged) tests still pass.

I also verified some simple cases work on a cluster on which this was deployed.