### PR TITLE
Profiling support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1655,7 +1655,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5dddb45857ff59292216934b6f39415befab65246afac26ba14976e3ec11a343"
+  digest = "1:4ede44d732fec3c64776a5ec3897efc2b5fbd42dd014f9bde56e69f3bece21e1"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1730,6 +1730,7 @@
     "metrics/metricskey",
     "metrics/metricstest",
     "metrics/testing",
+    "profiling",
     "ptr",
     "reconciler/testing",
     "signals",
@@ -1753,7 +1754,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "9f6e5334c25aeebd862b19cb6715f9fe5aa56467"
+  revision = "366ab85660d4e1c260795bd23c2aa09a4721c282"
 
 [[projects]]
   branch = "master"
@@ -1941,6 +1942,7 @@
     "knative.dev/pkg/metrics/metricskey",
     "knative.dev/pkg/metrics/metricstest",
     "knative.dev/pkg/metrics/testing",
+    "knative.dev/pkg/profiling",
     "knative.dev/pkg/ptr",
     "knative.dev/pkg/reconciler/testing",
     "knative.dev/pkg/signals",

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -44,6 +44,7 @@ import (
 	pkglogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/profiling"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/tracing"
@@ -235,19 +236,24 @@ func main() {
 	ah = activatorhandler.NewMetricHandler(revisionInformer.Lister(), reporter, logger, ah)
 	ah = network.NewProbeHandler(ah)
 
+	profilingHandler := profiling.NewHandler(logger, false)
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher.Watch(pkglogging.ConfigMapName(), pkglogging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
-	// Watch the observability config map and dynamically update metrics exporter.
-	configMapWatcher.Watch(metrics.ConfigMapName(), metrics.UpdateExporterFromConfigMap(component, logger))
-	// Watch the observability config map and dynamically update request logs.
-	configMapWatcher.Watch(metrics.ConfigMapName(), updateRequestLogFromConfigMap(logger, reqLogHandler))
+
+	// Watch the observability config map
+	configMapWatcher.Watch(metrics.ConfigMapName(),
+		metrics.UpdateExporterFromConfigMap(component, logger),
+		updateRequestLogFromConfigMap(logger, reqLogHandler),
+		profilingHandler.UpdateFromConfigMap)
+
 	if err = configMapWatcher.Start(ctx.Done()); err != nil {
 		logger.Fatalw("Failed to start configuration manager", zap.Error(err))
 	}
 
 	servers := map[string]*http.Server{
-		"http1": network.NewServer(":"+strconv.Itoa(networking.BackendHTTPPort), ah),
-		"h2c":   network.NewServer(":"+strconv.Itoa(networking.BackendHTTP2Port), ah),
+		"http1":   network.NewServer(":"+strconv.Itoa(networking.BackendHTTPPort), ah),
+		"h2c":     network.NewServer(":"+strconv.Itoa(networking.BackendHTTP2Port), ah),
+		"profile": profiling.NewServer(profilingHandler),
 	}
 
 	errCh := make(chan error, len(servers))
@@ -259,7 +265,6 @@ func main() {
 			}
 		}(name, server)
 	}
-
 	// Exit as soon as we see a shutdown signal or one of the servers failed.
 	select {
 	case <-ctx.Done():

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -34,6 +36,7 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/profiling"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -100,11 +103,15 @@ func main() {
 	statsCh := make(chan *autoscaler.StatMessage, statsBufferLen)
 	defer close(statsCh)
 
+	profilingHandler := profiling.NewHandler(logger, false)
+
 	cmw := configmap.NewInformedWatcher(kubeclient.Get(ctx), system.Namespace())
 	// Watch the logging config map and dynamically update logging levels.
 	cmw.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
-	// Watch the observability config map and dynamically update metrics exporter.
-	cmw.Watch(metrics.ConfigMapName(), metrics.UpdateExporterFromConfigMap(component, logger))
+	// Watch the observability config map
+	cmw.Watch(metrics.ConfigMapName(),
+		metrics.UpdateExporterFromConfigMap(component, logger),
+		profilingHandler.UpdateFromConfigMap)
 
 	endpointsInformer := endpointsinformer.Get(ctx)
 
@@ -142,19 +149,24 @@ func main() {
 		}
 	}()
 
+	profilingServer := profiling.NewServer(profilingHandler)
+
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		return customMetricsAdapter.Run(ctx.Done())
 	})
 	eg.Go(statsServer.ListenAndServe)
