### PR TITLE
Release 8.1

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -117,6 +117,7 @@ func (a *activationHandler) probeEndpoint(logger *zap.SugaredLogger, r *http.Req
 			url,
 			prober.WithHeader(network.ProbeHeaderName, queue.Name),
 			prober.ExpectsBody(queue.Name),
+			prober.ExpectsStatusCodes([]int{http.StatusOK}),
 			withOrigProto(r))
 		if err != nil {
 			logger.Warnw("Pod probe failed", zap.Error(err))

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -137,7 +137,8 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 	}
 	return prober.Do(ctx, rw.transport, httpDest.String(),
 		prober.WithHeader(network.ProbeHeaderName, queue.Name),
-		prober.ExpectsBody(queue.Name))
+		prober.ExpectsBody(queue.Name),
+		prober.ExpectsStatusCodes([]int{http.StatusOK}))
 
 }
 

--- a/pkg/network/prober/prober.go
+++ b/pkg/network/prober/prober.go
@@ -57,6 +57,18 @@ func ExpectsBody(body string) Verifier {
 	}
 }
 
+// ExpectsStatusCodes validates that the given status code of the probe response matches the provided int.
+func ExpectsStatusCodes(statusCodes []int) Verifier {
+	return func(r *http.Response, _ []byte) (bool, error) {
+		for _, v := range statusCodes {
+			if r.StatusCode == v {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}
+
 // Do sends a single probe to given target, e.g. `http://revision.default.svc.cluster.local:81`.
 // Do returns whether the probe was successful or not, or there was an error probing.
 func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...interface{}) (bool, error) {
@@ -89,7 +101,7 @@ func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...
 			}
 		}
 	}
-	return resp.StatusCode == http.StatusOK, nil
+	return true, nil
 }
 
 // Done is a callback that is executed when the async probe has finished.

--- a/pkg/network/prober/prober_test.go
+++ b/pkg/network/prober/prober_test.go
@@ -73,7 +73,7 @@ func TestDoServing(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue))
+			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue), ExpectsStatusCodes([]int{http.StatusOK}))
 			if want := test.want; got != want {
 				t.Errorf("Got = %v, want: %v", got, want)
 			}
@@ -90,7 +90,7 @@ func TestBlackHole(t *testing.T) {
 			Timeout: 10 * time.Millisecond,
 		}).Dial,
 	}
-	got, err := Do(context.Background(), transport, "http://gone.fishing.svc.custer.local:8080")
+	got, err := Do(context.Background(), transport, "http://gone.fishing.svc.custer.local:8080", ExpectsStatusCodes([]int{http.StatusOK}))
 	if want := false; got != want {
 		t.Errorf("Got = %v, want: %v", got, want)
 	}
@@ -100,7 +100,7 @@ func TestBlackHole(t *testing.T) {
 }
 
 func TestBadURL(t *testing.T) {
-	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo")
+	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo", ExpectsStatusCodes([]int{http.StatusOK}))
 	if err == nil {
 		t.Error("Do did not return an error")
 	}
@@ -158,7 +158,7 @@ func TestDoAsync(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			m := New(test.cb, network.NewProberTransport())
-			m.Offer(context.Background(), ts.URL, test.name, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue))
+			m.Offer(context.Background(), ts.URL, test.name, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(test.headerValue), ExpectsStatusCodes([]int{http.StatusOK}))
 			<-wch
 		})
 	}
@@ -195,7 +195,7 @@ func TestDoAsyncRepeat(t *testing.T) {
 		wch <- arg
 	}
 	m := New(cb, network.NewProberTransport())
-	m.Offer(context.Background(), ts.URL, 42, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, systemName), ExpectsBody(systemName))
+	m.Offer(context.Background(), ts.URL, 42, probeInterval, probeTimeout, WithHeader(network.ProbeHeaderName, systemName), ExpectsBody(systemName), ExpectsStatusCodes([]int{http.StatusOK}))
 	<-wch
 	if got, want := c.calls, 3; got != want {
 		t.Errorf("Probe invocation count = %d, want: %d", got, want)
@@ -218,7 +218,7 @@ func TestDoAsyncTimeout(t *testing.T) {
 		wch <- arg
 	}
 	m := New(cb, network.NewProberTransport())
-	m.Offer(context.Background(), ts.URL, 2009, probeInterval, probeTimeout)
+	m.Offer(context.Background(), ts.URL, 2009, probeInterval, probeTimeout, ExpectsStatusCodes([]int{http.StatusOK}))
 	<-wch
 }
 
@@ -233,10 +233,10 @@ func TestAsyncMultiple(t *testing.T) {
 		wch <- 2006
 	}
 	m := New(cb, network.NewProberTransport())
