### PR TITLE
Some improvements to KPA and tests

### DIFF
--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -173,9 +173,7 @@ func (c *Base) ReconcileMetric(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	} else if err != nil {
 		return perrors.Wrap(err, "error fetching metric")
 	} else {
-		// Ignore status when reconciling
-		desiredMetric.Status = metric.Status
-		if !equality.Semantic.DeepEqual(desiredMetric, metric) {
+		if !equality.Semantic.DeepEqual(desiredMetric.Spec, metric.Spec) {
 			want := metric.DeepCopy()
 			want.Spec = desiredMetric.Spec
 			if _, err = c.ServingClientSet.AutoscalingV1alpha1().Metrics(desiredMetric.Namespace).Update(want); err != nil {


### PR DESCRIPTION
- we had lots of phantom reconciles for the metric, even though there are no changes. So compare just the Specs. This removed lots of those writes.
- make min/max scale tests closer to reality with more real parameters in decider
- increase coverage by testing failure of metric creation
- increase coverage by testing more min/max scale scenarios.
- increase coverage by covering failure of metric update


/lint
/assign mattmoor