### PR TITLE
Use Status.URL instead of Status.URL.Host in E2E tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1674,7 +1674,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:28bec577231fb3a03b5918299e5c1747a786ff4fdae034747301809dcffcfddb"
+  digest = "1:63f2c3980f4c94a703dc4316151b361b22ec6919f1fa7d92e8f29ca76e057aba"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1782,7 +1782,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "4febcfe6aeade8dfa7df45d84ed1ca510ea1d466"
+  revision = "2d6c3459cedf2cc4f1e38845434d057c86e6be2e"
 
 [[projects]]
   branch = "master"

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 	"math"
+	"net/url"
 	"testing"
 
 	"golang.org/x/sync/errgroup"
@@ -113,52 +114,48 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	var blueDomain, greenDomain string
+	var blueURL, greenURL *url.URL
 	for _, tt := range service.Status.Traffic {
 		if tt.Tag == blue.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			blueDomain = tt.URL.Host
+			blueURL = tt.URL.URL()
 		}
 		if tt.Tag == green.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			greenDomain = tt.URL.Host
+			greenURL = tt.URL.URL()
 		}
 	}
-	if blueDomain == "" || greenDomain == "" {
+	if blueURL == nil || greenURL == nil {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
-	tealDomain := service.Status.URL.Host
+	tealURL := service.Status.URL.URL()
 
 	// Istio network programming takes some time to be effective.  Currently Istio
 	// does not expose a Status, so we rely on probes to know when they are effective.
 	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
-	t.Logf("Probing domain %s", greenDomain)
+	t.Logf("Probing %s", greenURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		greenDomain,
+		greenURL,
 		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", greenDomain, err)
+		t.Fatalf("Error probing %s: %v", greenURL, err)
 	}
 
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return checkDistribution(t, clients, tealDomain, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return checkDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, blueDomain, test.ConcurrentRequests, min, []string{expectedBlue})
+		return checkDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, greenDomain, test.ConcurrentRequests, min, []string{expectedGreen})
+		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatalf("Error sending requests: %v", err)

--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"testing"
 
@@ -76,30 +77,30 @@ func validateName(generateName, name string) error {
 
 func canServeRequests(t *testing.T, clients *test.Clients, route *v1.Route) error {
 	t.Logf("Route %s has a domain set in its status", route.Name)
-	var domain string
+	var url *url.URL
 	err := v1test.WaitForRouteState(
 		clients.ServingClient,
 		route.Name,
 		func(r *v1.Route) (bool, error) {
-			domain = r.Status.URL.Host
-			return domain != "", nil
+			url = r.Status.URL.URL()
+			return url != nil, nil
 		},
 		"RouteDomain",
 	)
 	if err != nil {
-		return fmt.Errorf("route did not get assigned a domain: %v", err)
+		return fmt.Errorf("route did not get assigned an URL: %v", err)
 	}
 
-	t.Logf("Route %s can serve the expected data at the endpoint", route.Name)
+	t.Logf("Route %s can serve the expected data at %s", route.Name, url)
 	_, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text %q: %v", route.Name, domain, test.HelloWorldText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", route.Name, url, test.HelloWorldText, err)
 	}
 
 	return nil
@@ -121,7 +122,7 @@ func TestServiceGenerateName(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer func() { test.TearDown(clients, names) }()
 
-	// Create the service using the generate name field. If the serivce does not become ready this will fail.
+	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
 	resources, err := v1test.CreateServiceReady(t, clients, &names, setServiceGenerateName(generateName))
 	if err != nil {

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -64,9 +65,9 @@ func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, r
 	return nil
 }
 
-// sendRequests send a request to "domain", returns error if unexpected response code, nil otherwise.
-func sendRequest(t *testing.T, clients *test.Clients, domain string, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+// sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
+func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, endpoint.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Logf("Spoofing client failed: %v", err)
 		return err
@@ -78,9 +79,14 @@ func sendRequest(t *testing.T, clients *test.Clients, domain string, initialSlee
 	start := time.Now().UnixNano()
 	defer func() {
 		end := time.Now().UnixNano()
-		t.Logf("domain: %v, initialSleep: %v, sleep: %v, request elapsed %.2f ms", domain, initialSleepMs, sleepMs, float64(end-start)/1e6)
+		t.Logf("URL: %v, initialSleep: %v, sleep: %v, request elapsed %.2f ms", endpoint, initialSleepMs, sleepMs, float64(end-start)/1e6)
 	}()
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s?initialTimeout=%v&timeout=%v", domain, initialSleepMs, sleepMs), nil)
+	u, _ := url.Parse(endpoint.String())
+	q := u.Query()
+	q.Set("initialTimeout", fmt.Sprintf("%d", initialSleepMs))
+	q.Set("timeout", fmt.Sprintf("%d", sleepMs))
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		t.Logf("Failed new request: %v", err)
 		return err
@@ -185,55 +191,51 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	var rev2sDomain, rev5sDomain string
+	var rev2sURL, rev5sURL *url.URL
 	for _, tt := range service.Status.Traffic {
 		if tt.Tag == rev2s.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			rev2sDomain = tt.URL.Host
+			rev2sURL = tt.URL.URL()
 		}
 		if tt.Tag == rev5s.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			rev5sDomain = tt.URL.Host
+			rev5sURL = tt.URL.URL()
 		}
 	}
-	if rev2sDomain == "" || rev5sDomain == "" {
+	if rev2sURL == nil || rev5sURL == nil {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
 
-	t.Logf("Probing domain %s", rev5sDomain)
+	t.Logf("Probing %s", rev5sURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		rev5sDomain,
+		rev5sURL,
 		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)
+		t.Fatalf("Error probing %s: %v", rev5sURL, err)
 	}
 
 	// Quick sanity check
-	if err := sendRequest(t, clients, rev2sDomain, 0, 0, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 0, 0, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
 	}
 
 	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sDomain, 5, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusServiceUnavailable); err != nil {
 		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 7, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusServiceUnavailable); err != nil {
 		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
 	}
 
 	// Not fail by not surpassing in the initial timeout, but in the overall request duration.
-	if err := sendRequest(t, clients, rev2sDomain, 1, 3, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 1, 3, http.StatusOK); err != nil {
 		t.Errorf("Did not fail request with sleep 1s/3s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 3, 3, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 3, 3, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 3s/3s with revision timeout 5s: %v", err)
 	}
 }

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -78,7 +78,7 @@ func TestService(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.URL)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -225,7 +225,7 @@ func TestServiceBYOName(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.URL)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -315,7 +315,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Service traffic should go to the first revision and be available on two names traffic targets: 'current' and 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedFirstRev, expectedFirstRev}); err != nil {
@@ -347,7 +347,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Since the Service is using release the Route will not be updated, but new revision will be available at 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedSecondRev, expectedFirstRev}); err != nil {
@@ -400,7 +400,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Traffic should be split between the two revisions and available on three named traffic targets, 'current', 'candidate', and 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"candidate", "latest", "current"},
 		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev}); err != nil {
@@ -430,7 +430,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Traffic should remain between the two images, and the new revision should be available on the named traffic target 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"latest", "candidate", "current"},
 		[]string{expectedThirdRev, expectedSecondRev, expectedFirstRev}); err != nil {
@@ -475,7 +475,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	}
 
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedThirdRev},
 		[]string{"latest", "candidate", "current"},
 		[]string{expectedThirdRev, expectedThirdRev, expectedFirstRev}); err != nil {

--- a/test/conformance/api/v1/single_threaded_test.go
+++ b/test/conformance/api/v1/single_threaded_test.go
@@ -50,22 +50,22 @@ func TestSingleConcurrency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
-	domain := objects.Service.Status.URL.Host
+	url := objects.Service.Status.URL.URL()
 
 	// Ready does not actually mean Ready for a Route just yet.
 	// See https://knative.dev/serving/issues/1582
-	t.Logf("Probing domain %s", domain)
+	t.Logf("Probing %s", url)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", domain, err)
+		t.Fatalf("Error probing %s: %v", url, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestSingleConcurrency(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		group.Go(func() error {
 			done := time.After(duration)
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
 				return fmt.Errorf("error creating http request: %v", err)
 			}

--- a/test/conformance/api/v1/volumes_test.go
+++ b/test/conformance/api/v1/volumes_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -411,7 +412,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Verify that we get multiple files mounted in, in this case from the
 	// second source, which was partially shadowed in our check above.
-	names.Domain = names.Domain + "/another"
+	names.URL.Path = path.Join(names.URL.Path, "another")
 	if err = validateDataPlane(t, clients, names, text2); err != nil {
 		t.Error(err)
 	}

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"net/url"
 
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,52 +118,48 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	var blueDomain, greenDomain string
+	var blueURL, greenURL *url.URL
 	for _, tt := range service.Status.Traffic {
 		if tt.Tag == blue.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			blueDomain = tt.URL.Host
+			blueURL = tt.URL.URL()
 		}
 		if tt.Tag == green.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			greenDomain = tt.URL.Host
+			greenURL = tt.URL.URL()
 		}
 	}
-	if blueDomain == "" || greenDomain == "" {
+	if blueURL == nil || greenURL == nil {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
-	tealDomain := service.Status.URL.Host
+	tealURL := service.Status.URL.URL()
 
 	// Istio network programming takes some time to be effective.  Currently Istio
 	// does not expose a Status, so we rely on probes to know when they are effective.
 	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
-	t.Logf("Probing domain %s", greenDomain)
+	t.Logf("Probing %s", greenURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		greenDomain,
+		greenURL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", greenDomain, err)
+		t.Fatalf("Error probing %s: %v", greenURL, err)
 	}
 
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return checkDistribution(t, clients, tealDomain, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return checkDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, blueDomain, test.ConcurrentRequests, min, []string{expectedBlue})
+		return checkDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, greenDomain, test.ConcurrentRequests, min, []string{expectedGreen})
+		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatalf("Error sending requests: %v", err)

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"testing"
 
@@ -76,30 +77,30 @@ func validateName(generateName, name string) error {
 
 func canServeRequests(t *testing.T, clients *test.Clients, route *v1alpha1.Route) error {
 	t.Logf("Route %s has a domain set in its status", route.Name)
-	var domain string
+	var url *url.URL
 	err := v1a1test.WaitForRouteState(
 		clients.ServingAlphaClient,
 		route.Name,
 		func(r *v1alpha1.Route) (bool, error) {
-			domain = r.Status.URL.Host
-			return domain != "", nil
+			url = r.Status.URL.URL()
+			return url != nil, nil
 		},
 		"RouteDomain",
 	)
 	if err != nil {
-		return fmt.Errorf("route did not get assigned a domain: %v", err)
+		return fmt.Errorf("route did not get assigned an URL : %v", err)
 	}
 
-	t.Logf("Route %s can serve the expected data at the endpoint", route.Name)
+	t.Logf("Route %s can serve the expected data at %s", route.Name, url)
 	_, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text %q: %v", route.Name, domain, test.HelloWorldText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", route.Name, url, test.HelloWorldText, err)
 	}
 
 	return nil
@@ -121,7 +122,7 @@ func TestServiceGenerateName(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer func() { test.TearDown(clients, names) }()
 
-	// Create the service using the generate name field. If the serivce does not become ready this will fail.
+	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, setServiceGenerateName(generateName))
 	if err != nil {

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -58,27 +59,27 @@ func TestCustomResourcesLimits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
-	domain := objects.Route.Status.URL.Host
+	endpoint := objects.Route.Status.URL.URL()
 
 	_, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		endpoint,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK)),
 		"ResourceTestServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("Error probing domain %s: %v", domain, err)
+		t.Fatalf("Error probing %s: %v", endpoint, err)
 	}
 
-	sendPostRequest := func(resolvableDomain bool, domain string, query string) (*spoof.Response, error) {
-		t.Logf("The domain of request is %s and its query is %s", domain, query)
-		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, resolvableDomain)
+	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
+		t.Logf("Request %s", url)
+		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), resolvableDomain)
 		if err != nil {
 			return nil, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s?%s", domain, query), nil)
+		req, err := http.NewRequest(http.MethodPost, url.String(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +87,11 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	pokeCowForMB := func(mb int) error {
-		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, domain, fmt.Sprintf("bloat=%d", mb))
+		u, _ := url.Parse(endpoint.String())
+		q := u.Query()
+		q.Set("bloat", fmt.Sprintf("%d", mb))
+		u.RawQuery = q.Encode()
+		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, u)
 		if err != nil {
 			return err
 		}

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -65,9 +66,9 @@ func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, r
 	return nil
 }
 
-// sendRequests send a request to "domain", returns error if unexpected response code, nil otherwise.
-func sendRequest(t *testing.T, clients *test.Clients, domain string, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+// sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
+func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, endpoint.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Logf("Spoofing client failed: %v", err)
 		return err
@@ -79,9 +80,14 @@ func sendRequest(t *testing.T, clients *test.Clients, domain string, initialSlee
 	start := time.Now().UnixNano()
 	defer func() {
 		end := time.Now().UnixNano()
-		t.Logf("domain: %v, initialSleep: %v, sleep: %v, request elapsed %.2f ms", domain, initialSleepMs, sleepMs, float64(end-start)/1e6)
+		t.Logf("URL: %v, initialSleep: %v, sleep: %v, request elapsed %.2f ms", endpoint, initialSleepMs, sleepMs, float64(end-start)/1e6)
 	}()
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s?initialTimeout=%v&timeout=%v", domain, initialSleepMs, sleepMs), nil)
+	u, _ := url.Parse(endpoint.String())
+	q := u.Query()
+	q.Set("initialTimeout", fmt.Sprintf("%d", initialSleepMs))
+	q.Set("timeout", fmt.Sprintf("%d", sleepMs))
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		t.Logf("Failed new request: %v", err)
 		return err
@@ -180,7 +186,7 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Failed to update Service: %v", err)
 	}
 
-	t.Log("Wait for the service domains to be ready")
+	t.Log("Wait for the service to be ready")
 	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
 	}
@@ -190,55 +196,51 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	var rev2sDomain, rev5sDomain string
+	var rev2sURL, rev5sURL *url.URL
 	for _, tt := range service.Status.Traffic {
 		if tt.Tag == rev2s.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			rev2sDomain = tt.URL.Host
+			rev2sURL = tt.URL.URL()
 		}
 		if tt.Tag == rev5s.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			rev5sDomain = tt.URL.Host
+			rev5sURL = tt.URL.URL()
 		}
 	}