-	if !m.Offer(context.Background(), ts.URL, 1984, probeInterval, probeTimeout) {
+	if !m.Offer(context.Background(), ts.URL, 1984, probeInterval, probeTimeout, ExpectsStatusCodes([]int{http.StatusOK})) {
 		t.Error("First call to offer returned false")
 	}
-	if m.Offer(context.Background(), ts.URL, 1982, probeInterval, probeTimeout) {
+	if m.Offer(context.Background(), ts.URL, 1982, probeInterval, probeTimeout, ExpectsStatusCodes([]int{http.StatusOK})) {
 		t.Error("Second call to offer returned true")
 	}
 	if got, want := m.len(), 1; got != want {
@@ -270,14 +270,15 @@ func TestWithHostOption(t *testing.T) {
 		success bool
 	}{{
 		name:    "no hosts",
+		options: []interface{}{ExpectsStatusCodes([]int{http.StatusOK})},
 		success: false,
 	}, {
 		name:    "expected host",
-		options: []interface{}{WithHost(host)},
+		options: []interface{}{WithHost(host), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: true,
 	}, {
 		name:    "wrong host",
-		options: []interface{}{WithHost("nope.com")},
+		options: []interface{}{WithHost("nope.com"), ExpectsStatusCodes([]int{http.StatusOK})},
 		success: false,
 	}}
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -67,6 +67,7 @@ const (
 var probeOptions = []interface{}{
 	prober.WithHeader(network.ProbeHeaderName, activator.Name),
 	prober.ExpectsBody(activator.Name),
+	prober.ExpectsStatusCodes([]int{http.StatusOK}),
 }
 
 // for mocking in tests

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -282,3 +282,16 @@ func isDefaultServer(server *v1alpha3.Server) bool {
 func isPlaceHolderServer(server *v1alpha3.Server) bool {
 	return equality.Semantic.DeepEqual(server, &placeholderServer)
 }
+
+// CanProbeGateway return whether the specified Gateway can be probed using HTTP on port 80.
+func CanProbeGateway(gateway *v1alpha3.Gateway) bool {
+	for _, server := range gateway.Spec.Servers {
+		if len(server.Hosts) == 1 &&
+			server.Hosts[0] == "*" &&
+			server.Port.Number == 80 &&
+			server.Port.Protocol == v1alpha3.ProtocolHTTP {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -627,3 +627,89 @@ func TestGatewayName(t *testing.T) {
 		t.Errorf("Unexpected gateway name. want %q, got %q", want, got)
 	}
 }
+
+func TestCanProbeGateway(t *testing.T) {
+	cases := []struct {
+		name string
+		gateway  *v1alpha3.Gateway
+		canProbe bool
+	}{{
+		name: "wildcard HTTP on port 80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 80,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: true,
+	},{
+		name: "specific host HTTP on port 80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"foo.bar.com"},
+					Port:v1alpha3.Port{
+						Number: 100,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	},{
+		name: "wildcard HTTP on port !80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 100,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	},{
+		name: "wildcard TCP on port 80",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 80,
+						Protocol: v1alpha3.ProtocolTCP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	},{
+		name: "wildcard HTTPS on port 443",
+		gateway: &v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{{
+					Hosts: []string{"*"},
+					Port:v1alpha3.Port{
+						Number: 100,
+						Protocol: v1alpha3.ProtocolHTTP,
+					},
+				}},
+			},
+		},
+		canProbe: false,
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := CanProbeGateway(c.gateway)
+			if got != c.canProbe {
+				t.Errorf("Expected %t, got %t", c.canProbe, got)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -260,7 +260,9 @@ func (m *StatusProber) processWorkItem() bool {
 		item.context,
 		m.transportFactory(),
 		fmt.Sprintf("http://%s/", item.podIP),
-		prober.WithHost(item.probeHost))
+		prober.WithHost(item.probeHost),
+		prober.ExpectsStatusCodes([]int{http.StatusOK, http.StatusMovedPermanently}),
+	)
 
 	// In case of cancellation, drop the work item
 	select {
@@ -303,6 +305,11 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 		gateway, err := m.gatewayLister.Gateways(namespace).Get(name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Gateway %s/%s: %v", namespace, name, err)
+		}
+
+		// Skip gateways that cannot be probed
+		if !resources.CanProbeGateway(gateway) {
+			continue
 		}
 
 		// List matching Pods

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -85,6 +85,13 @@ func TestIsReadyFailures(t *testing.T) {
 					Name:      "gateway",
 				},
 				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port:v1alpha3.Port{
+							Number: 80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
 					Selector: map[string]string{
 						"gwt": "istio",
 					},
@@ -160,6 +167,13 @@ func TestProbeLifecycle(t *testing.T) {
 					Name:      "gateway",
 				},
 				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port:v1alpha3.Port{
+							Number: 80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
 					Selector: map[string]string{
 						"gwt": "istio",
 					},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
/assign tcnhia
-->

Knative Serving 8.1

Contains
* https://github.com/knative/serving/pull/5194
* #5149


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Adds VirtualService probing support for HTTP redirect
* Disables VirtualService probing for unsupported Gateways
```
