### PR TITLE
Refactor test code for route

### DIFF
--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -208,7 +208,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func routeWithTraffic(namespace, name string, traffic v1alpha1.TrafficTarget) *v1alpha1.Route {
-	return Route(namespace, name, map[string]string{}, map[string]string{}, WithStatusTraffic(traffic))
+	return Route(namespace, name, WithStatusTraffic(traffic))
 }
 
 func simpleRunLatest(namespace, name, config string) *v1alpha1.Route {

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -207,18 +207,8 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
-func routeWithTraffic(namespace, name string, traffic ...v1alpha1.TrafficTarget) *v1alpha1.Route {
-	return &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Traffic: traffic,
-			},
-		},
-	}
+func routeWithTraffic(namespace, name string, traffic v1alpha1.TrafficTarget) *v1alpha1.Route {
+	return Route(namespace, name, map[string]string{}, map[string]string{}, WithStatusTraffic(traffic))
 }
 
 func simpleRunLatest(namespace, name, config string) *v1alpha1.Route {

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -38,6 +38,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/config"
 
 	. "knative.dev/pkg/reconciler/testing"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 func TestNewRouteCallsSyncHandler(t *testing.T) {
@@ -46,14 +47,12 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	// A standalone revision
 	rev := getTestRevision("test-rev")
 	// A route targeting the revision
-	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(100),
-			},
-		}},
-	)
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(100),
+		},
+	}))
 
 	// Create fake clients
 	configMapWatcher := configmap.NewStaticWatcher(&corev1.ConfigMap{

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -39,18 +39,14 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 
 	. "knative.dev/pkg/logging/testing"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 func TestReconcileIngressInsert(t *testing.T) {
 	_, _, reconciler, _, cancel := newTestReconciler(t)
 	defer cancel()
 
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-		},
-	}
+	r := Route("test-ns", "test-route")
 	ci := newTestIngress(t, r)
 
 	ira := &IngressResources{
@@ -69,13 +65,7 @@ func TestReconcileIngressUpdate(t *testing.T) {
 	ctx, _, reconciler, _, cancel := newTestReconciler(t)
 	defer cancel()
 
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-		},
-	}
-
+	r := Route("test-ns", "test-route")
 	ira := &IngressResources{
 		BaseIngressResources: BaseIngressResources{
 			servingClientSet: reconciler.ServingClientSet,
@@ -117,16 +107,7 @@ func TestReconcileTargetRevisions(t *testing.T) {
 	_, _, reconciler, _, cancel := newTestReconciler(t)
 	defer cancel()
 
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-			Labels: map[string]string{
-				"route": "test-route",
-			},
-		},
-	}
-
+	r := Route("test-ns", "test-route", WithRouteLabel(map[string]string{"route": "test-route"}))
 	cases := []struct {
 		name      string
 		tc        traffic.Config
@@ -205,12 +186,7 @@ func TestReconcileCertificatesInsert(t *testing.T) {
 	ctx, _, reconciler, _, cancel := newTestReconciler(t)
 	defer cancel()
 
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-		},
-	}
+	r := Route("test-ns", "test-route")
 	certificate := newCerts([]string{"*.default.example.com"}, r)
 	if _, err := reconciler.reconcileCertificate(TestContextWithLogger(t), r, certificate); err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -225,12 +201,7 @@ func TestReconcileCertificateUpdate(t *testing.T) {
 	ctx, _, reconciler, _, cancel := newTestReconciler(t)
 	defer cancel()
 
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-		},
-	}
+	r := Route("test-ns", "test-route")
 	certificate := newCerts([]string{"old.example.com"}, r)
 	if _, err := reconciler.reconcileCertificate(TestContextWithLogger(t), r, certificate); err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -271,3 +242,4 @@ func getContext() context.Context {
 	cfg := ReconcilerTestConfig(false)
 	return config.ToContext(context.Background(), cfg)
 }
+

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -36,7 +36,7 @@ var (
 		"v1.default.example.com":         "",
 		"v1-current.default.example.com": "current",
 	}
-	route = Route("default", "route", map[string]string{}, map[string]string{}, WithRouteUID("12345"))
+	route = Route("default", "route", WithRouteUID("12345"))
 )
 
 func TestMakeCertificates(t *testing.T) {

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 
 	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
@@ -84,22 +83,8 @@ func TestMakeCertificates(t *testing.T) {
 }
 
 func TestMakeCertificates_FilterLastAppliedAnno(t *testing.T) {
-	var orgRoute = &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "route",
-			Namespace: "default",
-			UID:       "12345",
-			Labels: map[string]string{
-				"label-from-route": "foo",
-				// serving.RouteLabelKey cannot be overridden.
-				serving.RouteLabelKey: "foo",
-			},
-			Annotations: map[string]string{
-				corev1.LastAppliedConfigAnnotation:       "something-last-applied",
-				networking.CertificateClassAnnotationKey: "passdown-cert",
-			},
-		},
-	}
+	var orgRoute = Route("default", "route", WithRouteUID("12345"), WithRouteLabel(map[string]string{"label-from-route": "foo", serving.RouteLabelKey: "foo"}),
+		WithRouteAnnotation(map[string]string{corev1.LastAppliedConfigAnnotation: "something-last-applied", networking.CertificateClassAnnotationKey: "passdown-cert"}))
 	want := []*netv1alpha1.Certificate{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -27,21 +27,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
-var route = &v1alpha1.Route{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "route",
-		Namespace: "default",
-		UID:       "12345",
-	},
-}
-
-var dnsNameTagMap = map[string]string{
-	"v1.default.example.com":         "",
-	"v1-current.default.example.com": "current",
-}
+var (
+	dnsNameTagMap = map[string]string{
+		"v1.default.example.com":         "",
+		"v1-current.default.example.com": "current",
+	}
+	route = Route("default", "route", map[string]string{}, map[string]string{}, WithRouteUID("12345"))
+)
 
 func TestMakeCertificates(t *testing.T) {
 	want := []*netv1alpha1.Certificate{

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 
 	. "knative.dev/serving/pkg/testing/v1alpha1"
 )

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -92,31 +92,6 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 	}
 }
 