-	if rev2sDomain == "" || rev5sDomain == "" {
+	if rev2sURL == nil || rev5sURL == nil {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
 
-	t.Logf("Probing domain %s", rev5sDomain)
+	t.Logf("Probing %s", rev5sURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		rev5sDomain,
+		rev5sURL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)
+		t.Fatalf("Error probing %s: %v", rev5sURL, err)
 	}
 
 	// Quick sanity check
-	if err := sendRequest(t, clients, rev2sDomain, 0, 0, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 0, 0, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
 	}
 
 	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sDomain, 5, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusServiceUnavailable); err != nil {
 		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 7, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusServiceUnavailable); err != nil {
 		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
 	}
 
 	// Not fail by not surpassing in the initial timeout, but in the overall request duration.
-	if err := sendRequest(t, clients, rev2sDomain, 1, 3, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 1, 3, http.StatusOK); err != nil {
 		t.Errorf("Did not fail request with sleep 1s/3s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 3, 3, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 3, 3, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 3s/3s with revision timeout 5s: %v", err)
 	}
 }

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"net/url"
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
@@ -27,7 +28,7 @@ import (
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
-func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, domain string, expectedGeneration, expectedText string) {
+func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedGeneration, expectedText string) {
 	t.Log("When the Route reports as Ready, everything should be ready.")
 	if err := v1a1test.WaitForRouteState(clients.ServingAlphaClient, names.Route, v1a1test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic to Revision %s: %v", names.Route, names.Revision, err)
@@ -39,12 +40,12 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, domain, expectedText, err)
+		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 
 	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
@@ -72,8 +73,8 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 	}
 }
 
