### PR TITLE
Set severity of CertificateReady to Info

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/route_lifecycle.go
@@ -126,7 +126,7 @@ func (rs *RouteStatus) MarkCertificateReady(name string) {
 	routeCondSet.Manage(rs).SetCondition(apis.Condition{
 		Type:     RouteConditionCertificateProvisioned,
 		Status:   corev1.ConditionTrue,
-		Severity: apis.ConditionSeverityWarning,
+		Severity: apis.ConditionSeverityInfo,
 		Reason:   "CertificateReady",
 		Message:  fmt.Sprintf("Certificate %s is successfully provisioned", name),
 	})


### PR DESCRIPTION
## Proposed Changes

When Route's `CertificateReady` becomes `True`, the Severity has
`Warning`. This patch changes it to `Info`.

Fixes #

**Release Note**

```release-note
NONE
```

#### BEORE

```
$ kubectl describe rt hello-example
Status:
  Conditions:
    Last Transition Time:  2019-08-12T08:56:34Z
    Status:                True
    Type:                  AllTrafficAssigned
    Last Transition Time:  2019-08-12T08:56:38Z
    Message:               Certificate route-140d1cdd-bcdf-11e9-bc67-02a7cb0e8f00 is successfully provisioned
    Reason:                CertificateReady
    Severity:              Warning
```

#### AFTER

```
  Conditions:
    Last Transition Time:  2019-08-12T08:56:34Z
    Status:                True
    Type:                  AllTrafficAssigned
    Last Transition Time:  2019-08-12T09:09:46Z
    Message:               Certificate route-140d1cdd-bcdf-11e9-bc67-02a7cb0e8f00 is successfully provisioned
    Reason:                CertificateReady
    Severity:              Info
```
