### PR TITLE
Make ingress prober ready when gets StatusMovedPermanently for the response

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -117,6 +117,7 @@ func (a *activationHandler) probeEndpoint(logger *zap.SugaredLogger, r *http.Req
 			url,
 			prober.WithHeader(network.ProbeHeaderName, queue.Name),
 			prober.ExpectsBody(queue.Name),
+			prober.ExpectsStatusCodes([]int{http.StatusOK}),
 			withOrigProto(r))
 		if err != nil {
 			logger.Warnw("Pod probe failed", zap.Error(err))

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -136,7 +136,8 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 	}
 	return prober.Do(ctx, rw.transport, httpDest.String(),
 		prober.WithHeader(network.ProbeHeaderName, queue.Name),
-		prober.ExpectsBody(queue.Name))
+		prober.ExpectsBody(queue.Name),
+		prober.ExpectsStatusCodes([]int{http.StatusOK}))
 
 }
 

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -38,6 +38,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 		options: []interface{}{
 			prober.WithHeader(ProbeHeaderName, ProbeHeaderValue),
 			prober.WithHeader(HashHeaderName, "foo-bar-baz"),
+			prober.ExpectsStatusCodes([]int{http.StatusOK}),
 		},
 		want: true,
 	}, {
@@ -47,6 +48,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 			prober.ExpectsBody(body),
 			// Validates the header is stripped before forwarding to the inner handler
 			prober.ExpectsHeader(HashHeaderName, "false"),
+			prober.ExpectsStatusCodes([]int{http.StatusOK}),
 		},
 		want: true,
 	}, {
@@ -58,12 +60,14 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 			prober.ExpectsHeader(ProbeHeaderName, "true"),
 			// Validates the header is stripped before forwarding to the inner handler
 			prober.ExpectsHeader(HashHeaderName, "false"),
+			prober.ExpectsStatusCodes([]int{http.StatusOK}),
 		},
 		want: true,
 	}, {
 		name: "failed probe when hash header is not present",
 		options: []interface{}{
 			prober.WithHeader(ProbeHeaderName, ProbeHeaderValue),
+			prober.ExpectsStatusCodes([]int{http.StatusOK}),
 		},
 		want: false,
 	}}

--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -73,7 +73,7 @@ func TestDoServing(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue))
+			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue), ExpectsStatusCodes([]int{http.StatusOK}))
 			if want := test.want; got != want {
 				t.Errorf("Got = %v, want: %v", got, want)
 			}
@@ -90,7 +90,7 @@ func TestBlackHole(t *testing.T) {
 			Timeout: 10 * time.Millisecond,
 		}).Dial,
 	}
-	got, err := Do(context.Background(), transport, "http://gone.fishing.svc.custer.local:8080")
+	got, err := Do(context.Background(), transport, "http://gone.fishing.svc.custer.local:8080", ExpectsStatusCodes([]int{http.StatusOK}))
 	if want := false; got != want {
 		t.Errorf("Got = %v, want: %v", got, want)
 	}
@@ -100,7 +100,7 @@ func TestBlackHole(t *testing.T) {
 }
 
 func TestBadURL(t *testing.T) {
-	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo")
+	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo", ExpectsStatusCodes([]int{http.StatusOK}))
 	if err == nil {
 		t.Error("Do did not return an error")
 	}
@@ -158,7 +158,7 @@ func TestDoAsync(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			m := New(test.cb, network.NewProberTransport())
-			m.Offer(context.Background(), ts.URL, test.name, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue))
+			m.Offer(context.Background(), ts.URL, test.name, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue), ExpectsStatusCodes([]int{http.StatusOK}))
 			<-wch
 		})
 	}
@@ -195,7 +195,7 @@ func TestDoAsyncRepeat(t *testing.T) {
 		wch <- arg
 	}
 	m := New(cb, network.NewProberTransport())
