### PR TITLE
More consistent lifecycle conditions for certificate

### DIFF
--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
@@ -35,13 +34,13 @@ func (cs *CertificateStatus) MarkReady() {
 	certificateCondSet.Manage(cs).MarkTrue(CertificateConditionReady)
 }
 
-// MarkUnknown marks the certificate status as unknown.
-func (cs *CertificateStatus) MarkUnknown(reason, message string) {
+// MarkNotReady marks the certificate status as unknown.
+func (cs *CertificateStatus) MarkNotReady(reason, message string) {
 	certificateCondSet.Manage(cs).MarkUnknown(CertificateConditionReady, reason, message)
 }
 
-// MarkNotReady marks the certificate as not ready.
-func (cs *CertificateStatus) MarkNotReady(reason, message string) {
+// MarkFailed marks the certificate as not ready.
+func (cs *CertificateStatus) MarkFailed(reason, message string) {
 	certificateCondSet.Manage(cs).MarkFalse(CertificateConditionReady, reason, message)
 }
 

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
@@ -63,20 +63,20 @@ func TestMarkReady(t *testing.T) {
 	}
 }
 
-func TestMarkUnknown(t *testing.T) {
-	c := &CertificateStatus{}
-	c.InitializeConditions()
-	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
-
-	c.MarkUnknown("unknow", "unknown")
-	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
-}
-
 func TestMarkNotReady(t *testing.T) {
 	c := &CertificateStatus{}
 	c.InitializeConditions()
 	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
 
-	c.MarkNotReady("not ready", "not ready")
+	c.MarkNotReady("unknow", "unknown")
+	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
+}
+
+func TestMarkFailed(t *testing.T) {
+	c := &CertificateStatus{}
+	c.InitializeConditions()
+	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
+
+	c.MarkFailed("failed", "failed")
 	apitest.CheckConditionFailed(c.duck(), CertificateConditionReady, t)
 }

--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -123,13 +123,13 @@ func (c *Reconciler) reconcile(ctx context.Context, knCert *v1alpha1.Certificate
 	cmCertReadyCondition := resources.GetReadyCondition(cmCert)
 	switch {
 	case cmCertReadyCondition == nil:
-		knCert.Status.MarkUnknown(noCMConditionReason, noCMConditionMessage)
+		knCert.Status.MarkNotReady(noCMConditionReason, noCMConditionMessage)
 	case cmCertReadyCondition.Status == cmv1alpha1.ConditionUnknown:
-		knCert.Status.MarkUnknown(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
+		knCert.Status.MarkNotReady(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
 	case cmCertReadyCondition.Status == cmv1alpha1.ConditionTrue:
 		knCert.Status.MarkReady()
 	case cmCertReadyCondition.Status == cmv1alpha1.ConditionFalse:
-		knCert.Status.MarkNotReady(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
+		knCert.Status.MarkFailed(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
 	}
 	return nil
 }


### PR DESCRIPTION
/lint

Related to #5076

## Proposed Changes
This PR fixes the inconsistencies in lifecycle conditions of certificate. As proposed [here](https://github.com/knative/serving/issues/5076#issuecomment-519295908), there are currently a lot of inconsistencies in our lifecycle Mark* methods. We'd like to use the following pattern:
- MarkFooReady -> Ready=True
- MarkFooNotReady -> Ready=Unknown
- MarkFooFailed -> Ready=False

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @jonjohnsonjr 