### PR TITLE
Add sleeps to the tests that panic in the logger.

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -1130,6 +1130,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 		if err := grp.Wait(); err != nil {
 			t.Errorf("Wait() = %v", err)
 		}
+		// To let the informers shut down.
+		time.Sleep(3 * time.Second)
 	}()
 
 	sharedClient := fakesharedclient.Get(ctx)

--- a/pkg/reconciler/configuration/queueing_test.go
+++ b/pkg/reconciler/configuration/queueing_test.go
@@ -85,7 +85,6 @@ func getTestConfiguration() *v1alpha1.Configuration {
 }
 
 func TestNewConfigurationCallsSyncHandler(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, cancel, informers := SetupFakeContextWithCancel(t)
 
 	configMapWatcher := configmap.NewStaticWatcher(&corev1.ConfigMap{
@@ -104,6 +103,9 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 		if err := eg.Wait(); err != nil {
 			t.Fatalf("Error running controller: %v", err)
 		}
+		// To let the informers shut down.
+		time.Sleep(3 * time.Second)
+		logtesting.ClearAll()
 	}()
 
 	servingClient := fakeservingclient.Get(ctx)

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -271,7 +271,10 @@ func (r *errorResolver) Resolve(_ string, _ k8schain.Options, _ sets.String) (st
 
 func TestResolutionFailed(t *testing.T) {
 	ctx, cancel, _, controller, _ := newTestController(t)
-	defer cancel()
+	defer func() {
+		cancel()
+		time.Sleep(3 * time.Second)
+	}()
 
 	// Unconditionally return this error during resolution.
 	errorMessage := "I am the expected error message, hear me ROAR!"
@@ -568,6 +571,8 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
+				// To allow all the informers shut down.
+				time.Sleep(3 * time.Second)
 			}()
 
 			servingClient := fakeservingclient.Get(ctx)
@@ -722,6 +727,8 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
+				// To allow all the informers shut down.
+				time.Sleep(3 * time.Second)
 			}()
 
 			kubeClient := fakekubeclient.Get(ctx)


### PR DESCRIPTION
Currently we have no way to knowing when the informers stop. And if that's even possible.
So these are bandaids for the tests that are now failing a lot on the prow.
I've verified all of them with -race -count=5 setup on my machine,
but let's see how they work on Prod.

Longer term, we need to find a way to find out whether the informer stopped actually doing stuff
or do something with logger so that it knows test terminated and does not pass on to t.Logf.

/assign mattmoor

