### PR TITLE
Remove the wildcard HTTPS server from knative-ingress-gateway

### DIFF
--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -31,11 +31,3 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
-  - port:
-      number: 443
-      name: https
-      protocol: HTTPS
-    hosts:
-    - "*"
-    tls:
-      mode: PASSTHROUGH


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

*  Remove the wildcard HTTPS server from knative-ingress-gateway

When users need HTTPS feature, the HTTPS configuration usually is customized. Providing a default HTTPS server is useless in the most cases and could be misleading (https://github.com/knative/serving/issues/4862#issuecomment-517651224).

