### PR TITLE
Remove clusteringress resources in route reconcile loop

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -48,18 +48,12 @@ func routeOwnerLabelSelector(route *v1alpha1.Route) labels.Selector {
 	}).AsSelector()
 }
 
-func (c *Reconciler) deleteIngressesForRoute(route *v1alpha1.Route) error {
+func (c *Reconciler) deleteIngressForRoute(route *v1alpha1.Route) error {
 
 	// We always use DeleteCollection because even with a fixed name, we apply the labels.
 	selector := routeOwnerLabelSelector(route).String()
 
-	// Delete ClusterIngresses and Ingresses owned by this route.
-
-	if err := c.ServingClientSet.NetworkingV1alpha1().ClusterIngresses().DeleteCollection(
-		nil, metav1.ListOptions{LabelSelector: selector}); err != nil {
-		return err
-	}
-
+	// Delete Ingresses owned by this route.
 	return c.ServingClientSet.NetworkingV1alpha1().Ingresses(route.Namespace).DeleteCollection(
 		nil, metav1.ListOptions{LabelSelector: selector})
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5024

## Proposed Changes

* Remove clusteringress resources in route's reconcile loop
* reconcileDeletion() only removes namespaced ingress resources

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
