### PR TITLE
Add serving.knative.dev/release pod labels to networking-certmanager and networking-istio deployments

### DIFF
--- a/config/networking-certmanager.yaml
+++ b/config/networking-certmanager.yaml
@@ -31,6 +31,7 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: networking-certmanager
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/networking-istio.yaml
+++ b/config/networking-istio.yaml
@@ -31,6 +31,7 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:


### PR DESCRIPTION
## Proposed Changes

Networking-certmanager and networking-istio deployments are missing
'serving.knative.dev/release' label in their pod template. Add it for
consistency with all other knative controller deployments

/lint