### PR TITLE
This picks up the changes to how we do global resyncs.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1655,7 +1655,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4ede44d732fec3c64776a5ec3897efc2b5fbd42dd014f9bde56e69f3bece21e1"
+  digest = "1:548b1d27f85504952643a8673792d31d7d216678476ad091190c0b55c18d3a04"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1754,7 +1754,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "366ab85660d4e1c260795bd23c2aa09a4721c282"
+  revision = "1a3a36a996dec7645bee7084153ef8b7273e1028"
 
 [[projects]]
   branch = "master"

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -93,7 +93,7 @@ func NewController(
 		&autoscaler.Config{},
 	}
 	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		controller.SendGlobalUpdates(paInformer.Informer(), paHandler)
+		impl.FilteredGlobalResync(onlyHpaClass, paInformer.Informer())
 	})
 	configStore := config.NewStore(c.Logger.Named("config-store"), resync)
 	configStore.WatchConfigs(cmw)

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -106,7 +106,7 @@ func NewController(
 		&autoscaler.Config{},
 	}
 	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		controller.SendGlobalUpdates(paInformer.Informer(), paHandler)
+		impl.FilteredGlobalResync(onlyKpaClass, paInformer.Informer())
 	})
 	configStore := config.NewStore(c.Logger.Named("config-store"), resync)
 	configStore.WatchConfigs(cmw)

--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -105,7 +105,7 @@ func (c *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 		&network.Config{},
 	}
 	resyncIngressesOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		controller.SendGlobalUpdates(clusterIngressInformer.Informer(), clusterIngressHandler)
+		impl.FilteredGlobalResync(myFilterFunc, clusterIngressInformer.Informer())
 	})
 	configStore := config.NewStore(c.Logger.Named("config-store"), resyncIngressesOnConfigChange)
 	configStore.WatchConfigs(cmw)

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -163,7 +163,7 @@ func (r *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 		&network.Config{},
 	}
 	resyncIngressesOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		controller.SendGlobalUpdates(ingressInformer.Informer(), ingressHandler)
+		impl.FilteredGlobalResync(myFilterFunc, ingressInformer.Informer())
 	})
 	configStore := config.NewStore(r.Logger.Named("config-store"), resyncIngressesOnConfigChange)
 	configStore.WatchConfigs(cmw)

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -1326,6 +1326,7 @@
     "k8s.io/client-go/informers/rbac/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/vendor/knative.dev/pkg/controller/controller.go
+++ b/vendor/knative.dev/pkg/controller/controller.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -255,12 +256,14 @@ func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj in
 // EnqueueKey takes a namespace/name string and puts it onto the work queue.
 func (c *Impl) EnqueueKey(key string) {
 	c.WorkQueue.Add(key)
+	c.logger.Debugf("Adding to queue %s (depth: %d)", key, c.WorkQueue.Len())
 }
 
 // EnqueueKeyAfter takes a namespace/name string and schedules its execution in
 // the work queue after given delay.
 func (c *Impl) EnqueueKeyAfter(key string, delay time.Duration) {
 	c.WorkQueue.AddAfter(key, delay)
+	c.logger.Debugf("Adding to queue %s (delay: %v, depth: %d)", key, delay, c.WorkQueue.Len())
 }
 
 // Run starts the controller's worker threads, the number of which is threadiness.
@@ -299,6 +302,8 @@ func (c *Impl) processNextWorkItem() bool {
 		return false
 	}
 	key := obj.(string)
+
+	c.logger.Debugf("Processing from queue %s (depth: %d)", key, c.WorkQueue.Len())
 
 	startTime := time.Now()
 	// Send the metrics for the current queue depth
@@ -347,16 +352,28 @@ func (c *Impl) handleErr(err error, key string) {
 	// Re-queue the key if it's an transient error.
 	if !IsPermanentError(err) {
 		c.WorkQueue.AddRateLimited(key)
+		c.logger.Debugf("Requeuing key %s due to non-permanent error (depth: %d)", key, c.WorkQueue.Len())
 		return
 	}
 
 	c.WorkQueue.Forget(key)
 }
 
