### PR TITLE
Still sendUpdate from checkDests after ClusterIP is up.

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -401,7 +401,6 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 	for _, tc := range []struct {
 		name               string
 		endpointsArr       []*corev1.Endpoints
-		deleteEndpoints    []*corev1.Endpoints
 		revisions          []*v1alpha1.Revision
 		services           []*corev1.Service
 		probeResponses     []activatortest.FakeResponse
@@ -560,35 +559,6 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{},
 		updateCnt:   0,
-	}, {
-		name:            "removed endpoint",
-		endpointsArr:    []*corev1.Endpoints{ep("test-revision", 1234, "http", "128.0.0.1")},
-		deleteEndpoints: []*corev1.Endpoints{ep("test-revision", 1234, "http", "128.0.0.1")},
-		revisions: []*v1alpha1.Revision{
-			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
-		},
-		services: []*corev1.Service{
-			privateSksService(types.NamespacedName{"test-namespace", "test-revision"}, "129.0.0.1",
-				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
-		},
-		probeHostResponses: map[string][]activatortest.FakeResponse{
-			"129.0.0.1:1234": {{
-				Err:  nil,
-				Code: http.StatusOK,
-				Body: queue.Name,
-			}},
-			"128.0.0.1:1234": {{
-				Err:  nil,
-				Code: http.StatusServiceUnavailable,
-				Body: queue.Name,
-			}},
-		},
-		expectDests: map[types.NamespacedName]RevisionDestsUpdate{
-			{"test-namespace", "test-revision"}: {
-				Rev: types.NamespacedName{"test-namespace", "test-revision"},
-			},
-		},
-		updateCnt: 2,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			defer ClearAll()
@@ -630,14 +600,6 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			for _, ep := range tc.endpointsArr {
 				fake.CoreV1().Endpoints("test-namespace").Create(ep)
 				endpointsInformer.Informer().GetIndexer().Add(ep)
-			}
-
-			if tc.deleteEndpoints != nil {
-				time.Sleep(100 * time.Millisecond)
-			}
-			for _, ep := range tc.deleteEndpoints {
-				fake.CoreV1().Endpoints("test-namespace").Delete(ep.Name, nil)
-				endpointsInformer.Informer().GetIndexer().Delete(ep)
 			}
 
 			revDests := make(map[types.NamespacedName]RevisionDestsUpdate)


### PR DESCRIPTION
Previously we elided the sendUpdate when the ClusterIP had been successfully probed, but this had the side effect that backend capacity of the revisions wasn't updated until either:
1. The revision scales to zero, or
1. The activator restarts.

This is a problem for both increasing and decreasing the capacity of the Revision when the activator is on the request path.

The change is to simply elide the probe, but still sendUpdate with the same payload we'd send if we had just probed successfully.

With this change (and lots of omitted logging) I was able to confirm that cases where we previously ended up with inadequate capacity now have the appropriate target capacity for throttling in the case I was using to reproduce the problem.