-func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, error) {
-	var domain string
+func getRouteURL(clients *test.Clients, names test.ResourceNames) (*url.URL, error) {
+	var url *url.URL
 
 	err := v1a1test.WaitForRouteState(
 		clients.ServingAlphaClient,
@@ -82,12 +83,12 @@ func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, er
 			if r.Status.URL == nil {
 				return false, nil
 			}
-			domain = r.Status.URL.Host
-			return domain != "", nil
+			url = r.Status.URL.URL()
+			return url != nil, nil
 		},
-		"RouteDomain",
+		"RouteURL",
 	)
-	return domain, err
+	return url, err
 }
 
 func TestRouteCreation(t *testing.T) {
@@ -125,16 +126,16 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}
 
-	domain, err := getRouteDomain(clients, names)
+	url, err := getRouteURL(clients, names)
 	if err != nil {
-		t.Fatalf("Failed to get domain from route %s: %v", names.Route, err)
+		t.Fatalf("Failed to get URL from route %s: %v", names.Route, err)
 	}
 
-	t.Logf("The Route domain is: %s", domain)
-	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, domain, "1", test.PizzaPlanetText1)
+	t.Logf("The Route URL is: %s", url)
+	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "1", test.PizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, domain)
+	prober := test.RunRouteProber(t.Logf, clients, url)
 	defer test.AssertProberDefault(t, prober)
 
 	t.Log("Updating the Configuration to use a different image")
@@ -149,5 +150,5 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, test.PizzaPlanet2, err)
 	}
 
