### PR TITLE
Revert back to 200 as default TBC

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -81,7 +81,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "0"
+    target-burst-capacity: "200"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -115,7 +115,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}, {
 		key:          "target-burst-capacity",
 		field:        &lc.TargetBurstCapacity,
-		defaultValue: 0,
+		defaultValue: 200,
 	}, {
 		key:          "panic-window-percentage",
 		field:        &lc.PanicWindowPercentage,

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -32,7 +32,7 @@ var defaultConfig = Config{
 	ContainerConcurrencyTargetDefault:  100.0,
 	RPSTargetDefault:                   200.0,
 	TargetUtilization:                  0.7,
-	TargetBurstCapacity:                0,
+	TargetBurstCapacity:                200,
 	MaxScaleUpRate:                     1000.0,
 	StableWindow:                       time.Minute,
 	PanicWindow:                        6 * time.Second,
@@ -69,6 +69,7 @@ func TestNewConfig(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.5
 			c.ContainerConcurrencyTargetDefault = 10
 			c.MaxScaleUpRate = 1
+			c.TargetBurstCapacity = 0
 			c.StableWindow = 5 * time.Minute
 			c.PanicWindow = 10 * time.Second
 			return &c


### PR DESCRIPTION
Now that istio update seems to have fixed our problems with the
high error rates for TBC, let's put the default 200 back in.


/lint

/assign @mattmoor 