### PR TITLE
Try to use sets everywhere in the activator code.

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -58,6 +58,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -124,7 +125,7 @@ func TestActivationHandler(t *testing.T) {
 		endpointsInformer: endpointsInformer(endpoints(testNamespace, testRevName, 1000, networking.ServicePortNameHTTP1)),
 		destsUpdates: []*activatornet.RevisionDestsUpdate{{
 			Rev:   types.NamespacedName{"fake-namespace", testRevName},
-			Dests: []string{},
+			Dests: sets.NewString(),
 		}},
 		reporterCalls: nil,
 		tryTimeout:    100 * time.Millisecond,
@@ -612,10 +613,10 @@ func sksLister(skss ...*nv1a1.ServerlessService) netlisters.ServerlessServiceLis
 	return services.Lister()
 }
 
-func dests(count int) []string {
-	ret := make([]string, count)
+func dests(count int) sets.String {
+	ret := sets.NewString()
 	for i := 1; i <= count; i++ {
-		ret[i-1] = fmt.Sprintf("127.0.0.%v:1234", i)
+		ret.Insert(fmt.Sprintf("127.0.0.%v:1234", i))
 	}
 	return ret
 }

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -21,13 +21,15 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"knative.dev/serving/pkg/apis/networking"
 )
 
-// EndpointsToDests takes an endpoints object and a port name and returns a list
+// endpointsToDests takes an endpoints object and a port name and returns a list
 // of l4 dests in the endpoints object which have that port
