### PR TITLE
Call MarkCertificateNotOwned() when getting NotOwnResource error

### DIFF
--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -161,6 +161,11 @@ func MarkCertificateNotReady(r *v1alpha1.Route) {
 	r.Status.MarkCertificateNotReady(routenames.Certificate(r))
 }
 
+// MarkCertificateNotOwned calls the method of the same name on .Status
+func MarkCertificateNotOwned(r *v1alpha1.Route) {
+	r.Status.MarkCertificateNotOwned(routenames.Certificate(r))
+}
+
 // MarkCertificateReady calls the method of the same name on .Status
 func MarkCertificateReady(r *v1alpha1.Route) {
 	r.Status.MarkCertificateReady(routenames.Certificate(r))


### PR DESCRIPTION
When ReconcileCertificate() is failed with NotOwnResource error*1, Route
should call MarkCertificateNotOwned() to update the status.

This patch makes the tiny change.

*1 https://github.com/knative/serving/blob/b498f76ef904fdebf13e571b7c1e3135e140d9a3/pkg/reconciler/accessor/networking/certificate.go#L65-L69

/lint

## Proposed Changes

* Call MarkCertificateNotOwned() when getting NotOwnResource error

**Release Note**

```release-note
NONE
```
