### PR TITLE
Remove injection setting to default namespace in e2e test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -138,7 +138,6 @@ function install_knative_serving() {
     return
   fi
   echo ">> Installing Knative serving from custom YAMLs"
-  kubectl label namespace default istio-injection=enabled
   echo "Custom YAML files: ${INSTALL_CUSTOM_YAMLS}"
   for yaml in ${INSTALL_CUSTOM_YAMLS}; do
     echo "Installing '${yaml}'"


### PR DESCRIPTION
## Proposed Changes

When running e2e tests with custom YAMLs, e2e-common.sh adds
`istio-injection=enabled` to default namespace.
It is not necessary and may cause some trouble after the tests.

This patch removes the addition of the label.

**Release Note**

```release-note
NONE
```