-func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
-	targets := map[string]traffic.RevisionTargets{}
-	ingressClass := "foo-ingress"
-	r := Route("test-ns", "test-route", WithRouteUID("1234-5678"), WithURL)
-	expected := metav1.ObjectMeta{
-		Name: "route-1234-5678",
-		Labels: map[string]string{
-			serving.RouteLabelKey:          "test-route",
-			serving.RouteNamespaceLabelKey: "test-ns",
-		},
-		Annotations: map[string]string{
-			networking.IngressClassAnnotationKey: ingressClass,
-		},
-	}
-	ia, err := MakeClusterIngress(getContext(), r, &traffic.Config{Targets: targets}, nil, getServiceVisibility(), ingressClass)
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-
-	ci := ia.(*netv1alpha1.ClusterIngress)
-	if !cmp.Equal(expected, ci.ObjectMeta) {
-		t.Errorf("Unexpected metadata (-want, +got): %s", cmp.Diff(expected, ci.ObjectMeta))
-	}
-}
-
 func TestIngress_NoKubectlAnnotation(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	r := Route(ns, testRouteName, WithRouteAnnotation(map[string]string{
@@ -156,6 +131,7 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 	}
 
 	r := Route(ns, "test-route", WithURL)
+
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
 			"test-route." + ns + ".svc.cluster.local",
@@ -815,4 +791,3 @@ func getContext() context.Context {
 	cfg := testConfig()
 	return config.ToContext(ctx, cfg)
 }
-

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -92,6 +92,31 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 	}
 }
 
+func TestMakeClusterIngress_CorrectMetadata(t *testing.T) {
+	targets := map[string]traffic.RevisionTargets{}
+	ingressClass := "foo-ingress"
+	r := Route("test-ns", "test-route", WithRouteUID("1234-5678"), WithURL)
+	expected := metav1.ObjectMeta{
+		Name: "route-1234-5678",
+		Labels: map[string]string{
+			serving.RouteLabelKey:          "test-route",
+			serving.RouteNamespaceLabelKey: "test-ns",
+		},
+		Annotations: map[string]string{
+			networking.IngressClassAnnotationKey: ingressClass,
+		},
+	}
+	ia, err := MakeClusterIngress(getContext(), r, &traffic.Config{Targets: targets}, nil, getServiceVisibility(), ingressClass)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	ci := ia.(*netv1alpha1.ClusterIngress)
+	if !cmp.Equal(expected, ci.ObjectMeta) {
+		t.Errorf("Unexpected metadata (-want, +got): %s", cmp.Diff(expected, ci.ObjectMeta))
+	}
+}
+
 func TestIngress_NoKubectlAnnotation(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	r := Route(ns, testRouteName, WithRouteAnnotation(map[string]string{
@@ -131,7 +156,6 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 	}
 
 	r := Route(ns, "test-route", WithURL)
-
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
 			"test-route." + ns + ".svc.cluster.local",

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -35,11 +35,11 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 
 	_ "knative.dev/pkg/system/testing"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 const (
@@ -58,30 +58,14 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	ingressClass := "ng-ingress"
 	passdownIngressClass := "ok-ingress"
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: ns,
-			Labels: map[string]string{
-				serving.RouteLabelKey:          "try-to-override",
-				serving.RouteNamespaceLabelKey: "try-to-override",
-				"test-label":                   "foo",
-			},
-			Annotations: map[string]string{
-				networking.IngressClassAnnotationKey: passdownIngressClass,
-				"test-annotation":                    "bar",
-			},
-			UID: "1234-5678",
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Scheme: "http",
-					Host:   "domain.com",
-				},
-			},
-		},
-	}
+	r := Route(ns, "test-route", WithRouteLabel(map[string]string{
+		serving.RouteLabelKey:          "try-to-override",
+		serving.RouteNamespaceLabelKey: "try-to-override",
+		"test-label":                   "foo",
+	}), WithRouteAnnotation(map[string]string{
+		networking.IngressClassAnnotationKey: passdownIngressClass,
+		"test-annotation":                    "bar",
+	}), WithRouteUID("1234-5678"), WithURL)
 	expected := metav1.ObjectMeta{
 		Name:      "test-route",
 		Namespace: ns,
@@ -110,25 +94,10 @@ func TestMakeIngress_CorrectMetadata(t *testing.T) {
 
 func TestIngress_NoKubectlAnnotation(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testRouteName,
-			Namespace: ns,
-			Annotations: map[string]string{
-				networking.IngressClassAnnotationKey: testIngressClass,
-				corev1.LastAppliedConfigAnnotation:   testAnnotationValue,
-			},
-			UID: "1234-5678",
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Scheme: "http",
-					Host:   "domain.com",
-				},
-			},
-		},
-	}
+	r := Route(ns, testRouteName, WithRouteAnnotation(map[string]string{
+		networking.IngressClassAnnotationKey: testIngressClass,
+		corev1.LastAppliedConfigAnnotation:   testAnnotationValue,
+	}), WithRouteUID("1234-5678"), WithURL)
 	ia, err := MakeIngress(getContext(), r, &traffic.Config{Targets: targets}, nil, getServiceVisibility(), testIngressClass)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -161,20 +130,7 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 		}},
 	}
 
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: ns,
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Scheme: "http",
-					Host:   "domain.com",
-				},
-			},
-		},
-	}
+	r := Route(ns, "test-route", WithURL)
 
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
@@ -235,40 +191,23 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 func TestMakeIngressSpec_CorrectVisibility(t *testing.T) {
 	cases := []struct {
 		name               string
-		route              v1alpha1.Route
+		route              *v1alpha1.Route
 		serviceVisibility  sets.String
 		expectedVisibility netv1alpha1.IngressVisibility
 	}{{
-		name: "public route",
-		route: v1alpha1.Route{
-			Status: v1alpha1.RouteStatus{
-				RouteStatusFields: v1alpha1.RouteStatusFields{
-					URL: &apis.URL{
-						Scheme: "http",
-						Host:   "domain.com",
-					},
-				},
-			},
-		},
+		name:  "public route",
+		route: Route("", "", WithURL),
+
 		expectedVisibility: netv1alpha1.IngressVisibilityExternalIP,
 	}, {
-		name: "private route",
-		route: v1alpha1.Route{
-			Status: v1alpha1.RouteStatus{
-				RouteStatusFields: v1alpha1.RouteStatusFields{
-					URL: &apis.URL{
-						Scheme: "http",
-						Host:   "local-route.default.svc.cluster.local",
-					},
-				},
-			},
-		},
+		name:               "private route",
+		route:              Route("", "", WithAddress),
 		serviceVisibility:  sets.NewString(""),
 		expectedVisibility: netv1alpha1.IngressVisibilityClusterLocal,
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ci, err := MakeIngressSpec(getContext(), &c.route, nil, c.serviceVisibility, nil)
+			ci, err := MakeIngressSpec(getContext(), c.route, nil, c.serviceVisibility, nil)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}
@@ -283,25 +222,13 @@ func TestMakeIngressSpec_CorrectVisibility(t *testing.T) {
 func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 	cases := []struct {
 		name               string
-		route              v1alpha1.Route
+		route              *v1alpha1.Route
 		targets            map[string]traffic.RevisionTargets
 		serviceVisibility  sets.String
 		expectedVisibility netv1alpha1.IngressVisibility
 	}{{
-		name: "public route",
-		route: v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "myroute",
-			},
-			Status: v1alpha1.RouteStatus{
-				RouteStatusFields: v1alpha1.RouteStatusFields{
-					URL: &apis.URL{
-						Scheme: "http",
-						Host:   "domain.com",
-					},
-				},
-			},
-		},
+		name:  "public route",
+		route: Route("default", "myroute", WithURL),
 		targets: map[string]traffic.RevisionTargets{
 			traffic.DefaultTarget: {{
 				TrafficTarget: v1.TrafficTarget{
@@ -315,20 +242,8 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 		},
 		expectedVisibility: netv1alpha1.IngressVisibilityExternalIP,
 	}, {
-		name: "private route",
-		route: v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "myroute",
-			},
-			Status: v1alpha1.RouteStatus{
-				RouteStatusFields: v1alpha1.RouteStatusFields{
-					URL: &apis.URL{
-						Scheme: "http",
-						Host:   "local-route.default.svc.cluster.local",
-					},
-				},
-			},
-		},
+		name:  "private route",
+		route: Route("default", "myroute", WithLocalDomain),
 		targets: map[string]traffic.RevisionTargets{
 			traffic.DefaultTarget: {{
 				TrafficTarget: v1.TrafficTarget{
@@ -343,20 +258,8 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 		serviceVisibility:  sets.NewString("myroute"),
 		expectedVisibility: netv1alpha1.IngressVisibilityClusterLocal,
 	}, {
-		name: "unspecified route",
-		route: v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "myroute",
-			},
-			Status: v1alpha1.RouteStatus{
-				RouteStatusFields: v1alpha1.RouteStatusFields{
-					URL: &apis.URL{
-						Scheme: "http",
-						Host:   "local-route.default.svc.cluster.local",
-					},
-				},
-			},
-		},
+		name:  "unspecified route",
+		route: Route("default", "myroute", WithLocalDomain),
 		targets: map[string]traffic.RevisionTargets{
 			traffic.DefaultTarget: {{
 				TrafficTarget: v1.TrafficTarget{
@@ -373,7 +276,7 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ci, err := MakeIngressSpec(getContext(), &c.route, nil, c.serviceVisibility, c.targets)
+			ci, err := MakeIngressSpec(getContext(), c.route, nil, c.serviceVisibility, c.targets)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}
@@ -386,21 +289,7 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 }
 
 func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
-	const base = "test-route." + ns
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: ns,
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Scheme: "http",
-					Host:   base,
-				},
-			},
-		},
-	}
+	r := Route("test-ns", "test-route", WithURL)
 	expected := []string{
 		"test-route." + ns + ".svc.cluster.local",
 		"test-route." + ns + ".example.com",
@@ -415,21 +304,7 @@ func TestGetRouteDomains_NamelessTargetDup(t *testing.T) {
 	}
 }
 func TestGetRouteDomains_NamelessTarget(t *testing.T) {
-	const base = "domain.com"
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: ns,
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Scheme: "http",
-					Host:   base,
-				},
-			},
-		},
-	}
+	r := Route("test-ns", "test-route", WithURL)
 	expected := []string{
 		"test-route." + ns + ".svc.cluster.local",
 		"test-route." + ns + ".example.com",
@@ -447,22 +322,8 @@ func TestGetRouteDomains_NamelessTarget(t *testing.T) {
 func TestGetRouteDomains_NamedTarget(t *testing.T) {
 	const (
 		name = "v1"
-		base = "domain.com"
 	)
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Scheme: "http",
-					Host:   base,
-				},
-			},
-		},
-	}
+	r := Route("test-ns", "test-route", WithURL)
 	expected := []string{
 
 		"v1-test-route." + ns + ".svc.cluster.local",
@@ -864,20 +725,7 @@ func TestMakeIngressRule_NilPercentTargetInactive(t *testing.T) {
 func TestMakeIngress_WithTLS(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	ingressClass := "foo-ingress"
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: ns,
-			UID:       "1234-5678",
-		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
-				URL: &apis.URL{
-					Host: "domain.com",
-				},
-			},
-		},
-	}
+	r := Route(ns, "test-route", WithRouteUID("1234-5678"), WithURL)
 	tls := []netv1alpha1.IngressTLS{
 		{
 			Hosts:             []string{"*.default.domain.com"},
@@ -943,3 +791,4 @@ func getContext() context.Context {
 	cfg := testConfig()
 	return config.ToContext(ctx, cfg)
 }
+

--- a/pkg/reconciler/route/resources/names/names_test.go
+++ b/pkg/reconciler/route/resources/names/names_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -32,41 +33,25 @@ func TestNamer(t *testing.T) {
 		f     func(kmeta.Accessor) string
 		want  string
 	}{{
-		name: "K8sService",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blah",
-				Namespace: "default",
-			},
-		},
-		f:    K8sService,
-		want: "blah",
+		name:  "K8sService",
+		route: getRoute("blah", "default", ""),
+		f:     K8sService,
+		want:  "blah",
 	}, {
-		name: "K8sServiceFullname",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "default",
-			},
-		},
-		f:    K8sServiceFullname,
-		want: "bar.default.svc.cluster.local",
+		name:  "K8sServiceFullname",
+		route: getRoute("bar", "default", ""),
+		f:     K8sServiceFullname,
+		want:  "bar.default.svc.cluster.local",
 	}, {
 		name:  "IngressPrefix",
 		route: getRoute("bar", "default", "1234-5678-910"),
 		f:     Ingress,
 		want:  "bar",
 	}, {
-		name: "Certificate",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "default",
-				UID:       "1234-5678-910",
-			},
-		},
-		f:    Certificate,
-		want: "route-1234-5678-910",
+		name:  "Certificate",
+		route: getRoute("bar", "default", "1234-5678-910"),
+		f:     Certificate,
+		want:  "route-1234-5678-910",
 	}}
 
 	for _, test := range tests {
@@ -88,4 +73,3 @@ func getRoute(name, ns string, uid types.UID) *v1alpha1.Route {
 		},
 	}
 }
-

--- a/pkg/reconciler/route/resources/names/names_test.go
+++ b/pkg/reconciler/route/resources/names/names_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -33,25 +32,41 @@ func TestNamer(t *testing.T) {
 		f     func(kmeta.Accessor) string
 		want  string
 	}{{
-		name:  "K8sService",
-		route: getRoute("blah", "default", ""),
-		f:     K8sService,
-		want:  "blah",
+		name: "K8sService",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "blah",
+				Namespace: "default",
+			},
+		},
+		f:    K8sService,
+		want: "blah",
 	}, {
-		name:  "K8sServiceFullname",
-		route: getRoute("bar", "default", ""),
-		f:     K8sServiceFullname,
-		want:  "bar.default.svc.cluster.local",
+		name: "K8sServiceFullname",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+			},
+		},
+		f:    K8sServiceFullname,
+		want: "bar.default.svc.cluster.local",
 	}, {
 		name:  "IngressPrefix",
 		route: getRoute("bar", "default", "1234-5678-910"),
 		f:     Ingress,
 		want:  "bar",
 	}, {
-		name:  "Certificate",
-		route: getRoute("bar", "default", "1234-5678-910"),
-		f:     Certificate,
-		want:  "route-1234-5678-910",
+		name: "Certificate",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				UID:       "1234-5678-910",
+			},
+		},
+		f:    Certificate,
+		want: "route-1234-5678-910",
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/route/resources/names/names_test.go
+++ b/pkg/reconciler/route/resources/names/names_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -32,47 +33,25 @@ func TestNamer(t *testing.T) {
 		f     func(kmeta.Accessor) string
 		want  string
 	}{{
-		name: "K8sService",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blah",
-				Namespace: "default",
-			},
-		},
-		f:    K8sService,
-		want: "blah",
+		name:  "K8sService",
+		route: getRoute("blah", "default", ""),
+		f:     K8sService,
+		want:  "blah",
 	}, {
-		name: "K8sServiceFullname",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "default",
-			},
-		},
-		f:    K8sServiceFullname,
-		want: "bar.default.svc.cluster.local",
+		name:  "K8sServiceFullname",
+		route: getRoute("bar", "default", ""),
+		f:     K8sServiceFullname,
+		want:  "bar.default.svc.cluster.local",
 	}, {
-		name: "IngressPrefix",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "default",
-				UID:       "1234-5678-910",
-			},
-		},
-		f:    Ingress,
-		want: "bar",
+		name:  "IngressPrefix",
+		route: getRoute("bar", "default", "1234-5678-910"),
+		f:     Ingress,
+		want:  "bar",
 	}, {
-		name: "Certificate",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "default",
-				UID:       "1234-5678-910",
-			},
-		},
-		f:    Certificate,
-		want: "route-1234-5678-910",
+		name:  "Certificate",
+		route: getRoute("bar", "default", "1234-5678-910"),
+		f:     Certificate,
+		want:  "route-1234-5678-910",
 	}}
 
 	for _, test := range tests {
@@ -84,3 +63,14 @@ func TestNamer(t *testing.T) {
 		})
 	}
 }
+
+func getRoute(name, ns string, uid types.UID) *v1alpha1.Route {
+	return &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			UID:       uid,
+		},
+	}
+}
+

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -268,7 +268,7 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 		wantErr: false,
 	}, {
 		name:  "cluster local route",
-		route: Route("test-ns", "test-route", WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal)),
+		route: Route("test-ns", "test-route", WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal})),
 		expectedSpec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.svc.cluster.local",
@@ -415,6 +415,7 @@ func TestGetDesiredServiceNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := testConfig()
 			ctx := config.ToContext(context.Background(), cfg)
