### PR TITLE
Add RPS support when resolving target value for scaling 

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -57,6 +57,12 @@ data:
     # horizontally scale the application based on this target concurrency.
     container-concurrency-target-default: "100"
 
+    # The requests per second (RPS) target default is what the Autoscaler will
+    # try to maintain when the Revision specifies unlimited RPS.
+    # Even when specifying unlimited RPS, the autoscaler will
+    # horizontally scale the application based on this target RPS.
+    requests-per-second-target-default: "100"
+
     # The target burst capacity specifies the size of burst in concurrent
     # requests that the system operator expects the system will receive.
     # Autoscaler will try to protect the system from queueing by introducing

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -61,7 +61,8 @@ data:
     # try to maintain when the Revision specifies unlimited RPS.
     # Even when specifying unlimited RPS, the autoscaler will
     # horizontally scale the application based on this target RPS.
-    requests-per-second-target-default: "100"
+    # Must be greater than 1.0.
+    requests-per-second-target-default: "200"
 
     # The target burst capacity specifies the size of burst in concurrent
     # requests that the system operator expects the system will receive.

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -52,16 +52,21 @@ data:
     container-concurrency-target-percentage: "70"
 
     # The container concurrency target default is what the Autoscaler will
-    # try to maintain when the Revision specifies unlimited concurrency.
+    # try to maintain when concurrency is used as the scaling metric for a
+    # Revision and the Revision specifies unlimited concurrency.
     # Even when specifying unlimited concurrency, the autoscaler will
     # horizontally scale the application based on this target concurrency.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
     container-concurrency-target-default: "100"
 
     # The requests per second (RPS) target default is what the Autoscaler will
-    # try to maintain when the Revision specifies unlimited RPS.
-    # Even when specifying unlimited RPS, the autoscaler will
-    # horizontally scale the application based on this target RPS.
+    # try to maintain when RPS is used as the scaling metric for a Revision and
+    # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+    # the autoscaler will horizontally scale the application based on this
+    # target RPS.
     # Must be greater than 1.0.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    # NOTE: This has no effect now.
     requests-per-second-target-default: "200"
 
     # The target burst capacity specifies the size of burst in concurrent

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -50,6 +50,8 @@ const (
 	Concurrency = "concurrency"
 	// CPU is the amount of the requested cpu actually being consumed by the Pod.
 	CPU = "cpu"
+	// RPS is the requests per second reaching the Pod.
+	RPS = "rps"
 
 	// TargetAnnotationKey is the annotation to specify what metric value the
 	// PodAutoscaler should attempt to maintain. For example,

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -58,6 +58,7 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 			}
 		case autoscaling.HPA:
 			switch metric {
+			// TODO(yanweiguo): implement RPS autoscaling for HPA.
 			case autoscaling.CPU, autoscaling.Concurrency:
 				return nil
 			}

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -52,6 +52,7 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 		switch pa.Class() {
 		case autoscaling.KPA:
 			switch metric {
+			// TODO(yanweiguo): implement RPS autoscaling for KPA.
 			case autoscaling.Concurrency:
 				return nil
 			}
@@ -60,7 +61,6 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 			case autoscaling.CPU, autoscaling.Concurrency:
 				return nil
 			}
