### PR TITLE
Add json inline annotation

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -118,7 +118,7 @@ const (
 
 // PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).
 type PodAutoscalerStatus struct {
-	duckv1.Status
+	duckv1.Status `json:",inline"`
 
 	// ServiceName is the K8s Service name that serves the revision, scaled by this PA.
 	// The service is created and owned by the ServerlessService object owned by this PA.


### PR DESCRIPTION
Add inline annotation to status for pod autoscaler to match all other
types. The missing annotation is doesn't seem to change behaviori
as embedded struct fields get processed as inlined JSON fields without it.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->