### PR TITLE
Try GC collection threshold of 500%

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -43,6 +43,10 @@ spec:
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: knative.dev/serving/cmd/activator
+        env:
+          # Run Activator with GC collection when newly generated memory is 500%
+          - name: GOGC
+            value: 500
         ports:
         - name: http1
           containerPort: 8012


### PR DESCRIPTION
This should reduce the amount of GC we're doing.
This seems to help with the activator throughput.

If this does not help much to the existing benchmarks, we can roll it back.

/assign mattmoor

