### PR TITLE
Add option to run all e2e tests with different http and https settings

### DIFF
--- a/pkg/reconciler/revision/config/testdata/config-defaults.yaml
+++ b/pkg/reconciler/revision/config/testdata/config-defaults.yaml
@@ -1,0 +1,1 @@
+../../../../../config/config-defaults.yaml

--- a/test/README.md
+++ b/test/README.md
@@ -169,6 +169,7 @@ these flags:
 - [`--tag`](#using-a-docker-tag)
 - [`--ingressendpoint`](#using-a-custom-ingress-endpoint)
 - [`--resolvabledomain`](#using-a-resolvable-domain)
+- [`--https`](#using-https)
 
 ### Overridding docker repo
 
@@ -226,3 +227,7 @@ the header.
 If you have configured your cluster to use a resolvable domain, you can use the
 `--resolvabledomain` flag to indicate that the test should make requests
 directly against `Route.Status.Domain` and does not need to spoof the `Host`.
+
+### Using https
+
+You can use the `--https` flag to have all tests run with https.

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -68,7 +68,8 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -124,7 +124,9 @@ func TestServiceGenerateName(t *testing.T) {
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, setServiceGenerateName(generateName))
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)
 	}

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -55,7 +55,9 @@ func TestCustomResourcesLimits(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithResourceRequirements(resources))
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		v1a1opts.WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -53,7 +53,8 @@ func TestRunLatestService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -196,7 +197,9 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	revName := names.Service + "-byoname"
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, func(svc *v1alpha1.Service) {
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		func(svc *v1alpha1.Service) {
 		svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
 	})
 	if err != nil {
@@ -265,7 +268,8 @@ func TestReleaseService(t *testing.T) {
 	)
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -529,7 +533,8 @@ func TestAnnotationPropagation(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	// Setup initial Service
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -45,7 +45,9 @@ func TestSingleConcurrency(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithContainerConcurrency(1))
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -90,7 +90,9 @@ func TestConfigMapVolume(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume, withOptionalBadVolume); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -162,7 +164,9 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -228,7 +232,9 @@ func TestSecretVolume(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume, withOptionalBadVolume); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -298,7 +304,9 @@ func TestProjectedSecretVolume(t *testing.T) {
 	}
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume, withSubpath); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withVolume, withSubpath); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
@@ -395,7 +403,9 @@ func TestProjectedComplex(t *testing.T) {
 	})
 
 	// Setup initial Service
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withVolume); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -44,7 +44,9 @@ func TestProbeRuntime(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	_, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithReadinessProbe(
+	_, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		v1a1opts.WithReadinessProbe(
 		&corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -54,7 +54,9 @@ func fetchRuntimeInfo(
 		svc.Spec.Template.Spec.Containers[0].ImagePullPolicy = "Always"
 	})
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, serviceOpts...)
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		serviceOpts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -29,6 +29,8 @@ CERT_MANAGER_VERSION="0.9.1"
 ISTIO_VERSION=""
 GLOO_VERSION=""
 
+HTTPS=0
+
 # Current YAMLs used to install Knative Serving.
 INSTALL_RELEASE_YAML=""
 INSTALL_MONITORING_YAML=""
@@ -66,6 +68,10 @@ function parse_flags() {
       ;;
     --no-mesh)
       readonly MESH=0
+      return 1
+      ;;
+    --https)
+      readonly HTTPS=1
       return 1
       ;;
     --install-monitoring)
@@ -290,6 +296,14 @@ function use_resolvable_domain() {
   echo "false"
 }
 
+# Check if we should use --https.
+function use_https() {
+  if (( HTTPS )); then
+    echo "--https"
+  else
+    echo ""
+  fi
+}
 
 # Uninstalls Knative Serving from the current cluster.
 function knative_teardown() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -52,7 +52,7 @@ go_test_e2e -timeout=30m \
   ./test/conformance/... \
   ./test/e2e \
   ${parallelism} \
-  "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+  "--resolvabledomain=$(use_resolvable_domain)" "$(use_https)" || failed=1
 
 # Run scale tests.
 go_test_e2e -timeout=10m \
@@ -63,7 +63,7 @@ go_test_e2e -timeout=10m \
 if [[ -n "${ISTIO_VERSION}" ]]; then
   go_test_e2e -timeout=10m \
     ./test/e2e/istio \
-    "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+    "--resolvabledomain=$(use_resolvable_domain)" "$(use_https)" || failed=1
 fi
 
 # Dump cluster state in case of failure

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -68,7 +68,7 @@ TIMEOUT=10m
 header "Running preupgrade tests"
 
 go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) || fail_test
+  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" || fail_test
 
 header "Starting prober test"
 
@@ -76,7 +76,7 @@ header "Starting prober test"
 rm -f /tmp/prober-signal
 
 go_test_e2e -tags=probe -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) &
+  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" &
 PROBER_PID=$!
 echo "Prober PID is ${PROBER_PID}"
 
