### PR TITLE
Use Gateway endpoint for external access test without resolvable domain

### DIFF
--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
-	ingress "knative.dev/pkg/test/ingress"
+	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
@@ -105,7 +105,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 	// ref: https://github.com/knative/serving/issues/5389
 	if !test.ServingFlags.ResolvableDomain && accessibleExternal {
 		gatewayTarget := pkgTest.Flags.IngressEndpoint
-		if pkgTest.Flags.IngressEndpoint == "" {
+		if gatewayTarget == "" {
 			var err error
 			if gatewayTarget, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube); err != nil {
 				t.Fatalf("Failed to get gateway IP: %v", err)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
+	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
@@ -47,6 +48,7 @@ import (
 
 const (
 	targetHostEnv      = "TARGET_HOST"
+	gatewayHostEnv     = "GATEWAY_HOST"
 	helloworldResponse = "Hello World! How about some tasty noodles?"
 )
 
@@ -98,6 +100,22 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
 		Name:  targetHostEnv,
 		Value: helloworldDomain,
 	}}
+
+	// When resolvable domain is not set for external access test, use gateway for the endpoint as xip.io is flaky.
+	// ref: https://github.com/knative/serving/issues/5389
+	if !test.ServingFlags.ResolvableDomain && accessibleExternal {
+		gatewayTarget := pkgTest.Flags.IngressEndpoint
+		if pkgTest.Flags.IngressEndpoint == "" {
+			var err error
+			if gatewayTarget, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube); err != nil {
+				t.Fatalf("Failed to get gateway IP: %v", err)
+			}
+		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  gatewayHostEnv,
+			Value: gatewayTarget,
+		})
+	}
 
 	// Set up httpproxy app.
 	t.Log("Creating a Service for the httpproxy test app.")
@@ -284,8 +302,6 @@ func TestServiceToServiceCallViaActivator(t *testing.T) {
 // It verifies that the helloworld service is accessible internally from both internal domain and external domain.
 // But it's only accessible from external via the external domain
 func TestCallToPublicService(t *testing.T) {
-	t.Skip("Skipping until #5389 is resolved.")
-
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	targetHostEnv = "TARGET_HOST"
+	targetHostEnv  = "TARGET_HOST"
+	gatewayHostEnv = "GATEWAY_HOST"
 )
 
 var (
@@ -70,7 +71,16 @@ func main() {
 	log.Print("HTTP Proxy app started.")
 
 	targetHost := getTargetHostEnv()
+
+	// Gateway is an optional value. It is used only when resolvable domain is not set
+	// for external access test, as xip.io is flaky.
+	// ref: https://github.com/knative/serving/issues/5389
+	gateway := os.Getenv(gatewayHostEnv)
+	if len(gateway) > 0 {
+		targetHost = gateway
+	}
 	targetURL := fmt.Sprintf("http://%s", targetHost)
+	log.Print("target is " + targetURL)
 	httpProxy = initialHTTPProxy(targetURL)
 
 	test.ListenAndServeGracefully(":8080", handler)

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -76,7 +76,7 @@ func main() {
 	// for external access test, as xip.io is flaky.
 	// ref: https://github.com/knative/serving/issues/5389
 	gateway := os.Getenv(gatewayHostEnv)
-	if len(gateway) > 0 {
+	if gateway != "" {
 		targetHost = gateway
 	}
 	targetURL := fmt.Sprintf("http://%s", targetHost)


### PR DESCRIPTION
## Proposed Changes

Testing from httpproxy to xip.io flakes a lot due to unstable DNS
resolution for xip.io.

This patch adds `GATEWAY_HOST` env var to httpproxy to forward the
request to gateway endpoint with http host header, if the value is set.

/lint

Fixes https://github.com/knative/serving/issues/5389

**Release Note**

```release-note
NONE
```
