### PR TITLE
Validate max scale up rate and make sure we can scale up.

### DIFF
--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -128,6 +128,14 @@ func TestAutoscalerStableModeNoChangeAlreadyScaled(t *testing.T) {
 	a.expectScale(t, time.Now(), 5, expectedEBC(10, 100, 50, 5), true)
 }
 
+func TestAutoscalerStableModeIncreaseWithSmallScaleUpRate(t *testing.T) {
+	metrics := &autoscalerfake.MetricClient{StableConcurrency: 3}
+	a := newTestAutoscaler(t, 1 /* target */, 1982 /* TBC */, metrics)
+	a.deciderSpec.MaxScaleUpRate = 1.1
+	endpoints(2, testService)
+	a.expectScale(t, time.Now(), 3, expectedEBC(1, 1982, 3, 2), true)
+}
+
 func TestAutoscalerStableModeIncreaseWithConcurrencyDefault(t *testing.T) {
 	metrics := &autoscalerfake.MetricClient{StableConcurrency: 50.0}
 	a := newTestAutoscaler(t, 10, 101, metrics)

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -196,6 +196,10 @@ func validate(lc *Config) (*Config, error) {
 		return nil, fmt.Errorf("requests-per-second-target-default must be at least %v, got %v", autoscaling.TargetMin, lc.RPSTargetDefault)
 	}
 
+	if lc.MaxScaleUpRate <= 1.0 {
+		return nil, fmt.Errorf("max-scale-up-rate = %v, must be greater than 1.0", lc.MaxScaleUpRate)
+	}
+
 	// We can't permit stable window be less than our aggregation window for correctness.
 	if lc.StableWindow < autoscaling.WindowMin {
 		return nil, fmt.Errorf("stable-window = %v, must be at least %v", lc.StableWindow, BucketSize)

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -55,7 +55,7 @@ func TestNewConfig(t *testing.T) {
 	}, {
 		name: "minimum",
 		input: map[string]string{
-			"max-scale-up-rate":                       "1.0",
+			"max-scale-up-rate":                       "1.001",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
 			"target-burst-capacity":                   "0",
@@ -68,7 +68,7 @@ func TestNewConfig(t *testing.T) {
 		want: func(c Config) *Config {
 			c.ContainerConcurrencyTargetFraction = 0.5
 			c.ContainerConcurrencyTargetDefault = 10
-			c.MaxScaleUpRate = 1
+			c.MaxScaleUpRate = 1.001
 			c.TargetBurstCapacity = 0
 			c.StableWindow = 5 * time.Minute
 			c.PanicWindow = 10 * time.Second
@@ -96,7 +96,7 @@ func TestNewConfig(t *testing.T) {
 		name: "with toggles on",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
-			"max-scale-up-rate":                       "1.0",
+			"max-scale-up-rate":                       "1.01",
 			"container-concurrency-target-percentage": "0.71",
 			"container-concurrency-target-default":    "10.5",
 			"requests-per-second-target-default":      "10.11",
@@ -112,7 +112,7 @@ func TestNewConfig(t *testing.T) {
 			c.ContainerConcurrencyTargetDefault = 10.5
 			c.ContainerConcurrencyTargetFraction = 0.71
 			c.RPSTargetDefault = 10.11
-			c.MaxScaleUpRate = 1
+			c.MaxScaleUpRate = 1.01
 			c.StableWindow = 5 * time.Minute
 			c.PanicWindow = 11 * time.Second
 			return &c
@@ -184,6 +184,12 @@ func TestNewConfig(t *testing.T) {
 		input: map[string]string{
 			"container-concurrency-target-percentage": "30.0",
 			"container-concurrency-target-default":    "2",
+		},
+		wantErr: true,
+	}, {
+		name: "max scale up rate 1.0",
+		input: map[string]string{
+			"max-scale-up-rate": "1",
 		},
 		wantErr: true,
 	}, {

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -88,7 +88,7 @@ const (
 
 func defaultConfigMapData() map[string]string {
 	return map[string]string{
-		"max-scale-up-rate":                       "1.0",
+		"max-scale-up-rate":                       "12.0",
 		"container-concurrency-target-percentage": fmt.Sprintf("%f", defaultTU),
 		"container-concurrency-target-default":    fmt.Sprintf("%f", defaultConcurrencyTarget),
 		"stable-window":                           stableWindow.String(),

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -182,7 +182,7 @@ func newTestController(t *testing.T) (
 				Name:      autoscaler.ConfigName,
 			},
 			Data: map[string]string{
-				"max-scale-up-rate":                       "1.0",
+				"max-scale-up-rate":                       "2.0",
 				"container-concurrency-target-percentage": "0.5",
 				"container-concurrency-target-default":    "10.0",
 				"stable-window":                           "5m",

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -158,7 +158,7 @@ func newTestControllerWithConfig(t *testing.T, deploymentConfig *deployment.Conf
 			Name:      autoscaler.ConfigName,
 		},
 		Data: map[string]string{
-			"max-scale-up-rate":                       "1.0",
+			"max-scale-up-rate":                       "11.0",
 			"container-concurrency-target-percentage": "0.5",
 			"container-concurrency-target-default":    "10.0",
 			"stable-window":                           "5m",


### PR DESCRIPTION
Fix a few things around autoscaler.
- Add validation for the max scale up rate values. Currently there's none, beyond it being a floating point.
- If the provided max scale up rate value is small, make sure we can grow by at least one pod if we need to scale up
- Update tests

/assign mattmoor
/assign @yanweiguo 
/lint