### PR TITLE
Further reducing Istio resources.

### DIFF
--- a/third_party/istio-1.1.13/istio-lean.yaml
+++ b/third_party/istio-1.1.13/istio-lean.yaml
@@ -547,7 +547,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 10m
+              cpu: 500m
+              memory: 512Mi
 
           env:
           - name: POD_NAME
@@ -734,8 +735,8 @@ spec:
               cpu: 2000m
               memory: 1024Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 500m
+              memory: 512Mi
 
           env:
           - name: POD_NAME

--- a/third_party/istio-1.1.13/values-lean.yaml
+++ b/third_party/istio-1.1.13/values-lean.yaml
@@ -23,8 +23,8 @@ gateways:
     autoscaleMax: 4
     resources:
       requests:
-        cpu: 1000m
-        memory: 1024Mi
+        cpu: 500m
+        memory: 512Mi
     ports:
     - name: status-port
       port: 15020
@@ -40,7 +40,10 @@ gateways:
     replicaCount: 2
     autoscaleMin: 2
     autoscaleMax: 4
-    resources: {}
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
     cpu:
       targetAverageUtilization: 80
     loadBalancerIP: ""

--- a/third_party/istio-1.2.4/istio-lean.yaml
+++ b/third_party/istio-1.2.4/istio-lean.yaml
@@ -479,7 +479,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 10m
+              cpu: 500m
+              memory: 512Mi
 
           env:
           - name: NODE_NAME
@@ -675,8 +676,8 @@ spec:
               cpu: 2000m
               memory: 1024Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 500m
+              memory: 512Mi
 
           env:
           - name: NODE_NAME
@@ -927,7 +928,7 @@ metadata:
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
-  maxReplicas: 4
+  maxReplicas: 5
   minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1

--- a/third_party/istio-1.2.4/values-lean.yaml
+++ b/third_party/istio-1.2.4/values-lean.yaml
@@ -21,11 +21,11 @@ gateways:
       enabled: true
     replicaCount: 2
     autoscaleMin: 2
-    autoscaleMax: 4
+    autoscaleMax: 5
     resources:
       requests:
-        cpu: 1000m
-        memory: 1024Mi
+        cpu: 500m
+        memory: 512Mi
     ports:
     - name: status-port
       port: 15020
@@ -40,8 +40,11 @@ gateways:
       istio: cluster-local-gateway
     replicaCount: 2
     autoscaleMin: 2
-    autoscaleMax: 4
-    resources: {}
+    autoscaleMax: 5
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
     cpu:
       targetAverageUtilization: 80
     loadBalancerIP: ""


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Integration tests seem stable enough so I am going to reduce istio-lean.yaml footprint a bit more.

## Proposed Changes

* Update istio-lean.yaml to use less resource.  Also don't use default for cluster-local-gateway, since the default request is 10m causing excessive jittering of cluster-local-gateway HPA.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