-	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, domain, "2", test.PizzaPlanetText2)
+	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "2", test.PizzaPlanetText2)
 }

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -77,7 +77,7 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.URL)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -225,7 +225,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.URL)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -323,7 +323,7 @@ func TestReleaseService(t *testing.T) {
 
 	t.Log("Service traffic should go to the first revision and be available on two names traffic targets: 'current' and 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedFirstRev, expectedFirstRev}); err != nil {
@@ -357,7 +357,7 @@ func TestReleaseService(t *testing.T) {
 
 	t.Log("Since the Service is using release the Route will not be updated, but new revision will be available at 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedSecondRev, expectedFirstRev}); err != nil {
@@ -422,7 +422,7 @@ func TestReleaseService(t *testing.T) {
 
 	t.Log("Traffic should be split between the two revisions and available on three named traffic targets, 'current', 'candidate', and 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"candidate", "latest", "current"},
 		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev}); err != nil {
@@ -454,7 +454,7 @@ func TestReleaseService(t *testing.T) {
 
 	t.Log("Traffic should remain between the two images, and the new revision should be available on the named traffic target 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"latest", "candidate", "current"},
 		[]string{expectedThirdRev, expectedSecondRev, expectedFirstRev}); err != nil {
@@ -507,7 +507,7 @@ func TestReleaseService(t *testing.T) {
 	}
 
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedThirdRev},
 		[]string{"latest", "candidate", "current"},
 		[]string{expectedThirdRev, expectedThirdRev, expectedFirstRev}); err != nil {

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -35,12 +36,12 @@ import (
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
-func waitForExpectedResponse(t *testing.T, clients *test.Clients, domain, expectedResponse string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, expectedResponse string) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -49,11 +50,13 @@ func waitForExpectedResponse(t *testing.T, clients *test.Clients, domain, expect
 }
 
 func validateDomains(
-	t *testing.T, clients *test.Clients, baseDomain string,
+	t *testing.T, clients *test.Clients, baseDomain *url.URL,
 	baseExpected, trafficTargets, targetsExpected []string) error {
-	var subdomains []string
+	var subdomains []*url.URL
 	for _, target := range trafficTargets {
-		subdomains = append(subdomains, target+"-"+baseDomain)
+		subdomain, _ := url.Parse(baseDomain.String())
+		subdomain.Host = target + "-" + baseDomain.Host
+		subdomains = append(subdomains, subdomain)
 	}
 
 	g, _ := errgroup.WithContext(context.Background())
@@ -64,14 +67,14 @@ func validateDomains(
 		// Check for each of the responses we expect from the base domain.
 		resp := resp
 		g.Go(func() error {
-			t.Logf("Waiting for route to update domain: %s", baseDomain)
+			t.Logf("Waiting for route to update %s", baseDomain)
 			return waitForExpectedResponse(t, clients, baseDomain, resp)
 		})
 	}
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Logf("Waiting for route to update domain: %s", s)
+			t.Logf("Waiting for route to update %s", s)
 			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
 		})
 	}
@@ -102,19 +105,19 @@ func validateDomains(
 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t *testing.T, clients *test.Clients, domain string, num, min int, expectedResponses []string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
 
-	t.Logf("Performing %d concurrent requests to %s", num, domain)
-	actualResponses, err := sendRequests(client, domain, num)
+	t.Logf("Performing %d concurrent requests to %s", num, url)
+	actualResponses, err := sendRequests(client, url, num)
 	if err != nil {
 		return err
 	}
 
-	return checkResponses(t, num, min, domain, expectedResponses, actualResponses)
+	return checkResponses(t, num, min, url.Hostname(), expectedResponses, actualResponses)
 }
 
 // checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
@@ -166,8 +169,8 @@ func checkResponses(t *testing.T, num int, min int, domain string, expectedRespo
 	return nil
 }
 
-// sendRequests sends "num" requests to "domain", returning a string for each spoof.Response.Body.
-func sendRequests(client spoof.Interface, domain string, num int) ([]string, error) {
+// sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
+func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
 	responses := make([]string, num)
 
 	// Launch "num" requests, recording the responses we get in "responses".
@@ -176,7 +179,7 @@ func sendRequests(client spoof.Interface, domain string, num int) ([]string, err
 		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
 		result := &responses[i]
 		g.Go(func() error {
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
 				return err
 			}
@@ -201,12 +204,12 @@ func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		names.Domain,
+		names.URL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, names.Domain, expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL.String(), expectedText, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -411,7 +412,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Verify that we get multiple files mounted in, in this case from the
 	// second source, which was partially shadowed in our check above.
-	names.Domain = names.Domain + "/another"
+	names.URL.Path = path.Join(names.URL.Path, "another")
 	if err = validateRunLatestDataPlane(t, clients, names, text2); err != nil {
 		t.Error(err)
 	}

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"context"
 	"math"
+	"net/url"
 	"testing"
 
 	"golang.org/x/sync/errgroup"
@@ -113,52 +114,48 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	var blueDomain, greenDomain string
+	var blueURL, greenURL *url.URL
 	for _, tt := range service.Status.Traffic {
 		if tt.Tag == blue.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			blueDomain = tt.URL.Host
+			blueURL = tt.URL.URL()
 		}
 		if tt.Tag == green.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			greenDomain = tt.URL.Host
+			greenURL = tt.URL.URL()
 		}
 	}
-	if blueDomain == "" || greenDomain == "" {
+	if blueURL == nil || greenURL == nil {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
-	tealDomain := service.Status.URL.Host
+	tealURL := service.Status.URL.URL()
 
 	// Istio network programming takes some time to be effective.  Currently Istio
 	// does not expose a Status, so we rely on probes to know when they are effective.
 	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
-	t.Logf("Probing domain %s", greenDomain)
+	t.Logf("Probing %s", greenURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		greenDomain,
+		greenURL,
 		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", greenDomain, err)
+		t.Fatalf("Error probing %s: %v", greenURL, err)
 	}
 
-	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
+	// Send concurrentRequests to blueURL, greenURL, and tealURL.
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return checkDistribution(t, clients, tealDomain, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return checkDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, blueDomain, test.ConcurrentRequests, min, []string{expectedBlue})
+		return checkDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, greenDomain, test.ConcurrentRequests, min, []string{expectedGreen})
+		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatalf("Error sending requests: %v", err)

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"testing"
 
@@ -76,13 +77,13 @@ func validateName(generateName, name string) error {
 
 func canServeRequests(t *testing.T, clients *test.Clients, route *v1beta1.Route) error {
 	t.Logf("Route %s has a domain set in its status", route.Name)
-	var domain string
+	var url *url.URL
 	err := v1b1test.WaitForRouteState(
 		clients.ServingBetaClient,
 		route.Name,
 		func(r *v1beta1.Route) (bool, error) {
-			domain = r.Status.URL.Host
-			return domain != "", nil
+			url = r.Status.URL.URL()
+			return url != nil, nil
 		},
 		"RouteDomain",
 	)
@@ -90,16 +91,16 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1beta1.Route)
 		return fmt.Errorf("route did not get assigned a domain: %v", err)
 	}
 
-	t.Logf("Route %s can serve the expected data at the endpoint", route.Name)
+	t.Logf("Route %s can serve the expected data at %s", route.Name, url)
 	_, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text %q: %v", route.Name, domain, test.HelloWorldText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", route.Name, url, test.HelloWorldText, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1beta1/resources_test.go
+++ b/test/conformance/api/v1beta1/resources_test.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -59,27 +60,27 @@ func TestCustomResourcesLimits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
-	domain := objects.Route.Status.URL.Host
+	endpoint := objects.Route.Status.URL.URL()
 
 	_, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		endpoint,
 		v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK)),
 		"ResourceTestServesText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("Error probing domain %s: %v", domain, err)
+		t.Fatalf("Error probing %s: %v", endpoint, err)
 	}
 
-	sendPostRequest := func(resolvableDomain bool, domain string, query string) (*spoof.Response, error) {
-		t.Logf("The domain of request is %s and its query is %s", domain, query)
-		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, resolvableDomain)
+	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
+		t.Logf("Request %s", url)
+		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), resolvableDomain)
 		if err != nil {
 			return nil, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s?%s", domain, query), nil)
+		req, err := http.NewRequest(http.MethodPost, url.String(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +88,11 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	pokeCowForMB := func(mb int) error {
-		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, domain, fmt.Sprintf("bloat=%d", mb))
+		u, _ := url.Parse(endpoint.String())
+		q := u.Query()
+		q.Set("bloat", fmt.Sprintf("%d", mb))
+		u.RawQuery = q.Encode()
+		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, u)
 		if err != nil {
 			return err
 		}

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -65,9 +66,9 @@ func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, r
 	return nil
 }
 
-// sendRequests send a request to "domain", returns error if unexpected response code, nil otherwise.
-func sendRequest(t *testing.T, clients *test.Clients, domain string, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+// sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
+func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL, initialSleepSeconds int, sleepSeconds int, expectedResponseCode int) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, endpoint.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Logf("Spoofing client failed: %v", err)
 		return err
@@ -79,9 +80,14 @@ func sendRequest(t *testing.T, clients *test.Clients, domain string, initialSlee
 	start := time.Now().UnixNano()
 	defer func() {
 		end := time.Now().UnixNano()
-		t.Logf("domain: %v, initialSleep: %v, sleep: %v, request elapsed %.2f ms", domain, initialSleepMs, sleepMs, float64(end-start)/1e6)
+		t.Logf("URL: %v, initialSleep: %v, sleep: %v, request elapsed %.2f ms", endpoint, initialSleepMs, sleepMs, float64(end-start)/1e6)
 	}()
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s?initialTimeout=%v&timeout=%v", domain, initialSleepMs, sleepMs), nil)
+	u, _ := url.Parse(endpoint.String())
+	q := u.Query()
+	q.Set("initialTimeout", fmt.Sprintf("%d", initialSleepMs))
+	q.Set("timeout", fmt.Sprintf("%d", sleepMs))
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		t.Logf("Failed new request: %v", err)
 		return err
@@ -186,55 +192,51 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}
 
-	var rev2sDomain, rev5sDomain string
+	var rev2sURL, rev5sURL *url.URL
 	for _, tt := range service.Status.Traffic {
 		if tt.Tag == rev2s.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			rev2sDomain = tt.URL.Host
+			rev2sURL = tt.URL.URL()
 		}
 		if tt.Tag == rev5s.TrafficTarget {
-			// Strip prefix as WaitForEndPointState expects a domain
-			// without scheme.
-			rev5sDomain = tt.URL.Host
+			rev5sURL = tt.URL.URL()
 		}
 	}
-	if rev2sDomain == "" || rev5sDomain == "" {
+	if rev2sURL == nil || rev5sURL == nil {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
 
-	t.Logf("Probing domain %s", rev5sDomain)
+	t.Logf("Probing %s", rev5sURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		rev5sDomain,
+		rev5sURL,
 		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", rev5sDomain, err)
+		t.Fatalf("Error probing %s: %v", rev5sURL, err)
 	}
 
 	// Quick sanity check
-	if err := sendRequest(t, clients, rev2sDomain, 0, 0, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 0, 0, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
 	}
 
 	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sDomain, 5, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusServiceUnavailable); err != nil {
 		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 7, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusServiceUnavailable); err != nil {
 		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
 	}
 
 	// Not fail by not surpassing in the initial timeout, but in the overall request duration.
-	if err := sendRequest(t, clients, rev2sDomain, 1, 3, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 1, 3, http.StatusOK); err != nil {
 		t.Errorf("Did not fail request with sleep 1s/3s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sDomain, 3, 3, http.StatusOK); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 3, 3, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 3s/3s with revision timeout 5s: %v", err)
 	}
 }

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"net/url"
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
@@ -29,7 +30,7 @@ import (
 	rtesting "knative.dev/serving/pkg/testing/v1beta1"
 )
 
-func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, domain string, expectedGeneration, expectedText string) {
+func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedGeneration, expectedText string) {
 	t.Log("When the Route reports as Ready, everything should be ready.")
 	if err := v1b1test.WaitForRouteState(clients.ServingBetaClient, names.Route, v1b1test.IsRouteReady, "RouteIsReady"); err != nil {
 		t.Fatalf("The Route %s was not marked as Ready to serve traffic to Revision %s: %v", names.Route, names.Revision, err)
@@ -41,12 +42,12 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, domain, expectedText, err)
+		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 
 	// We want to verify that the endpoint works as soon as Ready: True, but there are a bunch of other pieces of state that we validate for conformance.
@@ -74,8 +75,8 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 	}
 }
 
