### PR TITLE
Add podIP check short circuit when all are healthy in RBM

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -374,7 +374,7 @@ func TestRevisionWatcher(t *testing.T) {
 				tc.expectUpdates[i].Rev = revID
 			}
 
-			if got, want := tc.expectUpdates, updates; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
+			if got, want := updates, tc.expectUpdates; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
 				t.Errorf("revisionDests updates = %v, want: %v, diff (-want, +got):\n %s", got, want, cmp.Diff(want, got))
 			}
 		})


### PR DESCRIPTION
One potential large GC pressure is we rebuild our podIP list every time
we tick in RBM. Theres an obvious short circuit path when all the dests
are currently healthy.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
