### PR TITLE
Alter the load-test to rotate through several TBC settings.

### DIFF
--- a/test/performance/load-test/load-test-setup.yaml
+++ b/test/performance/load-test/load-test-setup.yaml
@@ -15,9 +15,41 @@
 apiVersion: serving.knative.dev/v1beta1
 kind: Service
 metadata:
-  name: load-test
+  name: load-test-always
 spec:
   template:
+    metadata:
+      annotations:
+        # Always hook the activator in.
+        autoscaling.knative.dev/targetBurstCapacity: "-1"
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
+  name: load-test-zero
+spec:
+  template:
+    metadata:
+      annotations:
+        # Only hook the activator in at zero
+        autoscaling.knative.dev/targetBurstCapacity: "0"
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
+  name: load-test-200
+spec:
+  template:
+    metadata:
+      annotations:
+        # Hook the activator in until we reach a higher capacity.
+        autoscaling.knative.dev/targetBurstCapacity: "200"
     spec:
       containers:
       - image: knative.dev/serving/test/test_images/autoscale

--- a/test/performance/load-test/load-test.config
+++ b/test/performance/load-test/load-test.config
@@ -1,9 +1,9 @@
 # Creating this benchmark:
 # mako create_benchmark \
-#   test/performance/config/load-test-1000.config
+#   test/performance/load-test/load-test.config
 project_name: "Knative"
-benchmark_name: "serving load testing"
-description: "Load test 0->1k->2k->3k against a ksvc."
+benchmark_name: "Serving load testing"
+description: "Load test 0->1k->2k->3k against a ksvc (with several TBC values)."
 benchmark_key: '5352009922248704'
 
 # Only owners can write to the benchmark
@@ -12,6 +12,7 @@ owner_list: "vagababov@google.com"
 owner_list: "srinivashegde@google.com"
 owner_list: "chizhg@google.com"
 owner_list: "yanweiguo@google.com"
+
 # Add your robot here:
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
 

--- a/test/performance/load-test/load-test.yaml
+++ b/test/performance/load-test/load-test.yaml
@@ -45,9 +45,9 @@ roleRef:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: load-test
+  name: load-test-zero
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "0,30 * * * *"
   jobTemplate:
     spec:
       parallelism: 1
@@ -59,12 +59,87 @@ spec:
             image: knative.dev/serving/test/performance/load-test
             args:
             - "-benchmark=5352009922248704"
+            - "-flavor=zero"
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          restartPolicy: Never
+      backoffLimit: 0
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: load-test-always
+spec:
+  schedule: "10,40 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          serviceAccountName: loader
+          containers:
+          - name: load-test
+            image: knative.dev/serving/test/performance/load-test
+            args:
+            - "-benchmark=5352009922248704"
+            - "-flavor=always"
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+          - name: mako
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          restartPolicy: Never
+      backoffLimit: 0
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: load-test-200
+spec:
+  schedule: "20,50 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          serviceAccountName: loader
+          containers:
+          - name: load-test
+            image: knative.dev/serving/test/performance/load-test
+            args:
+            - "-benchmark=5352009922248704"
+            - "-flavor=200"
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+          - name: mako
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json


### PR DESCRIPTION
This changes the load-test performance monitoring to rotate through load testing against three variations of ksvc, each tagged with their "flavor".

You can see the combined data that I have been running overnight [here](https://mako.dev/benchmark?benchmark_key=6052172353503232&~l=p95000&~es=p95000&~rs=p95000&~dp=p95000&~ap=p95000&~sks=p95000), which can alos be filtered down to the individual variations:
 - [TBC=0](https://mako.dev/benchmark?benchmark_key=6052172353503232&~l=p95000&~es=p95000&~rs=p95000&~dp=p95000&~ap=p95000&~sks=p95000&tag=tbc%3Dzero)
 - [TBC=200](https://mako.dev/benchmark?benchmark_key=6052172353503232&~l=p95000&~es=p95000&~rs=p95000&~dp=p95000&~ap=p95000&~sks=p95000&tag=tbc%3D200)
 - [TBC=-1](https://mako.dev/benchmark?benchmark_key=6052172353503232&~l=p95000&~es=p95000&~rs=p95000&~dp=p95000&~ap=p95000&~sks=p95000&tag=tbc%3Dalways)

You can pivot this data a variety of ways, for examples:
 - [This](https://mako.dev/benchmark?benchmark_key=6052172353503232&~sks=mean) graph shows our rotation through the TBC configurations very clearly as the graph, which averages the presence of the activator proxy on the data path rotates between 0 (basically never there), 1 (always there), and 0.8 (mostly there).
 - [This](https://mako.dev/benchmark?benchmark_key=6052172353503232&~l=p95000) graph shows the same as it impacts our dataplane p95 latency.

