### PR TITLE
Enable mTLS on services in serving-tests ns when mesh is enabled for e2e test

### DIFF
--- a/test/config/mtls/destinationrule.yaml
+++ b/test/config/mtls/destinationrule.yaml
@@ -1,0 +1,34 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "mtls-services"
+  namespace: "serving-tests"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    # Do not use mTLS for metric ports as tests fail when istio injection is disabled
+    # for services. - e.g TestServiceToServiceCallViaActivator/*-disabled
+    # autoscaler, which has istio-proxy, fails to access without these config.
+    PortTrafficPolicy:
+      port: 9090
+      tls:
+        mode: DISABLE
+      port: 9091
+      tls:
+        mode: DISABLE

--- a/test/config/mtls/policy.yaml
+++ b/test/config/mtls/policy.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+  namespace: "serving-tests"
+spec:
+  peers:
+  - mtls:
+    # Currently STRICT does not work when istio injection is enabled,
+    # as autoscaler fails to access metric ports.
+    # - e.g TestServiceToServiceCallViaActivator/both-enabled
+     mode: PERMISSIVE

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -333,6 +333,9 @@ function test_setup() {
 
   echo ">> Creating test resources (test/config/)"
   ko apply ${KO_FLAGS} -f test/config/ || return 1
+  if (( ISTIO_MESH )); then 
+    ko apply ${KO_FLAGS} -f test/config/mtls/ || return 1
+  fi
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
   wait_until_pods_running knative-serving || return 1
   if [[ -z "${GLOO_VERSION}" ]]; then
@@ -355,6 +358,7 @@ function test_setup() {
 function test_teardown() {
   echo ">> Removing test resources (test/config/)"
   ko delete --ignore-not-found=true --now -f test/config/
+  (( ISTIO_MESH )) && ko delete --ignore-not-found=true --now -f test/config/mtls/
   echo ">> Ensuring test namespaces are clean"
   kubectl delete all --all --ignore-not-found --now --timeout 60s -n serving-tests
   kubectl delete --ignore-not-found --now --timeout 60s namespace serving-tests


### PR DESCRIPTION
## Proposed Changes

Current e2e test does not enable mTLS config during e2e test.

This patch adds DestinationRule and Policy in serving-tests namespace
when mesh is enabled for e2e test, so services in serving-tests namespace 
uses mTLS for each access.

/lint

Fixes https://github.com/knative/serving/issues/3584

**Release Note**

```release-note
NONE
```
