### PR TITLE
Normally compute and propagate metric status

### DIFF
--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 
 	"knative.dev/pkg/controller"
@@ -27,6 +29,8 @@ import (
 	listers "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
 	rbase "knative.dev/serving/pkg/reconciler"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
 )
@@ -49,23 +53,65 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if namespace == "" || err != nil {
-		logger.Errorf("Invalid resource key: %s", key)
+		logger.Error("Invalid resource key: " + key)
 		return nil
 	}
 
-	metric, err := r.metricLister.Metrics(namespace).Get(name)
+	original, err := r.metricLister.Metrics(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
+		// The metric object is gone, so delete the collection.
 		return r.collector.Delete(namespace, name)
 	} else if err != nil {
-		return errors.Wrapf(err, "failed to fetch metric %q", key)
+		return errors.Wrapf(err, "failed to fetch metric "+key)
 	}
 
+	// Don't mess with informer's copy.
+	metric := original.DeepCopy()
+	metric.SetDefaults(ctx)
 	metric.Status.InitializeConditions()
 
-	if err := r.collector.CreateOrUpdate(metric); err != nil {
-		return errors.Wrapf(err, "failed to initiate or update scraping")
+	if err = r.reconcileCollection(ctx, metric); err != nil {
+		logger.Errorw("Error reconciling metric collection", zap.Error(err))
+		r.Recorder.Event(metric, corev1.EventTypeWarning, "InternalError", err.Error())
+	} else {
+		metric.Status.MarkMetricReady()
 	}
 
-	metric.Status.MarkMetricReady()
+	if !equality.Semantic.DeepEqual(original.Status, metric.Status) {
+		// Change of status, need to update the object.
+		if uErr := r.updateStatus(metric); uErr != nil {
+			logger.Warnw("Failed to update metric  status", zap.Error(uErr))
+			r.Recorder.Eventf(metric, corev1.EventTypeWarning, "UpdateFailed",
+				"Failed to update metric status: %v", uErr)
+			return uErr
+		}
+		r.Recorder.Eventf(metric, corev1.EventTypeNormal, "Updated", "Successfully updated metric status %s", key)
+	}
+	return err
+}
+
+func (r *reconciler) reconcileCollection(ctx context.Context, metric *v1alpha1.Metric) error {
+	err := r.collector.CreateOrUpdate(metric)
+	if err != nil {
+		// If create or update failes, we won't be able to collect at all.
+		metric.Status.MarkMetricFailed("CollectionFailed", "Failed to reconcile metric collection")
+		return errors.Wrapf(err, "failed to initiate or update scraping")
+	}
 	return nil
+}
+
+func (r *reconciler) updateStatus(m *v1alpha1.Metric) error {
+	ex, err := r.metricLister.Metrics(m.Namespace).Get(m.Name)
+	if err != nil {
+		// If something deleted metric while we were reconciling ¯\(°_o)/¯.
+		return err
+	}
+	if equality.Semantic.DeepEqual(ex.Status, m.Status) {
+		// no-op
+		return nil
+	}
+	ex = ex.DeepCopy()
+	ex.Status = m.Status
+	_, err = r.ServingClientSet.AutoscalingV1alpha1().Metrics(ex.Namespace).UpdateStatus(ex)
+	return err
 }

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -80,7 +80,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	if !equality.Semantic.DeepEqual(original.Status, metric.Status) {
 		// Change of status, need to update the object.
 		if uErr := r.updateStatus(metric); uErr != nil {
-			logger.Warnw("Failed to update metric  status", zap.Error(uErr))
+			logger.Warnw("Failed to update metric status", zap.Error(uErr))
 			r.Recorder.Eventf(metric, corev1.EventTypeWarning, "UpdateFailed",
 				"Failed to update metric status: %v", uErr)
 			return uErr

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -62,7 +62,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 		// The metric object is gone, so delete the collection.
 		return r.collector.Delete(namespace, name)
 	} else if err != nil {
-		return errors.Wrapf(err, "failed to fetch metric "+key)
+		return errors.Wrap(err, "failed to fetch metric "+key)
 	}
 
 	// Don't mess with informer's copy.
@@ -95,7 +95,7 @@ func (r *reconciler) reconcileCollection(ctx context.Context, metric *v1alpha1.M
 	if err != nil {
 		// If create or update failes, we won't be able to collect at all.
 		metric.Status.MarkMetricFailed("CollectionFailed", "Failed to reconcile metric collection")
-		return errors.Wrapf(err, "failed to initiate or update scraping")
+		return errors.Wrap(err, "failed to initiate or update scraping")
 	}
 	return nil
 }


### PR DESCRIPTION
Currently I've added the cases when metric creation fails.
And the corresponding tests.
We need to think how to deal with the case when collection is successfully created (always, basically in reality)
and the collection process fails.
But this is for the next round.

For #5395 

/assign @nak3 mattmoor @markusthoemmes

