### PR TITLE
Fix wrong log format in certificate

### DIFF
--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -109,7 +109,7 @@ func (c *Reconciler) reconcile(ctx context.Context, knCert *v1alpha1.Certificate
 	knCert.SetDefaults(ctx)
 	knCert.Status.InitializeConditions()
 
-	logger.Info("Reconciling Cert-Manager certificate for Knative cert %s/%s.", knCert.Namespace, knCert.Name)
+	logger.Infof("Reconciling Cert-Manager certificate for Knative cert %s/%s.", knCert.Namespace, knCert.Name)
 	cmConfig := config.FromContext(ctx).CertManager
 	cmCert := resources.MakeCertManagerCertificate(cmConfig, knCert)
 	cmCert, err := c.reconcileCMCertificate(ctx, knCert, cmCert)


### PR DESCRIPTION
## Proposed Changes

Currently cert-manager produces logs with invlaid format
`Reconciling Cert-Manager certificate for Knative cert %s/%s.defaultroute-6ad0cab4-bcbf-11e9-bc67-02a7cb0e8f00`, so fix the format.

Fixes #

**Release Note**

```release-note
NONE
```

#### BEFORE
```
{"level":"info","ts":"2019-08-12T05:09:53.231Z","logger":"certcontroller.certificate-controller","caller":"certificate/certificate.go:112","msg":"Reconciling Cert-Manager certificate for Knative cert %s/%s.defaultroute-6ad0cab4-bcbf-11e9-bc67-02a7cb0e8f00","knative.dev/controller":"certificate-controller","knative.dev/traceid":"226be108-1b44-47f2-a9f9-081fa1ea4a02","knative.dev/key":"default/route-6ad0cab4-bcbf-11e9-bc67-02a7cb0e8f00"}
```

#### AFTER

```
{"level":"info","ts":"2019-08-12T05:24:59.286Z","logger":"certcontroller.certificate-controller","caller":"certificate/certificate.go:112","msg":"Reconciling Cert-Manager certificate for Knative cert default/route-81e0f5a8-bcc1-11e9-bc67-02a7cb0e8f00.","knative.dev/controller":"certificate-controller","knative.dev/traceid":"afdb8fe4-4788-4a81-b384-d72ccc1acb62","knative.dev/key":"default/route-81e0f5a8-bcc1-11e9-bc67-02a7cb0e8f00"}
```