+	eg.Go(profilingServer.ListenAndServe)
 
 	// This will block until either a signal arrives or one of the grouped functions
 	// returns an error.
 	<-egCtx.Done()
 
 	statsServer.Shutdown(5 * time.Second)
-	if err := eg.Wait(); err != nil {
-		logger.Errorw("Error while shutting down", zap.Error(err))
+	profilingServer.Shutdown(context.Background())
+	// Don't forward ErrServerClosed as that indicates we're already shutting down.
+	if err := eg.Wait(); err != nil && err != http.ErrServerClosed {
+		logger.Errorw("Error while running server", zap.Error(err))
 	}
 }
 

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -44,11 +44,11 @@ spec:
         # and substituted here.
         image: knative.dev/serving/cmd/activator
         ports:
-        - name: http1-port
+        - name: http1
           containerPort: 8012
-        - name: h2c-port
+        - name: h2c
           containerPort: 8013
-        - name: metrics-port
+        - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -44,12 +44,14 @@ spec:
         # and substituted here.
         image: knative.dev/serving/cmd/activator
         ports:
-        - name: http1
+        - name: http1-port
           containerPort: 8012
-        - name: h2c
+        - name: h2c-port
           containerPort: 8013
-        - name: metrics
+        - name: metrics-port
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         args:
           # Disable glog writing into stderr. Our code doesn't use glog
           # and seeing k8s logs in addition to ours is not useful.

--- a/config/autoscaler-hpa.yaml
+++ b/config/autoscaler-hpa.yaml
@@ -49,6 +49,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -78,6 +78,8 @@ spec:
           containerPort: 9090
         - name: custom-metrics
           containerPort: 8443
+        - name: profiling
+          containerPort: 8008
         args:
         - "--secure-port=8443"
         - "--cert-dir=/tmp"

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -99,3 +99,9 @@ data:
     # flag to "true" could cause extra Stackdriver charge.
     # If metrics.backend-destination is not Stackdriver, this is ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -50,6 +50,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/config/networking-certmanager.yaml
+++ b/config/networking-certmanager.yaml
@@ -48,6 +48,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/config/networking-istio.yaml
+++ b/config/networking-istio.yaml
@@ -48,6 +48,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -44,6 +44,8 @@ spec:
         ports:
         - name: metrics-port
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         resources:
           # Request 2x what we saw running e2e
           requests:

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -1217,14 +1217,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:305af75fc194c059ae710a75276ca8f1870c959214b18ed33f7ef8671995947f"
+  digest = "1:a68a49f889453ee0abab8d32ceaa19c12a1e86c7919e9cecb3d5ceac6aac199c"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "f3fe0bcc30693df8e3c9616358b16045efb9ed10"
+  revision = "d2746f8b9470e8c8452a997e95190aba5320678a"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/pkg/apis/url.go
+++ b/vendor/knative.dev/pkg/apis/url.go
@@ -57,11 +57,14 @@ func (u *URL) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &ref); err != nil {
 		return err
 	}
-	r, err := ParseURL(ref)
-	if err != nil {
+	if r, err := ParseURL(ref); err != nil {
 		return err
+	} else if r != nil {
+		*u = *r
+	} else {
+		*u = URL{}
 	}
-	*u = *r
+
 	return nil
 }
 

--- a/vendor/knative.dev/pkg/configmap/informed_watcher.go
+++ b/vendor/knative.dev/pkg/configmap/informed_watcher.go
@@ -79,7 +79,7 @@ var _ Watcher = (*InformedWatcher)(nil)
 var _ DefaultingWatcher = (*InformedWatcher)(nil)
 
 // WatchWithDefault implements DefaultingWatcher.
-func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o Observer) {
+func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o ...Observer) {
 	i.defaults[cm.Name] = &cm
 
 	i.m.Lock()
@@ -94,7 +94,7 @@ func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o Observer) {
 		panic("cannot WatchWithDefault after the InformedWatcher has started")
 	}
 
