### PR TITLE
Generalize the benchmark tagging.

### DIFF
--- a/test/performance/dataplane-probe/main.go
+++ b/test/performance/dataplane-probe/main.go
@@ -44,7 +44,7 @@ func main() {
 	defer cancel()
 
 	// Use the benchmark key created
-	q, qclose, err := mako.Setup(ctx)
+	ctx, q, qclose, err := mako.Setup(ctx)
 	if err != nil {
 		log.Fatalf("Failed to setup mako: %v", err)
 	}

--- a/test/performance/mako/sidecar.go
+++ b/test/performance/mako/sidecar.go
@@ -18,7 +18,6 @@ package mako
 
 import (
 	"context"
-	"flag"
 	"runtime"
 	"strings"
 
@@ -26,7 +25,7 @@ import (
 
 	"github.com/google/mako/helpers/go/quickstore"
 	qpb "github.com/google/mako/helpers/proto/quickstore/quickstore_go_proto"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 	"knative.dev/pkg/changeset"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -39,11 +38,7 @@ const (
 	sidecarAddress = "localhost:9813"
 )
 
-var (
-	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-)
-
+// EscapeTag replaces characters that Mako doesn't accept with ones it does.
 func EscapeTag(tag string) string {
 	return strings.ReplaceAll(tag, ".", "_")
 }
@@ -61,7 +56,7 @@ func Setup(ctx context.Context, extraTags ...string) (context.Context, *quicksto
 
 	// Setup a deployment informer, so that we can use the lister to track
 	// desired and available pod counts.
-	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
This moves the K8s version tagging into `mako.Setup` and adds a Go version tag.

You can see a sample run of the dataplane-probe (now with K8s tagging!) here:
https://mako.dev/run?run_key=6230979358228480&~kd=1&~id=1&~qp=1&~a=1&~ke=1&~ie=1&~qe=1&~ae=1

