### PR TITLE
Move validation of autoscaling.knative.dev/metric to RevisionTemplateSpec

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -41,7 +41,7 @@ func ValidateAnnotations(anns map[string]string) *apis.FieldError {
 	if len(anns) == 0 {
 		return nil
 	}
-	return validateMinMaxScale(anns).Also(validateFloats(anns)).Also(validateWindows(anns))
+	return validateMinMaxScale(anns).Also(validateFloats(anns)).Also(validateWindows(anns).Also(validateMetric(anns)))
 }
 
 func validateFloats(annotations map[string]string) *apis.FieldError {
@@ -114,4 +114,33 @@ func validateMinMaxScale(annotations map[string]string) *apis.FieldError {
 		})
 	}
 	return errs
+}
+
+func validateMetric(annotations map[string]string) *apis.FieldError {
+	if metric, ok := annotations[MetricAnnotationKey]; ok {
+		var classValue string
+		if c, ok := annotations[ClassAnnotationKey]; ok {
+			classValue = c
+		} else {
+			// Default to "kpa" class for backward compatibility.
+			classValue = KPA
+		}
+		switch classValue {
+		case KPA:
+			switch metric {
+			case Concurrency, RPS:
+				return nil
+			}
+		case HPA:
+			switch metric {
+			case CPU, Concurrency, RPS:
+				return nil
+			}
+		default:
+			// Leave other classes of PodAutoscaler alone.
+			return nil
+		}
+		return apis.ErrInvalidValue(metric, MetricAnnotationKey)
+	}
+	return nil
 }

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -118,12 +118,9 @@ func validateMinMaxScale(annotations map[string]string) *apis.FieldError {
 
 func validateMetric(annotations map[string]string) *apis.FieldError {
 	if metric, ok := annotations[MetricAnnotationKey]; ok {
-		var classValue string
+		classValue := KPA
 		if c, ok := annotations[ClassAnnotationKey]; ok {
 			classValue = c
-		} else {
-			// Default to "kpa" class for backward compatibility.
-			classValue = KPA
 		}
 		switch classValue {
 		case KPA:

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -199,6 +199,9 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "valid class HPA with metric RPS",
 		annotations: map[string]string{ClassAnnotationKey: HPA, MetricAnnotationKey: RPS},
+	}, {
+		name:        "other than HPA and KPA class",
+		annotations: map[string]string{ClassAnnotationKey: "other", MetricAnnotationKey: RPS},
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -43,23 +43,23 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is -1",
 		annotations: map[string]string{MinScaleAnnotationKey: "-1"},
-		expectErr:   "expected 1 <= -1 <= 2147483647: autoscaling.knative.dev/minScale",
+		expectErr:   "expected 1 <= -1 <= 2147483647: " + MinScaleAnnotationKey,
 	}, {
 		name:        "maxScale is -1",
 		annotations: map[string]string{MaxScaleAnnotationKey: "-1"},
-		expectErr:   "expected 1 <= -1 <= 2147483647: autoscaling.knative.dev/maxScale",
+		expectErr:   "expected 1 <= -1 <= 2147483647: " + MaxScaleAnnotationKey,
 	}, {
 		name:        "minScale is foo",
 		annotations: map[string]string{MinScaleAnnotationKey: "foo"},
-		expectErr:   "expected 1 <= foo <= 2147483647: autoscaling.knative.dev/minScale",
+		expectErr:   "expected 1 <= foo <= 2147483647: " + MinScaleAnnotationKey,
 	}, {
 		name:        "maxScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar"},
-		expectErr:   "expected 1 <= bar <= 2147483647: autoscaling.knative.dev/maxScale",
+		expectErr:   "expected 1 <= bar <= 2147483647: " + MaxScaleAnnotationKey,
 	}, {
 		name:        "max/minScale is bar",
 		annotations: map[string]string{MaxScaleAnnotationKey: "bar", MinScaleAnnotationKey: "bar"},
-		expectErr:   "expected 1 <= bar <= 2147483647: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
+		expectErr:   "expected 1 <= bar <= 2147483647: " + MaxScaleAnnotationKey + ", " + MinScaleAnnotationKey,
 	}, {
 		name:        "minScale is 5",
 		annotations: map[string]string{MinScaleAnnotationKey: "5"},
@@ -72,7 +72,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "minScale is 5, maxScale is 2",
 		annotations: map[string]string{MinScaleAnnotationKey: "5", MaxScaleAnnotationKey: "2"},
-		expectErr:   "maxScale=2 is less than minScale=5: autoscaling.knative.dev/maxScale, autoscaling.knative.dev/minScale",
+		expectErr:   "maxScale=2 is less than minScale=5: " + MaxScaleAnnotationKey + ", " + MinScaleAnnotationKey,
 	}, {
 		name: "minScale is 0, maxScale is 0",
 		annotations: map[string]string{
@@ -82,45 +82,45 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "panic window percentange bad",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "-1"},
-		expectErr:   "expected 1 <= -1 <= 100: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "expected 1 <= -1 <= 100: " + PanicWindowPercentageAnnotationKey,
 	}, {
 		name:        "panic window percentange bad2",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "202"},
-		expectErr:   "expected 1 <= 202 <= 100: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "expected 1 <= 202 <= 100: " + PanicWindowPercentageAnnotationKey,
 	}, {
 		name:        "panic window percentange bad3",
 		annotations: map[string]string{PanicWindowPercentageAnnotationKey: "fifty"},
-		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicWindowPercentage",
+		expectErr:   "invalid value: fifty: " + PanicWindowPercentageAnnotationKey,
 	}, {
 		name:        "panic window percentange good",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "210"},
 	}, {
 		name:        "panic threshold percentange bad2",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "109"},
