### PR TITLE
add an option to run e2e test with reconcileExternalGateway enabled

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -76,12 +76,6 @@ else
   LABEL_YAML_CMD=(cat)
 fi
 
-# Turn on reconcileExternalGateway if it is configured.
-if (( RECONCILE_GATEWAY )); then
-  echo "Turning on reconcileExternalGateway"
-  echo "  reconcileExternalGateway: \"true\"" >> config/config-istio.yaml
-fi
-
 : ${KO_DOCKER_REPO:="ko.local"}
 export KO_DOCKER_REPO
 

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -76,6 +76,12 @@ else
   LABEL_YAML_CMD=(cat)
 fi
 
+# Turn on reconcileExternalGateway if it is configured.
+if (( RECONCILE_GATEWAY )); then
+  echo "Turning on reconcileExternalGateway"
+  echo "  reconcileExternalGateway: \"true\"" >> config/config-istio.yaml
+fi
+
 : ${KO_DOCKER_REPO:="ko.local"}
 export KO_DOCKER_REPO
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -219,7 +219,7 @@ function install_knative_serving_standard() {
   if (( RECONCILE_GATEWAY )); then
     echo ">>Turning on reconcileExternalGateway."
     kubectl get cm config-istio -n knative-serving -o yaml | \
-      sed 's/\ \ reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' |\
+      sed 's/  reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' |\
         kubectl replace -f -
   fi
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -216,9 +216,11 @@ function install_knative_serving_standard() {
   echo ">> Bringing up Serving"
   kubectl apply -f "${INSTALL_RELEASE_YAML}" || return 1
 
-  if ((RECONCILE_GATEWAY)); then
+  if (( RECONCILE_GATEWAY )); then
     echo ">>Turning on reconcileExternalGateway."
-    kubectl get cm config-istio -n knative-serving -o yaml | sed 's/\ \ reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' | kubectl replace -f -
+    kubectl get cm config-istio -n knative-serving -o yaml | \
+      sed 's/\ \ reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' |\
+        kubectl replace -f -
   fi
 
   echo ">> Adding more activator pods."

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -217,10 +217,10 @@ function install_knative_serving_standard() {
   kubectl apply -f "${INSTALL_RELEASE_YAML}" || return 1
 
   if (( RECONCILE_GATEWAY )); then
-    echo ">>Turning on reconcileExternalGateway."
+    echo ">> Turning on reconcileExternalGateway"
     kubectl get cm config-istio -n knative-serving -o yaml | \
-      sed 's/  reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' |\
-        kubectl replace -f -
+      sed 's/  reconcileExternalGateway: "false"/reconcileExternalGateway: "true"/g' |\
+      kubectl replace -f -
   fi
 
   echo ">> Adding more activator pods."

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -38,6 +38,8 @@ INSTALL_MONITORING=0
 
 INSTALL_BETA=1
 
+RECONCILE_GATEWAY=0
+
 # List of custom YAMLs to install, if specified (space-separated).
 INSTALL_CUSTOM_YAMLS=""
 
@@ -77,6 +79,10 @@ function parse_flags() {
       ;;
     --install-beta)
       readonly INSTALL_BETA=1
+      return 1
+      ;;
+    --reconcile-gateway)
+      readonly RECONCILE_GATEWAY=1
       return 1
       ;;
     --custom-yamls)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -216,6 +216,11 @@ function install_knative_serving_standard() {
   echo ">> Bringing up Serving"
   kubectl apply -f "${INSTALL_RELEASE_YAML}" || return 1
 
+  if ((RECONCILE_GATEWAY)); then
+    echo ">>Turning on reconcileExternalGateway."
+    kubectl get cm config-istio -n knative-serving -o yaml | sed -i 's/\ \ reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' | kubectl replace -f -
+  fi
+
   echo ">> Adding more activator pods."
   # This command would fail if the HPA already exist, like during upgrade test.
   # Therefore we don't exit on failure, and don't log an error message.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -218,7 +218,7 @@ function install_knative_serving_standard() {
 
   if ((RECONCILE_GATEWAY)); then
     echo ">>Turning on reconcileExternalGateway."
-    kubectl get cm config-istio -n knative-serving -o yaml | sed -i 's/\ \ reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' | kubectl replace -f -
+    kubectl get cm config-istio -n knative-serving -o yaml | sed 's/\ \ reconcileExternalGateway: \"false\"/reconcileExternalGateway: \"true\"/g' | kubectl replace -f -
   fi
 
   echo ">> Adding more activator pods."


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* add an option to run e2e test with reconcileExternalGateway enabled

This is a part of work for: https://github.com/knative/serving/issues/5092

