### PR TITLE
Improve error from readiness probe validation

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -458,14 +458,14 @@ func validateReadinessProbe(p *corev1.Probe) *apis.FieldError {
 		if p.FailureThreshold != 0 {
 			errs = errs.Also(&apis.FieldError{
 				Message: "failureThreshold is disallowed when periodSeconds is zero",
-				Paths:   []string{"periodSeconds", "failureThreshold"},
+				Paths:   []string{"failureThreshold"},
 			})
 		}
 
 		if p.TimeoutSeconds != 0 {
 			errs = errs.Also(&apis.FieldError{
 				Message: "timeoutSeconds is disallowed when periodSeconds is zero",
-				Paths:   []string{"periodSeconds", "timeoutSeconds"},
+				Paths:   []string{"timeoutSeconds"},
 			})
 		}
 	} else {

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -456,11 +456,17 @@ func validateReadinessProbe(p *corev1.Probe) *apis.FieldError {
 	// PeriodSeconds == 0 indicates Knative's special probe with aggressive retries
 	if p.PeriodSeconds == 0 {
 		if p.FailureThreshold != 0 {
-			errs = errs.Also(apis.ErrDisallowedFields("failureThreshold"))
+			errs = errs.Also(&apis.FieldError{
+				Message: "failureThreshold is disallowed when periodSeconds is zero",
+				Paths:   []string{"periodSeconds", "failureThreshold"},
+			})
 		}
 
 		if p.TimeoutSeconds != 0 {
-			errs = errs.Also(apis.ErrDisallowedFields("timeoutSeconds"))
+			errs = errs.Also(&apis.FieldError{
+				Message: "timeoutSeconds is disallowed when periodSeconds is zero",
+				Paths:   []string{"periodSeconds", "timeoutSeconds"},
+			})
 		}
 	} else {
 		if p.TimeoutSeconds < 1 {

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -610,7 +610,10 @@ func TestContainerValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrDisallowedFields("readinessProbe.failureThreshold"),
+		want: &apis.FieldError{
+			Message: "failureThreshold is disallowed when periodSeconds is zero",
+			Paths:   []string{"readinessProbe.periodSeconds", "readinessProbe.failureThreshold"},
+		},
 	}, {
 		name: "invalid readiness probe (has timeoutSeconds while using special probe)",
 		c: corev1.Container{
@@ -626,7 +629,10 @@ func TestContainerValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrDisallowedFields("readinessProbe.timeoutSeconds"),
+		want: &apis.FieldError{
+			Message: "timeoutSeconds is disallowed when periodSeconds is zero",
+			Paths:   []string{"readinessProbe.periodSeconds", "readinessProbe.timeoutSeconds"},
+		},
 	}, {
 		name: "out of bounds probe values",
 		c: corev1.Container{

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -612,7 +612,7 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "failureThreshold is disallowed when periodSeconds is zero",
-			Paths:   []string{"readinessProbe.periodSeconds", "readinessProbe.failureThreshold"},
+			Paths:   []string{"readinessProbe.failureThreshold"},
 		},
 	}, {
 		name: "invalid readiness probe (has timeoutSeconds while using special probe)",
@@ -631,7 +631,7 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "timeoutSeconds is disallowed when periodSeconds is zero",
-			Paths:   []string{"readinessProbe.periodSeconds", "readinessProbe.timeoutSeconds"},
+			Paths:   []string{"readinessProbe.timeoutSeconds"},
 		},
 	}, {
 		name: "out of bounds probe values",


### PR DESCRIPTION
## Proposed Changes

As described in https://github.com/knative/serving/issues/5382,
`failureThreshold` and `timeoutSeconds` in readinessprobe are
disapplowed only when `periodSeconds` is zero. This patch improves the
error.

- Error message after this patch:
```
error: services.serving.knative.dev "hello-example" could not be patched: Internal error occurred: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: timeoutSeconds is disallowed when periodSeconds is zero: spec.template.spec.containers[0].readinessProbe.failureThreshold, spec.template.spec.containers[0].readinessProbe.periodSeconds
```

/lint

Fixes https://github.com/knative/serving/issues/5382



**Release Note**

```release-note
NONE
```
