### PR TITLE
Add MarkResourceNotOwned to PodAutoscaler when metrics is not owned

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -312,6 +312,29 @@ func TestReconcile(t *testing.T) {
 				`PodAutoscaler: "test-revision" does not own HPA: "test-revision"`),
 		},
 	}, {
+		Name: "metric is disowned",
+		Objects: []runtime.Object{
+			hpa(pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency))),
+			pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency),
+				WithMSvcStatus(testRevision+"-metrics"), WithTraffic, WithPAStatusService(testRevision)),
+			deploy(testNamespace, testRevision),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
+			metric(pa(testNamespace, testRevision,
+				WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency)), testRevision+"-metrics", WithMetricOwnersRemoved),
+			metricsSvc(testNamespace, testRevision, WithSvcSelector(usualSelector),
+				SvcWithAnnotationValue(autoscaling.ClassAnnotationKey, autoscaling.HPA),
+				SvcWithAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Concurrency)),
+		},
+		Key:     key(testNamespace, testRevision),
+		WantErr: true,
+		WantStatusUpdates: []ktesting.UpdateActionImpl{{
+			Object: pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation(autoscaling.Concurrency),
+				WithMSvcStatus(testRevision+"-metrics"), WithTraffic, WithPAStatusService(testRevision), MarkResourceNotOwnedByPA("Metric", testRevision)),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "InternalError", `error reconciling metric: PA: test-revision does not own Metric: test-revision`),
+		},
+	}, {
 		Name: "nop deletion reconcile",
 		// Test that with a DeletionTimestamp we do nothing.
 		Objects: []runtime.Object{
@@ -502,8 +525,14 @@ func metricsSvc(ns, n string, opts ...K8sServiceOption) *corev1.Service {
 	return svc
 }
 
-func metric(pa *asv1a1.PodAutoscaler, msvcName string) *asv1a1.Metric {
-	return aresources.MakeMetric(context.Background(), pa, msvcName, defaultConfig().Autoscaler)
+type metricOption func(*asv1a1.Metric)
+
+func metric(pa *asv1a1.PodAutoscaler, msvcName string, opts ...metricOption) *asv1a1.Metric {
+	m := aresources.MakeMetric(context.Background(), pa, msvcName, defaultConfig().Autoscaler)
+	for _, o := range opts {
+		o(m)
+	}
+	return m
 }
 
 func defaultConfig() *config.Config {

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -172,6 +172,9 @@ func (c *Base) ReconcileMetric(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		}
 	} else if err != nil {
 		return perrors.Wrap(err, "error fetching metric")
+	} else if !metav1.IsControlledBy(metric, pa) {
+		pa.Status.MarkResourceNotOwned("Metric", desiredMetric.Name)
+		return fmt.Errorf("PA: %s does not own Metric: %s", pa.Name, desiredMetric.Name)
 	} else {
 		if !equality.Semantic.DeepEqual(desiredMetric.Spec, metric.Spec) {
 			want := metric.DeepCopy()

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -187,6 +187,11 @@ func WithMetricAnnotation(metric string) PodAutoscalerOption {
 	return withAnnotationValue(autoscaling.MetricAnnotationKey, metric)
 }
 
+// WithMetricOwnersRemoved clears the owner references of this PodAutoscaler.
+func WithMetricOwnersRemoved(m *asv1a1.Metric) {
+	m.OwnerReferences = nil
+}
+
 // WithUpperScaleBound sets maxScale to the given number.
 func WithUpperScaleBound(i int) PodAutoscalerOption {
 	return withAnnotationValue(autoscaling.MaxScaleAnnotationKey, strconv.Itoa(i))


### PR DESCRIPTION
## Proposed Changes

This patch adds MarkResourceNotOwned to PodAutoscaler when the metric
which will be reconciled is not owned by the PodAutoscaler.

/lint

**Release Note**

```release-note
NONE
```