-	m.Offer(context.Background(), ts.URL, 42, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, systemName), ExpectsBody(systemName))
+	m.Offer(context.Background(), ts.URL, 42, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, systemName), ExpectsBody(systemName), ExpectsStatusCodes([]int{http.StatusOK}))
 	<-wch
 	if got, want := c.calls, 3; got != want {
 		t.Errorf("Probe invocation count = %d, want: %d", got, want)
@@ -218,7 +218,7 @@ func TestDoAsyncTimeout(t *testing.T) {
 		wch <- arg
 	}
 	m := New(cb, network.NewProberTransport())
-	m.Offer(context.Background(), ts.URL, 2009, probeInterval, probeTimeout)
+	m.Offer(context.Background(), ts.URL, 2009, probeInterval, probeTimeout, ExpectsStatusCodes([]int{http.StatusOK}))
 	<-wch
 }
 
@@ -233,10 +233,10 @@ func TestAsyncMultiple(t *testing.T) {
 		wch <- 2006
 	}
 	m := New(cb, network.NewProberTransport())
-	if !m.Offer(context.Background(), ts.URL, 1984, probeInterval, probeTimeout) {
+	if !m.Offer(context.Background(), ts.URL, 1984, probeInterval, probeTimeout, ExpectsStatusCodes([]int{http.StatusOK})) {
 		t.Error("First call to offer returned false")
 	}
-	if m.Offer(context.Background(), ts.URL, 1982, probeInterval, probeTimeout) {
+	if m.Offer(context.Background(), ts.URL, 1982, probeInterval, probeTimeout, ExpectsStatusCodes([]int{http.StatusOK})) {
 		t.Error("Second call to offer returned true")
 	}
 	if got, want := m.len(), 1; got != want {
@@ -270,14 +270,15 @@ func TestWithHostOption(t *testing.T) {
 		success bool
 	}{{
 		name:    "no hosts",
+		options: []interface{}{ExpectsStatusCodes([]int{http.StatusOK})},
 		success: false,
 	}, {
 		name:    "expected host",
-		options: []interface{}{WithHost(host)},
+		options: []interface{}{WithHost(host), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: true,
 	}, {
 		name:    "wrong host",
-		options: []interface{}{WithHost("nope.com")},
+		options: []interface{}{WithHost("nope.com"), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: false,
 	}}
 
@@ -306,15 +307,15 @@ func TestExpectsHeaderOption(t *testing.T) {
 		success bool
 	}{{
 		name:    "header is present",
-		options: []interface{}{ExpectsHeader("Foo", "Bar")},
+		options: []interface{}{ExpectsHeader("Foo", "Bar"), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: true,
 	}, {
 		name:    "header is absent",
-		options: []interface{}{ExpectsHeader("Baz", "Nope")},
+		options: []interface{}{ExpectsHeader("Baz", "Nope"), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: false,
 	}, {
 		name:    "header value doesn't match",
-		options: []interface{}{ExpectsHeader("Foo", "Baz")},
+		options: []interface{}{ExpectsHeader("Foo", "Baz"), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: false,
 	}}
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -67,6 +67,7 @@ const (
 var probeOptions = []interface{}{
 	prober.WithHeader(network.ProbeHeaderName, activator.Name),
 	prober.ExpectsBody(activator.Name),
+	prober.ExpectsStatusCodes([]int{http.StatusOK}),
 }
 
 // for mocking in tests

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -260,7 +260,9 @@ func (m *StatusProber) processWorkItem() bool {
 		item.context,
 		m.transportFactory(),
 		fmt.Sprintf("http://%s/", item.podIP),
-		prober.WithHost(item.probeHost))
+		prober.WithHost(item.probeHost),
+		prober.ExceptStatusCode(http.StatusMovedPermanently),
+	)
 
 	// In case of cancellation, drop the work item
 	select {

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -261,7 +261,7 @@ func (m *StatusProber) processWorkItem() bool {
 		m.transportFactory(),
 		fmt.Sprintf("http://%s/", item.podIP),
 		prober.WithHost(item.probeHost),
-		prober.ExceptStatusCode(http.StatusMovedPermanently),
+		prober.ExpectsStatusCodes([]int{http.StatusOK, http.StatusMovedPermanently}),
 	)
 
 	// In case of cancellation, drop the work item


### PR DESCRIPTION
## Proposed Changes

When httpProtocol is configured as "Redirected", http response
StatusMovedPermanently(301) instead of StatusOK(200).
This patch allows ingress prober to pass 301 response as the exception.

/lint

Fixes https://github.com/knative/serving/issues/5192

**Release Note**

```release-note
NONE
```