+
 			if tt.traffic != nil {
 				route = Route("default", "myroute", tt.traffic)
 			} else {

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -36,15 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/kmeta"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 var (
-	r = &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-ns",
-		},
-	}
+	r            = Route("test-ns", "test-route", map[string]string{}, map[string]string{})
 	expectedMeta = metav1.ObjectMeta{
 		Name:      "test-route",
 		Namespace: "test-ns",
@@ -271,16 +267,8 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		name: "cluster local route",
-		route: &v1alpha1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-route",
-				Namespace: "test-ns",
-				Labels: map[string]string{
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
-				},
-			},
-		},
+		name:  "cluster local route",
+		route: Route("test-ns", "test-route", map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}, map[string]string{}),
 		expectedSpec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.svc.cluster.local",
@@ -425,7 +413,6 @@ func TestGetDesiredServiceNames(t *testing.T) {
 					Traffic: tt.traffic,
 				},
 			}
-
 			got, err := GetDesiredServiceNames(ctx, route)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDesiredServiceNames() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	r            = Route("test-ns", "test-route", map[string]string{}, map[string]string{})
+	r            = Route("test-ns", "test-route")
 	expectedMeta = metav1.ObjectMeta{
 		Name:      "test-route",
 		Namespace: "test-ns",
@@ -268,7 +268,7 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 		wantErr: false,
 	}, {
 		name:  "cluster local route",
-		route: Route("test-ns", "test-route", map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}, map[string]string{}),
+		route: Route("test-ns", "test-route", WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal)),
 		expectedSpec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.svc.cluster.local",

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -57,6 +57,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/domains"
 
 	. "knative.dev/pkg/reconciler/testing"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 const (
@@ -65,22 +66,8 @@ const (
 	prodDomainSuffix    = "prod-domain.com"
 )
 
-func getTestRouteWithTrafficTargets(traffic []v1alpha1.TrafficTarget) *v1alpha1.Route {
-	route := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/test-route",
-			Name:      "test-route",
-			Namespace: testNamespace,
-			Labels: map[string]string{
-				"route": "test-route",
-			},
-		},
-		Spec: v1alpha1.RouteSpec{
-			Traffic: traffic,
-		},
-	}
-	route.SetDefaults(context.Background())
-	return route
+func getTestRouteWithTrafficTargets(ro RouteOption) *v1alpha1.Route {
+	return Route(testNamespace, "test-route", map[string]string{"route": "test-route"}, map[string]string{}, ro)
 }
 
 func getTestRevision(name string) *v1alpha1.Revision {
@@ -264,15 +251,13 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A route targeting the revision
-	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName:      "test-rev",
-				ConfigurationName: "test-config",
-				Percent:           ptr.Int64(100),
-			},
-		}},
-	)
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName:      "test-rev",
+			ConfigurationName: "test-config",
+			Percent:           ptr.Int64(100),
+		},
+	}))
 	fakeservingclient.Get(ctx).ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
@@ -377,19 +362,17 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(cfgrev)
 
 	// A route targeting both the config and standalone revision.
-	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           ptr.Int64(90),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName: rev.Name,
-				Percent:      ptr.Int64(10),
-			},
-		}},
-	)
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: config.Name,
+			Percent:           ptr.Int64(90),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: rev.Name,
+			Percent:      ptr.Int64(10),
+		},
+	}))
 	fakeservingclient.Get(ctx).ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since Reconcile looks in the lister, we need to add it to the informer.
 	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
@@ -466,20 +449,18 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(cfgrev)
 
 	// A route targeting both the config and standalone revision
-	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				ConfigurationName: config.Name,
-				Percent:           ptr.Int64(90),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName:      rev.Name,
-				ConfigurationName: "test-config",
-				Percent:           ptr.Int64(10),
-			},
-		}},
-	)
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: config.Name,
+			Percent:           ptr.Int64(90),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName:      rev.Name,
+			ConfigurationName: "test-config",
+			Percent:           ptr.Int64(10),
+		},
+	}))
 	fakeservingclient.Get(ctx).ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
@@ -553,47 +534,45 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(cfgrev)
 
 	// A route with duplicate targets. These will be deduped.
-	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				ConfigurationName: "test-config",
-				Percent:           ptr.Int64(30),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				ConfigurationName: "test-config",
-				Percent:           ptr.Int64(20),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(10),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(5),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          "test-revision-1",
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(10),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          "test-revision-1",
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(10),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          "test-revision-2",
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(15),
-			},
-		}},
-	)
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: "test-config",
+			Percent:           ptr.Int64(30),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: "test-config",
+			Percent:           ptr.Int64(20),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(10),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(5),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:          "test-revision-1",
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(10),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:          "test-revision-1",
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(10),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:          "test-revision-2",
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(15),
+		},
+	}))
 	fakeservingclient.Get(ctx).ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
@@ -713,21 +692,19 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 
 	// A route targeting both the config and standalone revision with named
 	// targets
-	route := getTestRouteWithTrafficTargets(
-		[]v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          "foo",
-				RevisionName: "test-rev",
-				Percent:      ptr.Int64(50),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				Tag:               "bar",
-				ConfigurationName: "test-config",
-				Percent:           ptr.Int64(50),
-			},
-		}},
-	)
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:          "foo",
+			RevisionName: "test-rev",
+			Percent:      ptr.Int64(50),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:               "bar",
+			ConfigurationName: "test-config",
+			Percent:           ptr.Int64(50),
+		},
+	}))
 
 	fakeservingclient.Get(ctx).ServingV1alpha1().Routes(testNamespace).Create(route)
 	// Since Reconcile looks in the lister, we need to add it to the informer
@@ -829,7 +806,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 func TestUpdateDomainConfigMap(t *testing.T) {
 	ctx, _, reconciler, watcher, cf := newTestReconciler(t)
 	defer cf()
-	route := getTestRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 	routeClient := fakeservingclient.Get(ctx).ServingV1alpha1().Routes(route.Namespace)
 
 	// Create a route.
@@ -1010,7 +987,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })
 
 			// Create a route.
-			route := getTestRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+			route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 			route.Labels = map[string]string{"app": "prod"}
 
 			servingClient.ServingV1alpha1().Routes(route.Namespace).Create(route)
@@ -1025,20 +1002,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 }
 
 func TestRouteDomain(t *testing.T) {
-	route := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/myapp",
-			Name:      "myapp",
-			Namespace: "default",
-			Labels: map[string]string{
-				"route": "myapp",
-			},
-			Annotations: map[string]string{
-				"sub": "mysub",
-			},
-		},
-	}
-
+	route := Route("default", "myapp", map[string]string{"route": "myapp"}, map[string]string{"sub": "mysub"})
 	context := context.Background()
 	cfg := ReconcilerTestConfig(false)
 	context = config.ToContext(context, cfg)

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -66,8 +66,8 @@ const (
 	prodDomainSuffix    = "prod-domain.com"
 )
 
-func getTestRouteWithTrafficTargets(ro RouteOption) *v1alpha1.Route {
-	return Route(testNamespace, "test-route", map[string]string{"route": "test-route"}, map[string]string{}, ro)
+func getTestRouteWithTrafficTargets(trafficTarget RouteOption) *v1alpha1.Route {
+	return Route(testNamespace, "test-route", WithRouteLabel("route", "test-route"), trafficTarget)
 }
 
 func getTestRevision(name string) *v1alpha1.Revision {
@@ -1002,7 +1002,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 }
 
 func TestRouteDomain(t *testing.T) {
-	route := Route("default", "myapp", map[string]string{"route": "myapp"}, map[string]string{"sub": "mysub"})
+	route := Route("default", "myapp", WithRouteLabel("route", "myapp"), WithRouteAnnotation("sub", "mysub"))
 	context := context.Background()
 	cfg := ReconcilerTestConfig(false)
 	context = config.ToContext(context, cfg)

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -67,7 +67,7 @@ const (
 )
 
 func getTestRouteWithTrafficTargets(trafficTarget RouteOption) *v1alpha1.Route {
-	return Route(testNamespace, "test-route", WithRouteLabel("route", "test-route"), trafficTarget)
+	return Route(testNamespace, "test-route", WithRouteLabel(map[string]string{"route": "test-route"}), trafficTarget)
 }
 
 func getTestRevision(name string) *v1alpha1.Revision {
@@ -1002,7 +1002,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 }
 
 func TestRouteDomain(t *testing.T) {
-	route := Route("default", "myapp", WithRouteLabel("route", "myapp"), WithRouteAnnotation("sub", "mysub"))
+	route := Route("default", "myapp", WithRouteLabel(map[string]string{"route": "myapp"}), WithRouteAnnotation(map[string]string{"sub": "mysub"}))
 	context := context.Background()
 	cfg := ReconcilerTestConfig(false)
 	context = config.ToContext(context, cfg)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2493,6 +2493,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 			simpleIngress(
 				Route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
+				Route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -314,6 +314,9 @@ func TestReconcile(t *testing.T) {
 		WantUpdates: []clientgotesting.UpdateActionImpl{
 			{Object: simpleK8sService(Route("default", "becomes-ready", WithConfigTarget("config")))},
 		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers("default", "becomes-ready"),
+		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				// Populated by reconciliation when the route becomes ready.
@@ -343,6 +346,21 @@ func TestReconcile(t *testing.T) {
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			simpleReadyClusterIngress(
+				Route("default", "create-svc-failure", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
 		},
 		WantCreates: []runtime.Object{
 			simplePlaceholderK8sService(getContext(), Route("default", "create-svc-failure", WithConfigTarget("config")), ""),
@@ -485,6 +503,21 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "unhappy-owner"),
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			simpleReadyClusterIngress(
+				Route("default", "unhappy-owner", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
 			simpleK8sService(Route("default", "unhappy-owner", WithConfigTarget("config")),
 				WithK8sSvcOwnersRemoved),
 		},
@@ -634,6 +667,22 @@ func TestReconcile(t *testing.T) {
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("magnolia")),
 			// This is the name of the new revision we're referencing above.
 			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithServiceName("belltown")),
+			simpleReadyClusterIngress(
+				Route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							ServiceName: "magnolia",
+							Active:      true,
+						}},
+					},
+				},
+			),
 			simpleReadyIngress(
 				Route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -929,6 +978,15 @@ func TestReconcile(t *testing.T) {
 			simpleK8sService(Route("default", "svc-mutation",
 				WithConfigTarget("config")), MutateK8sService),
 		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "svc-mutation",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config"))),
 		}},
@@ -975,6 +1033,15 @@ func TestReconcile(t *testing.T) {
 			simpleK8sService(Route("default", "svc-mutation",
 				WithConfigTarget("config")), MutateK8sService),
 		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "svc-mutation",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config"))),
 		}},
@@ -1022,6 +1089,15 @@ func TestReconcile(t *testing.T) {
 			simpleK8sService(Route("default", "cluster-ip",
 				WithConfigTarget("config")), WithClusterIP("127.0.0.1")),
 		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "cluster-ip",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleK8sService(Route("default", "cluster-ip", WithConfigTarget("config"))),
 		}},
@@ -1064,6 +1140,15 @@ func TestReconcile(t *testing.T) {
 			simpleK8sService(Route("default", "external-name",
 				WithConfigTarget("config")), WithExternalName("this-is-the-wrong-name")),
 		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "external-name",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleK8sService(Route("default", "external-name", WithConfigTarget("config"))),
 		}},
@@ -1087,6 +1172,22 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "ingress-mutation"),
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("windemere")),
+			mutateIngress(simpleReadyClusterIngress(
+				Route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							ServiceName: "magnusson-park",
+							Active:      true,
+						}},
+					},
+				},
+			)),
 			mutateIngress(simpleReadyIngress(
 				Route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -1105,6 +1206,15 @@ func TestReconcile(t *testing.T) {
 			)),
 			simpleK8sService(Route("default", "ingress-mutation", WithConfigTarget("config"))),
 		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "ingress-mutation",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyIngress(
 				Route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
@@ -1244,6 +1354,22 @@ func TestReconcile(t *testing.T) {
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleK8sService(Route("default", "pinned-becomes-ready", WithConfigTarget("config"))),
+			simpleReadyClusterIngress(
+				Route("default", "pinned-becomes-ready", WithConfigTarget("config"),
+					WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
 			simpleReadyIngress(
 				Route("default", "pinned-becomes-ready", WithConfigTarget("config"),
 					WithURL),
@@ -1667,6 +1793,21 @@ func TestReconcile(t *testing.T) {
 				WithLatestCreated("green-00001")),
 			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001")),
 			rev("default", "green", 1, WithRevName("green-00001")),
+			simpleReadyClusterIngress(
+				Route("default", "split", WithConfigTarget("blue"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "blue-00001",
+								Percent:      ptr.Int64(100),
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
 			simpleK8sService(Route("default", "split", WithConfigTarget("blue"))),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -1758,6 +1899,22 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "old-naming"),
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			// Make sure that we can find the ingress by labels if the name is different.
+			changeIngressName(simpleReadyClusterIngress(
+				Route("default", "old-naming", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							Active: true,
+						}},
+					},
+				},
+			)),
 			simpleReadyIngress(
 				Route("default", "old-naming", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -1776,6 +1933,85 @@ func TestReconcile(t *testing.T) {
 			simpleK8sService(Route("default", "old-naming", WithConfigTarget("config"))),
 		},
 		Key: "default/old-naming",
+		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "old-naming",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
+		Key:                     "default/old-naming",
+		SkipNamespaceValidation: true, // remove with WantDeleteCollections
+	}, {
+		Name: "check that we do nothing with a deletion timestamp and no finalizers",
+		Objects: []runtime.Object{
+			Route("default", "delete-in-progress", WithConfigTarget("config"), WithRouteDeletionTimestamp,
+				WithURL, WithAddress, WithInitRouteConditions,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1alpha1.TrafficTarget{
+						TrafficTarget: v1.TrafficTarget{
+							RevisionName: "config-00001",
+							Percent:      ptr.Int64(100),
+						},
+					})),
+		},
+		Key: "default/delete-in-progress",
+	}, {
+		Name: "check that we do nothing with a deletion timestamp and another finalizer first",
+		Objects: []runtime.Object{
+			Route("default", "delete-in-progress", WithConfigTarget("config"),
+				WithRouteDeletionTimestamp, WithAnotherRouteFinalizer, WithRouteFinalizer,
+				WithURL, WithAddress, WithInitRouteConditions,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1alpha1.TrafficTarget{
+						TrafficTarget: v1.TrafficTarget{
+							RevisionName: "config-00001",
+							Percent:      ptr.Int64(100),
+						},
+					})),
+		},
+		Key: "default/delete-in-progress",
+	}, {
+		Name: "check that we do nothing with a deletion timestamp and route finalizer first",
+		Objects: []runtime.Object{
+			Route("default", "delete-in-progress", WithConfigTarget("config"),
+				WithRouteDeletionTimestamp, WithRouteFinalizer, WithAnotherRouteFinalizer,
+				WithURL, WithAddress, WithInitRouteConditions,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1alpha1.TrafficTarget{
+						TrafficTarget: v1.TrafficTarget{
+							RevisionName: "config-00001",
+							Percent:      ptr.Int64(100),
+						},
+					})),
+		},
+		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{{
+			ListRestrictions: clientgotesting.ListRestrictions{
+				Labels: labels.Set(map[string]string{
+					serving.RouteLabelKey:          "delete-in-progress",
+					serving.RouteNamespaceLabelKey: "default",
+				}).AsSelector(),
+				Fields: fields.Nothing(),
+			},
+		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: Route("default", "delete-in-progress", WithConfigTarget("config"),
+				WithRouteDeletionTimestamp, // Removed: WithRouteFinalizer,
+				WithAnotherRouteFinalizer,
+				WithURL, WithAddress, WithInitRouteConditions,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1alpha1.TrafficTarget{
+						TrafficTarget: v1.TrafficTarget{
+							RevisionName: "config-00001",
+							Percent:      ptr.Int64(100),
+						},
+					})),
+		}},
+		SkipNamespaceValidation: true,
+		Key:                     "default/delete-in-progress",
 	}, {
 		Name: "deletes service when route no longer references service",
 		Objects: []runtime.Object{
@@ -1851,6 +2087,21 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "steady-state"),
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			simpleReadyClusterIngress(
+				Route("default", "my-route", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								// Use the Revision name from the config.
+								RevisionName: "config-00001",
+								Percent:      ptr.Int64(100),
+							},
+							Active: true,
+						}},
+					},
+				},
+			),
 			simpleK8sService(Route("default", "my-route", WithConfigTarget("config"))),
 			simpleK8sService(Route("default", "my-route"), OverrideServiceName("old-service-name")),
 		},
