### PR TITLE
Update resources to use duckv1 type for Status

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1655,7 +1655,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:845161fa3410fee06ef74c53a1581724d9675f656c42f08b71de8fad64108bc6"
+  digest = "1:38226cb742766a4f78effcbbae38ce0c83ff696529553356c908467a1871fdd8"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1668,7 +1668,7 @@
     "apis/istio/authentication/v1alpha1",
     "apis/istio/common/v1alpha1",
     "apis/istio/v1alpha3",
-    "apis/testing",
+    "apis/testing/v1",
     "apis/v1alpha1",
     "changeset",
     "client/clientset/versioned",
@@ -1765,7 +1765,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "bf5252e748cfaf9017228abdc74a93a42b3bcbff"
+  revision = "5f0515d33675c298c4054ac52268700bae3ceaa7"
 
 [[projects]]
   branch = "master"
@@ -1901,7 +1901,7 @@
     "knative.dev/pkg/apis/duck/v1beta1",
     "knative.dev/pkg/apis/istio/common/v1alpha1",
     "knative.dev/pkg/apis/istio/v1alpha3",
-    "knative.dev/pkg/apis/testing",
+    "knative.dev/pkg/apis/testing/v1",
     "knative.dev/pkg/client/clientset/versioned",
     "knative.dev/pkg/client/clientset/versioned/fake",
     "knative.dev/pkg/client/informers/externalversions",

--- a/pkg/apis/autoscaling/v1alpha1/metric_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_lifecycle.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 const (
@@ -68,6 +68,6 @@ func (ms *MetricStatus) IsReady() bool {
 	return condSet.Manage(ms.duck()).IsHappy()
 }
 
-func (ms *MetricStatus) duck() *duckv1beta1.Status {
-	return (*duckv1beta1.Status)(&ms.Status)
+func (ms *MetricStatus) duck() *duckv1.Status {
+	return (*duckv1.Status)(&ms.Status)
 }

--- a/pkg/apis/autoscaling/v1alpha1/metric_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_lifecycle_test.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitest "knative.dev/pkg/apis/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 	"knative.dev/serving/pkg/apis/autoscaling"
 )
 
@@ -35,7 +35,7 @@ func TestMetricDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -60,8 +60,8 @@ func TestMetricIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: MetricStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "FooCondition",
 					Status: corev1.ConditionTrue,
 				}},
@@ -71,8 +71,8 @@ func TestMetricIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: MetricStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   MetricConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -82,8 +82,8 @@ func TestMetricIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: MetricStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   MetricConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -93,8 +93,8 @@ func TestMetricIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: MetricStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: MetricConditionReady,
 				}},
 			},
@@ -103,8 +103,8 @@ func TestMetricIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: MetricStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   MetricConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -140,26 +140,26 @@ func TestMetricGetSetCondition(t *testing.T) {
 func TestTypicalFlowWithMetricCondition(t *testing.T) {
 	m := &MetricStatus{}
 	m.InitializeConditions()
-	apitest.CheckConditionOngoing(m.duck(), MetricConditionReady, t)
+	apitestv1.CheckConditionOngoing(m.duck(), MetricConditionReady, t)
 
 	const (
 		wantReason  = "reason"
 		wantMessage = "the error message"
 	)
 	m.MarkMetricFailed(wantReason, wantMessage)
-	apitest.CheckConditionFailed(m.duck(), MetricConditionReady, t)
+	apitestv1.CheckConditionFailed(m.duck(), MetricConditionReady, t)
 	if got := m.GetCondition(MetricConditionReady); got == nil || got.Reason != wantReason || got.Message != wantMessage {
 		t.Errorf("MarkMetricFailed = %v, wantReason %v, wantMessage %v", got, wantReason, wantMessage)
 	}
 
 	m.MarkMetricNotReady(wantReason, wantMessage)
-	apitest.CheckConditionOngoing(m.duck(), MetricConditionReady, t)
+	apitestv1.CheckConditionOngoing(m.duck(), MetricConditionReady, t)
 	if got := m.GetCondition(MetricConditionReady); got == nil || got.Reason != wantReason || got.Message != wantMessage {
 		t.Errorf("MarkMetricNotReady = %v, wantReason %v, wantMessage %v", got, wantReason, wantMessage)
 	}
 
 	m.MarkMetricReady()
-	apitest.CheckConditionSucceeded(m.duck(), MetricConditionReady, t)
+	apitestv1.CheckConditionSucceeded(m.duck(), MetricConditionReady, t)
 }
 
 func TestMetricGetGroupVersionKind(t *testing.T) {

--- a/pkg/apis/autoscaling/v1alpha1/metric_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_types.go
@@ -21,7 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -65,7 +65,7 @@ type MetricSpec struct {
 
 // MetricStatus reflects the status of metric collection for this specific entity.
 type MetricStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 }
 
 // MetricList is a list of Metric resources

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/autoscaling"
 )
 
@@ -216,8 +216,8 @@ func (pas *PodAutoscalerStatus) inStatusFor(status corev1.ConditionStatus, now t
 	return now.Sub(cond.LastTransitionTime.Inner.Add(dur))
 }
 
-func (pas *PodAutoscalerStatus) duck() *duckv1beta1.Status {
-	return (*duckv1beta1.Status)(&pas.Status)
+func (pas *PodAutoscalerStatus) duck() *duckv1.Status {
+	return (*duckv1.Status)(&pas.Status)
 }
 
 // GetDesiredScale returns the desired scale if ever set, or -1.

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -25,8 +25,8 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitest "knative.dev/pkg/apis/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
 )
@@ -37,7 +37,7 @@ func TestPodAutoscalerDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -78,8 +78,8 @@ func TestCanScaleToZero(t *testing.T) {
 	}, {
 		name: "active condition",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}},
