### PR TITLE
Fix the metric name in the dataplane probe

### DIFF
--- a/test/performance/dataplane-probe/sla.go
+++ b/test/performance/dataplane-probe/sla.go
@@ -121,7 +121,7 @@ var (
 				URL:    "http://queue-proxy.default.svc.cluster.local?sleep=100",
 			},
 			stat:      "qp",
-			estat:     "qp",
+			estat:     "qe",
 			analyzers: []*tpb.ThresholdAnalyzerInput{Queue95PercentileLatency},
 		},
 		"activator": {


### PR DESCRIPTION
I am pretty sure  for  must be .
Probably throws a wrench in the data each time there's an error.

/assign @mattmoor
