### PR TITLE
Route cluster-local visibility should take precedence over placeholder Services

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -31,7 +31,6 @@ import (
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 )
 
@@ -107,10 +106,6 @@ func makeK8sService(ctx context.Context, route *v1alpha1.Route, targetName strin
 
 	svcLabels := map[string]string{
 		serving.RouteLabelKey: route.Name,
-	}
-
-	if visibility, ok := route.Labels[config.VisibilityLabelKey]; ok {
-		svcLabels[config.VisibilityLabelKey] = visibility
 	}
 
 	return &corev1.Service{

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -287,8 +287,7 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 		expectedLabels: map[string]string{
-			serving.RouteLabelKey:     "test-route",
-			config.VisibilityLabelKey: config.VisibilityClusterLocal,
+			serving.RouteLabelKey: "test-route",
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
When Route has cluster-local visibility, all sub-Route should use that
and ignore settings on placeholder Services.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  `cluster-local` visibility on Route will take precedence over placeholder Services' setting.
*  Do not copy visibility setting from Route to placeholder Services, because that would overwrite user settings.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix a bug in cluster-local Service handling that cause cluster-local visibility setting to be not changeable for ksvc and Route.
```