-			// TODO: implement OPS autoscaling.
 		default:
 			// Leave other classes of PodAutoscaler alone.
 			return nil

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -47,7 +47,8 @@ type Config struct {
 	// configurable now. Customers can override it by specifying
 	// autoscaling.knative.dev//targetUtilizationPercentage in Revision annotation.
 	TargetUtilization float64
-	RPSTargetDefault  float64
+	// RPSTargetDefault is the default target value for requests per second.
+	RPSTargetDefault float64
 	// NB: most of our computations are in floats, so this is float to avoid casting.
 	TargetBurstCapacity float64
 

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -41,6 +41,8 @@ type Config struct {
 	// Target concurrency knobs for different container concurrency configurations.
 	ContainerConcurrencyTargetFraction float64
 	ContainerConcurrencyTargetDefault  float64
+	TargetUtilization                  float64
+	RPSTargetDefault                   float64
 	// NB: most of our computations are in floats, so this is float to avoid casting.
 	TargetBurstCapacity float64
 
@@ -96,6 +98,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key:          "container-concurrency-target-default",
 		field:        &lc.ContainerConcurrencyTargetDefault,
 		defaultValue: 100.0,
+	}, {
+		key:          "requests-per-second-target-default",
+		field:        &lc.RPSTargetDefault,
+		defaultValue: 200.0,
 	}, {
 		key:          "target-burst-capacity",
 		field:        &lc.TargetBurstCapacity,

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -30,6 +30,8 @@ import (
 const (
 	// ConfigName is the name of the config map of the autoscaler.
 	ConfigName = "config-autoscaler"
+
+	defaultTargetUtilization = 0.7
 )
 
 // Config defines the tunable autoscaler parameters
@@ -41,8 +43,11 @@ type Config struct {
 	// Target concurrency knobs for different container concurrency configurations.
 	ContainerConcurrencyTargetFraction float64
 	ContainerConcurrencyTargetDefault  float64
-	TargetUtilization                  float64
-	RPSTargetDefault                   float64
+	// TargetUtilization is used for the metrics other than concurrency. This is not
+	// configurable now. Customers can override it by specifying
+	// autoscaling.knative.dev//targetUtilizationPercentage in Revision annotation.
+	TargetUtilization float64
+	RPSTargetDefault  float64
 	// NB: most of our computations are in floats, so this is float to avoid casting.
 	TargetBurstCapacity float64
 
@@ -60,7 +65,9 @@ type Config struct {
 
 // NewConfigFromMap creates a Config from the supplied map
 func NewConfigFromMap(data map[string]string) (*Config, error) {
-	lc := &Config{}
+	lc := &Config{
+		TargetUtilization: defaultTargetUtilization,
+	}
 
 	// Process bool fields.
 	for _, b := range []struct {
@@ -93,7 +100,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key:   "container-concurrency-target-percentage",
 		field: &lc.ContainerConcurrencyTargetFraction,
 		// TODO(#1956): Tune target usage based on empirical data.
-		defaultValue: 0.7,
+		defaultValue: defaultTargetUtilization,
 	}, {
 		key:          "container-concurrency-target-default",
 		field:        &lc.ContainerConcurrencyTargetDefault,
@@ -178,8 +185,12 @@ func validate(lc *Config) (*Config, error) {
 		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of (0, 100]", lc.ContainerConcurrencyTargetFraction)
 	}
 
-	if x := lc.ContainerConcurrencyTargetFraction * lc.ContainerConcurrencyTargetDefault; x < 1.0 {
+	if x := lc.ContainerConcurrencyTargetFraction * lc.ContainerConcurrencyTargetDefault; x < autoscaling.TargetMin {
 		return nil, fmt.Errorf("container-concurrency-target-percentage and container-concurrency-target-default yield target concurrency of %f, can't be less than 1", x)
+	}
+
+	if lc.RPSTargetDefault < autoscaling.TargetMin {
+		return nil, fmt.Errorf("requests-per-second-target-default must be at least %v, got %v", autoscaling.TargetMin, lc.RPSTargetDefault)
 	}
 
 	// We can't permit stable window be less than our aggregation window for correctness.

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -45,7 +45,9 @@ type Config struct {
 	ContainerConcurrencyTargetDefault  float64
 	// TargetUtilization is used for the metrics other than concurrency. This is not
 	// configurable now. Customers can override it by specifying
-	// autoscaling.knative.dev//targetUtilizationPercentage in Revision annotation.
+	// autoscaling.knative.dev/targetUtilizationPercentage in Revision annotation.
+	// TODO(yanweiguo): Expose this to config-autoscaler configmap and eventually
+	// deprecate ContainerConcurrencyTargetFraction.
 	TargetUtilization float64
 	// RPSTargetDefault is the default target value for requests per second.
 	RPSTargetDefault float64

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -30,6 +30,8 @@ var defaultConfig = Config{
 	EnableScaleToZero:                  true,
 	ContainerConcurrencyTargetFraction: 0.7,
 	ContainerConcurrencyTargetDefault:  100.0,
+	RPSTargetDefault:                   200.0,
+	TargetUtilization:                  0.7,
 	TargetBurstCapacity:                0,
 	MaxScaleUpRate:                     1000.0,
 	StableWindow:                       time.Minute,
@@ -96,6 +98,7 @@ func TestNewConfig(t *testing.T) {
 			"max-scale-up-rate":                       "1.0",
 			"container-concurrency-target-percentage": "0.71",
 			"container-concurrency-target-default":    "10.5",
+			"requests-per-second-target-default":      "10.11",
 			"target-burst-capacity":                   "12345",
 			"stable-window":                           "5m",
 			"panic-window":                            "11s",
@@ -107,6 +110,7 @@ func TestNewConfig(t *testing.T) {
 			c.TargetBurstCapacity = 12345
 			c.ContainerConcurrencyTargetDefault = 10.5
 			c.ContainerConcurrencyTargetFraction = 0.71
+			c.RPSTargetDefault = 10.11
 			c.MaxScaleUpRate = 1
 			c.StableWindow = 5 * time.Minute
 			c.PanicWindow = 11 * time.Second
@@ -166,6 +170,12 @@ func TestNewConfig(t *testing.T) {
 		name: "invalid target %, too big",
 		input: map[string]string{
 			"container-concurrency-target-percentage": "142.4",
+		},
+		wantErr: true,
+	}, {
+		name: "invalid RPS target, too small",
+		input: map[string]string{
+			"requests-per-second-target-default": "-5.25",
 		},
 		wantErr: true,
 	}, {

--- a/pkg/reconciler/autoscaling/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/resources/metric_test.go
@@ -167,6 +167,8 @@ var config = &autoscaler.Config{
 	EnableScaleToZero:                  true,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
+	RPSTargetDefault:                   200.0,
+	TargetUtilization:                  0.7,
 	MaxScaleUpRate:                     10.0,
 	StableWindow:                       60 * time.Second,
 	PanicThresholdPercentage:           200,

--- a/pkg/reconciler/autoscaling/resources/target.go
+++ b/pkg/reconciler/autoscaling/resources/target.go
@@ -24,23 +24,18 @@ import (
 	"knative.dev/serving/pkg/autoscaler"
 )
 
-// defaultTargetUtilization is set to the same default value of config.ContainerConcurrencyTargetFraction.
-// This is used for the metrics other than concurrency. This is not configurable now.
-// Customers can override it by specifying autoscaling.knative.dev//targetUtilizationPercentage
-// in Revision annotation.
-const defaultTargetUtilization = 0.7
-
 // ResolveMetricTarget takes scaling metric knobs from multiple locations
 // and resolves them to the final value to be used by the autoscaler.
 // `target` is the target value of scaling metric that we autoscaler will aim for;
 // `total` is the maximum possible value of scaling metric that is permitted on the pod.
 func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) (target float64, total float64) {
-	tu := defaultTargetUtilization
+	var tu float64
 
 	metric := pa.Metric()
 	switch metric {
 	case autoscaling.RPS:
 		total = config.RPSTargetDefault
+		tu = config.TargetUtilization
 	case autoscaling.Concurrency:
 		// Concurrency is used by default
 		fallthrough

--- a/pkg/reconciler/autoscaling/resources/target.go
+++ b/pkg/reconciler/autoscaling/resources/target.go
@@ -52,6 +52,7 @@ func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) 
 		tu = v
 	}
 	target = math.Max(1, total*tu)
+
 	// Use the target provided via annotation, if applicable.
 	if annotationTarget, ok := pa.Target(); ok {
 		// We pick the smaller value between the calculated target and the annotationTarget

--- a/pkg/reconciler/autoscaling/resources/target.go
+++ b/pkg/reconciler/autoscaling/resources/target.go
@@ -31,15 +31,12 @@ import (
 func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) (target float64, total float64) {
 	var tu float64
 
-	metric := pa.Metric()
-	switch metric {
+	switch pa.Metric() {
 	case autoscaling.RPS:
 		total = config.RPSTargetDefault
 		tu = config.TargetUtilization
-	case autoscaling.Concurrency:
-		// Concurrency is used by default
-		fallthrough
 	default:
+		// Concurrency is used by default
 		total = float64(pa.Spec.ContainerConcurrency)
 		// If containerConcurrency is 0 we'll always target the default.
 		if total == 0 {

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -165,11 +165,9 @@ func TestResolveMetricTarget(t *testing.T) {
 				cfg = tc.cfgOpt(*cfg)
 			}
 			gotTgt, gotTot := ResolveMetricTarget(tc.pa, cfg)
-			if gotTgt != tc.wantTgt {
-				t.Errorf("ResolveMetricTarget(%v, %v) = %v, want %v", tc.pa, config, gotTgt, tc.wantTgt)
-			}
-			if gotTot != tc.wantTot {
-				t.Errorf("ResolveMetricTarget(%v, %v) = %v, want %v", tc.pa, config, gotTot, tc.wantTot)
+			if gotTgt != tc.wantTgt || gotTot != tc.wantTot {
+				t.Errorf("ResolveMetricTarget(%v, %v) = (%v, %v), want (%v, %v)",
+					tc.pa, config, gotTgt, gotTot, tc.wantTgt, tc.wantTot)
 			}
 		})
 	}

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"testing"
 
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 
@@ -64,6 +65,7 @@ func TestResolveMetricTarget(t *testing.T) {
 			return &c
 		},
 		wantTgt: 9,
+		wantTot: 12,
 	}, {
 		name: "with container concurrency 10 and TU=80%",
 		pa:   pa(WithPAContainerConcurrency(10)),
@@ -72,6 +74,7 @@ func TestResolveMetricTarget(t *testing.T) {
 			return &c
 		},
 		wantTgt: 8,
+		wantTot: 10,
 	}, {
 		name: "with container concurrency 1 and TU=80%",
 		pa:   pa(WithPAContainerConcurrency(1)),
@@ -80,10 +83,12 @@ func TestResolveMetricTarget(t *testing.T) {
 			return &c
 		},
 		wantTgt: 1, // Not permitting less than 1.
+		wantTot: 1,
 	}, {
 		name:    "with container concurrency 1",
 		pa:      pa(WithPAContainerConcurrency(1)),
 		wantTgt: 1,
+		wantTot: 1,
 	}, {
 		name: "with container concurrency 10 and TU=80%",
 		pa:   pa(WithPAContainerConcurrency(10)),
@@ -97,10 +102,12 @@ func TestResolveMetricTarget(t *testing.T) {
 		name:    "with container concurrency 10",
 		pa:      pa(WithPAContainerConcurrency(10)),
 		wantTgt: 10,
+		wantTot: 10,
 	}, {
 		name:    "with target annotation 1",
 		pa:      pa(WithTargetAnnotation("1")),
 		wantTgt: 1,
+		wantTot: 1,
 	}, {
 		name: "with target annotation 1 and TU=75%",
 		pa:   pa(WithTargetAnnotation("1")),
@@ -129,6 +136,26 @@ func TestResolveMetricTarget(t *testing.T) {
 		pa:      pa(WithPAContainerConcurrency(1), WithTargetAnnotation("10")),
 		wantTgt: 1,
 		wantTot: 1,
+	}, {
+		name:    "RPS: defaults",
+		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithPAContainerConcurrency(1)),
+		wantTgt: 140,
+		wantTot: 200,
+	}, {
+		name:    "RPS: with target annotation 1",
+		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("1")),
+		wantTgt: 1,
+		wantTot: 1,
+	}, {
+		name:    "RPS: with TU annotation 75%",
+		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTUAnnotation("75")),
+		wantTgt: 150,
+		wantTot: 200,
+	}, {
+		name:    "RPS: with target annotation greater than default (ignore annotation for safety)",
+		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("300")),
+		wantTgt: 140,
+		wantTot: 200,
 	}}
 
 	for _, tc := range cases {
@@ -137,8 +164,12 @@ func TestResolveMetricTarget(t *testing.T) {
 			if tc.cfgOpt != nil {
 				cfg = tc.cfgOpt(*cfg)
 			}
-			if gotTgt, _ := ResolveMetricTarget(tc.pa, cfg); gotTgt != tc.wantTgt {
+			gotTgt, gotTot := ResolveMetricTarget(tc.pa, cfg)
+			if gotTgt != tc.wantTgt {
 				t.Errorf("ResolveMetricTarget(%v, %v) = %v, want %v", tc.pa, config, gotTgt, tc.wantTgt)
+			}
+			if gotTot != tc.wantTot {
+				t.Errorf("ResolveMetricTarget(%v, %v) = %v, want %v", tc.pa, config, gotTot, tc.wantTot)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #3416

## Proposed Changes

* Introduces `requests-per-second-target-default` flag in configmap for autoscaler.
* Adds RPS support when resolving target value for scaling.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
