### PR TITLE
Make port name in Gateway unique by adding namespace prefix

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -72,13 +72,17 @@ func GetHTTPServer(gateway *v1alpha3.Gateway) *v1alpha3.Server {
 }
 
 func belongsToClusterIngress(server *v1alpha3.Server, ia v1alpha1.IngressAccessor) bool {
-	// The format of the portName should be "<clusteringress-name>:<number>".
-	// For example, route-test:0.
+	// The format of the portName should be "<namespace>-<ingress_name>:<number>".
+	// For example, default-routetest:0.
 	portNameSplits := strings.Split(server.Port.Name, ":")
 	if len(portNameSplits) != 2 {
 		return false
 	}
-	return portNameSplits[0] == ia.GetName()
+	// TODO: This should be removed after ClusterIngress codes are cleaned up.
+	if len(ia.GetNamespace()) == 0 {
+		return portNameSplits[0] == ia.GetName()
+	}
+	return portNameSplits[0] == ia.GetNamespace()+"-"+ia.GetName()
 }
 
 // SortServers sorts `Server` according to its port name.
@@ -177,10 +181,17 @@ func MakeTLSServers(ia v1alpha1.IngressAccessor, gatewayServiceNamespace string,
 			}
 			credentialName = targetSecret(originSecret, ia)
 		}
+
+		port := ia.GetName()
+		// TODO: This namespace check should be removed after ClusterIngress codes are cleaned up.
+		if len(ia.GetNamespace()) > 0 {
+			port = ia.GetNamespace() + "-" + ia.GetName()
+		}
+
 		servers[i] = v1alpha3.Server{
 			Hosts: tls.Hosts,
 			Port: v1alpha3.Port{
-				Name:     fmt.Sprintf("%s:%d", ia.GetName(), i),
+				Name:     fmt.Sprintf("%s:%d", port, i),
 				Number:   443,
 				Protocol: v1alpha3.ProtocolHTTPS,
 			},

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -72,8 +72,8 @@ func GetHTTPServer(gateway *v1alpha3.Gateway) *v1alpha3.Server {
 }
 
 func belongsToClusterIngress(server *v1alpha3.Server, ia v1alpha1.IngressAccessor) bool {
-	// The format of the portName should be "<namespace>-<ingress_name>:<number>".
-	// For example, default-routetest:0.
+	// The format of the portName should be "<namespace>/<ingress_name>:<number>".
+	// For example, default/routetest:0.
 	portNameSplits := strings.Split(server.Port.Name, ":")
 	if len(portNameSplits) != 2 {
 		return false
@@ -82,7 +82,7 @@ func belongsToClusterIngress(server *v1alpha3.Server, ia v1alpha1.IngressAccesso
 	if len(ia.GetNamespace()) == 0 {
 		return portNameSplits[0] == ia.GetName()
 	}
-	return portNameSplits[0] == ia.GetNamespace()+"-"+ia.GetName()
+	return portNameSplits[0] == ia.GetNamespace()+"/"+ia.GetName()
 }
 
 // SortServers sorts `Server` according to its port name.
@@ -185,7 +185,7 @@ func MakeTLSServers(ia v1alpha1.IngressAccessor, gatewayServiceNamespace string,
 		port := ia.GetName()
 		// TODO: This namespace check should be removed after ClusterIngress codes are cleaned up.
 		if len(ia.GetNamespace()) > 0 {
-			port = ia.GetNamespace() + "-" + ia.GetName()
+			port = ia.GetNamespace() + "/" + ia.GetName()
 		}
 
 		servers[i] = v1alpha3.Server{

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -223,8 +223,8 @@ func TestMakeTLSServers(t *testing.T) {
 		expected: []v1alpha3.Server{{
 			Hosts: []string{"host1.example.com"},
 			Port: v1alpha3.Port{
-				// port name is created with <namespace>-<name>
-				Name:     "default-ingress:0",
+				// port name is created with <namespace>/<name>
+				Name:     "default/ingress:0",
 				Number:   443,
 				Protocol: v1alpha3.ProtocolHTTPS,
 			},

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -101,22 +101,32 @@ var gatewayWithPlaceholderServer = v1alpha3.Gateway{
 	},
 }
 
+var ingressSpec = v1alpha1.IngressSpec{
+	Rules: []v1alpha1.IngressRule{{
+		Hosts: []string{"host1.example.com"},
+	}},
+	TLS: []v1alpha1.IngressTLS{{
+		Hosts:             []string{"host1.example.com"},
+		SecretName:        "secret0",
+		SecretNamespace:   system.Namespace(),
+		ServerCertificate: "tls.crt",
+		PrivateKey:        "tls.key",
+	}},
+}
+
 var clusterIngress = v1alpha1.ClusterIngress{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "clusteringress",
 	},
-	Spec: v1alpha1.IngressSpec{
-		Rules: []v1alpha1.IngressRule{{
-			Hosts: []string{"host1.example.com"},
-		}},
-		TLS: []v1alpha1.IngressTLS{{
-			Hosts:             []string{"host1.example.com"},
-			SecretName:        "secret0",
-			SecretNamespace:   system.Namespace(),
-			ServerCertificate: "tls.crt",
-			PrivateKey:        "tls.key",
-		}},
+	Spec: ingressSpec,
+}
+
+var ingress = v1alpha1.Ingress{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ingress",
+		Namespace: "default",
 	},
+	Spec: ingressSpec,
 }
 
 func TestGetServers(t *testing.T) {
@@ -160,7 +170,7 @@ func TestGetHTTPServer(t *testing.T) {
 func TestMakeTLSServers(t *testing.T) {
 	cases := []struct {
 		name                    string
-		ci                      *v1alpha1.ClusterIngress
+		ci                      v1alpha1.IngressAccessor
 		gatewayServiceNamespace string
 		originSecrets           map[string]*corev1.Secret
 		expected                []v1alpha3.Server
@@ -195,6 +205,26 @@ func TestMakeTLSServers(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: v1alpha3.Port{
 				Name:     "clusteringress:0",
+				Number:   443,
+				Protocol: v1alpha3.ProtocolHTTPS,
+			},
+			TLS: &v1alpha3.TLSOptions{
+				Mode:              v1alpha3.TLSModeSimple,
+				ServerCertificate: "tls.crt",
+				PrivateKey:        "tls.key",
+				CredentialName:    "secret0",
+			},
+		}},
+	}, {
+		name:                    "port name is created with ingress namespace-name",
+		ci:                      &ingress,
+		gatewayServiceNamespace: system.Namespace(),
+		originSecrets:           originSecrets,
+		expected: []v1alpha3.Server{{
+			Hosts: []string{"host1.example.com"},
+			Port: v1alpha3.Port{
+				// port name is created with <namespace>-<name>
+				Name:     "default-ingress:0",
 				Number:   443,
 				Protocol: v1alpha3.ProtocolHTTPS,
 			},


### PR DESCRIPTION
/lint

Fixes https://github.com/knative/serving/issues/5324

## Proposed Changes

* Make port name in Gateway unique by adding namespace prefix

**Release Note**

```release-note
NONE
```

/cc @ZhiminXiang  @tcnghia