### PR TITLE
Remove @grantr from serving approvers.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,6 @@ aliases:
   serving-api-approvers:
   - dgerd
   - dprotaso
-  - grantr
   - markusthoemmes
   - mattmoor
   - tcnghia


### PR DESCRIPTION
It seems that Grant is completely in the Eventing world, so reducing his email load.

/assign mattmoor