### PR TITLE
Enable profiling for e2e test to make sure it is harmless

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -234,9 +234,15 @@ function install_knative_serving_standard() {
   fi
 
   echo ">> Turning on profiling.enable"
-  kubectl get cm config-observability -n knative-serving -o yaml | \
-    sed 's/  profiling.enable: "false"/profiling.enable: "true"/g' |\
-    kubectl replace -f -
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+data:
+  profiling.enable: "true"
+EOF
 
   echo ">> Adding more activator pods."
   # This command would fail if the HPA already exist, like during upgrade test.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -233,6 +233,11 @@ function install_knative_serving_standard() {
       kubectl replace -f -
   fi
 
+  echo ">> Turning on profiling.enable"
+  kubectl get cm config-observability -n knative-serving -o yaml | \
+    sed 's/  profiling.enable: "false"/profiling.enable: "true"/g' |\
+    kubectl replace -f -
+
   echo ">> Adding more activator pods."
   # This command would fail if the HPA already exist, like during upgrade test.
   # Therefore we don't exit on failure, and don't log an error message.


### PR DESCRIPTION
This patch turns on `profiling.enable` in config-observability for e2e.

We are pretty sure that it is harmless to enable profiling, but we
should run e2e and performance tests with profiling to make sure
it is harmless like no port confliction or no performance degradation.

## Proposed Changes

* Enable profiling for e2e test to make sure it is harmless

**Release Note**

```release-note
NONE
```
