### PR TITLE
Remove unused contaxt from ValidateContainerConcurrency

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -36,7 +36,7 @@ func (pa *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(pa, &PodAutoscalerSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
-	return serving.ValidateNamespacedObjectReference(&pa.ScaleTargetRef).ViaField("scaleTargetRef").Also(serving.ValidateContainerConcurrency(ctx, &pa.ContainerConcurrency).ViaField("containerConcurrency")).Also(validateSKSFields(ctx, pa))
+	return serving.ValidateNamespacedObjectReference(&pa.ScaleTargetRef).ViaField("scaleTargetRef").Also(serving.ValidateContainerConcurrency(&pa.ContainerConcurrency).ViaField("containerConcurrency")).Also(validateSKSFields(ctx, pa))
 }
 
 func validateSKSFields(ctx context.Context, rs *PodAutoscalerSpec) (errs *apis.FieldError) {

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -88,7 +88,7 @@ func ValidateTimeoutSeconds(ctx context.Context, timeoutSeconds int64) *apis.Fie
 
 // ValidateContainerConcurrency function validates the ContainerConcurrency field
 // TODO(#5007): Move this to autoscaling.
-func ValidateContainerConcurrency(ctx context.Context, containerConcurrency *int64) *apis.FieldError {
+func ValidateContainerConcurrency(containerConcurrency *int64) *apis.FieldError {
 	if containerConcurrency != nil {
 		if *containerConcurrency < 0 || *containerConcurrency > config.DefaultMaxRevisionContainerConcurrency {
 			return apis.ErrOutOfBoundsValue(

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -232,3 +232,32 @@ func TestValidateTimeoutSecond(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateContainerConcurrency(t *testing.T) {
+	cases := []struct {
+		name                 string
+		containerConcurrency *int64
+		expectErr            error
+	}{{
+		name:                 "empty containerConcurrency",
+		containerConcurrency: nil,
+		expectErr:            (*apis.FieldError)(nil),
+	}, {
+		name:                 "invalid containerConcurrency value",
+		containerConcurrency: ptr.Int64(2000),
+		expectErr: apis.ErrOutOfBoundsValue(
+			2000, 0, config.DefaultMaxRevisionContainerConcurrency, apis.CurrentField),
+	}, {
+		name:                 "valid containerConcurrency value",
+		containerConcurrency: ptr.Int64(10),
+		expectErr:            (*apis.FieldError)(nil),
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateContainerConcurrency(c.containerConcurrency)
+			if !reflect.DeepEqual(c.expectErr, err) {
+				t.Errorf("Expected: '%#v', Got: '%#v'", c.expectErr, err)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -147,7 +147,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(err)
 	} else {
 		if rs.ContainerConcurrency != nil {
-			errs = errs.Also(serving.ValidateContainerConcurrency(ctx, rs.ContainerConcurrency).ViaField("containerConcurrency"))
+			errs = errs.Also(serving.ValidateContainerConcurrency(rs.ContainerConcurrency).ViaField("containerConcurrency"))
 		}
 	}
 

--- a/pkg/apis/serving/v1beta1/revision_validation.go
+++ b/pkg/apis/serving/v1beta1/revision_validation.go
@@ -118,7 +118,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if rs.ContainerConcurrency != nil {
-		errs = errs.Also(serving.ValidateContainerConcurrency(ctx, rs.ContainerConcurrency).ViaField("containerConcurrency"))
+		errs = errs.Also(serving.ValidateContainerConcurrency(rs.ContainerConcurrency).ViaField("containerConcurrency"))
 	}
 
 	return errs

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -273,7 +273,7 @@ func TestContainerConcurrencyValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := serving.ValidateContainerConcurrency(context.Background(), &test.cc)
+			got := serving.ValidateContainerConcurrency(&test.cc)
 			if got, want := got.Error(), test.want.Error(); !cmp.Equal(got, want) {
 				t.Errorf("Validate (-want, +got) = %v", cmp.Diff(want, got))
 			}


### PR DESCRIPTION
## Proposed Changes

* Removed unused context from ValidateContainerConcurrency function (pkg/apis/serving/metadata_validation.go)

