### PR TITLE
Remove sleeps from the tests now that they are no longer required.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1655,7 +1655,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0dca180a6449f2cd457f8efea003336352c5a412212fce072cad9661d5a71b61"
+  digest = "1:317a3a16bca32f918782654b282480b64d9cc5fd6357bd0bf2e36e174bf556bd"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1765,7 +1765,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "528ad1c1dd627059b95aef17ccf27f9ab0f46c10"
+  revision = "7db4b798fbbc6b3960c3d7f9a4c97f0471dafcaf"
 
 [[projects]]
   branch = "master"

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -1130,8 +1130,6 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 		if err := grp.Wait(); err != nil {
 			t.Errorf("Wait() = %v", err)
 		}
-		// To let the informers shut down.
-		time.Sleep(3 * time.Second)
 	}()
 
 	sharedClient := fakesharedclient.Get(ctx)

--- a/pkg/reconciler/configuration/queueing_test.go
+++ b/pkg/reconciler/configuration/queueing_test.go
@@ -103,8 +103,6 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 		if err := eg.Wait(); err != nil {
 			t.Fatalf("Error running controller: %v", err)
 		}
-		// To let the informers shut down.
-		time.Sleep(3 * time.Second)
 		logtesting.ClearAll()
 	}()
 

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -195,7 +194,6 @@ func TestUpdateDomainTemplate(t *testing.T) {
 	ctx, cancel, reconciler, watcher := newTestSetup(t)
 	defer func() {
 		cancel()
-		time.Sleep(3 * time.Second)
 		ClearAll()
 	}()
 
@@ -311,7 +309,6 @@ func TestDomainConfigDefaultDomain(t *testing.T) {
 	ctx, cancel, reconciler, _ := newTestSetup(t, domCfg)
 	defer func() {
 		cancel()
-		time.Sleep(3 * time.Second)
 		ClearAll()
 	}()
 
@@ -349,7 +346,6 @@ func TestDomainConfigExplicitDefaultDomain(t *testing.T) {
 	ctx, cancel, reconciler, _ := newTestSetup(t, domCfg)
 	defer func() {
 		cancel()
-		time.Sleep(3 * time.Second)
 		ClearAll()
 	}()
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -271,10 +271,7 @@ func (r *errorResolver) Resolve(_ string, _ k8schain.Options, _ sets.String) (st
 
 func TestResolutionFailed(t *testing.T) {
 	ctx, cancel, _, controller, _ := newTestController(t)
-	defer func() {
-		cancel()
-		time.Sleep(3 * time.Second)
-	}()
+	defer cancel()
 
 	// Unconditionally return this error during resolution.
 	errorMessage := "I am the expected error message, hear me ROAR!"
@@ -571,8 +568,6 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
-				// To allow all the informers shut down.
-				time.Sleep(3 * time.Second)
 			}()
 
 			servingClient := fakeservingclient.Get(ctx)
@@ -727,8 +722,6 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
-				// To allow all the informers shut down.
-				time.Sleep(3 * time.Second)
 			}()
 
 			kubeClient := fakekubeclient.Get(ctx)


### PR DESCRIPTION
/assign mattmoor

Now that the controller knows how to wait for the queue to drain we can remove the sleeps.
Fixes  #5452