-		expectErr:   "expected 110 <= 109 <= 1000: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "expected 110 <= 109 <= 1000: " + PanicThresholdPercentageAnnotationKey,
 	}, {
 		name:        "panic threshold percentange bad2.5",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "10009"},
-		expectErr:   "expected 110 <= 10009 <= 1000: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "expected 110 <= 10009 <= 1000: " + PanicThresholdPercentageAnnotationKey,
 	}, {
 		name:        "panic threshold percentange bad3",
 		annotations: map[string]string{PanicThresholdPercentageAnnotationKey: "fifty"},
-		expectErr:   "invalid value: fifty: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr:   "invalid value: fifty: " + PanicThresholdPercentageAnnotationKey,
 	}, {
 		name:        "target negative",
 		annotations: map[string]string{TargetAnnotationKey: "-11"},
-		expectErr:   "invalid value: -11: autoscaling.knative.dev/target",
+		expectErr:   "invalid value: -11: " + TargetAnnotationKey,
 	}, {
 		name:        "target 0",
 		annotations: map[string]string{TargetAnnotationKey: "0"},
-		expectErr:   "invalid value: 0: autoscaling.knative.dev/target",
+		expectErr:   "invalid value: 0: " + TargetAnnotationKey,
 	}, {
 		name:        "target okay",
 		annotations: map[string]string{TargetAnnotationKey: "11"},
 	}, {
 		name:        "TBC negative",
 		annotations: map[string]string{TargetBurstCapacityKey: "-11"},
-		expectErr:   "invalid value: -11: autoscaling.knative.dev/targetBurstCapacity",
+		expectErr:   "invalid value: -11: " + TargetBurstCapacityKey,
 	}, {
 		name:        "TBC 0",
 		annotations: map[string]string{TargetBurstCapacityKey: "0"},
@@ -133,31 +133,31 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "TBC invalid",
 		annotations: map[string]string{TargetBurstCapacityKey: "qarashen"},
-		expectErr:   "invalid value: qarashen: autoscaling.knative.dev/targetBurstCapacity",
+		expectErr:   "invalid value: qarashen: " + TargetBurstCapacityKey,
 	}, {
 		name:        "TU too small",
 		annotations: map[string]string{TargetUtilizationPercentageKey: "0"},
-		expectErr:   "expected 1 <= 0 <= 100: autoscaling.knative.dev/targetUtilizationPercentage",
+		expectErr:   "expected 1 <= 0 <= 100: " + TargetUtilizationPercentageKey,
 	}, {
 		name:        "TU too big",
 		annotations: map[string]string{TargetUtilizationPercentageKey: "101"},
-		expectErr:   "expected 1 <= 101 <= 100: autoscaling.knative.dev/targetUtilizationPercentage",
+		expectErr:   "expected 1 <= 101 <= 100: " + TargetUtilizationPercentageKey,
 	}, {
 		name:        "TU invalid",
 		annotations: map[string]string{TargetUtilizationPercentageKey: "dghyak"},
-		expectErr:   "invalid value: dghyak: autoscaling.knative.dev/targetUtilizationPercentage",
+		expectErr:   "invalid value: dghyak: " + TargetUtilizationPercentageKey,
 	}, {
 		name:        "window invalid",
 		annotations: map[string]string{WindowAnnotationKey: "jerry-was-a-racecar-driver"},
-		expectErr:   "invalid value: jerry-was-a-racecar-driver: autoscaling.knative.dev/window",
+		expectErr:   "invalid value: jerry-was-a-racecar-driver: " + WindowAnnotationKey,
 	}, {
 		name:        "window too short",
 		annotations: map[string]string{WindowAnnotationKey: "1s"},
-		expectErr:   "expected 6s <= 1s <= 1h0m0s: autoscaling.knative.dev/window",
+		expectErr:   "expected 6s <= 1s <= 1h0m0s: " + WindowAnnotationKey,
 	}, {
 		name:        "window too long",
 		annotations: map[string]string{WindowAnnotationKey: "365h"},
-		expectErr:   "expected 6s <= 365h <= 1h0m0s: autoscaling.knative.dev/window",
+		expectErr:   "expected 6s <= 365h <= 1h0m0s: " + WindowAnnotationKey,
 	}, {
 		name: "all together now fail",
 		annotations: map[string]string{
@@ -166,7 +166,7 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MinScaleAnnotationKey:                 "-4",
 			MaxScaleAnnotationKey:                 "never",
 		},
-		expectErr: "expected 1 <= -11 <= 100: autoscaling.knative.dev/panicWindowPercentage\nexpected 1 <= -4 <= 2147483647: autoscaling.knative.dev/minScale\nexpected 1 <= never <= 2147483647: autoscaling.knative.dev/maxScale\ninvalid value: fifty: autoscaling.knative.dev/panicThresholdPercentage",
+		expectErr: "expected 1 <= -11 <= 100: " + PanicWindowPercentageAnnotationKey + "\nexpected 1 <= -4 <= 2147483647: " + MinScaleAnnotationKey + "\nexpected 1 <= never <= 2147483647: " + MaxScaleAnnotationKey + "\ninvalid value: fifty: " + PanicThresholdPercentageAnnotationKey,
 	}, {
 		name: "all together now, succeed",
 		annotations: map[string]string{
@@ -176,8 +176,30 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 			MaxScaleAnnotationKey:                 "8",
 			WindowAnnotationKey:                   "1984s",
 		},
+	}, {
+		name:        "invalid metric for default class(KPA)",
+		annotations: map[string]string{MetricAnnotationKey: CPU},
+		expectErr:   "invalid value: cpu: " + MetricAnnotationKey,
+	}, {
+		name:        "invalid metric for HPA class",
+		annotations: map[string]string{MetricAnnotationKey: "metrics", ClassAnnotationKey: HPA},
+		expectErr:   "invalid value: metrics: " + MetricAnnotationKey,
+	}, {
+		name:        "valid class KPA with metric RPS",
+		annotations: map[string]string{MetricAnnotationKey: RPS},
+	}, {
+		name:        "valid class KPA with metric Concurrency",
+		annotations: map[string]string{MetricAnnotationKey: Concurrency},
+	}, {
+		name:        "valid class HPA with metric Concurrency",
+		annotations: map[string]string{ClassAnnotationKey: HPA, MetricAnnotationKey: Concurrency},
+	}, {
+		name:        "valid class HPA with metric CPU",
+		annotations: map[string]string{ClassAnnotationKey: HPA, MetricAnnotationKey: CPU},
+	}, {
+		name:        "valid class HPA with metric RPS",
+		annotations: map[string]string{ClassAnnotationKey: HPA, MetricAnnotationKey: RPS},
 	}}
