### PR TITLE
Remove -port suffix from webhook and activator

### DIFF
--- a/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
+++ b/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
@@ -73,7 +73,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_port_name]
         action: keep
-        regex: knative-serving;activator;metrics-port
+        regex: knative-serving;activator;metrics
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace
@@ -91,7 +91,7 @@ data:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_role, __meta_kubernetes_pod_container_port_name]
         action: keep
-        regex: knative-serving;webhook;metrics-port
+        regex: knative-serving;webhook;metrics
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -42,7 +42,7 @@ spec:
         # and substituted here.
         image: knative.dev/serving/cmd/webhook
         ports:
-        - name: metrics-port
+        - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008


### PR DESCRIPTION
Also fix Prometheus scraping for activator and webhook

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
