### PR TITLE
Move activator svc name to networking api

### DIFF
--- a/pkg/activator/activator.go
+++ b/pkg/activator/activator.go
@@ -23,8 +23,6 @@ import (
 const (
 	// Name is the name of the component.
 	Name = "activator"
-	// K8sServiceName is the name of the activator Kubernetes service.
-	K8sServiceName = "activator-service"
 	// RevisionHeaderName is the header key for revision name.
 	RevisionHeaderName = "Knative-Serving-Revision"
 	// RevisionHeaderNamespace is the header key for revision's namespace.

--- a/pkg/activator/throttler.go
+++ b/pkg/activator/throttler.go
@@ -111,7 +111,7 @@ func NewThrottler(
 
 	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: reconciler.ChainFilterFuncs(
-			reconciler.NameFilterFunc(K8sServiceName),
+			reconciler.NameFilterFunc(networking.ActivatorServiceName),
 			reconciler.NamespaceFilterFunc(system.Namespace()),
 		),
 		Handler: cache.ResourceEventHandlerFuncs{

--- a/pkg/activator/throttler_test.go
+++ b/pkg/activator/throttler_test.go
@@ -183,7 +183,7 @@ func TestThrottlerActivatorEndpoints(t *testing.T) {
 		t.Run(s.name, func(t *testing.T) {
 			activatorEp := &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      K8sServiceName,
+					Name:      networking.ActivatorServiceName,
 					Namespace: system.Namespace(),
 				},
 				Subsets: endpointsSubset(1, s.activatorCount),

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -73,6 +73,9 @@ const (
 	// value a different reconciliation logic may be used (for examples,
 	// Cert-Manager-based Certificate will reconcile into a Cert-Manager Certificate).
 	CertificateClassAnnotationKey = GroupName + "/certificate.class"
+
+	// ActivatorServiceName is the name of the activator Kubernetes service.
+	ActivatorServiceName = "activator-service"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -28,7 +28,6 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/system"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	presources "knative.dev/serving/pkg/resources"
@@ -85,7 +84,7 @@ func NewController(
 		// Accept only ActivatorService K8s service objects.
 		FilterFunc: pkgreconciler.ChainFilterFuncs(
 			pkgreconciler.NamespaceFilterFunc(system.Namespace()),
-			pkgreconciler.NameFilterFunc(activator.K8sServiceName)),
+			pkgreconciler.NameFilterFunc(networking.ActivatorServiceName)),
 		Handler: controller.HandleAll(grCb),
 	})
 

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -25,12 +25,12 @@ import (
 
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	fakekubeclient "knative.dev/pkg/injection/clients/kubeclient/fake"
+	"knative.dev/serving/pkg/apis/networking"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
-	"knative.dev/serving/pkg/activator"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -137,7 +137,7 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 			t.Logf("Registering expected hook update for endpoints %s", eps.Name)
 			return HookComplete
 		}
-		if eps.Name == activator.K8sServiceName {
+		if eps.Name == networking.ActivatorServiceName {
 			// Expected, but not the one we're waiting for.
 			t.Log("Registering activator endpoint update")
 		} else {

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -36,7 +36,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	listers "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
@@ -188,7 +187,7 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 		srcEps                *corev1.Endpoints
 		foundServingEndpoints bool
 	)
-	activatorEps, err := r.endpointsLister.Endpoints(system.Namespace()).Get(activator.K8sServiceName)
+	activatorEps, err := r.endpointsLister.Endpoints(system.Namespace()).Get(networking.ActivatorServiceName)
 	if err != nil {
 		logger.Errorw("Error obtaining activator service endpoints", zap.Error(err))
 		return err

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -32,7 +32,6 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/networking"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	rpkg "knative.dev/serving/pkg/reconciler"
@@ -774,7 +773,7 @@ func activatorEndpoints(eo ...EndpointsOption) *corev1.Endpoints {
 	ep := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      activator.K8sServiceName,
+			Name:      networking.ActivatorServiceName,
 		},
 	}
 	for _, opt := range eo {

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -34,7 +34,6 @@ import (
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
@@ -396,7 +395,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	grp.Go(func() error {
 		return generateTraffic(ctx, 7, duration, stopCh)
 	})
-	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting activator endpoints: %v", err)
 	}
@@ -466,7 +465,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 		t.Fatalf("Error retrieving autoscaler configmap: %v", err)
 	}
 	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(
-		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting activator endpoints: %v", err)
 	}

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -35,8 +35,8 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/networking"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	ping "knative.dev/serving/test/test_images/grpc-ping/proto"
@@ -215,7 +215,7 @@ func TestGRPCStreamingPing(t *testing.T) {
 
 func waitForActivatorEPS(resources *v1a1test.ResourceObjects, clients *test.Clients) error {
 	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
-		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting activator endpoints: %v", err)
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -30,7 +30,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
-	"knative.dev/serving/pkg/activator"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/networking"
 	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	. "knative.dev/serving/pkg/testing/v1alpha1"
@@ -237,7 +237,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	}
 
 	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
-		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting activator endpoints: %v", err)
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -31,8 +31,8 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/networking"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -166,7 +166,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	}
 
 	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
-		system.Namespace()).Get(activator.K8sServiceName, metav1.GetOptions{})
+		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting activator endpoints: %v", err)
 	}


### PR DESCRIPTION
We need to reference the activator service name constant from within the
activator package in #5008. Move this constant to the API package which
is a better location.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
