### PR TITLE
Remove useless make(map) in revisionbackends

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -232,7 +232,7 @@ func (rw *revisionWatcher) checkDests() {
 		rw.logger.Errorw(fmt.Sprintf("Failed to probe clusterIP %s/%s", svc.Namespace, svc.Name), zap.Error(err))
 	} else if ok {
 		rw.clusterIPHealthy = true
-		rw.healthStates = make(map[string]bool)
+		rw.healthStates = nil
 		rw.updateCh <- &RevisionDestsUpdate{Rev: rw.rev, ClusterIPDest: dest}
 		return
 	}


### PR DESCRIPTION
It was noticed in a follow on review that this map allocation is
entirely useless.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
