### PR TITLE
Kill kail process after test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -327,6 +327,9 @@ function test_setup() {
 
   # Capture all logs.
   kail > ${ARTIFACTS}/k8s.log.txt &
+  local kail_pid=$!
+  # Clean up kail so it doesn't interfere with job shutting down
+  trap "kill $kail_pid || true" EXIT
 
   echo ">> Creating test resources (test/config/)"
   ko apply ${KO_FLAGS} -f test/config/ || return 1


### PR DESCRIPTION
`kail` is started as a background process during test setup, and causes a few random errors at the end of Prow jobs. Kill it to avoid those errors.

Update: just confirmed that these errors also added ~10 minutes to e2e tests

/cc @tcnghia 