### PR TITLE
New probe handling in Queue-Proxy & Activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -242,6 +242,7 @@ func main() {
 	ah = &activatorhandler.HealthHandler{HealthCheck: statSink.Status, NextHandler: ah}
 	// NOTE: MetricHandler is being used as the outermost handler for the purpose of measuring the request latency.
 	ah = activatorhandler.NewMetricHandler(revisionInformer.Lister(), reporter, logger, ah)
+	ah = network.NewProbeHandler(ah)
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher.Watch(pkglogging.ConfigMapName(), pkglogging.UpdateLevelFromConfigMap(logger, atomicLevel, component))

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -388,6 +388,7 @@ func main() {
 		composedHandler = pushRequestMetricHandler(composedHandler, requestCountM, responseTimeInMsecM, env)
 	}
 	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
+	composedHandler = network.NewProbeHandler(composedHandler)
 	server := network.NewServer(":"+strconv.Itoa(env.QueueServingPort), composedHandler)
 
 	adminMux := http.NewServeMux()

--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -68,7 +68,7 @@ func extractData(body io.Reader) (*Stat, error) {
 	for m, pv := range map[string]*float64{
 		"queue_average_concurrent_requests":         &stat.AverageConcurrentRequests,
 		"queue_average_proxied_concurrent_requests": &stat.AverageProxiedConcurrentRequests,
-		"queue_requests_per_second":               &stat.RequestCount,
+		"queue_requests_per_second":                 &stat.RequestCount,
 		"queue_proxied_operations_per_second":       &stat.ProxiedRequestCount,
 	} {
 		pm := prometheusMetric(metricFamilies, m)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -42,6 +42,10 @@ const (
 	// uses to mark requests going through it.
 	ProxyHeaderName = "K-Proxy-Request"
 
+	// HashHeaderName is the name of an internal header that Ingress controller
+	// uses to find out which version of the networking config is deployed.
+	HashHeaderName = "K-Network-Hash"
+
 	// OriginalHostHeader is used to avoid Istio host based routing rules
 	// in Activator.
 	// The header contains the original Host value that can be rewritten

--- a/pkg/network/probe_handler.go
+++ b/pkg/network/probe_handler.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ProbeHeaderValue is the value used in 'K-Network-Probe'
+var ProbeHeaderValue = "probe"
+
+type handler struct {
+	next http.Handler
+}
+
+// NewProbeHandler wraps a HTTP handler handling probing requests around the provided HTTP handler
+func NewProbeHandler(next http.Handler) http.Handler {
+	return &handler{next: next}
+}
+
+// ServeHTTP handles probing requests
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if ph := r.Header.Get(ProbeHeaderName); ph != ProbeHeaderValue {
+		r.Header.Del(HashHeaderName)
+		h.next.ServeHTTP(w, r)
+		return
+	}
+
+	hh := r.Header.Get(HashHeaderName)
+	if hh == "" {
+		http.Error(w, fmt.Sprintf("a probe request must contain a non-empty %q header", HashHeaderName), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set(HashHeaderName, hh)
+	w.WriteHeader(200)
+}

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "knative.dev/pkg/system/testing"
+	"knative.dev/serving/pkg/network/prober"
+)
+
+func TestProbeHandlerSuccessfulProbe(t *testing.T) {
+	body := "Inner Body"
+	cases := []struct {
+		name    string
+		options []interface{}
+		want    bool
+	}{{
+		name: "successful probe when both headers are specified",
+		options: []interface{}{
+			prober.WithHeader(ProbeHeaderName, ProbeHeaderValue),
+			prober.WithHeader(HashHeaderName, "foo-bar-baz"),
+		},
+		want: true,
+	}, {
+		name: "forwards to inner handler when probe header is not specified",
+		options: []interface{}{
+			prober.WithHeader(HashHeaderName, "foo-bar-baz"),
+			prober.ExpectsBody(body),
+			// Validates the header is stripped before forwarding to the inner handler
+			prober.ExpectsHeader(HashHeaderName, "false"),
+		},
+		want: true,
+	}, {
+		name: "forwards to inner handler when probe header is not 'probe'",
+		options: []interface{}{
+			prober.WithHeader(ProbeHeaderName, "queue"),
+			prober.WithHeader(HashHeaderName, "foo-bar-baz"),
+			prober.ExpectsBody(body),
+			prober.ExpectsHeader(ProbeHeaderName, "true"),
+			// Validates the header is stripped before forwarding to the inner handler
+			prober.ExpectsHeader(HashHeaderName, "false"),
+		},
+		want: true,
+	}, {
+		name: "failed probe when hash header is not present",
+		options: []interface{}{
+			prober.WithHeader(ProbeHeaderName, ProbeHeaderValue),
+		},
+		want: false,
+	}}
+
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, ok := r.Header[ProbeHeaderName]
+		w.Header().Set(ProbeHeaderName, fmt.Sprintf("%t", ok))
+		_, ok = r.Header[HashHeaderName]
+		w.Header().Set(HashHeaderName, fmt.Sprintf("%t", ok))
+		w.Write([]byte(body))
+	})
+	h = NewProbeHandler(h)
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := prober.Do(context.Background(), AutoTransport, ts.URL, c.options...)
+			if err != nil {
+				t.Errorf("failed to probe: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("unexpected probe result: want: %t, got: %t", c.want, got)
+			}
+		})
+	}
+}

--- a/pkg/network/prober/prober.go
+++ b/pkg/network/prober/prober.go
@@ -57,6 +57,13 @@ func ExpectsBody(body string) Verifier {
 	}
 }
 
+// ExpectsHeader validates that the given header of the probe response matches the provided string.
+func ExpectsHeader(name, value string) Verifier {
+	return func(r *http.Response, _ []byte) (bool, error) {
+		return r.Header.Get(name) == value, nil
+	}
+}
+
 // Do sends a single probe to given target, e.g. `http://revision.default.svc.cluster.local:81`.
 // Do returns whether the probe was successful or not, or there was an error probing.
 func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...interface{}) (bool, error) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/vagababov
/lint
-->

Part 1 & 2 & 3 of #5156.

## Proposed Changes
I am not 100% sure why, but today Activator and Queue-Proxy care if the a probe request was sent to them **specifically**. For #5156, we need to be able to probe Envoy though the real data path (eventually reaching either Activator or Queue-Proxy) without distinction. This change introduces a new probe handler at the head of the handlers pipeline doing just that as well as a new header that will be populated by Envoy and used to find out which version of the VirtualService/Gateway Envoy is using.  

## Next
Maybe take a holistic look at probing in all components and consolidate/refactor.