### PR TITLE
Add permissions for caching.internal.knative.dev to namespace admin role

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -20,6 +20,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     serving.knative.dev/release: devel
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
     verbs: ["*"]


### PR DESCRIPTION
This patch is similar to https://github.com/knative/serving/pull/4605.

Currently even namespace's admin cannot access to knative resource
`caching.internal.knative.dev`.

This patch adds the role to namespace admin in the same manner with
other `*.internal.knative.dev`.


**Release Note**

```release-note
NONE
```
