### PR TITLE
Add annotation info /creator and /lastModifier to Configuration and Route

### DIFF
--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -116,7 +116,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 		objectMeta: &metav1.ObjectMeta{
 			GenerateName: "some-name",
 			Annotations: map[string]string{
-				"serving.knative.dev/creator": "svc-creator",
+				CreatorAnnotation: "svc-creator",
 			},
 		},
 
@@ -126,7 +126,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 		objectMeta: &metav1.ObjectMeta{
 			GenerateName: "some-name",
 			Annotations: map[string]string{
-				"serving.knative.dev/lastModifier": "svc-modifier",
+				UpdaterAnnotation: "svc-modifier",
 			},
 		},
 		expectErr: (*apis.FieldError)(nil),
@@ -135,7 +135,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 		objectMeta: &metav1.ObjectMeta{
 			GenerateName: "some-name",
 			Annotations: map[string]string{
-				"serving.knative.dev/lastPinned": "pinned-val",
+				RevisionLastPinnedAnnotationKey: "pinned-val",
 			},
 		},
 		expectErr: (*apis.FieldError)(nil),
@@ -343,8 +343,8 @@ func TestAnnotationCreate(t *testing.T) {
 			Spec: getSpec("foo"),
 		},
 		want: map[string]string{
-			"serving.knative.dev/creator":      u1,
-			"serving.knative.dev/lastModifier": u1,
+			CreatorAnnotation: u1,
+			UpdaterAnnotation: u1,
 		},
 	}, {
 		name: "create annotation should override user provided annotations",
@@ -352,15 +352,15 @@ func TestAnnotationCreate(t *testing.T) {
 		this: &WithPod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"serving.knative.dev/creator":      u2,
-					"serving.knative.dev/lastModifier": u2,
+					CreatorAnnotation: u2,
+					UpdaterAnnotation: u2,
 				},
 			},
 			Spec: getSpec("foo"),
 		},
 		want: map[string]string{
-			"serving.knative.dev/creator":      u1,
-			"serving.knative.dev/lastModifier": u1,
+			CreatorAnnotation: u1,
+			UpdaterAnnotation: u1,
 		},
 	}}
 	for _, test := range tests {
@@ -393,8 +393,8 @@ func TestAnnotationUpdate(t *testing.T) {
 		this: &WithPod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"serving.knative.dev/creator":      u1,
-					"serving.knative.dev/lastModifier": u1,
+					CreatorAnnotation: u1,
+					UpdaterAnnotation: u1,
 				},
 			},
 			Spec: getSpec("foo"),
@@ -403,8 +403,8 @@ func TestAnnotationUpdate(t *testing.T) {
 			Spec: getSpec("foo"),
 		},
 		want: map[string]string{
-			"serving.knative.dev/creator":      u1,
-			"serving.knative.dev/lastModifier": u1,
+			CreatorAnnotation: u1,
+			UpdaterAnnotation: u1,
 		},
 	}, {
 		name: "update annotation with spec changes",
@@ -412,8 +412,8 @@ func TestAnnotationUpdate(t *testing.T) {
 		this: &WithPod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"serving.knative.dev/creator":      u1,
-					"serving.knative.dev/lastModifier": u1,
+					CreatorAnnotation: u1,
+					UpdaterAnnotation: u1,
 				},
 			},
 			Spec: getSpec("bar"),
@@ -422,8 +422,8 @@ func TestAnnotationUpdate(t *testing.T) {
 			Spec: getSpec("foo"),
 		},
 		want: map[string]string{
-			"serving.knative.dev/creator":      u1,
-			"serving.knative.dev/lastModifier": u2,
+			CreatorAnnotation: u1,
+			UpdaterAnnotation: u2,
 		},
 	}}
 	for _, test := range tests {

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
@@ -194,6 +197,22 @@ func TestValidateQueueSidecarAnnotation(t *testing.T) {
 			Message: "invalid value: ",
 			Paths:   []string{fmt.Sprintf("[%s]", QueueSideCarResourcePercentageAnnotation)},
 		},
+	}, {
+		name:       "empty annotation",
+		annotation: map[string]string{},
+		expectErr:  (*apis.FieldError)(nil),
+	}, {
+		name: "different annotation other than QueueSideCarResourcePercentageAnnotation",
+		annotation: map[string]string{
+			CreatorAnnotation: "",
+		},
+		expectErr: (*apis.FieldError)(nil),
+	}, {
+		name: "valid value for Queue sidecar resource percentage annotation",
+		annotation: map[string]string{
+			QueueSideCarResourcePercentageAnnotation: "100",
+		},
+		expectErr: (*apis.FieldError)(nil),
 	}}
 
 	for _, c := range cases {
@@ -291,4 +310,134 @@ func TestValidateClusterVisibilityLabel(t *testing.T) {
 		})
 	}
 
