### PR TITLE
Ensure that the Route label isn't propagated to the Deployment.

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -218,6 +218,7 @@ var (
 			Labels: map[string]string{
 				serving.ConfigurationLabelKey: "cfg",
 				serving.ServiceLabelKey:       "svc",
+				serving.RouteLabelKey:         "im-a-route",
 			},
 		},
 		Spec: v1alpha1.RevisionSpec{

--- a/pkg/reconciler/revision/resources/meta.go
+++ b/pkg/reconciler/revision/resources/meta.go
@@ -25,7 +25,12 @@ import (
 
 // makeLabels constructs the labels we will apply to K8s resources.
 func makeLabels(revision *v1alpha1.Revision) map[string]string {
-	labels := resources.UnionMaps(revision.GetLabels(), map[string]string{
+	labels := resources.FilterMap(revision.GetLabels(), func(k string) bool {
+		// Exclude the Route label so that a Revision becoming routable
+		// doesn't trigger deployment updates.
+		return k == serving.RouteLabelKey
+	})
+	labels = resources.UnionMaps(labels, map[string]string{
 		serving.RevisionLabelKey: revision.Name,
 		serving.RevisionUID:      string(revision.UID),
 	})


### PR DESCRIPTION
We recently started to apply the serving.knative.dev/route label to
Revisions in addition to Configurations.  I noticed that when I was
deploying things there was higher pod churn then expected, and this
was due to the fact that when the Revision became routable and the
label was applied a rollout of the Deployment with the new label
was triggered.

This simply filters the label from those we propagate down to the
Deployment.
