### PR TITLE
Rely on a given point in time for 'inStatusFor' checks.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -186,7 +186,7 @@ func (pas *PodAutoscalerStatus) MarkResourceFailedCreation(kind, name string) {
 // CanScaleToZero checks whether the pod autoscaler has been in an inactive state
 // for at least the specified grace period.
 func (pas *PodAutoscalerStatus) CanScaleToZero(now time.Time, gracePeriod time.Duration) bool {
-	return pas.inStatusFor(corev1.ConditionFalse, time.Now(), gracePeriod) > 0
+	return pas.inStatusFor(corev1.ConditionFalse, now, gracePeriod) > 0
 }
 
 // ActiveFor returns the time PA spent being active.

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -185,30 +185,30 @@ func (pas *PodAutoscalerStatus) MarkResourceFailedCreation(kind, name string) {
 
 // CanScaleToZero checks whether the pod autoscaler has been in an inactive state
 // for at least the specified grace period.
-func (pas *PodAutoscalerStatus) CanScaleToZero(gracePeriod time.Duration) bool {
-	return pas.inStatusFor(corev1.ConditionFalse, gracePeriod) > 0
+func (pas *PodAutoscalerStatus) CanScaleToZero(now time.Time, gracePeriod time.Duration) bool {
+	return pas.inStatusFor(corev1.ConditionFalse, time.Now(), gracePeriod) > 0
 }
 
 // ActiveFor returns the time PA spent being active.
-func (pas *PodAutoscalerStatus) ActiveFor() time.Duration {
-	return pas.inStatusFor(corev1.ConditionTrue, 0)
+func (pas *PodAutoscalerStatus) ActiveFor(now time.Time) time.Duration {
+	return pas.inStatusFor(corev1.ConditionTrue, now, 0)
 }
 
 // CanFailActivation checks whether the pod autoscaler has been activating
 // for at least the specified idle period.
-func (pas *PodAutoscalerStatus) CanFailActivation(idlePeriod time.Duration) bool {
-	return pas.inStatusFor(corev1.ConditionUnknown, idlePeriod) > 0
+func (pas *PodAutoscalerStatus) CanFailActivation(now time.Time, idlePeriod time.Duration) bool {
+	return pas.inStatusFor(corev1.ConditionUnknown, now, idlePeriod) > 0
 }
 
 // inStatusFor returns positive duration if the PodAutoscalerStatus's Active condition has stayed in
 // the specified status for at least the specified duration. Otherwise it returns negative duration,
 // including when the status is undetermined (Active condition is not found.)
-func (pas *PodAutoscalerStatus) inStatusFor(status corev1.ConditionStatus, dur time.Duration) time.Duration {
+func (pas *PodAutoscalerStatus) inStatusFor(status corev1.ConditionStatus, now time.Time, dur time.Duration) time.Duration {
 	cond := pas.GetCondition(PodAutoscalerConditionActive)
 	if cond == nil || cond.Status != status {
 		return -1
 	}
-	return time.Since(cond.LastTransitionTime.Inner.Add(dur))
+	return now.Sub(cond.LastTransitionTime.Inner.Add(dur))
 }
 
 func (pas *PodAutoscalerStatus) duck() *duckv1beta1.Status {

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -62,6 +62,7 @@ func TestGeneration(t *testing.T) {
 }
 
 func TestCanScaleToZero(t *testing.T) {
+	now := time.Now()
 	cases := []struct {
 		name   string
 		status PodAutoscalerStatus
@@ -105,7 +106,7 @@ func TestCanScaleToZero(t *testing.T) {
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionFalse,
 					LastTransitionTime: apis.VolatileTime{
-						Inner: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+						Inner: metav1.NewTime(now.Add(-30 * time.Second)),
 					},
 					// LTT = 30 seconds ago.
 				}},
@@ -121,7 +122,7 @@ func TestCanScaleToZero(t *testing.T) {
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionFalse,
 					LastTransitionTime: apis.VolatileTime{
-						Inner: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+						Inner: metav1.NewTime(now.Add(-10 * time.Second)),
 					},
 					// LTT = 10 seconds ago.
 				}},
@@ -133,7 +134,7 @@ func TestCanScaleToZero(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if e, a := tc.result, tc.status.CanScaleToZero(tc.grace); e != a {
+			if e, a := tc.result, tc.status.CanScaleToZero(now, tc.grace); e != a {
 				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 			}
 		})
@@ -141,6 +142,7 @@ func TestCanScaleToZero(t *testing.T) {
 }
 
 func TestActiveFor(t *testing.T) {
+	now := time.Now()
 	cases := []struct {
 		name   string
 		status PodAutoscalerStatus
@@ -191,7 +193,7 @@ func TestActiveFor(t *testing.T) {
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 					LastTransitionTime: apis.VolatileTime{
-						Inner: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+						Inner: metav1.NewTime(now.Add(-30 * time.Second)),
 					},
 					// LTT = 30 seconds ago.
 				}},
@@ -206,7 +208,7 @@ func TestActiveFor(t *testing.T) {
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 					LastTransitionTime: apis.VolatileTime{
-						Inner: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+						Inner: metav1.NewTime(now.Add(-10 * time.Second)),
 					},
 					// LTT = 10 seconds ago.
 				}},
@@ -216,7 +218,7 @@ func TestActiveFor(t *testing.T) {
 	}}
 
 	for _, tc := range cases {
-		if got, want := tc.result, tc.status.ActiveFor(); absDiff(got, want) > 10*time.Millisecond {
+		if got, want := tc.status.ActiveFor(now), tc.result; absDiff(got, want) > 10*time.Millisecond {
 			t.Errorf("ActiveFor = %v, want: %v", got, want)
 		}
 	}
@@ -231,6 +233,7 @@ func absDiff(a, b time.Duration) time.Duration {
 }
 
 func TestCanFailActivation(t *testing.T) {
+	now := time.Now()
 	cases := []struct {
 		name   string
 		status PodAutoscalerStatus
@@ -274,7 +277,7 @@ func TestCanFailActivation(t *testing.T) {
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 					LastTransitionTime: apis.VolatileTime{
-						Inner: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+						Inner: metav1.NewTime(now.Add(-30 * time.Second)),
 					},
 					// LTT = 30 seconds ago.
 				}},
@@ -290,7 +293,7 @@ func TestCanFailActivation(t *testing.T) {
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 					LastTransitionTime: apis.VolatileTime{
-						Inner: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+						Inner: metav1.NewTime(now.Add(-10 * time.Second)),
 					},
 					// LTT = 10 seconds ago.
 				}},
@@ -302,7 +305,7 @@ func TestCanFailActivation(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if e, a := tc.result, tc.status.CanFailActivation(tc.grace); e != a {
+			if e, a := tc.result, tc.status.CanFailActivation(now, tc.grace); e != a {
 				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 			}
 		})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We all know relying on the global clock is kinda bad and will at some point drop on your feet. This happened here in that the 'ActiveFor' tests are flaky because it checks against a fixed value, which can never be guaranteed and will be skewed if the CPU scheduler goes out for lunch in between executing two statements under test.

Instead of making the test accept diluted values, I opted to actually inject the point in time to check against to make it reliable in tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
