### PR TITLE
Don't mark the revision as `Updating` when reconciling PA

### DIFF
--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -166,9 +166,6 @@ func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1alpha1.Revision) er
 		if pa, err = c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).Update(want); err != nil {
 			return err
 		}
-		// This change will trigger PA -> SKS -> K8s service change;
-		// and those after reconciliation will back progpagate here.
-		rev.Status.MarkDeploying("Updating")
 	}
 
 	// Propagate the service name from the PA.


### PR DESCRIPTION
If a scaled-to-zero revision's PA needs reconciliation, the revision will be stuck `Updating`. See discussion here:
https://github.com/knative/serving/pull/4884#discussion_r311835250

## Proposed Changes

* Don't mark Revision as `Updating` when reconciling the PA