### PR TITLE
Fix tests to run with -count=2 that started failing with Go1.13

### DIFF
--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -93,6 +93,7 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			defer testing2.ClearAll()
 			buf.Reset()
 			cm := &corev1.ConfigMap{}
 			cm.Data = map[string]string{"logging.request-log-template": test.template}

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -96,6 +96,7 @@ func TestRequestMetricHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.label, func(t *testing.T) {
+			defer ClearAll()
 			reporter := &fakeReporter{}
 			handler := NewMetricHandler(revisionLister(revision(testNamespace, testRevName)), reporter,
 				TestLogger(t), test.baseHandler)


### PR DESCRIPTION
I think go changed the ordering of the test execution and that
started to show up as new errors when executed with count > 1

/assign mattmoor


/lint
