### PR TITLE
Classify parts of the queue-proxy config and make more of it optional.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -124,25 +124,33 @@ var (
 )
 
 type config struct {
-	ContainerConcurrency              int                       `split_words:"true" required:"true"`
-	QueueServingPort                  int                       `split_words:"true" required:"true"`
-	RevisionTimeoutSeconds            int                       `split_words:"true" required:"true"`
-	UserPort                          int                       `split_words:"true" required:"true"`
-	EnableVarLogCollection            bool                      `split_words:"true"` // optional
-	ServingConfiguration              string                    `split_words:"true" required:"true"`
-	ServingNamespace                  string                    `split_words:"true" required:"true"`
-	ServingPodIP                      string                    `split_words:"true" required:"true"`
-	ServingPod                        string                    `split_words:"true" required:"true"`
-	ServingRevision                   string                    `split_words:"true" required:"true"`
-	ServingService                    string                    `split_words:"true"` // optional
-	UserContainerName                 string                    `split_words:"true" required:"true"`
-	VarLogVolumeName                  string                    `split_words:"true" required:"true"`
-	InternalVolumePath                string                    `split_words:"true" required:"true"`
-	ServingLoggingConfig              string                    `split_words:"true" required:"true"`
-	ServingLoggingLevel               string                    `split_words:"true" required:"true"`
-	ServingRequestMetricsBackend      string                    `split_words:"true" required:"true"`
-	ServingRequestLogTemplate         string                    `split_words:"true" required:"true"`
-	ServingReadinessProbe             string                    `split_words:"true" required:"true"`
+	ContainerConcurrency   int    `split_words:"true" required:"true"`
+	QueueServingPort       int    `split_words:"true" required:"true"`
+	UserPort               int    `split_words:"true" required:"true"`
+	RevisionTimeoutSeconds int    `split_words:"true" required:"true"`
+	ServingReadinessProbe  string `split_words:"true" required:"true"`
+
+	// Logging configuration
+	ServingLoggingConfig      string `split_words:"true" required:"true"`
+	ServingLoggingLevel       string `split_words:"true" required:"true"`
+	ServingRequestLogTemplate string `split_words:"true"` // optional
+
+	// Metrics configuration
+	ServingNamespace             string `split_words:"true" required:"true"`
+	ServingRevision              string `split_words:"true" required:"true"`
+	ServingConfiguration         string `split_words:"true" required:"true"`
+	ServingPodIP                 string `split_words:"true" required:"true"`
+	ServingPod                   string `split_words:"true" required:"true"`
+	ServingService               string `split_words:"true"` // optional
+	ServingRequestMetricsBackend string `split_words:"true"` // optional
+
+	// /var/log configuration
+	EnableVarLogCollection bool   `split_words:"true"` // optional
+	UserContainerName      string `split_words:"true"` // optional
+	VarLogVolumeName       string `split_words:"true"` // optional
+	InternalVolumePath     string `split_words:"true"` // optional
+
+	// Tracing configuration
 	TracingConfigDebug                bool                      `split_words:"true"` // optional
 	TracingConfigBackend              tracingconfig.BackendType `split_words:"true"` // optional
 	TracingConfigSampleRate           float64                   `split_words:"true"` // optional


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

I was doing some local deployments of the queue-proxy for load testing and found I have to define an obscene amount of configuration so I gave these options a little love to more closely reflect if they are actually optional or not.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
