### PR TITLE
Return error type from queue breaker

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -132,11 +132,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Errorw("Throttler try error", zap.Error(err))
 
 		switch err {
-		case activatornet.ErrActivatorOverload:
-			fallthrough
-		case context.DeadlineExceeded:
-			fallthrough
-		case queue.ErrRequestQueueFull:
+		case activatornet.ErrActivatorOverload, context.DeadlineExceeded, queue.ErrRequestQueueFull:
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		default:
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -154,7 +154,7 @@ func TestActivationHandler(t *testing.T) {
 		label:             "broken get k8s svc",
 		namespace:         testNamespace,
 		name:              testRevName,
-		wantBody:          activatornet.ErrActivatorOverload.Error() + "\n",
+		wantBody:          context.DeadlineExceeded.Error() + "\n",
 		wantCode:          http.StatusServiceUnavailable,
 		wantErr:           nil,
 		endpointsInformer: endpointsInformer(endpoints("bogus-namespace", testRevName, 1000, networking.ServicePortNameHTTP1)),

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -509,6 +509,6 @@ func (ib *InfiniteBreaker) Maybe(ctx context.Context, thunk func()) error {
 		return nil
 	case <-ctx.Done():
 		ib.logger.Infof("Context is closed: %v", ctx.Err())
-		return queue.ErrContextDone
+		return ctx.Err()
 	}
 }

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -140,7 +140,7 @@ func TestThrottler(t *testing.T) {
 		},
 		expectTryResults: []tryResult{
 			{Dest: "129.0.0.1:1234"},
-			{ErrString: queue.ErrContextDone.Error()},
+			{ErrString: context.DeadlineExceeded.Error()},
 		},
 	}, {
 		name: "remove before try",
@@ -285,7 +285,7 @@ func TestMultipleActivator(t *testing.T) {
 		results := tryThrottler(throttler, []types.NamespacedName{revID, revID}, tryContext)
 		if diff := cmp.Diff([]tryResult{
 			{Dest: "128.0.0.1:1234"},
-			{ErrString: queue.ErrContextDone.Error()},
+			{ErrString: context.DeadlineExceeded.Error()},
 		}, results); diff != "" {
 			t.Errorf("Got unexpected try results (-want, +got): %v", diff)
 		}

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -140,7 +140,7 @@ func TestThrottler(t *testing.T) {
 		},
 		expectTryResults: []tryResult{
 			{Dest: "129.0.0.1:1234"},
-			{ErrString: ErrActivatorOverload.Error()},
+			{ErrString: queue.ErrContextDone.Error()},
 		},
 	}, {
 		name: "remove before try",
@@ -285,7 +285,7 @@ func TestMultipleActivator(t *testing.T) {
 		results := tryThrottler(throttler, []types.NamespacedName{revID, revID}, tryContext)
 		if diff := cmp.Diff([]tryResult{
 			{Dest: "128.0.0.1:1234"},
-			{ErrString: ErrActivatorOverload.Error()},
+			{ErrString: queue.ErrContextDone.Error()},
 		}, results); diff != "" {
 			t.Errorf("Got unexpected try results (-want, +got): %v", diff)
 		}
@@ -336,7 +336,7 @@ func TestInfiniteBreaker(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if b.Maybe(ctx, nil) {
+	if err := b.Maybe(ctx, nil); err == nil {
 		t.Error("Should have failed, but didn't")
 	}
 
@@ -351,7 +351,7 @@ func TestInfiniteBreaker(t *testing.T) {
 		ctx, cancel = context.WithCancel(context.Background())
 		cancel()
 		res := false
-		if !b.Maybe(ctx, func() { res = true }) {
+		if err := b.Maybe(ctx, func() { res = true }); err != nil {
 			t.Error("Should have succeeded, but didn't")
 		}
 		if !res {
@@ -365,7 +365,7 @@ func TestInfiniteBreaker(t *testing.T) {
 	// Repeat initial test.
 	ctx, cancel = context.WithCancel(context.Background())
 	cancel()
-	if b.Maybe(ctx, nil) {
+	if err := b.Maybe(ctx, nil); err == nil {
 		t.Error("Should have failed, but didn't")
 	}
 	if got, want := b.Capacity(), 0; got != want {
@@ -382,7 +382,7 @@ func TestInfiniteBreaker(t *testing.T) {
 		b.UpdateConcurrency(1)
 	}()
 	res := false
-	if !b.Maybe(ctx, func() { res = true }) {
+	if err := b.Maybe(ctx, func() { res = true }); err != nil {
 		t.Error("Should have succeeded, but didn't")
 	}
 	if !res {

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -28,8 +28,6 @@ var (
 	ErrUpdateCapacity = errors.New("failed to add all capacity to the breaker")
 	// ErrRelease indicates that release was called more often than acquire.
 	ErrRelease = errors.New("semaphore release error: returned tokens must be <= acquired tokens")
-	// ErrContextDone indicates that the request context completed before opened. Usually this means a timeout.
-	ErrContextDone = errors.New("semaphore acquire failed due to cancelled context")
 	// ErrRequestQueueFull indicates the breaker queue depth was exceeded.
 	ErrRequestQueueFull = errors.New("pending request queue full")
 )
@@ -147,7 +145,7 @@ func (s *semaphore) acquire(ctx context.Context) error {
 	case <-s.queue:
 		return nil
 	case <-ctx.Done():
-		return ErrContextDone
+		return ctx.Err()
 	}
 }
 

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -28,6 +28,10 @@ var (
 	ErrUpdateCapacity = errors.New("failed to add all capacity to the breaker")
 	// ErrRelease indicates that release was called more often than acquire.
 	ErrRelease = errors.New("semaphore release error: returned tokens must be <= acquired tokens")
+	// ErrContextDone indicates that the request context completed before opened. Usually this means a timeout.
+	ErrContextDone = errors.New("semaphore acquire failed due to cancelled context")
+	// ErrRequestQueueFull indicates the breaker queue depth was exceeded.
+	ErrRequestQueueFull = errors.New("pending request queue full")
 )
 
 // BreakerParams defines the parameters of the breaker.
@@ -69,11 +73,11 @@ func NewBreaker(params BreakerParams) *Breaker {
 // and queue parameters. If the concurrency limit and queue capacity are
 // already consumed, Maybe returns immediately without calling thunk. If
 // the thunk was executed, Maybe returns true, else false.
-func (b *Breaker) Maybe(ctx context.Context, thunk func()) bool {
+func (b *Breaker) Maybe(ctx context.Context, thunk func()) error {
 	select {
 	default:
 		// Pending request queue is full.  Report failure.
-		return false
+		return ErrRequestQueueFull
 	case b.pendingRequests <- struct{}{}:
 		// Pending request has capacity.
 		// Defer releasing pending request queue.
@@ -82,8 +86,8 @@ func (b *Breaker) Maybe(ctx context.Context, thunk func()) bool {
 		}()
 
 		// Wait for capacity in the active queue.
-		if !b.sem.acquire(ctx) {
-			return false
+		if err := b.sem.acquire(ctx); err != nil {
+			return err
 		}
 		// Defer releasing capacity in the active.
 		// It's safe to ignore the error returned by release since we
@@ -94,7 +98,7 @@ func (b *Breaker) Maybe(ctx context.Context, thunk func()) bool {
 		// Do the thing.
 		thunk()
 		// Report success
-		return true
+		return nil
 	}
 }
 
@@ -138,12 +142,12 @@ type semaphore struct {
 }
 
 // acquire receives the token from the semaphore, potentially blocking.
-func (s *semaphore) acquire(ctx context.Context) bool {
+func (s *semaphore) acquire(ctx context.Context) error {
 	select {
 	case <-s.queue:
-		return true
+		return nil
 	case <-ctx.Done():
-		return false
+		return ErrContextDone
 	}
 }
 

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -371,10 +371,10 @@ func (r *requestor) request() {
 // or block until processSuccessfully is called.
 func (r *requestor) requestWithContext(ctx context.Context) {
 	go func() {
-		ok := r.breaker.Maybe(ctx, func() {
+		err := r.breaker.Maybe(ctx, func() {
 			<-r.barrierCh
 		})
-		r.acceptedCh <- ok
+		r.acceptedCh <- err == nil
 	}()
 }
 


### PR DESCRIPTION
Right now queue.Breaker.Maybe only returns true or false for success but
it has two failure modes: overload and timeout. Distinguish these by
retrurning an error so we can better debug failures.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
