### PR TITLE
Always refresh activator endpoint in setup of TestServiceToServiceViaActivator

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -394,16 +394,15 @@ func TestTargetBurstCapacity(t *testing.T) {
 	grp.Go(func() error {
 		return generateTraffic(ctx, 7, duration, stopCh)
 	})
-	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error getting activator endpoints: %v", err)
-	}
-	t.Logf("Activator endpoints: %v", aeps)
 
 	// Wait for the endpoints to equalize.
 	// There's some jitter in the beginning possible, since it takes 2 seconds
 	// for us to start evaluating things.
 	if err := wait.Poll(250*time.Millisecond, 2*cfg.StableWindow, func() (bool, error) {
+		aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
 		svcEps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
 			ctx.resources.Revision.Status.ServiceName, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -240,7 +240,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	}
 
 	// Wait for the endpoints to equalize.
-	if err := wait.Poll(200*time.Millisecond, 1*time.Minute, func() (bool, error) {
+	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
 		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
 			system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -244,7 +244,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
 			system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("Error getting activator endpoints: %v", err)
+			return false, err
 		}
 		svcEps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
 			resources.Revision.Status.ServiceName, metav1.GetOptions{})

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -239,15 +239,13 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 		t.Fatalf("Failed to create a service: %v", err)
 	}
 
-	aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
-		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error getting activator endpoints: %v", err)
-	}
-	t.Logf("Activator endpoints: %v", aeps)
-
 	// Wait for the endpoints to equalize.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.Poll(200*time.Millisecond, 1*time.Minute, func() (bool, error) {
+		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
+			system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Error getting activator endpoints: %v", err)
+		}
 		svcEps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
 			resources.Revision.Status.ServiceName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* Always refresh activator endpoint in setup of TestServiceToServiceViaActivator

Probably will fix #5272 #5271 #5270 #5269

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
