### PR TITLE
Fix comment for API reference docs

### DIFF
--- a/pkg/apis/serving/v1beta1/revision_types.go
+++ b/pkg/apis/serving/v1beta1/revision_types.go
@@ -83,7 +83,8 @@ type RevisionSpec struct {
 
 	// ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
 	// requests per container of the Revision.  Defaults to `0` which means
-	// unlimited concurrency.
+	// concurrency to the application is not limited, and the system decides the
+	// target concurrency for the autoscaler.
 	// +optional
 	ContainerConcurrency RevisionContainerConcurrencyType `json:"containerConcurrency,omitempty"`
 


### PR DESCRIPTION
Update containerConcurrency to better describe current behavior.

Fixes #4227

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
