### PR TITLE
Refactor route.go to use accessor model to reconcile Certificate

### DIFF
--- a/pkg/reconciler/accessor/core/secret.go
+++ b/pkg/reconciler/accessor/core/secret.go
@@ -50,7 +50,7 @@ func ReconcileSecret(ctx context.Context, owner kmeta.Accessor, desired *corev1.
 	if apierrs.IsNotFound(err) {
 		secret, err = accessor.GetKubeClient().CoreV1().Secrets(desired.Namespace).Create(desired)
 		if err != nil {
-			logger.Errorw("Failed to create Certificate Secret", zap.Error(err))
+			logger.Errorw("Failed to create Secret", zap.Error(err))
 			recorder.Eventf(owner, corev1.EventTypeWarning, "CreationFailed",
 				"Failed to create Secret %s/%s: %v", desired.Namespace, desired.Name, err)
 			return nil, err

--- a/pkg/reconciler/accessor/networking/certificate.go
+++ b/pkg/reconciler/accessor/networking/certificate.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/logging"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	clientset "knative.dev/serving/pkg/client/clientset/versioned"
+	listers "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
+	kaccessor "knative.dev/serving/pkg/reconciler/accessor"
+)
+
+// CertificateAccessor is an interface for accessing Knative Certificate.
+type CertificateAccessor interface {
+	GetServingClient() clientset.Interface
+	GetCertificateLister() listers.CertificateLister
+}
+
+// ReconcileCertificate reconciles Certificate to the desired status.
+func ReconcileCertificate(ctx context.Context, owner kmeta.Accessor, desired *v1alpha1.Certificate,
+	certAccessor CertificateAccessor) (*v1alpha1.Certificate, error) {
+
+	logger := logging.FromContext(ctx)
+	recorder := controller.GetEventRecorder(ctx)
+	if recorder == nil {
+		return nil, fmt.Errorf("recoder for reconciling Certificate %s/%s is not created", desired.Namespace, desired.Name)
+	}
+	cert, err := certAccessor.GetCertificateLister().Certificates(desired.Namespace).Get(desired.Name)
+	if apierrs.IsNotFound(err) {
+		cert, err = certAccessor.GetServingClient().NetworkingV1alpha1().Certificates(desired.Namespace).Create(desired)
+		if err != nil {
+			logger.Error("Failed to create Certificate", zap.Error(err))
+			recorder.Eventf(owner, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create Certificate %s/%s: %v", desired.Namespace, desired.Name, err)
+			return nil, err
+		}
+		recorder.Eventf(owner, corev1.EventTypeNormal, "Created", "Created Certificate %s/%s", cert.Namespace, cert.Name)
+		return cert, nil
+	} else if err != nil {
+		return nil, err
+	} else if !metav1.IsControlledBy(cert, owner) {
+		// Return an error with NotControlledBy information.
+		return nil, kaccessor.NewAccessorError(
+			fmt.Errorf("owner: %s with Type %T does not own Certificate: %q", owner.GetName(), owner, cert.Name),
+			kaccessor.NotOwnResource)
+	} else {
+		if !equality.Semantic.DeepEqual(cert.Spec, desired.Spec) {
+			// Don't modify the informers copy
+			existing := cert.DeepCopy()
+			existing.Spec = desired.Spec
+			cert, err := certAccessor.GetServingClient().NetworkingV1alpha1().Certificates(existing.Namespace).Update(existing)
+			if err != nil {
+				recorder.Eventf(owner, corev1.EventTypeWarning, "UpdateFailed",
+					"Failed to update Certificate %s/%s: %v", existing.Namespace, existing.Name, err)
+				return nil, err
+			}
+			recorder.Eventf(owner, corev1.EventTypeNormal, "Updated",
+				"Updated Spec for Certificate %s/%s", existing.Namespace, existing.Name)
+			return cert, nil
+		}
+	}
+	return cert, nil
+}

--- a/pkg/reconciler/accessor/networking/certificate_test.go
+++ b/pkg/reconciler/accessor/networking/certificate_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/controller"
+	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	clientset "knative.dev/serving/pkg/client/clientset/versioned"
+	sharedfake "knative.dev/serving/pkg/client/clientset/versioned/fake"
+	informers "knative.dev/serving/pkg/client/informers/externalversions"
+	fakeclient "knative.dev/serving/pkg/client/injection/client/fake"
+	listers "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
+
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+var (
+	ownerObj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ownerObj",
+			Namespace: "default",
+			UID:       "abcd",
+		},
+	}
+
+	ownerRef = metav1.OwnerReference{
+		Kind:       ownerObj.Kind,
+		Name:       ownerObj.Name,
+		UID:        ownerObj.UID,
+		Controller: ptr.Bool(true),
+	}
+
+	origin = &v1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cert",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: v1alpha1.CertificateSpec{
+			DNSNames:   []string{"origin.example.com"},
+			SecretName: "secret0",
+		},
+	}
+
+	desired = &v1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cert",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: v1alpha1.CertificateSpec{
+			DNSNames:   []string{"desired.example.com"},
+			SecretName: "secret0",
+		},
+	}
+)
+
+type FakeAccessor struct {
+	client     clientset.Interface
+	certLister listers.CertificateLister
+}
+
+func (f *FakeAccessor) GetServingClient() clientset.Interface {
+	return f.client
+}
+
+func (f *FakeAccessor) GetCertificateLister() listers.CertificateLister {
+	return f.certLister
+}
+
+func TestReconcileCertificateCreate(t *testing.T) {
+	defer logtesting.ClearAll()
+	ctx, _ := SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	grp := errgroup.Group{}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Errorf("Wait() = %v", err)
+		}
+	}()
+
+	client := fakeclient.Get(ctx)
+
+	h := NewHooks()
+	h.OnCreate(&client.Fake, "certificates", func(obj runtime.Object) HookResult {
+		got := obj.(*v1alpha1.Certificate)
+		if diff := cmp.Diff(got, desired); diff != "" {
+			t.Logf("Unexpected Certificate (-want, +got): %v", diff)
+			return HookIncomplete
+		}
+		return HookComplete
+	})
+
+	accessor := setup(ctx, []*v1alpha1.Certificate{}, client, t)
+	ReconcileCertificate(ctx, ownerObj, desired, accessor)
+
+	if err := h.WaitForHooks(3 * time.Second); err != nil {
+		t.Errorf("Failed to Reconcile Certificate: %v", err)
+	}
+}
+
+func TestReconcileCertificateUpdate(t *testing.T) {
+	defer logtesting.ClearAll()
+	ctx, _ := SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	grp := errgroup.Group{}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Errorf("Wait() = %v", err)
+		}
+	}()
+
+	client := fakeclient.Get(ctx)
+	accessor := setup(ctx, []*v1alpha1.Certificate{origin}, client, t)
+
+	h := NewHooks()
+	h.OnUpdate(&client.Fake, "certificates", func(obj runtime.Object) HookResult {
+		got := obj.(*v1alpha1.Certificate)
+		if diff := cmp.Diff(got, desired); diff != "" {
+			t.Logf("Unexpected Certificate (-want, +got): %v", diff)
+			return HookIncomplete
+		}
+		return HookComplete
+	})
+
+	ReconcileCertificate(ctx, ownerObj, desired, accessor)
+	if err := h.WaitForHooks(3 * time.Second); err != nil {
+		t.Errorf("Failed to Reconcile Certificate: %v", err)
+	}
+}
+
+func setup(ctx context.Context, certs []*v1alpha1.Certificate,
+	client clientset.Interface, t *testing.T) *FakeAccessor {
+
+	fake := sharedfake.NewSimpleClientset()
+	informer := informers.NewSharedInformerFactory(fake, 0)
+	certInformer := informer.Networking().V1alpha1().Certificates()
+
+	for _, cert := range certs {
+		fake.NetworkingV1alpha1().Certificates(cert.Namespace).Create(cert)
+		certInformer.Informer().GetIndexer().Add(cert)
+	}
+
+	if err := controller.StartInformers(ctx.Done(), certInformer.Informer()); err != nil {
+		t.Fatalf("failed to start Certificate informer: %v", err)
+	}
+
+	return &FakeAccessor{
+		client:     client,
+		certLister: certInformer.Lister(),
+	}
+}

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -41,9 +41,11 @@ import (
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	networkinglisters "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
 	listers "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
 	"knative.dev/serving/pkg/reconciler"
+	networkaccessor "knative.dev/serving/pkg/reconciler/accessor/networking"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 	"knative.dev/serving/pkg/reconciler/route/resources"
@@ -93,7 +95,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 	logger := logging.FromContext(ctx)
-
+	ctx = controller.WithEventRecorder(ctx, c.Recorder)
 	ctx = c.configStore.ToContext(ctx)
 
 	// Get the Route resource with this namespace/name.
@@ -321,7 +323,7 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 	desiredCerts := resources.MakeCertificates(r, tagToDomainMap, certClass(ctx, r))
 	for _, desiredCert := range desiredCerts {
 
-		cert, err := c.reconcileCertificate(ctx, r, desiredCert)
+		cert, err := networkaccessor.ReconcileCertificate(ctx, r, desiredCert, c)
 		if err != nil {
 			r.Status.MarkCertificateProvisionFailed(desiredCert.Name)
 			return nil, err
@@ -507,6 +509,16 @@ func (c *Reconciler) getServiceNames(ctx context.Context, route *v1alpha1.Route)
 		desiredPublicServiceNames:        desiredPublicServiceNames,
 		desiredClusterLocalServiceNames:  desiredClusterLocalServiceNames,
 	}, nil
+}
+
+// GetServingClient returns the client to access Knative serving resources.
+func (c *Reconciler) GetServingClient() clientset.Interface {
+	return c.ServingClientSet
+}
+
+// GetCertificateLister returns the lister for Knative Certificate.
+func (c *Reconciler) GetCertificateLister() networkinglisters.CertificateLister {
+	return c.certificateLister
 }
 
 /////////////////////////////////////////


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Refactor route.go to use accessor model to reconcile Certificate


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

