### PR TITLE
Remove ability to save zipkin tracing for perf tests

### DIFF
--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -49,58 +49,6 @@ if err != nil {
 }
 ```
 
-## Zipkin trace
-
-Zipkin tracing can be enabled if needed by the performance test during setup.
-
-```go
-perfClients, err := Setup(t, EnableZipkinTracing)
-```
-
-Once enabled, all requests made by the `SpoofingClient` will have an additional
-trace header. This can be used to get the entire request trace and store it in a
-trace file in the artifacts directory using the
-[AddTrace()](https://github.com/knative/serving/blob/master/test/performance/performance.go)
-method.
-
-Sample Trace:
-
-```
-[
-    ...
-    {
-      "traceId": "f5bd1989e056eec7aa790bbb914b77f9",
-      "parentId": "b7dfefa0fe93308b",
-      "id": "c994972581898fcd",
-      "kind": "SERVER",
-      "name": "activator-service.knative-serving.svc.cluster.local:80/*",
-      "timestamp": 1552595276313951,
-      "duration": 1872929,
-      "localEndpoint": {
-        "serviceName": "activator",
-        "ipv4": "10.16.4.89"
-      },
-      "tags": {
-        "component": "proxy",
-        "downstream_cluster": "-",
-        "error": "true",
-        "guid:x-request-id": "efacbe52-9a03-40a7-a7f2-d35f9c8b1dff",
-        "http.method": "GET",
-        "http.protocol": "HTTP/1.1",
-        "http.status_code": "500",
-        "http.url": "http://scale-to-n-scale-100-40-xxackadp.serving-tests.example.com/",
-        "node_id": "sidecar~10.16.4.89~activator-68664559c9-zl2sl.knative-serving~knative-serving.svc.cluster.local",
-        "request_size": "0",
-        "response_flags": "-",
-        "response_size": "0",
-        "upstream_cluster": "inbound|80||activator-service.knative-serving.svc.cluster.local",
-        "user_agent": "Go-http-client/1.1"
-      },
-      "shared": true
-    }
-]
-```
-
 ## Displaying metrics
 
 Once the test is done, each test can define which metrics they want to be

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -17,9 +17,6 @@ limitations under the License.
 package performance
 
 import (
-	"fmt"
-	"os"
-	"path"
 	"strings"
 	"testing"
 	"time"
@@ -27,10 +24,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/prometheus"
-	"knative.dev/pkg/test/zipkin"
 	"knative.dev/serving/test"
-	"knative.dev/test-infra/shared/common"
-	"knative.dev/test-infra/shared/prow"
 
 	// Mysteriously required to support GCP auth (required by k8s libs). Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -41,14 +35,12 @@ const (
 	// Property name used by testgrid.
 	perfLatency = "perf_latency"
 	duration    = 1 * time.Minute
-	traceSuffix = "-Trace.json"
 	httpPrefix  = "http://"
 )
 
 // Enable monitoring components
 const (
 	EnablePrometheus = iota
-	EnableZipkinTracing
 )
 
 // Client is the client used in the performance tests.
@@ -56,9 +48,6 @@ type Client struct {
 	E2EClients *test.Clients
 	PromClient *prometheus.PromProxy
 }
-
-// traceFile is the name of the
-var traceFile *os.File
 
 // Setup creates all the clients that we need to interact with in our tests
 func Setup(t *testing.T, monitoring ...int) (*Client, error) {
@@ -74,22 +63,6 @@ func Setup(t *testing.T, monitoring ...int) (*Client, error) {
 			t.Log("Creating prometheus proxy client")
 			p = &prometheus.PromProxy{Namespace: monitoringNS}
 			p.Setup(clients.KubeClient.Kube, t.Logf)
-		case EnableZipkinTracing:
-			// Enable zipkin tracing
-			zipkin.SetupZipkinTracing(clients.KubeClient.Kube, t.Logf)
-
-			// Create file to store traces
-			dir := prow.GetLocalArtifactsDir()
-			if err := common.CreateDir(dir); nil != err {
-				t.Log("Cannot create the artifacts dir. Will not log tracing.")
-			} else {
-				name := path.Join(dir, t.Name()+traceSuffix)
-				t.Logf("Storing traces in %s", name)
-				traceFile, err = os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-				if err != nil {
-					t.Log("Unable to create tracing file.")
-				}
-			}
 		default:
 			t.Log("No monitoring components enabled")
 		}
@@ -105,34 +78,6 @@ func TearDown(client *Client, names test.ResourceNames, logf logging.FormatLogge
 	// Teardown prometheus client
 	if client.PromClient != nil {
 		client.PromClient.Teardown(logf)
-	}
-
-	// disable zipkin
-	if traceFile != nil {
-		zipkin.CleanupZipkinTracingSetup(logf)
-		traceFile.Close()
-	}
-}
-
-// AddTrace gets the JSON zipkin trace for the traceId and stores it.
-// https://github.com/openzipkin/zipkin-go/blob/master/model/span.go defines the struct for the JSON
-func AddTrace(logf logging.FormatLogger, tName string, traceID string) {
-	if traceFile == nil {
-		logf("Trace file is not setup correctly. Exiting without adding trace")
-		return
-	}
-
-	// Sleep to get traces
-	time.Sleep(5 * time.Second)
-
-	trace, err := zipkin.JSONTrace(traceID)
-	if err != nil {
-		logf("Skipping trace %s due to error: %v", traceID, err)
-		return
-	}
-
-	if _, err := traceFile.WriteString(fmt.Sprintf("%s,\n", trace)); err != nil {
-		logf("Cannot write to trace file: %v", err)
 	}
 }
 


### PR DESCRIPTION
This feature is currently not working as expected and not being used by the current perf infra. We are modifying the zipkin lib to actually work and will serving will need some other way to integrate with that lib for tests with the current perf infra.