### PR TITLE
 Remove unnecessary volume mounts. 

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -98,20 +98,8 @@ spec:
             value: config-observability
           - name: METRICS_DOMAIN
             value: knative.dev/serving
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
-        - name: config-observability
-          mountPath: /etc/config-observability
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging
-        - name: config-observability
-          configMap:
-            name: config-observability
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/config/autoscaler-hpa.yaml
+++ b/config/autoscaler-hpa.yaml
@@ -49,9 +49,6 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -65,7 +62,3 @@ spec:
           value: knative.dev/serving
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -81,13 +81,6 @@ spec:
         args:
         - "--secure-port=8443"
         - "--cert-dir=/tmp"
-        volumeMounts:
-        - name: config-autoscaler
-          mountPath: /etc/config-autoscaler
-        - name: config-logging
-          mountPath: /etc/config-logging
-        - name: config-observability
-          mountPath: /etc/config-observability
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -101,13 +94,3 @@ spec:
           value: knative.dev/serving
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-autoscaler
-          configMap:
-            name: config-autoscaler
-        - name: config-logging
-          configMap:
-            name: config-logging
-        - name: config-observability
-          configMap:
-            name: config-observability

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -50,9 +50,6 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -66,7 +63,3 @@ spec:
           value: knative.dev/serving
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging

--- a/config/networking-certmanager.yaml
+++ b/config/networking-certmanager.yaml
@@ -48,9 +48,6 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -64,7 +61,3 @@ spec:
           value: knative.dev/serving
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging

--- a/config/networking-istio.yaml
+++ b/config/networking-istio.yaml
@@ -48,9 +48,6 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -64,7 +61,3 @@ spec:
           value: knative.dev/serving
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -53,9 +53,6 @@ spec:
           limits:
             cpu: 200m
             memory: 200Mi
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -69,7 +66,3 @@ spec:
           value: knative.dev/serving
         securityContext:
           allowPrivilegeEscalation: false
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We don't read configuration from file anywhere anymore so in theory we shouldn't need to mount these configMaps as volumes.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
