### PR TITLE
Revert #5241 to rule our resource problem for 503s.

### DIFF
--- a/third_party/istio-1.1.13/istio-lean.yaml
+++ b/third_party/istio-1.1.13/istio-lean.yaml
@@ -547,8 +547,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1024Mi
 
           env:
           - name: POD_NAME
@@ -735,8 +735,8 @@ spec:
               cpu: 2000m
               memory: 1024Mi
             requests:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1024Mi
 
           env:
           - name: POD_NAME

--- a/third_party/istio-1.1.13/values-lean.yaml
+++ b/third_party/istio-1.1.13/values-lean.yaml
@@ -23,8 +23,8 @@ gateways:
     autoscaleMax: 4
     resources:
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 1000m
+        memory: 1024Mi
     ports:
     - name: status-port
       port: 15020
@@ -42,8 +42,8 @@ gateways:
     autoscaleMax: 4
     resources:
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 1000m
+        memory: 1024Mi
     cpu:
       targetAverageUtilization: 80
     loadBalancerIP: ""

--- a/third_party/istio-1.2.4/istio-lean.yaml
+++ b/third_party/istio-1.2.4/istio-lean.yaml
@@ -479,8 +479,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1024Mi
 
           env:
           - name: NODE_NAME
@@ -676,8 +676,8 @@ spec:
               cpu: 2000m
               memory: 1024Mi
             requests:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1024Mi
 
           env:
           - name: NODE_NAME

--- a/third_party/istio-1.2.4/values-lean.yaml
+++ b/third_party/istio-1.2.4/values-lean.yaml
@@ -24,8 +24,8 @@ gateways:
     autoscaleMax: 5
     resources:
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 1000m
+        memory: 1024Mi
     ports:
     - name: status-port
       port: 15020
@@ -43,8 +43,8 @@ gateways:
     autoscaleMax: 5
     resources:
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 1000m
+        memory: 1024Mi
     cpu:
       targetAverageUtilization: 80
     loadBalancerIP: ""


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We see more empty body 503s lately, which usually happen when Istio pods (pilot / proxy are overloaded).

## Proposed Changes

*  Revert #5241 .

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
