### PR TITLE
Update log level to run tests on debug level

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -43,7 +43,7 @@ cp -a "${REPO_ROOT_DIR}/config"/* "${TMP_DIFFROOT}/config"
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
-diff -Nupr "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
+diff -Nupr --no-dereference "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
 diff -Nupr --no-dereference "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
 
 # Restore working tree state

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -96,7 +96,7 @@ func TestOurConfig(t *testing.T) {
 }
 
 func TestLogLevelTestConfig(t *testing.T) {
-	wantCfg := `{
+	const wantCfg = `{
   "level": "debug",
   "development": false,
   "outputPaths": ["stdout"],
@@ -117,7 +117,7 @@ func TestLogLevelTestConfig(t *testing.T) {
   }
 }
 `
-	wantLevel := zapcore.DebugLevel
+	const wantLevel = zapcore.DebugLevel
 	components := []string{
 		"autoscaler",
 		"controller",
@@ -141,7 +141,7 @@ func TestLogLevelTestConfig(t *testing.T) {
 		}
 	}
 	if got := cfg.LoggingConfig; got != wantCfg {
-		t.Errorf("LoggingConfig = %v, want %v, diff %s", got, wantCfg, cmp.Diff(got, wantCfg))
+		t.Errorf("LoggingConfig = %v, want %v, diff(-want +got) %s", got, wantCfg, cmp.Diff(wantCfg, got))
 	}
 }
 

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -19,16 +19,18 @@ package logging
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "knative.dev/pkg/configmap/testing"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
-
-	. "knative.dev/pkg/configmap/testing"
 )
+
+const testConfigFileName = "test-config-logging"
 
 func TestNewConfigNoEntry(t *testing.T) {
 	c, err := logging.NewConfigFromConfigMap(&corev1.ConfigMap{
@@ -90,6 +92,56 @@ func TestOurConfig(t *testing.T) {
 		t.Errorf("Expected no errors. got: %v", err)
 	} else if cfg == nil {
 		t.Errorf("NewConfigFromConfigMap(example) = %v, want non-nil", cfg)
+	}
+}
+
+func TestLogLevelTestConfig(t *testing.T) {
+	wantCfg := `{
+  "level": "debug",
+  "development": false,
+  "outputPaths": ["stdout"],
+  "errorOutputPaths": ["stderr"],
+  "encoding": "json",
+  "encoderConfig": {
+    "timeKey": "ts",
+    "levelKey": "level",
+    "nameKey": "logger",
+    "callerKey": "caller",
+    "messageKey": "msg",
+    "stacktraceKey": "stacktrace",
+    "lineEnding": "",
+    "levelEncoder": "",
+    "timeEncoder": "iso8601",
+    "durationEncoder": "",
+    "callerEncoder": ""
+  }
+}
+`
+	wantLevel := zapcore.DebugLevel
+	components := []string{
+		"autoscaler",
+		"controller",
+		"queueproxy",
+		"webhook",
+		"activator",
+	}
+	cm, _ := ConfigMapsFromTestFile(t, testConfigFileName, "loglevel.autoscaler", "loglevel.controller", "loglevel.queueproxy", "loglevel.webhook", "loglevel.activator", "zap-logger-config")
+	cfg, err := logging.NewConfigFromConfigMap(cm)
+
+	if err != nil {
+		t.Errorf("Expected no errors. got: %v", err)
+	}
+	if cfg == nil {
+		t.Errorf("NewConfigFromConfigMap(actual) = %v, want non-nil", cfg)
+	}
+
+	for _, c := range components {
+		if got := cfg.LoggingLevel[c]; got != wantLevel {
+			t.Errorf("LoggingLevel[%q] = %v, want %v", c, got, wantLevel)
+		}
+	}
+	if got := cfg.LoggingConfig; got != wantCfg {
+		t.Errorf("LoggingConfig = %v, want %v, diff %s", got, wantCfg, cmp.Diff(got, wantCfg))
 	}
 }
 

--- a/pkg/logging/testdata/test-config-logging.yaml
+++ b/pkg/logging/testdata/test-config-logging.yaml
@@ -1,0 +1,1 @@
+../../../test/config/config-logging.yaml

--- a/test/config/config-logging.yaml
+++ b/test/config/config-logging.yaml
@@ -1,0 +1,103 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # For all components except the autoscaler and queue proxy,
+    # changes are be picked up immediately.
+    # For autoscaler and queue proxy, changes require recreation of the pods.
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+
+  zap-logger-config: |
+    {
+      "level": "debug",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+
+  # Log level overrides
+  # For all components except the autoscaler and queue proxy,
+  # changes are be picked up immediately.
+  # For autoscaler and queue proxy, changes require recreation of the pods.
+  loglevel.controller: "debug"
+  loglevel.autoscaler: "debug"
+  loglevel.queueproxy: "debug"
+  loglevel.webhook: "debug"
+  loglevel.activator: "debug"


### PR DESCRIPTION
/lint

Fixes #2313

## Proposed Changes

* Update log level to run tests on debug level

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
