### PR TITLE
Fix missing value in log message

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -176,7 +176,7 @@ func (ks *scaler) handleScaleToZero(ctx context.Context, pa *pav1alpha1.PodAutos
 		}
 		// Otherwise, scale down to at most 1 for the remainder of the idle period and then
 		// reconcile PA again.
-		logger.Infof("%s sleeping additionally for %v before can scale to 0", sw-af)
+		logger.Infof("%s sleeping additionally for %v before can scale to 0", pa.Name, sw-af)
 		ks.enqueueCB(pa, sw-af)
 		desiredScale = 1
 	} else { // Active=False


### PR DESCRIPTION
This makes a tiny change to add missing value in log message.

/lint

**Release Note**

```release-note
NONE
```

#### Current log message prints as:

```
57.035131457s sleeping additionally for %!!(MISSING)v(MISSING) before can scale to 0
```

#### (Full message)

```
    kubelogs.go:152: I 01:11:03.964 [kpa-class-podautoscaler-controller] [serving-tests/target-burst-capacity-zgianyzq-svqlg] 57.035131457s sleeping additionally for %!!(MISSING)v(MISSING) before can scale to 0
````

