### PR TITLE
Add labels and annotations to Certificates resources

### DIFF
--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -32,7 +32,7 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 			Name:            knCert.Name,
 			Namespace:       knCert.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(knCert)},
-			Annotations:     GetCertificateUpdaterAnnotations(knCert),
+			Annotations:     getCertificateUpdaterAnnotations(knCert),
 			Labels:          knCert.GetLabels(),
 		},
 		Spec: certmanagerv1alpha1.CertificateSpec{
@@ -49,8 +49,8 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 	}
 }
 
-// GetCertificateUpdaterAnnotations gets a Knative Certificate's updater annotation if exists.
-func GetCertificateUpdaterAnnotations(knCert *v1alpha1.Certificate) map[string]string {
+// getCertificateUpdaterAnnotations gets a Knative Certificate's updater annotation if exists.
+func getCertificateUpdaterAnnotations(knCert *v1alpha1.Certificate) map[string]string {
 	if val, ok := knCert.GetAnnotations()[serving.UpdaterAnnotation]; ok {
 		return map[string]string{serving.CreatorAnnotation: val}
 	}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/reconciler/certificate/config"
 )
 
@@ -32,7 +31,7 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 			Name:            knCert.Name,
 			Namespace:       knCert.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(knCert)},
-			Annotations:     getCertificateUpdaterAnnotations(knCert),
+			Annotations:     knCert.GetAnnotations(),
 			Labels:          knCert.GetLabels(),
 		},
 		Spec: certmanagerv1alpha1.CertificateSpec{
@@ -47,14 +46,6 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 			},
 		},
 	}
-}
-
-// getCertificateUpdaterAnnotations gets a Knative Certificate's updater annotation if exists.
-func getCertificateUpdaterAnnotations(knCert *v1alpha1.Certificate) map[string]string {
-	if val, ok := knCert.GetAnnotations()[serving.UpdaterAnnotation]; ok {
-		return map[string]string{serving.CreatorAnnotation: val}
-	}
-	return nil
 }
 
 // GetReadyCondition gets the ready condition of a Cert-Manager `Certificate`.

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/reconciler/certificate/config"
 )
 
@@ -31,6 +32,12 @@ var cert = &v1alpha1.Certificate{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "test-cert",
 		Namespace: "test-ns",
+		Labels: map[string]string{
+			serving.RouteLabelKey: "test-route",
+		},
+		Annotations: map[string]string{
+			serving.UpdaterAnnotation: "someone",
+		},
 	},
 	Spec: v1alpha1.CertificateSpec{
 		DNSNames:   []string{"host1.example.com", "host2.example.com"},
@@ -56,6 +63,12 @@ func TestMakeCertManagerCertificate(t *testing.T) {
 			Name:            "test-cert",
 			Namespace:       "test-ns",
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(cert)},
+			Labels: map[string]string{
+				serving.RouteLabelKey: "test-route",
+			},
+			Annotations: map[string]string{
+				serving.CreatorAnnotation: "someone",
+			},
 		},
 		Spec: certmanagerv1alpha1.CertificateSpec{
 			SecretName: "secret0",

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -36,6 +36,7 @@ var cert = &v1alpha1.Certificate{
 			serving.RouteLabelKey: "test-route",
 		},
 		Annotations: map[string]string{
+			serving.CreatorAnnotation: "someone",
 			serving.UpdaterAnnotation: "someone",
 		},
 	},
@@ -68,6 +69,7 @@ func TestMakeCertManagerCertificate(t *testing.T) {
 			},
 			Annotations: map[string]string{
 				serving.CreatorAnnotation: "someone",
+				serving.UpdaterAnnotation: "someone",
 			},
 		},
 		Spec: certmanagerv1alpha1.CertificateSpec{

--- a/pkg/reconciler/route/resources/certificate.go
+++ b/pkg/reconciler/route/resources/certificate.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/resources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,9 @@ func MakeCertificates(route *v1alpha1.Route, domainTagMap map[string]string, cer
 					map[string]string{
 						networking.CertificateClassAnnotationKey: certClass,
 					}),
+				Labels: map[string]string{
+					serving.RouteLabelKey: route.Name,
+				},
 			},
 			Spec: networkingv1alpha1.CertificateSpec{
 				DNSNames:   []string{dnsName},

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/serving"
 
 	"knative.dev/pkg/kmeta"
 
@@ -51,6 +52,9 @@ func TestMakeCertificates(t *testing.T) {
 				Annotations: map[string]string{
 					networking.CertificateClassAnnotationKey: "foo-cert",
 				},
+				Labels: map[string]string{
+					serving.RouteLabelKey: "route",
+				},
 			},
 			Spec: netv1alpha1.CertificateSpec{
 				DNSNames:   []string{"v1-current.default.example.com"},
@@ -64,6 +68,9 @@ func TestMakeCertificates(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
 				Annotations: map[string]string{
 					networking.CertificateClassAnnotationKey: "foo-cert",
+				},
+				Labels: map[string]string{
+					serving.RouteLabelKey: "route",
 				},
 			},
 			Spec: netv1alpha1.CertificateSpec{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2278,6 +2278,9 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					Annotations: map[string]string{
 						networking.CertificateClassAnnotationKey: network.CertManagerCertificateClassName,
 					},
+					Labels: map[string]string{
+						serving.RouteLabelKey: "becomes-ready",
+					},
 				},
 				Spec: netv1alpha1.CertificateSpec{
 					DNSNames: []string{"abc.test.example.com"},


### PR DESCRIPTION
## Proposed Changes

Currently both knCert and cmCert do not have labels and annotations
properly. So, it is difficult to find who created or filter the label
sometimes.

To address it, this patch changes to:
- Add knCert's label with `serving.knative.dev/route: ROUTE_NAME`.
- Add cmCert's label by taking over from knCert.
- Add cmCert's annotations by taking over from knCert.
- ~~Add cmCert's creator annotation from knCert's updater annotation.~~

__NOTE__
cmCert = certmanager's cert object
knCert = knative's cert object

/lint

Fixes #

**Release Note**

```release-note
NONE
```
