### PR TITLE
Add json struct tag to ProtocolType on PA

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -85,7 +85,7 @@ type PodAutoscalerSpec struct {
 	DeprecatedServiceName string `json:"serviceName"`
 
 	// The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.
-	ProtocolType net.ProtocolType
+	ProtocolType net.ProtocolType `json:"protocolType"`
 }
 
 const (


### PR DESCRIPTION
Makes the `kubectl -o yaml get pa` output looks like this:
```yaml
  ...
  spec:
    protocolType: http1
    scaleTargetRef:
      apiVersion: apps/v1
      kind: Deployment
      name: helloworld-test-image-qlchd-deployment
    serviceName: ""
  ...
```

Instead of this:
```yaml
  ...
  spec:
    ProtocolType: http1
    scaleTargetRef:
      apiVersion: apps/v1
      kind: Deployment
      name: helloworld-test-image-qlchd-deployment
    serviceName: ""
  ...
```