### PR TITLE
Add support for auto TLS HTTP01 challenges

### DIFF
--- a/config/200-clusterrole-certmanager.yaml
+++ b/config/200-clusterrole-certmanager.yaml
@@ -23,5 +23,5 @@ metadata:
     networking.knative.dev/certificate-provider: cert-manager
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates"]
+    resources: ["certificates", "challenges"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]

--- a/pkg/reconciler/testing/v1alpha1/listers.go
+++ b/pkg/reconciler/testing/v1alpha1/listers.go
@@ -172,6 +172,11 @@ func (l *Listers) GetCMCertificateLister() certmanagerlisters.CertificateLister 
 	return certmanagerlisters.NewCertificateLister(l.IndexerFor(&certmanagerv1alpha1.Certificate{}))
 }
 
+// GetCMChallengeLister gets lister for Cert Manager Challenge resource.
+func (l *Listers) GetCMChallengeLister() certmanagerlisters.ChallengeLister {
+	return certmanagerlisters.NewChallengeLister(l.IndexerFor(&certmanagerv1alpha1.Challenge{}))
+}
+
 func (l *Listers) GetImageLister() cachinglisters.ImageLister {
 	return cachinglisters.NewImageLister(l.IndexerFor(&cachingv1alpha1.Image{}))
 }


### PR DESCRIPTION
## Proposed Changes

When cert-manager creates a solver service the Knative
certificate reconciler will populate `Status.HTTP01Challenges`
of the corresponding Knative certificate. This challenge information
is used to create an IngressRule to route traffic from Let's Encrypt
to the solver service.

Fixes: #4100
Co-Authored-By: Mike Petersen <mpetason@gmail.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```