### PR TITLE
Add a simple overload test.

### DIFF
--- a/test/performance/load-test/load-test-1000.config
+++ b/test/performance/load-test/load-test-1000.config
@@ -1,10 +1,10 @@
 # Creating this benchmark:
 # mako create_benchmark \
-#   test/performance/dataplane-probe/dataplane-probe.config
+#   test/performance/config/load-test-1000.config
 project_name: "Knative"
-benchmark_name: "Serving dataplane probe"
-description: "Measure dataplane component latency and reliability."
-benchmark_key: '5142965274017792'
+benchmark_name: "serving load testing"
+description: "Load test 0->1k->2k->3k against a ksvc."
+benchmark_key: '5352009922248704'
 
 # Only owners can write to the benchmark
 owner_list: "mattmoor@google.com"
@@ -12,7 +12,6 @@ owner_list: "vagababov@google.com"
 owner_list: "srinivashegde@google.com"
 owner_list: "chizhg@google.com"
 owner_list: "yanweiguo@google.com"
-
 # Add your robot here:
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
 
@@ -25,35 +24,30 @@ input_value_info: {
 
 # Note: value_key is stored repeatedly and should be very short (ideally one or two characters).
 metric_info_list: {
-  value_key: "kd"
-  label: "kube-deployment"
-}
-metric_info_list: {
-  value_key: "id"
-  label: "istio-deployment"
-}
-metric_info_list: {
-  value_key: "qp"
-  label: "queue-proxy"
-}
-metric_info_list: {
-  value_key: "a"
-  label: "activator"
+  value_key: "l"
+  label: "latency"
 }
 
+# Used to track errors/sec and requests/sec alongside latency
 metric_info_list: {
-  value_key: "ke"
-  label: "kube-errors"
+  value_key: "es"
+  label: "errs-sec"
 }
 metric_info_list: {
-  value_key: "ie"
-  label: "istio-errors"
+  value_key: "rs"
+  label: "requests-sec"
+}
+
+# Used to track desired and actual pod counts alongside latency
+metric_info_list: {
+  value_key: "dp"
+  label: "desired-pods"
 }
 metric_info_list: {
-  value_key: "qe"
-  label: "queue-errors"
+  value_key: "ap"
+  label: "available-pods"
 }
 metric_info_list: {
-  value_key: "ae"
-  label: "activator-errors"
+  value_key: "sks"
+  label: "sks-proxy"
 }

--- a/test/performance/load-test/load-test-1000.yaml
+++ b/test/performance/load-test/load-test-1000.yaml
@@ -1,0 +1,80 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loader
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: load-testing
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["serverlessservices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: load-testing-loader
+subjects:
+  - kind: ServiceAccount
+    name: loader
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: load-testing
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: load-test
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          serviceAccountName: loader
+          containers:
+          - name: load-test
+            image: knative.dev/serving/test/performance/load-test
+            args:
+            - "-benchmark=5352009922248704"
+            - "-qps=1000"
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+          - name: mako
+            image: us.gcr.io/knative-performance/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          restartPolicy: Never
+      backoffLimit: 0

--- a/test/performance/load-test/load-test-setup.yaml
+++ b/test/performance/load-test/load-test-setup.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
+  name: load-test
+spec:
+  template:
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale

--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/mako/helpers/go/quickstore"
+	qpb "github.com/google/mako/helpers/proto/quickstore/quickstore_go_proto"
+	vegeta "github.com/tsenart/vegeta/lib"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/clientcmd"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	deploymentinformer "knative.dev/pkg/injection/informers/kubeinformers/appsv1/deployment"
+	"knative.dev/pkg/signals"
+	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	sksinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
+
+	"knative.dev/serving/test/performance/mako"
+)
+
+var (
+	benchmark  = flag.String("benchmark", "", "The mako benchmark ID")
+	qps        = flag.Int("qps", 0, "The number of requests to send per second.")
+	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+)
+
+func processResults(ctx context.Context, q *quickstore.Quickstore, results <-chan *vegeta.Result) {
+	dl := deploymentinformer.Get(ctx).Lister()
+	sksl := sksinformer.Get(ctx).Lister()
+
+	// Create a ticker to tick every second that prompts us to report a new
+	// summary sample point.
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	// Accumulate the error and request rates along second boundaries.
+	errors := make(map[int64]int64)
+	requests := make(map[int64]int64)
+
+	// When the benchmark completes, iterate over the accumulated rates
+	// and add them as sample points.
+	defer func() {
+		for t, req := range requests {
+			q.AddSamplePoint(mako.XTime(time.Unix(t, 0)), map[string]float64{
+				"rs": float64(req),
+			})
+		}
+		for t, err := range errors {
+			q.AddSamplePoint(mako.XTime(time.Unix(t, 0)), map[string]float64{
+				"es": float64(err),
+			})
+		}
+	}()
+
+	for {
+		select {
+		case res, ok := <-results:
+			// If there are no more results, then we're done!
+			if !ok {
+				return
+			}
+			// Handle the result by reporting an error or a latency sample point.
+			var isAnError int64
+			if res.Error != "" {
+				q.AddError(mako.XTime(res.Timestamp), res.Error)
+				isAnError = 1
+			} else {
+				q.AddSamplePoint(mako.XTime(res.Timestamp), map[string]float64{
+					"l": res.Latency.Seconds(),
+				})
+				isAnError = 0
+			}
+			// Update our error and request rates.
+			// We handle errors this way to force zero values into every time for
+			// which we have data, even if there is no error.
+			errors[res.Timestamp.Unix()] += isAnError
+			requests[res.Timestamp.Unix()]++
+
+		case t := <-ticker.C:
+			// Each tick, fetch the state of the environment from our informer caches
+			// and overlay the resulting data.
+
+			// Overlay the desired and ready pod counts.
+			deployments, err := dl.Deployments("default").List(labels.Everything())
+			if err != nil {
+				log.Printf("Error listing deployments: %v", err)
+				break
+			}
+			// TODO(mattmoor): Consider alternatives to a singleton.
+			for _, d := range deployments {
+				q.AddSamplePoint(mako.XTime(t), map[string]float64{
+					"dp": float64(*d.Spec.Replicas),
+					"ap": float64(d.Status.ReadyReplicas),
+				})
+			}
+
+			// Overlay the SKS "mode".
+			skses, err := sksl.ServerlessServices("default").List(labels.Everything())
+			if err != nil {
+				log.Printf("Error listing deployments: %v", err)
+				break
+			}
+			// TODO(mattmoor): Consider alternatives to a singleton.
+			for _, sks := range skses {
+				mode := float64(0)
+				if sks.Spec.Mode == netv1alpha1.SKSOperationModeProxy {
+					mode = 1.0
+				}
+				q.AddSamplePoint(mako.XTime(t), map[string]float64{
+					"sks": mode,
+				})
+			}
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	// We want this for properly handling Kubernetes container lifecycle events.
+	ctx := signals.NewContext()
+
+	// We cron every 10 minutes, so give ourselves 6 minutes to complete.
+	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
+	defer cancel()
+
+	// Use the benchmark key created
+	q, qclose, err := quickstore.NewAtAddress(ctx, &qpb.QuickstoreInput{
+		BenchmarkKey: proto.String(*benchmark),
+		Tags:         []string{"master"},
+	}, mako.SidecarAddress)
+	if err != nil {
+		log.Fatalf("failed NewAtAddress: %v", err)
+	}
+	// Use a fresh context here so that our RPC to terminate the sidecar
+	// isn't subject to our timeout (or we won't shut it down when we time out)
+	defer qclose(context.Background())
+
+	// Wrap fatalf in a helper or our sidecar will live forever.
+	fatalf := func(f string, args ...interface{}) {
+		qclose(context.Background())
+		log.Fatalf(f, args...)
+	}
+
+	// Validate flags after setting up "fatalf" or our sidecar will run forever.
+	if *benchmark == "" {
+		fatalf("-benchmark is a required flag.")
+	}
+	if *qps < 1 {
+		fatalf("-qps is a required flag, and must have a positive value.")
+	}
+
+	// Setup a deployment informer, so that we can use the lister to track
+	// desired and available pod counts.
+	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+	if err != nil {
+		fatalf("Error building kubeconfig: %v", err)
+	}
+	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
+	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+		fatalf("Failed to start informers: %v", err)
+	}
+
+	q.Input.ThresholdInputs = append(q.Input.ThresholdInputs,
+		LoadTest95PercentileLatency, LoadTestMaximumLatency)
+
+	log.Printf("Starting the load test.")
+	// Ramp up load from 1k to 3k in 2 minute steps.
+	const duration = 2 * time.Minute
+	targeter := vegeta.NewStaticTargeter(vegeta.Target{
+		Method: "GET",
+		URL:    "http://load-test.default.svc.cluster.local?sleep=100",
+	})
+	// TODO(mattmoor): Replace this ramp up with a pacer.
+	for i := 1; i < 4; i++ {
+		rate := vegeta.Rate{Freq: i, Per: time.Millisecond}
+		results := vegeta.NewAttacker().Attack(targeter, rate, duration, "load-test")
+		processResults(ctx, q, results)
+	}
+
+	out, err := q.Store()
+	if err != nil {
+		fatalf("q.Store error: %s %v", out.String(), err)
+	}
+	fmt.Printf("Done! Run: %s\n", out.GetRunChartLink())
+}

--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"time"
 
@@ -186,7 +185,7 @@ func main() {
 	q.Input.ThresholdInputs = append(q.Input.ThresholdInputs,
 		LoadTest95PercentileLatency, LoadTestMaximumLatency)
 
-	log.Printf("Starting the load test.")
+	log.Print("Starting the load test.")
 	// Ramp up load from 1k to 3k in 2 minute steps.
 	const duration = 2 * time.Minute
 	targeter := vegeta.NewStaticTargeter(vegeta.Target{
@@ -204,5 +203,5 @@ func main() {
 	if err != nil {
 		fatalf("q.Store error: %s %v", out.String(), err)
 	}
-	fmt.Printf("Done! Run: %s\n", out.GetRunChartLink())
+	log.Printf("Done! Run: %s", out.GetRunChartLink())
 }

--- a/test/performance/load-test/sla.go
+++ b/test/performance/load-test/sla.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	tpb "github.com/google/mako/clients/proto/analyzers/threshold_analyzer_go_proto"
+	mpb "github.com/google/mako/spec/proto/mako_go_proto"
+)
+
+var (
+	// This analyzer validates that the p95 latency over the 0->3k stepped burst
+	// falls in the +15ms range.   This includes a mix of cold-starts and steady
+	// state (once the autoscaling decisions have leveled off).
+	LoadTest95PercentileLatency = &tpb.ThresholdAnalyzerInput{
+		Name: proto.String("95p latency"),
+		Configs: []*tpb.ThresholdConfig{{
+			Min: bound(100 * time.Millisecond),
+			Max: bound(115 * time.Millisecond),
+			DataFilter: &mpb.DataFilter{
+				DataType:            mpb.DataFilter_METRIC_AGGREGATE_PERCENTILE.Enum(),
+				PercentileMilliRank: proto.Int32(95000),
+				ValueKey:            proto.String("l"),
+			},
+		}},
+	}
+
+	// This analyzer validates that the maximum request latency observed over the 0->3k
+	// stepped burst is no more than +15 seconds.  This is not strictly a cold-start
+	// metric, but it is a superset that includes steady state latency and the latency
+	// of non-cold-start overload requests.
+	LoadTestMaximumLatency = &tpb.ThresholdAnalyzerInput{
+		Name: proto.String("Maximum latency"),
+		Configs: []*tpb.ThresholdConfig{{
+			Min: bound(100 * time.Millisecond),
+			Max: bound(100*time.Millisecond + 15*time.Second),
+			DataFilter: &mpb.DataFilter{
+				DataType: mpb.DataFilter_METRIC_AGGREGATE_MAX.Enum(),
+				ValueKey: proto.String("l"),
+			},
+		}},
+	}
+)
+
+// bound is a helper for making the inline SLOs more readable by expressing
+// them as durations.
+func bound(d time.Duration) *float64 {
+	return proto.Float64(d.Seconds())
+}


### PR DESCRIPTION
This has been running for some time [here](https://mako.dev/benchmark?benchmark_key=5352009922248704&~l=mean&~es=mean&~rs=mean&~dp=mean&~ap=mean&~sks=mean&tseconds=86400&yscale=log), but the mako.dev client was just opened up, so this upstreams the benchmark source.  I have cleaned up and documented the code, so that it is a bit more
approachable, but the most notable element is the separation of `sla.go`, which I have done to make the thresholds easier to reference via stable links.

Fixes: https://github.com/knative/serving/issues/4117

WIP until https://github.com/knative/serving/pull/5067 lands.