+}
+
+type WithPod struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              corev1.PodSpec `json:"spec,omitempty"`
+}
+
+func getSpec(image string) corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Image: image,
+		}},
+	}
+}
+
+func TestAnnotationCreate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+	)
+	tests := []struct {
+		name string
+		user string
+		this *WithPod
+		want map[string]string
+	}{{
+		name: "create annotation",
+		user: u1,
+		this: &WithPod{
+			Spec: getSpec("foo"),
+		},
+		want: map[string]string{
+			"serving.knative.dev/creator":      u1,
+			"serving.knative.dev/lastModifier": u1,
+		},
+	}, {
+		name: "create annotation should override user provided annotations",
+		user: u1,
+		this: &WithPod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"serving.knative.dev/creator":      u2,
+					"serving.knative.dev/lastModifier": u2,
+				},
+			},
+			Spec: getSpec("foo"),
+		},
+		want: map[string]string{
+			"serving.knative.dev/creator":      u1,
+			"serving.knative.dev/lastModifier": u1,
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			SetUserInfo(ctx, nil, test.this.Spec, test.this)
+			if !reflect.DeepEqual(test.this.Annotations, test.want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", test.this.Annotations, test.want, cmp.Diff(test.this.Annotations, test.want))
+			}
+		})
+	}
+}
+
+func TestAnnotationUpdate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+	)
+	tests := []struct {
+		name string
+		user string
+		prev *WithPod
+		this *WithPod
+		want map[string]string
+	}{{
+		name: "update annotation without spec changes",
+		user: u2,
+		this: &WithPod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"serving.knative.dev/creator":      u1,
+					"serving.knative.dev/lastModifier": u1,
+				},
+			},
+			Spec: getSpec("foo"),
+		},
+		prev: &WithPod{
+			Spec: getSpec("foo"),
+		},
+		want: map[string]string{
+			"serving.knative.dev/creator":      u1,
+			"serving.knative.dev/lastModifier": u1,
+		},
+	}, {
+		name: "update annotation with spec changes",
+		user: u2,
+		this: &WithPod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"serving.knative.dev/creator":      u1,
+					"serving.knative.dev/lastModifier": u1,
+				},
+			},
+			Spec: getSpec("bar"),
+		},
+		prev: &WithPod{
+			Spec: getSpec("foo"),
+		},
+		want: map[string]string{
+			"serving.knative.dev/creator":      u1,
+			"serving.knative.dev/lastModifier": u2,
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+			}
+			SetUserInfo(ctx, test.prev.Spec, test.this.Spec, test.this)
+			if !reflect.DeepEqual(test.this.Annotations, test.want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", test.this.Annotations, test.want, cmp.Diff(test.this.Annotations, test.want))
+			}
+		})
+	}
 }

--- a/pkg/apis/serving/v1/configuration_defaults.go
+++ b/pkg/apis/serving/v1/configuration_defaults.go
@@ -20,12 +20,20 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // SetDefaults implements apis.Defaultable
 func (c *Configuration) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, c.ObjectMeta)
 	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+	if c.GetOwnerReferences() == nil {
+		if apis.IsInUpdate(ctx) {
+			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Configuration).Spec, c.Spec, c)
+		} else {
+			serving.SetUserInfo(ctx, nil, c.Spec, c)
+		}
+	}
 }
 
 // SetDefaults implements apis.Defaultable

--- a/pkg/apis/serving/v1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1/configuration_defaults_test.go
@@ -21,10 +21,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 func TestConfigurationDefaulting(t *testing.T) {
@@ -122,6 +126,121 @@ func TestConfigurationDefaulting(t *testing.T) {
 			if !cmp.Equal(got, test.want, ignoreUnexportedResources) {
 				t.Errorf("SetDefaults (-want, +got) = %v",
 					cmp.Diff(test.want, got, ignoreUnexportedResources))
+			}
+		})
+	}
+}
+
+func TestConfigurationUserInfo(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	withUserAnns := func(u1, u2 string, s *Configuration) *Configuration {
+		a := s.GetAnnotations()
+		if a == nil {
+			a = map[string]string{}
+			s.SetAnnotations(a)
+		}
+		a[serving.CreatorAnnotation] = u1
+		a[serving.UpdaterAnnotation] = u2
+		return s
+	}
+	tests := []struct {
+		name     string
+		user     string
+		this     *Configuration
+		prev     *Configuration
+		wantAnns map[string]string
+	}{{
+		name: "create-new",
+		user: u1,
+		this: &Configuration{},
+		prev: nil,
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		// Old objects don't have the annotation, and unless there's a change in
+		// data they won't get it.
+		name:     "update-no-diff-old-object",
+		user:     u1,
+		this:     &Configuration{},
+		prev:     &Configuration{},
+		wantAnns: map[string]string{},
+	}, {
+		name: "update-no-diff-new-object",
+		user: u2,
+		this: withUserAnns(u1, u1, &Configuration{}),
+		prev: withUserAnns(u1, u1, &Configuration{}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		name: "update-diff-old-object",
+		user: u2,
+		this: &Configuration{
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						ContainerConcurrency: ptr.Int64(1),
+					},
+				},
+			},
+		},
+		prev: &Configuration{
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						ContainerConcurrency: ptr.Int64(2),
+					},
+				},
+			},
+		},
+		wantAnns: map[string]string{
+			serving.UpdaterAnnotation: u2,
+		},
+	}, {
+		name: "update-diff-new-object",
+		user: u3,
+		this: withUserAnns(u1, u2, &Configuration{
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						ContainerConcurrency: ptr.Int64(1),
+					},
+				},
+			},
+		}),
+		prev: withUserAnns(u1, u2, &Configuration{
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						ContainerConcurrency: ptr.Int64(2),
+					},
+				},
+			},
+		}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u3,
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+				test.prev.SetDefaults(ctx)
+			}
+			test.this.SetDefaults(ctx)
+			if got, want := test.this.GetAnnotations(), test.wantAnns; !cmp.Equal(got, want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -43,7 +43,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
-
+		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
+			c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
 		err := c.Spec.Template.VerifyNameChange(ctx, original.Spec.Template)
 		errs = errs.Also(err.ViaField("spec.template"))
 	}

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -609,3 +609,135 @@ func TestConfigurationSubresourceUpdate(t *testing.T) {
 		})
 	}
 }
