### PR TITLE
Remove useless strings.Split

### DIFF
--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -52,9 +52,8 @@ func validateDomains(
 	t *testing.T, clients *test.Clients, baseDomain string,
 	baseExpected, trafficTargets, targetsExpected []string) error {
 	var subdomains []string
-	split := strings.SplitN(baseDomain, ".", 2)
 	for _, target := range trafficTargets {
-		subdomains = append(subdomains, fmt.Sprintf("%s-%s.%s", target, split[0], split[1]))
+		subdomains = append(subdomains, target + "-" + baseDomain)
 	}
 
 	g, _ := errgroup.WithContext(context.Background())

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -52,9 +52,8 @@ func validateDomains(
 	t *testing.T, clients *test.Clients, baseDomain string,
 	baseExpected, trafficTargets, targetsExpected []string) error {
 	var subdomains []string
-	split := strings.SplitN(baseDomain, ".", 2)
 	for _, target := range trafficTargets {
-		subdomains = append(subdomains, fmt.Sprintf("%s-%s.%s", target, split[0], split[1]))
+		subdomains = append(subdomains, target + "-" + baseDomain)
 	}
 
 	g, _ := errgroup.WithContext(context.Background())


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
AFAIK
```
split := strings.SplitN(baseDomain, ".", 2)
fmt.Sprintf("%s-%s.%s", target, split[0], split[1])
```
is just
```
target + "-" + baseDomain
```