@@ -90,8 +90,8 @@ func TestCanScaleToZero(t *testing.T) {
 	}, {
 		name: "inactive condition (no LTT)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionFalse,
 					// No LTT = beginning of time, so for sure we can.
@@ -103,8 +103,8 @@ func TestCanScaleToZero(t *testing.T) {
 	}, {
 		name: "inactive condition (LTT longer than grace period ago)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionFalse,
 					LastTransitionTime: apis.VolatileTime{
@@ -119,8 +119,8 @@ func TestCanScaleToZero(t *testing.T) {
 	}, {
 		name: "inactive condition (LTT less than grace period ago)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionFalse,
 					LastTransitionTime: apis.VolatileTime{
@@ -156,8 +156,8 @@ func TestActiveFor(t *testing.T) {
 	}, {
 		name: "unknown condition",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -167,8 +167,8 @@ func TestActiveFor(t *testing.T) {
 	}, {
 		name: "inactive condition",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionFalse,
 				}},
@@ -178,8 +178,8 @@ func TestActiveFor(t *testing.T) {
 	}, {
 		name: "active condition (no LTT)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 					// No LTT = beginning of time, so for sure we can.
@@ -190,8 +190,8 @@ func TestActiveFor(t *testing.T) {
 	}, {
 		name: "active condition (LTT longer than idle period ago)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 					LastTransitionTime: apis.VolatileTime{
@@ -205,8 +205,8 @@ func TestActiveFor(t *testing.T) {
 	}, {
 		name: "active condition (LTT less than idle period ago)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 					LastTransitionTime: apis.VolatileTime{
@@ -249,8 +249,8 @@ func TestCanFailActivation(t *testing.T) {
 	}, {
 		name: "active condition",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}},
@@ -261,8 +261,8 @@ func TestCanFailActivation(t *testing.T) {
 	}, {
 		name: "activating condition (no LTT)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 					// No LTT = beginning of time, so for sure we can.
@@ -274,8 +274,8 @@ func TestCanFailActivation(t *testing.T) {
 	}, {
 		name: "activating condition (LTT longer than grace period ago)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 					LastTransitionTime: apis.VolatileTime{
@@ -290,8 +290,8 @@ func TestCanFailActivation(t *testing.T) {
 	}, {
 		name: "activating condition (LTT less than grace period ago)",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 					LastTransitionTime: apis.VolatileTime{
@@ -326,8 +326,8 @@ func TestIsActivating(t *testing.T) {
 	}, {
 		name: "active=unknown",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -337,8 +337,8 @@ func TestIsActivating(t *testing.T) {
 	}, {
 		name: "active=true",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}},
@@ -348,8 +348,8 @@ func TestIsActivating(t *testing.T) {
 	}, {
 		name: "active=false",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}},
@@ -377,8 +377,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}},
@@ -388,8 +388,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -399,8 +399,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -410,8 +410,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: PodAutoscalerConditionReady,
 				}},
 			},
@@ -420,8 +420,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -431,8 +431,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status should be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -445,8 +445,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		status: PodAutoscalerStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   PodAutoscalerConditionActive,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -606,7 +606,7 @@ func TestMarkResourceNotOwned(t *testing.T) {
 func TestMarkResourceFailedCreation(t *testing.T) {
 	pa := &PodAutoscalerStatus{}
 	pa.MarkResourceFailedCreation("doesn't", "matter")
-	apitest.CheckConditionFailed(pa.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionFailed(pa.duck(), PodAutoscalerConditionActive, t)
 
 	active := pa.GetCondition("Active")
 	if active.Status != corev1.ConditionFalse {
@@ -868,38 +868,38 @@ func pa(annotations map[string]string) *PodAutoscaler {
 func TestTypicalFlow(t *testing.T) {
 	r := &PodAutoscalerStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), PodAutoscalerConditionActive, t)
-	apitest.CheckConditionOngoing(r.duck(), PodAutoscalerConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionOngoing(r.duck(), PodAutoscalerConditionReady, t)
 
 	// When we see traffic, mark ourselves active.
 	r.MarkActive()
-	apitest.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionActive, t)
-	apitest.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionReady, t)
 
 	// Check idempotency.
 	r.MarkActive()
-	apitest.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionActive, t)
-	apitest.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionReady, t)
 
 	// When we stop seeing traffic, mark outselves inactive.
 	r.MarkInactive("TheReason", "the message")
-	apitest.CheckConditionFailed(r.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionFailed(r.duck(), PodAutoscalerConditionActive, t)
 	if !r.IsInactive() {
 		t.Errorf("IsInactive was not set.")
 	}
-	apitest.CheckConditionFailed(r.duck(), PodAutoscalerConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), PodAutoscalerConditionReady, t)
 
 	// When traffic hits the activator and we scale up the deployment we mark
 	// ourselves as activating.
 	r.MarkActivating("Activating", "Red team, GO!")
-	apitest.CheckConditionOngoing(r.duck(), PodAutoscalerConditionActive, t)
-	apitest.CheckConditionOngoing(r.duck(), PodAutoscalerConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionOngoing(r.duck(), PodAutoscalerConditionReady, t)
 
 	// When the activator successfully forwards traffic to the deployment,
 	// we mark ourselves as active once more.
 	r.MarkActive()
-	apitest.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionActive, t)
-	apitest.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), PodAutoscalerConditionReady, t)
 }
 
 func TestTargetBC(t *testing.T) {

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 	net "knative.dev/serving/pkg/apis/networking"
 )
@@ -118,7 +118,7 @@ const (
 
 // PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).
 type PodAutoscalerStatus struct {
-	duckv1beta1.Status
+	duckv1.Status
 
 	// ServiceName is the K8s Service name that serves the revision, scaled by this PA.
 	// The service is created and owned by the ServerlessService object owned by this PA.

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 // InitializeConditions initializes the certificate conditions.
@@ -75,6 +75,6 @@ func (c *Certificate) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Certificate")
 }
 
-func (cs *CertificateStatus) duck() *duckv1beta1.Status {
+func (cs *CertificateStatus) duck() *duckv1.Status {
 	return &cs.Status
 }

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitest "knative.dev/pkg/apis/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 )
 
 func TestCertificateDuckTypes(t *testing.T) {
@@ -31,7 +31,7 @@ func TestCertificateDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -55,7 +55,7 @@ func TestCertificateGetGroupVersionKind(t *testing.T) {
 func TestMarkReady(t *testing.T) {
 	c := &CertificateStatus{}
 	c.InitializeConditions()
-	apitest.CheckConditionOngoing(c.duck(), CertificateConditionReady, t)
+	apitestv1.CheckConditionOngoing(c.duck(), CertificateConditionReady, t)
 
 	c.MarkReady()
 	if !c.IsReady() {
@@ -66,17 +66,17 @@ func TestMarkReady(t *testing.T) {
 func TestMarkNotReady(t *testing.T) {
 	c := &CertificateStatus{}
 	c.InitializeConditions()
-	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
+	apitestv1.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
 
 	c.MarkNotReady("unknow", "unknown")
-	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
+	apitestv1.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
 }
 
 func TestMarkFailed(t *testing.T) {
 	c := &CertificateStatus{}
 	c.InitializeConditions()
-	apitest.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
+	apitestv1.CheckCondition(c.duck(), CertificateConditionReady, corev1.ConditionUnknown)
 
 	c.MarkFailed("failed", "failed")
-	apitest.CheckConditionFailed(c.duck(), CertificateConditionReady, t)
+	apitestv1.CheckConditionFailed(c.duck(), CertificateConditionReady, t)
 }

--- a/pkg/apis/networking/v1alpha1/certificate_types.go
+++ b/pkg/apis/networking/v1alpha1/certificate_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -88,7 +88,7 @@ type CertificateStatus struct {
 	// - The target secret exists
 	// - The target secret contains a certificate that has not expired
 	// - The target secret contains a private key valid for the certificate
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	// The expiration time of the TLS certificate stored in the secret named
 	// by this resource in spec.secretName.

--- a/pkg/apis/networking/v1alpha1/clusteringress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/clusteringress_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1alpha1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestClusterIngressDuckTypes(t *testing.T) {
@@ -29,7 +29,7 @@ func TestClusterIngressDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var ingressCondSet = apis.NewLivingConditionSet(
@@ -89,6 +89,6 @@ func (is *IngressStatus) IsReady() bool {
 	return ingressCondSet.Manage(is).IsHappy()
 }
 
-func (is *IngressStatus) duck() *duckv1beta1.Status {
+func (is *IngressStatus) duck() *duckv1.Status {
 	return &is.Status
 }

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1alpha1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	apitestv1 "knative.dev/pkg/apis/testing/v1"
 )
 
@@ -30,7 +30,7 @@ func TestIngressDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1alpha1"
-	apitest "knative.dev/pkg/apis/testing"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 )
 
 func TestIngressDuckTypes(t *testing.T) {
@@ -73,17 +73,17 @@ func TestIngressTypicalFlow(t *testing.T) {
 	r := &IngressStatus{}
 	r.InitializeConditions()
 
-	apitest.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
 
 	// Then network is configured.
 	r.MarkNetworkConfigured()
-	apitest.CheckConditionSucceeded(r.duck(), IngressConditionNetworkConfigured, t)
-	apitest.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), IngressConditionNetworkConfigured, t)
+	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
 
 	// Then ingress is pending.
 	r.MarkLoadBalancerPending()
-	apitest.CheckConditionOngoing(r.duck(), IngressConditionLoadBalancerReady, t)
-	apitest.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionLoadBalancerReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
 
 	// Then ingress has address.
 	r.MarkLoadBalancerReady(
@@ -91,24 +91,24 @@ func TestIngressTypicalFlow(t *testing.T) {
 		[]LoadBalancerIngressStatus{{DomainInternal: "gateway.default.svc"}},
 		[]LoadBalancerIngressStatus{{DomainInternal: "private.gateway.default.svc"}},
 	)
-	apitest.CheckConditionSucceeded(r.duck(), IngressConditionLoadBalancerReady, t)
-	apitest.CheckConditionSucceeded(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), IngressConditionLoadBalancerReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), IngressConditionReady, t)
 	if !r.IsReady() {
 		t.Fatal("IsReady()=false, wanted true")
 	}
 
 	// Mark not owned.
 	r.MarkResourceNotOwned("i own", "you")
-	apitest.CheckConditionFailed(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), IngressConditionReady, t)
 
 	// Mark network configured, and check that ingress is ready again
 	r.MarkNetworkConfigured()
-	apitest.CheckConditionSucceeded(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), IngressConditionReady, t)
 	if !r.IsReady() {
 		t.Fatal("IsReady()=false, wanted true")
 	}
 
 	// Mark ingress not ready
 	r.MarkIngressNotReady("", "")
-	apitest.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
 }

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -276,7 +276,7 @@ type HTTPRetry struct {
 
 // IngressStatus describe the current state of the Ingress.
 type IngressStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	// LoadBalancer contains the current status of the load-balancer.
 	// This is to be superseded by the combination of `PublicLoadBalancer` and `PrivateLoadBalancer`

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var serverlessServiceCondSet = apis.NewLivingConditionSet(
@@ -91,7 +91,7 @@ func (sss *ServerlessServiceStatus) IsReady() bool {
 	return serverlessServiceCondSet.Manage(sss).IsHappy()
 }
 
-func (sss *ServerlessServiceStatus) duck() *duckv1beta1.Status {
+func (sss *ServerlessServiceStatus) duck() *duckv1.Status {
 	return &sss.Status
 }
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitest "knative.dev/pkg/apis/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 )
 
 func TestServerlessServiceDuckTypes(t *testing.T) {
@@ -31,7 +31,7 @@ func TestServerlessServiceDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -56,41 +56,41 @@ func TestSSTypicalFlow(t *testing.T) {
 	r := &ServerlessServiceStatus{}
 	r.InitializeConditions()
 
-	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
 
 	r.MarkEndpointsReady()
-	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionEndspointsPopulated, t)
-	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionEndspointsPopulated, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
 
 	// Verify that activator endpoints status is informational and does not
 	// affect readiness.
 	r.MarkActivatorEndpointsPopulated()
-	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
 	r.MarkActivatorEndpointsRemoved()
-	apitest.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ServerlessServiceConditionReady, t)
 
 	// Or another way to check the same condition.
 	if !r.IsReady() {
 		t.Error("IsReady=false, want: true")
 	}
 	r.MarkEndpointsNotReady("random")
-	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
 
 	// Verify that activator endpoints status is informational and does not
 	// affect readiness.
 	r.MarkActivatorEndpointsPopulated()
-	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
 	r.MarkActivatorEndpointsRemoved()
-	apitest.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ServerlessServiceConditionReady, t)
 
 	r.MarkEndpointsNotOwned("service", "jukebox")
-	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
 
 	// Verify that activator endpoints status is informational and does not
 	// affect readiness.
 	r.MarkActivatorEndpointsPopulated()
-	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
-	apitest.CheckConditionSucceeded(r.duck(), ActivatorEndpointsPopulated, t)
+	apitestv1.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ActivatorEndpointsPopulated, t)
 
 	time.Sleep(time.Millisecond * 1)
 	if got, want := r.ProxyFor(), time.Duration(0); got == want {
@@ -98,8 +98,8 @@ func TestSSTypicalFlow(t *testing.T) {
 	}
 
 	r.MarkActivatorEndpointsRemoved()
-	apitest.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
-	apitest.CheckConditionFailed(r.duck(), ActivatorEndpointsPopulated, t)
+	apitestv1.CheckConditionFailed(r.duck(), ServerlessServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ActivatorEndpointsPopulated, t)
 
 	if got, want := r.ProxyFor(), time.Duration(0); got != want {
 		t.Errorf("ProxyFor = %v, want: %v", got, want)

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 	networking "knative.dev/serving/pkg/apis/networking"
 )
@@ -104,7 +104,7 @@ type ServerlessServiceSpec struct {
 
 // ServerlessServiceStatus describes the current state of the ServerlessService.
 type ServerlessServiceStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	// ServiceName holds the name of a core K8s Service resource that
 	// load balances over the pods backing this Revision (activator or revision).

--- a/pkg/apis/serving/k8s_lifecycle.go
+++ b/pkg/apis/serving/k8s_lifecycle.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var depCondSet = apis.NewLivingConditionSet(
@@ -41,10 +41,10 @@ const (
 )
 
 // transformDeploymentStatus transforms the kubernetes DeploymentStatus into a
-// duckv1beta1.Status that uses ConditionSets to propagate failures and expose
+// duckv1.Status that uses ConditionSets to propagate failures and expose
 // a top-level happy state, per our condition conventions.
-func TransformDeploymentStatus(ds *appsv1.DeploymentStatus) *duckv1beta1.Status {
-	s := &duckv1beta1.Status{}
+func TransformDeploymentStatus(ds *appsv1.DeploymentStatus) *duckv1.Status {
+	s := &duckv1.Status{}
 
 	depCondSet.Manage(s).InitializeConditions()
 	// The absence of this condition means no failure has occurred. If we find it

--- a/pkg/apis/serving/k8s_lifecycle_test.go
+++ b/pkg/apis/serving/k8s_lifecycle_test.go
@@ -24,18 +24,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestTransformDeploymentStatus(t *testing.T) {
 	tests := []struct {
 		name string
 		ds   *appsv1.DeploymentStatus
-		want *duckv1beta1.Status
+		want *duckv1.Status
 	}{{
 		name: "initial conditions",
 		ds:   &appsv1.DeploymentStatus{},
-		want: &duckv1beta1.Status{
+		want: &duckv1.Status{
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionUnknown,
@@ -55,7 +55,7 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			}},
 		},
-		want: &duckv1beta1.Status{
+		want: &duckv1.Status{
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionTrue,
@@ -78,7 +78,7 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Status: corev1.ConditionFalse,
 			}},
 		},
-		want: &duckv1beta1.Status{
+		want: &duckv1.Status{
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionTrue,
@@ -101,7 +101,7 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Status: corev1.ConditionUnknown,
 			}},
 		},
-		want: &duckv1beta1.Status{
+		want: &duckv1.Status{
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionFalse,
@@ -124,7 +124,7 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			}},
 		},
-		want: &duckv1beta1.Status{
+		want: &duckv1.Status{
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionUnknown,
@@ -149,7 +149,7 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Message: "Something bag happened",
 			}},
 		},
-		want: &duckv1beta1.Status{
+		want: &duckv1.Status{
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionUnknown,

--- a/pkg/apis/serving/v1alpha1/configuration_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_conversion_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -85,9 +85,9 @@ func TestConfigurationConversion(t *testing.T) {
 				},
 			},
 			Status: ConfigurationStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -124,9 +124,9 @@ func TestConfigurationConversion(t *testing.T) {
 				},
 			},
 			Status: ConfigurationStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},

--- a/pkg/apis/serving/v1alpha1/configuration_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/configuration_lifecycle.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var confCondSet = apis.NewLivingConditionSet()
@@ -112,6 +112,6 @@ func (cs *ConfigurationStatus) MarkLatestReadyDeleted() {
 		"Revision %q was deleted.", cs.LatestReadyRevisionName)
 }
 
-func (cs *ConfigurationStatus) duck() *duckv1beta1.Status {
+func (cs *ConfigurationStatus) duck() *duckv1.Status {
 	return &cs.Status
 }

--- a/pkg/apis/serving/v1alpha1/configuration_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_lifecycle_test.go
@@ -22,8 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitesting "knative.dev/pkg/apis/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 )
 
 func TestConfigurationDuckTypes(t *testing.T) {
@@ -32,7 +32,7 @@ func TestConfigurationDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -57,8 +57,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}},
@@ -68,8 +68,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -79,8 +79,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -90,8 +90,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: ConfigurationConditionReady,
 				}},
 			},
@@ -100,8 +100,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -111,8 +111,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status should be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}, {
@@ -125,8 +125,8 @@ func TestConfigurationIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}, {
@@ -155,8 +155,8 @@ func TestLatestReadyRevisionNameUpToDate(t *testing.T) {
 	}{{
 		name: "Not ready status should not be up-to-date",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -166,8 +166,8 @@ func TestLatestReadyRevisionNameUpToDate(t *testing.T) {
 	}, {
 		name: "Missing LatestReadyRevisionName should not be up-to-date",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -180,8 +180,8 @@ func TestLatestReadyRevisionNameUpToDate(t *testing.T) {
 	}, {
 		name: "Different revision names should not be up-to-date",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -195,8 +195,8 @@ func TestLatestReadyRevisionNameUpToDate(t *testing.T) {
 	}, {
 		name: "Same revision names and ready status should be up-to-date",
 		status: ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ConfigurationConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -219,80 +219,80 @@ func TestLatestReadyRevisionNameUpToDate(t *testing.T) {
 func TestTypicalFlow(t *testing.T) {
 	r := &ConfigurationStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 	r.SetLatestCreatedRevisionName("foo")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestReadyRevisionName("foo")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 
 	// Verify a second call to SetLatestCreatedRevisionName doesn't change the status from Ready
 	// e.g. on a subsequent reconciliation.
 	r.SetLatestCreatedRevisionName("foo")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestCreatedRevisionName("bar")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestReadyRevisionName("bar")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 
 	r.MarkResourceNotConvertible(ConvertErrorf("build", "something something not allowed.").(*CannotConvertError))
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
-	apitesting.CheckConditionFailed(r.duck(), ConditionTypeConvertible, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ConditionTypeConvertible, t)
 }
 
 func TestFailingFirstRevisionWithRecovery(t *testing.T) {
 	r := &ConfigurationStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	// Our first attempt to create the revision fails
 	const want = "transient API server failure"
 	r.MarkRevisionCreationFailed(want)
-	apitesting.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
 	if c := r.GetCondition(ConfigurationConditionReady); !strings.Contains(c.Message, want) {
 		t.Errorf("MarkRevisionCreationFailed = %v, want substring %v", c.Message, want)
 	}
 
 	r.SetLatestCreatedRevisionName("foo")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	// Then we create it, but it fails to come up.
 	const want2 = "the message"
 	r.MarkLatestCreatedFailed("foo", want2)
-	apitesting.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
 	if c := r.GetCondition(ConfigurationConditionReady); !strings.Contains(c.Message, want2) {
 		t.Errorf("MarkLatestCreatedFailed = %v, want substring %v", c.Message, want2)
 	}
 
 	// When a new revision comes along the Ready condition becomes Unknown.
 	r.SetLatestCreatedRevisionName("bar")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	// When the new revision becomes ready, then Ready becomes true as well.
 	r.SetLatestReadyRevisionName("bar")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 }
 
 func TestFailingSecondRevision(t *testing.T) {
 	r := &ConfigurationStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestCreatedRevisionName("foo")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestReadyRevisionName("foo")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestCreatedRevisionName("bar")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	// When the second revision fails, the Configuration becomes Failed.
 	const want = "the message"
 	r.MarkLatestCreatedFailed("bar", want)
-	apitesting.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
 	if c := r.GetCondition(ConfigurationConditionReady); !strings.Contains(c.Message, want) {
 		t.Errorf("MarkLatestCreatedFailed = %v, want substring %v", c.Message, want)
 	}
@@ -301,28 +301,28 @@ func TestFailingSecondRevision(t *testing.T) {
 func TestLatestRevisionDeletedThenFixed(t *testing.T) {
 	r := &ConfigurationStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestCreatedRevisionName("foo")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestReadyRevisionName("foo")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 
 	// When the latest revision is deleted, the Configuration became Failed.
 	const want = "was deleted"
 	r.MarkLatestReadyDeleted()
-	apitesting.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), ConfigurationConditionReady, t)
 	if cnd := r.GetCondition(ConfigurationConditionReady); cnd == nil || !strings.Contains(cnd.Message, want) {
 		t.Errorf("MarkLatestReadyDeleted = %v, want substring %v", cnd.Message, want)
 	}
 
 	// But creating new revision 'bar' and making it Ready will fix things.
 	r.SetLatestCreatedRevisionName("bar")
-	apitesting.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), ConfigurationConditionReady, t)
 
 	r.SetLatestReadyRevisionName("bar")
-	apitesting.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), ConfigurationConditionReady, t)
 }
 
 func TestConfigurationGetGroupVersionKind(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/configuration_types.go
+++ b/pkg/apis/serving/v1alpha1/configuration_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -98,7 +98,7 @@ const (
 	ConfigurationConditionReady = apis.ConditionReady
 )
 
-// ConfigurationStatusFields holds all of the non-duckv1beta1.Status status fields of a Route.
+// ConfigurationStatusFields holds all of the non-duckv1.Status status fields of a Route.
 // These are defined outline so that we can also inline them into Service, and more easily
 // copy them.
 type ConfigurationStatusFields struct {
@@ -115,7 +115,7 @@ type ConfigurationStatusFields struct {
 
 // ConfigurationStatus communicates the observed state of the Configuration (from the controller).
 type ConfigurationStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	ConfigurationStatusFields `json:",inline"`
 }

--- a/pkg/apis/serving/v1alpha1/revision_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_conversion_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -81,9 +81,9 @@ func TestRevisionConversion(t *testing.T) {
 				},
 			},
 			Status: RevisionStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -132,9 +132,9 @@ func TestRevisionConversion(t *testing.T) {
 				},
 			},
 			Status: RevisionStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -232,9 +232,9 @@ func TestRevisionConversionError(t *testing.T) {
 				},
 			},
 			Status: RevisionStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -263,9 +263,9 @@ func TestRevisionConversionError(t *testing.T) {
 				},
 			},
 			Status: RevisionStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	net "knative.dev/serving/pkg/apis/networking"
@@ -316,7 +316,7 @@ func (r *Revision) IsReachable() bool {
 	return r.ObjectMeta.Labels[serving.RouteLabelKey] != ""
 }
 
-func (rs *RevisionStatus) duck() *duckv1beta1.Status {
+func (rs *RevisionStatus) duck() *duckv1.Status {
 	return &rs.Status
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitest "knative.dev/pkg/apis/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 	"knative.dev/pkg/ptr"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	net "knative.dev/serving/pkg/apis/networking"
@@ -43,7 +43,7 @@ func TestRevisionDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -68,8 +68,8 @@ func TestIsActivationRequired(t *testing.T) {
 	}, {
 		name: "Ready status should not be inactive",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -79,8 +79,8 @@ func TestIsActivationRequired(t *testing.T) {
 	}, {
 		name: "Inactive status should be inactive",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionActive,
 					Status: corev1.ConditionFalse,
 				}},
@@ -90,8 +90,8 @@ func TestIsActivationRequired(t *testing.T) {
 	}, {
 		name: "Updating status should be inactive",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionUnknown,
 					Reason: "Updating",
@@ -106,8 +106,8 @@ func TestIsActivationRequired(t *testing.T) {
 	}, {
 		name: "NotReady status without reason should not be inactive",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -117,8 +117,8 @@ func TestIsActivationRequired(t *testing.T) {
 	}, {
 		name: "Ready/Unknown status without reason should not be inactive",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -148,8 +148,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionResourcesAvailable,
 					Status: corev1.ConditionTrue,
 				}},
@@ -159,8 +159,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -170,8 +170,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -181,8 +181,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: RevisionConditionReady,
 				}},
 			},
@@ -191,8 +191,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -202,8 +202,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status should be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionResourcesAvailable,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -216,8 +216,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionResourcesAvailable,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -263,14 +263,14 @@ func TestGetSetCondition(t *testing.T) {
 func TestTypicalFlowWithProgressDeadlineExceeded(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
 
 	const want = "the error message"
 	r.MarkProgressDeadlineExceeded(want)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
 	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Message != want {
 		t.Errorf("MarkProgressDeadlineExceeded = %v, want %v", got, want)
 	}
@@ -282,15 +282,15 @@ func TestTypicalFlowWithProgressDeadlineExceeded(t *testing.T) {
 func TestTypicalFlowWithContainerMissing(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
 
 	const want = "something about the container being not found"
 	r.MarkContainerMissing(want)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
 	if got := r.GetCondition(RevisionConditionContainerHealthy); got == nil || got.Message != want {
 		t.Errorf("MarkContainerMissing = %v, want %v", got, want)
 	} else if got.Reason != "ContainerMissing" {
@@ -306,58 +306,58 @@ func TestTypicalFlowWithContainerMissing(t *testing.T) {
 func TestTypicalFlowWithSuspendResume(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
 
 	// Enter a Ready state.
 	r.MarkActive()
 	r.MarkContainerHealthy()
 	r.MarkResourcesAvailable()
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
 
 	// From a Ready state, make the revision inactive to simulate scale to zero.
 	const want = "Deactivated"
 	r.MarkInactive(want, "Reserve")
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionActive, t)
 	if got := r.GetCondition(RevisionConditionActive); got == nil || got.Reason != want {
 		t.Errorf("MarkInactive = %v, want %v", got, want)
 	}
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
 
 	// From an Inactive state, start to activate the revision.
 	const want2 = "Activating"
 	r.MarkActivating(want2, "blah blah blah")
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
 	if got := r.GetCondition(RevisionConditionActive); got == nil || got.Reason != want2 {
 		t.Errorf("MarkInactive = %v, want %v", got, want2)
 	}
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
 
 	// From the activating state, simulate the transition back to readiness.
 	r.MarkActive()
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
 }
 
 func TestRevisionNotOwnedStuff(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
 
 	const want = "NotOwned"
 	r.MarkResourceNotOwned("Resource", "mark")
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
 	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Reason != want {
 		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
 	}
@@ -369,14 +369,14 @@ func TestRevisionNotOwnedStuff(t *testing.T) {
 func TestRevisionResourcesUnavailable(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
 
 	const wantReason, wantMessage = "unschedulable", "insufficient energy"
 	r.MarkResourcesUnavailable(wantReason, wantMessage)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
 	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Reason != wantReason {
 		t.Errorf("RevisionConditionResourcesAvailable = %v, want %v", got, wantReason)
 	}
@@ -621,17 +621,17 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 	rev.InitializeConditions()
 
 	// We start out ongoing.
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
 
 	// Empty deployment conditions shouldn't affect our readiness.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
 		Conditions: []appsv1.DeploymentCondition{},
 	})
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
 
 	// Deployment failures should be propagated and not affect ContainerHealthy.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
@@ -643,15 +643,15 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 			Status: corev1.ConditionUnknown,
 		}},
 	})
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
 
 	// Marking container healthy doesn't affect deployment status.
 	rev.MarkContainerHealthy()
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
 
 	// We can recover from deployment failures.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
@@ -660,9 +660,9 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		}},
 	})
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
 
 	// We can go unknown.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
@@ -671,9 +671,9 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 			Status: corev1.ConditionUnknown,
 		}},
 	})
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
 
 	// ReplicaFailure=True translates into Ready=False.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
@@ -682,9 +682,9 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		}},
 	})
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
 
 	// ReplicaFailure=True trumps Progressing=Unknown.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
