### PR TITLE
Remove GenerateName for the metrics service

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -124,7 +124,7 @@ func TestReconcile(t *testing.T) {
 		Key: key(testNamespace, testRevision),
 		WantCreates: []runtime.Object{
 			metric(pa(testNamespace, testRevision,
-				WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency)), testRevision+"-00001"),
+				WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency)), testRevision+"-metrics"),
 			sks(testNamespace, testRevision, WithDeployRef(deployName)),
 			hpa(pa(testNamespace, testRevision,
 				WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency))),
@@ -135,7 +135,7 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency),
 				WithNoTraffic("ServicesNotReady", "SKS Services are not ready yet"),
-				WithMSvcStatus(testRevision+"-00001")),
+				WithMSvcStatus(testRevision+"-metrics")),
 		}},
 	}, {
 		Name: "reconcile sks is still not ready",

--- a/pkg/reconciler/autoscaling/resources/service.go
+++ b/pkg/reconciler/autoscaling/resources/service.go
@@ -33,8 +33,8 @@ import (
 func MakeMetricsService(pa *pav1alpha1.PodAutoscaler, selector map[string]string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: pa.Name + "-",
-			Namespace:    pa.Namespace,
+			Name:      kmeta.ChildName(pa.Name, "-metrics"),
+			Namespace: pa.Namespace,
 			Labels: resources.UnionMaps(pa.GetLabels(), map[string]string{
 				autoscaling.KPALabelKey:   pa.Name,
 				networking.ServiceTypeKey: string(networking.ServiceTypeMetrics),


### PR DESCRIPTION
This removes the generate name code from the metrics service generation
and instead uses ChildName, which is predictable well formed name.

The change is safe, since:

- we have code that lists all the services and picks existing one (so existing ones would not be hurt)
- if the metrics service changes the rest of the code can handle it (autoscaler and scraper both change the targets when this value changes)


/lint
/assign mattmoor