### PR TITLE
Consolidate a network.ErrorProxy implementation for our reverse proxies.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -415,10 +415,7 @@ func buildServer(env config, rp *readiness.Probe, reqChan chan queue.ReqEvent, l
 
 	httpProxy := httputil.NewSingleHostReverseProxy(target)
 	httpProxy.Transport = buildTransport(env, logger)
-	httpProxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
-		logger.Infof("error reverse proxying request: %v", err)
-		http.Error(w, err.Error(), http.StatusBadGateway)
-	}
+	httpProxy.ErrorHandler = network.ErrorHandler(logger)
 
 	httpProxy.FlushInterval = -1
 	activatorutil.SetupHeaderPruning(httpProxy)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -151,10 +151,7 @@ func (a *activationHandler) proxyRequest(logger *zap.SugaredLogger, w http.Respo
 		}
 	}
 	proxy.FlushInterval = -1
-	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
-		logger.Infof("error reverse proxying request: %v", err)
-		http.Error(w, err.Error(), http.StatusBadGateway)
-	}
+	proxy.ErrorHandler = network.ErrorHandler(logger)
 
 	r.Header.Set(network.ProxyHeaderName, activator.Name)
 

--- a/pkg/network/error_handler.go
+++ b/pkg/network/error_handler.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+func ErrorHandler(logger *zap.SugaredLogger) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, req *http.Request, err error) {
+		ss := readSockStat(logger)
+		logger.Errorw("error reverse proxying request; sockstat: "+ss, zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
+}
+
+func readSockStat(logger *zap.SugaredLogger) string {
+	b, err := ioutil.ReadFile("/proc/net/sockstat")
+	if err != nil {
+		logger.Errorw("Unable to read sockstat", zap.Error(err))
+		return ""
+	}
+	return string(b)
+}


### PR DESCRIPTION
This also implements an idea from @tcnghia about dumping `/proc/net/sockstat` on failures.