@@ -696,9 +696,9 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		}},
 	})
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
 
 	// ReplicaFailure=False + Progressing=True yields Ready.
 	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
@@ -710,59 +710,59 @@ func TestPropagateDeploymentStatus(t *testing.T) {
 			Status: corev1.ConditionFalse,
 		}},
 	})
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionResourcesAvailable, t)
-	apitest.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
 }
 
 func TestPropagateAutoscalerStatus(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
 
 	// PodAutoscaler has no active condition, so we are just coming up.
 	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
-		Status: duckv1beta1.Status{},
+		Status: duckv1.Status{},
 	})
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
 
 	// PodAutoscaler becomes ready, making us active.
 	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   av1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionActive, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
 
 	// PodAutoscaler flipping back to Unknown causes Active become ongoing immediately.
 	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   av1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
 	})
-	apitest.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
 
 	// PodAutoscaler becoming unready makes Active false, but doesn't affect readiness.
 	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   av1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitest.CheckConditionFailed(r.duck(), RevisionConditionActive, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
-	apitest.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
 }
 
 func TestGetContainerConcurrency(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -173,7 +173,7 @@ const (
 
 // RevisionStatus communicates the observed state of the Revision (from the controller).
 type RevisionStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	// ServiceName holds the name of a core Kubernetes Service resource that
 	// load balances over the pods backing this Revision.

--- a/pkg/apis/serving/v1alpha1/route_conversion.go
+++ b/pkg/apis/serving/v1alpha1/route_conversion.go
@@ -22,6 +22,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
@@ -76,7 +77,10 @@ func (source *RouteStatusFields) ConvertUp(ctx context.Context, sink *v1beta1.Ro
 	}
 
 	if source.Address != nil {
-		sink.Address = source.Address.Addressable.DeepCopy()
+		if sink.Address == nil {
+			sink.Address = &duckv1beta1.Addressable{}
+		}
+		source.Address.ConvertUp(ctx, sink.Address)
 	}
 
 	sink.Traffic = make([]v1beta1.TrafficTarget, len(source.Traffic))
@@ -125,9 +129,10 @@ func (sink *RouteStatusFields) ConvertDown(ctx context.Context, source v1beta1.R
 	}
 
 	if source.Address != nil {
-		sink.Address = &duckv1alpha1.Addressable{
-			Addressable: *source.Address,
+		if sink.Address == nil {
+			sink.Address = &duckv1alpha1.Addressable{}
 		}
+		sink.Address.ConvertDown(ctx, source.Address)
 	}
 
 	sink.Traffic = make([]TrafficTarget, len(source.Traffic))

--- a/pkg/apis/serving/v1alpha1/route_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/route_conversion_test.go
@@ -24,6 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -63,9 +65,9 @@ func TestRouteConversion(t *testing.T) {
 				}},
 			},
 			Status: RouteStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -77,9 +79,20 @@ func TestRouteConversion(t *testing.T) {
 							Percent:      ptr.Int64(100),
 						},
 					}},
