### PR TITLE
Remove build from clean-up instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -322,7 +322,6 @@ You can delete all of the service components with:
 ko delete --ignore-not-found=true \
   -f config/monitoring/100-namespace.yaml \
   -f config/ \
-  -f ./third_party/config/build/release.yaml \
   -f ./third_party/istio-1.2-latest/istio.yaml \
   -f ./third_party/istio-1.2-latest/istio-crds.yaml \
   -f ./third_party/cert-manager-0.6.1/cert-manager-crds.yaml \


### PR DESCRIPTION
The build release.yaml no longer exists which causes the clean-up
command to fail.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
