### PR TITLE
This adds a custom error handler to our reverse proxies.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -415,6 +415,10 @@ func buildServer(env config, rp *readiness.Probe, reqChan chan queue.ReqEvent, l
 
 	httpProxy := httputil.NewSingleHostReverseProxy(target)
 	httpProxy.Transport = buildTransport(env, logger)
+	httpProxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		logger.Infof("error reverse proxying request: %v", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
 
 	httpProxy.FlushInterval = -1
 	activatorutil.SetupHeaderPruning(httpProxy)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -193,7 +193,7 @@ func TestActivationHandler(t *testing.T) {
 		label:             "request error",
 		namespace:         testNamespace,
 		name:              testRevName,
-		wantBody:          "",
+		wantBody:          "request error\n",
 		wantCode:          http.StatusBadGateway,
 		wantErr:           errors.New("request error"),
 		endpointsInformer: endpointsInformer(endpoints(testNamespace, testRevName, 1000)),

--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -104,13 +104,17 @@ func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.Ro
 // NewProberTransport creates a RoundTripper that is useful for probing,
 // since it will not cache connections.
 func NewProberTransport() http.RoundTripper {
-	return newAutoTransport(newHTTPTransport(DefaultConnTimeout, true /*disable keep-alives*/), NewH2CTransport())
+	return newAutoTransport(
+		newHTTPTransport(DefaultConnTimeout, true /*disable keep-alives*/),
+		NewH2CTransport())
 }
 
 // NewAutoTransport creates a RoundTripper that can use appropriate transport
 // based on the request's HTTP version.
 func NewAutoTransport() http.RoundTripper {
-	return newAutoTransport(newHTTPTransport(DefaultConnTimeout, false /*disable keep-alives*/), NewH2CTransport())
+	return newAutoTransport(
+		newHTTPTransport(DefaultConnTimeout, false /*disable keep-alives*/),
+		NewH2CTransport())
 }
 
 // AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others


### PR DESCRIPTION
This custom error handler includes more information in both the 502 response and logs things in a way that will give us more information about the rash of 502s we've been seeing.

