### PR TITLE
golang format tools

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,12 +19,12 @@ package main
 import (
 	// The set of controllers this controller process runs.
 	"knative.dev/serving/pkg/reconciler/configuration"
+	"knative.dev/serving/pkg/reconciler/gc"
 	"knative.dev/serving/pkg/reconciler/labeler"
 	"knative.dev/serving/pkg/reconciler/revision"
 	"knative.dev/serving/pkg/reconciler/route"
 	"knative.dev/serving/pkg/reconciler/serverlessservice"
 	"knative.dev/serving/pkg/reconciler/service"
-	"knative.dev/serving/pkg/reconciler/gc"
 
 	// This defines the shared main for injected controllers.
 	"knative.dev/pkg/injection/sharedmain"

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -18,11 +18,12 @@ package handler
 import (
 	"bytes"
 	"errors"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/activator"
@@ -46,14 +47,14 @@ func TestRequestMetricHandler(t *testing.T) {
 			baseHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}),
-			newHeader:     map[string]string{"User-Agent": network.KubeProbeUAPrefix},
+			newHeader: map[string]string{"User-Agent": network.KubeProbeUAPrefix},
 		},
 		{
 			label: "network probe response",
 			baseHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}),
-			newHeader:     map[string]string{network.ProbeHeaderName: "test-service"},
+			newHeader: map[string]string{network.ProbeHeaderName: "test-service"},
 		},
 		{
 			label: "normal response",

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -65,7 +65,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
-					Name: corev1.ResourceCPU,
+					Name:                     corev1.ResourceCPU,
 					TargetAverageUtilization: ptr.Int32(int32(math.Ceil(target))),
 				},
 			}}

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -19,12 +19,12 @@ package configuration
 import (
 	"context"
 
-	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 	"knative.dev/serving/pkg/reconciler"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
