### PR TITLE
Run the deployment prober for longer.

### DIFF
--- a/test/performance/deployment-probe/benchmark.yaml
+++ b/test/performance/deployment-probe/benchmark.yaml
@@ -47,7 +47,7 @@ kind: CronJob
 metadata:
   name: deployment-probe
 spec:
-  # Run 15 minutes past the hour for 25 minutes.
+  # Run 15 minutes past the hour for 35 minutes.
   schedule: "15 * * * *"
   jobTemplate:
     spec:
@@ -60,7 +60,7 @@ spec:
             image: knative.dev/serving/test/performance/deployment-probe
             args:
             - "-template=basic"
-            - "-duration=25m"
+            - "-duration=35m"
             - "-frequency=5s"
             resources:
               requests:

--- a/test/performance/deployment-probe/sla.go
+++ b/test/performance/deployment-probe/sla.go
@@ -45,15 +45,15 @@ func newDeploy95PercentileLatency(tags ...string) *tpb.ThresholdAnalyzerInput {
 }
 
 // This analyzer validates that the number of services deployed to "Ready=True".
-// Configured to run for 25m with a frequency of 5s, the theoretical limit is 300
+// Configured to run for 35m with a frequency of 5s, the theoretical limit is 420
 // if deployments take 0s.  Factoring in deployment latency, we will miss a
-// handful of the trailing deployments, so we relax this to 295.
+// handful of the trailing deployments, so we relax this to 410.
 func newReadyDeploymentCount(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
 		Name: proto.String("Ready deployment count"),
 		Configs: []*tpb.ThresholdConfig{{
-			Min: proto.Float64(295),
-			Max: proto.Float64(300),
+			Min: proto.Float64(410),
+			Max: proto.Float64(420),
 			DataFilter: &mpb.DataFilter{
 				DataType: mpb.DataFilter_METRIC_AGGREGATE_COUNT.Enum(),
 				ValueKey: proto.String("dl"),


### PR DESCRIPTION
This benchmark originally ran twice an hour for 25 minutes, but one run was being truncated by the hourly serving install, which aborts in-progress jobs, which lead to reporting the partial data for the run, which consistently tripped our analyzers.  Now that this runs once an hour, run it for longer.