-func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, error) {
-	var domain string
+func getRouteURL(clients *test.Clients, names test.ResourceNames) (*url.URL, error) {
+	var url *url.URL
 
 	err := v1b1test.WaitForRouteState(
 		clients.ServingBetaClient,
@@ -84,13 +85,13 @@ func getRouteDomain(clients *test.Clients, names test.ResourceNames) (string, er
 			if r.Status.URL == nil {
 				return false, nil
 			}
-			domain = r.Status.URL.Host
-			return domain != "", nil
+			url = r.Status.URL.URL()
+			return url != nil, nil
 		},
-		"RouteDomain",
+		"RouteURL",
 	)
 
-	return domain, err
+	return url, err
 }
 
 func TestRouteCreation(t *testing.T) {
@@ -128,16 +129,16 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}
 
-	domain, err := getRouteDomain(clients, names)
+	url, err := getRouteURL(clients, names)
 	if err != nil {
-		t.Fatalf("Failed to get domain from route %s: %v", names.Route, err)
+		t.Fatalf("Failed to get URL from route %s: %v", names.Route, err)
 	}
 
-	t.Logf("The Route domain is: %s", domain)
-	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, domain, "1", test.PizzaPlanetText1)
+	t.Logf("The Route URL is: %s", url)
+	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "1", test.PizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, domain)
+	prober := test.RunRouteProber(t.Logf, clients, url)
 	defer test.AssertProberDefault(t, prober)
 
 	t.Log("Updating the Configuration to use a different image")
@@ -152,5 +153,5 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, test.PizzaPlanet2, err)
 	}
 
-	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, domain, "2", test.PizzaPlanetText2)
+	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "2", test.PizzaPlanetText2)
 }

--- a/test/conformance/api/v1beta1/service_test.go
+++ b/test/conformance/api/v1beta1/service_test.go
@@ -79,7 +79,7 @@ func TestService(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.URL)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -226,7 +226,7 @@ func TestServiceBYOName(t *testing.T) {
 	}
 
 	// We start a background prober to test if Route is always healthy even during Route update.
-	prober := test.RunRouteProber(t.Logf, clients, names.Domain)
+	prober := test.RunRouteProber(t.Logf, clients, names.URL)
 	defer test.AssertProberDefault(t, prober)
 
 	// Update Container Image
@@ -316,7 +316,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Service traffic should go to the first revision and be available on two names traffic targets: 'current' and 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedFirstRev, expectedFirstRev}); err != nil {
@@ -348,7 +348,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Since the Service is using release the Route will not be updated, but new revision will be available at 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev},
 		[]string{"latest", "current"},
 		[]string{expectedSecondRev, expectedFirstRev}); err != nil {
@@ -401,7 +401,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Traffic should be split between the two revisions and available on three named traffic targets, 'current', 'candidate', and 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"candidate", "latest", "current"},
 		[]string{expectedSecondRev, expectedSecondRev, expectedFirstRev}); err != nil {
@@ -431,7 +431,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Traffic should remain between the two images, and the new revision should be available on the named traffic target 'latest'")
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedSecondRev},
 		[]string{"latest", "candidate", "current"},
 		[]string{expectedThirdRev, expectedSecondRev, expectedFirstRev}); err != nil {
@@ -476,7 +476,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	}
 
 	if err := validateDomains(t, clients,
-		names.Domain,
+		names.URL,
 		[]string{expectedFirstRev, expectedThirdRev},
 		[]string{"latest", "candidate", "current"},
 		[]string{expectedThirdRev, expectedThirdRev, expectedFirstRev}); err != nil {

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -50,22 +50,22 @@ func TestSingleConcurrency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
-	domain := objects.Service.Status.URL.Host
+	url := objects.Service.Status.URL.URL()
 
 	// Ready does not actually mean Ready for a Route just yet.
 	// See https://knative.dev/serving/issues/1582
-	t.Logf("Probing domain %s", domain)
+	t.Logf("Probing %s", url)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", domain, err)
+		t.Fatalf("Error probing %s: %v", url, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestSingleConcurrency(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		group.Go(func() error {
 			done := time.After(duration)
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
 				return fmt.Errorf("error creating http request: %v", err)
 			}

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -35,12 +36,12 @@ import (
 	v1b1test "knative.dev/serving/test/v1beta1"
 )
 
-func waitForExpectedResponse(t *testing.T, clients *test.Clients, domain, expectedResponse string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, expectedResponse string) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -49,11 +50,13 @@ func waitForExpectedResponse(t *testing.T, clients *test.Clients, domain, expect
 }
 
 func validateDomains(
-	t *testing.T, clients *test.Clients, baseDomain string,
+	t *testing.T, clients *test.Clients, baseDomain *url.URL,
 	baseExpected, trafficTargets, targetsExpected []string) error {
-	var subdomains []string
+	var subdomains []*url.URL
 	for _, target := range trafficTargets {
-		subdomains = append(subdomains, target+"-"+baseDomain)
+		subdomain, _ := url.Parse(baseDomain.String())
+		subdomain.Host = target + "-" + baseDomain.Host
+		subdomains = append(subdomains, subdomain)
 	}
 
 	g, _ := errgroup.WithContext(context.Background())
@@ -64,14 +67,14 @@ func validateDomains(
 		// Check for each of the responses we expect from the base domain.
 		resp := resp
 		g.Go(func() error {
-			t.Logf("Waiting for route to update domain: %s", baseDomain)
+			t.Logf("Waiting for route to update %s", baseDomain)
 			return waitForExpectedResponse(t, clients, baseDomain, resp)
 		})
 	}
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Logf("Waiting for route to update domain: %s", s)
+			t.Logf("Waiting for route to update %s", s)
 			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
 		})
 	}
@@ -102,19 +105,19 @@ func validateDomains(
 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t *testing.T, clients *test.Clients, domain string, num, min int, expectedResponses []string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
 	}
 
-	t.Logf("Performing %d concurrent requests to %s", num, domain)
-	actualResponses, err := sendRequests(client, domain, num)
+	t.Logf("Performing %d concurrent requests to %s", num, url)
+	actualResponses, err := sendRequests(client, url, num)
 	if err != nil {
 		return err
 	}
 
-	return checkResponses(t, num, min, domain, expectedResponses, actualResponses)
+	return checkResponses(t, num, min, url.Hostname(), expectedResponses, actualResponses)
 }
 
 // checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
@@ -166,8 +169,8 @@ func checkResponses(t *testing.T, num int, min int, domain string, expectedRespo
 	return nil
 }
 
-// sendRequests sends "num" requests to "domain", returning a string for each spoof.Response.Body.
-func sendRequests(client spoof.Interface, domain string, num int) ([]string, error) {
+// sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
+func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
 	responses := make([]string, num)
 
 	// Launch "num" requests, recording the responses we get in "responses".
@@ -176,7 +179,7 @@ func sendRequests(client spoof.Interface, domain string, num int) ([]string, err
 		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
 		result := &responses[i]
 		g.Go(func() error {
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s", domain), nil)
+			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
 				return err
 			}
@@ -201,12 +204,12 @@ func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceN
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		names.Domain,
+		names.URL,
 		v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, names.Domain, expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL, expectedText, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1beta1/volumes_test.go
+++ b/test/conformance/api/v1beta1/volumes_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -411,7 +412,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Verify that we get multiple files mounted in, in this case from the
 	// second source, which was partially shadowed in our check above.
-	names.Domain = names.Domain + "/another"
+	names.URL.Path = path.Join(names.URL.Path, "another")
 	if err = validateDataPlane(t, clients, names, text2); err != nil {
 		t.Error(err)
 	}

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -62,7 +62,7 @@ func fetchRuntimeInfo(
 	resp, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		objects.Service.Status.URL.Host,
+		objects.Service.Status.URL.URL(),
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"RuntimeInfo",
 		test.ServingFlags.ResolvableDomain,

--- a/test/crd.go
+++ b/test/crd.go
@@ -19,6 +19,7 @@ package test
 // crd contains functions that construct boilerplate CRD definitions.
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -32,7 +33,7 @@ type ResourceNames struct {
 	Revision      string
 	Service       string
 	TrafficTarget string
-	Domain        string
+	URL           *url.URL
 	Image         string
 }
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -80,7 +81,7 @@ func TestDestroyPodInflight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error fetching Route %s: %v", names.Route, err)
 	}
-	domain := route.Status.URL.Host
+	routeURL := route.Status.URL.URL()
 
 	err = v1a1test.WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
@@ -96,21 +97,25 @@ func TestDestroyPodInflight(t *testing.T) {
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		routeURL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(timeoutExpectedOutput))),
 		"TimeoutAppServesText",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, domain, timeoutExpectedOutput, err)
+		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, routeURL, timeoutExpectedOutput, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, routeURL.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}
 
 	// The timeout app sleeps for the time passed via the timeout query parameter in milliseconds
 	timeoutRequestDurationInMillis := timeoutRequestDuration / time.Millisecond
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/?timeout=%d", domain, timeoutRequestDurationInMillis), nil)
+	u, _ := url.Parse(routeURL.String())
+	q := u.Query()
+	q.Set("timeout", fmt.Sprintf("%d", timeoutRequestDurationInMillis))
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		t.Fatalf("Error creating http request: %v", err)
 	}
