### PR TITLE
Fix for latestRevision routes may point to older revisions if latestCreated is not ready

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -204,10 +204,6 @@ func (c *Reconciler) findAndSetLatestReadyRevision(config *v1alpha1.Configuratio
 	}
 	for _, rev := range sortedRevisions {
 		if rev.Status.IsReady() {
-			// No need to update latest ready revision in this case
-			if rev.Name == config.Status.LatestReadyRevisionName && !lcrReady {
-				return nil
-			}
 			old, new := config.Status.LatestReadyRevisionName, rev.Name
 			config.Status.SetLatestReadyRevisionName(rev.Name)
 			if old != new {

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -187,17 +187,14 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 		return fmt.Errorf("unrecognized condition status: %v on revision %q", rc.Status, revName)
 	}
 
-	lcrReady := rc != nil && rc.Status == corev1.ConditionTrue
-	if err = c.findAndSetLatestReadyRevision(config, lcrReady); err != nil {
+	if err = c.findAndSetLatestReadyRevision(config); err != nil {
 		return fmt.Errorf("failed to find and set latest ready revision: %w", err)
 	}
-
 	return nil
 }
 
 // findAndSetLatestReadyRevision finds the last ready revision and sets LatestReadyRevisionName to it.
-// lcrReady indicates whether the latest created revision is ready or not.
-func (c *Reconciler) findAndSetLatestReadyRevision(config *v1alpha1.Configuration, lcrReady bool) error {
+func (c *Reconciler) findAndSetLatestReadyRevision(config *v1alpha1.Configuration) error {
 	sortedRevisions, err := c.getSortedCreatedRevisions(config)
 	if err != nil {
 		return err

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -186,18 +186,24 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 	default:
 		return fmt.Errorf("unrecognized condition status: %v on revision %q", rc.Status, revName)
 	}
-
-	lcrReady := rc != nil && rc.Status == corev1.ConditionTrue
-	if err = c.findAndSetLatestReadyRevision(config, lcrReady); err != nil {
-		return fmt.Errorf("failed to find and set latest ready revision: %w", err)
+	if rc != nil && rc.Status == corev1.ConditionTrue {
+		old, new := config.Status.LatestReadyRevisionName, lcr.Name
+		config.Status.SetLatestReadyRevisionName(lcr.Name)
+		if old != new {
+			c.Recorder.Eventf(config, corev1.EventTypeNormal, "LatestReadyUpdate",
+				"LatestReadyRevisionName updated to %q", new)
+		}
+	} else {
+		if err = c.findAndSetLatestReadyRevision(config); err != nil {
+			return fmt.Errorf("failed to find and set latest ready revision: %w", err)
+		}
 	}
 
 	return nil
 }
 
-// findAndSetLatestReadyRevision finds the last ready revision and sets LatestReadyRevisionName to it.
-// lcrReady indicates whether the latest created revision is ready or not.
-func (c *Reconciler) findAndSetLatestReadyRevision(config *v1alpha1.Configuration, lcrReady bool) error {
+// findAndSetLatestReadyRevision finds the last ready revision and sets LatestReadyRevisionName to it
+func (c *Reconciler) findAndSetLatestReadyRevision(config *v1alpha1.Configuration) error {
 	sortedRevisions, err := c.getSortedCreatedRevisions(config)
 	if err != nil {
 		return err
@@ -205,15 +211,12 @@ func (c *Reconciler) findAndSetLatestReadyRevision(config *v1alpha1.Configuratio
 	for _, rev := range sortedRevisions {
 		if rev.Status.IsReady() {
 			// No need to update latest ready revision in this case
-			if rev.Name == config.Status.LatestReadyRevisionName && !lcrReady {
+			if rev.Name == config.Status.LatestReadyRevisionName {
 				return nil
 			}
-			old, new := config.Status.LatestReadyRevisionName, rev.Name
 			config.Status.SetLatestReadyRevisionName(rev.Name)
-			if old != new {
-				c.Recorder.Eventf(config, corev1.EventTypeNormal, "LatestReadyUpdate",
-					"LatestReadyRevisionName updated to %q", rev.Name)
-			}
+			c.Recorder.Eventf(config, corev1.EventTypeNormal, "LatestReadyUpdate",
+				"LatestReadyRevisionName updated to %q", rev.Name)
 			return nil
 		}
 	}

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -404,7 +404,7 @@ func TestReconcile(t *testing.T) {
 				WithCreationTimestamp(now), MarkRevisionReady),
 			rev("threerevs", "foo", 3,
 				WithRevName("threerevs-00003"),
-				WithCreationTimestamp(now), MarkRevisionFailed),
+				WithCreationTimestamp(now), MarkInactive("", "")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfg("threerevs", "foo", 3,
@@ -415,6 +415,9 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "LatestReadyUpdate", "LatestReadyRevisionName updated to %q", "threerevs-00002"),
+		},
 		Key: "foo/threerevs",
 	}}
 

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -156,6 +156,13 @@ func MarkRevisionReady(r *v1alpha1.Revision) {
 	r.Status.MarkContainerHealthyTrue()
 }
 
+// MarkRevisionFailed calls the necessary helpers to make the Revision Ready=False.
+func MarkRevisionFailed(r *v1alpha1.Revision) {
+	WithInitRevConditions(r)
+	MarkInactive("", "")
+	r.Status.MarkInactive("", "")
+}
+
 // WithRevisionLabel attaches a particular label to the revision.
 func WithRevisionLabel(key, value string) RevisionOption {
 	return func(config *v1alpha1.Revision) {

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -156,13 +156,6 @@ func MarkRevisionReady(r *v1alpha1.Revision) {
 	r.Status.MarkContainerHealthyTrue()
 }
 
-// MarkRevisionFailed calls the necessary helpers to make the Revision Ready=False.
-func MarkRevisionFailed(r *v1alpha1.Revision) {
-	WithInitRevConditions(r)
-	MarkInactive("", "")
-	r.Status.MarkInactive("", "")
-}
-
 // WithRevisionLabel attaches a particular label to the revision.
 func WithRevisionLabel(key, value string) RevisionOption {
 	return func(config *v1alpha1.Revision) {


### PR DESCRIPTION
/lint

Fixes #5285

## Proposed Changes

* In configuration reconciliation, obtain a list of sorted revisions instead of just the last created revision, so that we can update the last ready revision if the last created revision is not ready yet.

**Release Note**

```release-note
NONE
```
/cc @dgerd 