-					// TODO(mattmoor): Addressable
-					// TODO(mattmoor): Domain
-					// TODO(mattmoor): DomainInternal
+					Address: &duckv1alpha1.Addressable{
+						Addressable: duckv1beta1.Addressable{
+							URL: &apis.URL{
+								Scheme: "http",
+								Host:   "hostname.com",
+							},
+						},
+					},
+					URL: &apis.URL{
+						Scheme: "http",
+						Host:   "hostname.com",
+					},
+					// TODO(mattmoor): Domain is emptied
+					// TODO(mattmoor): DomainInternal is emptied
 				},
 			},
 		},
@@ -100,9 +113,9 @@ func TestRouteConversion(t *testing.T) {
 				}},
 			},
 			Status: RouteStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -114,9 +127,20 @@ func TestRouteConversion(t *testing.T) {
 							Percent:      ptr.Int64(100),
 						},
 					}},
-					// TODO(mattmoor): Addressable
-					// TODO(mattmoor): Domain
-					// TODO(mattmoor): DomainInternal
+					Address: &duckv1alpha1.Addressable{
+						Addressable: duckv1beta1.Addressable{
+							URL: &apis.URL{
+								Scheme: "http",
+								Host:   "hostname.com",
+							},
+						},
+					},
+					URL: &apis.URL{
+						Scheme: "http",
+						Host:   "hostname.com",
+					},
+					// TODO(mattmoor): Domain is emptied
+					// TODO(mattmoor): DomainInternal is emptied
 				},
 			},
 		},
