### PR TITLE
Reduce complexity of queue-proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -157,30 +157,7 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.H
 		ph := network.KnativeProbeHeader(r)
 		switch {
 		case ph != "":
-			_, probeSpan := trace.StartSpan(r.Context(), "probe")
-			if ph != queue.Name {
-				http.Error(w, fmt.Sprintf(badProbeTemplate, ph), http.StatusBadRequest)
-				probeSpan.Annotate([]trace.Attribute{
-					trace.StringAttribute("queueproxy.probe.error", fmt.Sprintf(badProbeTemplate, ph))}, "error")
-				probeSpan.End()
-				return
-			}
-			if prober != nil {
-				if prober() {
-					// Respond with the name of the component handling the request.
-					w.Write([]byte(queue.Name))
-				} else {
-					http.Error(w, "container not ready", http.StatusServiceUnavailable)
-					probeSpan.Annotate([]trace.Attribute{
-						trace.StringAttribute("queueproxy.probe.error", "container not ready")}, "error")
-				}
-
-			} else {
-				http.Error(w, "no probe", http.StatusInternalServerError)
-				probeSpan.Annotate([]trace.Attribute{
-					trace.StringAttribute("queueproxy.probe.error", "no probe")}, "error")
-			}
-			probeSpan.End()
+			handleKnativeProbe(w, r, ph, prober)
 			return
 		case network.IsKubeletProbe(r):
 			probeCtx, probeSpan := trace.StartSpan(r.Context(), "probe")
@@ -213,6 +190,35 @@ func handler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, handler http.H
 			handler.ServeHTTP(w, r.WithContext(proxyCtx))
 		}
 	}
+}
+
+func handleKnativeProbe(w http.ResponseWriter, r *http.Request, ph string, prober func() bool) {
+	_, probeSpan := trace.StartSpan(r.Context(), "probe")
+	defer probeSpan.End()
+
+	if ph != queue.Name {
+		http.Error(w, fmt.Sprintf(badProbeTemplate, ph), http.StatusBadRequest)
+		probeSpan.Annotate([]trace.Attribute{
+			trace.StringAttribute("queueproxy.probe.error", fmt.Sprintf(badProbeTemplate, ph))}, "error")
+		return
+	}
+
+	if prober == nil {
+		http.Error(w, "no probe", http.StatusInternalServerError)
+		probeSpan.Annotate([]trace.Attribute{
+			trace.StringAttribute("queueproxy.probe.error", "no probe")}, "error")
+		return
+	}
+
+	if !prober() {
+		http.Error(w, "container not ready", http.StatusServiceUnavailable)
+		probeSpan.Annotate([]trace.Attribute{
+			trace.StringAttribute("queueproxy.probe.error", "container not ready")}, "error")
+		return
+	}
+
+	// Respond with the name of the component handling the request.
+	w.Write([]byte(queue.Name))
 }
 
 func probeQueueHealthPath(port int, timeoutSeconds int) error {
@@ -285,43 +291,8 @@ func main() {
 		zap.String(logkey.Key, types.NamespacedName{Namespace: env.ServingNamespace, Name: env.ServingRevision}.String()),
 		zap.String(logkey.Pod, env.ServingPod))
 
-	// Setup the reverse proxy to forward requests.
-	target := &url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(env.UserPort)),
-	}
-
-	httpProxy := httputil.NewSingleHostReverseProxy(target)
-	httpProxy.Transport = network.AutoTransport
-
-	if env.TracingConfigBackend != tracingconfig.None {
-		oct := tracing.NewOpenCensusTracer(tracing.WithExporter(env.ServingPod, logger))
-		oct.ApplyConfig(&tracingconfig.Config{
-			Backend:              env.TracingConfigBackend,
-			Debug:                env.TracingConfigDebug,
-			ZipkinEndpoint:       env.TracingConfigZipkinEndpoint,
-			StackdriverProjectID: env.TracingConfigStackdriverProjectID,
-			SampleRate:           env.TracingConfigSampleRate,
-		})
-
-		httpProxy.Transport = &ochttp.Transport{
-			Base: network.AutoTransport,
-		}
-	}
-
-	httpProxy.FlushInterval = -1
-	activatorutil.SetupHeaderPruning(httpProxy)
-
-	// Setup the breaker to enforce containreConcurrency.
-	// If env.ContainerConcurrency == 0 then concurrency is unlimited.
-	var breaker *queue.Breaker
-	if env.ContainerConcurrency > 0 {
-		// We set the queue depth to be equal to the container concurrency * 10 to
-		// allow the autoscaler time to react.
-		queueDepth := env.ContainerConcurrency * 10
-		params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: env.ContainerConcurrency, InitialCapacity: env.ContainerConcurrency}
-		breaker = queue.NewBreaker(params)
-		logger.Infof("Queue container is starting with %#v", params)
+	if err := validateEnv(env); err != nil {
+		logger.Fatal(err.Error())
 	}
 
 	// Setup reporters and processes to handle stat reporting.
