### PR TITLE
Fix the pacer issue in perf tests

### DIFF
--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -208,8 +208,8 @@ func main() {
 	pacers := make([]vegeta.Pacer, 3)
 	durations := make([]time.Duration, 3)
 	for i := 1; i < 4; i++ {
-		pacers = append(pacers, vegeta.Rate{Freq: i, Per: time.Millisecond})
-		durations = append(durations, duration)
+		pacers[i-1] = vegeta.Rate{Freq: i, Per: time.Millisecond}
+		durations[i-1] = duration
 	}
 	pacer, err := pkgpacers.NewCombined(pacers, durations)
 	if err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @srinivashegde86 