### PR TITLE
Refactor metadata validation tests

### DIFF
--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
@@ -99,66 +98,72 @@ func TestValidateObjectMetadata(t *testing.T) {
 			Message: "name or generateName is required",
 			Paths:   []string{"name"},
 		},
+	}, {
+		name: "valid forceUpgrade annotation label",
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				"serving.knative.dev/forceUpgrade": "true",
+			},
+		},
+		expectErr: (*apis.FieldError)(nil),
+	}, {
+		name: "valid creator annotation label",
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				"serving.knative.dev/creator": "svc-creator",
+			},
+		},
+
+		expectErr: (*apis.FieldError)(nil),
+	}, {
+		name: "valid lastModifier annotation label",
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				"serving.knative.dev/lastModifier": "svc-modifier",
+			},
+		},
+		expectErr: (*apis.FieldError)(nil),
+	}, {
+		name: "valid lastPinned annotation label",
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				"serving.knative.dev/lastPinned": "pinned-val",
+			},
+		},
+		expectErr: (*apis.FieldError)(nil),
+	}, {
+		name: "invalid knative prefix annotation",
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				"serving.knative.dev/testAnnotation": "value",
+			},
+		},
+		expectErr: (&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+			(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+				(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+					apis.ErrInvalidKeyName("serving.knative.dev/testAnnotation", "annotations"),
+				))),
+	}, {
+		name: "valid non-knative prefix annotation label",
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				"testAnnotation": "testValue",
+			},
+		},
+		expectErr: (*apis.FieldError)(nil),
 	}}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-
 			err := ValidateObjectMetadata(c.objectMeta)
 
 			if !reflect.DeepEqual(c.expectErr, err) {
-				t.Errorf("Expected: '%#v', Got: '%#v'", c.expectErr, err)
-			}
-		})
-	}
-}
-
-func TestAnnotationValidation(t *testing.T) {
-	cases := []struct {
-		name        string
-		annotations map[string]string
-		expectErr   *apis.FieldError
-	}{{
-		name: "valid forceUpgrade annotation label",
-		annotations: map[string]string{
-			"serving.knative.dev/forceUpgrade": "true",
-		},
-		expectErr: nil,
-	}, {
-		name: "valid creator annotation label",
-		annotations: map[string]string{
-			"serving.knative.dev/creator": "svc-creator",
-		},
-		expectErr: nil,
-	}, {
-		name: "valid lastModifier annotation label",
-		annotations: map[string]string{
-			"serving.knative.dev/lastModifier": "svc-modifier",
-		},
-		expectErr: nil,
-	}, {
-		name: "valid lastPinned annotation label",
-		annotations: map[string]string{
-			"serving.knative.dev/lastPinned": "pinned-val",
-		},
-		expectErr: nil,
-	}, {
-		name: "invalid knative prefix annotation",
-		annotations: map[string]string{
-			"serving.knative.dev/testAnnotation": "value",
-		},
-		expectErr: apis.ErrInvalidKeyName("serving.knative.dev/testAnnotation", ""),
-	}, {
-		name: "valid non-knative prefix annotation label",
-		annotations: map[string]string{
-			"testAnnotation": "testValue",
-		},
-		expectErr: nil,
-	}}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			err := validateKnativeAnnotations(c.annotations)
-			if d := cmp.Diff(c.expectErr.Error(), err.Error()); d != "" {
 				t.Errorf("Expected: '%#v', Got: '%#v'", c.expectErr, err)
 			}
 		})


### PR DESCRIPTION
/lint

## Proposed Changes

* Updated test to use public API instead of private function
* For context https://github.com/knative/serving/pull/4995#pullrequestreview-269077575