### PR TITLE
Make ingress skip copying over last-applied-configuration annotation from Route

### DIFF
--- a/pkg/reconciler/route/resources/certificate.go
+++ b/pkg/reconciler/route/resources/certificate.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/resources"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -62,10 +63,11 @@ func MakeCertificates(route *v1alpha1.Route, domainTagMap map[string]string, cer
 				Name:            certName,
 				Namespace:       route.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(route)},
-				Annotations: resources.UnionMaps(route.ObjectMeta.Annotations,
-					map[string]string{
-						networking.CertificateClassAnnotationKey: certClass,
-					}),
+				Annotations: resources.FilterMap(resources.UnionMaps(map[string]string{
+					networking.CertificateClassAnnotationKey: certClass,
+				}, route.ObjectMeta.Annotations), func(key string) bool {
+					return key == corev1.LastAppliedConfigAnnotation
+				}),
 				Labels: map[string]string{
 					serving.RouteLabelKey: route.Name,
 				},

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -86,7 +86,7 @@ func TestMakeCertificates(t *testing.T) {
 	}
 }
 
-func TestMakeCertificates_CorrectMetadata(t *testing.T) {
+func TestMakeCertificates_FilterLastAppliedAnno(t *testing.T) {
 	var orgRoute = &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "route",

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/kmeta"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -80,6 +81,65 @@ func TestMakeCertificates(t *testing.T) {
 		},
 	}
 	got := MakeCertificates(route, dnsNameTagMap, "foo-cert")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("MakeCertificate (-want, +got) = %v", diff)
+	}
+}
+
+func TestMakeCertificates_CorrectMetadata(t *testing.T) {
+	var orgRoute = &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+			UID:       "12345",
+			Labels: map[string]string{
+				"label-from-route": "foo",
+				// serving.RouteLabelKey cannot be overridden.
+				serving.RouteLabelKey: "foo",
+			},
+			Annotations: map[string]string{
+				corev1.LastAppliedConfigAnnotation:       "something-last-applied",
+				networking.CertificateClassAnnotationKey: "passdown-cert",
+			},
+		},
+	}
+	want := []*netv1alpha1.Certificate{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "route-12345-200999684",
+				Namespace:       "default",
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(orgRoute)},
+				Annotations: map[string]string{
+					networking.CertificateClassAnnotationKey: "passdown-cert",
+				},
+				Labels: map[string]string{
+					serving.RouteLabelKey: "route",
+				},
+			},
+			Spec: netv1alpha1.CertificateSpec{
+				DNSNames:   []string{"v1-current.default.example.com"},
+				SecretName: "route-12345-200999684",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "route-12345",
+				Namespace:       "default",
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(orgRoute)},
+				Annotations: map[string]string{
+					networking.CertificateClassAnnotationKey: "passdown-cert",
+				},
+				Labels: map[string]string{
+					serving.RouteLabelKey: "route",
+				},
+			},
+			Spec: netv1alpha1.CertificateSpec{
+				DNSNames:   []string{"v1.default.example.com"},
+				SecretName: "route-12345",
+			},
+		},
+	}
+	got := MakeCertificates(orgRoute, dnsNameTagMap, "default-cert")
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("MakeCertificate (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sort"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -99,9 +100,11 @@ func MakeIngress(
 				serving.RouteLabelKey:          r.Name,
 				serving.RouteNamespaceLabelKey: r.Namespace,
 			}),
-			Annotations: resources.UnionMaps(map[string]string{
+			Annotations: resources.FilterMap(resources.UnionMaps(map[string]string{
 				networking.IngressClassAnnotationKey: ingressClass,
-			}, r.ObjectMeta.Annotations),
+			}, r.GetAnnotations()), func(key string) bool {
+				return key == corev1.LastAppliedConfigAnnotation
+			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 		},
 		Spec: spec,


### PR DESCRIPTION
## Proposed Changes

When Route is created directly, Ingress takes over annotations from
Route with `last-applied-configuration` annotation*1.

This patch adds the filter for the annotation to skip it.

*1. Currently, following annotations is added via Route.
```
$ kubectl get ingresses.networking.internal.knative.dev  route-example -o yaml
apiVersion: networking.internal.knative.dev/v1alpha1
kind: Ingress
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"serving.knative.dev/v1alpha1","kind":"Route","metadata":{"annotations":{},"name":"route-example","namespace":"default"},"spec":{"traffic":[{"configurationName":"configuration-example","percent":100}]}}
      ...
```

Please also refer to https://github.com/knative/serving/pull/5202.

/lint

Fixes https://github.com/knative/serving/pull/5467#issuecomment-529729414

**Release Note**

```release-note
NONE
```

/cc @tcnghia 