-// GlobalResync enqueues all objects from the passed SharedInformer
+// GlobalResync enqueues (with a delay) all objects from the passed SharedInformer
 func (c *Impl) GlobalResync(si cache.SharedInformer) {
-	for _, key := range si.GetStore().ListKeys() {
-		c.EnqueueKey(key)
+	alwaysTrue := func(interface{}) bool { return true }
+	c.FilteredGlobalResync(alwaysTrue, si)
+}
+
+// FilteredGlobalResync enqueues (with a delay) all objects from the
+// SharedInformer that pass the filter function
+func (c *Impl) FilteredGlobalResync(f func(interface{}) bool, si cache.SharedInformer) {
+	list := si.GetStore().List()
+	count := float64(len(list))
+	for _, obj := range list {
+		if f(obj) {
+			c.EnqueueAfter(obj, wait.Jitter(time.Second, count))
+		}
 	}
 }
 

--- a/vendor/knative.dev/pkg/controller/helper.go
+++ b/vendor/knative.dev/pkg/controller/helper.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
 	"knative.dev/pkg/kmeta"
 )
@@ -49,19 +48,5 @@ func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 
 		// Pass in the mutated copy (accessor is not just a type cast)
 		f(copy)
-	}
-}
-
-// SendGlobalUpdates triggers an update event for all objects from the
-// passed SharedInformer.
-//
-// Since this is triggered not by a real update of these objects
-// themselves, we have no way of knowing the change to these objects
-// if any, so we call handler.OnUpdate(obj, obj) for all of them
-// regardless if they have changes or not.
-func SendGlobalUpdates(si cache.SharedInformer, handler cache.ResourceEventHandler) {
-	store := si.GetStore()
-	for _, obj := range store.List() {
-		handler.OnUpdate(obj, obj)
 	}
 }

--- a/vendor/knative.dev/pkg/network/doc.go
+++ b/vendor/knative.dev/pkg/network/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package network holds the typed objects that define the schemas for
+// configuring the knative networking layer.
+package network

--- a/vendor/knative.dev/pkg/network/domain.go
+++ b/vendor/knative.dev/pkg/network/domain.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	resolverFileName  = "/etc/resolv.conf"
+	defaultDomainName = "cluster.local"
+)
+
+var (
+	domainName string
+	once       sync.Once
+)
+
+// GetServiceHostname returns the fully qualified service hostname
+func GetServiceHostname(name string, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc.%s", name, namespace, GetClusterDomainName())
+}
+
+// GetClusterDomainName returns cluster's domain name or an error
+// Closes issue: https://github.com/knative/eventing/issues/714
+func GetClusterDomainName() string {
+	once.Do(func() {
+		f, err := os.Open(resolverFileName)
+		if err == nil {
+			defer f.Close()
+			domainName = getClusterDomainName(f)
+
+		} else {
+			domainName = defaultDomainName
+		}
+	})
+
+	return domainName
+}
+
+func getClusterDomainName(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		elements := strings.Split(scanner.Text(), " ")
+		if elements[0] != "search" {
+			continue
+		}
+		for i := 1; i < len(elements)-1; i++ {
+			if strings.HasPrefix(elements[i], "svc.") {
+				return strings.TrimSuffix(elements[i][4:], ".")
+			}
+		}
+	}
+	// For all abnormal cases return default domain name
+	return defaultDomainName
+}

