### PR TITLE
Add an ErrorHandler to the httpproxy image.

### DIFF
--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -57,7 +57,12 @@ func initialHTTPProxy(proxyURL string) *httputil.ReverseProxy {
 	if err != nil {
 		log.Fatalf("Failed to parse url %v", proxyURL)
 	}
-	return httputil.NewSingleHostReverseProxy(target)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		log.Printf("error reverse proxying request: %v", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
+	return proxy
 }
 
 func main() {


### PR DESCRIPTION
This attempts to get additional logging out of the httpproxy image about why it is failing to proxy the request.

This is @tcnghia's idea, I am just the voluntary fingertips here. :)