### PR TITLE
Remove obsolete comment for 404 retry exception in e2e test

### DIFF
--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -70,7 +70,6 @@ func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, 
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
-// - 404 until the route is propagated to the proxy
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -116,7 +116,6 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
-// - 404 until the route is propagated to the proxy
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.


### PR DESCRIPTION
## Proposed Changes

This patch removes obsolete comment which is solved by https://github.com/knative/serving/pull/4976.

**Release Note**

```release-note
NONE
```
