### PR TITLE
Propagate ingress label from route label

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -95,10 +95,10 @@ func MakeIngress(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Ingress(r),
 			Namespace: r.Namespace,
-			Labels: map[string]string{
+			Labels: resources.UnionMaps(r.GetLabels(), map[string]string{
 				serving.RouteLabelKey:          r.Name,
 				serving.RouteNamespaceLabelKey: r.Namespace,
-			},
+			}),
 			Annotations: resources.UnionMaps(map[string]string{
 				networking.IngressClassAnnotationKey: ingressClass,
 			}, r.ObjectMeta.Annotations),

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -95,7 +95,7 @@ func MakeIngress(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Ingress(r),
 			Namespace: r.Namespace,
-			Labels: resources.UnionMaps(r.GetLabels(), map[string]string{
+			Labels: resources.UnionMaps(r.ObjectMeta.Labels, map[string]string{
 				serving.RouteLabelKey:          r.Name,
 				serving.RouteNamespaceLabelKey: r.Namespace,
 			}),

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -44,6 +45,51 @@ const ns = "test-ns"
 
 func getServiceVisibility() sets.String {
 	return sets.NewString()
+}
+
+func TestMakeIngress_CorrectMetadata(t *testing.T) {
+	targets := map[string]traffic.RevisionTargets{}
+	ingressClass := "foo-ingress"
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"test-label": "foo",
+			},
+			UID: "1234-5678",
+		},
+		Status: v1alpha1.RouteStatus{
+			RouteStatusFields: v1alpha1.RouteStatusFields{
+				URL: &apis.URL{
+					Scheme: "http",
+					Host:   "domain.com",
+				},
+			},
+		},
+	}
+	expected := metav1.ObjectMeta{
+		Name:      "test-route",
+		Namespace: "test-ns",
+		Labels: map[string]string{
+			serving.RouteLabelKey:          "test-route",
+			serving.RouteNamespaceLabelKey: "test-ns",
+			"test-label":                   "foo",
+		},
+		Annotations: map[string]string{
+			networking.IngressClassAnnotationKey: ingressClass,
+		},
+		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
+	}
+	ia, err := MakeIngress(getContext(), r, &traffic.Config{Targets: targets}, nil, getServiceVisibility(), ingressClass)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	ci := ia.(*netv1alpha1.Ingress)
+	if !cmp.Equal(expected, ci.ObjectMeta) {
+		t.Errorf("Unexpected metadata (-want, +got): %s", cmp.Diff(expected, ci.ObjectMeta))
+	}
 }
 
 func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -57,6 +57,9 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 			Labels: map[string]string{
 				"test-label": "foo",
 			},
+			Annotations: map[string]string{
+				"test-annotation": "bar",
+			},
 			UID: "1234-5678",
 		},
 		Status: v1alpha1.RouteStatus{
@@ -78,6 +81,7 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 		},
 		Annotations: map[string]string{
 			networking.IngressClassAnnotationKey: ingressClass,
+			"test-annotation":                    "bar",
 		},
 		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 	}

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -49,16 +49,20 @@ func getServiceVisibility() sets.String {
 
 func TestMakeIngress_CorrectMetadata(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
-	ingressClass := "foo-ingress"
+	ingressClass := "ng-ingress"
+	passdownIngressClass := "ok-ingress"
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				"test-label": "foo",
+				serving.RouteLabelKey:          "try-to-override",
+				serving.RouteNamespaceLabelKey: "try-to-override",
+				"test-label":                   "foo",
 			},
 			Annotations: map[string]string{
-				"test-annotation": "bar",
+				networking.IngressClassAnnotationKey: passdownIngressClass,
+				"test-annotation":                    "bar",
 			},
 			UID: "1234-5678",
 		},
@@ -80,7 +84,8 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 			"test-label":                   "foo",
 		},
 		Annotations: map[string]string{
-			networking.IngressClassAnnotationKey: ingressClass,
+			// Make sure to get passdownIngressClass instead of ingressClass
+			networking.IngressClassAnnotationKey: passdownIngressClass,
 			"test-annotation":                    "bar",
 		},
 		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -309,6 +309,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	expectedLabels := map[string]string{
 		serving.RouteLabelKey:          route.Name,
 		serving.RouteNamespaceLabelKey: route.Namespace,
+		"route":                        "test-route",
 	}
 	if diff := cmp.Diff(expectedLabels, ci.Labels); diff != "" {
 		t.Errorf("Unexpected label diff (-want +got): %v", diff)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -840,7 +840,7 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 			simpleIngress(
-				route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23")),
+				route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -940,7 +940,7 @@ func TestReconcile(t *testing.T) {
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngress(
 				route("default", "becomes-public", WithConfigTarget("config"),
-					WithRouteUID("65-23")),
+					WithRouteUID("65-23"), WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{


### PR DESCRIPTION
## Proposed Changes

This patch changes to propagate ingress's labels from parent Route's label.

Fixes https://github.com/knative/serving/issues/5462

/lint

**Release Note**

```release-note
NONE
```
