### PR TITLE
Add the missing comments and fix a bug in the perf tests.

### DIFF
--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -19,8 +19,10 @@ package autoscaling
 import "time"
 
 const (
+	// The internal autoscaling group name. This is used for CRDs.
 	InternalGroupName = "autoscaling.internal.knative.dev"
 
+	// The publuc autoscaling group name. This is used for annotations, labels, etc.
 	GroupName = "autoscaling.knative.dev"
 
 	// ClassAnnotationKey is the annotation for the explicit class of autoscaler

--- a/test/performance/metrics/runtime.go
+++ b/test/performance/metrics/runtime.go
@@ -106,14 +106,14 @@ func FetchSKSMode(
 func startTick(duration time.Duration, stop <-chan struct{}, action func(t time.Time) error) {
 	ticker := time.NewTicker(duration)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case t := <-ticker.C:
 				if err := action(t); err != nil {
-					break
+					return
 				}
 			case <-stop:
-				ticker.Stop()
 				return
 			}
 		}


### PR DESCRIPTION
- `break` inside select breaks out select, rather than `for`. Breaking out of select is meaningless. So replace it with `return`, which makes sense in case of an error. Also make sure we close the ticker in every case.
- add the missing comments to the public strings

/assign mattmoor @yanweiguo 