### PR TITLE
Add the public interface to the new scale down rate functionality in Autoscaler

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -106,11 +106,19 @@ data:
     # Max scale up rate limits the rate at which the autoscaler will
     # increase pod count. It is the maximum ratio of desired pods versus
     # observed pods.
+    # Cannot less or equal to 1.
+    # I.e with value of 2.0 the number of pods can at most go N to 2N
+    # over single Autoscler period (see tick-interval), but at least N to
+    # N+1, if Autoscaler needs to scale up.
     max-scale-up-rate: "1000.0"
 
     # Max scale down rate limits the rate at which the autoscaler will
     # decrease pod count. It is the maximum ratio of observed pods versus
     # desired pods.
+    # Cannot less or equal to 1.
+    # I.e. with value of 2.0 the number of pods can at most go N to N/2
+    # over single Autoscaler evaluation period (see tick-interval), but at
+    # least N to N-1, if Autoscaler needs to scale down.
     # Not yet used // TODO(vagababov) remove once other parts are ready.
     max-scale-down-rate: "2.0"
 

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -108,7 +108,7 @@ data:
     # observed pods.
     # Cannot less or equal to 1.
     # I.e with value of 2.0 the number of pods can at most go N to 2N
-    # over single Autoscler period (see tick-interval), but at least N to
+    # over single Autoscaler period (see tick-interval), but at least N to
     # N+1, if Autoscaler needs to scale up.
     max-scale-up-rate: "1000.0"
 

--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -108,6 +108,12 @@ data:
     # observed pods.
     max-scale-up-rate: "1000.0"
 
+    # Max scale down rate limits the rate at which the autoscaler will
+    # decrease pod count. It is the maximum ratio of observed pods versus
+    # desired pods.
+    # Not yet used // TODO(vagababov) remove once other parts are ready.
+    max-scale-down-rate: "2.0"
+
     # Scale to zero feature flag
     enable-scale-to-zero: "true"
 

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -56,6 +56,7 @@ type Config struct {
 
 	// General autoscaler algorithm configuration.
 	MaxScaleUpRate           float64
+	MaxScaleDownRate         float64
 	StableWindow             time.Duration
 	PanicWindowPercentage    float64
 	PanicThresholdPercentage float64
@@ -99,6 +100,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key:          "max-scale-up-rate",
 		field:        &lc.MaxScaleUpRate,
 		defaultValue: 1000.0,
+	}, {
+		key:          "max-scale-down-rate",
+		field:        &lc.MaxScaleDownRate,
+		defaultValue: 2.0,
 	}, {
 		key:   "container-concurrency-target-percentage",
 		field: &lc.ContainerConcurrencyTargetFraction,
@@ -198,6 +203,10 @@ func validate(lc *Config) (*Config, error) {
 
 	if lc.MaxScaleUpRate <= 1.0 {
 		return nil, fmt.Errorf("max-scale-up-rate = %v, must be greater than 1.0", lc.MaxScaleUpRate)
+	}
+
+	if lc.MaxScaleDownRate <= 1.0 {
+		return nil, fmt.Errorf("max-scale-down-rate = %v, must be greater than 1.0", lc.MaxScaleDownRate)
 	}
 
 	// We can't permit stable window be less than our aggregation window for correctness.

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -29,11 +29,12 @@ import (
 var defaultConfig = Config{
 	EnableScaleToZero:                  true,
 	ContainerConcurrencyTargetFraction: 0.7,
-	ContainerConcurrencyTargetDefault:  100.0,
-	RPSTargetDefault:                   200.0,
+	ContainerConcurrencyTargetDefault:  100,
+	RPSTargetDefault:                   200,
 	TargetUtilization:                  0.7,
 	TargetBurstCapacity:                200,
-	MaxScaleUpRate:                     1000.0,
+	MaxScaleUpRate:                     1000,
+	MaxScaleDownRate:                   2,
 	StableWindow:                       time.Minute,
 	PanicWindow:                        6 * time.Second,
 	ScaleToZeroGracePeriod:             30 * time.Second,
@@ -96,6 +97,7 @@ func TestNewConfig(t *testing.T) {
 		name: "with toggles on",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
+			"max-scale-down-rate":                     "3.0",
 			"max-scale-up-rate":                       "1.01",
 			"container-concurrency-target-percentage": "0.71",
 			"container-concurrency-target-default":    "10.5",
@@ -112,6 +114,7 @@ func TestNewConfig(t *testing.T) {
 			c.ContainerConcurrencyTargetDefault = 10.5
 			c.ContainerConcurrencyTargetFraction = 0.71
 			c.RPSTargetDefault = 10.11
+			c.MaxScaleDownRate = 3
 			c.MaxScaleUpRate = 1.01
 			c.StableWindow = 5 * time.Minute
 			c.PanicWindow = 11 * time.Second
@@ -190,6 +193,18 @@ func TestNewConfig(t *testing.T) {
 		name: "max scale up rate 1.0",
 		input: map[string]string{
 			"max-scale-up-rate": "1",
+		},
+		wantErr: true,
+	}, {
+		name: "max down down rate negative",
+		input: map[string]string{
+			"max-scale-down-rate": "-55",
+		},
+		wantErr: true,
+	}, {
+		name: "max down down rate 1.0",
+		input: map[string]string{
+			"max-scale-down-rate": "1",
 		},
 		wantErr: true,
 	}, {

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -42,8 +42,9 @@ type Decider struct {
 
 // DeciderSpec is the parameters in which the Revision should scaled.
 type DeciderSpec struct {
-	TickInterval   time.Duration
-	MaxScaleUpRate float64
+	TickInterval     time.Duration
+	MaxScaleUpRate   float64
+	MaxScaleDownRate float64
 	// The metric used for scaling, i.e. concurrency, rps.
 	ScalingMetric string
 	// The value of scaling metric per pod that we target to maintain.


### PR DESCRIPTION
As described in #4993 currently we have no scale down functionality
that matches scaleup rate, but it helps to smooth out sudden sharp short (SSS) drops in traffic
and permits avoiding jitter due to new pod scraping that do not have enough concurrency yet.

This is the public interface to the functionality and the core implementation to follow.
/assign mattmoor @yanweiguo @markusthoemmes

/lint

## Proposed Changes

* Config map value
* Validation of said value
* Unit tests

