### PR TITLE
Work with go1.13 by simply deleting explicit flag parsing

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -63,7 +63,6 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
 		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
 
-	flag.Parse()
 	flag.Set("alsologtostderr", "true")
 	logging.InitializeLogger(test.Flags.LogVerbose)
 

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -57,6 +57,8 @@ type ServingEnvironmentFlags struct {
 	ResolvableDomain bool // Resolve Route controller's `domainSuffix`
 }
 
+// initializeServingFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
+// go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
 func initializeServingFlags() *ServingEnvironmentFlags {
 	var f ServingEnvironmentFlags
 


### PR DESCRIPTION
`go test` with any flag failed to work with go.1.13, as reported in https://github.com/knative/test-infra/issues/1329. The root cause is testing level flags (i.e. `-v`) are registered in `testing.Init()` according to [release note](https://golang.org/doc/go1.13#testing) as part of generated `main()` function, which is executed later than global variable initialization, such as [`initializeServingFlags`](https://github.com/knative/serving/blob/d2bf8fd8fb9d290f84530cbb88bb98fcef633bd0/test/e2e_flags.go#L53) call, which failed to parse flags as they are not registered yet.

Deleting [`flag.Parse()`](https://github.com/knative/serving/blob/d2bf8fd8fb9d290f84530cbb88bb98fcef633bd0/test/e2e_flags.go#L66) from [`initializeServingFlags`](https://github.com/knative/serving/blob/d2bf8fd8fb9d290f84530cbb88bb98fcef633bd0/test/e2e_flags.go#L53) seems not affecting flags parsing in both go1.12 and go1.13, in the latter it's done via `testing.Init()`. And in go1.12 it also works as the execution order is:
[`initializeServingFlags`](https://github.com/knative/serving/blob/d2bf8fd8fb9d290f84530cbb88bb98fcef633bd0/test/e2e_flags.go#L53) -> [`testing.M.Run (where flag.Parse is invoked implicitly)`](https://go.googlesource.com/go/+/refs/tags/go1.12.9/src/testing/testing.go#1043) -> `Running each individual test`

Fixes https://github.com/knative/test-infra/issues/1329