@@ -156,9 +180,9 @@ func TestRouteConversion(t *testing.T) {
 				}},
 			},
 			Status: RouteStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 3,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -230,9 +254,9 @@ func TestRouteConversion(t *testing.T) {
 				}},
 			},
 			Status: RouteStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 3,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},

--- a/pkg/apis/serving/v1alpha1/route_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/route_lifecycle.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 )
 
@@ -170,6 +170,6 @@ func (rs *RouteStatus) PropagateIngressStatus(cs v1alpha1.IngressStatus) {
 	}
 }
 
-func (rs *RouteStatus) duck() *duckv1beta1.Status {
+func (rs *RouteStatus) duck() *duckv1.Status {
 	return &rs.Status
 }

--- a/pkg/apis/serving/v1alpha1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/route_lifecycle_test.go
@@ -21,9 +21,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitesting "knative.dev/pkg/apis/testing"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 )
 
@@ -33,7 +33,7 @@ func TestRouteDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}, {
 		name: "addressable",
 		t:    &duckv1alpha1.Addressable{},
@@ -61,8 +61,8 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RouteConditionAllTrafficAssigned,
 					Status: corev1.ConditionTrue,
 				}},
@@ -72,8 +72,8 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RouteConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -83,9 +83,9 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
+			Status: duckv1.Status{
 
-				Conditions: duckv1beta1.Conditions{{
+				Conditions: duckv1.Conditions{{
 					Type:   RouteConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -95,8 +95,8 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: RouteConditionReady,
 				}},
 			},
@@ -105,8 +105,8 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RouteConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -116,8 +116,8 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status should be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RouteConditionAllTrafficAssigned,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -130,8 +130,8 @@ func TestRouteIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		status: RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RouteConditionAllTrafficAssigned,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -155,181 +155,181 @@ func TestRouteIsReady(t *testing.T) {
 func TestTypicalRouteFlow(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkTrafficAssigned()
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   netv1alpha1.IngressConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionReady, t)
 }
 
 func TestTrafficNotAssignedFlow(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkMissingTrafficTarget("Revision", "does-not-exist")
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
 }
 
 func TestTargetConfigurationNotYetReadyFlow(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkConfigurationNotReady("i-have-no-ready-revision")
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 }
 
 func TestUnknownErrorWhenConfiguringTraffic(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkUnknownTrafficError("unknown-error")
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 }
 
 func TestTargetConfigurationFailedToBeReadyFlow(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkConfigurationFailed("permanently-failed")
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
 }
 
 func TestTargetRevisionNotYetReadyFlow(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkRevisionNotReady("not-yet-ready")
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 }
 
 func TestTargetRevisionFailedToBeReadyFlow(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkRevisionFailed("cannot-find-image")
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
 }
 
 func TestClusterIngressFailureRecovery(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   netv1alpha1.IngressConditionReady,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
 	})
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	// Empty IngressStatus marks ingress "NotConfigured"
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{})
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkTrafficAssigned()
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   netv1alpha1.IngressConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionReady, t)
 
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   netv1alpha1.IngressConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
 
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   netv1alpha1.IngressConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionReady, t)
 }
 
 func TestRouteNotOwnedStuff(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
 	r.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   netv1alpha1.IngressConditionReady,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
 	})
 
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionReady, t)
 
 	r.MarkServiceNotOwned("evan")
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionIngressReady, t)
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionAllTrafficAssigned, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
 }
 
 func TestRouteGetGroupVersionKind(t *testing.T) {
@@ -349,7 +349,7 @@ func TestCertificateReady(t *testing.T) {
 	r.InitializeConditions()
 	r.MarkCertificateReady("cert")
 
-	apitesting.CheckConditionSucceeded(r.duck(), RouteConditionCertificateProvisioned, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RouteConditionCertificateProvisioned, t)
 }
 
 func TestCertificateNotReady(t *testing.T) {
@@ -357,7 +357,7 @@ func TestCertificateNotReady(t *testing.T) {
 	r.InitializeConditions()
 	r.MarkCertificateNotReady("cert")
 
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionCertificateProvisioned, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionCertificateProvisioned, t)
 }
 
 func TestCertificateProvisionFailed(t *testing.T) {
@@ -365,7 +365,7 @@ func TestCertificateProvisionFailed(t *testing.T) {
 	r.InitializeConditions()
 	r.MarkCertificateProvisionFailed("cert")
 
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionCertificateProvisioned, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionCertificateProvisioned, t)
 }
 
 func TestRouteNotOwnCertificate(t *testing.T) {
@@ -373,7 +373,7 @@ func TestRouteNotOwnCertificate(t *testing.T) {
 	r.InitializeConditions()
 	r.MarkCertificateNotOwned("cert")
 
-	apitesting.CheckConditionFailed(r.duck(), RouteConditionCertificateProvisioned, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionCertificateProvisioned, t)
 }
 
 func TestIngressNotConfigured(t *testing.T) {
@@ -381,5 +381,5 @@ func TestIngressNotConfigured(t *testing.T) {
 	r.InitializeConditions()
 	r.MarkIngressNotConfigured()
 
-	apitesting.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RouteConditionIngressReady, t)
 }

--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
 
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -112,7 +112,7 @@ const (
 	RouteConditionCertificateProvisioned apis.ConditionType = "CertificateProvisioned"
 )
 
-// RouteStatusFields holds all of the non-duckv1beta1.Status status fields of a Route.
+// RouteStatusFields holds all of the non-duckv1.Status status fields of a Route.
 // These are defined outline so that we can also inline them into Service, and more easily
 // copy them.
 type RouteStatusFields struct {
@@ -147,7 +147,7 @@ type RouteStatusFields struct {
 
 // RouteStatus communicates the observed state of the Route (from the controller).
 type RouteStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	RouteStatusFields `json:",inline"`
 }

--- a/pkg/apis/serving/v1alpha1/service_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/service_conversion_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
@@ -94,9 +94,9 @@ func TestServiceConversion(t *testing.T) {
 				},
 			},
 			Status: ServiceStatus{
-				Status: duckv1beta1.Status{
+				Status: duckv1.Status{
 					ObservedGeneration: 1,
-					Conditions: duckv1beta1.Conditions{{
+					Conditions: duckv1.Conditions{{
 						Type:   "Ready",
 						Status: "True",
 					}},
@@ -140,9 +140,9 @@ func TestServiceConversion(t *testing.T) {
 
 func TestServiceConversionFromDeprecated(t *testing.T) {
 	status := ServiceStatus{
-		Status: duckv1beta1.Status{
+		Status: duckv1.Status{
 			ObservedGeneration: 1,
-			Conditions: duckv1beta1.Conditions{{
+			Conditions: duckv1.Conditions{{
 				Type:   "Ready",
 				Status: "True",
 			}},

--- a/pkg/apis/serving/v1alpha1/service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/service_lifecycle.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var serviceCondSet = apis.NewLivingConditionSet(
@@ -156,6 +156,6 @@ func (ss *ServiceStatus) PropagateRouteStatus(rs *RouteStatus) {
 	}
 }
 
-func (ss *ServiceStatus) duck() *duckv1beta1.Status {
+func (ss *ServiceStatus) duck() *duckv1.Status {
 	return &ss.Status
 }

--- a/pkg/apis/serving/v1alpha1/service_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/service_lifecycle_test.go
@@ -23,9 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	apitesting "knative.dev/pkg/apis/testing"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -37,7 +37,7 @@ func TestServiceDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}, {
 		name: "addressable",
 		t:    &duckv1alpha1.Addressable{},
@@ -78,8 +78,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}},
@@ -89,8 +89,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ServiceConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -100,8 +100,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ServiceConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -111,8 +111,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: ServiceConditionReady,
 				}},
 			},
@@ -121,8 +121,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   ServiceConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -132,8 +132,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status should be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}, {
@@ -146,8 +146,8 @@ func TestServiceIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		status: ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}, {
@@ -169,77 +169,77 @@ func TestServiceIsReady(t *testing.T) {
 func TestServiceHappyPath(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Nothing from Configuration is nothing to us.
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Nothing from Route is nothing to us.
 	svc.PropagateRouteStatus(&RouteStatus{})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Done from Configuration moves our ConfigurationsReady condition
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	svc.MarkResourceNotConvertible(ConvertErrorf("manual", "something something not allowed.").(*CannotConvertError))
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ConditionTypeConvertible, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ConditionTypeConvertible, t)
 
 	// Done from Route moves our RoutesReady condition, which triggers us to be Ready.
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Check idempotency.
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 }
 
 func TestMarkRouteNotYetReady(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	svc.MarkRouteNotYetReady()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
 	dt := svc.GetCondition(ServiceConditionReady)
 	if got, want := dt.Reason, trafficNotMigratedReason; got != want {
 		t.Errorf("Condition Reason: got: %s, want: %s", got, want)
@@ -252,173 +252,173 @@ func TestMarkRouteNotYetReady(t *testing.T) {
 func TestFailureRecovery(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Config failure causes us to become unready immediately (route still ok).
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Route failure causes route to become failed (config and service still failed).
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Fix Configuration moves our ConfigurationsReady condition (route and service still failed).
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Fix route, should make everything ready.
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 }
 
 func TestConfigurationFailurePropagation(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Failure causes us to become unready immediately.
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 }
 
 func TestConfigurationFailureRecovery(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Done from Route moves our RoutesReady condition
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Failure causes us to become unready immediately (route still ok).
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Fixed the glitch.
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 }
 
 func TestConfigurationUnknownPropagation(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Configuration and Route become ready, making us ready.
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Configuration flipping back to Unknown causes us to become ongoing immediately
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
 	})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
 	// Route is unaffected.
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 }
 
 func TestConfigurationStatusPropagation(t *testing.T) {
@@ -444,128 +444,128 @@ func TestConfigurationStatusPropagation(t *testing.T) {
 func TestRouteFailurePropagation(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Failure causes us to become unready immediately
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
 }
 
 func TestRouteFailureRecovery(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Done from Configuration moves our ConfigurationsReady condition
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Failure causes us to become unready immediately (config still ok).
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Fixed the glitch.
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 }
 
 func TestRouteUnknownPropagation(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Configuration and Route become ready, making us ready.
 	svc.PropagateConfigurationStatus(&ConfigurationStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   ConfigurationConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionTrue,
 			}},
 		},
 	})
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
 
 	// Route flipping back to Unknown causes us to become ongoing immediately.
 	svc.PropagateRouteStatus(&RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   RouteConditionReady,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
 	})
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 	// Configuration is unaffected.
-	apitesting.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
 }
 
 func TestServiceNotOwnedStuff(t *testing.T) {
 	svc := &ServiceStatus{}
 	svc.InitializeConditions()
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
 
 	svc.MarkRouteNotOwned("mark")
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
 
 	svc.MarkConfigurationNotOwned("jon")
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
-	apitesting.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
 }
 
 func TestRouteStatusPropagation(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/service_types.go
+++ b/pkg/apis/serving/v1alpha1/service_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -176,7 +176,7 @@ const (
 
 // ServiceStatus represents the Status stanza of the Service resource.
 type ServiceStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	RouteStatusFields `json:",inline"`
 

--- a/pkg/apis/serving/v1beta1/configuration_lifecycle_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestConfigurationDuckTypes(t *testing.T) {
@@ -29,7 +29,7 @@ func TestConfigurationDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1beta1/configuration_types.go
+++ b/pkg/apis/serving/v1beta1/configuration_types.go
@@ -19,7 +19,7 @@ package v1beta1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -86,7 +86,7 @@ type ConfigurationStatusFields struct {
 
 // ConfigurationStatus communicates the observed state of the Configuration (from the controller).
 type ConfigurationStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	ConfigurationStatusFields `json:",inline"`
 }

--- a/pkg/apis/serving/v1beta1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1beta1/revision_lifecycle_test.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
 )
 
@@ -32,7 +32,7 @@ func TestRevisionDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {
@@ -69,8 +69,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionTrue,
 				}},
@@ -80,8 +80,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionFalse,
 				}},
@@ -91,8 +91,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
@@ -102,8 +102,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: RevisionConditionReady,
 				}},
 			},
@@ -112,8 +112,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   RevisionConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
@@ -123,8 +123,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status should be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -137,8 +137,8 @@ func TestIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		status: RevisionStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionTrue,
 				}, {

--- a/pkg/apis/serving/v1beta1/revision_types.go
+++ b/pkg/apis/serving/v1beta1/revision_types.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -93,7 +93,7 @@ const (
 
 // RevisionStatus communicates the observed state of the Revision (from the controller).
 type RevisionStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	// ServiceName holds the name of a core Kubernetes Service resource that
 	// load balances over the pods backing this Revision.

--- a/pkg/apis/serving/v1beta1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1beta1/route_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestRouteDuckTypes(t *testing.T) {
@@ -29,7 +29,7 @@ func TestRouteDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1beta1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1beta1/route_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestRouteDuckTypes(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/route_types.go
+++ b/pkg/apis/serving/v1beta1/route_types.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
 )
@@ -144,7 +145,7 @@ type RouteStatusFields struct {
 
 // RouteStatus communicates the observed state of the Route (from the controller).
 type RouteStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	RouteStatusFields `json:",inline"`
 }

--- a/pkg/apis/serving/v1beta1/service_lifecycle_test.go
+++ b/pkg/apis/serving/v1beta1/service_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestServiceDuckTypes(t *testing.T) {
@@ -29,7 +29,7 @@ func TestServiceDuckTypes(t *testing.T) {
 		t    duck.Implementable
 	}{{
 		name: "conditions",
-		t:    &duckv1beta1.Conditions{},
+		t:    &duckv1.Conditions{},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1beta1/service_lifecycle_test.go
+++ b/pkg/apis/serving/v1beta1/service_lifecycle_test.go
@@ -20,7 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis/duck"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestServiceDuckTypes(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/service_types.go
+++ b/pkg/apis/serving/v1beta1/service_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -91,7 +91,7 @@ const (
 
 // ServiceStatus represents the Status stanza of the Service resource.
 type ServiceStatus struct {
-	duckv1beta1.Status `json:",inline"`
+	duckv1.Status `json:",inline"`
 
 	// In addition to inlining ConfigurationSpec, we also inline the fields
 	// specific to ConfigurationStatus.

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	. "knative.dev/pkg/logging/testing"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -237,7 +237,7 @@ func TestMetricCollectorError(t *testing.T) {
 		name                 string
 		scraper              *testScraper
 		metric               *av1alpha1.Metric
-		expectedMetricStatus duckv1beta1.Status
+		expectedMetricStatus duckv1.Status
 	}{{
 		name: "Failed to get endpoints scraper error",
 		scraper: &testScraper{
@@ -257,8 +257,8 @@ func TestMetricCollectorError(t *testing.T) {
 				ScrapeTarget: testRevision + "-zhudex",
 			},
 		},
-		expectedMetricStatus: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		expectedMetricStatus: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:    av1alpha1.MetricConditionReady,
 				Status:  corev1.ConditionUnknown,
 				Reason:  "NoEndpoints",
@@ -284,8 +284,8 @@ func TestMetricCollectorError(t *testing.T) {
 				ScrapeTarget: testRevision + "-zhudex",
 			},
 		},
-		expectedMetricStatus: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		expectedMetricStatus: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:    av1alpha1.MetricConditionReady,
 				Status:  corev1.ConditionFalse,
 				Reason:  "DidNotReceiveStat",
@@ -311,8 +311,8 @@ func TestMetricCollectorError(t *testing.T) {
 				ScrapeTarget: testRevision + "-zhudex",
 			},
 		},
-		expectedMetricStatus: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		expectedMetricStatus: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:    av1alpha1.MetricConditionReady,
 				Status:  corev1.ConditionUnknown,
 				Reason:  "CreateOrUpdateFailed",
@@ -330,7 +330,7 @@ func TestMetricCollectorError(t *testing.T) {
 			coll.CreateOrUpdate(test.metric)
 			key := types.NamespacedName{Namespace: test.metric.Namespace, Name: test.metric.Name}
 
-			var got duckv1beta1.Status
+			var got duckv1.Status
 			wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 				collection, ok := coll.collections[key]
 				if ok {

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/system"
@@ -94,9 +94,9 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: knCertWithStatus("knCert", "foo",
 				&v1alpha1.CertificateStatus{
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
@@ -122,9 +122,9 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: knCertWithStatus("knCert", "foo",
 				&v1alpha1.CertificateStatus{
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
@@ -143,9 +143,9 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			knCertWithStatusAndGeneration("knCert", "foo",
 				&v1alpha1.CertificateStatus{
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation + 1,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:   v1alpha1.CertificateConditionReady,
 							Status: corev1.ConditionTrue,
 						}},
@@ -163,9 +163,9 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: knCertWithStatusAndGeneration("knCert", "foo",
 				&v1alpha1.CertificateStatus{
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation + 1,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
@@ -193,9 +193,9 @@ func TestReconcile(t *testing.T) {
 			Object: knCertWithStatus("knCert", "foo",
 				&v1alpha1.CertificateStatus{
 					NotAfter: notAfter,
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -214,9 +214,9 @@ func TestReconcile(t *testing.T) {
 			Object: knCertWithStatus("knCert", "foo",
 				&v1alpha1.CertificateStatus{
 					NotAfter: notAfter,
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
@@ -235,9 +235,9 @@ func TestReconcile(t *testing.T) {
 			Object: knCertWithStatus("knCert", "foo",
 				&v1alpha1.CertificateStatus{
 					NotAfter: notAfter,
-					Status: duckv1beta1.Status{
+					Status: duckv1.Status{
 						ObservedGeneration: generation,
-						Conditions: duckv1beta1.Conditions{{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionFalse,
 							Severity: apis.ConditionSeverityError,

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -43,7 +43,7 @@ import (
 	"knative.dev/pkg/kmeta"
 
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis/istio/v1alpha3"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -209,8 +209,8 @@ func TestReconcile(t *testing.T) {
 							{MeshOnly: true},
 						},
 					},
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -243,8 +243,8 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			ingressWithStatus("reconcile-failed", 1234,
 				v1alpha1.IngressStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:   v1alpha1.IngressConditionLoadBalancerReady,
 							Status: corev1.ConditionTrue,
 						}, {
@@ -281,8 +281,8 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithStatus("reconcile-failed", 1234,
 				v1alpha1.IngressStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:   v1alpha1.IngressConditionLoadBalancerReady,
 							Status: corev1.ConditionTrue,
 						}, {
@@ -369,8 +369,8 @@ func TestReconcile(t *testing.T) {
 							{MeshOnly: true},
 						},
 					},
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -462,8 +462,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{MeshOnly: true},
 						},
 					},
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -506,8 +506,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Object: ingressWithTLSAndStatus("reconciling-clusteringress", 1234,
 				ingressTLS,
 				v1alpha1.IngressStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
@@ -607,8 +607,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{MeshOnly: true},
 						},
 					},
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -709,8 +709,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{MeshOnly: true},
 						},
 					},
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -765,8 +765,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							{MeshOnly: true},
 						},
 					},
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
 							Status:   corev1.ConditionTrue,
 							Severity: apis.ConditionSeverityError,
@@ -1086,8 +1086,8 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 					{DomainInternal: ""},
 				},
 			},
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.IngressConditionLoadBalancerReady,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -1169,8 +1169,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 					{DomainInternal: originDomainInternal},
 				},
 			},
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.IngressConditionLoadBalancerReady,
 					Status: corev1.ConditionTrue,
 				}, {

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -280,8 +280,8 @@ func TestReconcile(t *testing.T) {
 			rev("bad-condition", "foo", 5555,
 				WithRevName("bad-condition"),
 				WithRevStatus(v1alpha1.RevisionStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.RevisionConditionReady,
 							Status:   "Bad",
 							Severity: "Error",

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -226,8 +226,8 @@ func TestIsRevisionStale(t *testing.T) {
 				CreationTimestamp: metav1.NewTime(staleTime),
 			},
 			Status: v1alpha1.RevisionStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
 						Type:   v1alpha1.RevisionConditionReady,
 						Status: "True",
 					}},
@@ -243,8 +243,8 @@ func TestIsRevisionStale(t *testing.T) {
 				CreationTimestamp: metav1.NewTime(staleTime),
 			},
 			Status: v1alpha1.RevisionStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
 						Type:   v1alpha1.RevisionConditionReady,
 						Status: "Unknown",
 					}},

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -106,8 +106,8 @@ func getTestRevisionWithCondition(name string, cond apis.Condition) *v1alpha1.Re
 		},
 		Status: v1alpha1.RevisionStatus{
 			ServiceName: name,
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{cond},
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{cond},
 			},
 		},
 	}

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -27,7 +27,7 @@ import (
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/route/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/service/fake"
 
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -1399,8 +1399,8 @@ func MutateRoute(rt *v1alpha1.Route) {
 
 func RouteReady(cfg *v1alpha1.Route) {
 	cfg.Status = v1alpha1.RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   "Ready",
 				Status: "True",
 			}},
@@ -1411,8 +1411,8 @@ func RouteReady(cfg *v1alpha1.Route) {
 func RouteFailed(reason, message string) RouteOption {
 	return func(cfg *v1alpha1.Route) {
 		cfg.Status = v1alpha1.RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:    "Ready",
 					Status:  "False",
 					Reason:  reason,

--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/ptr"
@@ -176,8 +177,8 @@ func WithReadyCertificateName(name string) func(*v1alpha1.Route) {
 // MarkIngressReady propagates a Ready=True ClusterIngress status to the Route.
 func MarkIngressReady(r *v1alpha1.Route) {
 	r.Status.PropagateIngressStatus(netv1alpha1.IngressStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   "Ready",
 				Status: "True",
 			}},

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/ptr"
@@ -352,8 +353,8 @@ func WithInitSvcConditions(s *v1alpha1.Service) {
 // WithReadyRoute reflects the Route's readiness in the Service resource.
 func WithReadyRoute(s *v1alpha1.Service) {
 	s.Status.PropagateRouteStatus(&v1alpha1.RouteStatus{
-		Status: duckv1beta1.Status{
-			Conditions: duckv1beta1.Conditions{{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
 				Type:   "Ready",
 				Status: "True",
 			}},
@@ -397,8 +398,8 @@ func WithSvcStatusTraffic(targets ...v1alpha1.TrafficTarget) ServiceOption {
 func WithFailedRoute(reason, message string) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		s.Status.PropagateRouteStatus(&v1alpha1.RouteStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:    "Ready",
 					Status:  "False",
 					Reason:  reason,
@@ -415,8 +416,8 @@ func WithFailedRoute(reason, message string) ServiceOption {
 func WithReadyConfig(name string) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		s.Status.PropagateConfigurationStatus(&v1alpha1.ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Ready",
 					Status: "True",
 				}},
@@ -434,8 +435,8 @@ func WithReadyConfig(name string) ServiceOption {
 func WithFailedConfig(name, reason, message string) ServiceOption {
 	return func(s *v1alpha1.Service) {
 		s.Status.PropagateConfigurationStatus(&v1alpha1.ConfigurationStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Ready",
 					Status: "False",
 					Reason: reason,

--- a/test/performance/deployment-probe/main.go
+++ b/test/performance/deployment-probe/main.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/signals"
@@ -74,7 +74,7 @@ func readTemplate() (*v1beta1.Service, error) {
 	return svc, nil
 }
 
-func handle(q *quickstore.Quickstore, svc kmeta.Accessor, status duckv1beta1.Status,
+func handle(q *quickstore.Quickstore, svc kmeta.Accessor, status duckv1.Status,
 	seen *sets.String, metric string) {
 	if seen.Has(svc.GetName()) {
 		return
@@ -157,7 +157,7 @@ func main() {
 
 	lo := metav1.ListOptions{TimeoutSeconds: ptr.Int64(int64(duration.Seconds()))}
 
-	// TODO(mattmoor): We could maybe use a duckv1beta1.KResource to eliminate this boilerplate.
+	// TODO(mattmoor): We could maybe use a duckv1.KResource to eliminate this boilerplate.
 
 	serviceWI, err := sc.ServingV1beta1().Services(tmpl.Namespace).Watch(lo)
 	if err != nil {

--- a/vendor/knative.dev/pkg/apis/duck/v1/addressable_types.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1/addressable_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -34,8 +37,12 @@ type Addressable struct {
 	URL *apis.URL `json:"url,omitempty"`
 }
 
-// Addressable is an Implementable "duck type".
-var _ duck.Implementable = (*Addressable)(nil)
+var (
+	// Addressable is an Implementable "duck type".
+	_ duck.Implementable = (*Addressable)(nil)
+	// Addressable is a Convertible type.
+	_ apis.Convertible = (*Addressable)(nil)
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,6 +73,16 @@ var (
 // GetFullType implements duck.Implementable
 func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
+}
+
+// ConvertUp implements apis.Convertible
+func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", to)
+}
+
+// ConvertDown implements apis.Convertible
+func (a *Addressable) ConvertDown(ctx context.Context, from apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", from)
 }
 
 // Populate implements duck.Populatable

--- a/vendor/knative.dev/pkg/apis/duck/v1alpha1/addressable_types.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1alpha1/addressable_types.go
@@ -17,11 +17,15 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
@@ -37,8 +41,12 @@ type Addressable struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-// Addressable is an Implementable "duck type".
-var _ duck.Implementable = (*Addressable)(nil)
+var (
+	// Addressable is an Implementable "duck type".
+	_ duck.Implementable = (*Addressable)(nil)
+	// Addressable is a Convertible type.
+	_ apis.Convertible = (*Addressable)(nil)
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -71,6 +79,35 @@ func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
 }
 
+// ConvertUp implements apis.Convertible
+func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
+	url := a.GetURL()
+	switch sink := to.(type) {
+	case *v1.Addressable:
+		sink.URL = url.DeepCopy()
+		return nil
+	case *v1beta1.Addressable:
+		sink.URL = url.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", to)
+	}
+}
+
+// ConvertDown implements apis.Convertible
+func (a *Addressable) ConvertDown(ctx context.Context, from apis.Convertible) error {
+	switch source := from.(type) {
+	case *v1.Addressable:
+		a.URL = source.URL.DeepCopy()
+		return nil
+	case *v1beta1.Addressable:
+		a.URL = source.URL.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", from)
+	}
+}
+
 // Populate implements duck.Populatable
 func (t *AddressableType) Populate() {
 	t.Status = AddressStatus{
@@ -87,6 +124,7 @@ func (t *AddressableType) Populate() {
 	}
 }
 
+// GetURL returns the URL type for the Addressable.
 func (a Addressable) GetURL() apis.URL {
 	if a.URL != nil {
 		return *a.URL

--- a/vendor/knative.dev/pkg/apis/duck/v1beta1/addressable_types.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1beta1/addressable_types.go
@@ -17,11 +17,15 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/apis/duck/v1"
 )
 
 // Addressable provides a generic mechanism for a custom resource
@@ -34,8 +38,12 @@ type Addressable struct {
 	URL *apis.URL `json:"url,omitempty"`
 }
 
-// Addressable is an Implementable "duck type".
-var _ duck.Implementable = (*Addressable)(nil)
+var (
+	// Addressable is an Implementable "duck type".
+	_ duck.Implementable = (*Addressable)(nil)
+	// Addressable is a Convertible type.
+	_ apis.Convertible = (*Addressable)(nil)
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,6 +74,28 @@ var (
 // GetFullType implements duck.Implementable
 func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
+}
+
+// ConvertUp implements apis.Convertible
+func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
+	switch sink := to.(type) {
+	case *v1.Addressable:
+		sink.URL = a.URL.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", to)
+	}
+}
+
+// ConvertDown implements apis.Convertible
+func (a *Addressable) ConvertDown(ctx context.Context, from apis.Convertible) error {
+	switch source := from.(type) {
+	case *v1.Addressable:
+		a.URL = source.URL.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", from)
+	}
 }
 
 // Populate implements duck.Populatable

--- a/vendor/knative.dev/pkg/apis/testing/v1/conditions.go
+++ b/vendor/knative.dev/pkg/apis/testing/v1/conditions.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+package v1
 
 import (
 	"fmt"
@@ -21,12 +21,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
-	duckv1b1 "knative.dev/pkg/apis/duck/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 // CheckCondition checks if condition `c` on `cc` has value `cs`.
-// DEPRECATED: Use versioned test helper
-func CheckCondition(s *duckv1b1.Status, c apis.ConditionType, cs corev1.ConditionStatus) error {
+func CheckCondition(s *duckv1.Status, c apis.ConditionType, cs corev1.ConditionStatus) error {
 	cond := s.GetCondition(c)
 	if cond == nil {
 		return fmt.Errorf("condition %v is nil", c)
@@ -38,8 +37,7 @@ func CheckCondition(s *duckv1b1.Status, c apis.ConditionType, cs corev1.Conditio
 }
 
 // CheckConditionOngoing checks if the condition is in state `Unknown`.
-// DEPRECATED: Use versioned test helper
-func CheckConditionOngoing(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
+func CheckConditionOngoing(s *duckv1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionUnknown); err != nil {
 		t.Error(err)
@@ -47,8 +45,7 @@ func CheckConditionOngoing(s *duckv1b1.Status, c apis.ConditionType, t *testing.
 }
 
 // CheckConditionFailed checks if the condition is in state `False`.
-// DEPRECATED: Use versioned test helper
-func CheckConditionFailed(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
+func CheckConditionFailed(s *duckv1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionFalse); err != nil {
 		t.Error(err)
@@ -56,8 +53,7 @@ func CheckConditionFailed(s *duckv1b1.Status, c apis.ConditionType, t *testing.T
 }
 
 // CheckConditionSucceeded checks if the condition is in state `True`.
-// DEPRECATED: Use versioned test helper
-func CheckConditionSucceeded(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
+func CheckConditionSucceeded(s *duckv1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionTrue); err != nil {
 		t.Error(err)

--- a/vendor/knative.dev/pkg/apis/testing/v1beta1/conditions.go
+++ b/vendor/knative.dev/pkg/apis/testing/v1beta1/conditions.go
@@ -25,7 +25,6 @@ import (
 )
 
 // CheckCondition checks if condition `c` on `cc` has value `cs`.
-// DEPRECATED: Use versioned test helper
 func CheckCondition(s *duckv1b1.Status, c apis.ConditionType, cs corev1.ConditionStatus) error {
 	cond := s.GetCondition(c)
 	if cond == nil {
@@ -38,7 +37,6 @@ func CheckCondition(s *duckv1b1.Status, c apis.ConditionType, cs corev1.Conditio
 }
 
 // CheckConditionOngoing checks if the condition is in state `Unknown`.
-// DEPRECATED: Use versioned test helper
 func CheckConditionOngoing(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionUnknown); err != nil {
@@ -47,7 +45,6 @@ func CheckConditionOngoing(s *duckv1b1.Status, c apis.ConditionType, t *testing.
 }
 
 // CheckConditionFailed checks if the condition is in state `False`.
-// DEPRECATED: Use versioned test helper
 func CheckConditionFailed(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionFalse); err != nil {
@@ -56,7 +53,6 @@ func CheckConditionFailed(s *duckv1b1.Status, c apis.ConditionType, t *testing.T
 }
 
 // CheckConditionSucceeded checks if the condition is in state `True`.
-// DEPRECATED: Use versioned test helper
 func CheckConditionSucceeded(s *duckv1b1.Status, c apis.ConditionType, t *testing.T) {
 	t.Helper()
 	if err := CheckCondition(s, c, corev1.ConditionTrue); err != nil {


### PR DESCRIPTION
As part of integrating the v1 API types all types need to have the same
type of duck-typed status so they can be readily converted between each
other. This change also updates the Route converters to use the new
convertible addressable.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
