### PR TITLE
Make reconciler dashboard valid only for serving

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative-reconciler.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative-reconciler.yaml
@@ -556,7 +556,7 @@ data:
             "multi": false,
             "name": "reconciler",
             "options": [],
-            "query": "label_values(controller_reconcile_count, reconciler)",
+            "query": "label_values(controller_reconcile_count{namespace=\"knative-serving\"}, reconciler)",
             "refresh": 1,
             "regex": "",
             "sort": 0,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Right now, if eventing and serving is installed in a k8s cluster and eventing-controller is scrappable. The `Knative Serving - Reconciler` dashboard would show data points from eventing as well. Hence, I tweaked the query to just get data from `knative-serving` namespace 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
