### PR TITLE
Fix wrong cat and kubectl usage in test script

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -123,7 +123,7 @@ function update_cluster() {
         --patch '{"spec": {"minReplicas": 10}}'
 
   echo ">> Setting up 'prod' config-mako"
-  cat | kubectl apply -f - <<EOF
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
This command does not input anything to `cat` command.

```
cat | kubectl apply -f - <<EOF
```

Hence, `kubectl apply` works fine, but we need to push `Enter` key to
finish cat command and proceed the script.

To fix it, we need either

```
kubectl apply -f - <<EOF
```

or

```
cat <<EOF | kubectl apply -f -
```

This patch changes the script to the latter, which is same style with
https://kubernetes.io/docs/reference/kubectl/cheatsheet/.

## Proposed Changes

* Fix wrong cat and kubectl usage in test script

**Release Note**

```release-note
NONE
```
