### PR TITLE
Add a missing res.Body.Close() that @tcnghia found.

### DIFF
--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -85,6 +85,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	if !IsHTTPProbeReady(res) {
 		return fmt.Errorf("HTTP probe did not respond Ready, got status code: %d", res.StatusCode)


### PR DESCRIPTION
We are speculating that this combined with aggressive probing might be a source of connection exhaustion.
