### PR TITLE
Add support for distinct performance test environments.

### DIFF
--- a/test/performance/config/config-mako.yaml
+++ b/test/performance/config/config-mako.yaml
@@ -1,0 +1,42 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-mako
+
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # The Mako environment in which we are running.
+    # Only our performance automation should run in "prod", but
+    # there should be a "dev" environment with a fairly broad
+    # write ACL.  Users can also develop against custom configurations
+    # by adding `foo.config` under their benchmark's kodata directory.
+    environment: dev

--- a/test/performance/dataplane-probe/dataplane-probe.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe.yaml
@@ -27,13 +27,16 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-benchmark=5142965274017792", "-target=deployment"]
+            args: ["-target=deployment"]
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -44,6 +47,9 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0
 ---
@@ -62,13 +68,16 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-benchmark=5142965274017792", "-target=istio"]
+            args: ["-target=istio"]
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -79,6 +88,9 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0
 ---
@@ -97,13 +109,16 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-benchmark=5142965274017792", "-target=queue"]
+            args: ["-target=queue"]
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -114,6 +129,9 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0
 ---
@@ -132,13 +150,16 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-benchmark=5142965274017792", "-target=activator"]
+            args: ["-target=activator"]
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -149,5 +170,8 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0

--- a/test/performance/dataplane-probe/dataplane-probe.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe.yaml
@@ -36,7 +36,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -77,7 +77,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -118,7 +118,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -159,7 +159,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json

--- a/test/performance/dataplane-probe/dev.config
+++ b/test/performance/dataplane-probe/dev.config
@@ -1,20 +1,22 @@
 # Creating this benchmark:
 # mako create_benchmark \
-#   test/performance/dataplane-probe/dataplane-probe.config
+#   test/performance/dataplane-probe/dev.config
 project_name: "Knative"
-benchmark_name: "Serving dataplane probe"
+benchmark_name: "Development - Serving dataplane probe"
 description: "Measure dataplane component latency and reliability."
-benchmark_key: '5142965274017792'
+benchmark_key: '6316266134437888'
 
-# Only owners can write to the benchmark
+# Human owners for manual benchmark adjustments.
 owner_list: "mattmoor@google.com"
 owner_list: "vagababov@google.com"
 owner_list: "srinivashegde@google.com"
 owner_list: "chizhg@google.com"
 owner_list: "yanweiguo@google.com"
 
-# Add your robot here:
+# Anyone can add their IAM robot here to publish to this benchmark.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+# This is mattmoor's robot:
+owner_list: "mako-upload@convoy-adapter.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/dataplane-probe/kodata/dev.config
+++ b/test/performance/dataplane-probe/kodata/dev.config
@@ -1,0 +1,1 @@
+../dev.config

--- a/test/performance/dataplane-probe/kodata/prod.config
+++ b/test/performance/dataplane-probe/kodata/prod.config
@@ -1,0 +1,1 @@
+../prod.config

--- a/test/performance/dataplane-probe/main.go
+++ b/test/performance/dataplane-probe/main.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/mako/helpers/go/quickstore"
 	qpb "github.com/google/mako/helpers/proto/quickstore/quickstore_go_proto"
 	vegeta "github.com/tsenart/vegeta/lib"
