### PR TITLE
Switch to random podIP forwarding

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -88,24 +88,6 @@ func TestThrottler(t *testing.T) {
 			{Dest: "129.0.0.1:1234"},
 		},
 	}, {
-		name: "spread podIP load",
-		revisions: []*v1alpha1.Revision{
-			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
-		},
-		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			Dests:             []string{"128.0.0.1:1234", "128.0.0.2:1234"},
-			ReadyAddressCount: 2,
-		}},
-		trys: []types.NamespacedName{
-			{Namespace: "test-namespace", Name: "test-revision"},
-			{Namespace: "test-namespace", Name: "test-revision"},
-		},
-		expectTryResults: []tryResult{
-			{Dest: "128.0.0.1:1234"},
-			{Dest: "128.0.0.2:1234"},
-		},
-	}, {
 		name: "multiple clusterip requests after podip",
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),


### PR DESCRIPTION
We are noticing significant slowdown with CC > 1 in activator after
switching to new podIP forwarding code. This section of code takes out a
write lock per request so removing it may fix this.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
