### PR TITLE
Fixes the problems where restarting autoscaler messes up SKS state

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -151,11 +151,16 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	}
 
 	mode := nv1alpha1.SKSOperationModeServe
-	// We put activator in the serving path in two cases:
-	// 1. The revision is scaled to 0.
+	// We put activator in the serving path in the following cases:
+	// 1. The revision is scaled to 0:
+	//   a. want == 0
+	//   b. want == -1 && PA is inactive (Autoscaler has no previous knowledge of
+	//			this revision, e.g. after a restart) but PA status is inactive (it was
+	//			already scaled to 0).
 	// 2. The excess burst capacity is negative.
-	if want == 0 || decider.Status.ExcessBurstCapacity < 0 {
-		logger.Infof("SKS is in proxy mode: want = %d, ebc = %d", want, decider.Status.ExcessBurstCapacity)
+	if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == -1 && pa.Status.IsInactive() {
+		logger.Infof("SKS should be in proxy mode: want = %d, ebc = %d, PA Inactive? = %v",
+			want, decider.Status.ExcessBurstCapacity, pa.Status.IsInactive())
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 
@@ -171,6 +176,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 
 	// Propagate service name.
 	pa.Status.ServiceName = sks.Status.ServiceName
+	// Currently, SKS.IsReady==True when revision has >0 ready pods.
 	if sks.Status.IsReady() {
 		podCounter := resourceutil.NewScopedEndpointsCounter(c.endpointsLister, pa.Namespace, sks.Status.PrivateServiceName)
 		got, err = podCounter.ReadyCount()
@@ -178,11 +184,10 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 			return perrors.Wrapf(err, "error checking endpoints %s", sks.Status.PrivateServiceName)
 		}
 	}
-	logger.Infof("PA scale got=%d, want=%d", got, want)
+	logger.Infof("PA scale got=%d, want=%d, ebc=%d", got, want, decider.Status.ExcessBurstCapacity)
 	pa.Status.DesiredScale, pa.Status.ActualScale = &want, ptr.Int32(int32(got))
 
-	err = reportMetrics(pa, want, got)
-	if err != nil {
+	if err = reportMetrics(pa, want, got); err != nil {
 		return perrors.Wrap(err, "error reporting metrics")
 	}
 
@@ -270,6 +275,7 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
 	case got >= minReady:
 		if want > 0 || !pa.Status.IsInactive() {
 			// SKS should already be active.
+			fmt.Printf("### MARKING ACTIVE\n")
 			pa.Status.MarkActive()
 		}
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -275,7 +275,6 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
 	case got >= minReady:
 		if want > 0 || !pa.Status.IsInactive() {
 			// SKS should already be active.
-			fmt.Printf("### MARKING ACTIVE\n")
 			pa.Status.MarkActive()
 		}
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -311,7 +311,7 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`error checking endpoints test-revision-rand: endpoints "test-revision-rand" not found`),
+				`error checking endpoints test-revision-private: endpoints "test-revision-private" not found`),
 		},
 	}, {
 		Name: "metric-service-mismatch",
@@ -500,7 +500,7 @@ func TestReconcile(t *testing.T) {
 		WantErr: true,
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`error checking endpoints test-revision-rand: endpoints "test-revision-rand" not found`),
+				`error checking endpoints test-revision-private: endpoints "test-revision-private" not found`),
 		},
 	}, {
 		Name: "pa activates",
@@ -531,7 +531,8 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, WithTraffic, withMSvcStatus(testRevision),
 				withScales(0, defaultScale), WithPAStatusService(testRevision)),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPubService, WithPrivateService(testRevision+"-rand")),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPubService,
+				WithPrivateService(testRevision+"-private")),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision),
 			defaultDeployment, defaultEndpoints,
@@ -956,9 +957,9 @@ func TestReconcile(t *testing.T) {
 		Ctx: context.WithValue(context.Background(), deciderKey,
 			decider(testNamespace, testRevision, -1 /* desiredScale */, 0 /* ebc */)),
 		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, markInactive, withMSvcStatus("yak-40"),
-				withScales(0, 0), WithPAStatusService(testRevision)),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode),
+			kpa(testNamespace, testRevision, markInactive, withMSvcStatus(testRevision),
+				withScales(0, -1), WithPAStatusService(testRevision)),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode, WithPubService),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision),
 			defaultDeployment, defaultEndpoints,

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -251,7 +251,7 @@ func TestReconcile(t *testing.T) {
 		)
 	}
 
-	defaultSks := sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady)
+	defaultSKS := sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady)
 	defaultMetricsSvc := metricsSvc(
 		testNamespace, testRevision, withSvcSelector(usualSelector), withMSvcName("cargo"),
 	)
@@ -301,7 +301,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, withMSvcStatus("a330-200x"), WithPAStatusService(testRevision),
 				withScales(1, defaultScale)),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
 				withMSvcName("a330-200x")),
 			metric(testNamespace, testRevision, "a330-200x"),
@@ -322,7 +322,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("a350-900ULR"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
 				withMSvcName("b777-200LR")),
 			metric(testNamespace, testRevision, "a350-900ULR"),
