### PR TITLE
Remove redundant namespace label from namespaced ingress

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -96,8 +96,7 @@ func MakeIngress(
 			Name:      names.Ingress(r),
 			Namespace: r.Namespace,
 			Labels: map[string]string{
-				serving.RouteLabelKey:          r.Name,
-				serving.RouteNamespaceLabelKey: r.Namespace,
+				serving.RouteLabelKey: r.Name,
 			},
 			Annotations: resources.UnionMaps(map[string]string{
 				networking.IngressClassAnnotationKey: ingressClass,

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -231,8 +231,7 @@ func getRouteClusterIngressFromClient(ctx context.Context, t *testing.T, route *
 func getRouteIngressFromClient(ctx context.Context, t *testing.T, route *v1alpha1.Route) *netv1alpha1.Ingress {
 	opts := metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
-			serving.RouteLabelKey:          route.Name,
-			serving.RouteNamespaceLabelKey: route.Namespace,
+			serving.RouteLabelKey: route.Name,
 		}).AsSelector().String(),
 	}
 	ingresses, err := fakeservingclient.Get(ctx).NetworkingV1alpha1().Ingresses(route.Namespace).List(opts)
@@ -305,8 +304,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 
 	// Check labels
 	expectedLabels := map[string]string{
-		serving.RouteLabelKey:          route.Name,
-		serving.RouteNamespaceLabelKey: route.Namespace,
+		serving.RouteLabelKey: route.Name,
 	}
 	if diff := cmp.Diff(expectedLabels, ci.Labels); diff != "" {
 		t.Errorf("Unexpected label diff (-want +got): %v", diff)


### PR DESCRIPTION
## Proposed Changes

Although ingress has `serving.knative.dev/routeNamespace` label, the
route is always same namespace with the ingress.
(ClusterIngresss needed this label, but Ingress does not need it.)

This patch removes the redundant label from ingress.

#### BEFORE
```
$ kubectl get ingresses.networking.internal.knative.dev  --show-labels  hello-example
NAME            READY   REASON   LABELS
hello-example   True             serving.knative.dev/route=hello-example,serving.knative.dev/routeNamespace=default
```
#### AFTER

```
$ kubectl get ingresses.networking.internal.knative.dev  --show-labels  hello-example
NAME            READY   REASON   LABELS
hello-example   True             serving.knative.dev/route=hello-example
```

/lint

**Release Note**

```release-note
NONE
```
