### PR TITLE
Validate volume-sources and -projections more deeply.

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -98,13 +98,13 @@ func validateVolume(volume corev1.Volume) *apis.FieldError {
 	if vs.Secret != nil {
 		specified = append(specified, "secret")
 		for i, item := range vs.Secret.Items {
-			errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
+			errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("items", i))
 		}
 	}
 	if vs.ConfigMap != nil {
 		specified = append(specified, "configMap")
 		for i, item := range vs.ConfigMap.Items {
-			errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
+			errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("items", i))
 		}
 	}
 	if vs.Projected != nil {
@@ -149,7 +149,7 @@ func validateConfigMapProjection(cmp *corev1.ConfigMapProjection) *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 	for i, item := range cmp.Items {
-		errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
+		errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("items", i))
 	}
 	return errs
 }
@@ -162,7 +162,7 @@ func validateSecretProjection(sp *corev1.SecretProjection) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 	for i, item := range sp.Items {
-		errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
+		errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("items", i))
 	}
 	return errs
 }

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -97,9 +97,15 @@ func validateVolume(volume corev1.Volume) *apis.FieldError {
 	specified := []string{}
 	if vs.Secret != nil {
 		specified = append(specified, "secret")
+		for i, item := range vs.Secret.Items {
+			errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+		}
 	}
 	if vs.ConfigMap != nil {
 		specified = append(specified, "configMap")
+		for i, item := range vs.ConfigMap.Items {
+			errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+		}
 	}
 	if vs.Projected != nil {
 		specified = append(specified, "projected")
@@ -143,7 +149,7 @@ func validateConfigMapProjection(cmp *corev1.ConfigMapProjection) *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 	for i, item := range cmp.Items {
-		errs = errs.Also(apis.CheckDisallowedFields(item, *KeyToPathMask(&item)).ViaIndex(i))
+		errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
 	}
 	return errs
 }
@@ -156,7 +162,18 @@ func validateSecretProjection(sp *corev1.SecretProjection) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 	for i, item := range sp.Items {
-		errs = errs.Also(apis.CheckDisallowedFields(item, *KeyToPathMask(&item)).ViaIndex(i))
+		errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+	}
+	return errs
+}
+
+func validateKeyToPath(k2p corev1.KeyToPath) *apis.FieldError {
+	errs := apis.CheckDisallowedFields(k2p, *KeyToPathMask(&k2p))
+	if k2p.Key == "" {
+		errs = errs.Also(apis.ErrMissingField("key"))
+	}
+	if k2p.Path == "" {
+		errs = errs.Also(apis.ErrMissingField("path"))
 	}
 	return errs
 }

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -98,13 +98,13 @@ func validateVolume(volume corev1.Volume) *apis.FieldError {
 	if vs.Secret != nil {
 		specified = append(specified, "secret")
 		for i, item := range vs.Secret.Items {
-			errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+			errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
 		}
 	}
 	if vs.ConfigMap != nil {
 		specified = append(specified, "configMap")
 		for i, item := range vs.ConfigMap.Items {
-			errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+			errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
 		}
 	}
 	if vs.Projected != nil {
@@ -149,7 +149,7 @@ func validateConfigMapProjection(cmp *corev1.ConfigMapProjection) *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 	for i, item := range cmp.Items {
-		errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+		errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
 	}
 	return errs
 }
@@ -162,7 +162,7 @@ func validateSecretProjection(sp *corev1.SecretProjection) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 	for i, item := range sp.Items {
-		errs = errs.Also(validateKeyToPath(item).ViaIndex(i).ViaField("Items"))
+		errs = errs.Also(validateKeyToPath(item).ViaFieldIndex("Items", i))
 	}
 	return errs
 }

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -984,6 +984,59 @@ func TestVolumeValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrInvalidValue("@@@", "name"),
+	}, {
+		name: "secret missing keyToPath values",
+		v: corev1.Volume{
+			Name: "foo",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "foo",
+					Items:      []corev1.KeyToPath{{}},
+				},
+			},
+		},
+		want: apis.ErrMissingField("Items[0].key").Also(apis.ErrMissingField("Items[0].path")),
+	}, {
+		name: "configMap missing keyToPath values",
+		v: corev1.Volume{
+			Name: "foo",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "foo",
+					},
+					Items: []corev1.KeyToPath{{}},
+				},
+			},
+		},
+		want: apis.ErrMissingField("Items[0].key").Also(apis.ErrMissingField("Items[0].path")),
+	}, {
+		name: "projection missing keyToPath values",
+		v: corev1.Volume{
+			Name: "foo",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{{
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "foo",
+							},
+							Items: []corev1.KeyToPath{{}},
+						}}, {
+						ConfigMap: &corev1.ConfigMapProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "foo",
+							},
+							Items: []corev1.KeyToPath{{}},
+						}},
+					},
+				},
+			},
+		},
+		want: apis.ErrMissingField("projected[0].secret.Items[0].key").Also(
+			apis.ErrMissingField("projected[0].secret.Items[0].path")).Also(
+			apis.ErrMissingField("projected[1].configMap.Items[0].key")).Also(
+			apis.ErrMissingField("projected[1].configMap.Items[0].path")),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -995,7 +995,7 @@ func TestVolumeValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrMissingField("Items[0].key").Also(apis.ErrMissingField("Items[0].path")),
+		want: apis.ErrMissingField("items[0].key").Also(apis.ErrMissingField("items[0].path")),
 	}, {
 		name: "configMap missing keyToPath values",
 		v: corev1.Volume{
@@ -1009,7 +1009,7 @@ func TestVolumeValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrMissingField("Items[0].key").Also(apis.ErrMissingField("Items[0].path")),
+		want: apis.ErrMissingField("items[0].key").Also(apis.ErrMissingField("items[0].path")),
 	}, {
 		name: "projection missing keyToPath values",
 		v: corev1.Volume{
@@ -1033,10 +1033,10 @@ func TestVolumeValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrMissingField("projected[0].secret.Items[0].key").Also(
-			apis.ErrMissingField("projected[0].secret.Items[0].path")).Also(
-			apis.ErrMissingField("projected[1].configMap.Items[0].key")).Also(
-			apis.ErrMissingField("projected[1].configMap.Items[0].path")),
+		want: apis.ErrMissingField("projected[0].secret.items[0].key").Also(
+			apis.ErrMissingField("projected[0].secret.items[0].path")).Also(
+			apis.ErrMissingField("projected[1].configMap.items[0].key")).Also(
+			apis.ErrMissingField("projected[1].configMap.items[0].path")),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5127 

## Proposed Changes

Today we don't thoroughly validate volume-sources and -projections, especially the KeyToPath parts of it. This adds that validation to prevent obscure pod deployment issues if these are applied the wrong way.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Validate volume-sources and -projections more deeply to prevent obscure pod deployment issues.
```

/assign @mattmoor 
