### PR TITLE
Note that we're using the same analyzers.

### DIFF
--- a/test/performance/dataplane-probe/sla.go
+++ b/test/performance/dataplane-probe/sla.go
@@ -150,7 +150,7 @@ var (
 			},
 			stat:  "ac",
 			estat: "be",
-			// We use the same threshold analyzer, since we want Breaker to exert minimal latency impact.
+			// We use the same threshold analyzer, since we want Throttler/Breaker to exert minimal latency impact.
 			analyzers: []*tpb.ThresholdAnalyzerInput{Activator95PercentileLatency},
 		},
 	}

--- a/test/performance/dataplane-probe/sla.go
+++ b/test/performance/dataplane-probe/sla.go
@@ -129,8 +129,9 @@ var (
 				Method: "GET",
 				URL:    "http://queue-proxy-with-cc.default.svc.cluster.local?sleep=100",
 			},
-			stat:      "qc",
-			estat:     "re",
+			stat:  "qc",
+			estat: "re",
+			// We use the same threshold analyzer, since we want Breaker to exert minimal latency impact.
 			analyzers: []*tpb.ThresholdAnalyzerInput{Queue95PercentileLatency},
 		},
 		"activator": {
@@ -147,8 +148,9 @@ var (
 				Method: "GET",
 				URL:    "http://activator-with-cc.default.svc.cluster.local?sleep=100",
 			},
-			stat:      "ac",
-			estat:     "be",
+			stat:  "ac",
+			estat: "be",
+			// We use the same threshold analyzer, since we want Breaker to exert minimal latency impact.
 			analyzers: []*tpb.ThresholdAnalyzerInput{Activator95PercentileLatency},
 		},
 	}


### PR DESCRIPTION
Historical run shows that while breaker _does_ have some impact on the
performance it is on the order of few hundred microseconds at 100cc level.

/assign @mattmoor

Graph: https://mako.dev/benchmark?benchmark_key=5142965274017792&tseconds=604800&~kd=p95000&~id=p95000&~qp=p95000&~a=p95000&~qc=p95000&~ac=p95000&~ke=p95000&~ie=p95000&~qe=p95000&~ae=p95000