### PR TITLE
Refactor deployment status propagation

### DIFF
--- a/pkg/apis/serving/k8s_lifecycle.go
+++ b/pkg/apis/serving/k8s_lifecycle.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+var depCondSet = apis.NewLivingConditionSet(
+	DeploymentConditionProgressing,
+	DeploymentConditionReplicaSetReady,
+)
+
+const (
+	// DeploymentConditionReady means the underlying deployment is ready.
+	DeploymentConditionReady = apis.ConditionReady
+	// DeploymentConditionReplicaSetready inverts the underlying deployment's
+	// ReplicaSetFailure condition.
+	DeploymentConditionReplicaSetReady apis.ConditionType = "ReplicaSetReady"
+	// DeploymentConditionProgressing reflects the underlying deployment's
+	// Progressing condition.
+	DeploymentConditionProgressing apis.ConditionType = "Progressing"
+)
+
+// transformDeploymentStatus transforms the kubernetes DeploymentStatus into a
+// duckv1beta1.Status that uses ConditionSets to propagate failures and expose
+// a top-level happy state, per our condition conventions.
+func TransformDeploymentStatus(ds *appsv1.DeploymentStatus) *duckv1beta1.Status {
+	s := &duckv1beta1.Status{}
+
+	depCondSet.Manage(s).InitializeConditions()
+	// The absence of this condition means no failure has occurred. If we find it
+	// below, we'll ovewrwrite this.
+	depCondSet.Manage(s).MarkTrue(DeploymentConditionReplicaSetReady)
+
+	for _, cond := range ds.Conditions {
+		// TODO(jonjohnsonjr): Should we care about appsv1.DeploymentAvailable here?
+		switch cond.Type {
+		case appsv1.DeploymentProgressing:
+			switch cond.Status {
+			case corev1.ConditionUnknown:
+				depCondSet.Manage(s).MarkUnknown(DeploymentConditionProgressing, cond.Reason, cond.Message)
+			case corev1.ConditionTrue:
+				depCondSet.Manage(s).MarkTrue(DeploymentConditionProgressing)
+			case corev1.ConditionFalse:
+				depCondSet.Manage(s).MarkFalse(DeploymentConditionProgressing, cond.Reason, cond.Message)
+			}
+		case appsv1.DeploymentReplicaFailure:
+			switch cond.Status {
+			case corev1.ConditionUnknown:
+				depCondSet.Manage(s).MarkUnknown(DeploymentConditionReplicaSetReady, cond.Reason, cond.Message)
+			case corev1.ConditionTrue:
+				depCondSet.Manage(s).MarkFalse(DeploymentConditionReplicaSetReady, cond.Reason, cond.Message)
+			case corev1.ConditionFalse:
+				depCondSet.Manage(s).MarkTrue(DeploymentConditionReplicaSetReady)
+			}
+		}
+	}
+	return s
+}

--- a/pkg/apis/serving/k8s_lifecycle_test.go
+++ b/pkg/apis/serving/k8s_lifecycle_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package serving
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+func TestTransformDeploymentStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   *appsv1.DeploymentStatus
+		want *duckv1beta1.Status
+	}{{
+		name: "initial conditions",
+		ds:   &appsv1.DeploymentStatus{},
+		want: &duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:   DeploymentConditionProgressing,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   DeploymentConditionReplicaSetReady,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   DeploymentConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}, {
+		name: "happy without rs",
+		ds: &appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+		want: &duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:   DeploymentConditionProgressing,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   DeploymentConditionReplicaSetReady,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   DeploymentConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}, {
+		name: "happy with rs",
+		ds: &appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   appsv1.DeploymentReplicaFailure,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+		want: &duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:   DeploymentConditionProgressing,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   DeploymentConditionReplicaSetReady,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   DeploymentConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}, {
+		name: "false progressing unknown rs",
+		ds: &appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionFalse,
+			}, {
+				Type:   appsv1.DeploymentReplicaFailure,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+		want: &duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:   DeploymentConditionProgressing,
+				Status: corev1.ConditionFalse,
+			}, {
+				Type:   DeploymentConditionReplicaSetReady,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   DeploymentConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}, {
+		name: "unknown progressing failed rs",
+		ds: &appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   appsv1.DeploymentReplicaFailure,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+		want: &duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:   DeploymentConditionProgressing,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   DeploymentConditionReplicaSetReady,
+				Status: corev1.ConditionFalse,
+			}, {
+				Type:   DeploymentConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}, {
+		name: "reason and message propagate",
+		ds: &appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:    appsv1.DeploymentReplicaFailure,
+				Status:  corev1.ConditionTrue,
+				Reason:  "ReplicaSetReason",
+				Message: "Something bag happened",
+			}},
+		},
+		want: &duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:   DeploymentConditionProgressing,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:    DeploymentConditionReplicaSetReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ReplicaSetReason",
+				Message: "Something bag happened",
+			}, {
+				Type:    DeploymentConditionReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ReplicaSetReason",
+				Message: "Something bag happened",
+			}},
+		},
+	}}
+
+	opts := []cmp.Option{
+		cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime"),
+		cmpopts.SortSlices(func(a, b apis.Condition) bool {
+			return a.Type < b.Type
+		}),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			want, got := test.want, TransformDeploymentStatus(test.ds)
+			if diff := cmp.Diff(want, got, opts...); diff != "" {
+				t.Errorf("GetCondition refs diff (-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -123,8 +123,10 @@ func MarkDeploying(reason string) RevisionOption {
 
 // MarkProgressDeadlineExceeded calls the method of the same name on the Revision
 // with the message we expect the Revision Reconciler to pass.
-func MarkProgressDeadlineExceeded(r *v1alpha1.Revision) {
-	r.Status.MarkProgressDeadlineExceeded("Unable to create pods for more than 120 seconds.")
+func MarkProgressDeadlineExceeded(message string) RevisionOption {
+	return func(r *v1alpha1.Revision) {
+		r.Status.MarkProgressDeadlineExceeded(message)
+	}
 }
 
 // MarkContainerMissing calls .Status.MarkContainerMissing on the Revision.


### PR DESCRIPTION
This change brings the Deployment -> Revision status propagation more in
line with how other reconcilers work. Since this is at the edge between
knative and kubernetes resource conventions, we need to transform the
deployment conditions to conform to our conventions, e.g. by inverting
appsv1.DeploymentReplicaFailure to be a happy condition and exposing a
top-level happy state ("Ready") for the deployment.

There are some changes to behavior:

- An event is no longer emitted when the deployment times out.
- We surface the underlying DeploymentProgressing Reason/Message instead
of hard-coding our own.
- We surface the DeploymentReplicaFailure message as well.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4416

Part of https://github.com/knative/serving/issues/5076