+
+func getConfigurationSpec(image string) ConfigurationSpec {
+	return ConfigurationSpec{
+		Template: RevisionTemplateSpec{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: image,
+					}},
+				},
+				TimeoutSeconds: ptr.Int64(config.DefaultMaxRevisionTimeoutSeconds),
+			},
+		},
+	}
+}
+
+func TestConfigurationAnnotationUpdate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	tests := []struct {
+		name string
+		prev *Configuration
+		this *Configuration
+		want *apis.FieldError
+	}{{
+		name: "update creator annotation",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update creator annotation with spec changes",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:bar"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier annotation without spec changes",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u2,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier annotation with spec changes",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:bar"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.prev)
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1/route_defaults.go
+++ b/pkg/apis/serving/v1/route_defaults.go
@@ -21,11 +21,19 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // SetDefaults implements apis.Defaultable
 func (r *Route) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
+	if r.GetOwnerReferences() == nil {
+		if apis.IsInUpdate(ctx) {
+			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Route).Spec, r.Spec, r)
+		} else {
+			serving.SetUserInfo(ctx, nil, r.Spec, r)
+		}
+	}
 }
 
 // SetDefaults implements apis.Defaultable

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -33,6 +33,12 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 		r.validateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Route)
+		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
+			r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+	}
 	return errs
 }
 

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -647,3 +647,130 @@ func TestRouteLabelValidation(t *testing.T) {
 		})
 	}
 }
+
+func getRouteSpec(confName string) RouteSpec {
+	return RouteSpec{
+		Traffic: []TrafficTarget{{
+			LatestRevision:    ptr.Bool(true),
+			Percent:           ptr.Int64(100),
+			ConfigurationName: confName,
+		}},
+	}
+}
+
+func TestRouteAnnotationUpdate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	tests := []struct {
+		name string
+		prev *Route
+		this *Route
+		want *apis.FieldError
+	}{{
+		name: "update creator annotation",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update creator annotation with spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier annotation without spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u2,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier annotation with spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.prev)
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1/service_defaults.go
+++ b/pkg/apis/serving/v1/service_defaults.go
@@ -19,8 +19,6 @@ package v1
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -30,23 +28,10 @@ func (s *Service) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, s.ObjectMeta)
 	s.Spec.SetDefaults(apis.WithinSpec(ctx))
 
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := s.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			s.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Service)
-			if equality.Semantic.DeepEqual(old.Spec, s.Spec) {
-				return
-			}
-			ans[serving.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[serving.CreatorAnnotation] = ui.Username
-			ans[serving.UpdaterAnnotation] = ui.Username
-		}
+	if apis.IsInUpdate(ctx) {
+		serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Service).Spec, s.Spec, s)
+	} else {
+		serving.SetUserInfo(ctx, nil, s.Spec, s)
 	}
 }
 

--- a/pkg/apis/serving/v1/service_defaults_test.go
+++ b/pkg/apis/serving/v1/service_defaults_test.go
@@ -334,9 +334,7 @@ func TestAnnotateUserInfo(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -663,8 +663,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.service)
 			ctx = apis.WithinSubResourceUpdate(ctx, test.service, test.subresource)
-			got := test.service.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.service.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -780,8 +779,7 @@ func TestServiceAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/apis/serving/v1alpha1/configuration_defaults.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults.go
@@ -21,9 +21,8 @@ import (
 
 	"knative.dev/pkg/apis"
 
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func (c *Configuration) SetDefaults(ctx context.Context) {
@@ -40,10 +39,10 @@ func (c *Configuration) SetDefaults(ctx context.Context) {
 
 func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
 	if v1.IsUpgradeViaDefaulting(ctx) {
-		v1 := v1.ConfigurationSpec{}
-		if cs.ConvertUp(ctx, &v1) == nil {
+		v := v1.ConfigurationSpec{}
+		if cs.ConvertUp(ctx, &v) == nil {
 			alpha := ConfigurationSpec{}
-			if alpha.ConvertDown(ctx, v1) == nil {
+			if alpha.ConvertDown(ctx, v) == nil {
 				*cs = alpha
 			}
 		}

--- a/pkg/apis/serving/v1alpha1/configuration_defaults.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults.go
@@ -22,11 +22,20 @@ import (
 	"knative.dev/pkg/apis"
 
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 func (c *Configuration) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, c.ObjectMeta)
 	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+	if c.GetOwnerReferences() == nil {
+		if apis.IsInUpdate(ctx) {
+			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Configuration).Spec, c.Spec, c)
+		} else {
+			serving.SetUserInfo(ctx, nil, c.Spec, c)
+		}
+	}
 }
 
 func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -29,9 +29,8 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/config"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 var (
@@ -269,12 +268,32 @@ func TestConfigurationUserInfo(t *testing.T) {
 		user: u3,
 		this: withUserAnns(u1, u2, &Configuration{
 			Spec: ConfigurationSpec{
-				DeprecatedRevisionTemplate: &RevisionTemplateSpec{},
+				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						RevisionSpec: v1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Image: "busybox",
+								}},
+							},
+						},
+					},
+				},
 			},
 		}),
 		prev: withUserAnns(u1, u2, &Configuration{
 			Spec: ConfigurationSpec{
-				Template: &RevisionTemplateSpec{},
+				Template: &RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						RevisionSpec: v1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Image: "helloworld",
+								}},
+							},
+						},
+					},
+				},
 			},
 		}),
 		wantAnns: map[string]string{
@@ -283,9 +302,7 @@ func TestConfigurationUserInfo(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -22,12 +22,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 var (
@@ -191,6 +195,107 @@ func TestConfigurationDefaulting(t *testing.T) {
 			got.SetDefaults(ctx)
 			if diff := cmp.Diff(test.want, got, ignoreUnexportedResources); diff != "" {
 				t.Errorf("SetDefaults (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestConfigurationUserInfo(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	withUserAnns := func(u1, u2 string, s *Configuration) *Configuration {
+		a := s.GetAnnotations()
+		if a == nil {
+			a = map[string]string{}
+			s.SetAnnotations(a)
+		}
+		a[serving.CreatorAnnotation] = u1
+		a[serving.UpdaterAnnotation] = u2
+		return s
+	}
+	tests := []struct {
+		name     string
+		user     string
+		this     *Configuration
+		prev     *Configuration
+		wantAnns map[string]string
+	}{{
+		name: "create-new",
+		user: u1,
+		this: &Configuration{},
+		prev: nil,
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		// Old objects don't have the annotation, and unless there's a change in
+		// data they won't get it.
+		name:     "update-no-diff-old-object",
+		user:     u1,
+		this:     &Configuration{},
+		prev:     &Configuration{},
+		wantAnns: map[string]string{},
+	}, {
+		name: "update-no-diff-new-object",
+		user: u2,
+		this: withUserAnns(u1, u1, &Configuration{}),
+		prev: withUserAnns(u1, u1, &Configuration{}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		name: "update-diff-old-object",
+		user: u2,
+		this: &Configuration{
+			Spec: ConfigurationSpec{
+				DeprecatedRevisionTemplate: &RevisionTemplateSpec{},
+			},
+		},
+		prev: &Configuration{
+			Spec: ConfigurationSpec{
+				Template: &RevisionTemplateSpec{},
+			},
+		},
+		wantAnns: map[string]string{
+			serving.UpdaterAnnotation: u2,
+		},
+	}, {
+		name: "update-diff-new-object",
+		user: u3,
+		this: withUserAnns(u1, u2, &Configuration{
+			Spec: ConfigurationSpec{
+				DeprecatedRevisionTemplate: &RevisionTemplateSpec{},
+			},
+		}),
+		prev: withUserAnns(u1, u2, &Configuration{
+			Spec: ConfigurationSpec{
+				Template: &RevisionTemplateSpec{},
+			},
+		}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u3,
+		},
+	}}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+				test.prev.SetDefaults(ctx)
+			}
+			test.this.SetDefaults(ctx)
+			if got, want := test.this.GetAnnotations(), test.wantAnns; !cmp.Equal(got, want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -39,7 +39,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
-
+		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
+			c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
 		err := c.Spec.GetTemplate().VerifyNameChange(ctx,
 			original.Spec.GetTemplate())
 		errs = errs.Also(err.ViaField("spec.revisionTemplate"))

--- a/pkg/apis/serving/v1alpha1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation_test.go
@@ -30,9 +30,8 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/config"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestConfigurationSpecValidation(t *testing.T) {
@@ -154,8 +153,7 @@ func TestConfigurationSpecValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.c.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.c.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("validateContainer (-want, +got) = %v", diff)
 			}
 		})
@@ -315,8 +313,7 @@ func TestConfigurationValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.c.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.c.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("validateContainer (-want, +got) = %v", diff)
 			}
 		})