@@ -229,16 +234,16 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}
-	domain := objects.Route.Status.URL.Host
+	routeURL := objects.Route.Status.URL.URL()
 
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		routeURL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"RouteServes",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("The endpoint for Route %s at domain %s didn't serve correctly: %v", names.Route, domain, err)
+		t.Fatalf("The endpoint for Route %s at %s didn't serve correctly: %v", names.Route, routeURL, err)
 	}
 
 	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace).List(metav1.ListOptions{
@@ -249,11 +254,15 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	}
 
 	// The request will sleep for more than 25 seconds.
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s?sleep=25001", domain), nil)
+	u, _ := url.Parse(routeURL.String())
+	q := u.Query()
+	q.Set("sleep", "25001")
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		t.Fatalf("Error creating HTTP request: %v", err)
 	}
-	httpClient, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain)
+	httpClient, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, u.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -56,13 +56,13 @@ func TestEgressTraffic(t *testing.T) {
 	if service.Route.Status.URL == nil {
 		t.Fatalf("Can't get internal request domain: service.Route.Status.URL is nil")
 	}
-	t.Log(service.Route.Status.URL.Host)
+	t.Log(service.Route.Status.URL.String())
 
-	domain := service.Route.Status.URL.Host
+	url := service.Route.Status.URL.URL()
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"HTTPProxy",
 		test.ServingFlags.ResolvableDomain); err != nil {

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -55,7 +55,7 @@ func TestHelloWorld(t *testing.T) {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
 
-	url := resources.Route.Status.URL.String()
+	url := resources.Route.Status.URL.URL()
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -115,16 +115,16 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
-	domain := resources.Route.Status.URL.Host
+	url := resources.Route.Status.URL.URL()
 
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, domain, test.HelloWorldText, err)
+		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, test.HelloWorldText, err)
 	}
 
 	revision := resources.Revision

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -36,12 +36,12 @@ func checkResponse(t *testing.T, clients *test.Clients, names test.ResourceNames
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		names.Domain,
+		names.URL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, names.Domain, expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL.String(), expectedText, err)
 	}
 
 	return nil

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -85,9 +85,10 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 	// helloworld app and its route are ready. Running the test cases now.
 	for _, tc := range testCases {
 		domain := fmt.Sprintf("%s-%s", tag, resources.Route.Status.Address.URL.Host)
-		helloworldDomain := strings.TrimSuffix(domain, tc.suffix)
+		helloworldURL := resources.Route.Status.Address.URL.URL()
+		helloworldURL.Host = strings.TrimSuffix(domain, tc.suffix)
 		t.Run(tc.name, func(t *testing.T) {
-			testProxyToHelloworld(t, clients, helloworldDomain, true, false)
+			testProxyToHelloworld(t, clients, helloworldURL, true, false)
 		})
 	}
 }

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -80,7 +80,7 @@ func validateWebSocketConnection(t *testing.T, clients *test.Clients, names test
 	}
 
 	// Establish the websocket connection.
-	conn, err := connect(t, gatewayIP, names.Domain)
+	conn, err := connect(t, gatewayIP, names.URL.Hostname())
 	if err != nil {
 		return err
 	}

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -23,6 +23,7 @@ package performance
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -68,28 +69,30 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
 
-	domain := objs.Route.Status.URL.Host
+	routeURL := objs.Route.Status.URL.URL()
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		routeURL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing domain %s: %v", domain, err)
+		t.Fatalf("Error probing %s: %v", routeURL, err)
 	}
 
-	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, domain, test.ServingFlags.ResolvableDomain,
+	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, routeURL.Hostname(), test.ServingFlags.ResolvableDomain,
 		pkgTest.Flags.IngressEndpoint)
 	if err != nil {
 		t.Fatalf("Cannot resolve service endpoint: %v", err)
 	}
 
+	u, _ := url.Parse(routeURL.String())
+	u.Host = endpoint
 	pacer := vegeta.ConstantPacer{Freq: baseQPS, Per: time.Second}
 	targeter := vegeta.NewStaticTargeter(vegeta.Target{
 		Method: http.MethodGet,
-		Header: resolvedHeaders(domain, test.ServingFlags.ResolvableDomain),
-		URL:    sanitizedURL(endpoint) + "?" + query,
+		Header: resolvedHeaders(routeURL.Hostname(), test.ServingFlags.ResolvableDomain),
+		URL:    u.String() + "?" + query,
 	})
 	attacker := vegeta.NewAttacker()
 

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -17,7 +17,6 @@ limitations under the License.
 package performance
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -35,7 +34,6 @@ const (
 	// Property name used by testgrid.
 	perfLatency = "perf_latency"
 	duration    = 1 * time.Minute
-	httpPrefix  = "http://"
 )
 
 // Enable monitoring components
@@ -88,12 +86,4 @@ func resolvedHeaders(domain string, resolvableDomain bool) map[string][]string {
 		headers["Host"] = []string{domain}
 	}
 	return headers
-}
-
-// sanitizedURL returns a URL that is guaranteed to have an httpPrefix.
-func sanitizedURL(endpoint string) string {
-	if !strings.HasPrefix(endpoint, httpPrefix) {
-		return httpPrefix + endpoint
-	}
-	return endpoint
 }

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -59,7 +59,7 @@ func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *v1a1test
 	t.Helper()
 	deploymentName := names.Deployment(ro.Revision)
 
