### PR TITLE
Fixes the bug that isAggressive is used as isNotAggressive

### DIFF
--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -82,10 +82,10 @@ func (h *State) drainFinished() {
 }
 
 // HealthHandler constructs a handler that returns the current state of the
-// health server. If isNotAggressive is true and prober has succeeded previously,
+// health server. If isAggressive is false and prober has succeeded previously,
 // the function return success without probing user-container again (until
 // shutdown).
-func (h *State) HealthHandler(prober func() bool, isNotAggressive bool) func(w http.ResponseWriter, r *http.Request) {
+func (h *State) HealthHandler(prober func() bool, isAggressive bool) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sendAlive := func() {
 			io.WriteString(w, "alive: true")
@@ -97,7 +97,7 @@ func (h *State) HealthHandler(prober func() bool, isNotAggressive bool) func(w h
 		}
 
 		switch {
-		case isNotAggressive && h.IsAlive():
+		case !isAggressive && h.IsAlive():
 			sendAlive()
 		case h.IsShuttingDown():
 			sendNotAlive()

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -66,85 +66,85 @@ func TestHealthStateSetsState(t *testing.T) {
 
 func TestHealthStateHealthHandler(t *testing.T) {
 	tests := []struct {
-		name            string
-		state           *State
-		prober          func() bool
-		isNotAggressive bool
-		wantStatus      int
-		wantBody        string
+		name         string
+		state        *State
+		prober       func() bool
+		isAggressive bool
+		wantStatus   int
+		wantBody     string
 	}{{
-		name:            "alive: true, K-Probe",
-		state:           &State{alive: true},
-		isNotAggressive: true,
-		wantStatus:      http.StatusOK,
-		wantBody:        aliveBody,
+		name:         "alive: true, K-Probe",
+		state:        &State{alive: true},
+		isAggressive: false,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:            "alive: false, prober: true, K-Probe",
-		state:           &State{alive: false},
-		prober:          func() bool { return true },
-		isNotAggressive: true,
-		wantStatus:      http.StatusOK,
-		wantBody:        aliveBody,
+		name:         "alive: false, prober: true, K-Probe",
+		state:        &State{alive: false},
+		prober:       func() bool { return true },
+		isAggressive: false,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:            "alive: false, prober: false, K-Probe",
-		state:           &State{alive: false},
-		prober:          func() bool { return false },
-		isNotAggressive: true,
-		wantStatus:      http.StatusBadRequest,
-		wantBody:        notAliveBody,
+		name:         "alive: false, prober: false, K-Probe",
+		state:        &State{alive: false},
+		prober:       func() bool { return false },
+		isAggressive: false,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}, {
-		name:            "alive: false, no prober, K-Probe",
-		state:           &State{alive: false},
-		isNotAggressive: true,
-		wantStatus:      http.StatusOK,
-		wantBody:        aliveBody,
+		name:         "alive: false, no prober, K-Probe",
+		state:        &State{alive: false},
+		isAggressive: false,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:            "shuttingDown: true, K-Probe",
-		state:           &State{shuttingDown: true},
-		isNotAggressive: true,
-		wantStatus:      http.StatusBadRequest,
-		wantBody:        notAliveBody,
+		name:         "shuttingDown: true, K-Probe",
+		state:        &State{shuttingDown: true},
+		isAggressive: false,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}, {
-		name:            "no prober, shuttingDown: false",
-		state:           &State{},
-		isNotAggressive: false,
-		wantStatus:      http.StatusOK,
-		wantBody:        aliveBody,
+		name:         "no prober, shuttingDown: false",
+		state:        &State{},
+		isAggressive: true,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:            "prober: true, shuttingDown: true",
-		state:           &State{shuttingDown: true},
-		prober:          func() bool { return true },
-		isNotAggressive: false,
-		wantStatus:      http.StatusBadRequest,
-		wantBody:        notAliveBody,
+		name:         "prober: true, shuttingDown: true",
+		state:        &State{shuttingDown: true},
+		prober:       func() bool { return true },
+		isAggressive: true,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}, {
-		name:            "prober: true, shuttingDown: false",
-		state:           &State{},
-		prober:          func() bool { return true },
-		isNotAggressive: false,
-		wantStatus:      http.StatusOK,
-		wantBody:        aliveBody,
+		name:         "prober: true, shuttingDown: false",
+		state:        &State{},
+		prober:       func() bool { return true },
+		isAggressive: true,
+		wantStatus:   http.StatusOK,
+		wantBody:     aliveBody,
 	}, {
-		name:            "prober: false, shuttingDown: false",
-		state:           &State{},
-		prober:          func() bool { return false },
-		isNotAggressive: false,
-		wantStatus:      http.StatusBadRequest,
-		wantBody:        notAliveBody,
+		name:         "prober: false, shuttingDown: false",
+		state:        &State{},
+		prober:       func() bool { return false },
+		isAggressive: true,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}, {
-		name:            "prober: false, shuttingDown: true",
-		state:           &State{},
-		prober:          func() bool { return false },
-		isNotAggressive: false,
-		wantStatus:      http.StatusBadRequest,
-		wantBody:        notAliveBody,
+		name:         "prober: false, shuttingDown: true",
+		state:        &State{},
+		prober:       func() bool { return false },
+		isAggressive: true,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}, {
-		name:            "alive: true, prober: false, shuttingDown: false",
-		state:           &State{alive: true},
-		prober:          func() bool { return false },
-		isNotAggressive: false,
-		wantStatus:      http.StatusBadRequest,
-		wantBody:        notAliveBody,
+		name:         "alive: true, prober: false, shuttingDown: false",
+		state:        &State{alive: true},
+		prober:       func() bool { return false },
+		isAggressive: true,
+		wantStatus:   http.StatusBadRequest,
+		wantBody:     notAliveBody,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestHealthStateHealthHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(test.state.HealthHandler(test.prober, test.isNotAggressive))
+			handler := http.HandlerFunc(test.state.HealthHandler(test.prober, test.isAggressive))
 
 			handler.ServeHTTP(rr, req)
 


### PR DESCRIPTION
Currently `isAggressive()` is used as `isNotAggressive` parameter: https://github.com/knative/serving/blob/master/cmd/queue/main.go#L509

By default, `isAggressive` returns true. So `:8012/health` of queue-proxy will only send the first probe to user-container then uses the cache if the probe succeeds.

I think we want to probe user-container each time by default.

## Proposed Changes

* Use `isAggressive` instead of isNotAggressive as the name and meaning for a arg of `HealthHandler`.
* Kubectl probe will probe user-container each time by default via queue-proxy.

**Release Note**

```release-note
Queue-proxy sends probe to user-container for each kubelet probe by default.
```