@@ -32,8 +31,7 @@ import (
 )
 
 var (
-	benchmark = flag.String("benchmark", "", "The mako benchmark we are running.")
-	target    = flag.String("target", "", "The target to attack.")
+	target = flag.String("target", "", "The target to attack.")
 )
 
 func main() {
@@ -47,9 +45,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
 	defer cancel()
 
+	log.Printf("GOT benchmark_key: %v", *mako.MustGetBenchmark())
+
 	// Use the benchmark key created
 	q, qclose, err := quickstore.NewAtAddress(ctx, &qpb.QuickstoreInput{
-		BenchmarkKey: proto.String(*benchmark),
+		BenchmarkKey: mako.MustGetBenchmark(),
 		Tags:         []string{"master"},
 	}, mako.SidecarAddress)
 	if err != nil {

--- a/test/performance/dataplane-probe/main.go
+++ b/test/performance/dataplane-probe/main.go
@@ -45,8 +45,6 @@ func main() {
 	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
 	defer cancel()
 
-	log.Printf("GOT benchmark_key: %v", *mako.MustGetBenchmark())
-
 	// Use the benchmark key created
 	q, qclose, err := quickstore.NewAtAddress(ctx, &qpb.QuickstoreInput{
 		BenchmarkKey: mako.MustGetBenchmark(),

--- a/test/performance/dataplane-probe/prod.config
+++ b/test/performance/dataplane-probe/prod.config
@@ -1,0 +1,59 @@
+# Creating this benchmark:
+# mako create_benchmark \
+#   test/performance/dataplane-probe/prod.config
+project_name: "Knative"
+benchmark_name: "Serving dataplane probe"
+description: "Measure dataplane component latency and reliability."
+benchmark_key: '5142965274017792'
+
+# Human owners for manual benchmark adjustments.
+owner_list: "mattmoor@google.com"
+owner_list: "vagababov@google.com"
+owner_list: "srinivashegde@google.com"
+owner_list: "chizhg@google.com"
+owner_list: "yanweiguo@google.com"
+
+# Only this robot should publish data to Mako for this key!
+owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+
+# Define the name and type for x-axis of run charts
+input_value_info: {
+  value_key: "t"
+  label: "time"
+  type: TIMESTAMP
+}
+
+# Note: value_key is stored repeatedly and should be very short (ideally one or two characters).
+metric_info_list: {
+  value_key: "kd"
+  label: "kube-deployment"
+}
+metric_info_list: {
+  value_key: "id"
+  label: "istio-deployment"
+}
+metric_info_list: {
+  value_key: "qp"
+  label: "queue-proxy"
+}
+metric_info_list: {
+  value_key: "a"
+  label: "activator"
+}
+
+metric_info_list: {
+  value_key: "ke"
+  label: "kube-errors"
+}
+metric_info_list: {
+  value_key: "ie"
+  label: "istio-errors"
+}
+metric_info_list: {
+  value_key: "qe"
+  label: "queue-errors"
+}
+metric_info_list: {
+  value_key: "ae"
+  label: "activator-errors"
+}

--- a/test/performance/load-test/dev.config
+++ b/test/performance/load-test/dev.config
@@ -1,20 +1,21 @@
 # Creating this benchmark:
 # mako create_benchmark \
-#   test/performance/load-test/load-test.config
+#   test/performance/load-test/dev.config
 project_name: "Knative"
-benchmark_name: "Serving load testing"
+benchmark_name: "Development - Serving load testing"
 description: "Load test 0->1k->2k->3k against a ksvc (with several TBC values)."
-benchmark_key: '5352009922248704'
 
-# Only owners can write to the benchmark
+# Human owners for manual benchmark adjustments.
 owner_list: "mattmoor@google.com"
 owner_list: "vagababov@google.com"
 owner_list: "srinivashegde@google.com"
 owner_list: "chizhg@google.com"
 owner_list: "yanweiguo@google.com"
 
-# Add your robot here:
+# Anyone can add their IAM robot here to publish to this benchmark.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+# This is mattmoor's robot:
+owner_list: "mako-upload@convoy-adapter.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/load-test/kodata/dev.config
+++ b/test/performance/load-test/kodata/dev.config
@@ -1,0 +1,1 @@
+../dev.config

--- a/test/performance/load-test/kodata/prod.config
+++ b/test/performance/load-test/kodata/prod.config
@@ -1,0 +1,1 @@
+../prod.config

--- a/test/performance/load-test/load-test.yaml
+++ b/test/performance/load-test/load-test.yaml
@@ -67,7 +67,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -109,7 +109,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -151,7 +151,7 @@ spec:
             - name: config-mako
               mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/mattmoor-public/mako-microservice:latest
+            image: gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json

--- a/test/performance/load-test/load-test.yaml
+++ b/test/performance/load-test/load-test.yaml
@@ -58,14 +58,16 @@ spec:
           - name: load-test
             image: knative.dev/serving/test/performance/load-test
             args:
-            - "-benchmark=5352009922248704"
             - "-flavor=zero"
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -76,6 +78,9 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0
 ---
@@ -95,14 +100,16 @@ spec:
           - name: load-test
             image: knative.dev/serving/test/performance/load-test
             args:
-            - "-benchmark=5352009922248704"
             - "-flavor=always"
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -113,6 +120,9 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0
 ---
@@ -132,14 +142,16 @@ spec:
           - name: load-test
             image: knative.dev/serving/test/performance/load-test
             args:
-            - "-benchmark=5352009922248704"
             - "-flavor=200"
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
           - name: mako
-            image: us.gcr.io/knative-performance/mako-microservice:latest
+            image: us.gcr.io/mattmoor-public/mako-microservice:latest
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secret/robot.json
@@ -150,5 +162,8 @@ spec:
           - name: service-account
             secret:
               secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
           restartPolicy: Never
       backoffLimit: 0

--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -28,7 +28,6 @@ import (
 	deploymentinformer "knative.dev/pkg/injection/informers/kubeinformers/appsv1/deployment"
 	sksinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/mako/helpers/go/quickstore"
 	qpb "github.com/google/mako/helpers/proto/quickstore/quickstore_go_proto"
 	vegeta "github.com/tsenart/vegeta/lib"
@@ -45,7 +44,6 @@ import (
 )
 
 var (
-	benchmark  = flag.String("benchmark", "", "The mako benchmark ID")
 	flavor     = flag.String("flavor", "", "The flavor of the benchmark to run.")
 	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
@@ -172,16 +170,13 @@ func main() {
 	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
 	defer cancel()
 
-	if *benchmark == "" {
-		log.Fatalf("-benchmark is a required flag.")
-	}
 	if *flavor == "" {
 		log.Fatalf("-flavor is a required flag.")
 	}
 
 	// Use the benchmark key created
 	q, qclose, err := quickstore.NewAtAddress(ctx, &qpb.QuickstoreInput{
-		BenchmarkKey: proto.String(*benchmark),
+		BenchmarkKey: mako.MustGetBenchmark(),
 		Tags: []string{
 			"master",
 			fmt.Sprintf("tbc=%s", *flavor),

--- a/test/performance/load-test/prod.config
+++ b/test/performance/load-test/prod.config
@@ -1,0 +1,54 @@
+# Creating this benchmark:
+# mako create_benchmark \
+#   test/performance/load-test/prod.config
+project_name: "Knative"
+benchmark_name: "Serving load testing"
+description: "Load test 0->1k->2k->3k against a ksvc (with several TBC values)."
+benchmark_key: '5352009922248704'
+
+# Human owners for manual benchmark adjustments.
+owner_list: "mattmoor@google.com"
+owner_list: "vagababov@google.com"
+owner_list: "srinivashegde@google.com"
+owner_list: "chizhg@google.com"
+owner_list: "yanweiguo@google.com"
+
+# Only this robot should publish data to Mako for this key!
+owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+
+# Define the name and type for x-axis of run charts
+input_value_info: {
+  value_key: "t"
+  label: "time"
+  type: TIMESTAMP
+}
+
+# Note: value_key is stored repeatedly and should be very short (ideally one or two characters).
+metric_info_list: {
+  value_key: "l"
+  label: "latency"
+}
+
+# Used to track errors/sec and requests/sec alongside latency
+metric_info_list: {
+  value_key: "es"
+  label: "errs-sec"
+}
+metric_info_list: {
+  value_key: "rs"
+  label: "requests-sec"
+}
+
+# Used to track desired and actual pod counts alongside latency
+metric_info_list: {
+  value_key: "dp"
+  label: "desired-pods"
+}
+metric_info_list: {
+  value_key: "ap"
+  label: "available-pods"
+}
+metric_info_list: {
+  value_key: "sks"
+  label: "sks-proxy"
+}

--- a/test/performance/mako/benchmark.go
+++ b/test/performance/mako/benchmark.go
@@ -29,17 +29,19 @@ import (
 
 const koDataPathEnvName = "KO_DATA_PATH"
 
+// MustGetBenchmark wraps getBenchmark in log.Fatalf
 func MustGetBenchmark() *string {
-	b, err := GetBenchmark()
+	b, err := getBenchmark()
 	if err != nil {
 		log.Fatalf("unable to determine benchmark_key: %v", err)
 	}
 	return b
 }
 
-func GetBenchmark() (*string, error) {
+// getBenchmark fetches the appropriate benchmark_key for this configured environment.
+func getBenchmark() (*string, error) {
 	// Figure out what environment we're running in from the Mako configmap.
-	env, err := GetEnvironment()
+	env, err := getEnvironment()
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +51,8 @@ func GetBenchmark() (*string, error) {
 		return nil, err
 	}
 	// Parse the Mako config file.
-	bi := mpb.BenchmarkInfo{}
-	if err := proto.UnmarshalText(string(data), &bi); err != nil {
+	bi := &mpb.BenchmarkInfo{}
+	if err := proto.UnmarshalText(string(data), bi); err != nil {
 		return nil, err
 	}
 
@@ -62,8 +64,7 @@ func GetBenchmark() (*string, error) {
 func readConfigFromKoData(environment string) ([]byte, error) {
 	koDataPath := os.Getenv(koDataPathEnvName)
 	if koDataPath == "" {
-		err := fmt.Errorf("%q does not exist or is empty", koDataPathEnvName)
-		return nil, err
+		return nil, fmt.Errorf("%q does not exist or is empty", koDataPathEnvName)
 	}
 	fullFilename := filepath.Join(koDataPath, environment+".config")
 	return ioutil.ReadFile(fullFilename)

--- a/test/performance/mako/benchmark.go
+++ b/test/performance/mako/benchmark.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mako
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/protobuf/proto"
+	mpb "github.com/google/mako/spec/proto/mako_go_proto"
+)
+
+const koDataPathEnvName = "KO_DATA_PATH"
+
+func MustGetBenchmark() *string {
+	b, err := GetBenchmark()
+	if err != nil {
+		log.Fatalf("unable to determine benchmark_key: %v", err)
+	}
+	return b
+}
+
+func GetBenchmark() (*string, error) {
+	// Figure out what environment we're running in from the Mako configmap.
+	env, err := GetEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	// Read the Mako config file for this environment.
+	data, err := readConfigFromKoData(env)
+	if err != nil {
+		return nil, err
+	}
+	// Parse the Mako config file.
+	bi := mpb.BenchmarkInfo{}
+	if err := proto.UnmarshalText(string(data), &bi); err != nil {
+		return nil, err
+	}
+
+	// Return the benchmark_key from this environment's config file.
+	return bi.BenchmarkKey, nil
+}
+
+// readConfigFromKoData reads the named config file from kodata.
+func readConfigFromKoData(environment string) ([]byte, error) {
+	koDataPath := os.Getenv(koDataPathEnvName)
+	if koDataPath == "" {
+		err := fmt.Errorf("%q does not exist or is empty", koDataPathEnvName)
+		return nil, err
+	}
+	fullFilename := filepath.Join(koDataPath, environment+".config")
+	return ioutil.ReadFile(fullFilename)
+}

--- a/test/performance/mako/config.go
+++ b/test/performance/mako/config.go
@@ -33,11 +33,11 @@ type Config struct {
 
 // NewConfigFromMap creates a Config from the supplied map
 func NewConfigFromMap(data map[string]string) (*Config, error) {
-	lc := &Config{}
+	lc := &Config{
+		Environment: "dev",
+	}
 
-	if raw, ok := data["environment"]; !ok {
-		lc.Environment = "dev"
-	} else {
+	if raw, ok := data["environment"]; ok {
 		lc.Environment = raw
 	}
 

--- a/test/performance/mako/config.go
+++ b/test/performance/mako/config.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mako
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// ConfigName is the name of the config map for mako options.
+	ConfigName = "config-mako"
+)
+
+// Config defines the mako configuration options.
+type Config struct {
+	// Environment holds the
+	Environment string
+}
+
+// NewConfigFromMap creates a Config from the supplied map
+func NewConfigFromMap(data map[string]string) (*Config, error) {
+	lc := &Config{}
+
+	if raw, ok := data["environment"]; !ok {
+		lc.Environment = "dev"
+	} else {
+		lc.Environment = raw
+	}
+
+	return lc, nil
+}
+
+// NewConfigFromConfigMap creates a Config from the supplied ConfigMap
+func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
+	return NewConfigFromMap(configMap.Data)
+}

--- a/test/performance/mako/config_test.go
+++ b/test/performance/mako/config_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mako
+
+import (
+	"testing"
+
+	. "knative.dev/pkg/configmap/testing"
+)
+
+func TestOurConfig(t *testing.T) {
+	cm, example := ConfigMapsFromTestFile(t, ConfigName)
+	if _, err := NewConfigFromConfigMap(cm); err != nil {
+		t.Errorf("NewConfigFromConfigMap(actual) = %v", err)
+	}
+	if _, err := NewConfigFromConfigMap(example); err != nil {
+		t.Errorf("NewConfigFromConfigMap(example) = %v", err)
+	}
+}

--- a/test/performance/mako/environment.go
+++ b/test/performance/mako/environment.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mako
+
+import (
+	"path/filepath"
+
+	"knative.dev/pkg/configmap"
+)
+
+func GetEnvironment() (string, error) {
+	makoCM, err := configmap.Load(filepath.Join("/etc", ConfigName))
+	if err != nil {
+		return "", err
+	}
+	cfg, err := NewConfigFromMap(makoCM)
+	if err != nil {
+		return "", err
+	}
+	return cfg.Environment, nil
+}

--- a/test/performance/mako/environment.go
+++ b/test/performance/mako/environment.go
@@ -22,7 +22,8 @@ import (
 	"knative.dev/pkg/configmap"
 )
 
-func GetEnvironment() (string, error) {
+// getEnvironment fetches the Mako config environment to which this cluster should publish.
+func getEnvironment() (string, error) {
 	makoCM, err := configmap.Load(filepath.Join("/etc", ConfigName))
 	if err != nil {
 		return "", err

--- a/test/performance/mako/testdata/config-mako.yaml
+++ b/test/performance/mako/testdata/config-mako.yaml
@@ -1,0 +1,1 @@
+../../config/config-mako.yaml

--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -132,6 +132,17 @@ function update_cluster() {
   kubectl patch hpa -n knative-serving activator \
         --patch '{"spec": {"minReplicas": 10}}'
 
+  echo ">> Setting up 'prod' config-mako"
+  cat | kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-mako
+data:
+  # This should only be used by our performance automation.
+  environment: prod
+EOF
+
   echo ">> Applying all the yamls"
   # install the service and cronjob to run the benchmark
   # NOTE: this assumes we have a benchmark with the same name as the cluster


### PR DESCRIPTION
This change modifies the benchmarks to read their benchmark key from one
of several Mako config files available in `kodata`.  The resolution logic
is as follows:
1. Read `/etc/config-mako` and extract the `environment` key (defaults to "dev")
1. Read `$KO_DATA_PATH/{environment}.config` for the appropriate Mako config
1. Extract the `benchmark_key` to pass to Quickstore.

In support of this I have:
1. Moved the current configs to `prod.config`,
1. Copied each `prod.config` to `dev.config` and generated new benchmark keys,
1. Symlinked both `{prod,dev}.config` into `kodata`
1. Removed `-benchmark` and replaced with new calls to `mako.MustGetBenchmark()`,
  which follows the resolution logic above.


cc @srinivashegde86 @vagababov @timford