-func EndpointsToDests(endpoints *corev1.Endpoints, portName string) []string {
-	ret := []string{}
+func endpointsToDests(endpoints *corev1.Endpoints, portName string) sets.String {
+	ret := sets.NewString()
 
 	for _, es := range endpoints.Subsets {
 		for _, port := range es.Ports {
@@ -35,7 +37,7 @@ func EndpointsToDests(endpoints *corev1.Endpoints, portName string) []string {
 				portStr := strconv.Itoa(int(port.Port))
 				for _, addr := range es.Addresses {
 					// Prefer IP as we can avoid a DNS lookup this way.
-					ret = append(ret, net.JoinHostPort(addr.IP, portStr))
+					ret.Insert(net.JoinHostPort(addr.IP, portStr))
 				}
 			}
 		}

--- a/pkg/activator/net/helpers_test.go
+++ b/pkg/activator/net/helpers_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/serving/pkg/apis/networking"
 )
 
@@ -91,9 +92,9 @@ func TestEndpointsToDests(t *testing.T) {
 			if tc.protocol == "" {
 				tc.protocol = networking.ProtocolHTTP1
 			}
-			dests := EndpointsToDests(&tc.endpoints, networking.ServicePortName(tc.protocol))
+			dests := endpointsToDests(&tc.endpoints, networking.ServicePortName(tc.protocol))
 
-			if got, want := dests, tc.expectDests; !cmp.Equal(got, want) {
+			if got, want := dests, sets.NewString(tc.expectDests...); !got.Equal(want) {
 				t.Errorf("Got unexpected dests (-want, +got): %s", cmp.Diff(want, got))
 			}
 		})

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -57,7 +56,7 @@ import (
 type RevisionDestsUpdate struct {
 	Rev           types.NamespacedName
 	ClusterIPDest string
-	Dests         []string
+	Dests         sets.String
 }
 
 const (
@@ -79,13 +78,13 @@ type revisionWatcher struct {
 	clusterIPHealthy bool
 
 	transport     http.RoundTripper
-	destsChan     <-chan []string
+	destsChan     <-chan sets.String
 	serviceLister corev1listers.ServiceLister
 	logger        *zap.SugaredLogger
 }
 
 func newRevisionWatcher(doneCh <-chan struct{}, rev types.NamespacedName, protocol networking.ProtocolType,
-	updateCh chan<- *RevisionDestsUpdate, destsChan <-chan []string,
+	updateCh chan<- *RevisionDestsUpdate, destsChan <-chan sets.String,
 	transport http.RoundTripper, serviceLister corev1listers.ServiceLister,
 	logger *zap.SugaredLogger) *revisionWatcher {
 	return &revisionWatcher{
@@ -156,27 +155,24 @@ func (rw *revisionWatcher) probeClusterIP(dest string) (bool, error) {
 }
 
 // probePodIPs will probe the given target Pod IPs and will return
-// the ones that are successfully probed, or an error.
-func (rw *revisionWatcher) probePodIPs(dests []string) (sets.String, error) {
+// the ones that are successfully probed, whether the update was a no-op, or an error.
+func (rw *revisionWatcher) probePodIPs(dests sets.String) (sets.String, bool, error) {
 	// Short circuit case where dests == healthyPods
-	if rw.allDestsHealthy(dests) {
-		return rw.healthyPods, nil
+	if rw.healthyPods.Equal(dests) {
+		return rw.healthyPods, true /*no-op*/, nil
 	}
+
+	toProbe := dests.Difference(rw.healthyPods)
+	healthy := dests.Intersection(rw.healthyPods)
 
 	// Context used for our probe requests
 	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
 
 	var probeGroup errgroup.Group
-	healthyDests := make(chan string, len(dests))
+	healthyDests := make(chan string, len(toProbe))
 
-	for _, dest := range dests {
-		// Good known Pod, no need to re-probe.
-		if rw.healthyPods.Has(dest) {
-			healthyDests <- dest
-			continue
-		}
-
+	for dest := range toProbe {
 		dest := dest // Standard Go concurrency pattern.
 		probeGroup.Go(func() error {
 			ok, err := rw.probe(ctx, dest)
@@ -190,15 +186,13 @@ func (rw *revisionWatcher) probePodIPs(dests []string) (sets.String, error) {
 	err := probeGroup.Wait()
 	close(healthyDests)
 
-	hs := sets.NewString()
 	for d := range healthyDests {
-		hs.Insert(d)
+		healthy.Insert(d)
 	}
-
-	return hs, err
+	return healthy, false, err
 }
 
-func (rw *revisionWatcher) sendUpdate(clusterIP string, dests []string) {
+func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String) {
 	select {
 	case <-rw.doneCh:
 		// We're not closing updateCh because this would result in 1 close per revisionWatcher.
@@ -213,7 +207,7 @@ func (rw *revisionWatcher) sendUpdate(clusterIP string, dests []string) {
 
 // checkDests performs probing and potentially sends a dests update. It is
 // assumed this method is not called concurrently.
-func (rw *revisionWatcher) checkDests(dests []string) {
+func (rw *revisionWatcher) checkDests(dests sets.String) {
 	if len(dests) == 0 {
 		// We must have scaled down.
 		rw.clusterIPHealthy = false
@@ -251,33 +245,21 @@ func (rw *revisionWatcher) checkDests(dests []string) {
 		return
 	}
 
-	hs, err := rw.probePodIPs(dests)
+	hs, noop, err := rw.probePodIPs(dests)
 	if err != nil {
 		rw.logger.Errorw("Failed probing", zap.Error(err))
 		// We dont want to return here as an error still affects health states.
 	}
 
 	rw.logger.Debugf("Done probing, got %d healthy pods", len(hs))
-	if !reflect.DeepEqual(rw.healthyPods, hs) {
+	if !noop && !hs.Equal(rw.healthyPods) {
 		rw.healthyPods = hs
-		rw.sendUpdate("" /*clusterIP not ready yet*/, hs.UnsortedList())
+		rw.sendUpdate("" /*clusterIP not ready yet*/, hs)
 	}
-}
-
-func (rw *revisionWatcher) allDestsHealthy(dests []string) bool {
-	if len(dests) != len(rw.healthyPods) {
-		return false
-	}
-	for _, dest := range dests {
-		if !rw.healthyPods.Has(dest) {
-			return false
-		}
-	}
-	return true
 }
 
 func (rw *revisionWatcher) run(probeFrequency time.Duration) {
-	var dests []string
+	var dests sets.String
 	var timer *time.Timer
 
 	for {
@@ -311,7 +293,7 @@ func (rw *revisionWatcher) run(probeFrequency time.Duration) {
 
 type revisionWatcherCh struct {
 	revisionWatcher *revisionWatcher
-	ch              chan []string
+	ch              chan sets.String
 }
 
 // RevisionBackendsManager listens to revision endpoints and keeps track of healthy
@@ -391,7 +373,7 @@ func (rbm *RevisionBackendsManager) getOrCreateRevisionWatcher(rev types.Namespa
 			return nil, err
 		}
 
-		destsCh := make(chan []string)
+		destsCh := make(chan sets.String)
 		rw := newRevisionWatcher(rbm.doneCh, rev, proto, rbm.updateCh, destsCh, rbm.transport, rbm.serviceLister, rbm.logger)
 		rbm.revisionWatchers[rev] = &revisionWatcherCh{rw, destsCh}
 		go rw.run(rbm.probeFrequency)
@@ -414,7 +396,7 @@ func (rbm *RevisionBackendsManager) endpointsUpdated(newObj interface{}) {
 			zap.Error(err))
 		return
 	}
-	dests := EndpointsToDests(endpoints, networking.ServicePortName(rwCh.revisionWatcher.protocol))
+	dests := endpointsToDests(endpoints, networking.ServicePortName(rwCh.revisionWatcher.protocol))
 	rbm.logger.Debugf("Updating Endpoints: %q (backends: %d)", revID.String(), len(dests))
 	rwCh.ch <- dests
 }

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -249,7 +249,7 @@ func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update *Revision
 		trackers := make([]*podIPTracker, 0, len(update.Dests))
 
 		// Loop over dests, reuse existing tracker if we have one otherwise create new
-		for _, newDest := range update.Dests {
+		for newDest := range update.Dests {
 			tracker, ok := trackersMap[newDest]
 			if !ok {
 				tracker = &podIPTracker{dest: newDest}

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
@@ -62,7 +63,7 @@ func TestThrottler(t *testing.T) {
 		},
 		initUpdates: []*RevisionDestsUpdate{{
 			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
-			Dests: []string{"128.0.0.1:1234"},
+			Dests: sets.NewString("128.0.0.1:1234"),
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -78,7 +79,7 @@ func TestThrottler(t *testing.T) {
 		initUpdates: []*RevisionDestsUpdate{{
 			Rev:           types.NamespacedName{"test-namespace", "test-revision"},
 			ClusterIPDest: "129.0.0.1:1234",
-			Dests:         []string{"128.0.0.1:1234"},
+			Dests:         sets.NewString("128.0.0.1:1234"),
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -93,7 +94,7 @@ func TestThrottler(t *testing.T) {
 		},
 		initUpdates: []*RevisionDestsUpdate{{
 			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
-			Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
+			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -110,11 +111,11 @@ func TestThrottler(t *testing.T) {
 		},
 		initUpdates: []*RevisionDestsUpdate{{
 			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
-			Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
+			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}, {
 			Rev:           types.NamespacedName{"test-namespace", "test-revision"},
 			ClusterIPDest: "129.0.0.1:1234",
-			Dests:         []string{"128.0.0.1:1234", "128.0.0.2:1234"},
+			Dests:         sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -132,7 +133,7 @@ func TestThrottler(t *testing.T) {
 		initUpdates: []*RevisionDestsUpdate{{
 			Rev:           types.NamespacedName{"test-namespace", "test-revision"},
 			ClusterIPDest: "129.0.0.1:1234",
-			Dests:         []string{"128.0.0.1:1234"},
+			Dests:         sets.NewString("128.0.0.1:1234"),
 		}},
 		trys: []types.NamespacedName{
 			{Namespace: "test-namespace", Name: "test-revision"},
@@ -149,7 +150,7 @@ func TestThrottler(t *testing.T) {
 		},
 		initUpdates: []*RevisionDestsUpdate{{
 			Rev:   types.NamespacedName{"test-namespace", "test-revision"},
-			Dests: []string{"128.0.0.1:1234"},
+			Dests: sets.NewString("128.0.0.1:1234"),
 		}},
 		deletes: []types.NamespacedName{
 			{"test-namespace", "test-revision"},
@@ -228,6 +229,7 @@ func TestThrottler(t *testing.T) {
 }
 
 func TestMultipleActivator(t *testing.T) {
+	defer ClearAll()
 	fake := kubefake.NewSimpleClientset()
 	informer := kubeinformers.NewSharedInformerFactory(fake, 0)
 	endpoints := informer.Core().V1().Endpoints()
@@ -254,10 +256,11 @@ func TestMultipleActivator(t *testing.T) {
 	throttler := NewThrottler(params, revisions, endpoints, TestLogger(t))
 
 	revID := types.NamespacedName{"test-namespace", "test-revision"}
-	updateCh := make(chan *RevisionDestsUpdate, 10)
+	possibleDests := sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.23:1234")
+	updateCh := make(chan *RevisionDestsUpdate, 1)
 	updateCh <- &RevisionDestsUpdate{
 		Rev:   revID,
-		Dests: []string{"128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.23:1234"},
+		Dests: possibleDests,
 	}
 	close(updateCh)
 	throttler.Run(updateCh)
@@ -283,18 +286,18 @@ func TestMultipleActivator(t *testing.T) {
 		defer cancel()
 
 		results := tryThrottler(throttler, []types.NamespacedName{revID, revID}, tryContext)
-		if diff := cmp.Diff([]tryResult{
-			{Dest: "128.0.0.1:1234"},
-			{ErrString: context.DeadlineExceeded.Error()},
-		}, results); diff != "" {
-			t.Errorf("Got unexpected try results (-want, +got): %v", diff)
+		if !possibleDests.Has(results[0].Dest) {
+			t.Errorf("Request went to an unknown destination: %s, possibles: %v", results[0].Dest, possibleDests)
 		}
-
+		if got, want := results[1].ErrString, context.DeadlineExceeded.Error(); got != want {
+			t.Errorf("Error = %s, want: %s", got, want)
+		}
 	}()
 }
 
 func tryThrottler(throttler *Throttler, trys []types.NamespacedName, ctx context.Context) []tryResult {
 	resCh := make(chan tryResult)
+	defer close(resCh)
 	var tryWaitg sync.WaitGroup
 	tryWaitg.Add(len(trys))
 	for _, revID := range trys {
@@ -317,8 +320,6 @@ func tryThrottler(throttler *Throttler, trys []types.NamespacedName, ctx context
 	for i := range trys {
 		res[i] = <-resCh
 	}
-	close(resCh)
-
 	return res
 }
 

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -236,7 +236,6 @@ func TestServiceToServiceCall(t *testing.T) {
 }
 
 func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA bool, injectB bool) {
-
 	t.Log("Creating helloworld Service")
 
 	testNames := test.ResourceNames{


### PR DESCRIPTION
Sets have a few nice functions (like we can easily compute the set of things to probe),
but also harden our tests, since the map iteration order is not guaranteed to be the same (hence I had to patch one of the tests that expected a specific IP, but in reality any of them are just as good).

Also hide `endspointsToDests` since its scope is the package.

/assign @greghaynes @markusthoemmes mattmoor

/lint