-	domain := ro.Route.Status.URL.Host
+	url := ro.Route.Status.URL.URL()
 	t.Logf("%02d: waiting for deployment to scale to zero.", idx)
 	if err := e2e.WaitForScaleToZero(t, deploymentName, clients); err != nil {
 		m := fmt.Sprintf("%02d: failed waiting for deployment to scale to zero: %v", idx, err)
@@ -72,11 +72,11 @@ func runScaleFromZero(idx int, t *testing.T, clients *test.Clients, ro *v1a1test
 	if _, err := pkgTest.WaitForEndpointStateWithTimeout(
 		clients.KubeClient,
 		t.Logf,
-		domain,
+		url,
 		pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(helloWorldExpectedOutput)),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain, waitToServe); err != nil {
-		m := fmt.Sprintf("%02d: the endpoint for Route %q at domain %q didn't serve the expected text %q: %v", idx, ro.Route.Name, domain, helloWorldExpectedOutput, err)
+		m := fmt.Sprintf("%02d: the endpoint for Route %q at %q didn't serve the expected text %q: %v", idx, ro.Route.Name, url, helloWorldExpectedOutput, err)
 		t.Log(m)
 		return 0, errors.New(m)
 	}

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -55,14 +55,14 @@ func TestProbe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
-	domain := objects.Service.Status.URL.Host
+	url := objects.Service.Status.URL.URL()
 
 	// This polls until we get a 200 with the right body.
-	assertServiceResourcesUpdated(t, clients, names, domain, test.PizzaPlanetText1)
+	assertServiceResourcesUpdated(t, clients, names, url , test.PizzaPlanetText1)
 
 	// Use log.Printf instead of t.Logf because we want to see failures
 	// inline with other logs instead of buffered until the end.
-	prober := test.RunRouteProber(log.Printf, clients, domain)
+	prober := test.RunRouteProber(log.Printf, clients, url)
 	defer test.AssertProberDefault(t, prober)
 
 	// e2e-upgrade-test.sh will close this pipe to signal the upgrade is

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -54,10 +54,10 @@ func updateService(serviceName string, t *testing.T) {
 	names.Config = serviceresourcenames.Configuration(svc)
 	names.Revision = svc.Status.LatestCreatedRevisionName
 
-	routeDomain := svc.Status.URL.Host
+	routeURL := svc.Status.URL.URL()
 
 	t.Log("Check that we can hit the old service and get the old response.")
-	assertServiceResourcesUpdated(t, clients, names, routeDomain, test.PizzaPlanetText1)
+	assertServiceResourcesUpdated(t, clients, names, routeURL, test.PizzaPlanetText1)
 
 	t.Log("Updating the Service to use a different image")
 	newImage := ptest.ImagePath(test.PizzaPlanet2)
@@ -76,5 +76,5 @@ func updateService(serviceName string, t *testing.T) {
 	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
 	}
-	assertServiceResourcesUpdated(t, clients, names, routeDomain, test.PizzaPlanetText2)
+	assertServiceResourcesUpdated(t, clients, names, routeURL, test.PizzaPlanetText2)
 }

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -45,8 +45,8 @@ func TestRunLatestServicePreUpgrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
-	domain := resources.Service.Status.URL.Host
-	assertServiceResourcesUpdated(t, clients, names, domain, test.PizzaPlanetText1)
+	url := resources.Service.Status.URL.URL()
+	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
 }
 
 func TestRunLatestServicePreUpgradeAndScaleToZero(t *testing.T) {
@@ -65,8 +65,8 @@ func TestRunLatestServicePreUpgradeAndScaleToZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
-	domain := resources.Service.Status.URL.Host
-	assertServiceResourcesUpdated(t, clients, names, domain, test.PizzaPlanetText1)
+	url := resources.Service.Status.URL.URL()
+	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
 
 	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
 		t.Fatalf("Could not scale to zero: %v", err)

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -17,6 +17,7 @@ limitations under the License.
 package upgrade
 
 import (
+	"net/url"
 	"testing"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
@@ -37,17 +38,17 @@ const (
 )
 
 // Shamelessly cribbed from conformance/service_test.
-func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names test.ResourceNames, routeDomain, expectedText string) {
+func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
 	t.Helper()
 	// TODO(#1178): Remove "Wait" from all checks below this point.
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		routeDomain,
+		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text %q: %v", names.Route, routeDomain, expectedText, err)
+		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 }

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -40,7 +40,7 @@ func validateCreatedServiceStatus(clients *test.Clients, names *test.ResourceNam
 		if s.Status.URL == nil || s.Status.URL.Host == "" {
 			return false, fmt.Errorf("url is not present in Service status: %v", s)
 		}
-		names.Domain = s.Status.URL.Host
+		names.URL = s.Status.URL.URL()
 		if s.Status.LatestCreatedRevisionName == "" {
 			return false, fmt.Errorf("lastCreatedRevision is not present in Service status: %v", s)
 		}

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -42,18 +42,18 @@ import (
 func validateCreatedServiceStatus(clients *test.Clients, names *test.ResourceNames) error {
 	return CheckServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		if s.Status.URL == nil || s.Status.URL.Host == "" {
-			return false, fmt.Errorf("url is not present in Service status: %v", s)
+			return false, fmt.Errorf("URL is not present in Service status: %v", s)
 		}
-		names.Domain = s.Status.URL.Host
+		names.URL = s.Status.URL.URL()
 		if s.Status.LatestCreatedRevisionName == "" {
-			return false, fmt.Errorf("lastCreatedRevision is not present in Service status: %v", s)
+			return false, fmt.Errorf("LatestCreatedCreatedRevisionName is not present in Service status: %v", s)
 		}
 		names.Revision = s.Status.LatestCreatedRevisionName
 		if s.Status.LatestReadyRevisionName == "" {
-			return false, fmt.Errorf("lastReadyRevision is not present in Service status: %v", s)
+			return false, fmt.Errorf("LatestReadyRevisionName is not present in Service status: %v", s)
 		}
 		if s.Status.ObservedGeneration != 1 {
-			return false, fmt.Errorf("observedGeneration is not 1 in Service status: %v", s)
+			return false, fmt.Errorf("ObservedGeneration is not 1 in Service status: %v", s)
 		}
 		return true, nil
 	})

--- a/test/v1beta1/service.go
+++ b/test/v1beta1/service.go
@@ -39,18 +39,18 @@ import (
 func validateCreatedServiceStatus(clients *test.Clients, names *test.ResourceNames) error {
 	return CheckServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
 		if s.Status.URL == nil || s.Status.URL.Host == "" {
-			return false, fmt.Errorf("url is not present in Service status: %v", s)
+			return false, fmt.Errorf("URL is not present in Service status: %v", s)
 		}
-		names.Domain = s.Status.URL.Host
+		names.URL = s.Status.URL.URL()
 		if s.Status.LatestCreatedRevisionName == "" {
-			return false, fmt.Errorf("lastCreatedRevision is not present in Service status: %v", s)
+			return false, fmt.Errorf("LatestCreatedRevisionName is not present in Service status: %v", s)
 		}
 		names.Revision = s.Status.LatestCreatedRevisionName
 		if s.Status.LatestReadyRevisionName == "" {
-			return false, fmt.Errorf("lastReadyRevision is not present in Service status: %v", s)
+			return false, fmt.Errorf("LatestReadyRevisionName is not present in Service status: %v", s)
 		}
 		if s.Status.ObservedGeneration != 1 {
-			return false, fmt.Errorf("observedGeneration is not 1 in Service status: %v", s)
+			return false, fmt.Errorf("ObservedGeneration is not 1 in Service status: %v", s)
 		}
 		return true, nil
 	})

--- a/vendor/knative.dev/pkg/apis/url.go
+++ b/vendor/knative.dev/pkg/apis/url.go
@@ -76,3 +76,9 @@ func (u *URL) String() string {
 	uu := url.URL(*u)
 	return uu.String()
 }
+
+// URL returns the URL as a url.URL.
+func (u *URL) URL() *url.URL {
+	url := url.URL(*u)
+	return &url
+}

--- a/vendor/knative.dev/pkg/test/zipkin/util.go
+++ b/vendor/knative.dev/pkg/test/zipkin/util.go
@@ -126,12 +126,6 @@ func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 	})
 }
 
