### PR TITLE
Route is ready only when the Ingress is ready and has been reconciled

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -270,7 +270,11 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 		return err
 	}
 
-	r.Status.PropagateIngressStatus(*ingress.GetStatus())
+	if ingress.GetObjectMeta().GetGeneration() != ingress.GetStatus().ObservedGeneration {
+		r.Status.MarkIngressNotConfigured()
+	} else {
+		r.Status.PropagateIngressStatus(*ingress.GetStatus())
+	}
 
 	logger.Info("Updating placeholder k8s services with clusterIngress information")
 	if err := c.updatePlaceholderServices(ctx, r, services, ingress); err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5056 

## Proposed Changes

* Check that the Ingress has been reconciled

/test pull-knative-serving-istio-1.1-mesh
/test pull-knative-serving-istio-1.1-no-mesh
/test pull-knative-serving-istio-1.2-mesh
/test pull-knative-serving-istio-1.2-no-mesh
/assign vagababov
/assign tcnghia