### PR TITLE
Add support of CA issuer

### DIFF
--- a/config/config-certmanager.yaml
+++ b/config/config-certmanager.yaml
@@ -37,6 +37,11 @@ data:
     # These sample configuration options may be copied out of
     # this block and unindented to actually change the configuration.
 
+    # IssuerRef is a type of issuer.
+    # Please refer to `Supported Issuer types` in https://docs.cert-manager.io/en/latest/reference/issuers.html#supported-issuer-types
+    # Currently supported values: acme, ca.
+    issuerKind: acme
+
     # IssuerRef is a reference to the issuer for this certificate.
     # IssuerRef should be either `ClusterIssuer` or `Issuer`.
     # Please refer `IssuerRef` in https://github.com/jetstack/cert-manager/blob/master/pkg/apis/certmanager/v1alpha1/types_certificate.go

--- a/pkg/reconciler/certificate/config/cert_manager.go
+++ b/pkg/reconciler/certificate/config/cert_manager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"strings"
+
 	"github.com/ghodss/yaml"
 
 	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -26,6 +28,7 @@ import (
 const (
 	solverConfigKey = "solverConfig"
 	issuerRefKey    = "issuerRef"
+	issuerKindKey   = "issuerKind"
 
 	// CertManagerConfigName is the name of the configmap containing all
 	// configuration related to Cert-Manager.
@@ -37,15 +40,18 @@ const (
 type CertManagerConfig struct {
 	SolverConfig *certmanagerv1alpha1.SolverConfig
 	IssuerRef    *certmanagerv1alpha1.ObjectReference
+	IssuerKind   string
 }
 
 // NewCertManagerConfigFromConfigMap creates an CertManagerConfig from the supplied ConfigMap
 func NewCertManagerConfigFromConfigMap(configMap *corev1.ConfigMap) (*CertManagerConfig, error) {
 	// TODO(zhiminx): do we need to provide the default values here?
+	// TODO: validation check.
 
 	config := &CertManagerConfig{
 		SolverConfig: &certmanagerv1alpha1.SolverConfig{},
 		IssuerRef:    &certmanagerv1alpha1.ObjectReference{},
+		IssuerKind:   "acme",
 	}
 
 	if v, ok := configMap.Data[solverConfigKey]; ok {
@@ -58,6 +64,10 @@ func NewCertManagerConfigFromConfigMap(configMap *corev1.ConfigMap) (*CertManage
 		if err := yaml.Unmarshal([]byte(v), config.IssuerRef); err != nil {
 			return nil, err
 		}
+	}
+
+	if v, ok := configMap.Data[issuerKindKey]; ok {
+		config.IssuerKind = strings.ToLower(v)
 	}
 	return config, nil
 }

--- a/pkg/reconciler/certificate/config/cert_manager_test.go
+++ b/pkg/reconciler/certificate/config/cert_manager_test.go
@@ -62,11 +62,16 @@ func TestIssuerRef(t *testing.T) {
 		name:    "valid IssuerRef",
 		wantErr: false,
 		wantConfig: &CertManagerConfig{
-			SolverConfig: &certmanagerv1alpha1.SolverConfig{},
+			SolverConfig: &certmanagerv1alpha1.SolverConfig{
+				DNS01: &certmanagerv1alpha1.DNS01SolverConfig{
+					Provider: "cloud-dns-provider",
+				},
+			},
 			IssuerRef: &certmanagerv1alpha1.ObjectReference{
 				Name: "letsencrypt-issuer",
 				Kind: "ClusterIssuer",
 			},
+			IssuerKind: "acme",
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -74,7 +79,9 @@ func TestIssuerRef(t *testing.T) {
 				Name:      CertManagerConfigName,
 			},
 			Data: map[string]string{
-				issuerRefKey: "kind: ClusterIssuer\nname: letsencrypt-issuer",
+				issuerRefKey:    "kind: ClusterIssuer\nname: letsencrypt-issuer",
+				issuerKindKey:   "acme",
+				solverConfigKey: "dns01:\n  provider: cloud-dns-provider",
 			},
 		},
 	}}
@@ -119,7 +126,11 @@ func TestSolverConfig(t *testing.T) {
 					Provider: "cloud-dns-provider",
 				},
 			},
-			IssuerRef: &certmanagerv1alpha1.ObjectReference{},
+			IssuerRef: &certmanagerv1alpha1.ObjectReference{
+				Name: "letencrypt-issuer",
+				Kind: "ClusterIssuer",
+			},
+			IssuerKind: "acme",
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -128,6 +139,7 @@ func TestSolverConfig(t *testing.T) {
 			},
 			Data: map[string]string{
 				solverConfigKey: "dns01:\n  provider: cloud-dns-provider",
+				issuerRefKey:    "kind: ClusterIssuer\nname: letencrypt-issuer",
 			},
 		},
 	}, {
@@ -139,7 +151,11 @@ func TestSolverConfig(t *testing.T) {
 					Ingress: "test-ingress",
 				},
 			},