@@ -342,73 +313,23 @@ func main() {
 
 	reqChan := make(chan queue.ReqEvent, requestCountingQueueLength)
 	defer close(reqChan)
+
 	reportTicker := time.NewTicker(reportingPeriod)
 	defer reportTicker.Stop()
+
 	queue.NewStats(env.ServingPod, queue.Channels{
 		ReqChan:    reqChan,
 		ReportChan: reportTicker.C,
 		StatChan:   statChan,
 	}, time.Now())
 
-	// Setup request metrics reporting for end-user metrics.
-	metricsSupported := false
-	if env.ServingRequestMetricsBackend != "" {
-		if err := setupMetricsExporter(env.ServingRequestMetricsBackend); err == nil {
-			metricsSupported = true
-		} else {
-			logger.Errorw("Error setting up request metrics exporter. Request metrics will be unavailable.", zap.Error(err))
-		}
-	}
-
 	// Setup probe to run for checking user-application healthiness.
-	coreProbe, err := readiness.DecodeProbe(env.ServingReadinessProbe)
-	if err != nil {
-		logger.Fatalw("Queue container failed to parse readiness probe", zap.Error(err))
-	}
-	rp := readiness.NewProbe(coreProbe)
-
-	// Create queue handler chain.
-	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
-	var composedHandler http.Handler = httpProxy
-	if metricsSupported {
-		composedHandler = pushRequestMetricHandler(httpProxy, appRequestCountM, appResponseTimeInMsecM,
-			queueDepthM, breaker, env)
-	}
-	composedHandler = http.HandlerFunc(handler(reqChan, breaker, composedHandler, rp.ProbeContainer))
-	composedHandler = queue.ForwardedShimHandler(composedHandler)
-	composedHandler = queue.TimeToFirstByteTimeoutHandler(composedHandler,
-		time.Duration(env.RevisionTimeoutSeconds)*time.Second, "request timeout")
-	composedHandler = pushRequestLogHandler(composedHandler, env)
-
-	if metricsSupported {
-		composedHandler = pushRequestMetricHandler(composedHandler, requestCountM, responseTimeInMsecM,
-			nil /*queueDepthM*/, nil /*breaker*/, env)
-	}
-	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
-	composedHandler = network.NewProbeHandler(composedHandler)
-	server := network.NewServer(":"+strconv.Itoa(env.QueueServingPort), composedHandler)
-
-	adminMux := http.NewServeMux()
+	probe := buildProbe(env.ServingReadinessProbe)
 	healthState := &health.State{}
-	adminMux.HandleFunc(requestQueueHealthPath, healthState.HealthHandler(func() bool {
-		if !rp.ProbeContainer() {
-			return false
-		}
-		logger.Info("User-container successfully probed.")
-		return true
-	}, rp.IsAggressive()))
-	adminMux.HandleFunc(queue.RequestQueueDrainPath, healthState.DrainHandler())
-	adminServer := &http.Server{
-		Addr:    ":" + strconv.Itoa(networking.QueueAdminPort),
-		Handler: adminMux,
-	}
 
-	metricsMux := http.NewServeMux()
-	metricsMux.Handle("/metrics", promStatReporter.Handler())
-	metricsServer := &http.Server{
-		Addr:    ":" + strconv.Itoa(networking.AutoscalingQueueMetricsPort),
-		Handler: metricsMux,
-	}
+	server := buildServer(env, probe, reqChan, logger)
+	adminServer := buildAdminServer(healthState, probe, logger)
+	metricsServer := buildMetricsServer(promStatReporter)
 
 	servers := map[string]*http.Server{
 		"main":    server,
@@ -429,12 +350,6 @@ func main() {
 	// Setup /var/log.
 	// Logic that isn't required to be executed before the critical path
 	// and should be started last to not impact start up latency
-	if env.VarLogVolumeName == "" && env.EnableVarLogCollection {
-		logger.Fatal("VAR_LOG_VOLUME_NAME must be specified when ENABLE_VAR_LOG_COLLECTION is true")
-	}
-	if env.InternalVolumePath == "" && env.EnableVarLogCollection {
-		logger.Fatal("INTERNAL_VOLUME_PATH must be specified when ENABLE_VAR_LOG_COLLECTION is true")
-	}
 	go func() {
 		if env.EnableVarLogCollection {
 			createVarLogLink(env)
@@ -466,6 +381,140 @@ func main() {
 		if err := adminServer.Shutdown(context.Background()); err != nil {
 			logger.Errorw("Failed to shutdown admin-server", zap.Error(err))
 		}
+	}
+}
+
+func validateEnv(env config) error {
+	if !env.EnableVarLogCollection {
+		return nil
+	}
+
+	if env.VarLogVolumeName == "" {
+		return errors.New("VAR_LOG_VOLUME_NAME must be specified when ENABLE_VAR_LOG_COLLECTION is true")
+	}
+	if env.InternalVolumePath == "" {
+		return errors.New("INTERNAL_VOLUME_PATH must be specified when ENABLE_VAR_LOG_COLLECTION is true")
+	}
+
+	return nil
+}
+
+func buildProbe(probeJSON string) *readiness.Probe {
+	coreProbe, err := readiness.DecodeProbe(probeJSON)
+	if err != nil {
+		logger.Fatalw("Queue container failed to parse readiness probe", zap.Error(err))
+	}
+	return readiness.NewProbe(coreProbe)
+}
+
+func buildServer(env config, rp *readiness.Probe, reqChan chan queue.ReqEvent, logger *zap.SugaredLogger) *http.Server {
+	target := &url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(env.UserPort)),
+	}
+
+	httpProxy := httputil.NewSingleHostReverseProxy(target)
+	httpProxy.Transport = buildTransport(env, logger)
+
+	httpProxy.FlushInterval = -1
+	activatorutil.SetupHeaderPruning(httpProxy)
+
+	breaker := buildBreaker(env)
+	metricsSupported := supportsMetrics(env, logger)
+
+	// Create queue handler chain.
+	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
+	var composedHandler http.Handler = httpProxy
+	if metricsSupported {
+		composedHandler = pushRequestMetricHandler(httpProxy, appRequestCountM, appResponseTimeInMsecM,
+			queueDepthM, breaker, env)
+	}
+	composedHandler = http.HandlerFunc(handler(reqChan, breaker, composedHandler, rp.ProbeContainer))
+	composedHandler = queue.ForwardedShimHandler(composedHandler)
+	composedHandler = queue.TimeToFirstByteTimeoutHandler(composedHandler,
+		time.Duration(env.RevisionTimeoutSeconds)*time.Second, "request timeout")
+	composedHandler = pushRequestLogHandler(composedHandler, env)
+
+	if metricsSupported {
+		composedHandler = pushRequestMetricHandler(composedHandler, requestCountM, responseTimeInMsecM,
+			nil /*queueDepthM*/, nil /*breaker*/, env)
+	}
+	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
+	composedHandler = network.NewProbeHandler(composedHandler)
+
+	return network.NewServer(":"+strconv.Itoa(env.QueueServingPort), composedHandler)
+}
+
+func buildTransport(env config, logger *zap.SugaredLogger) http.RoundTripper {
+	if env.TracingConfigBackend == tracingconfig.None {
+		return network.AutoTransport
+	}
+
+	oct := tracing.NewOpenCensusTracer(tracing.WithExporter(env.ServingPod, logger))
+	oct.ApplyConfig(&tracingconfig.Config{
+		Backend:              env.TracingConfigBackend,
+		Debug:                env.TracingConfigDebug,
+		ZipkinEndpoint:       env.TracingConfigZipkinEndpoint,
+		StackdriverProjectID: env.TracingConfigStackdriverProjectID,
+		SampleRate:           env.TracingConfigSampleRate,
+	})
+
+	return &ochttp.Transport{
+		Base: network.AutoTransport,
+	}
+}
+
+func buildBreaker(env config) *queue.Breaker {
+	if env.ContainerConcurrency < 1 {
+		return nil
+	}
+
+	// We set the queue depth to be equal to the container concurrency * 10 to
+	// allow the autoscaler time to react.
+	queueDepth := env.ContainerConcurrency * 10
+	params := queue.BreakerParams{QueueDepth: queueDepth, MaxConcurrency: env.ContainerConcurrency, InitialCapacity: env.ContainerConcurrency}
+	logger.Infof("Queue container is starting with %#v", params)
+
+	return queue.NewBreaker(params)
+}
+
+func supportsMetrics(env config, logger *zap.SugaredLogger) bool {
+	// Setup request metrics reporting for end-user metrics.
+	if env.ServingRequestMetricsBackend == "" {
+		return false
+	}
+
+	if err := setupMetricsExporter(env.ServingRequestMetricsBackend); err != nil {
+		logger.Errorw("Error setting up request metrics exporter. Request metrics will be unavailable.", zap.Error(err))
+		return false
+	}
+
+	return true
+}
+
+func buildAdminServer(healthState *health.State, probe *readiness.Probe, logger *zap.SugaredLogger) *http.Server {
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc(requestQueueHealthPath, healthState.HealthHandler(func() bool {
+		if !probe.ProbeContainer() {
+			return false
+		}
+		logger.Info("User-container successfully probed.")
+		return true
+	}, probe.IsAggressive()))
+	adminMux.HandleFunc(queue.RequestQueueDrainPath, healthState.DrainHandler())
+
+	return &http.Server{
+		Addr:    ":" + strconv.Itoa(networking.QueueAdminPort),
+		Handler: adminMux,
+	}
+}
+
+func buildMetricsServer(promStatReporter *queue.PrometheusStatsReporter) *http.Server {
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promStatReporter.Handler())
+	return &http.Server{
+		Addr:    ":" + strconv.Itoa(networking.AutoscalingQueueMetricsPort),
+		Handler: metricsMux,
 	}
 }
 


### PR DESCRIPTION
/lint


## Proposed Changes

* Move a bunch of stuff around in the queue-proxy with the hope of making it more approachable. I tried not to go too wild. Things are still pretty knotty. Extremely open to feedback, particularly with regard to naming choices.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