--- a/vendor/knative.dev/pkg/resolver/addressable_resolver.go
+++ b/vendor/knative.dev/pkg/resolver/addressable_resolver.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"knative.dev/pkg/apis"
+	pkgapisduck "knative.dev/pkg/apis/duck"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/network"
+	"knative.dev/pkg/tracker"
+
+	"knative.dev/pkg/injection/clients/dynamicclient"
+)
+
+// URIResolver resolves Destinations and ObjectReferences into a URI.
+type URIResolver struct {
+	tracker         tracker.Interface
+	informerFactory pkgapisduck.InformerFactory
+}
+
+// NewURIResolver constructs a new URIResolver with context and a callback passed to the URIResolver's tracker.
+func NewURIResolver(ctx context.Context, callback func(string)) *URIResolver {
+	ret := &URIResolver{}
+
+	ret.tracker = tracker.New(callback, controller.GetTrackerLease(ctx))
+	ret.informerFactory = &pkgapisduck.CachedInformerFactory{
+		Delegate: &pkgapisduck.EnqueueInformerFactory{
+			Delegate: &pkgapisduck.TypedInformerFactory{
+				Client:       dynamicclient.Get(ctx),
+				Type:         &duckv1beta1.AddressableType{},
+				ResyncPeriod: controller.GetResyncPeriod(ctx),
+				StopChannel:  ctx.Done(),
+			},
+			EventHandler: controller.HandleAll(ret.tracker.OnChanged),
+		},
+	}
+
+	return ret
+}
+
+// URIFromDestination resolves a Destination into a URI string.
+func (r *URIResolver) URIFromDestination(dest apisv1alpha1.Destination, parent interface{}) (string, error) {
+	// Prefer resolved object reference + path, then try URI + path, honoring the Destination documentation
+	if dest.ObjectReference != nil {
+		url, err := r.URIFromObjectReference(dest.ObjectReference, parent)
+		if err != nil {
+			return "", err
+		}
+		return extendPath(url, dest.Path).String(), nil
+	}
+
+	if dest.URI != nil {
+		return extendPath(dest.URI, dest.Path).String(), nil
+	}
+
+	return "", fmt.Errorf("destination missing ObjectReference and URI, expected exactly one")
+}
+
+// URIFromObjectReference resolves an ObjectReference to a URI string.
+func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent interface{}) (*apis.URL, error) {
+	if ref == nil {
+		return nil, errors.New("ref is nil")
+	}
+
+	if err := r.tracker.Track(*ref, parent); err != nil {
+		return nil, fmt.Errorf("failed to track %+v: %v", ref, err)
+	}
+
+	// K8s Services are special cased. They can be called, even though they do not satisfy the
+	// Callable interface.
+	// TODO(spencer-p,n3wscott) Verify that the service actually exists in K8s.
+	if ref.APIVersion == "v1" && ref.Kind == "Service" {
+		url := &apis.URL{
+			Scheme: "http",
+			Host:   ServiceHostName(ref.Name, ref.Namespace),
+			Path:   "/",
+		}
+		return url, nil
+	}
+
+	gvr, _ := meta.UnsafeGuessKindToResource(ref.GroupVersionKind())
+	_, lister, err := r.informerFactory.Get(gvr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lister for %+v: %v", gvr, err)
+	}
+
+	obj, err := lister.ByNamespace(ref.Namespace).Get(ref.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ref %+v: %v", ref, err)
+	}
+
+	addressable, ok := obj.(*duckv1beta1.AddressableType)
+	if !ok {
+		return nil, fmt.Errorf("%+v is not an AddressableType", ref)
+	}
+	if addressable.Status.Address == nil {
+		return nil, fmt.Errorf("address not set for %+v", ref)
+	}
+	url := addressable.Status.Address.URL
+	if url == nil {
+		return nil, fmt.Errorf("url missing in address of %+v", ref)
+	}
+	if url.Host == "" {
+		return nil, fmt.Errorf("hostname missing in address of %+v", ref)
+	}
+	return url, nil
+}
+
+// extendPath is a convenience wrapper to add a destination's path.
+func extendPath(url *apis.URL, extrapath *string) *apis.URL {
+	if extrapath == nil {
+		return url
+	}
+
+	url.Path = path.Join(url.Path, *extrapath)
+	return url
+}
+
+// ServiceHostName resolves the hostname for a Kubernetes Service.
+func ServiceHostName(serviceName, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, network.GetClusterDomainName())
+}

--- a/vendor/knative.dev/pkg/resolver/doc.go
+++ b/vendor/knative.dev/pkg/resolver/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resolver implements resolvers for resolving k8s references and URIs.
+package resolver


### PR DESCRIPTION
https://github.com/knative/pkg/pull/597 changed the way we handle
global resyncs to combine the two approaches we use today and add
a jitter to alleviate an issue we were seeing at scale.

