### PR TITLE
Use a WaitGroup instead of simulating one.

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -198,16 +198,15 @@ func TestThrottler(t *testing.T) {
 			}
 			close(updateCh)
 
-			var runLock sync.Mutex
-			runLock.Lock()
+			var wg sync.WaitGroup
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				throttler.Run(updateCh)
-				runLock.Unlock()
 			}()
 
 			// Wait for throttler to complete processing updates and exit
-			runLock.Lock()
-			runLock.Unlock()
+			wg.Wait()
 
 			for _, delRev := range tc.deletes {
 				servfake.ServingV1alpha1().Revisions(delRev.Namespace).Delete(delRev.Name, nil)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The behavior here is exactly what a WaitGroup should be used for (as stated by the comment even), so use one.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @greghaynes 
