### PR TITLE
Simplify the endpoint handling logic.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -211,13 +211,13 @@ func (rw *revisionWatcher) sendUpdate(update *RevisionDestsUpdate) {
 // assumed this method is not called concurrently.
 func (rw *revisionWatcher) checkDests(dests []string) {
 	if len(dests) == 0 {
-		if rw.clusterIPHealthy {
-			// We have a healthy clusterIP but revision is not ready. We must have scaled down.
-			rw.clusterIPHealthy = false
+		// We must have scaled down.
+		rw.clusterIPHealthy = false
 
-			// Send update that we are now inactive.
-			rw.sendUpdate(&RevisionDestsUpdate{Rev: rw.rev})
-		}
+		rw.logger.Debug("ClusterIP is no longer healthy.")
+
+		// Send update that we are now inactive.
+		rw.sendUpdate(&RevisionDestsUpdate{Rev: rw.rev})
 		return
 	}
 


### PR DESCRIPTION
Whenever we get an update with zero endpoints, set the "Cluster IP healthy" state to false and send along the update regardless of whether we previously thought the cluster IP was healthy.