-// CheckZipkinPortAvailability checks to see if Zipkin Port is available on the machine.
-// returns error if the port is not available.
-func CheckZipkinPortAvailability() error {
-	return monitoring.CheckPortAvailability(ZipkinPort)
-}
-
 // JSONTrace returns a trace for the given traceID. It will continually try to get the trace. If the
 // trace it gets has the expected number of spans, then it will be returned. If not, it will try
 // again. If it reaches timeout, then it returns everything it has so far with an error.
@@ -162,11 +156,6 @@ func (*TimeoutError) Error() string {
 // jsonTrace gets a trace from Zipkin and returns it.
 func jsonTrace(traceID string) ([]model.SpanModel, error) {
 	var empty []model.SpanModel
-
-	// Check if zipkin port forwarding is setup correctly
-	if err := CheckZipkinPortAvailability(); err == nil {
-		return empty, err
-	}
 
 	resp, err := http.Get(ZipkinTraceEndpoint + traceID)
 	if err != nil {

--- a/vendor/knative.dev/pkg/testutils/clustermanager/boskos/boskos.go
+++ b/vendor/knative.dev/pkg/testutils/clustermanager/boskos/boskos.go
@@ -47,7 +47,7 @@ type Client struct {
 }
 
 func newClient(host *string) *boskosclient.Client {
-	if nil == host {
+	if host == nil {
 		hostName := common.GetOSEnv("JOB_NAME")
 		host = &hostName
 	}
@@ -61,7 +61,7 @@ func (c *Client) AcquireGKEProject(host *string) (*boskoscommon.Resource, error)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultWaitDuration)
 	defer cancel()
 	p, err := newClient(host).AcquireWait(ctx, GKEProjectResource, boskoscommon.Free, boskoscommon.Busy)
-	if nil != err {
+	if err != nil {
 		return nil, fmt.Errorf("boskos failed to acquire GKE project: %v", err)
 	}
 	if p == nil {
@@ -77,7 +77,7 @@ func (c *Client) AcquireGKEProject(host *string) (*boskoscommon.Resource, error)
 // other processes, regardless of where the other process is running.
 func (c *Client) ReleaseGKEProject(host *string, name string) error {
 	client := newClient(host)
-	if err := client.Release(name, boskoscommon.Dirty); nil != err {
+	if err := client.Release(name, boskoscommon.Dirty); err != nil {
 		return fmt.Errorf("boskos failed to release GKE project '%s': %v", name, err)
 	}
 	return nil

--- a/vendor/knative.dev/pkg/testutils/clustermanager/boskos/fake/fake.go
+++ b/vendor/knative.dev/pkg/testutils/clustermanager/boskos/fake/fake.go
@@ -33,7 +33,7 @@ type FakeBoskosClient struct {
 }
 
 func (c *FakeBoskosClient) getOwner(host *string) string {
-	if nil == host {
+	if host == nil {
 		return fakeOwner
 	}
 	return *host

--- a/vendor/knative.dev/pkg/testutils/clustermanager/util.go
+++ b/vendor/knative.dev/pkg/testutils/clustermanager/util.go
@@ -35,13 +35,13 @@ type ResourceType string
 func getResourceName(rt ResourceType) (string, error) {
 	var resName string
 	repoName, err := common.GetRepoName()
-	if nil != err {
+	if err != nil {
 		return "", fmt.Errorf("failed getting reponame for forming resource name: '%v'", err)
 	}
 	resName = fmt.Sprintf("k%s-%s", repoName, string(rt))
 	if common.IsProw() {
 		buildNumStr := common.GetOSEnv("BUILD_NUMBER")
-		if "" == buildNumStr {
+		if buildNumStr == "" {
 			return "", fmt.Errorf("failed getting BUILD_NUMBER env var")
 		}
 		if len(buildNumStr) > 20 {
@@ -53,7 +53,7 @@ func getResourceName(rt ResourceType) (string, error) {
 }
 
 func getClusterLocation(region, zone string) string {
-	if "" != zone {
+	if zone != "" {
 		region = fmt.Sprintf("%s-%s", region, zone)
 	}
 	return region

--- a/vendor/knative.dev/pkg/testutils/common/common.go
+++ b/vendor/knative.dev/pkg/testutils/common/common.go
@@ -38,13 +38,13 @@ func standardExec(name string, args ...string) ([]byte, error) {
 
 // IsProw checks if the process is initialized by Prow
 func IsProw() bool {
-	return "" != GetOSEnv("PROW_JOB_ID")
+	return GetOSEnv("PROW_JOB_ID") != ""
 }
 
 // GetRepoName gets repo name by the path where the repo cloned to
 func GetRepoName() (string, error) {
 	out, err := StandardExec("git", "rev-parse", "--show-toplevel")
-	if nil != err {
+	if err != nil {
 		return "", fmt.Errorf("failed git rev-parse --show-toplevel: '%v'", err)
 	}
 	return strings.TrimSpace(path.Base(string(out))), nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/5419 - Part II

## Proposed Changes
Today, in 99% of the E2E tests when a `ksvc` is created, we get `Status.URL.Host` and use this as `domain` to issue requests. This is is problematic because a lot of information is lost, namely the scheme and the port (`ur.URL.Host` contains the port but the test logic mostly ignores it). Then a lot of code is used to reconstruct an actual URL and it assumes it is HTTP (e.g. [here](https://github.com/knative/serving/blob/master/test/performance/observed_concurency_test.go#L169), [here](https://github.com/knative/serving/blob/master/test/e2e/activator_test.go#L81), [here](https://github.com/knative/serving/blob/master/test/e2e/autoscale_test.go#L80), [here](https://github.com/knative/serving/blob/master/test/e2e/autoscale_test.go#L119), [here](https://github.com/knative/serving/blob/master/test/e2e/destroypod_test.go#L114), [here](https://github.com/knative/serving/blob/master/test/e2e/service_to_service_test.go#L90), [here](https://github.com/knative/serving/blob/master/test/conformance/api/v1alpha1/single_threaded_test.go#L79), [here](https://github.com/knative/serving/blob/master/test/conformance/api/v1alpha1/revision_timeout_test.go#L84), [here](https://github.com/knative/serving/blob/master/test/conformance/api/v1alpha1/resources_test.go#L81), [here](https://github.com/knative/serving/blob/master/test/conformance/api/v1beta1/revision_timeout_test.go#L83), [here](https://github.com/knative/serving/blob/master/test/conformance/api/v1beta1/single_threaded_test.go#L80), [here](https://github.com/knative/serving/blob/master/test/conformance/api/v1beta1/resources_test.go#L82)). Also, some codes makes assumptions if there is a scheme or not. It is all over the place.

We want tests to be protocol agnostic as much as possible to be able to run them for HTTP, HTTP2, HTTPS, and maybe gRPC.

This changes uses `Status.URL` directly instead of `Status.URL.Host`. Only a clean full URL is passed around.

## TODO
* [x] Cleanup the naming
* [x] Perf tests use custom spoofing, refactor?
* [x] Corresponding `knative.dev/pkg` PR: https://github.com/knative/pkg/pull/670
* [x] Revert `vendor/` temp changes
* [x] `dep ensure -update knative.dev/pkg && hack/update-deps.sh && hack/update-codegen.sh`