@@ -481,8 +478,7 @@ func TestImmutableConfigurationFields(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.old)
-			got := test.new.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.new.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -587,8 +583,7 @@ func TestConfigurationSubresourceUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinSubResourceUpdate(ctx, test.config, test.subresource)
-			got := test.config.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.config.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -599,7 +594,7 @@ func getConfigurationSpec(image string) ConfigurationSpec {
 	return ConfigurationSpec{
 		Template: &RevisionTemplateSpec{
 			Spec: RevisionSpec{
-				RevisionSpec: v1beta1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
 					PodSpec: corev1.PodSpec{Containers: []corev1.Container{{
 						Image: image,
 					}},
@@ -721,8 +716,7 @@ func TestConfigurationAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/apis/serving/v1alpha1/route_defaults.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults.go
@@ -22,10 +22,20 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 func (r *Route) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
+	if r.GetOwnerReferences() == nil {
+		if apis.IsInUpdate(ctx) {
+			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Route).Spec, r.Spec, r)
+		} else {
+			serving.SetUserInfo(ctx, nil, r.Spec, r)
+		}
+	}
+
 }
 
 func (rs *RouteSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/serving/v1alpha1/route_defaults.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults.go
@@ -21,9 +21,8 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func (r *Route) SetDefaults(ctx context.Context) {
@@ -40,10 +39,10 @@ func (r *Route) SetDefaults(ctx context.Context) {
 
 func (rs *RouteSpec) SetDefaults(ctx context.Context) {
 	if v1.IsUpgradeViaDefaulting(ctx) {
-		v1 := v1.RouteSpec{}
-		if rs.ConvertUp(ctx, &v1) == nil {
+		v := v1.RouteSpec{}
+		if rs.ConvertUp(ctx, &v) == nil {
 			alpha := RouteSpec{}
-			alpha.ConvertDown(ctx, v1)
+			alpha.ConvertDown(ctx, v)
 			*rs = alpha
 		}
 	}

--- a/pkg/apis/serving/v1alpha1/route_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults_test.go
@@ -21,9 +21,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	authv1 "k8s.io/api/authentication/v1"
 
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 func TestRouteDefaulting(t *testing.T) {
@@ -201,6 +205,123 @@ func TestRouteDefaulting(t *testing.T) {
 			got.SetDefaults(ctx)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("SetDefaults (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestRouteUserInfo(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	withUserAnns := func(u1, u2 string, s *Route) *Route {
+		a := s.GetAnnotations()
+		if a == nil {
+			a = map[string]string{}
+			s.SetAnnotations(a)
+		}
+		a[serving.CreatorAnnotation] = u1
+		a[serving.UpdaterAnnotation] = u2
+		return s
+	}
+	tests := []struct {
+		name     string
+		user     string
+		this     *Route
+		prev     *Route
+		wantAnns map[string]string
+	}{{
+		name: "create-new",
+		user: u1,
+		this: &Route{},
+		prev: nil,
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		// Old objects don't have the annotation, and unless there's a change in
+		// data they won't get it.
+		name:     "update-no-diff-old-object",
+		user:     u1,
+		this:     &Route{},
+		prev:     &Route{},
+		wantAnns: map[string]string{},
+	}, {
+		name: "update-no-diff-new-object",
+		user: u2,
+		this: withUserAnns(u1, u1, &Route{}),
+		prev: withUserAnns(u1, u1, &Route{}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		name: "update-diff-old-object",
+		user: u2,
+		this: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					TrafficTarget: v1beta1.TrafficTarget{
+						ConfigurationName: "new",
+					},
+				}},
+			},
+		},
+		prev: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					TrafficTarget: v1beta1.TrafficTarget{
+						ConfigurationName: "old",
+					},
+				}},
+			},
+		},
+		wantAnns: map[string]string{
+			serving.UpdaterAnnotation: u2,
+		},
+	}, {
+		name: "update-diff-new-object",
+		user: u3,
+		this: withUserAnns(u1, u2, &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					TrafficTarget: v1beta1.TrafficTarget{
+						ConfigurationName: "new",
+					},
+				}},
+			},
+		}),
+		prev: withUserAnns(u1, u2, &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					TrafficTarget: v1beta1.TrafficTarget{
+						ConfigurationName: "old",
+					},
+				}},
+			},
+		}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u3,
+		},
+	}}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+				test.prev.SetDefaults(ctx)
+			}
+			test.this.SetDefaults(ctx)
+			if got, want := test.this.GetAnnotations(), test.wantAnns; !cmp.Equal(got, want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha1/route_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/route_defaults_test.go
@@ -25,9 +25,8 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestRouteDefaulting(t *testing.T) {
@@ -264,7 +263,7 @@ func TestRouteUserInfo(t *testing.T) {
 		this: &Route{
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
-					TrafficTarget: v1beta1.TrafficTarget{
+					TrafficTarget: v1.TrafficTarget{
 						ConfigurationName: "new",
 					},
 				}},
@@ -273,7 +272,7 @@ func TestRouteUserInfo(t *testing.T) {
 		prev: &Route{
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
-					TrafficTarget: v1beta1.TrafficTarget{
+					TrafficTarget: v1.TrafficTarget{
 						ConfigurationName: "old",
 					},
 				}},
@@ -288,7 +287,7 @@ func TestRouteUserInfo(t *testing.T) {
 		this: withUserAnns(u1, u2, &Route{
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
-					TrafficTarget: v1beta1.TrafficTarget{
+					TrafficTarget: v1.TrafficTarget{
 						ConfigurationName: "new",
 					},
 				}},
@@ -297,7 +296,7 @@ func TestRouteUserInfo(t *testing.T) {
 		prev: withUserAnns(u1, u2, &Route{
 			Spec: RouteSpec{
 				Traffic: []TrafficTarget{{
-					TrafficTarget: v1beta1.TrafficTarget{
+					TrafficTarget: v1.TrafficTarget{
 						ConfigurationName: "old",
 					},
 				}},
@@ -309,9 +308,7 @@ func TestRouteUserInfo(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -28,6 +28,12 @@ import (
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Route)
+		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
+			r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+	}
 	return errs
 }
 

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -26,9 +26,8 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestRouteValidation(t *testing.T) {
@@ -161,8 +160,7 @@ func TestRouteValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.r.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.r.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -372,8 +370,7 @@ func TestRouteSpecValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.rs.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.rs.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -481,8 +478,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.tt.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.tt.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -492,7 +488,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 func getRouteSpec(confName string) RouteSpec {
 	return RouteSpec{
 		Traffic: []TrafficTarget{{
-			TrafficTarget: v1beta1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
 				LatestRevision:    ptr.Bool(true),
 				Percent:           ptr.Int64(100),
 				ConfigurationName: confName,
@@ -611,8 +607,7 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -27,6 +27,8 @@ import (
 	"knative.dev/pkg/ptr"
 
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 func TestRouteValidation(t *testing.T) {
@@ -480,6 +482,136 @@ func TestTrafficTargetValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.tt.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func getRouteSpec(confName string) RouteSpec {
+	return RouteSpec{
+		Traffic: []TrafficTarget{{
+			TrafficTarget: v1beta1.TrafficTarget{
+				LatestRevision:    ptr.Bool(true),
+				Percent:           ptr.Int64(100),
+				ConfigurationName: confName,
+			},
+		}},
+	}
+}
+
+func TestRouteAnnotationUpdate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	tests := []struct {
+		name string
+		prev *Route
+		this *Route
+		want *apis.FieldError
+	}{{
+		name: "update creator annotation",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update creator annotation with spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier without spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u2,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier with spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.prev)
+			got := test.this.Validate(ctx)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}

--- a/pkg/apis/serving/v1alpha1/service_defaults.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults.go
@@ -37,10 +37,10 @@ func (s *Service) SetDefaults(ctx context.Context) {
 
 func (ss *ServiceSpec) SetDefaults(ctx context.Context) {
 	if v1.IsUpgradeViaDefaulting(ctx) {
-		v1 := v1.ServiceSpec{}
-		if ss.ConvertUp(ctx, &v1) == nil {
+		v := v1.ServiceSpec{}
+		if ss.ConvertUp(ctx, &v) == nil {
 			alpha := ServiceSpec{}
-			if alpha.ConvertDown(ctx, v1) == nil {
+			if alpha.ConvertDown(ctx, v) == nil {
 				*ss = alpha
 			}
 		}

--- a/pkg/apis/serving/v1alpha1/service_defaults.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 
 	"knative.dev/serving/pkg/apis/serving"
@@ -29,24 +28,10 @@ import (
 func (s *Service) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, s.ObjectMeta)
 	s.Spec.SetDefaults(apis.WithinSpec(ctx))
-
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := s.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			s.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Service)
-			if equality.Semantic.DeepEqual(old.Spec, s.Spec) {
-				return
-			}
-			ans[serving.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[serving.CreatorAnnotation] = ui.Username
-			ans[serving.UpdaterAnnotation] = ui.Username
-		}
+	if apis.IsInUpdate(ctx) {
+		serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Service).Spec, s.Spec, s)
+	} else {
+		serving.SetUserInfo(ctx, nil, s.Spec, s)
 	}
 }
 

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -872,9 +872,7 @@ func TestAnnotateUserInfo(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -708,8 +708,7 @@ func TestServiceValidation(t *testing.T) {
 			if test.wc != nil {
 				ctx = test.wc(ctx)
 			}
-			got := test.s.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.s.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate() (-want, +got) = %v", diff)
 			}
 		})
@@ -755,8 +754,7 @@ func TestRunLatestTypeValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.rlt.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.rlt.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("validateContainer (-want, +got) = %v", diff)
 			}
 		})
@@ -818,8 +816,7 @@ func TestPinnedTypeValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.pt.Validate(context.Background())
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.pt.Validate(context.Background()).Error()); diff != "" {
 				t.Errorf("validateContainer (-want, +got) = %v", diff)
 			}
 		})
@@ -1099,8 +1096,7 @@ func TestImmutableServiceFields(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.old)
-			got := test.new.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.new.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -1221,8 +1217,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinSubResourceUpdate(ctx, test.service, test.subresource)
-			got := test.service.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.service.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -1340,8 +1335,7 @@ func TestServiceAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/apis/serving/v1beta1/configuration_defaults.go
+++ b/pkg/apis/serving/v1beta1/configuration_defaults.go
@@ -20,10 +20,18 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // SetDefaults implements apis.Defaultable
 func (c *Configuration) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, c.ObjectMeta)
 	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+	if c.GetOwnerReferences() == nil {
+		if apis.IsInUpdate(ctx) {
+			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Configuration).Spec, c.Spec, c)
+		} else {
+			serving.SetUserInfo(ctx, nil, c.Spec, c)
+		}
+	}
 }

--- a/pkg/apis/serving/v1beta1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_defaults_test.go
@@ -21,10 +21,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/ptr"
 
+	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 func TestConfigurationDefaulting(t *testing.T) {
@@ -55,6 +59,124 @@ func TestConfigurationDefaulting(t *testing.T) {
 			if !cmp.Equal(got, test.want, ignoreUnexportedResources) {
 				t.Errorf("SetDefaults (-want, +got) = %v",
 					cmp.Diff(test.want, got, ignoreUnexportedResources))
+			}
+		})
+	}
+}
+
+func TestConfigurationUserInfo(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	withUserAnns := func(u1, u2 string, s *Configuration) *Configuration {
+		a := s.GetAnnotations()
+		if a == nil {
+			a = map[string]string{}
+			s.SetAnnotations(a)
+		}
+		a[serving.CreatorAnnotation] = u1
+		a[serving.UpdaterAnnotation] = u2
+		return s
+	}
+	tests := []struct {
+		name     string
+		user     string
+		this     *Configuration
+		prev     *Configuration
+		wantAnns map[string]string
+	}{
+		{
+			name: "create-new",
+			user: u1,
+			this: &Configuration{},
+			prev: nil,
+			wantAnns: map[string]string{
+				serving.CreatorAnnotation: u1,
+				serving.UpdaterAnnotation: u1,
+			},
+		}, {
+			// Old objects don't have the annotation, and unless there's a change in
+			// data they won't get it.
+			name:     "update-no-diff-old-object",
+			user:     u1,
+			this:     &Configuration{},
+			prev:     &Configuration{},
+			wantAnns: map[string]string{},
+		}, {
+			name: "update-no-diff-new-object",
+			user: u2,
+			this: withUserAnns(u1, u1, &Configuration{}),
+			prev: withUserAnns(u1, u1, &Configuration{}),
+			wantAnns: map[string]string{
+				serving.CreatorAnnotation: u1,
+				serving.UpdaterAnnotation: u1,
+			},
+		}, {
+			name: "update-diff-old-object",
+			user: u2,
+			this: &Configuration{
+				Spec: ConfigurationSpec{
+					Template: RevisionTemplateSpec{
+						Spec: RevisionSpec{
+							ContainerConcurrency: ptr.Int64(1),
+						},
+					},
+				},
+			},
+			prev: &Configuration{
+				Spec: ConfigurationSpec{
+					Template: RevisionTemplateSpec{
+						Spec: RevisionSpec{
+							ContainerConcurrency: ptr.Int64(2),
+						},
+					},
+				},
+			},
+			wantAnns: map[string]string{
+				serving.UpdaterAnnotation: u2,
+			},
+		}, {
+			name: "update-diff-new-object",
+			user: u3,
+			this: withUserAnns(u1, u2, &Configuration{
+				Spec: ConfigurationSpec{
+					Template: RevisionTemplateSpec{
+						Spec: RevisionSpec{
+							ContainerConcurrency: ptr.Int64(1),
+						},
+					},
+				},
+			}),
+			prev: withUserAnns(u1, u2, &Configuration{
+				Spec: ConfigurationSpec{
+					Template: RevisionTemplateSpec{
+						Spec: RevisionSpec{
+							ContainerConcurrency: ptr.Int64(2),
+						},
+					},
+				},
+			}),
+			wantAnns: map[string]string{
+				serving.CreatorAnnotation: u1,
+				serving.UpdaterAnnotation: u3,
+			},
+		}}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+				test.prev.SetDefaults(ctx)
+			}
+			test.this.SetDefaults(ctx)
+			if got, want := test.this.GetAnnotations(), test.wantAnns; !cmp.Equal(got, want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1beta1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_defaults_test.go
@@ -22,13 +22,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	authv1 "k8s.io/api/authentication/v1"
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/config"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestConfigurationDefaulting(t *testing.T) {
@@ -117,18 +116,18 @@ func TestConfigurationUserInfo(t *testing.T) {
 			name: "update-diff-old-object",
 			user: u2,
 			this: &Configuration{
-				Spec: ConfigurationSpec{
-					Template: RevisionTemplateSpec{
-						Spec: RevisionSpec{
+				Spec: v1.ConfigurationSpec{
+					Template: v1.RevisionTemplateSpec{
+						Spec: v1.RevisionSpec{
 							ContainerConcurrency: ptr.Int64(1),
 						},
 					},
 				},
 			},
 			prev: &Configuration{
-				Spec: ConfigurationSpec{
-					Template: RevisionTemplateSpec{
-						Spec: RevisionSpec{
+				Spec: v1.ConfigurationSpec{
+					Template: v1.RevisionTemplateSpec{
+						Spec: v1.RevisionSpec{
 							ContainerConcurrency: ptr.Int64(2),
 						},
 					},
@@ -141,18 +140,18 @@ func TestConfigurationUserInfo(t *testing.T) {
 			name: "update-diff-new-object",
 			user: u3,
 			this: withUserAnns(u1, u2, &Configuration{
-				Spec: ConfigurationSpec{
-					Template: RevisionTemplateSpec{
-						Spec: RevisionSpec{
+				Spec: v1.ConfigurationSpec{
+					Template: v1.RevisionTemplateSpec{
+						Spec: v1.RevisionSpec{
 							ContainerConcurrency: ptr.Int64(1),
 						},
 					},
 				},
 			}),
 			prev: withUserAnns(u1, u2, &Configuration{
-				Spec: ConfigurationSpec{
-					Template: RevisionTemplateSpec{
-						Spec: RevisionSpec{
+				Spec: v1.ConfigurationSpec{
+					Template: v1.RevisionTemplateSpec{
+						Spec: v1.RevisionSpec{
 							ContainerConcurrency: ptr.Int64(2),
 						},
 					},
@@ -164,9 +163,7 @@ func TestConfigurationUserInfo(t *testing.T) {
 			},
 		}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -43,7 +43,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
-
+		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
+			c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
 		err := c.Spec.Template.VerifyNameChange(ctx, original.Spec.Template)
 		errs = errs.Also(err.ViaField("spec.template"))
 	}

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -563,3 +563,136 @@ func TestConfigurationSubresourceUpdate(t *testing.T) {
 		})
 	}
 }
+
+func getConfigurationSpec(image string) ConfigurationSpec {
+	return ConfigurationSpec{
+		Template: RevisionTemplateSpec{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: image,
+					}},
+				},
+				TimeoutSeconds: ptr.Int64(config.DefaultMaxRevisionTimeoutSeconds),
+			},
+		},
+	}
+}
+
+func TestConfigurationAnnotationUpdate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	tests := []struct {
+		name string
+		prev *Configuration
+		this *Configuration
+		want *apis.FieldError
+	}{{
+		name: "update creator annotation",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update creator annotation with spec changes",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:bar"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier without spec changes",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u2,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier with spec changes",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:bar"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.prev)
+			got := test.this.Validate(ctx)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -556,18 +556,17 @@ func TestConfigurationSubresourceUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinSubResourceUpdate(ctx, test.config, test.subresource)
-			got := test.config.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.config.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
 	}
 }
 
-func getConfigurationSpec(image string) ConfigurationSpec {
-	return ConfigurationSpec{
-		Template: RevisionTemplateSpec{
-			Spec: RevisionSpec{
+func getConfigurationSpec(image string) v1.ConfigurationSpec {
+	return v1.ConfigurationSpec{
+		Template: v1.RevisionTemplateSpec{
+			Spec: v1.RevisionSpec{
 				PodSpec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Image: image,
@@ -689,8 +688,7 @@ func TestConfigurationAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/apis/serving/v1beta1/route_defaults.go
+++ b/pkg/apis/serving/v1beta1/route_defaults.go
@@ -20,9 +20,19 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // SetDefaults implements apis.Defaultable
 func (r *Route) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
+	if r.GetOwnerReferences() == nil {
+		if apis.IsInUpdate(ctx) {
+			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Route).Spec, r.Spec, r)
+		} else {
+			serving.SetUserInfo(ctx, nil, r.Spec, r)
+		}
+	}
+
 }

--- a/pkg/apis/serving/v1beta1/route_defaults.go
+++ b/pkg/apis/serving/v1beta1/route_defaults.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
@@ -34,5 +33,4 @@ func (r *Route) SetDefaults(ctx context.Context) {
 			serving.SetUserInfo(ctx, nil, r.Spec, r)
 		}
 	}
-
 }

--- a/pkg/apis/serving/v1beta1/route_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/route_defaults_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	authv1 "k8s.io/api/authentication/v1"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -146,6 +148,115 @@ func TestRouteDefaulting(t *testing.T) {
 			if !cmp.Equal(test.want, got) {
 				t.Errorf("SetDefaults (-want, +got) = %v",
 					cmp.Diff(test.want, got))
+			}
+		})
+	}
+}
+
+func TestRouteUserInfo(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	withUserAnns := func(u1, u2 string, s *Route) *Route {
+		a := s.GetAnnotations()
+		if a == nil {
+			a = map[string]string{}
+			s.SetAnnotations(a)
+		}
+		a[serving.CreatorAnnotation] = u1
+		a[serving.UpdaterAnnotation] = u2
+		return s
+	}
+	tests := []struct {
+		name     string
+		user     string
+		this     *Route
+		prev     *Route
+		wantAnns map[string]string
+	}{{
+		name: "create-new",
+		user: u1,
+		this: &Route{},
+		prev: nil,
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		// Old objects don't have the annotation, and unless there's a change in
+		// data they won't get it.
+		name:     "update-no-diff-old-object",
+		user:     u1,
+		this:     &Route{},
+		prev:     &Route{},
+		wantAnns: map[string]string{},
+	}, {
+		name: "update-no-diff-new-object",
+		user: u2,
+		this: withUserAnns(u1, u1, &Route{}),
+		prev: withUserAnns(u1, u1, &Route{}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u1,
+		},
+	}, {
+		name: "update-diff-old-object",
+		user: u2,
+		this: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					ConfigurationName: "new",
+				}},
+			},
+		},
+		prev: &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					ConfigurationName: "old",
+				}},
+			},
+		},
+		wantAnns: map[string]string{
+			serving.UpdaterAnnotation: u2,
+		},
+	}, {
+		name: "update-diff-new-object",
+		user: u3,
+		this: withUserAnns(u1, u2, &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					ConfigurationName: "new",
+				}},
+			},
+		}),
+		prev: withUserAnns(u1, u2, &Route{
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					ConfigurationName: "old",
+				}},
+			},
+		}),
+		wantAnns: map[string]string{
+			serving.CreatorAnnotation: u1,
+			serving.UpdaterAnnotation: u3,
+		},
+	}}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
+				Username: test.user,
+			})
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+				test.prev.SetDefaults(ctx)
+			}
+			test.this.SetDefaults(ctx)
+			if got, want := test.this.GetAnnotations(), test.wantAnns; !cmp.Equal(got, want) {
+				t.Errorf("Annotations = %v, want: %v, diff (-got, +want): %s", got, want, cmp.Diff(got, want))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1beta1/route_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/route_defaults_test.go
@@ -24,6 +24,7 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -205,15 +206,15 @@ func TestRouteUserInfo(t *testing.T) {
 		name: "update-diff-old-object",
 		user: u2,
 		this: &Route{
-			Spec: RouteSpec{
-				Traffic: []TrafficTarget{{
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{
 					ConfigurationName: "new",
 				}},
 			},
 		},
 		prev: &Route{
-			Spec: RouteSpec{
-				Traffic: []TrafficTarget{{
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{
 					ConfigurationName: "old",
 				}},
 			},
@@ -225,15 +226,15 @@ func TestRouteUserInfo(t *testing.T) {
 		name: "update-diff-new-object",
 		user: u3,
 		this: withUserAnns(u1, u2, &Route{
-			Spec: RouteSpec{
-				Traffic: []TrafficTarget{{
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{
 					ConfigurationName: "new",
 				}},
 			},
 		}),
 		prev: withUserAnns(u1, u2, &Route{
-			Spec: RouteSpec{
-				Traffic: []TrafficTarget{{
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{
 					ConfigurationName: "old",
 				}},
 			},
@@ -244,9 +245,7 @@ func TestRouteUserInfo(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -31,6 +31,12 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 		r.validateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Route)
+		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
+			r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+	}
 	return errs
 }
 

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -631,3 +631,131 @@ func TestRouteLabelValidation(t *testing.T) {
 		})
 	}
 }
+
+func getRouteSpec(confName string) RouteSpec {
+	return RouteSpec{
+		Traffic: []TrafficTarget{{
+			LatestRevision:    ptr.Bool(true),
+			Percent:           ptr.Int64(100),
+			ConfigurationName: confName,
+		}},
+	}
+}
+
+func TestRouteAnnotationUpdate(t *testing.T) {
+	const (
+		u1 = "oveja@knative.dev"
+		u2 = "cabra@knative.dev"
+		u3 = "vaca@knative.dev"
+	)
+	tests := []struct {
+		name string
+		prev *Route
+		this *Route
+		want *apis.FieldError
+	}{{
+		name: "update creator annotation",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update creator annotation with spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u2,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: (&apis.FieldError{Message: "annotation value is immutable",
+			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier without spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u2,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
+	}, {
+		name: "update lastModifier with spec changes",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.prev)
+			got := test.this.Validate(ctx)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -632,9 +632,9 @@ func TestRouteLabelValidation(t *testing.T) {
 	}
 }
 
-func getRouteSpec(confName string) RouteSpec {
-	return RouteSpec{
-		Traffic: []TrafficTarget{{
+func getRouteSpec(confName string) v1.RouteSpec {
+	return v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{{
 			LatestRevision:    ptr.Bool(true),
 			Percent:           ptr.Int64(100),
 			ConfigurationName: confName,
@@ -752,8 +752,7 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/apis/serving/v1beta1/service_defaults.go
+++ b/pkg/apis/serving/v1beta1/service_defaults.go
@@ -19,8 +19,6 @@ package v1beta1
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -29,23 +27,9 @@ import (
 func (s *Service) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, s.ObjectMeta)
 	s.Spec.SetDefaults(apis.WithinSpec(ctx))
-
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := s.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			s.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Service)
-			if equality.Semantic.DeepEqual(old.Spec, s.Spec) {
-				return
-			}
-			ans[serving.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[serving.CreatorAnnotation] = ui.Username
-			ans[serving.UpdaterAnnotation] = ui.Username
-		}
+	if apis.IsInUpdate(ctx) {
+		serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Service).Spec, s.Spec, s)
+	} else {
+		serving.SetUserInfo(ctx, nil, s.Spec, s)
 	}
 }

--- a/pkg/apis/serving/v1beta1/service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/service_defaults_test.go
@@ -335,9 +335,7 @@ func TestAnnotateUserInfo(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := apis.WithUserInfo(context.Background(), &authv1.UserInfo{
 				Username: test.user,
 			})

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -664,8 +664,7 @@ func TestServiceSubresourceUpdate(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.service)
 			ctx = apis.WithinSubResourceUpdate(ctx, test.service, test.subresource)
-			got := test.service.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.service.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})
@@ -781,8 +780,7 @@ func TestServiceAnnotationUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = apis.WithinUpdate(ctx, test.prev)
-			got := test.this.Validate(ctx)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Errorf("Validate (-want, +got) = %v", diff)
 			}
 		})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #4781

## Proposed Changes

* Added /creator and /lastModifier  info to Configuration and Route
* Added validation check for /creator and /lastModifier annotation
* Added missing test cases to `metadata_validation.go`
