### PR TITLE
Remove logURL assertion from conformance tests.

### DIFF
--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -116,15 +116,6 @@ func TestContainerErrorMsg(t *testing.T) {
 		t.Fatalf("Failed to validate revision state: %s", err)
 	}
 
-	t.Log("When the revision has error condition, logUrl should be populated.")
-	logURL, err := getLogURLFromRevision(clients, revisionName)
-	if err != nil {
-		t.Fatalf("Failed to get logUrl from revision %s: %v", revisionName, err)
-	}
-
-	// TODO(jessiezcc): actually validate the logURL, but requires kibana setup
-	t.Logf("LogURL: %s", logURL)
-
 	t.Log("Checking to ensure Route is in desired state")
 	err = v1test.CheckRouteState(clients.ServingClient, names.Route, v1test.IsRouteNotReady)
 	if err != nil {
@@ -223,11 +214,6 @@ func TestContainerExitingMsg(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to validate revision state: %s", err)
 			}
-
-			t.Log("When the revision has error condition, logUrl should be populated.")
-			if _, err = getLogURLFromRevision(clients, revisionName); err != nil {
-				t.Fatalf("Failed to get logUrl from revision %s: %v", revisionName, err)
-			}
 		})
 	}
 }
@@ -242,16 +228,4 @@ func getRevisionFromConfiguration(clients *test.Clients, configName string) (str
 		return config.Status.LatestCreatedRevisionName, nil
 	}
 	return "", fmt.Errorf("No valid revision name found in configuration %s", configName)
-}
-
-// Get LogURL from revision.
-func getLogURLFromRevision(clients *test.Clients, revisionName string) (string, error) {
-	revision, err := clients.ServingClient.Revisions.Get(revisionName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if revision.Status.LogURL != "" && strings.Contains(revision.Status.LogURL, string(revision.GetUID())) {
-		return revision.Status.LogURL, nil
-	}
-	return "", fmt.Errorf("The revision %s does't have valid logUrl: %s", revisionName, revision.Status.LogURL)
 }

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -114,15 +114,6 @@ func TestContainerErrorMsg(t *testing.T) {
 		t.Fatalf("Failed to validate revision state: %s", err)
 	}
 
-	t.Log("When the revision has error condition, logUrl should be populated.")
-	logURL, err := getLogURLFromRevision(clients, revisionName)
-	if err != nil {
-		t.Fatalf("Failed to get logUrl from revision %s: %v", revisionName, err)
-	}
-
-	// TODO(jessiezcc): actually validate the logURL, but requires kibana setup
-	t.Logf("LogURL: %s", logURL)
-
 	t.Log("When the revision has error condition, route should not be ready.")
 	err = v1a1test.CheckRouteState(clients.ServingAlphaClient, names.Route, v1a1test.IsRouteNotReady)
 	if err != nil {
@@ -221,11 +212,6 @@ func TestContainerExitingMsg(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to validate revision state: %s", err)
 			}
-
-			t.Log("When the revision has error condition, logUrl should be populated.")
-			if _, err = getLogURLFromRevision(clients, revisionName); err != nil {
-				t.Fatalf("Failed to get logUrl from revision %s: %v", revisionName, err)
-			}
 		})
 	}
 }
@@ -240,16 +226,4 @@ func getRevisionFromConfiguration(clients *test.Clients, configName string) (str
 		return config.Status.LatestCreatedRevisionName, nil
 	}
 	return "", fmt.Errorf("No valid revision name found in configuration %s", configName)
-}
-
-// Get LogURL from revision.
-func getLogURLFromRevision(clients *test.Clients, revisionName string) (string, error) {
-	revision, err := clients.ServingAlphaClient.Revisions.Get(revisionName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if revision.Status.LogURL != "" && strings.Contains(revision.Status.LogURL, string(revision.GetUID())) {
-		return revision.Status.LogURL, nil
-	}
-	return "", fmt.Errorf("The revision %s does't have valid logUrl: %s", revisionName, revision.Status.LogURL)
 }

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -116,15 +116,6 @@ func TestContainerErrorMsg(t *testing.T) {
 		t.Fatalf("Failed to validate revision state: %s", err)
 	}
 
-	t.Log("When the revision has error condition, logUrl should be populated.")
-	logURL, err := getLogURLFromRevision(clients, revisionName)
-	if err != nil {
-		t.Fatalf("Failed to get logUrl from revision %s: %v", revisionName, err)
-	}
-
-	// TODO(jessiezcc): actually validate the logURL, but requires kibana setup
-	t.Logf("LogURL: %s", logURL)
-
 	t.Log("Checking to ensure Route is in desired state")
 	err = v1b1test.CheckRouteState(clients.ServingBetaClient, names.Route, v1b1test.IsRouteNotReady)
 	if err != nil {
@@ -223,11 +214,6 @@ func TestContainerExitingMsg(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to validate revision state: %s", err)
 			}
-
-			t.Log("When the revision has error condition, logUrl should be populated.")
-			if _, err = getLogURLFromRevision(clients, revisionName); err != nil {
-				t.Fatalf("Failed to get logUrl from revision %s: %v", revisionName, err)
-			}
 		})
 	}
 }
@@ -242,16 +228,4 @@ func getRevisionFromConfiguration(clients *test.Clients, configName string) (str
 		return config.Status.LatestCreatedRevisionName, nil
 	}
 	return "", fmt.Errorf("No valid revision name found in configuration %s", configName)
-}
-
-// Get LogURL from revision.
-func getLogURLFromRevision(clients *test.Clients, revisionName string) (string, error) {
-	revision, err := clients.ServingBetaClient.Revisions.Get(revisionName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if revision.Status.LogURL != "" && strings.Contains(revision.Status.LogURL, string(revision.GetUID())) {
-		return revision.Status.LogURL, nil
-	}
-	return "", fmt.Errorf("The revision %s does't have valid logUrl: %s", revisionName, revision.Status.LogURL)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We have sufficient coverage for logURL population in our unit tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
