### PR TITLE
Add RPS support for HPA

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -53,8 +53,7 @@ func (pa *PodAutoscaler) validateMetric() *apis.FieldError {
 			}
 		case autoscaling.HPA:
 			switch metric {
-			// TODO(yanweiguo): implement RPS autoscaling for HPA.
-			case autoscaling.CPU, autoscaling.Concurrency:
+			case autoscaling.CPU, autoscaling.Concurrency, autoscaling.RPS:
 				return nil
 			}
 		default:

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -231,6 +231,26 @@ func TestPodAutoscalerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "valid, HPA with RPS",
+		r: &PodAutoscaler{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					"autoscaling.knative.dev/metric": "rps",
+					"autoscaling.knative.dev/class":  "hpa.autoscaling.knative.dev",
+				},
+			},
+			Spec: PodAutoscalerSpec{
+				ScaleTargetRef: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+				},
+				ProtocolType: net.ProtocolH2C,
+			},
+		},
+		want: nil,
+	}, {
 		name: "bad protocol",
 		r: &PodAutoscaler{
 			ObjectMeta: v1.ObjectMeta{

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -135,7 +135,7 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 	}
 
 	// Only create metrics service and metric entity if we actually need to gather metrics.
-	if pa.Metric() == autoscaling.Concurrency {
+	if pa.Metric() == autoscaling.Concurrency || pa.Metric() == autoscaling.RPS {
 		metricSvc, err := c.ReconcileMetricsService(ctx, pa)
 		if err != nil {
 			return perrors.Wrap(err, "error reconciling metrics service")

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -116,7 +116,7 @@ func TestReconcile(t *testing.T) {
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet")),
 		}},
 	}, {
-		Name: "create hpa, sks and metric service",
+		Name: "create hpa, sks and metric service when Concurrency used",
 		Objects: []runtime.Object{
 			pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency)),
 			deploy(testNamespace, testRevision),
@@ -134,6 +134,28 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency),
+				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
+				WithMSvcStatus(testRevision+"-00001")),
+		}},
+	}, {
+		Name: "create hpa, sks and metric service when RPS used",
+		Objects: []runtime.Object{
+			pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.RPS)),
+			deploy(testNamespace, testRevision),
+		},
+		Key: key(testNamespace, testRevision),
+		WantCreates: []runtime.Object{
+			metric(pa(testNamespace, testRevision,
+				WithHPAClass, WithMetricAnnotation(autoscaling.RPS)), testRevision+"-00001"),
+			sks(testNamespace, testRevision, WithDeployRef(deployName)),
+			hpa(pa(testNamespace, testRevision,
+				WithHPAClass, WithMetricAnnotation(autoscaling.RPS))),
+			metricsSvc(testNamespace, testRevision, WithSvcSelector(usualSelector),
+				SvcWithAnnotationValue(autoscaling.ClassAnnotationKey, autoscaling.HPA),
+				SvcWithAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.RPS)),
+		},
+		WantStatusUpdates: []ktesting.UpdateActionImpl{{
+			Object: pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.RPS),
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
 				WithMSvcStatus(testRevision+"-00001")),
 		}},

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -146,7 +146,7 @@ func TestReconcile(t *testing.T) {
 		Key: key(testNamespace, testRevision),
 		WantCreates: []runtime.Object{
 			metric(pa(testNamespace, testRevision,
-				WithHPAClass, WithMetricAnnotation(autoscaling.RPS)), testRevision+"-00001"),
+				WithHPAClass, WithMetricAnnotation(autoscaling.RPS)), testRevision+"-metrics"),
 			sks(testNamespace, testRevision, WithDeployRef(deployName)),
 			hpa(pa(testNamespace, testRevision,
 				WithHPAClass, WithMetricAnnotation(autoscaling.RPS))),
@@ -157,7 +157,7 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.RPS),
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
-				WithMSvcStatus(testRevision+"-00001")),
+				WithMSvcStatus(testRevision+"-metrics")),
 		}},
 	}, {
 		Name: "reconcile sks is still not ready",

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -70,7 +70,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 				},
 			}}
 		}
-	case autoscaling.Concurrency:
+	case autoscaling.Concurrency, autoscaling.RPS:
 		t, _ := aresources.ResolveMetricTarget(pa, config)
 		target := int64(math.Ceil(t))
 		hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
@@ -81,7 +81,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) *autoscaling
 					Kind:       "revision",
 					Name:       pa.Name,
 				},
-				MetricName:   autoscaling.Concurrency,
+				MetricName:   pa.Metric(),
 				AverageValue: resource.NewQuantity(target, resource.DecimalSI),
 				TargetValue:  *resource.NewQuantity(target, resource.DecimalSI),
 			},

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -122,6 +122,43 @@ func TestMakeHPA(t *testing.T) {
 					TargetValue:  *resource.NewQuantity(50, resource.DecimalSI),
 				},
 			})),
+	}, {
+		name: "with metric=RPS",
+		pa:   pa(WithMetricAnnotation(autoscaling.RPS)),
+		want: hpa(
+			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.RPS),
+			withMetric(autoscalingv2beta1.MetricSpec{
+				Type: autoscalingv2beta1.ObjectMetricSourceType,
+				Object: &autoscalingv2beta1.ObjectMetricSource{
+					Target: autoscalingv2beta1.CrossVersionObjectReference{
+						APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "revision",
+						Name:       testName,
+					},
+					MetricName:   autoscaling.RPS,
+					AverageValue: resource.NewQuantity(200, resource.DecimalSI),
+					TargetValue:  *resource.NewQuantity(200, resource.DecimalSI),
+				},
+			})),
+	}, {
+		name: "with metric=RPS and target=50",
+		pa:   pa(WithTargetAnnotation("50"), WithMetricAnnotation(autoscaling.RPS)),
+		want: hpa(
+			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.RPS),
+			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
+			withMetric(autoscalingv2beta1.MetricSpec{
+				Type: autoscalingv2beta1.ObjectMetricSourceType,
+				Object: &autoscalingv2beta1.ObjectMetricSource{
+					Target: autoscalingv2beta1.CrossVersionObjectReference{
+						APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "revision",
+						Name:       testName,
+					},
+					MetricName:   autoscaling.RPS,
+					AverageValue: resource.NewQuantity(50, resource.DecimalSI),
+					TargetValue:  *resource.NewQuantity(50, resource.DecimalSI),
+				},
+			})),
 	}}
 
 	for _, tc := range cases {
@@ -230,6 +267,8 @@ var config = &autoscaler.Config{
 	EnableScaleToZero:                  true,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
+	RPSTargetDefault:                   200.0,
+	TargetUtilization:                  1.0,
 	MaxScaleUpRate:                     10.0,
 	StableWindow:                       60 * time.Second,
 	PanicThresholdPercentage:           200,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5216

## Proposed Changes

* Allow HPA to use RPS metric as annotation.
* Add RPS support for HPA.
* The `MetricProvider` change was done in #5238.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Autoscaling using HPA supports requests-per-second as metric. 
```
