### PR TITLE
[WIP] Attempt to reduce 502s in queue-proxy due to connect errors

### DIFF
--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -91,7 +91,7 @@ func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.Ro
 		Proxy:                 http.ProxyFromEnvironment,
 		MaxIdleConns:          1000,
 		MaxIdleConnsPerHost:   100,
-		IdleConnTimeout:       5 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		DisableKeepAlives:     disableKeepAlives,

--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -69,16 +69,13 @@ func dialBackOffHelper(ctx context.Context, network, address string, steps int, 
 	for i := 0; i < steps; i++ {
 		c, err := dialer.DialContext(ctx, network, address)
 		if err != nil {
-			if err, ok := err.(net.Error); ok && err.Temporary() {
-				if i == steps-1 {
-					break
-				}
-				to *= factor
-				dialer.Timeout = time.Duration(to)
-				time.Sleep(wait.Jitter(sleep, 1.0)) // Sleep with jitter.
-				continue
+			if i == steps-1 {
+				break
 			}
-			return nil, err
+			to *= factor
+			dialer.Timeout = time.Duration(to)
+			time.Sleep(wait.Jitter(sleep, 1.0)) // Sleep with jitter.
+			continue
 		}
 		return c, err
 	}

--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -69,7 +69,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, steps int, 
 	for i := 0; i < steps; i++ {
 		c, err := dialer.DialContext(ctx, network, address)
 		if err != nil {
-			if err, ok := err.(net.Error); ok && err.Timeout() {
+			if err, ok := err.(net.Error); ok && (err.Timeout() || err.Temporary()) {
 				if i == steps-1 {
 					break
 				}

--- a/pkg/network/transports.go
+++ b/pkg/network/transports.go
@@ -69,7 +69,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, steps int, 
 	for i := 0; i < steps; i++ {
 		c, err := dialer.DialContext(ctx, network, address)
 		if err != nil {
-			if err, ok := err.(net.Error); ok && (err.Timeout() || err.Temporary()) {
+			if err, ok := err.(net.Error); ok && err.Temporary() {
 				if i == steps-1 {
 					break
 				}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Also retry on 'connection refused' errors, instead of just 'connect timeout'.
* Reset the IdleConnectionTimeout back to 90s, since #4756 makes the change in #3996 unnecessary.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
