### PR TITLE
Ignore Gateways that cannot be probed (yet).

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -282,3 +282,16 @@ func isDefaultServer(server *v1alpha3.Server) bool {
 func isPlaceHolderServer(server *v1alpha3.Server) bool {
 	return equality.Semantic.DeepEqual(server, &placeholderServer)
 }
+
+// CanProbeGateway return whether the specified Gateway can be probe using HTTP on port 80.
+func CanProbeGateway(gateway *v1alpha3.Gateway) bool {
+	for _, server := range gateway.Spec.Servers {
+		if len(server.Hosts) == 1 &&
+			server.Hosts[0] == "*" &&
+			server.Port.Number == 80 &&
+			server.Port.Protocol == v1alpha3.ProtocolHTTP {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -283,7 +283,7 @@ func isPlaceHolderServer(server *v1alpha3.Server) bool {
 	return equality.Semantic.DeepEqual(server, &placeholderServer)
 }
 
-// CanProbeGateway return whether the specified Gateway can be probe using HTTP on port 80.
+// CanProbeGateway return whether the specified Gateway can be probed using HTTP on port 80.
 func CanProbeGateway(gateway *v1alpha3.Gateway) bool {
 	for _, server := range gateway.Spec.Servers {
 		if len(server.Hosts) == 1 &&

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -627,3 +627,89 @@ func TestGatewayName(t *testing.T) {
 		t.Errorf("Unexpected gateway name. want %q, got %q", want, got)
 	}
 }
+
+func TestCanProbeGateway(t *testing.T) {
+	cases := []struct {
+		name string
+		gateway  *v1alpha3.Gateway
+		canProbe bool
+	}{{
+		name: "wildcard HTTP on port 80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 80,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: true,
+	},{
+		name: "specific host HTTP on port 80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"foo.bar.com"},
+					Port:v1alpha3.Port{
+						Number: 100,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	},{
+		name: "wildcard HTTP on port !80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 100,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	},{
+		name: "wildcard TCP on port 80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 80,
+						Protocol: v1alpha3.ProtocolTCP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	},{
+		name: "wildcard HTTPS on port 443",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 100,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := CanProbeGateway(c.gateway)
+			if got != c.canProbe {
+				t.Errorf("Expected %t, got %t", c.canProbe, got)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -305,6 +305,11 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 			return nil, fmt.Errorf("failed to get Gateway %s/%s: %v", namespace, name, err)
 		}
 
+		// Skip gateways that cannot be probed
+		if !resources.CanProbeGateway(gateway) {
+			continue
+		}
+
 		// List matching Pods
 		selector := labels.NewSelector()
 		for key, value := range gateway.Spec.Selector {

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -85,6 +85,13 @@ func TestIsReadyFailures(t *testing.T) {
 					Name:      "gateway",
 				},
 				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port:v1alpha3.Port{
+							Number: 80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
 					Selector: map[string]string{
 						"gwt": "istio",
 					},
@@ -160,6 +167,13 @@ func TestProbeLifecycle(t *testing.T) {
 					Name:      "gateway",
 				},
 				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port:v1alpha3.Port{
+							Number: 80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
 					Selector: map[string]string{
 						"gwt": "istio",
 					},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign tcnghia
/lint
-->

Fixes #5129.

#4734 introduces VirtualService/Gateway probing. The current implementation doesn't work when HTTP is disabled. The fix for it is similar to this prototype: #5032. As it is a non-trivial change. This is a quick workaround until the proper long term fix is implemented.

## Proposed Changes
* Only probe VirtualService bound to Gateways that can actually be probed.