-			IssuerRef: &certmanagerv1alpha1.ObjectReference{},
+			IssuerRef: &certmanagerv1alpha1.ObjectReference{
+				Name: "letencrypt-issuer",
+				Kind: "ClusterIssuer",
+			},
+			IssuerKind: "acme",
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -148,6 +164,7 @@ func TestSolverConfig(t *testing.T) {
 			},
 			Data: map[string]string{
 				solverConfigKey: "http01:\n  ingress: test-ingress",
+				issuerRefKey:    "kind: ClusterIssuer\nname: letencrypt-issuer",
 			},
 		},
 	}}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -26,7 +26,7 @@ import (
 
 // MakeCertManagerCertificate creates a Cert-Manager `Certificate` for requesting a SSL certificate.
 func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1alpha1.Certificate) *certmanagerv1alpha1.Certificate {
-	return &certmanagerv1alpha1.Certificate{
+	cert := &certmanagerv1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            knCert.Name,
 			Namespace:       knCert.Namespace,
@@ -36,14 +36,21 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 			SecretName: knCert.Spec.SecretName,
 			DNSNames:   knCert.Spec.DNSNames,
 			IssuerRef:  *cmConfig.IssuerRef,
-			ACME: &certmanagerv1alpha1.ACMECertificateConfig{
-				Config: []certmanagerv1alpha1.DomainSolverConfig{{
-					Domains:      knCert.Spec.DNSNames,
-					SolverConfig: *cmConfig.SolverConfig,
-				}},
-			},
 		},
 	}
+
+	switch cmConfig.IssuerKind {
+	case "acme":
+		cert.Spec.ACME = &certmanagerv1alpha1.ACMECertificateConfig{
+			Config: []certmanagerv1alpha1.DomainSolverConfig{{
+				Domains:      knCert.Spec.DNSNames,
+				SolverConfig: *cmConfig.SolverConfig,
+			}},
+		}
+	case "ca":
+		// ca does not need any specific config.
+	}
+	return cert
 }
 
 // GetReadyCondition gets the ready condition of a Cert-Manager `Certificate`.

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -48,6 +48,7 @@ var cmConfig = &config.CertManagerConfig{
 		Kind: "ClusterIssuer",
 		Name: "Letsencrypt-issuer",
 	},
+	IssuerKind: "acme",
 }
 
 func TestMakeCertManagerCertificate(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes

This patch supports CA Issuer for autoTLS.

Currently autoTLS supports ACME Issuer, but there are two motivation for CA Issuer.

* It is very easy to setup and test.
* It is possible to use with off-line environment.

Also, some organization does not allow to use ACME issuer, so CA issuer could be
alternative option.

## additional info

Setting up is basically same with ACME Issuer. We just need to create ClusterIssuer beforhand by referring to https://docs.cert-manager.io/en/latest/tasks/issuers/setup-ca.html.

And here is an example for `config-certmanager`.
```
  issuerKind: ca
  issuerRef: |
    kind: ClusterIssuer
    name: ca-issuer  # Need to be replaced.
```

/lint


**Release Note**

```release-note
CA issuer is supported as an additional issuer type for autoTLS.
```