-	i.Watch(cm.Name, o)
+	i.Watch(cm.Name, o...)
 }
 
 // Start implements Watcher.

--- a/vendor/knative.dev/pkg/configmap/manual_watcher.go
+++ b/vendor/knative.dev/pkg/configmap/manual_watcher.go
@@ -35,14 +35,14 @@ type ManualWatcher struct {
 var _ Watcher = (*ManualWatcher)(nil)
 
 // Watch implements Watcher
-func (w *ManualWatcher) Watch(name string, o Observer) {
+func (w *ManualWatcher) Watch(name string, o ...Observer) {
 	w.m.Lock()
 	defer w.m.Unlock()
 
 	if w.observers == nil {
-		w.observers = make(map[string][]Observer, 1)
+		w.observers = make(map[string][]Observer, len(o))
 	}
-	w.observers[name] = append(w.observers[name], o)
+	w.observers[name] = append(w.observers[name], o...)
 }
 
 func (w *ManualWatcher) Start(<-chan struct{}) error {

--- a/vendor/knative.dev/pkg/configmap/static_watcher.go
+++ b/vendor/knative.dev/pkg/configmap/static_watcher.go
@@ -48,10 +48,12 @@ type StaticWatcher struct {
 var _ Watcher = (*StaticWatcher)(nil)
 
 // Watch implements Watcher
-func (di *StaticWatcher) Watch(name string, o Observer) {
+func (di *StaticWatcher) Watch(name string, o ...Observer) {
 	cm, ok := di.cfgs[name]
 	if ok {
-		o(cm)
+		for _, observer := range o {
+			observer(cm)
+		}
 	} else {
 		panic(fmt.Sprintf("Tried to watch unknown config with name %q", name))
 	}

--- a/vendor/knative.dev/pkg/configmap/watcher.go
+++ b/vendor/knative.dev/pkg/configmap/watcher.go
@@ -28,8 +28,8 @@ type Observer func(*corev1.ConfigMap)
 
 // Watcher defines the interface that a configmap implementation must implement.
 type Watcher interface {
-	// Watch is called to register a callback to be notified when a named ConfigMap changes.
-	Watch(string, Observer)
+	// Watch is called to register callbacks to be notified when a named ConfigMap changes.
+	Watch(string, ...Observer)
 
 	// Start is called to initiate the watches and provide a channel to signal when we should
 	// stop watching.  When Start returns, all registered Observers will be called with the
@@ -42,8 +42,8 @@ type Watcher interface {
 type DefaultingWatcher interface {
 	Watcher
 
-	// WatchWithDefault is called to register a callback to be notified when a named ConfigMap
+	// WatchWithDefault is called to register callbacks to be notified when a named ConfigMap
 	// changes. The provided default value is always observed before any real ConfigMap with that
 	// name is. If the real ConfigMap with that name is deleted, then the default value is observed.
-	WatchWithDefault(cm corev1.ConfigMap, o Observer)
+	WatchWithDefault(cm corev1.ConfigMap, o ...Observer)
 }

--- a/vendor/knative.dev/pkg/profiling/server.go
+++ b/vendor/knative.dev/pkg/profiling/server.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profiling
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"strconv"
+	"sync"
+
+	perrors "github.com/pkg/errors"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// profilingPort is the port where we expose profiling information if profiling is enabled
+	profilingPort = ":8008"
+
+	// profilingKey is the name of the key in config-observability config map that indicates whether profiling
+	// is enabled of disabled
+	profilingKey = "profiling.enable"
+)
+
+// Handler holds the main HTTP handler and a flag indicating
+// whether the handler is active
+type Handler struct {
+	enabled    bool
+	enabledMux sync.Mutex
+	handler    http.Handler
+	log        *zap.SugaredLogger
+}
+
+// NewHandler create a new ProfilingHandler which serves runtime profiling data
+// according to the given context path
+func NewHandler(logger *zap.SugaredLogger, enableProfiling bool) *Handler {
+	const pprofPrefix = "/debug/pprof/"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(pprofPrefix, pprof.Index)
+	mux.HandleFunc(pprofPrefix+"cmdline", pprof.Cmdline)
+	mux.HandleFunc(pprofPrefix+"profile", pprof.Profile)
+	mux.HandleFunc(pprofPrefix+"symbol", pprof.Symbol)
+	mux.HandleFunc(pprofPrefix+"trace", pprof.Trace)
+
+	logger.Infof("Profiling enabled: %t", enableProfiling)
+
+	return &Handler{
+		enabled: enableProfiling,
+		handler: mux,
+		log:     logger,
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.enabledMux.Lock()
+	defer h.enabledMux.Unlock()
+	if h.enabled {
+		h.handler.ServeHTTP(w, r)
+	} else {
+		http.NotFoundHandler().ServeHTTP(w, r)
+	}
+}
+
+func readProfilingFlag(configMap *corev1.ConfigMap) (bool, error) {
+	profiling, ok := configMap.Data[profilingKey]
+	if !ok {
+		return false, nil
+	}
+	enabled, err := strconv.ParseBool(profiling)
+	if err != nil {
+		return false, perrors.Wrapf(err, "failed to parse the profiling flag")
+	}
+	return enabled, nil
+}
+
+// UpdateFromConfigMap modifies the Enabled flag in the Handler
+// according to the value in the given ConfigMap
+func (h *Handler) UpdateFromConfigMap(configMap *corev1.ConfigMap) {
+	enabled, err := readProfilingFlag(configMap)
+	if err != nil {
+		h.log.Errorw("Failed to update the profiling flag", zap.Error(err))
+		return
+	}
+	h.enabledMux.Lock()
+	defer h.enabledMux.Unlock()
+	if h.enabled != enabled {
+		h.enabled = enabled
+		h.log.Infof("Profiling enabled: %t", h.enabled)
+	}
+}
+
+// NewServer creates a new http server that exposes profiling data using the
+// HTTP handler that is passed as an argument
+func NewServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:    profilingPort,
+		Handler: handler,
+	}
+}

--- a/vendor/knative.dev/pkg/test/mako/README.md
+++ b/vendor/knative.dev/pkg/test/mako/README.md
@@ -1,7 +1,8 @@
 # Mako
 
-[Mako](https://github.com/google/mako) is an open source project for performance testing in Knative.
-It offers capacities like data storage, charting, statistical aggregation and automated regression analysis.
+[Mako](https://github.com/google/mako) is an open source project for performance
+testing in Knative. It offers capacities like data storage, charting,
+statistical aggregation and automated regression analysis.
 
-This folder contains common code that can be used by all Knative projects, with which we can follow the
-same process to set up Mako and collaborate.
+This folder contains common code that can be used by all Knative projects, with
+which we can follow the same process to set up Mako and collaborate.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/4982

## Proposed Changes

* Introduce a new port 8008 where a web server will be listening and serving profiling data that are consumable by the pprof tool
* Introduce profiling.enable flag in config-observability.yaml that will be either true or false. It will indicate whether it's possible to access the URLs that server pprof-specific profiling data. 
* The profiling data are available for all pods that are currently running in the Knative Serving namespace
* Retrieving profiling data is on demand via wget/curl or web browser accessing certain urls

Steps to get profiling data:
1) Edit the config map and add `profiling.enable = "true"`
```oc edit configmap config-observability -n knative-serving```
2) Use port-forwarding to get access to Knative Serving pods
```
AUTOSCALER_POD=$(oc get pods -n knative-serving | grep autoscaler | grep -v hpa | awk '{print $1}')
kubectl port-forward -n knative-serving $AUTOSCALER_POD  8008:8008
```
3) Use either of these commands (detailed description at [url](https://golang.org/src/net/http/pprof/pprof.go)) to get/analyze pprof data:
```
go tool pprof http://localhost:8008/debug/pprof/heap
go tool pprof http://localhost:8008/debug/pprof/profile?seconds=5
go tool pprof http://localhost:8008/debug/pprof/symbol
```
4) Alternatively, use web browser to access `http://localhost:8008/debug/pprof/` and display the index page with information about available profiling options

There's another PR which needs to be reviewed/integrated first: https://github.com/knative/pkg/pull/562
Once it is integrated I'd update the current PR and reference code in knative.dev/pkg

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
