### PR TITLE
Add throttler test for scaling down clusterip

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -160,6 +160,20 @@ func TestThrottler(t *testing.T) {
 		expectTryResults: []tryResult{
 			{ErrString: "revision.serving.knative.dev \"test-revision\" not found"},
 		},
+	}, {
+		name: "ready addresses with no clusterip or dests",
+		revisions: []*v1alpha1.Revision{
+			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
+		},
+		initUpdates: []*RevisionDestsUpdate{{
+			Rev: types.NamespacedName{"test-namespace", "test-revision"},
+		}},
+		trys: []types.NamespacedName{
+			{Namespace: "test-namespace", Name: "test-revision"},
+		},
+		expectTryResults: []tryResult{
+			{ErrString: ErrActivatorOverload.Error()},
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			updateCh := make(chan *RevisionDestsUpdate, 100)


### PR DESCRIPTION
We are seeing odd behavior where capacity breakers are non-zero when
clusterip and podip are nil. Adding a test case.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