@@ -84,13 +84,13 @@ install_head
 
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) || fail_test
+  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" || fail_test
 
 install_latest_release
 
 header "Running postdowngrade tests"
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) || fail_test
+  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" || fail_test
 
 # The prober is blocking on /tmp/prober-signal to know when it should exit.
 #

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -59,7 +59,9 @@ func TestActivatorOverload(t *testing.T) {
 	t.Log("Creating a service with run latest configuration.")
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, func(service *v1alpha1.Service) {
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		func(service *v1alpha1.Service) {
 		service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
 		service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 	})

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -177,7 +177,8 @@ func setup(t *testing.T, class, metric string, target float64, targetUtilization
 		Image:   "autoscale",
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		append(fopts, rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:             class,
 			autoscaling.MetricAnnotationKey:            metric,

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -172,7 +172,9 @@ func TestDestroyPodTimely(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}
@@ -229,7 +231,9 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -49,7 +49,9 @@ func TestEgressTraffic(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, v1a1opts.WithEnv(envVars...))
+	service, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		v1a1opts.WithEnv(envVars...))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -169,7 +169,9 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, fopts...)
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -46,23 +46,41 @@ func TestHelloWorld(t *testing.T) {
 		Image:   "helloworld",
 	}
 
+	if test.ServingFlags.Https {
+		// Save the current Gateway to restore it after the test
+		oldGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(v1a1test.Namespace).Get(v1a1test.GatewayName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get Gateway %s/%s", v1a1test.Namespace, v1a1test.GatewayName)
+		}
+		test.CleanupOnInterrupt(func () { v1a1test.RestoreGateway(t, clients, *oldGateway) })
+		defer v1a1test.RestoreGateway(t, clients, *oldGateway)
+	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	resources, httpsTransportOption, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, test.ServingFlags.Https)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
 
 	url := resources.Route.Status.URL.URL()
-	if _, err = pkgTest.WaitForEndpointState(
+	var opt interface{}
+	if test.ServingFlags.Https {
+		url.Scheme = "https"
+		if httpsTransportOption == nil {
+			t.Fatalf("Https transport option is nil")
+		}
+		opt = *httpsTransportOption
+	}
+	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
 		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"HelloWorldServesText",
-		test.ServingFlags.ResolvableDomain); err != nil {
+		test.ServingFlags.ResolvableDomain,
+		opt); err != nil {
 		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.HelloWorldText, err)
 	}
 
@@ -99,7 +117,8 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName("cpu"):    resource.MustParse("50m"),

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -89,7 +89,8 @@ func TestIstioProbing(t *testing.T) {
 		}
 		test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 		defer test.TearDown(clients, names)
-		objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+		objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+			false /* https TODO(taragu) turn this on after helloworld test running with https */)
 		if err != nil {
 			t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 		}
@@ -264,7 +265,7 @@ func TestIstioProbing(t *testing.T) {
 			// Create the service and wait for it to be ready
 			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 			defer test.TearDown(clients, names)
-			_, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+			_, _, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names, false /* https */)
 			if err != nil {
 				t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 			}

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -62,7 +62,8 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
 
@@ -72,7 +73,8 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
 
@@ -124,7 +126,8 @@ func TestConflictingRouteService(t *testing.T) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
 }

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -66,7 +66,9 @@ func TestRollbackBYOName(t *testing.T) {
 	})
 
 	t.Logf("Creating a new Service with byo config name %q.", byoNameOld)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withTrafficSpecOld, func(svc *v1alpha1.Service) {
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withTrafficSpecOld, func(svc *v1alpha1.Service) {
 		svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameOld
 	})
 	if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -119,7 +119,8 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		v1alph1testing.WithEnv(envVars...),
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -195,7 +196,8 @@ func TestServiceToServiceCall(t *testing.T) {
 
 	withInternalVisibility := v1alph1testing.WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		withInternalVisibility,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -241,7 +243,8 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, testNames) })
 	defer test.TearDown(clients, testNames)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
@@ -296,7 +299,8 @@ func TestCallToPublicService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		}))

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -76,7 +76,9 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 		},
 	})
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withInternalVisibility, withTrafficSpec)
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -121,7 +123,9 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 			},
 		}},
 	})
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withTrafficSpec)
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %w", names.Service, err)
 	}
@@ -250,7 +254,9 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 			},
 		},
 	})
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, withTrafficSpec, withInternalVisibility)
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		withTrafficSpec, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -124,7 +124,8 @@ func TestWebSocket(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names); err != nil {
+	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
@@ -152,7 +153,8 @@ func TestWebSocketViaActivator(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}),

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -55,6 +55,7 @@ var ServingFlags = initializeServingFlags()
 // ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
 type ServingEnvironmentFlags struct {
 	ResolvableDomain bool // Resolve Route controller's `domainSuffix`
+	Https            bool // Indicates where the test service will be created with https
 }
 
 // initializeServingFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
@@ -64,6 +65,8 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
 		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
+	flag.BoolVar(&f.Https, "https", false,
+		"Set this flag to true to run all tests with https.")
 
 	flag.Set("alsologtostderr", "true")
 	logging.InitializeLogger(test.Flags.LogVerbose)

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -64,7 +64,8 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -152,7 +152,8 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+		false /* https TODO(taragu) turn this on after helloworld test running with https */,
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -131,8 +131,10 @@ func createServices(t *testing.T, pc *Client, count int) ([]*v1a1test.ResourceOb
 		ndx := i
 		g.Go(func() error {
 			var err error
-			if objs[ndx], err = v1a1test.CreateRunLatestServiceReady(t, pc.E2EClients, testNames[ndx], sos...); err != nil {
-				return fmt.Errorf("%02d: failed to create Ready service: %w", ndx, err)
+			if objs[ndx], _, err = v1a1test.CreateRunLatestServiceReady(t, pc.E2EClients, testNames[ndx],
+				false /* https TODO(taragu) turn this on after helloworld test running with https */,
+				sos...); err != nil {
+				return fmt.Errorf("%02d: failed to create Ready service: %v", ndx, err)
 			}
 			return nil
 		})


### PR DESCRIPTION
/lint

Part of #5148

## Proposed Changes

* Add option to run all e2e tests with different http and https settings

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @JRBANCEL 
/cc @ZhiminXiang 