### PR TITLE
Simplify the backend manager a bit.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -63,8 +63,6 @@ const (
 	probeFrequency time.Duration = 200 * time.Millisecond
 )
 
-var emptySet = sets.NewString()
-
 // revisionWatcher watches the podIPs and ClusterIP of the service for a revision. It implements the logic
 // to supply RevisionDestsUpdate events on updateCh
 type revisionWatcher struct {
@@ -91,7 +89,7 @@ func newRevisionWatcher(rev types.NamespacedName, protocol networking.ProtocolTy
 		rev:           rev,
 		protocol:      protocol,
 		updateCh:      updateCh,
-		healthyPods:   emptySet,
+		healthyPods:   sets.NewString(),
 		transport:     transport,
 		destsChan:     destsChan,
 		serviceLister: serviceLister,
@@ -233,7 +231,7 @@ func (rw *revisionWatcher) checkDests(dests []string) {
 		// We dont want to return here as an error still affects health states
 	}
 
-	rw.logger.Debug("Done probing, got healthy nodes: ", hs)
+	rw.logger.Debug("Done probing, got healthy pods: ", hs)
 	if !reflect.DeepEqual(rw.healthyPods, hs) {
 		rw.healthyPods = hs
 		rw.updateCh <- &RevisionDestsUpdate{

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -99,16 +99,6 @@ func newRevisionWatcher(rev types.NamespacedName, protocol networking.ProtocolTy
 	}
 }
 
-func filterHealthyDests(dests map[string]bool) []string {
-	ret := make([]string, 0, len(dests))
-	for dest, healthy := range dests {
-		if healthy {
-			ret = append(ret, dest)
-		}
-	}
-	return ret
-}
-
 func (rw *revisionWatcher) getK8sPrivateService() (*corev1.Service, error) {
 	selector := labels.SelectorFromSet(map[string]string{
 		serving.RevisionLabelKey:  rw.rev.Name,

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -94,7 +95,6 @@ func TestRevisionWatcher(t *testing.T) {
 		probeHostResponses map[string][]activatortest.FakeResponse
 		probeResponses     []activatortest.FakeResponse
 		ticks              []time.Time
-		updateCnt          int
 	}{{
 		name:  "single healthy podIP",
 		dests: []string{"128.0.0.1:1234"},
@@ -158,8 +158,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Name: "http",
 			Port: 1234,
 		},
-		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{}}},
+		clusterIP: "129.0.0.1",
 		probeResponses: []activatortest.FakeResponse{{
 			Err:  nil,
 			Code: http.StatusServiceUnavailable,
@@ -172,8 +171,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Name: "http",
 			Port: 1234,
 		},
-		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{}}},
+		clusterIP: "129.0.0.1",
 		probeResponses: []activatortest.FakeResponse{{
 			Err:  errors.New("Fake error"),
 			Code: http.StatusOK,
@@ -187,7 +185,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{}}, {Dests: []string{"128.0.0.1:1234"}}},
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}}},
 		probeResponses: []activatortest.FakeResponse{{
 			Err: errors.New("clusterIP transport error"),
 		}, {
@@ -201,8 +199,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Code: http.StatusOK,
 			Body: queue.Name,
 		}},
-		ticks:     []time.Time{time.Now()},
-		updateCnt: 2,
+		ticks: []time.Time{time.Now()},
 	}, {
 		name:  "multiple healthy podIP",
 		dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
@@ -210,10 +207,8 @@ func TestRevisionWatcher(t *testing.T) {
 			Name: "http",
 			Port: 1234,
 		},
-		clusterIP: "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{
-			{Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"}},
-		},
+		clusterIP:     "129.0.0.1",
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"}}},
 		probeResponses: []activatortest.FakeResponse{{
 			Err: errors.New("clusterIP transport error"),
 		}, {
@@ -228,10 +223,8 @@ func TestRevisionWatcher(t *testing.T) {
 			Name: "http",
 			Port: 1234,
 		},
-		clusterIP: "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{
-			{Dests: []string{"128.0.0.2:1234"}},
-		},
+		clusterIP:     "129.0.0.1",
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.2:1234"}}},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
 			"129.0.0.1:1234": {{
 				Err: errors.New("clusterIP transport error"),
@@ -254,7 +247,6 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 		clusterIP: "129.0.0.1",
 		expectUpdates: []RevisionDestsUpdate{
-			{Dests: []string{}},
 			{Dests: []string{"128.0.0.1:1234"}},
 			{ClusterIPDest: "129.0.0.1:1234"},
 		},
@@ -278,8 +270,7 @@ func TestRevisionWatcher(t *testing.T) {
 				Body: queue.Name,
 			}},
 		},
-		ticks:     []time.Time{time.Now(), time.Now()},
-		updateCnt: 3,
+		ticks: []time.Time{time.Now().Add(-time.Second), time.Now()},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			defer ClearAll()
@@ -296,11 +287,6 @@ func TestRevisionWatcher(t *testing.T) {
 
 			// This gets cleaned up as part of the test
 			destsCh := make(chan []string)
-
-			// Default for updateCnt is 1
-			if tc.updateCnt == 0 {
-				tc.updateCnt = 1
-			}
 
 			// Default for protocol is http1
 			if tc.protocol == "" {
@@ -342,13 +328,13 @@ func TestRevisionWatcher(t *testing.T) {
 			}
 
 			updates := []RevisionDestsUpdate{}
-			for i := 0; i < tc.updateCnt; i++ {
+			for i := 0; i < len(tc.expectUpdates); i++ {
 				select {
 				case update := <-updateCh:
 					sort.Strings(update.Dests)
 					updates = append(updates, *update)
 				case <-time.After(200 * time.Millisecond):
-					t.Errorf("Timed out waiting for update event")
+					t.Error("Timed out waiting for update event")
 				}
 			}
 
@@ -362,7 +348,7 @@ func TestRevisionWatcher(t *testing.T) {
 				tc.expectUpdates[i].Rev = revID
 			}
 
-			if got, want := tc.expectUpdates, updates; !cmp.Equal(got, want) {
+			if got, want := tc.expectUpdates, updates; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
 				t.Errorf("revisionDests updates = %v, want: %v, diff (-want, +got):\n %s", got, want, cmp.Diff(want, got))
 			}
 		})
@@ -403,7 +389,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		expectDests        map[types.NamespacedName]RevisionDestsUpdate
 		updateCnt          int
 	}{{
-		name:         "Add slow healthy",
+		name:         "add slow healthy",
 		endpointsArr: []*corev1.Endpoints{ep("test-revision", 1234, "http", "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
@@ -431,9 +417,9 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 				Dests: []string{"128.0.0.1:1234"},
 			},
 		},
-		updateCnt: 2,
+		updateCnt: 1,
 	}, {
-		name:         "Add slow ready http2",
+		name:         "add slow ready http2",
 		endpointsArr: []*corev1.Endpoints{ep("test-revision", 1234, "http2", "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolH2C),
@@ -461,9 +447,9 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 				Dests: []string{"128.0.0.1:1234"},
 			},
 		},
-		updateCnt: 2,
+		updateCnt: 1,
 	}, {
-		name: "Multiple revisions",
+		name: "multiple revisions",
 		endpointsArr: []*corev1.Endpoints{
 			ep("test-revision1", 1234, "http", "128.0.0.1"),
 			ep("test-revision2", 1235, "http", "128.1.0.2"),
@@ -526,9 +512,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 				ClusterIPDest: "129.0.0.1:1234",
 			},
 		},
-		updateCnt: 3,
+		updateCnt: 2,
 	}} {
-
 		t.Run(tc.name, func(t *testing.T) {
 			defer ClearAll()
 			fakeRt := activatortest.FakeRoundTripper{
@@ -571,10 +556,6 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			for _, ep := range tc.endpointsArr {
 				fake.CoreV1().Endpoints("test-namespace").Create(ep)
 				endpointsInformer.Informer().GetIndexer().Add(ep)
-			}
-
-			if tc.updateCnt == 0 {
-				tc.updateCnt = 1
 			}
 
 			revDests := make(map[types.NamespacedName]RevisionDestsUpdate)


### PR DESCRIPTION
- No reason to store or pass around unhealthy pod IPs, since we don't include them in the update anyway
- Since the state is basically only healthy nodes, switch to sets.String
- Now the tests have to be updated.
/assign mattmoor @greghaynes @markuesthoemmes

/lint
