### PR TITLE
Fix a test in pkg/activator/metric_handler_test.go

### DIFF
--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -52,7 +52,7 @@ type MetricHandler struct {
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Filter out probe and healthy requests
-	if network.IsKubeletProbe(r) || r.Header.Get(network.ProbeHeaderName) != "" {
+	if network.IsProbe(r) {
 		h.nextHandler.ServeHTTP(w, r)
 		return
 	}

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -42,7 +42,7 @@ func TestRequestMetricHandler(t *testing.T) {
 		reporterCalls []reporterCall
 		newHeader     map[string]string
 		wantCode      int
-		wantErr       bool
+		wantPanic     bool
 	}{
 		{
 			label: "kube probe request",
@@ -89,8 +89,8 @@ func TestRequestMetricHandler(t *testing.T) {
 				Config:     "config-real-name",
 				StatusCode: http.StatusInternalServerError,
 			}},
-			wantCode: http.StatusBadRequest,
-			wantErr:  true,
+			wantCode:  http.StatusBadRequest,
+			wantPanic: true,
 		},
 	}
 
@@ -112,7 +112,7 @@ func TestRequestMetricHandler(t *testing.T) {
 
 			defer func() {
 				err := recover()
-				if test.wantErr && err == nil {
+				if test.wantPanic && err == nil {
 					t.Error("Want ServeHTTP to panic, got nothing.")
 				}
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -41,6 +41,8 @@ func TestRequestMetricHandler(t *testing.T) {
 		baseHandler   http.HandlerFunc
 		reporterCalls []reporterCall
 		newHeader     map[string]string
+		wantCode      int
+		wantErr       bool
 	}{
 		{
 			label: "kube probe request",
@@ -48,6 +50,7 @@ func TestRequestMetricHandler(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}),
 			newHeader: map[string]string{"User-Agent": network.KubeProbeUAPrefix},
+			wantCode:  http.StatusOK,
 		},
 		{
 			label: "network probe response",
@@ -55,6 +58,7 @@ func TestRequestMetricHandler(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}),
 			newHeader: map[string]string{network.ProbeHeaderName: "test-service"},
+			wantCode:  http.StatusOK,
 		},
 		{
 			label: "normal response",
@@ -69,11 +73,12 @@ func TestRequestMetricHandler(t *testing.T) {
 				Config:     "config-real-name",
 				StatusCode: http.StatusOK,
 			}},
+			wantCode: http.StatusOK,
 		},
 		{
 			label: "panic response",
 			baseHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(http.StatusBadRequest)
 				panic(errors.New("handler error"))
 			}),
 			reporterCalls: []reporterCall{{
@@ -84,16 +89,14 @@ func TestRequestMetricHandler(t *testing.T) {
 				Config:     "config-real-name",
 				StatusCode: http.StatusInternalServerError,
 			}},
+			wantCode: http.StatusBadRequest,
+			wantErr:  true,
 		},
 	}
 
-	reporter := &fakeReporter{}
-
 	for _, test := range tests {
 		t.Run(test.label, func(t *testing.T) {
-			defer func() {
-				recover()
-			}()
+			reporter := &fakeReporter{}
 			handler := NewMetricHandler(revisionLister(revision(testNamespace, testRevName)), reporter,
 				TestLogger(t), test.baseHandler)
 
@@ -107,11 +110,21 @@ func TestRequestMetricHandler(t *testing.T) {
 				}
 			}
 
-			handler.ServeHTTP(resp, req)
+			defer func() {
+				err := recover()
+				if test.wantErr && err == nil {
+					t.Error("Want ServeHTTP to panic, got nothing.")
+				}
 
-			if diff := cmp.Diff(test.reporterCalls, reporter.calls, ignoreDurationOption); diff != "" {
-				t.Errorf("Reporting calls are different (-want, +got) = %v", diff)
-			}
+				if resp.Code != test.wantCode {
+					t.Errorf("Unexpected response status. Want %d, got %d", test.wantCode, resp.Code)
+				}
+				if diff := cmp.Diff(test.reporterCalls, reporter.calls, ignoreDurationOption); diff != "" {
+					t.Errorf("Reporting calls are different (-want, +got) = %v", diff)
+				}
+			}()
+
+			handler.ServeHTTP(resp, req)
 		})
 	}
 


### PR DESCRIPTION
Moves the assertions to `defer` otherwise the panic test case tests nothing. Also adds the verification for return code.