-
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got, want := ValidateAnnotations(c.annotations).Error(), c.expectErr; !reflect.DeepEqual(got, want) {

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -172,85 +172,6 @@ func TestPodAutoscalerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "valid, optional annotations",
-		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "valid",
-				Annotations: map[string]string{
-					autoscaling.MetricAnnotationKey:   autoscaling.RPS,
-					autoscaling.MinScaleAnnotationKey: "2",
-				},
-			},
-			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-				ProtocolType: net.ProtocolH2C,
-			},
-		},
-		want: nil,
-	}, {
-		name: "valid, KPA with RPS",
-		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "valid",
-				Annotations: map[string]string{
-					autoscaling.MetricAnnotationKey: autoscaling.RPS,
-				},
-			},
-			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-				ProtocolType: net.ProtocolH2C,
-			},
-		},
-		want: nil,
-	}, {
-		name: "valid, HPA with concurrency",
-		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "valid",
-				Annotations: map[string]string{
-					autoscaling.MetricAnnotationKey: autoscaling.Concurrency,
-					autoscaling.ClassAnnotationKey:  autoscaling.HPA,
-				},
-			},
-			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-				ProtocolType: net.ProtocolH2C,
-			},
-		},
-		want: nil,
-	}, {
-		name: "valid, HPA with RPS",
-		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "valid",
-				Annotations: map[string]string{
-					autoscaling.MetricAnnotationKey: autoscaling.RPS,
-					autoscaling.ClassAnnotationKey:  autoscaling.HPA,
-				},
-			},
-			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-				ProtocolType: net.ProtocolH2C,
-			},
-		},
-		want: nil,
-	}, {
 		name: "bad protocol",
 		r: &PodAutoscaler{
 			ObjectMeta: v1.ObjectMeta{
@@ -288,25 +209,6 @@ func TestPodAutoscalerValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrOutOfBoundsValue("FOO", 1, math.MaxInt32, autoscaling.MinScaleAnnotationKey).ViaField("metadata", "annotations"),
-	}, {
-		name: "bad metric",
-		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "valid",
-				Annotations: map[string]string{
-					autoscaling.MetricAnnotationKey: "memory",
-				},
-			},
-			Spec: PodAutoscalerSpec{
-				ScaleTargetRef: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "bar",
-				},
-				ProtocolType: net.ProtocolH2C,
-			},
-		},
-		want: apis.ErrInvalidValue("memory", autoscaling.MetricAnnotationKey).ViaField("annotations"),
 	}, {
 		name: "empty spec",
 		r: &PodAutoscaler{


### PR DESCRIPTION
## Proposed Changes

* Moved `autoscaling.knative.dev/metric` annotation validation from PodAutoscaler to RevisionTemplateSpec

**Actual:**
Create service with Invalid value of `autoscaling.knative.dev/metric` annotation  gives error message in the **revision** status
```
  Type     Reason         Age                From                 Message
  ----     ------         ----               ----                 -------
  Warning  InternalError  11s (x2 over 11s)  revision-controller  Operation cannot be fulfilled on deployments.apps "hello-4rzwr-deployment": the object has been modified; please apply your changes to the latest version and try again
  Warning  InternalError  4s (x10 over 12s)  revision-controller  admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: invalid value: cpu1: annotations.autoscaling.knative.dev/metric
```

**Expected:**
service create/update should fail with invalid `autoscaling.knative.dev/metric` annotation
```
kubectl create -f service.yaml 
Error from server (BadRequest): error when creating "service1.yaml": admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: invalid value: cpu1: spec.template.metadata.annotations.autoscaling.knative.dev/metric
```