### PR TITLE
Remove extremely chatty log entry

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -182,10 +182,8 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
-	tryStart := time.Now()
 	err = a.throttler.Try(tryContext, revID, func() {
 		trySpan.End()
-		logger.Debugf("Waiting for throttler took %v time", time.Since(tryStart))
 
 		// This opportunistically caches the probes, so
 		// a few concurrent requests might result in concurrent probes


### PR DESCRIPTION
This entry pollutes our integration tests to the level of obscuring anything useful in them
especially in tests that generate any load (e.g. autoscaler tests)

/assign @yanweiguo  mattmoor

