### PR TITLE
Always pass Healthy dests to the throttler

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -100,9 +100,8 @@ func TestActivationHandler(t *testing.T) {
 		wantErr:           nil,
 		endpointsInformer: endpointsInformer(endpoints(testNamespace, testRevName, 1000, networking.ServicePortNameHTTP1)),
 		destsUpdates: []*activatornet.RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{testNamespace, testRevName},
-			Dests:             dests(1000),
-			ReadyAddressCount: 1000,
+			Rev:   types.NamespacedName{testNamespace, testRevName},
+			Dests: dests(1000),
 		}},
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
@@ -124,9 +123,8 @@ func TestActivationHandler(t *testing.T) {
 		wantErr:           nil,
 		endpointsInformer: endpointsInformer(endpoints(testNamespace, testRevName, 1000, networking.ServicePortNameHTTP1)),
 		destsUpdates: []*activatornet.RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"fake-namespace", testRevName},
-			Dests:             []string{},
-			ReadyAddressCount: 0,
+			Rev:   types.NamespacedName{"fake-namespace", testRevName},
+			Dests: []string{},
 		}},
 		reporterCalls: nil,
 		tryTimeout:    100 * time.Millisecond,
@@ -139,9 +137,8 @@ func TestActivationHandler(t *testing.T) {
 		wantErr:           errors.New("request error"),
 		endpointsInformer: endpointsInformer(endpoints(testNamespace, testRevName, 1000, networking.ServicePortNameHTTP1)),
 		destsUpdates: []*activatornet.RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{testNamespace, testRevName},
-			Dests:             dests(1000),
-			ReadyAddressCount: 1000,
+			Rev:   types.NamespacedName{testNamespace, testRevName},
+			Dests: dests(1000),
 		}},
 		reporterCalls: []reporterCall{{
 			Op:         "ReportRequestCount",
@@ -306,9 +303,9 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	go throttler.Run(updateCh)
 
 	updateCh <- &activatornet.RevisionDestsUpdate{
-		Rev:               types.NamespacedName{namespace, revName},
-		ClusterIPDest:     "129.0.0.1:1234",
-		ReadyAddressCount: breakerParams.InitialCapacity,
+		Rev:           types.NamespacedName{namespace, revName},
+		ClusterIPDest: "129.0.0.1:1234",
+		Dests:         dests(breakerParams.InitialCapacity),
 	}
 
 	handler := &activationHandler{
@@ -405,9 +402,9 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 			go throttler.Run(updateCh)
 
 			updateCh <- &activatornet.RevisionDestsUpdate{
-				Rev:               types.NamespacedName{namespace, revName},
-				ClusterIPDest:     "129.0.0.1:1234",
-				ReadyAddressCount: breakerParams.InitialCapacity,
+				Rev:           types.NamespacedName{namespace, revName},
+				ClusterIPDest: "129.0.0.1:1234",
+				Dests:         dests(breakerParams.InitialCapacity),
 			}
 
 			handler := &activationHandler{

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -115,7 +115,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}, ReadyAddressCount: 1}},
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}}},
 		probeResponses: []activatortest.FakeResponse{{
 			Err: errors.New("clusterIP transport error"),
 		}, {
@@ -132,7 +132,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}, ReadyAddressCount: 1}},
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}}},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
 			"129.0.0.1:1234": {{
 				Err: errors.New("clusterIP transport error"),
@@ -152,7 +152,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{ClusterIPDest: "129.0.0.1:1234", ReadyAddressCount: 1}},
+		expectUpdates: []RevisionDestsUpdate{{ClusterIPDest: "129.0.0.1:1234", Dests: []string{"128.0.0.1:1234"}}},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
 			"129.0.0.1:1234": {{
 				Err:  nil,
@@ -206,7 +206,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}, ReadyAddressCount: 1}},
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234"}}},
 		probeResponses: []activatortest.FakeResponse{{
 			Err: errors.New("clusterIP transport error"),
 		}, {
@@ -229,7 +229,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"}, ReadyAddressCount: 2}},
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"}}},
 		probeResponses: []activatortest.FakeResponse{{
 			Err: errors.New("clusterIP transport error"),
 		}, {
@@ -245,7 +245,7 @@ func TestRevisionWatcher(t *testing.T) {
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.2:1234"}, ReadyAddressCount: 2}},
+		expectUpdates: []RevisionDestsUpdate{{Dests: []string{"128.0.0.2:1234"}}},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
 			"129.0.0.1:1234": {{
 				Err: errors.New("clusterIP transport error"),
@@ -268,8 +268,8 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 		clusterIP: "129.0.0.1",
 		expectUpdates: []RevisionDestsUpdate{
-			{Dests: []string{"128.0.0.1:1234"}, ReadyAddressCount: 1},
-			{ClusterIPDest: "129.0.0.1:1234", ReadyAddressCount: 1},
+			{Dests: []string{"128.0.0.1:1234"}},
+			{Dests: []string{"128.0.0.1:1234"}, ClusterIPDest: "129.0.0.1:1234"},
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
 			"129.0.0.1:1234": {{
@@ -448,8 +448,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{
 			{Namespace: "test-namespace", Name: "test-revision"}: {
-				Dests:             []string{"128.0.0.1:1234"},
-				ReadyAddressCount: 1,
+				Dests: []string{"128.0.0.1:1234"},
 			},
 		},
 		updateCnt: 1,
@@ -479,8 +478,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{
 			{Namespace: "test-namespace", Name: "test-revision"}: {
-				Dests:             []string{"128.0.0.1:1234"},
-				ReadyAddressCount: 1,
+				Dests: []string{"128.0.0.1:1234"},
 			},
 		},
 		updateCnt: 1,
@@ -506,12 +504,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{
 			{Namespace: "test-namespace", Name: "test-revision1"}: {
-				Dests:             []string{"128.0.0.1:1234"},
-				ReadyAddressCount: 1,
+				Dests: []string{"128.0.0.1:1234"},
 			},
 			{Namespace: "test-namespace", Name: "test-revision2"}: {
-				Dests:             []string{"128.1.0.2:1235"},
-				ReadyAddressCount: 1,
+				Dests: []string{"128.1.0.2:1235"},
 			},
 		},
 		updateCnt: 2,
@@ -547,8 +543,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{
 			{Namespace: "test-namespace", Name: "test-revision"}: {
-				ClusterIPDest:     "129.0.0.1:1234",
-				ReadyAddressCount: 1,
+				ClusterIPDest: "129.0.0.1:1234",
+				Dests:         []string{"128.0.0.1:1234"},
 			},
 		},
 		updateCnt: 2,
@@ -573,7 +569,6 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			}},
 		},
 		expectDests: map[types.NamespacedName]RevisionDestsUpdate{},
-		updateCnt:   0,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeRT := activatortest.FakeRoundTripper{

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -61,9 +61,8 @@ func TestThrottler(t *testing.T) {
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
 		},
 		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			Dests:             []string{"128.0.0.1:1234"},
-			ReadyAddressCount: 1,
+			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
+			Dests: []string{"128.0.0.1:1234"},
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -77,9 +76,9 @@ func TestThrottler(t *testing.T) {
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
 		},
 		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			ClusterIPDest:     "129.0.0.1:1234",
-			ReadyAddressCount: 1,
+			Rev:           types.NamespacedName{"test-namespace", "test-revision"},
+			ClusterIPDest: "129.0.0.1:1234",
+			Dests:         []string{"128.0.0.1:1234"},
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -93,9 +92,8 @@ func TestThrottler(t *testing.T) {
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
 		},
 		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			Dests:             []string{"128.0.0.1:1234", "128.0.0.2:1234"},
-			ReadyAddressCount: 2,
+			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
+			Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -106,18 +104,17 @@ func TestThrottler(t *testing.T) {
 			{Dest: "128.0.0.2:1234"},
 		},
 	}, {
-		name: "multiple clusterip requests after podip",
+		name: "multiple ClusterIP requests after PodIP",
 		revisions: []*v1alpha1.Revision{
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
 		},
 		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			Dests:             []string{"128.0.0.1:1234", "128.0.0.2:1234"},
-			ReadyAddressCount: 2,
+			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
+			Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
 		}, {
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			ClusterIPDest:     "129.0.0.1:1234",
-			ReadyAddressCount: 2,
+			Rev:           types.NamespacedName{"test-namespace", "test-revision"},
+			ClusterIPDest: "129.0.0.1:1234",
+			Dests:         []string{"128.0.0.1:1234", "128.0.0.2:1234"},
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -133,9 +130,9 @@ func TestThrottler(t *testing.T) {
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
 		},
 		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			ClusterIPDest:     "129.0.0.1:1234",
-			ReadyAddressCount: 1,
+			Rev:           types.NamespacedName{"test-namespace", "test-revision"},
+			ClusterIPDest: "129.0.0.1:1234",
+			Dests:         []string{"128.0.0.1:1234"},
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -151,9 +148,8 @@ func TestThrottler(t *testing.T) {
 			revision(types.NamespacedName{"test-namespace", "test-revision"}, networking.ProtocolHTTP1),
 		},
 		initUpdates: []*RevisionDestsUpdate{{
-			Rev:               types.NamespacedName{"test-namespace", "test-revision"},
-			Dests:             []string{"128.0.0.1:1234"},
-			ReadyAddressCount: 1,
+			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
+			Dests: []string{"128.0.0.1:1234"},
 		}},
 		deletes: []types.NamespacedName{
 			{"test-namespace", "test-revision"},
@@ -260,9 +256,8 @@ func TestMultipleActivator(t *testing.T) {
 	revID := types.NamespacedName{"test-namespace", "test-revision"}
 	updateCh := make(chan *RevisionDestsUpdate, 10)
 	updateCh <- &RevisionDestsUpdate{
-		Rev:               revID,
-		Dests:             []string{"128.0.0.1:1234"},
-		ReadyAddressCount: 3,
+		Rev:   revID,
+		Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.23:1234"},
 	}
 	close(updateCh)
 	throttler.Run(updateCh)


### PR DESCRIPTION
TL;DR: This is needed for future "ideal" load balancing in throttler wherein I
will need the actual pods to send traffic to -- so always send the ready
pod IPs. But this doubles as `ReadyPodCount`, so remove that.

As discussed with Greg, but for posterity:

Right now we know everything that is in dests is healthy. So when we switch to clusterIP
we can forward all the pods there for endpoints count reasons.

In future when we will have both healthy and unhealthy pods passed into the
we can combine and probe that combined list and send all the healthy ones to the throttler as we do now.

In any case backendCount==|dests|.

In theory we might probe unready addresses even when we're using cluster IP since we're delegating loadbalancing decision to the throttler,
but this might break the capacity computations, since there might be more pods to use than cluster IP can reach, so this might not be
a good initial approach, but a future enhancement.

/assign @greghaynes @markusthoemmes mattmoor

/lint
