### PR TITLE
Add moar benchmarks

### DIFF
--- a/test/performance/dataplane-probe/dataplane-probe-setup.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe-setup.yaml
@@ -48,6 +48,47 @@ spec:
 apiVersion: serving.knative.dev/v1beta1
 kind: Service
 metadata:
+  name: activator-with-cc-10
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "15"
+        autoscaling.knative.dev/maxScale: "15"
+        # Always hook the activator in.
+        autoscaling.knative.dev/targetBurstCapacity: "-1"
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale
+      containerConcurrency: 10
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
+  name: activator-with-cc-1
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "150"
+        autoscaling.knative.dev/maxScale: "150"
+        # Always hook the activator in.
+        autoscaling.knative.dev/targetBurstCapacity: "-1"
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 30m
+            memory: 100Mi
+      containerConcurrency: 1
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
   name: queue-proxy
 spec:
   template:
@@ -76,7 +117,62 @@ spec:
     spec:
       containers:
       - image: knative.dev/serving/test/test_images/autoscale
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 50m
+            memory: 150Mi
       containerConcurrency: 100
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
+  name: queue-proxy-with-cc-10
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "15"
+        autoscaling.knative.dev/maxScale: "15"
+        # Only hook the activator in when scaled to zero.
+        autoscaling.knative.dev/targetBurstCapacity: "0"
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 50m
+            memory: 150Mi
+      containerConcurrency: 10
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: Service
+metadata:
+  name: queue-proxy-with-cc-1
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "150"
+        autoscaling.knative.dev/maxScale: "150"
+        # Only hook the activator in when scaled to zero.
+        autoscaling.knative.dev/targetBurstCapacity: "0"
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/autoscale
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 30m
+            memory: 100Mi
+      containerConcurrency: 1
 ---
 apiVersion: v1
 kind: Service

--- a/test/performance/dataplane-probe/dataplane-probe.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe.yaml
@@ -17,7 +17,6 @@ kind: CronJob
 metadata:
   name: dataplane-probe-deployment
 spec:
-  # Run every 30 minutes, offset from other jobs.
   schedule: "0,30 * * * *"
   jobTemplate:
     spec:
@@ -27,7 +26,7 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-target=deployment"]
+            args: ["-target=deployment", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m
@@ -59,7 +58,8 @@ metadata:
   name: dataplane-probe-istio
 spec:
   # Run every thirty minutes, offset from other jobs.
-  schedule: "5,35 * * * *"
+  schedule: "3,33 * * * *"
+  # Run every 30 minutes, offset from other jobs.
   jobTemplate:
     spec:
       parallelism: 1
@@ -68,7 +68,7 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-target=istio"]
+            args: ["-target=istio", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m
@@ -100,7 +100,7 @@ metadata:
   name: dataplane-probe-queue
 spec:
   # Run every thirty minutes, offset from other jobs.
-  schedule: "10,40 * * * *"
+  schedule: "6,36 * * * *"
   jobTemplate:
     spec:
       parallelism: 1
@@ -109,7 +109,7 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-target=queue"]
+            args: ["-target=queue", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m
@@ -141,7 +141,7 @@ metadata:
   name: dataplane-probe-activator
 spec:
   # Run every thirty minutes, offset from other jobs.
-  schedule: "15,45 * * * *"
+  schedule: "9,39 * * * *"
   jobTemplate:
     spec:
       parallelism: 1
@@ -150,7 +150,7 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-target=activator"]
+            args: ["-target=activator", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m
@@ -182,7 +182,7 @@ metadata:
   name: dataplane-probe-activator-with-cc
 spec:
   # Run every thirty minutes, offset from other jobs.
-  schedule: "20,50 * * * *"
+  schedule: "12,42 * * * *"
   jobTemplate:
     spec:
       parallelism: 1
@@ -191,7 +191,7 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-target=activator-with-cc"]
+            args: ["-target=activator-with-cc", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m
@@ -223,7 +223,7 @@ metadata:
   name: dataplane-probe-queue-with-cc
 spec:
   # Run every thirty minutes, offset from other jobs.
-  schedule: "25,55 * * * *"
+  schedule: "15,45 * * * *"
   jobTemplate:
     spec:
       parallelism: 1
@@ -232,7 +232,171 @@ spec:
           containers:
           - name: dataplane-probe
             image: knative.dev/serving/test/performance/dataplane-probe
-            args: ["-target=queue-with-cc"]
+            args: ["-target=queue-with-cc", "--duration=3m"]
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
+          - name: mako
+            image: gcr.io/knative-performance/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
+          restartPolicy: Never
+      backoffLimit: 0
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dataplane-probe-queue-with-cc-10
+spec:
+  # Run every thirty minutes, offset from other jobs.
+  schedule: "18,48 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: dataplane-probe
+            image: knative.dev/serving/test/performance/dataplane-probe
+            args: ["-target=queue-with-cc-10", "--duration=3m"]
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
+          - name: mako
+            image: gcr.io/knative-performance/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
+          restartPolicy: Never
+      backoffLimit: 0
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dataplane-probe-queue-with-cc-1
+spec:
+  # Run every thirty minutes, offset from other jobs.
+  schedule: "21,51 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: dataplane-probe
+            image: knative.dev/serving/test/performance/dataplane-probe
+            args: ["-target=queue-with-cc-1", "--duration=3m"]
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
+          - name: mako
+            image: gcr.io/knative-performance/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
+          restartPolicy: Never
+      backoffLimit: 0
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dataplane-probe-activator-with-cc-10
+spec:
+  # Run every thirty minutes, offset from other jobs.
+  schedule: "24,54 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: dataplane-probe
+            image: knative.dev/serving/test/performance/dataplane-probe
+            args: ["-target=activator-with-cc-10", "--duration=3m"]
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+            volumeMounts:
+            - name: config-mako
+              mountPath: /etc/config-mako
+          - name: mako
+            image: gcr.io/knative-performance/mako-microservice:latest
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secret/robot.json
+            volumeMounts:
+            - name: service-account
+              mountPath: /var/secret
+          volumes:
+          - name: service-account
+            secret:
+              secretName: service-account
+          - name: config-mako
+            configMap:
+              name: config-mako
+          restartPolicy: Never
+      backoffLimit: 0
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dataplane-probe-activator-with-cc-1
+spec:
+  # Run every thirty minutes, offset from other jobs.
+  schedule: "27,57 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: dataplane-probe
+            image: knative.dev/serving/test/performance/dataplane-probe
+            args: ["-target=activator-with-cc-1", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m

--- a/test/performance/dataplane-probe/dev.config
+++ b/test/performance/dataplane-probe/dev.config
@@ -51,11 +51,27 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "qc"
-  label: "queue-proxy-with-cc"
+  label: "queue-proxy-with-cc-100"
+}
+metric_info_list: {
+  value_key: "qc1"
+  label: "queue-proxy-with-cc-1"
+}
+metric_info_list: {
+  value_key: "qct"
+  label: "queue-proxy-with-cc-10"
 }
 metric_info_list: {
   value_key: "ac"
-  label: "activator-with-cc"
+  label: "activator-with-cc-100"
+}
+metric_info_list: {
+  value_key: "act"
+  label: "activator-with-cc-10"
+}
+metric_info_list: {
+  value_key: "ac1"
+  label: "activator-with-cc-1"
 }
 
 metric_info_list: {
@@ -76,9 +92,25 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "re"
-  label: "queue-errors-with-cc"
+  label: "queue-errors-with-cc-100"
+}
+metric_info_list: {
+  value_key: "ret"
+  label: "queue-errors-with-cc-10"
+}
+metric_info_list: {
+  value_key: "re1"
+  label: "queue-errors-with-cc-1"
 }
 metric_info_list: {
   value_key: "be"
-  label: "activator-errors-with-cc"
+  label: "activator-errors-with-cc-100"
+}
+metric_info_list: {
+  value_key: "bet"
+  label: "activator-errors-with-cc-10"
+}
+metric_info_list: {
+  value_key: "be1"
+  label: "activator-errors-with-cc-1"
 }

--- a/test/performance/dataplane-probe/main.go
+++ b/test/performance/dataplane-probe/main.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	target = flag.String("target", "", "The target to attack.")
+	target   = flag.String("target", "", "The target to attack.")
+	duration = flag.Duration("duration", 5*time.Minute, "The duration of the probe")
 )
 
 func main() {
@@ -38,9 +39,9 @@ func main() {
 	// We want this for properly handling Kubernetes container lifecycle events.
 	ctx := signals.NewContext()
 
-	// We cron every 5 minutes, so make sure that we don't severely overrun to
+	// We cron quite often, so make sure that we don't severely overrun to
 	// limit how noisy a neighbor we can be.
-	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, *duration+time.Minute)
 	defer cancel()
 
 	// Use the benchmark key created
@@ -79,7 +80,6 @@ func main() {
 
 	// Send 1000 QPS (1 per ms) for 5 minutes with a 30s request timeout.
 	rate := vegeta.Rate{Freq: 1, Per: time.Millisecond}
-	const duration = 5 * time.Minute
 	targeter := vegeta.NewStaticTargeter(t.target)
 	attacker := vegeta.NewAttacker(vegeta.Timeout(30 * time.Second))
 
@@ -91,7 +91,7 @@ func main() {
 	errors := make(map[int64]int64, int(duration.Seconds()))
 
 	// Start the attack!
-	results := attacker.Attack(targeter, rate, duration, "load-test")
+	results := attacker.Attack(targeter, rate, *duration, "load-test")
 
 LOOP:
 	for {

--- a/test/performance/dataplane-probe/prod.config
+++ b/test/performance/dataplane-probe/prod.config
@@ -45,11 +45,27 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "qc"
-  label: "queue-proxy-with-cc"
+  label: "queue-proxy-with-cc-100"
+}
+metric_info_list: {
+  value_key: "qc1"
+  label: "queue-proxy-with-cc-1"
+}
+metric_info_list: {
+  value_key: "qct"
+  label: "queue-proxy-with-cc-10"
 }
 metric_info_list: {
   value_key: "ac"
-  label: "activator-with-cc"
+  label: "activator-with-cc-100"
+}
+metric_info_list: {
+  value_key: "act"
+  label: "activator-with-cc-10"
+}
+metric_info_list: {
+  value_key: "ac1"
+  label: "activator-with-cc-1"
 }
 
 metric_info_list: {
@@ -70,9 +86,25 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "re"
-  label: "queue-errors-with-cc"
+  label: "queue-errors-with-cc-100"
+}
+metric_info_list: {
+  value_key: "ret"
+  label: "queue-errors-with-cc-10"
+}
+metric_info_list: {
+  value_key: "re1"
+  label: "queue-errors-with-cc-1"
 }
 metric_info_list: {
   value_key: "be"
-  label: "activator-errors-with-cc"
+  label: "activator-errors-with-cc-100"
+}
+metric_info_list: {
+  value_key: "bet"
+  label: "activator-errors-with-cc-10"
+}
+metric_info_list: {
+  value_key: "be1"
+  label: "activator-errors-with-cc-1"
 }

--- a/test/performance/dataplane-probe/sla.go
+++ b/test/performance/dataplane-probe/sla.go
@@ -139,6 +139,26 @@ var (
 			// We use the same threshold analyzer, since we want Breaker to exert minimal latency impact.
 			analyzers: []*tpb.ThresholdAnalyzerInput{Queue95PercentileLatency},
 		},
+		"queue-with-cc-10": {
+			target: vegeta.Target{
+				Method: "GET",
+				URL:    "http://queue-proxy-with-cc-10.default.svc.cluster.local?sleep=100",
+			},
+			stat:  "qct",
+			estat: "ret",
+			// TODO(vagababov): determine values here.
+			analyzers: []*tpb.ThresholdAnalyzerInput{Queue95PercentileLatency},
+		},
+		"queue-with-cc-1": {
+			target: vegeta.Target{
+				Method: "GET",
+				URL:    "http://queue-proxy-with-cc-1.default.svc.cluster.local?sleep=100",
+			},
+			stat:  "qc1",
+			estat: "re1",
+			// TODO(vagababov): determine values here.
+			analyzers: []*tpb.ThresholdAnalyzerInput{Queue95PercentileLatency},
+		},
 		"activator": {
 			target: vegeta.Target{
 				Method: "GET",
@@ -156,6 +176,26 @@ var (
 			stat:  "ac",
 			estat: "be",
 			// We use the same threshold analyzer, since we want Throttler/Breaker to exert minimal latency impact.
+			analyzers: []*tpb.ThresholdAnalyzerInput{Activator95PercentileLatency},
+		},
+		"activator-with-cc-10": {
+			target: vegeta.Target{
+				Method: "GET",
+				URL:    "http://activator-with-cc-10.default.svc.cluster.local?sleep=100",
+			},
+			stat:  "act",
+			estat: "bet",
+			// TODO(vagababov): determine values here.
+			analyzers: []*tpb.ThresholdAnalyzerInput{Activator95PercentileLatency},
+		},
+		"activator-with-cc-1": {
+			target: vegeta.Target{
+				Method: "GET",
+				URL:    "http://activator-with-cc-1.default.svc.cluster.local?sleep=100",
+			},
+			stat:  "ac1",
+			estat: "be1",
+			// TODO(vagababov): determine values here.
 			analyzers: []*tpb.ThresholdAnalyzerInput{Activator95PercentileLatency},
 		},
 	}


### PR DESCRIPTION
This introduces
- QP with cc 10 and 1
- Activator with cc 10 and 1
- Appropriate deployments with 15/150 pods.
- New metrics.


/assign mattmoor