@@ -2124,6 +2375,9 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{},
 		WantCreates: []runtime.Object{
 			simplePlaceholderK8sService(getContext(), Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")), ""),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers("default", "becomes-ready"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "becomes-ready", WithConfigTarget("config"),

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -73,12 +73,12 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "configuration not yet ready",
 		Objects: []runtime.Object{
-			route("default", "first-reconcile", WithConfigTarget("not-ready")),
+			Route("default", "first-reconcile", WithConfigTarget("not-ready")),
 			cfg("default", "not-ready", WithGeneration(1), WithLatestCreated("not-ready-00001")),
 			rev("default", "not-ready", 1, WithInitRevConditions, WithRevName("not-ready-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "first-reconcile", WithConfigTarget("not-ready"), WithURL,
+			Object: Route("default", "first-reconcile", WithConfigTarget("not-ready"), WithURL,
 				// The first reconciliation initializes the conditions and reflects
 				// that the referenced configuration is not yet ready.
 				WithInitRouteConditions, MarkConfigurationNotReady("not-ready")),
@@ -87,7 +87,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "configuration permanently failed",
 		Objects: []runtime.Object{
-			route("default", "first-reconcile", WithConfigTarget("permanently-failed")),
+			Route("default", "first-reconcile", WithConfigTarget("permanently-failed")),
 			cfg("default", "permanently-failed",
 				WithGeneration(1), WithLatestCreated("permanently-failed-00001"), MarkLatestCreatedFailed("blah")),
 			rev("default", "permanently-failed", 1,
@@ -95,7 +95,7 @@ func TestReconcile(t *testing.T) {
 				WithInitRevConditions, MarkContainerMissing),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "first-reconcile", WithConfigTarget("permanently-failed"), WithURL,
+			Object: Route("default", "first-reconcile", WithConfigTarget("permanently-failed"), WithURL,
 				WithInitRouteConditions, MarkConfigurationFailed("permanently-failed")),
 		}},
 		Key: "default/first-reconcile",
@@ -106,12 +106,12 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "routes"),
 		},
 		Objects: []runtime.Object{
-			route("default", "first-reconcile", WithConfigTarget("not-ready")),
+			Route("default", "first-reconcile", WithConfigTarget("not-ready")),
 			cfg("default", "not-ready", WithGeneration(1), WithLatestCreated("not-ready-00001")),
 			rev("default", "not-ready", 1, WithInitRevConditions, WithRevName("not-ready-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "first-reconcile", WithConfigTarget("not-ready"), WithURL,
+			Object: Route("default", "first-reconcile", WithConfigTarget("not-ready"), WithURL,
 				WithInitRouteConditions, MarkConfigurationNotReady("not-ready")),
 		}},
 		WantEvents: []string{
@@ -122,14 +122,14 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "simple route becomes ready, ingress unknown",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
 					WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -147,12 +147,12 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 				"",
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -174,7 +174,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "custom ingress route becomes ready, ingress unknown",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready",
+			Route("default", "becomes-ready",
 				WithConfigTarget("config"), WithRouteUID("12-34"), WithIngressClass("custom-ingress-class")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
@@ -182,7 +182,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			ingressWithClass(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -201,13 +201,13 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "becomes-ready",
+				Route("default", "becomes-ready",
 					WithConfigTarget("config"), WithRouteUID("12-34"), WithIngressClass("custom-ingress-class")),
 				"",
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"), WithIngressClass("custom-ingress-class"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -229,8 +229,8 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "cluster local route becomes ready, ingress unknown",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithLocalDomain,
-				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithLocalDomain,
+				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
@@ -238,9 +238,9 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			simpleIngressWithVisibility(
-				route("default", "becomes-ready", WithConfigTarget("config"),
+				Route("default", "becomes-ready", WithConfigTarget("config"),
 					WithLocalDomain, WithRouteUID("65-23"),
-					WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
+					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -258,18 +258,18 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "becomes-ready", WithConfigTarget("config"), WithLocalDomain,
-					WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithLocalDomain,
+					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
 					WithRouteUID("65-23")),
 				"",
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("65-23"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
-				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
+				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						RevisionName:   "config-00001",
@@ -288,12 +288,12 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "simple route becomes ready",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config")),
+			Route("default", "becomes-ready", WithConfigTarget("config")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -309,13 +309,13 @@ func TestReconcile(t *testing.T) {
 			),
 		},
 		WantCreates: []runtime.Object{
-			simplePlaceholderK8sService(getContext(), route("default", "becomes-ready", WithConfigTarget("config")), ""),
+			simplePlaceholderK8sService(getContext(), Route("default", "becomes-ready", WithConfigTarget("config")), ""),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
-			{Object: simpleK8sService(route("default", "becomes-ready", WithConfigTarget("config")))},
+			{Object: simpleK8sService(Route("default", "becomes-ready", WithConfigTarget("config")))},
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				// Populated by reconciliation when the route becomes ready.
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
@@ -339,16 +339,16 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "services"),
 		},
 		Objects: []runtime.Object{
-			route("default", "create-svc-failure", WithConfigTarget("config"), WithRouteFinalizer),
+			Route("default", "create-svc-failure", WithConfigTarget("config"), WithRouteFinalizer),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 		},
 		WantCreates: []runtime.Object{
-			simplePlaceholderK8sService(getContext(), route("default", "create-svc-failure", WithConfigTarget("config")), ""),
+			simplePlaceholderK8sService(getContext(), Route("default", "create-svc-failure", WithConfigTarget("config")), ""),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "create-svc-failure", WithConfigTarget("config"),
+			Object: Route("default", "create-svc-failure", WithConfigTarget("config"),
 				WithRouteFinalizer,
 				// Populated by reconciliation when we've failed to create
 				// the K8s service.
@@ -371,7 +371,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "failure creating ingress",
 		Objects: []runtime.Object{
-			route("default", "ingress-create-failure", WithConfigTarget("config"), WithRouteFinalizer),
+			Route("default", "ingress-create-failure", WithConfigTarget("config"), WithRouteFinalizer),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("astrid")),
@@ -384,7 +384,7 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			//This is the Create we see for the ingress, but we induce a failure.
 			simpleIngress(
-				route("default", "ingress-create-failure", WithConfigTarget("config"),
+				Route("default", "ingress-create-failure", WithConfigTarget("config"),
 					WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -402,13 +402,13 @@ func TestReconcile(t *testing.T) {
 			),
 			func() *corev1.Service {
 				result, _ := resources.MakeK8sPlaceholderService(getContext(),
-					route("default", "ingress-create-failure", WithConfigTarget("config"), WithRouteFinalizer),
+					Route("default", "ingress-create-failure", WithConfigTarget("config"), WithRouteFinalizer),
 					"")
 				return result
 			}(),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "ingress-create-failure", WithConfigTarget("config"),
+			Object: Route("default", "ingress-create-failure", WithConfigTarget("config"),
 				WithRouteFinalizer,
 				// Populated by reconciliation when we fail to create
 				// the cluster ingress.
@@ -431,7 +431,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "steady state",
 		Objects: []runtime.Object{
-			route("default", "steady-state", WithConfigTarget("config"),
+			Route("default", "steady-state", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
@@ -449,7 +449,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "steady-state", WithConfigTarget("config"), WithURL),
+				Route("default", "steady-state", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -463,14 +463,14 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "steady-state", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "steady-state", WithConfigTarget("config"))),
 		},
 		Key: "default/steady-state",
 	}, {
 		Name:    "unhappy about ownership of placeholder service",
 		WantErr: true,
 		Objects: []runtime.Object{
-			route("default", "unhappy-owner", WithConfigTarget("config"),
+			Route("default", "unhappy-owner", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -485,11 +485,11 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "unhappy-owner"),
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-			simpleK8sService(route("default", "unhappy-owner", WithConfigTarget("config")),
+			simpleK8sService(Route("default", "unhappy-owner", WithConfigTarget("config")),
 				WithK8sSvcOwnersRemoved),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "unhappy-owner", WithConfigTarget("config"),
+			Object: Route("default", "unhappy-owner", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -512,7 +512,7 @@ func TestReconcile(t *testing.T) {
 		// state test above.
 		Name: "different labels, different domain - steady state",
 		Objects: []runtime.Object{
-			route("default", "different-domain", WithConfigTarget("config"),
+			Route("default", "different-domain", WithConfigTarget("config"),
 				WithAnotherDomain, WithAddress,
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(v1alpha1.TrafficTarget{
@@ -521,7 +521,7 @@ func TestReconcile(t *testing.T) {
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
 					},
-				}), WithRouteLabel("app", "prod")),
+				}), WithRouteLabel(map[string]string{"app": "prod"})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
 				// The Route controller attaches our label to this Configuration.
@@ -529,7 +529,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("my-service")),
 			simpleReadyIngress(
-				route("default", "different-domain", WithConfigTarget("config"),
+				Route("default", "different-domain", WithConfigTarget("config"),
 					WithAnotherDomain),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -545,12 +545,12 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "different-domain", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "different-domain", WithConfigTarget("config"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{
 			{
 				Object: simpleReadyIngress(
-					route("default", "different-domain", WithConfigTarget("config"),
+					Route("default", "different-domain", WithConfigTarget("config"),
 						WithAnotherDomain),
 					&traffic.Config{
 						Targets: map[string]traffic.RevisionTargets{
@@ -577,7 +577,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "new latest created revision",
 		Objects: []runtime.Object{
-			route("default", "new-latest-created", WithConfigTarget("config"),
+			Route("default", "new-latest-created", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -595,7 +595,7 @@ func TestReconcile(t *testing.T) {
 			// This is the name of the new revision we're referencing above.
 			rev("default", "config", 2, WithInitRevConditions, WithRevName("config-00002")),
 			simpleReadyIngress(
-				route("default", "new-latest-created", WithConfigTarget("config"), WithURL),
+				Route("default", "new-latest-created", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -610,14 +610,14 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "new-latest-created", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "new-latest-created", WithConfigTarget("config"))),
 		},
 		// A new LatestCreatedRevisionName on the Configuration alone should result in no changes to the Route.
 		Key: "default/new-latest-created",
 	}, {
 		Name: "new latest ready revision",
 		Objects: []runtime.Object{
-			route("default", "new-latest-ready", WithConfigTarget("config"),
+			Route("default", "new-latest-ready", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -635,7 +635,7 @@ func TestReconcile(t *testing.T) {
 			// This is the name of the new revision we're referencing above.
 			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithServiceName("belltown")),
 			simpleReadyIngress(
-				route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
+				Route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -650,12 +650,12 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "new-latest-ready", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "new-latest-ready", WithConfigTarget("config"))),
 		},
 		// A new LatestReadyRevisionName on the Configuration should result in the new Revision being rolled out.
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyIngress(
-				route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
+				Route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -672,7 +672,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "new-latest-ready", WithConfigTarget("config"),
+			Object: Route("default", "new-latest-ready", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -688,14 +688,14 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "public becomes cluster local",
 		Objects: []runtime.Object{
-			route("default", "becomes-local", WithConfigTarget("config"),
-				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
+			Route("default", "becomes-local", WithConfigTarget("config"),
+				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 			simpleIngress(
-				route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
+				Route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -710,15 +710,15 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "becomes-local", WithConfigTarget("config"),
-				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
+			simpleK8sService(Route("default", "becomes-local", WithConfigTarget("config"),
+				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
 				WithRouteUID("65-23"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngressWithVisibility(
-				route("default", "becomes-local", WithConfigTarget("config"),
+				Route("default", "becomes-local", WithConfigTarget("config"),
 					WithRouteUID("65-23"),
-					WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
+					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -736,11 +736,11 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-local", WithConfigTarget("config"),
+			Object: Route("default", "becomes-local", WithConfigTarget("config"),
 				WithRouteUID("65-23"),
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
-				WithRouteLabel("serving.knative.dev/visibility", "cluster-local"),
+				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						RevisionName:   "config-00001",
@@ -754,14 +754,14 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "cluster local becomes public",
 		Objects: []runtime.Object{
-			route("default", "becomes-public", WithConfigTarget("config"),
+			Route("default", "becomes-public", WithConfigTarget("config"),
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 			simpleIngressWithVisibility(
-				route("default", "becomes-public", WithConfigTarget("config"), WithRouteUID("65-23"),
-					WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
+				Route("default", "becomes-public", WithConfigTarget("config"), WithRouteUID("65-23"),
+					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -777,13 +777,13 @@ func TestReconcile(t *testing.T) {
 				},
 				sets.NewString("becomes-public"),
 			),
-			simpleK8sService(route("default", "becomes-public", WithConfigTarget("config"),
+			simpleK8sService(Route("default", "becomes-public", WithConfigTarget("config"),
 				WithRouteUID("65-23"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngress(
-				route("default", "becomes-public", WithConfigTarget("config"),
-					WithRouteUID("65-23"), WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
+				Route("default", "becomes-public", WithConfigTarget("config"),
+					WithRouteUID("65-23"), WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -800,7 +800,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-public", WithConfigTarget("config"),
+			Object: Route("default", "becomes-public", WithConfigTarget("config"),
 				WithRouteUID("65-23"),
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithAddress, WithInitRouteConditions, WithURL,
@@ -822,7 +822,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "ingresses"),
 		},
 		Objects: []runtime.Object{
-			route("default", "update-ci-failure", WithConfigTarget("config"),
+			Route("default", "update-ci-failure", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -840,7 +840,7 @@ func TestReconcile(t *testing.T) {
 			// This is the name of the new revision we're referencing above.
 			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithServiceName("wallingford")),
 			simpleReadyIngress(
-				route("default", "update-ci-failure", WithConfigTarget("config"), WithURL),
+				Route("default", "update-ci-failure", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -855,11 +855,11 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "update-ci-failure", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "update-ci-failure", WithConfigTarget("config"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyIngress(
-				route("default", "update-ci-failure", WithConfigTarget("config"), WithURL),
+				Route("default", "update-ci-failure", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -876,7 +876,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "update-ci-failure", WithConfigTarget("config"),
+			Object: Route("default", "update-ci-failure", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -895,7 +895,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "reconcile service mutation",
 		Objects: []runtime.Object{
-			route("default", "svc-mutation", WithConfigTarget("config"),
+			Route("default", "svc-mutation", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -912,7 +912,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
+				Route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -926,11 +926,11 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "svc-mutation",
+			simpleK8sService(Route("default", "svc-mutation",
 				WithConfigTarget("config")), MutateK8sService),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleK8sService(route("default", "svc-mutation", WithConfigTarget("config"))),
+			Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config"))),
 		}},
 		Key: "default/svc-mutation",
 	}, {
@@ -941,7 +941,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "services"),
 		},
 		Objects: []runtime.Object{
-			route("default", "svc-mutation", WithConfigTarget("config"), WithRouteFinalizer,
+			Route("default", "svc-mutation", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -958,7 +958,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
+				Route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -972,11 +972,11 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "svc-mutation",
+			simpleK8sService(Route("default", "svc-mutation",
 				WithConfigTarget("config")), MutateK8sService),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleK8sService(route("default", "svc-mutation", WithConfigTarget("config"))),
+			Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config"))),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update services"),
@@ -988,7 +988,7 @@ func TestReconcile(t *testing.T) {
 		// Services. Ensure that we drop the ClusterIP if it is set in the spec.
 		Name: "drop cluster ip",
 		Objects: []runtime.Object{
-			route("default", "cluster-ip", WithConfigTarget("config"), WithRouteFinalizer,
+			Route("default", "cluster-ip", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1005,7 +1005,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "cluster-ip", WithConfigTarget("config"), WithURL),
+				Route("default", "cluster-ip", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1019,18 +1019,18 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "cluster-ip",
+			simpleK8sService(Route("default", "cluster-ip",
 				WithConfigTarget("config")), WithClusterIP("127.0.0.1")),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleK8sService(route("default", "cluster-ip", WithConfigTarget("config"))),
+			Object: simpleK8sService(Route("default", "cluster-ip", WithConfigTarget("config"))),
 		}},
 		Key: "default/cluster-ip",
 	}, {
 		// Make sure we fix the external name if something messes with it.
 		Name: "fix external name",
 		Objects: []runtime.Object{
-			route("default", "external-name", WithConfigTarget("config"), WithRouteFinalizer,
+			Route("default", "external-name", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1047,7 +1047,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "external-name", WithConfigTarget("config"), WithURL),
+				Route("default", "external-name", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1061,17 +1061,17 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "external-name",
+			simpleK8sService(Route("default", "external-name",
 				WithConfigTarget("config")), WithExternalName("this-is-the-wrong-name")),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleK8sService(route("default", "external-name", WithConfigTarget("config"))),
+			Object: simpleK8sService(Route("default", "external-name", WithConfigTarget("config"))),
 		}},
 		Key: "default/external-name",
 	}, {
 		Name: "reconcile cluster ingress mutation",
 		Objects: []runtime.Object{
-			route("default", "ingress-mutation", WithConfigTarget("config"), WithRouteFinalizer,
+			Route("default", "ingress-mutation", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1088,7 +1088,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("windemere")),
 			mutateIngress(simpleReadyIngress(
-				route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
+				Route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1103,11 +1103,11 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			)),
-			simpleK8sService(route("default", "ingress-mutation", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "ingress-mutation", WithConfigTarget("config"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyIngress(
-				route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
+				Route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1129,7 +1129,7 @@ func TestReconcile(t *testing.T) {
 		Name: "switch to a different config",
 		Objects: []runtime.Object{
 			// The status reflects "oldconfig", but the spec "newconfig".
-			route("default", "change-configs", WithConfigTarget("newconfig"), WithRouteFinalizer,
+			Route("default", "change-configs", WithConfigTarget("newconfig"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1149,7 +1149,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "oldconfig", 1, MarkRevisionReady, WithRevName("oldconfig-00001"), WithServiceName("greenwood")),
 			rev("default", "newconfig", 1, MarkRevisionReady, WithRevName("newconfig-00001"), WithServiceName("broadview")),
 			simpleReadyIngress(
-				route("default", "change-configs", WithConfigTarget("oldconfig"), WithURL),
+				Route("default", "change-configs", WithConfigTarget("oldconfig"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1164,12 +1164,12 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "change-configs", WithConfigTarget("oldconfig"))),
+			simpleK8sService(Route("default", "change-configs", WithConfigTarget("oldconfig"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			// Updated to point to "newconfig" things.
 			Object: simpleReadyIngress(
-				route("default", "change-configs", WithConfigTarget("newconfig"), WithURL),
+				Route("default", "change-configs", WithConfigTarget("newconfig"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1187,7 +1187,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			// Status updated to "newconfig"
-			Object: route("default", "change-configs", WithConfigTarget("newconfig"),
+			Object: Route("default", "change-configs", WithConfigTarget("newconfig"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1202,50 +1202,50 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "configuration missing",
 		Objects: []runtime.Object{
-			route("default", "config-missing", WithConfigTarget("not-found")),
+			Route("default", "config-missing", WithConfigTarget("not-found")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "config-missing", WithConfigTarget("not-found"), WithURL,
+			Object: Route("default", "config-missing", WithConfigTarget("not-found"), WithURL,
 				WithInitRouteConditions, MarkMissingTrafficTarget("Configuration", "not-found")),
 		}},
 		Key: "default/config-missing",
 	}, {
 		Name: "revision missing (direct)",
 		Objects: []runtime.Object{
-			route("default", "missing-revision-direct", WithRevTarget("not-found")),
+			Route("default", "missing-revision-direct", WithRevTarget("not-found")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "missing-revision-direct", WithRevTarget("not-found"), WithURL,
+			Object: Route("default", "missing-revision-direct", WithRevTarget("not-found"), WithURL,
 				WithInitRouteConditions, MarkMissingTrafficTarget("Revision", "not-found")),
 		}},
 		Key: "default/missing-revision-direct",
 	}, {
 		Name: "revision missing (indirect)",
 		Objects: []runtime.Object{
-			route("default", "missing-revision-indirect", WithConfigTarget("config")),
+			Route("default", "missing-revision-indirect", WithConfigTarget("config")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "missing-revision-indirect", WithConfigTarget("config"), WithURL,
+			Object: Route("default", "missing-revision-indirect", WithConfigTarget("config"), WithURL,
 				WithInitRouteConditions, MarkMissingTrafficTarget("Revision", "config-00001")),
 		}},
 		Key: "default/missing-revision-indirect",
 	}, {
 		Name: "pinned route becomes ready",
 		Objects: []runtime.Object{
-			route("default", "pinned-becomes-ready",
+			Route("default", "pinned-becomes-ready",
 				// Use the Revision name from the config
 				WithRevTarget("config-00001"), WithRouteFinalizer,
 			),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-			simpleK8sService(route("default", "pinned-becomes-ready", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "pinned-becomes-ready", WithConfigTarget("config"))),
 			simpleReadyIngress(
-				route("default", "pinned-becomes-ready", WithConfigTarget("config"),
+				Route("default", "pinned-becomes-ready", WithConfigTarget("config"),
 					WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -1262,7 +1262,7 @@ func TestReconcile(t *testing.T) {
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "pinned-becomes-ready",
+			Object: Route("default", "pinned-becomes-ready",
 				// Use the Revision name from the config
 				WithRevTarget("config-00001"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -1280,7 +1280,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "traffic split becomes ready",
 		Objects: []runtime.Object{
-			route("default", "named-traffic-split", WithSpecTraffic(
+			Route("default", "named-traffic-split", WithSpecTraffic(
 				v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						ConfigurationName: "blue",
@@ -1301,7 +1301,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
-				route("default", "named-traffic-split", WithURL, WithSpecTraffic(
+				Route("default", "named-traffic-split", WithURL, WithSpecTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1.TrafficTarget{
 							ConfigurationName: "blue",
@@ -1337,7 +1337,7 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "named-traffic-split", WithSpecTraffic(
+				Route("default", "named-traffic-split", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1.TrafficTarget{
 							ConfigurationName: "blue",
@@ -1353,7 +1353,7 @@ func TestReconcile(t *testing.T) {
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "named-traffic-split", WithRouteFinalizer,
+			Object: Route("default", "named-traffic-split", WithRouteFinalizer,
 				WithSpecTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						ConfigurationName: "blue",
@@ -1390,7 +1390,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "same revision targets",
 		Objects: []runtime.Object{
-			route("default", "same-revision-targets", WithSpecTraffic(
+			Route("default", "same-revision-targets", WithSpecTraffic(
 				v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						Tag:               "gray",
@@ -1410,7 +1410,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
-				route("default", "same-revision-targets", WithURL, WithSpecTraffic(
+				Route("default", "same-revision-targets", WithURL, WithSpecTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1.TrafficTarget{
 							Tag:               "gray",
@@ -1458,7 +1458,7 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "same-revision-targets", WithSpecTraffic(
+				Route("default", "same-revision-targets", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1.TrafficTarget{
 							Tag:               "gray",
@@ -1476,7 +1476,7 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "same-revision-targets", WithSpecTraffic(
+				Route("default", "same-revision-targets", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1.TrafficTarget{
 							Tag:               "gray",
@@ -1494,7 +1494,7 @@ func TestReconcile(t *testing.T) {
 			),
 			simplePlaceholderK8sService(
 				getContext(),
-				route("default", "same-revision-targets", WithSpecTraffic(
+				Route("default", "same-revision-targets", WithSpecTraffic(
 					v1alpha1.TrafficTarget{
 						TrafficTarget: v1.TrafficTarget{
 							Tag:               "gray",
@@ -1512,7 +1512,7 @@ func TestReconcile(t *testing.T) {
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "same-revision-targets",
+			Object: Route("default", "same-revision-targets",
 				WithSpecTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						Tag:               "gray",
@@ -1564,7 +1564,7 @@ func TestReconcile(t *testing.T) {
 		Name: "change route configuration",
 		// Start from a steady state referencing "blue", and modify the route spec to point to "green" instead.
 		Objects: []runtime.Object{
-			route("default", "switch-configs", WithConfigTarget("green"),
+			Route("default", "switch-configs", WithConfigTarget("green"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1584,7 +1584,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001"), WithServiceName("alki-beach")),
 			rev("default", "green", 1, MarkRevisionReady, WithRevName("green-00001"), WithServiceName("rainier-beach")),
 			simpleReadyIngress(
-				route("default", "switch-configs", WithConfigTarget("blue"), WithURL),
+				Route("default", "switch-configs", WithConfigTarget("blue"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1599,11 +1599,11 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "switch-configs", WithConfigTarget("blue"))),
+			simpleK8sService(Route("default", "switch-configs", WithConfigTarget("blue"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleReadyIngress(
-				route("default", "switch-configs", WithConfigTarget("green"), WithURL),
+				Route("default", "switch-configs", WithConfigTarget("green"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1620,7 +1620,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "switch-configs", WithConfigTarget("green"),
+			Object: Route("default", "switch-configs", WithConfigTarget("green"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1638,7 +1638,7 @@ func TestReconcile(t *testing.T) {
 		// Start from a steady state referencing "blue", and modify the route spec to point to both
 		// "blue" and "green" instead, while "green" is not ready.
 		Objects: []runtime.Object{
-			route("default", "split", WithURL, WithAddress,
+			Route("default", "split", WithURL, WithAddress,
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				WithSpecTraffic(
 					v1alpha1.TrafficTarget{
@@ -1667,10 +1667,10 @@ func TestReconcile(t *testing.T) {
 				WithLatestCreated("green-00001")),
 			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001")),
 			rev("default", "green", 1, WithRevName("green-00001")),
-			simpleK8sService(route("default", "split", WithConfigTarget("blue"))),
+			simpleK8sService(Route("default", "split", WithConfigTarget("blue"))),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "split", WithURL, WithAddress,
+			Object: Route("default", "split", WithURL, WithAddress,
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				MarkConfigurationNotReady("green"),
 				WithSpecTraffic(
@@ -1699,7 +1699,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "Update stale lastPinned",
 		Objects: []runtime.Object{
-			route("default", "stale-lastpinned", WithConfigTarget("config"),
+			Route("default", "stale-lastpinned", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1718,7 +1718,7 @@ func TestReconcile(t *testing.T) {
 				WithRevName("config-00001"),
 				WithLastPinned(fakeCurTime.Add(-10*time.Minute))),
 			simpleReadyIngress(
-				route("default", "stale-lastpinned", WithConfigTarget("config"), WithURL),
+				Route("default", "stale-lastpinned", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1732,7 +1732,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "stale-lastpinned", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "stale-lastpinned", WithConfigTarget("config"))),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchLastPinned("default", "config-00001"),
@@ -1741,7 +1741,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "check that we can find the cluster ingress with old naming",
 		Objects: []runtime.Object{
-			route("default", "old-naming", WithConfigTarget("config"), WithRouteFinalizer,
+			Route("default", "old-naming", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
 					v1alpha1.TrafficTarget{
@@ -1759,7 +1759,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "old-naming", WithConfigTarget("config"), WithURL),
+				Route("default", "old-naming", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1773,13 +1773,13 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "old-naming", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "old-naming", WithConfigTarget("config"))),
 		},
 		Key: "default/old-naming",
 	}, {
 		Name: "deletes service when route no longer references service",
 		Objects: []runtime.Object{
-			route("default", "my-route", WithConfigTarget("config"),
+			Route("default", "my-route", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
@@ -1797,7 +1797,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
 			simpleReadyIngress(
-				route("default", "my-route", WithConfigTarget("config"), WithURL),
+				Route("default", "my-route", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -1811,8 +1811,8 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "my-route", WithConfigTarget("config"))),
-			simpleK8sService(route("default", "my-route"), OverrideServiceName("old-service-name")),
+			simpleK8sService(Route("default", "my-route", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "my-route"), OverrideServiceName("old-service-name")),
 		},
 		WantDeletes: []clientgotesting.DeleteActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
@@ -1834,7 +1834,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("delete", "services"),
 		},
 		Objects: []runtime.Object{
-			route("default", "my-route", WithConfigTarget("config"),
+			Route("default", "my-route", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
@@ -1851,8 +1851,8 @@ func TestReconcile(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "steady-state"),
 			),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-			simpleK8sService(route("default", "my-route", WithConfigTarget("config"))),
-			simpleK8sService(route("default", "my-route"), OverrideServiceName("old-service-name")),
+			simpleK8sService(Route("default", "my-route", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "my-route"), OverrideServiceName("old-service-name")),
 		},
 		WantDeletes: []clientgotesting.DeleteActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
@@ -1898,14 +1898,14 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		Name: "check that existing wildcard cert is used when creating a Route",
 		Objects: []runtime.Object{
 			wildcardCert("default", "example.com"),
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
 		},
 		WantCreates: []runtime.Object{
 			ingressWithTLS(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithHTTPSDomain,
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithHTTPSDomain,
 					WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -1929,12 +1929,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				},
 			),
 			simpleK8sService(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 				WithExternalName("becomes-ready.default.example.com"),
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
@@ -1955,16 +1955,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 	}, {
 		Name: "check that Certificate and IngressTLS are correctly configured when creating a Route",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeCertificates(route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
+			resources.MakeCertificates(Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
 				map[string]string{"becomes-ready.default.example.com": ""}, network.CertManagerCertificateClassName)[0],
 			ingressWithTLS(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
 					WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -1986,12 +1986,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				}},
 			),
 			simpleK8sService(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 				WithExternalName("becomes-ready.default.example.com"),
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -2013,7 +2013,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 	}, {
 		Name: "check that Certificate and IngressTLS are correctly updated when updating a Route",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
@@ -2024,7 +2024,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					Name:      "route-12-34",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(
-						route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")))},
+						Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")))},
 					Annotations: map[string]string{
 						networking.CertificateClassAnnotationKey: network.CertManagerCertificateClassName,
 					},
@@ -2040,7 +2040,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			ingressWithTLS(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
 					WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -2064,16 +2064,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				},
 			),
 			simpleK8sService(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 				WithExternalName("becomes-ready.default.example.com"),
 			),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: certificateWithStatus(resources.MakeCertificates(route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
+			Object: certificateWithStatus(resources.MakeCertificates(Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
 				map[string]string{"becomes-ready.default.example.com": ""}, network.CertManagerCertificateClassName)[0], readyCertStatus()),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
@@ -2098,7 +2098,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		Name:    "check that Route updates status and produces event log when valid name but not owned certificate",
 		WantErr: true,
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
@@ -2123,10 +2123,10 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		WantDeleteCollections: []clientgotesting.DeleteCollectionActionImpl{},
 		WantCreates: []runtime.Object{
-			simplePlaceholderK8sService(getContext(), route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")), ""),
+			simplePlaceholderK8sService(getContext(), Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")), ""),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				WithAddress, WithInitRouteConditions, WithURL,
 				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
@@ -2146,7 +2146,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 	}, {
 		Name: "check that Route is correctly updated when Certificate is not ready",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
@@ -2157,7 +2157,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					Name:      "route-12-34",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(
-						route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")))},
+						Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")))},
 					Labels: labels.Set(map[string]string{
 						serving.RouteLabelKey: "becomes-ready",
 					}),
@@ -2173,7 +2173,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			ingressWithTLS(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
 					WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -2197,16 +2197,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				},
 			),
 			simpleK8sService(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 				WithExternalName("becomes-ready.default.example.com"),
 			),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: certificateWithStatus(resources.MakeCertificates(route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
+			Object: certificateWithStatus(resources.MakeCertificates(Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
 				map[string]string{"becomes-ready.default.example.com": ""}, network.CertManagerCertificateClassName)[0], notReadyCertStatus()),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
@@ -2231,14 +2231,14 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		// This test is a same with "public becomes cluster local" above, but confirm it does not create certs with autoTLS for cluster-local.
 		Name: "public becomes cluster local w/ autoTLS",
 		Objects: []runtime.Object{
-			route("default", "becomes-local", WithConfigTarget("config"),
-				WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal),
+			Route("default", "becomes-local", WithConfigTarget("config"),
+				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 			simpleIngress(
-				route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel("serving.knative.dev/visibility", "cluster-local")),
+				Route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23"), WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -2253,15 +2253,15 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(route("default", "becomes-local", WithConfigTarget("config"),
-				WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal),
+			simpleK8sService(Route("default", "becomes-local", WithConfigTarget("config"),
+				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
 				WithRouteUID("65-23"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngressWithVisibility(
-				route("default", "becomes-local", WithConfigTarget("config"),
+				Route("default", "becomes-local", WithConfigTarget("config"),
 					WithRouteUID("65-23"),
-					WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal)),
+					WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -2279,11 +2279,11 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-local", WithConfigTarget("config"),
+			Object: Route("default", "becomes-local", WithConfigTarget("config"),
 				WithRouteUID("65-23"),
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
-				WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal),
+				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
 				WithStatusTraffic(v1alpha1.TrafficTarget{
 					TrafficTarget: v1.TrafficTarget{
 						RevisionName:   "config-00001",
@@ -2336,7 +2336,7 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 	table := TableTest{{
 		Name: "check that Route is correctly updated when Certificate is not ready",
 		Objects: []runtime.Object{
-			route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
@@ -2350,7 +2350,7 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 						serving.RouteLabelKey: "becomes-ready",
 					}),
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(
-						route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")))},
+						Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")))},
 					Annotations: map[string]string{
 						networking.CertificateClassAnnotationKey: network.CertManagerCertificateClassName,
 					},
@@ -2363,7 +2363,7 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			ingressWithTLS(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL,
 					WithRouteUID("12-34")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -2387,16 +2387,16 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 				},
 			),
 			simpleK8sService(
-				route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 				WithExternalName("becomes-ready.default.example.com"),
 			),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: certificateWithStatus(resources.MakeCertificates(route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
+			Object: certificateWithStatus(resources.MakeCertificates(Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
 				map[string]string{"becomes-ready.default.example.com": ""}, network.CertManagerCertificateClassName)[0], notReadyCertStatus()),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route("default", "becomes-ready", WithConfigTarget("config"),
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
@@ -2436,20 +2436,6 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 			clock: FakeClock{Time: fakeCurTime},
 		}
 	}))
-}
-
-func route(namespace, name string, ro ...RouteOption) *v1alpha1.Route {
-	r := &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
-	for _, opt := range ro {
-		opt(r)
-	}
-	r.SetDefaults(context.Background())
-	return r
 }
 
 func cfg(namespace, name string, co ...ConfigOption) *v1alpha1.Configuration {
@@ -2691,3 +2677,4 @@ func certificateWithStatus(cert *netv1alpha1.Certificate, status netv1alpha1.Cer
 	cert.Status = status
 	return cert
 }
+

--- a/pkg/reconciler/route/traffic/errors_test.go
+++ b/pkg/reconciler/route/traffic/errors_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 func TestIsFailure_Missing(t *testing.T) {
@@ -34,7 +35,7 @@ func TestIsFailure_Missing(t *testing.T) {
 
 func TestMarkBadTrafficTarget_Missing(t *testing.T) {
 	err := errMissingRevision("missing-rev")
-	r := testRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
@@ -66,7 +67,7 @@ func TestIsFailure_NotYetReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_NotYetReady(t *testing.T) {
 	err := errUnreadyConfiguration(unreadyConfig)
-	r := testRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
@@ -98,7 +99,7 @@ func TestIsFailure_ConfigFailedToBeReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_ConfigFailedToBeReady(t *testing.T) {
 	err := errUnreadyConfiguration(failedConfig)
-	r := testRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
@@ -122,7 +123,7 @@ func TestMarkBadTrafficTarget_ConfigFailedToBeReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_RevisionFailedToBeReady(t *testing.T) {
 	err := errUnreadyRevision(failedRev)
-	r := testRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
@@ -154,7 +155,7 @@ func TestIsFailure_RevFailedToBeReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_RevisionNotYetReady(t *testing.T) {
 	err := errUnreadyRevision(unreadyRev)
-	r := testRouteWithTrafficTargets([]v1alpha1.TrafficTarget{})
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -39,6 +39,7 @@ import (
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/domains"
+	. "knative.dev/serving/pkg/testing/v1alpha1"
 )
 
 const testNamespace string = "test"
@@ -125,13 +126,6 @@ func setUp() {
 
 // The vanilla use case of 100% directing to latest ready revision of a single configuration.
 func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
-	}}
-
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -139,6 +133,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -149,6 +144,7 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(100),
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -160,20 +156,23 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 			goodNewRev.Name: goodNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: goodConfig.Name,
+			Percent:           ptr.Int64(100),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
 	}
 }
 
+func testRouteWithTrafficTargets(ro RouteOption) *v1alpha1.Route {
+	return Route(testNamespace, "test-route", map[string]string{"route": "test-route"}, map[string]string{}, ro)
+}
+
 func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(100),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -181,6 +180,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 					RevisionName:      goodNewRev.Name,
 					ConfigurationName: goodConfig.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -191,6 +191,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(100),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -198,7 +199,12 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodNewRev.Name,
+			Percent:      ptr.Int64(100),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -207,12 +213,6 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 
 // The vanilla use case of 100% directing to latest revision of an inactive configuration.
 func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: inactiveConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -220,6 +220,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 					ConfigurationName: inactiveConfig.Name,
 					RevisionName:      inactiveRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   false,
 				Protocol: net.ProtocolHTTP1,
@@ -230,6 +231,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 				ConfigurationName: inactiveConfig.Name,
 				RevisionName:      inactiveRev.Name,
 				Percent:           ptr.Int64(100),
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   false,
 			Protocol: net.ProtocolHTTP1,
@@ -241,7 +243,12 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 			inactiveRev.Name: inactiveRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: inactiveConfig.Name,
+			Percent:           ptr.Int64(100),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -250,17 +257,6 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 
 // Transitioning from one good config to another by splitting traffic.
 func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: niceConfig.Name,
-			Percent:           ptr.Int64(90),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(10),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -268,6 +264,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
 					Percent:           ptr.Int64(90),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -276,6 +273,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(10),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -286,6 +284,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				ConfigurationName: niceConfig.Name,
 				RevisionName:      niceNewRev.Name,
 				Percent:           ptr.Int64(90),
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -294,6 +293,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(10),
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -307,7 +307,17 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 			niceNewRev.Name: niceNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: niceConfig.Name,
+			Percent:           ptr.Int64(90),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: goodConfig.Name,
+			Percent:           ptr.Int64(10),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -316,17 +326,6 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 
 // Splitting traffic between a fixed revision and the latest revision (canary).
 func TestBuildTrafficConfiguration_Canary(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(90),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(10),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -334,6 +333,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
 					Percent:           ptr.Int64(90),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -342,6 +342,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(10),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -352,6 +353,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
 				Percent:           ptr.Int64(90),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -360,6 +362,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(10),
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -372,7 +375,17 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 			goodNewRev.Name: goodNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(90),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: goodConfig.Name,
+			Percent:           ptr.Int64(10),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -381,25 +394,6 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 
 // Splitting traffic between latest revision and a fixed revision which is also latest.
 func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "one",
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(49),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "two",
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(50),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               "also-two",
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(1),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -408,6 +402,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
 					Percent:           ptr.Int64(49),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -417,6 +412,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(51),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -427,6 +423,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -437,6 +434,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -447,6 +445,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -458,6 +457,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
 				Percent:           ptr.Int64(49),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -467,6 +467,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(50),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -476,6 +477,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(1),
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -488,7 +490,25 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 			goodNewRev.Name: goodNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:          "one",
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(49),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:          "two",
+			RevisionName: goodNewRev.Name,
+			Percent:      ptr.Int64(50),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:               "also-two",
+			ConfigurationName: goodConfig.Name,
+			Percent:           ptr.Int64(1),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -497,17 +517,6 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 
 // Splitting traffic between a two fixed revisions.
 func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(90),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(10),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -515,6 +524,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
 					Percent:           ptr.Int64(90),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -523,6 +533,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(10),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -533,6 +544,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
 				Percent:           ptr.Int64(90),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -541,6 +553,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(10),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -553,7 +566,17 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 			goodOldRev.Name: goodOldRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(90),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodNewRev.Name,
+			Percent:      ptr.Int64(10),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -562,17 +585,6 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 
 // Splitting traffic between a two fixed revisions of two configurations.
 func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(40),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: niceNewRev.Name,
-			Percent:      ptr.Int64(60),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -580,6 +592,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(40),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -588,6 +601,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
 					Percent:           ptr.Int64(60),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -598,6 +612,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
 				Percent:           ptr.Int64(40),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -606,6 +621,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 				ConfigurationName: niceConfig.Name,
 				RevisionName:      niceNewRev.Name,
 				Percent:           ptr.Int64(60),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -619,7 +635,17 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 			niceNewRev.Name: niceNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(tts)); err != nil {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodNewRev.Name,
+			Percent:      ptr.Int64(40),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: niceNewRev.Name,
+			Percent:      ptr.Int64(60),
+		},
+	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -651,6 +677,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodOldRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolHTTP1,
@@ -659,6 +686,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Tag:               "beta",
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -667,6 +695,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					Tag:               "alpha",
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -677,6 +706,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					ConfigurationName: goodConfig.Name,
 					RevisionName:      goodNewRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(false),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -687,6 +717,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 					ConfigurationName: niceConfig.Name,
 					RevisionName:      niceNewRev.Name,
 					Percent:           ptr.Int64(100),
+					LatestRevision:    ptr.Bool(true),
 				},
 				Active:   true,
 				Protocol: net.ProtocolH2C,
@@ -697,6 +728,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodOldRev.Name,
 				Percent:           ptr.Int64(100),
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolHTTP1,
@@ -705,6 +737,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				Tag:               "beta",
 				ConfigurationName: goodConfig.Name,
 				RevisionName:      goodNewRev.Name,
+				LatestRevision:    ptr.Bool(false),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -713,6 +746,7 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 				Tag:               "alpha",
 				ConfigurationName: niceConfig.Name,
 				RevisionName:      niceNewRev.Name,
+				LatestRevision:    ptr.Bool(true),
 			},
 			Active:   true,
 			Protocol: net.ProtocolH2C,
@@ -747,10 +781,31 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 		},
 	}, {
 		TrafficTarget: v1.TrafficTarget{
-			Tag:               "alpha",
-			ConfigurationName: missingConfig.Name,
+=======
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(100),
 		},
-	}}
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          "beta",
+			RevisionName: goodNewRev.Name,
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+>>>>>>> Refactor test code for route
+			Tag:               "alpha",
+			ConfigurationName: niceConfig.Name,
+		},
+	}))); err != nil {
+		t.Errorf("Unexpected error %v", err)
+	} else if want, got := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
+	}
+}
+
+func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{
@@ -762,8 +817,22 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 		},
 	}
 	expectedErr := errMissingConfiguration(missingConfig.Name)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(100),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:          "beta",
+			RevisionName: goodNewRev.Name,
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1beta1.TrafficTarget{
+			Tag:               "alpha",
+			ConfigurationName: missingConfig.Name,
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -771,20 +840,18 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 }
 
 func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: unreadyRev.Name,
-			Percent:      ptr.Int64(100),
-		},
-	}}
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{},
 		Revisions:      map[string]*v1alpha1.Revision{unreadyRev.Name: unreadyRev},
 	}
 	expectedErr := errUnreadyRevision(unreadyRev)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: unreadyRev.Name,
+			Percent:      ptr.Int64(100),
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -792,20 +859,18 @@ func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
 }
 
 func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: unreadyConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
-	}}
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{unreadyConfig.Name: unreadyConfig},
 		Revisions:      map[string]*v1alpha1.Revision{},
 	}
 	expectedErr := errUnreadyConfiguration(unreadyConfig)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: unreadyConfig.Name,
+			Percent:           ptr.Int64(100),
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -813,13 +878,6 @@ func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
 }
 
 func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: emptyConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
-	}}
-
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{
@@ -829,8 +887,12 @@ func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 	}
 
 	expectedErr := errUnreadyConfiguration(emptyConfig)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: emptyConfig.Name,
+			Percent:           ptr.Int64(100),
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -838,17 +900,6 @@ func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 }
 
 func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: emptyConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: failedConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{
@@ -858,8 +909,17 @@ func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 		Revisions: map[string]*v1alpha1.Revision{},
 	}
 	expectedErr := errUnreadyConfiguration(failedConfig)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: emptyConfig.Name,
+			Percent:           ptr.Int64(50),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: failedConfig.Name,
+			Percent:           ptr.Int64(50),
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -867,17 +927,6 @@ func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 }
 
 func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: failedConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: emptyConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
-	}}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{
@@ -887,8 +936,17 @@ func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 		Revisions: map[string]*v1alpha1.Revision{},
 	}
 	expectedErr := errUnreadyConfiguration(failedConfig)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: failedConfig.Name,
+			Percent:           ptr.Int64(50),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			ConfigurationName: emptyConfig.Name,
+			Percent:           ptr.Int64(50),
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -896,25 +954,23 @@ func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 }
 
 func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: missingRev.Name,
-			Percent:      ptr.Int64(50),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(50),
-		},
-	}}
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
 	}
 	expectedErr := errMissingRevision(missingRev.Name)
-	r := testRouteWithTrafficTargets(tts)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); expectedErr.Error() != err.Error() {
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: missingRev.Name,
+			Percent:      ptr.Int64(50),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodNewRev.Name,
+			Percent:      ptr.Int64(50),
+		},
+	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected %s, saw %s", expectedErr.Error(), err.Error())
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
 		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
@@ -922,41 +978,48 @@ func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 }
 
 func TestRoundTripping(t *testing.T) {
-	tts := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(100),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "beta",
-			RevisionName: goodNewRev.Name,
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               "alpha",
-			ConfigurationName: niceConfig.Name,
-		},
-	}}
 	expected := []v1alpha1.TrafficTarget{{
 		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(100),
+			RevisionName:   goodOldRev.Name,
+			Percent:        ptr.Int64(100),
+			LatestRevision: ptr.Bool(false),
 		},
 	}, {
 		TrafficTarget: v1.TrafficTarget{
+			Tag:            "beta",
+			RevisionName:   goodNewRev.Name,
+			URL:            domains.URL(domains.HTTPScheme, "beta-test-route.test.example.com"),
+			LatestRevision: ptr.Bool(false),
+		},
+	}, {
+		TrafficTarget: v1.TrafficTarget{
+			Tag:            "alpha",
+			RevisionName:   niceNewRev.Name,
+			URL:            domains.URL(domains.HTTPScheme, "alpha-test-route.test.example.com"),
+			LatestRevision: ptr.Bool(true),
+		},
+	}}
+	route := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(100),
+		},
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
 			Tag:          "beta",
 			RevisionName: goodNewRev.Name,
-			URL:          domains.URL(domains.HTTPScheme, "beta-test-route.test.example.com"),
 		},
 	}, {
 		TrafficTarget: v1.TrafficTarget{
 			Tag:          "alpha",
 			RevisionName: niceNewRev.Name,
 			URL:          domains.URL(domains.HTTPScheme, "alpha-test-route.test.example.com"),
+	}, v1alpha1.TrafficTarget{
+		TrafficTarget: v1.TrafficTarget{
+			Tag:               "alpha",
+			ConfigurationName: niceConfig.Name,
 		},
-	}}
-	route := testRouteWithTrafficTargets(tts)
+	}))
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, route); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else {
@@ -1002,21 +1065,6 @@ func testRevForConfig(config *v1alpha1.Configuration, name string) *v1alpha1.Rev
 			},
 		},
 		Spec: *config.Spec.GetTemplate().Spec.DeepCopy(),
-	}
-}
-
-func testRouteWithTrafficTargets(traffic []v1alpha1.TrafficTarget) *v1alpha1.Route {
-	return &v1alpha1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: testNamespace,
-			Labels: map[string]string{
-				"route": "test-route",
-			},
-		},
-		Spec: v1alpha1.RouteSpec{
-			Traffic: traffic,
-		},
 	}
 }
 

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -897,7 +897,8 @@ func TestReconcile(t *testing.T) {
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: config("update-route-and-config-labels", "foo", WithRunLatestRollout, WithConfigLabel("new-label", "new-value")),
 		}, {
-			Object: route("update-route-and-config-labels", "foo", WithRunLatestRollout, WithRouteLabel("new-label", "new-value")),
+			Object: route("update-route-and-config-labels", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
+				"serving.knative.dev/service": "update-route-and-config-labels"})),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
@@ -921,7 +922,8 @@ func TestReconcile(t *testing.T) {
 			Object: config("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithConfigLabel("new-label", "new-value"),
 				WithConfigLabel("serving.knative.dev/route", "update-child-labels-ignore-route-label")),
 		}, {
-			Object: route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithRouteLabel("new-label", "new-value")),
+			Object: route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
+				"serving.knative.dev/service": "update-child-labels-ignore-route-label"})),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{

--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -228,6 +228,16 @@ func WithRouteLabel(key, value string) RouteOption {
 	}
 }
 
+// WithRouteAnnotation sets the specified annotation on the Route.
+func WithRouteAnnotation(key, value string) RouteOption {
+	return func(r *v1alpha1.Route) {
+		if r.Annotations == nil {
+			r.Annotations = make(map[string]string)
+		}
+		r.Annotations[key] = value
+	}
+}
+
 // WithIngressClass sets the ingress class annotation on the Route.
 func WithIngressClass(ingressClass string) RouteOption {
 	return func(r *v1alpha1.Route) {
@@ -238,14 +248,12 @@ func WithIngressClass(ingressClass string) RouteOption {
 	}
 }
 
-// Route creates a route with ServiceOptions
-func Route(namespace, name string, labels, annotations map[string]string, ro ...RouteOption) *v1alpha1.Route {
+// Route creates a route with RouteOptions
+func Route(namespace, name string, ro ...RouteOption) *v1alpha1.Route {
 	r := &v1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Labels:      labels,
-			Annotations: annotations,
+			Namespace: namespace,
+			Name:      name,
 		},
 	}
 	for _, opt := range ro {

--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -235,4 +236,21 @@ func WithIngressClass(ingressClass string) RouteOption {
 		}
 		r.Annotations[networking.IngressClassAnnotationKey] = ingressClass
 	}
+}
+
+// Route creates a route with ServiceOptions
+func Route(namespace, name string, labels, annotations map[string]string, ro ...RouteOption) *v1alpha1.Route {
+	r := &v1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+	for _, opt := range ro {
+		opt(r)
+	}
+	r.SetDefaults(context.Background())
+	return r
 }

--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -219,22 +219,12 @@ func MarkConfigurationFailed(name string) RouteOption {
 }
 
 // WithRouteLabel sets the specified label on the Route.
-func WithRouteLabel(key, value string) RouteOption {
+func WithRouteLabel(labels map[string]string) RouteOption {
 	return func(r *v1alpha1.Route) {
 		if r.Labels == nil {
 			r.Labels = make(map[string]string)
 		}
-		r.Labels[key] = value
-	}
-}
-
-// WithRouteAnnotation sets the specified annotation on the Route.
-func WithRouteAnnotation(key, value string) RouteOption {
-	return func(r *v1alpha1.Route) {
-		if r.Annotations == nil {
-			r.Annotations = make(map[string]string)
-		}
-		r.Annotations[key] = value
+		r.Labels = labels
 	}
 }
 
@@ -245,6 +235,16 @@ func WithIngressClass(ingressClass string) RouteOption {
 			r.Annotations = make(map[string]string)
 		}
 		r.Annotations[networking.IngressClassAnnotationKey] = ingressClass
+	}
+}
+
+// WithRouteAnnotation sets the specified annotation on the Route.
+func WithRouteAnnotation(annotation map[string]string) RouteOption {
+	return func(r *v1alpha1.Route) {
+		if r.Annotations == nil {
+			r.Annotations = make(map[string]string)
+		}
+		r.Annotations = annotation
 	}
 }
 

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -39,7 +39,7 @@ import (
 
 // CreateRoute creates a route in the given namespace using the route name in names
 func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...v1alpha1testing.RouteOption) (*v1alpha1.Route, error) {
-	fopt = append(fopt, rtesting.WithSpecTraffic(v1alpha1.TrafficTarget{
+	fopt = append(fopt, v1alpha1testing.WithSpecTraffic(v1alpha1.TrafficTarget{
 		TrafficTarget: v1.TrafficTarget{
 			Tag:               names.TrafficTarget,
 			ConfigurationName: names.Config,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5469

## Proposed Changes

* Refactored unit test case for route to use the shared function to get `v1alpha1.Route` structure

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
