### PR TITLE
Add scaling based on RPS for KPA

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -49,8 +49,7 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 		switch pa.Class() {
 		case autoscaling.KPA:
 			switch metric {
-			// TODO(yanweiguo): implement RPS autoscaling for KPA.
-			case autoscaling.Concurrency:
+			case autoscaling.Concurrency, autoscaling.RPS:
 				return nil
 			}
 		case autoscaling.HPA:

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -193,6 +193,25 @@ func TestPodAutoscalerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "valid, KPA with RPS",
+		r: &PodAutoscaler{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					"autoscaling.knative.dev/metric": "rps",
+				},
+			},
+			Spec: PodAutoscalerSpec{
+				ScaleTargetRef: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+				},
+				ProtocolType: net.ProtocolH2C,
+			},
+		},
+		want: nil,
+	}, {
 		name: "valid, HPA with concurrency",
 		r: &PodAutoscaler{
 			ObjectMeta: v1.ObjectMeta{

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -162,10 +162,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 
 	logger.Debugw(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
 		observedStableValue, spec.TargetValue),
-		zap.String(metricName, "stable"))
+		zap.String("mode", "stable"))
 	logger.Debugw(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
 		observedPanicValue, spec.TargetValue),
-		zap.String(metricName, "panic"))
+		zap.String("mode", "panic"))
 
 	isOverPanicThreshold := observedPanicValue/readyPodsCount >= spec.PanicThreshold
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -135,6 +135,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	switch spec.ScalingMetric {
 	case autoscaling.RPS:
 		observedStableValue, observedPanicValue, err = a.metricClient.StableAndPanicRPS(metricKey, now)
+		// TODO: Add metrics for RPS used in autoscaler.
 	default:
 		metricName = autoscaling.Concurrency // concurrency is used by default
 		observedStableValue, observedPanicValue, err = a.metricClient.StableAndPanicConcurrency(metricKey, now)
@@ -156,11 +157,11 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	desiredStablePodCount := int32(math.Min(math.Ceil(observedStableValue/spec.TargetValue), maxScaleUp))
 	desiredPanicPodCount := int32(math.Min(math.Ceil(observedPanicValue/spec.TargetValue), maxScaleUp))
 
-	logger.Debugw(fmt.Sprintf("Observed average %0.3f %v, targeting %0.3f.",
-		observedStableValue, metricName, spec.TargetValue),
+	logger.Debugw(fmt.Sprintf("Observed average %s: %0.3f, targeting %0.3f.",
+		metricName, observedStableValue, spec.TargetValue),
 		zap.String(metricName, "stable"))
-	logger.Debugw(fmt.Sprintf("Observed average %0.3f %v, targeting %0.3f.",
-		observedPanicValue, metricName, spec.TargetValue),
+	logger.Debugw(fmt.Sprintf("Observed average %s: %0.3f, targeting %0.3f.",
+		metricName, observedPanicValue, spec.TargetValue),
 		zap.String(metricName, "panic"))
 
 	isOverPanicThreshold := observedPanicValue/readyPodsCount >= spec.PanicThreshold

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -160,11 +160,11 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	desiredStablePodCount := int32(math.Min(math.Ceil(observedStableValue/spec.TargetValue), maxScaleUp))
 	desiredPanicPodCount := int32(math.Min(math.Ceil(observedPanicValue/spec.TargetValue), maxScaleUp))
 
-	logger.Debugw(fmt.Sprintf("Observed average %s: %0.3f, targeting %0.3f.",
-		metricName, observedStableValue, spec.TargetValue),
+	logger.Debugw(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
+		observedStableValue, spec.TargetValue),
 		zap.String(metricName, "stable"))
-	logger.Debugw(fmt.Sprintf("Observed average %s: %0.3f, targeting %0.3f.",
-		metricName, observedPanicValue, spec.TargetValue),
+	logger.Debugw(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
+		observedPanicValue, spec.TargetValue),
 		zap.String(metricName, "panic"))
 
 	isOverPanicThreshold := observedPanicValue/readyPodsCount >= spec.PanicThreshold

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -130,9 +130,8 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 
 	metricKey := types.NamespacedName{Namespace: a.namespace, Name: a.revision}
 
-	var observedStableValue, observedPanicValue float64
-
 	metricName := spec.ScalingMetric
+	var observedStableValue, observedPanicValue float64
 	switch spec.ScalingMetric {
 	case autoscaling.RPS:
 		observedStableValue, observedPanicValue, err = a.metricClient.StableAndPanicRPS(metricKey, now)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -144,6 +144,9 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		a.reporter.ReportTargetRequestConcurrency(spec.TargetValue)
 	}
 
+	// Put the scaling metric to logs.
+	logger = logger.With(zap.String("metric", metricName))
+
 	if err != nil {
 		if err == ErrNoData {
 			logger.Debug("No data to scale on yet")

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -159,10 +159,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 
 	logger.Debugw(fmt.Sprintf("Observed average %0.3f %v, targeting %0.3f.",
 		observedStableValue, metricName, spec.TargetValue),
-		zap.String("concurrency", "stable"))
+		zap.String(metricName, "stable"))
 	logger.Debugw(fmt.Sprintf("Observed average %0.3f %v, targeting %0.3f.",
 		observedPanicValue, metricName, spec.TargetValue),
-		zap.String("concurrency", "panic"))
+		zap.String(metricName, "panic"))
 
 	isOverPanicThreshold := observedPanicValue/readyPodsCount >= spec.PanicThreshold
 

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -43,6 +43,8 @@ type Decider struct {
 type DeciderSpec struct {
 	TickInterval   time.Duration
 	MaxScaleUpRate float64
+	// The metric used for scaling, i.e. concurrency, rps.
+	ScalingMetric string
 	// The value of scaling metric per pod that we target to maintain.
 	// TargetValue <= TotalValue.
 	TargetValue float64

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -63,6 +63,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 		Spec: autoscaler.DeciderSpec{
 			TickInterval:        config.TickInterval,
 			MaxScaleUpRate:      config.MaxScaleUpRate,
+			ScalingMetric:       pa.Metric(),
 			TargetValue:         target,
 			TotalValue:          total,
 			TargetBurstCapacity: tbc,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #3416

## Proposed Changes

* Introduce `ScalingMetric` field in `Decider` and use it to determine which metric to use for autoscaling.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
KPA now supports autoscaling based on requests-per-second. Use the following annotations on revision template to specify RPS based autoscaling:
* autoscaling.knative.dev/metric: rps # Use RPS
* autoscaling.knative.dev/target: 200 # The RPS value autoscaler attempt to maintain for a pod.
* autoscaling.knative.dev/targetUtilizationPercentage: 70 # If actual RPS exceeds target*targetUtilizationPercentage, autoscaler will requests more pods.
```
