### PR TITLE
Refactor autoscaling e2e tests

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
+	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -49,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -69,6 +71,34 @@ type testContext struct {
 	targetUtilization float64
 	targetValue       int
 	metric            string
+}
+
+func getVegetaTarget(kubeClientset *kubernetes.Clientset, domain, endpointOverride string, resolvable bool) (vegeta.Target, error) {
+	if resolvable {
+		return vegeta.Target{
+			Method: "GET",
+			URL:    fmt.Sprintf("http://%s?sleep=100", domain),
+		}, nil
+	}
+
+	endpoint := &endpointOverride
+	if endpointOverride == "" {
+		var err error
+		// If the domain that the Route controller is configured to assign to Route.Status.Domain
+		// (the domainSuffix) is not resolvable, we need to retrieve the endpoint and spoof
+		// the Host in our requests.
+		if endpoint, err = ingress.GetIngressEndpoint(kubeClientset); err != nil {
+			return vegeta.Target{}, err
+		}
+	}
+
+	h := http.Header{}
+	h.Set("Host", domain)
+	return vegeta.Target{
+		Method: "GET",
+		URL:    fmt.Sprintf("http://%s?sleep=100", *endpoint),
+		Header: h,
+	}, nil
 }
 
 func generateTraffic(ctx *testContext, concurrency int, duration time.Duration, stopChan chan struct{}) error {
@@ -136,9 +166,10 @@ func generateTrafficAtFixedRPS(ctx *testContext, rps int, duration time.Duration
 	)
 
 	rate := vegeta.Rate{Freq: rps, Per: time.Second}
-	target := vegeta.Target{
-		Method: "GET",
-		URL:    fmt.Sprintf("http://%s?sleep=100", ctx.domain),
+	target, err := getVegetaTarget(
+		ctx.clients.KubeClient.Kube, ctx.domain, pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		return fmt.Errorf("error creating vegeta target: %v", err)
 	}
 	targeter := vegeta.NewStaticTargeter(target)
 	attacker := vegeta.NewAttacker(vegeta.Timeout(duration))

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -371,7 +371,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, 10, targetUtilization,
+	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey:                "7",
 			autoscaling.PanicThresholdPercentageAnnotationKey: "200", // makes panicking rare
@@ -452,7 +452,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, 10, targetUtilization,
+	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}))

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -406,8 +406,6 @@ func TestRPSBasedAutoscaleUpCountPods(t *testing.T) {
 	defer cancel()
 
 	ctx := setup(t, autoscaling.KPA, autoscaling.RPS, 10, targetUtilization)
-	ctx.targetUtilization = 0.7
-	ctx.targetValue = 10
 	defer test.TearDown(ctx.clients, ctx.names)
 
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -137,7 +138,7 @@ func generateTraffic(ctx *testContext, concurrency int, duration time.Duration, 
 					}
 
 					if res.StatusCode != http.StatusOK {
-						ctx.t.Logf("Status = %d, want: %d", res.StatusCode, http.StatusOK)
+						ctx.t.Logf("Status = %d, want: 200", res.StatusCode)
 						ctx.t.Logf("Response: %s", res)
 						continue
 					}
@@ -192,7 +193,7 @@ func generateTrafficAtFixedRPS(ctx *testContext, rps int, duration time.Duration
 
 			atomic.AddInt32(&totalRequests, 1)
 			if res.Code != http.StatusOK {
-				ctx.t.Logf("Status = %d, want: %d", res.Code, http.StatusOK)
+				ctx.t.Logf("Status = %d, want: 200", res.Code)
 				ctx.t.Logf("Response: %v", res)
 				continue
 			}
@@ -226,8 +227,8 @@ func setup(t *testing.T, class, metric string, target int, targetUtilization flo
 		append(fopts, rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:             class,
 			autoscaling.MetricAnnotationKey:            metric,
-			autoscaling.TargetAnnotationKey:            fmt.Sprintf("%v", target),
-			autoscaling.TargetUtilizationPercentageKey: fmt.Sprintf("%f", targetUtilization*100),
+			autoscaling.TargetAnnotationKey:            strconv.FormatFloat(float64(target), 'f', -1, 64),
+			autoscaling.TargetUtilizationPercentageKey: strconv.FormatFloat(targetUtilization*100, 'f', -1, 64),
 		}), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("512Mi"),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #5217. I separate #5244 to see how the newly added e2e test impacts e2e tests flakiness.

## Proposed Changes

* Make `target` and `targetUtilization` as required args for `setup` function instead of using the global constants defined in test or from configmap.

