### PR TITLE
Use tag.MustNewKey instead tag.NewKey

### DIFF
--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -72,43 +72,19 @@ func NewStatsReporter() (*Reporter, error) {
 	var r = &Reporter{}
 
 	// Create the tag keys that will be used to add tags to our measurements.
-	nsTag, err := tag.NewKey(metricskey.LabelNamespaceName)
-	if err != nil {
-		return nil, err
-	}
-	r.namespaceTagKey = nsTag
-	serviceTag, err := tag.NewKey(metricskey.LabelServiceName)
-	if err != nil {
-		return nil, err
-	}
-	r.serviceTagKey = serviceTag
-	configTag, err := tag.NewKey(metricskey.LabelConfigurationName)
-	if err != nil {
-		return nil, err
-	}
-	r.configTagKey = configTag
-	revTag, err := tag.NewKey(metricskey.LabelRevisionName)
-	if err != nil {
-		return nil, err
-	}
-	r.revisionTagKey = revTag
-	responseCodeTag, err := tag.NewKey("response_code")
-	if err != nil {
-		return nil, err
-	}
-	r.responseCodeKey = responseCodeTag
-	responseCodeClassTag, err := tag.NewKey("response_code_class")
-	if err != nil {
-		return nil, err
-	}
-	r.responseCodeClassKey = responseCodeClassTag
-	numTriesTag, err := tag.NewKey("num_tries")
-	if err != nil {
-		return nil, err
-	}
-	r.numTriesKey = numTriesTag
+	// Tag keys must conform to the restrictions described in
+	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
+	// - length between 1 and 255 inclusive
+	// - characters are printable US-ASCII
+	r.namespaceTagKey = tag.MustNewKey(metricskey.LabelNamespaceName)
+	r.serviceTagKey = tag.MustNewKey(metricskey.LabelServiceName)
+	r.configTagKey = tag.MustNewKey(metricskey.LabelConfigurationName)
+	r.revisionTagKey = tag.MustNewKey(metricskey.LabelRevisionName)
+	r.responseCodeKey = tag.MustNewKey("response_code")
+	r.responseCodeClassKey = tag.MustNewKey("response_code_class")
+	r.numTriesKey = tag.MustNewKey("num_tries")
 	// Create view to see our measurements.
-	err = view.Register(
+	err := view.Register(
 		&view.View{
 			Description: "Concurrent requests that are routed to Activator",
 			Measure:     requestConcurrencyM,

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -73,10 +73,16 @@ var (
 		"panic_mode",
 		"1 if autoscaler is in panic mode, 0 otherwise",
 		stats.UnitDimensionless)
-	namespaceTagKey tag.Key
-	configTagKey    tag.Key
-	revisionTagKey  tag.Key
-	serviceTagKey   tag.Key
+
+	// Create the tag keys that will be used to add tags to our measurements.
+	// Tag keys must conform to the restrictions described in
+	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
+	// - length between 1 and 255 inclusive
+	// - characters are printable US-ASCII
+	namespaceTagKey = tag.MustNewKey(metricskey.LabelNamespaceName)
+	serviceTagKey   = tag.MustNewKey(metricskey.LabelServiceName)
+	configTagKey    = tag.MustNewKey(metricskey.LabelConfigurationName)
+	revisionTagKey  = tag.MustNewKey(metricskey.LabelRevisionName)
 )
 
 func init() {
@@ -85,27 +91,6 @@ func init() {
 
 func register() {
 	var err error
-	// Create the tag keys that will be used to add tags to our measurements.
-	// Tag keys must conform to the restrictions described in
-	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
-	// - length between 1 and 255 inclusive
-	// - characters are printable US-ASCII
-	namespaceTagKey, err = tag.NewKey(metricskey.LabelNamespaceName)
-	if err != nil {
-		panic(err)
-	}
-	serviceTagKey, err = tag.NewKey(metricskey.LabelServiceName)
-	if err != nil {
-		panic(err)
-	}
-	configTagKey, err = tag.NewKey(metricskey.LabelConfigurationName)
-	if err != nil {
-		panic(err)
-	}
-	revisionTagKey, err = tag.NewKey(metricskey.LabelRevisionName)
-	if err != nil {
-		panic(err)
-	}
 
 	// Create views to see our measurements. This can return an error if
 	// a previously-registered view has the same name with a different value.

--- a/pkg/queue/stats/stats_reporter.go
+++ b/pkg/queue/stats/stats_reporter.go
@@ -69,33 +69,19 @@ func NewStatsReporter(ns, service, config, rev string, countMetric *stats.Int64M
 	}
 
 	// Create the tag keys that will be used to add tags to our measurements.
-	nsTag, err := tag.NewKey(metricskey.LabelNamespaceName)
-	if err != nil {
-		return nil, err
-	}
-	svcTag, err := tag.NewKey(metricskey.LabelServiceName)
-	if err != nil {
-		return nil, err
-	}
-	configTag, err := tag.NewKey(metricskey.LabelConfigurationName)
-	if err != nil {
-		return nil, err
-	}
-	revTag, err := tag.NewKey(metricskey.LabelRevisionName)
-	if err != nil {
-		return nil, err
-	}
-	responseCodeTag, err := tag.NewKey("response_code")
-	if err != nil {
-		return nil, err
-	}
-	responseCodeClassTag, err := tag.NewKey("response_code_class")
-	if err != nil {
-		return nil, err
-	}
+	// Tag keys must conform to the restrictions described in
+	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
+	// - length between 1 and 255 inclusive
+	// - characters are printable US-ASCII
+	nsTag := tag.MustNewKey(metricskey.LabelNamespaceName)
+	svcTag := tag.MustNewKey(metricskey.LabelServiceName)
+	configTag := tag.MustNewKey(metricskey.LabelConfigurationName)
+	revTag := tag.MustNewKey(metricskey.LabelRevisionName)
+	responseCodeTag := tag.MustNewKey("response_code")
+	responseCodeClassTag := tag.MustNewKey("response_code_class")
 
 	// Create view to see our measurements.
-	if err = view.Register(
+	if err := view.Register(
 		&view.View{
 			Description: "The number of requests that are routed to queue-proxy",
 			Measure:     countMetric,
@@ -113,7 +99,7 @@ func NewStatsReporter(ns, service, config, rev string, countMetric *stats.Int64M
 	}
 	// If queue size reporter is provided register the view for it too.
 	if queueSizeMetric != nil {
-		if err = view.Register(
+		if err := view.Register(
 			&view.View{
 				Description: "The number of items queued at this queue proxy.",
 				Measure:     queueSizeMetric,

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -44,19 +44,17 @@ var (
 		"Number of services that became ready",
 		stats.UnitDimensionless)
 
-	reconcilerTagKey tag.Key
-	keyTagKey        tag.Key
-)
-
-func init() {
-	var err error
 	// Create the tag keys that will be used to add tags to our measurements.
 	// Tag keys must conform to the restrictions described in
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
 	// - characters are printable US-ASCII
-	reconcilerTagKey = mustNewTagKey("reconciler")
-	keyTagKey = mustNewTagKey("key")
+	reconcilerTagKey = tag.MustNewKey("reconciler")
+	keyTagKey        = tag.MustNewKey("key")
+)
+
+func init() {
+	var err error
 
 	// Create views to see our measurements. This can return an error if
 	// a previously-registered view has the same name with a different value.
@@ -134,12 +132,4 @@ func (r *reporter) ReportServiceReady(namespace, service string, d time.Duration
 	metrics.Record(ctx, serviceReadyCountStat.M(1))
 	metrics.Record(ctx, serviceReadyLatencyStat.M(v))
 	return nil
-}
-
-func mustNewTagKey(s string) tag.Key {
-	tagKey, err := tag.NewKey(s)
-	if err != nil {
-		panic(err)
-	}
-	return tagKey
 }

--- a/pkg/reconciler/stats_reporter_test.go
+++ b/pkg/reconciler/stats_reporter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -81,4 +82,10 @@ func getMetric(t *testing.T, metric string) *view.Row {
 		return nil
 	}
 	return rows[0]
+}
+
+func TestWithStatsReporter(t *testing.T) {
+	if WithStatsReporter(context.TODO(), nil) == nil {
+		t.Errorf("stats reporter reports empty context")
+	}
 }


### PR DESCRIPTION
## Proposed Changes

* Used existing function MustNewKey to get the key

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