@@ -357,7 +357,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("a380-800"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
 				withMSvcName("a380-800")),
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
@@ -388,7 +388,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			defaultDeployment,
 			defaultEndpoints,
 		},
@@ -410,7 +410,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
 				WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			defaultDeployment,
 			defaultEndpoints,
 		},
@@ -427,7 +427,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			deploy(testNamespace, testRevision),
@@ -450,7 +450,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			deploy(testNamespace, testRevision),
@@ -473,7 +473,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("a321neo"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			defaultDeployment, defaultEndpoints,
 			metricsSvc(testNamespace, testRevision, withMSvcName("a321neo")),
 			metric(testNamespace, testRevision, "a321neo"),
@@ -492,7 +492,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("b767-300er"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			defaultDeployment, defaultEndpoints,
 			metricsSvc(testNamespace, testRevision, withMSvcName("b767-300er")),
 		},
@@ -511,7 +511,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
 				withScales(1, defaultScale), WithPAStatusService(testRevision), withMSvcStatus("b737max-800")),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector), func(s *corev1.Service) {
 				s.OwnerReferences = nil
 			}, withMSvcName("b737max-800")),
@@ -532,7 +532,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive,
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment,
@@ -584,7 +584,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment, defaultEndpoints,
@@ -597,7 +597,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, withMinScale(2), withScales(1, defaultScale), WithReachabilityReachable),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment, defaultEndpoints,
@@ -614,7 +614,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, withMinScale(2), withScales(1, defaultScale), WithReachabilityUnknown),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment, defaultEndpoints,
@@ -631,7 +631,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, withMinScale(2), withScales(1, defaultScale), WithReachabilityUnreachable),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment, defaultEndpoints,
@@ -649,7 +649,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActivating, withMinScale(2), WithPAStatusService(testRevision),
 				withScales(1, defaultScale), WithReachabilityReachable),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment,
@@ -668,7 +668,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActivating, withMinScale(2), WithPAStatusService(testRevision),
 				withScales(1, defaultScale), WithReachabilityUnknown),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector)),
 			metric(testNamespace, testRevision, ""),
 			defaultDeployment,
@@ -826,7 +826,7 @@ func TestReconcile(t *testing.T) {
 			kpa(testNamespace, testRevision, markActive, markOld, withScales(0, 0),
 				WithPAStatusService(testRevision),
 				withMSvcStatus("and-into-the-black")),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
 				withMSvcName("and-into-the-black")),
 			metric(testNamespace, testRevision, "and-into-the-black"),
@@ -848,7 +848,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withScales(1, 1),
 				WithPAStatusService(testRevision), withMSvcStatus("but-you-pay-for-that")),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
 				withMSvcName("but-you-pay-for-that")),
 			metric(testNamespace, testRevision, "but-you-pay-for-that"),
@@ -863,7 +863,7 @@ func TestReconcile(t *testing.T) {
 			kpa(testNamespace, testRevision, markActivating, markOld,
 				WithPAStatusService(testRevision), withScales(0, 0),
 				withMSvcStatus("once-you're-gone")),
-			defaultSks,
+			defaultSKS,
 			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
 				withMSvcName("once-you're-gone")),
 			metric(testNamespace, testRevision, "once-you're-gone"),
@@ -889,11 +889,13 @@ func TestReconcile(t *testing.T) {
 		Name: "underscaled, PA inactive",
 		// No-op
 		Key: key,
-		Ctx: context.WithValue(context.Background(), deciderKey, decider(testNamespace,
-			testRevision, unknownScale, 0 /* ebc */)),
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, unknownScale, 0 /* ebc */)),
 		Objects: []runtime.Object{
-			inactiveKPAMinScale(10), underscaledEndpoints, underscaledDeployment,
-			defaultSks, defaultMetric, defaultMetricsSvc,
+			inactiveKPAMinScale(0), underscaledEndpoints, underscaledDeployment,
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode,
+				WithPubService, WithPrivateService("king-crimson")),
+			defaultMetric, defaultMetricsSvc,
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: defaultMetric,
@@ -905,7 +907,7 @@ func TestReconcile(t *testing.T) {
 		Ctx: context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, defaultScale, 0 /* ebc */)),
 		Objects: []runtime.Object{
 			activatingKPAMinScale(underscale), underscaledEndpoints, underscaledDeployment,
-			defaultSks, defaultMetric, defaultMetricsSvc,
+			defaultSKS, defaultMetric, defaultMetricsSvc,
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			minScalePatch,
@@ -920,7 +922,7 @@ func TestReconcile(t *testing.T) {
 		Ctx: context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, defaultScale, 0 /* ebc */)),
 		Objects: []runtime.Object{
 			activeKPAMinScale(underscale, defaultScale), underscaledEndpoints, underscaledDeployment,
-			defaultSks, defaultMetric, defaultMetricsSvc,
+			defaultSKS, defaultMetric, defaultMetricsSvc,
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			minScalePatch,
@@ -932,31 +934,48 @@ func TestReconcile(t *testing.T) {
 			Object: defaultMetric,
 		}},
 	}, {
+		// Scale to `minScale` and mark PA "active"
 		Name: "overscaled, PA inactive",
-		// No-op
-		Key: key,
-		Ctx: context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, unknownScale, 0 /* ebc */)),
+		Key:  key,
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, 0 /*wantScale*/, 0 /* ebc */)),
 		Objects: []runtime.Object{
 			inactiveKPAMinScale(overscale), overscaledEndpoints, overscaledDeployment,
-			defaultSks, defaultMetric, defaultMetricsSvc,
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode, WithSKSReady),
+			defaultMetric, defaultMetricsSvc,
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: defaultMetric,
+		}, {
+			Object: sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			minScalePatch,
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: activeKPAMinScale(overscale, defaultScale),
 		}},
 	}, {
 		Name: "overscaled, PA activating",
 		// Scale to `minScale` and mark PA "active"
 		Key: key,
-		Ctx: context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, overscale, 0 /* ebc */)),
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, 1 /*wantScale*/, 0 /* ebc */)),
 		Objects: []runtime.Object{
-			activatingKPAMinScale(overscale), overscaledEndpoints, overscaledDeployment,
-			defaultSks, defaultMetric, defaultMetricsSvc,
+			inactiveKPAMinScale(overscale), overscaledEndpoints, overscaledDeployment,
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode, WithSKSReady),
+			defaultMetric, defaultMetricsSvc,
 		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: activeKPAMinScale(overscale, overscale),
