### PR TITLE
Set default timeout when 0 is specified

### DIFF
--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -39,7 +39,7 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 
 	// Default TimeoutSeconds based on our configmap
-	if rs.TimeoutSeconds == nil || *ptr.Int64(*rs.TimeoutSeconds) == 0 {
+	if rs.TimeoutSeconds == nil || *rs.TimeoutSeconds == 0 {
 		ts := cfg.Defaults.RevisionTimeoutSeconds
 		rs.TimeoutSeconds = &ts
 	}

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -40,8 +40,7 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 
 	// Default TimeoutSeconds based on our configmap
 	if rs.TimeoutSeconds == nil || *rs.TimeoutSeconds == 0 {
-		ts := cfg.Defaults.RevisionTimeoutSeconds
-		rs.TimeoutSeconds = &ts
+		rs.TimeoutSeconds = ptr.Int64(cfg.Defaults.RevisionTimeoutSeconds)
 	}
 
 	// Default ContainerConcurrency based on our configmap

--- a/pkg/apis/serving/v1beta1/revision_defaults.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults.go
@@ -39,7 +39,7 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 
 	// Default TimeoutSeconds based on our configmap
-	if rs.TimeoutSeconds == nil {
+	if rs.TimeoutSeconds == nil || *ptr.Int64(*rs.TimeoutSeconds) == 0 {
 		ts := cfg.Defaults.RevisionTimeoutSeconds
 		rs.TimeoutSeconds = &ts
 	}


### PR DESCRIPTION
## Proposed Changes

This patch sets `timeoutSeconds` to default value when `0` is specified.

Fixes https://github.com/knative/serving/issues/5221

/lint

**Release Note**

```release-note
NONE
```
