### PR TITLE
Don't copy over v1 to v1alpha1 on update-codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -27,7 +27,7 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
 # Clone the v1beta1 types to v1alpha1 sans v1beta1.
 for x in $(ls "${REPO_ROOT_DIR}/config/v1beta1"); do
-  sed -e '28,30d' "${REPO_ROOT_DIR}/config/v1beta1/$x" > "${REPO_ROOT_DIR}/config/v1alpha1/$x"
+  sed -e '28,33d' "${REPO_ROOT_DIR}/config/v1beta1/$x" > "${REPO_ROOT_DIR}/config/v1alpha1/$x"
 done
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}


### PR DESCRIPTION
Extend the sed statement to remove the new v1 endpoint from the v1alpha1
folder. Ideally we should generate both from a common template, but
keeping this change small as to unblock other changes that nee to run
update-codegen.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
