### PR TITLE
Skip copying over kubectl.kubernetes.io/last-applied-configuration annotation

### DIFF
--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/kmeta"
@@ -39,7 +40,9 @@ func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, erro
 				serving.RouteLabelKey:   names.Route(service),
 				serving.ServiceLabelKey: service.Name,
 			}),
-			Annotations: service.GetAnnotations(),
+			Annotations: resources.FilterMap(service.GetAnnotations(), func(key string) bool {
+				return key == corev1.LastAppliedConfigAnnotation
+			}),
 		},
 		Spec: service.Spec.ConfigurationSpec,
 	}, nil

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -125,5 +127,16 @@ func TestInlineConfigurationSpec(t *testing.T) {
 	}
 	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {
 		t.Errorf("expected %q labels got %q", want, got)
+	}
+}
+
+func TestConfigurationHasNoKubectlAnnotation(t *testing.T) {
+	s := createServiceWithKubectlAnnotation()
+	c, err := makeConfiguration(s)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if v, ok := c.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
+		t.Errorf("Annotation %s = %q, want empty", corev1.LastAppliedConfigAnnotation, v)
 	}
 }

--- a/pkg/reconciler/service/resources/route.go
+++ b/pkg/reconciler/service/resources/route.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/kmeta"
@@ -35,7 +36,9 @@ func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(service),
 			},
-			Annotations: service.GetAnnotations(),
+			Annotations: resources.FilterMap(service.GetAnnotations(), func(key string) bool {
+				return key == corev1.LastAppliedConfigAnnotation
+			}),
 			Labels: resources.UnionMaps(service.GetLabels(), map[string]string{
 				// Add this service's name to the route annotations.
 				serving.ServiceLabelKey: service.Name,

--- a/pkg/reconciler/service/resources/route_test.go
+++ b/pkg/reconciler/service/resources/route_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -39,7 +41,7 @@ func TestRouteRunLatest(t *testing.T) {
 	testConfigName := names.Configuration(s)
 	r, err := makeRoute(s)
 	if err != nil {
-		t.Errorf("UnExpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 	if got, want := r.Name, testServiceName; got != want {
 		t.Errorf("Expected %q for service name got %q", want, got)
@@ -360,7 +362,7 @@ func TestInlineRouteSpec(t *testing.T) {
 	testConfigName := names.Configuration(s)
 	r, err := makeRoute(s)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 	if got, want := r.Name, testServiceName; got != want {
 		t.Errorf("Expected %q for service name got %q", want, got)
@@ -388,5 +390,16 @@ func TestInlineRouteSpec(t *testing.T) {
 	}
 	if got, want := r.Labels[serving.ServiceLabelKey], testServiceName; got != want {
 		t.Errorf("expected %q labels got %q", want, got)
+	}
+}
+
+func TestRouteHasNoKubectlAnnotation(t *testing.T) {
+	s := createServiceWithKubectlAnnotation()
+	r, err := makeRoute(s)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if v, ok := r.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
+		t.Errorf("Annotation %s = %q, want empty", corev1.LastAppliedConfigAnnotation, v)
 	}
 }

--- a/pkg/reconciler/service/resources/shared_test.go
+++ b/pkg/reconciler/service/resources/shared_test.go
@@ -116,3 +116,11 @@ func createServiceWithRelease(numRevision int, rolloutPercent int) *v1alpha1.Ser
 		WithReleaseRolloutAndPercentageConfigSpec(rolloutPercent, createConfiguration(testContainerNameRelease), revisions...),
 		WithServiceLabel(testLabelKey, testLabelValueRelease))
 }
+
+func createServiceWithKubectlAnnotation() *v1alpha1.Service {
+	return Service(testServiceName, testServiceNamespace,
+		WithRunLatestConfigSpec(createConfiguration(testContainerNameRunLatest)),
+		WithServiceAnnotations(map[string]string{
+			corev1.LastAppliedConfigAnnotation: testAnnotationValue,
+		}))
+}


### PR DESCRIPTION
Skip copying over kubectl.kubernetes.io/last-applied-configuration annotation
when creating new Configurations and Routes from Knative Services.

/lint