### PR TITLE
Service port names should follow istio-naming convention?

### DIFF
--- a/config/400-activator-service.yaml
+++ b/config/400-activator-service.yaml
@@ -32,7 +32,7 @@ spec:
     protocol: TCP
     port: 81
     targetPort: 8013
-  - name: metrics
+  - name: http-metrics
     protocol: TCP
     port: 9090
     targetPort: 9090

--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-  - name: metrics
+  - name: http-metrics
     port: 9090
     protocol: TCP
     targetPort: 9090

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -22,7 +22,8 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     role: webhook

--- a/config/autoscaler-service.yaml
+++ b/config/autoscaler-service.yaml
@@ -30,7 +30,7 @@ spec:
     port: 9090
     protocol: TCP
     targetPort: 9090
-  - name: custom-metrics
+  - name: https-custom-metrics
     port: 443
     protocol: TCP
     targetPort: 8443

--- a/config/autoscaler-service.yaml
+++ b/config/autoscaler-service.yaml
@@ -26,7 +26,7 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: 8080
-  - name: metrics
+  - name: http-metrics
     port: 9090
     protocol: TCP
     targetPort: 9090

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -52,11 +52,11 @@ const (
 
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.
-	UserQueueMetricsPortName = "user-metrics"
+	UserQueueMetricsPortName = "tcp-usermetrics"
 
 	// ServiceQueueMetricsPortName is the name of the port that serves metrics
 	// on the Kubernetes service.
-	ServiceQueueMetricsPortName = "metrics"
+	ServiceQueueMetricsPortName = "tcp-metrics"
 )
 
 var revCondSet = apis.NewLivingConditionSet(

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -44,7 +44,7 @@ const (
 
 	// QueueAdminPortName specifies the port name for
 	// health check and lifecycle hooks for queue-proxy.
-	QueueAdminPortName string = "queueadm-port"
+	QueueAdminPortName string = "http-queueadm"
 
 	// AutoscalingQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for autoscaler.
@@ -52,11 +52,11 @@ const (
 
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.
-	UserQueueMetricsPortName = "tcp-usermetrics"
+	UserQueueMetricsPortName = "http-usermetric"
 
 	// ServiceQueueMetricsPortName is the name of the port that serves metrics
 	// on the Kubernetes service.
-	ServiceQueueMetricsPortName = "tcp-metrics"
+	ServiceQueueMetricsPortName = "http-metrics"
 )
 
 var revCondSet = apis.NewLivingConditionSet(


### PR DESCRIPTION
Service port name to istio-naming convention https://github.com/knative/serving/issues/5018
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Service port name should follow the istio naming convention based on this link:
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

Note: Please update if I missed something but the idea is there.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Service port name should follow the istio naming convention based on this link:
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
```