-		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: defaultMetric,
+		}, {
+			Object: sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			minScalePatch,
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: activeKPAMinScale(overscale, defaultScale),
 		}},
 	}, {
 		Name: "overscaled, PA active",
@@ -965,15 +984,30 @@ func TestReconcile(t *testing.T) {
 		Ctx: context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, overscale, 0 /* ebc */)),
 		Objects: []runtime.Object{
 			activeKPAMinScale(overscale, overscale), overscaledEndpoints, overscaledDeployment,
-			defaultSks, defaultMetric, defaultMetricsSvc,
+			defaultSKS, defaultMetric, defaultMetricsSvc,
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: defaultMetric,
 		}},
 	}, {
+		Name: "scaled-to-0-no-scale-data",
+		Key:  key,
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, -1 /* desiredScale */, 0 /* ebc */)),
+		Objects: []runtime.Object{
+			kpa(testNamespace, testRevision, markInactive, withMSvcStatus("yak-40"),
+				withScales(0, 0), WithPAStatusService(testRevision)),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithProxyMode),
+			metricsSvc(testNamespace, testRevision, withSvcSelector(usualSelector),
+				withMSvcName("yak-40")),
+			metric(testNamespace, testRevision, "yak-40"),
+			defaultDeployment, defaultEndpoints,
+		},
+	}, {
 		Name: "steady not enough capacity",
 		Key:  key,
-		Ctx:  context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, defaultScale /* desiredScale */, -1 /* ebc */)),
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, defaultScale /* desiredScale */, -42 /* ebc */)),
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("yak-40"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
@@ -986,7 +1020,8 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "traffic increased, no longer enough burst capacity",
 		Key:  key,
-		Ctx:  context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, defaultScale /* desiredScale */, -1 /* ebc */)),
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, defaultScale /* desiredScale */, -18 /* ebc */)),
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("yak-42"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
@@ -1003,7 +1038,8 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "traffic decreased, now we have enough burst capacity",
 		Key:  key,
-		Ctx:  context.WithValue(context.Background(), deciderKey, decider(testNamespace, testRevision, defaultScale /* desiredScale */, 1 /* ebc */)),
+		Ctx: context.WithValue(context.Background(), deciderKey,
+			decider(testNamespace, testRevision, defaultScale /* desiredScale */, 1 /* ebc */)),
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, withMSvcStatus("ssj-100"),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
@@ -1501,11 +1537,10 @@ func newTestRevision(namespace string, name string) *v1alpha1.Revision {
 }
 
 func makeSKSPrivateEndpoints(num int, ns, n string) *corev1.Endpoints {
-	s := sks(testNamespace, testRevision, WithPrivateService(n+"-rand"))
 	eps := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: s.Namespace,
-			Name:      s.Status.PrivateServiceName,
+			Namespace: ns,
+			Name:      n + "-private",
 		},
 	}
 	for i := 0; i < num; i++ {

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -349,7 +349,7 @@ func WithDeployRef(name string) SKSOption {
 
 // WithSKSReady marks SKS as ready.
 func WithSKSReady(sks *netv1alpha1.ServerlessService) {
-	WithPrivateService(sks.Name + "-rand")(sks)
+	WithPrivateService(sks.Name + "-private")(sks)
 	WithPubService(sks)
 	sks.Status.MarkEndpointsReady()
 }


### PR DESCRIPTION
Basically we did not cover earlier the case when want=-1 and PA.Ready==False. This worked earlier on because we reconciled SKS twice, and the second one enforced the proper state, but recently we removed it.
So this fixes it...

/lint
Fixes #5327

## Proposed Changes

* deal with want=-1 better when scaled to 0
* update tests 
* fix lots of other tests to be more correct

/assign mattmoor