### PR TITLE
Use gateway endpoints instead of pods in the status prober.

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/pkg/apis/istio/v1alpha3"
 	gatewayinformer "knative.dev/pkg/client/injection/informers/istio/v1alpha3/gateway"
 	virtualserviceinformer "knative.dev/pkg/client/injection/informers/istio/v1alpha3/virtualservice"
-	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
+	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/tracker"
@@ -84,7 +84,7 @@ func (c *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 	c.Logger.Info("Setting up Ingress event handlers")
 	clusterIngressInformer := clusteringressinformer.Get(ctx)
 	gatewayInformer := gatewayinformer.Get(ctx)
-	podInformer := podinformer.Get(ctx)
+	endpointsInformer := endpointsinformer.Get(ctx)
 
 	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
 	clusterIngressHandler := cache.FilteringResourceEventHandler{
@@ -117,7 +117,7 @@ func (c *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 		impl.EnqueueLabelOfClusterScopedResource(networking.ClusterIngressLabelKey)(vs)
 	}
 	statusProber := ing.NewStatusProber(c.Logger.Named("status-manager"), gatewayInformer.Lister(),
-		podInformer.Lister(), network.NewAutoTransport, resyncIngressOnVirtualServiceReady)
+		endpointsInformer.Lister(), network.NewAutoTransport, resyncIngressOnVirtualServiceReady)
 	c.BaseIngressReconciler.StatusManager = statusProber
 	statusProber.Start(ctx.Done())
 

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -27,7 +27,7 @@ import (
 	_ "knative.dev/pkg/client/injection/informers/istio/v1alpha3/gateway/fake"
 	_ "knative.dev/pkg/client/injection/informers/istio/v1alpha3/virtualservice/fake"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/clusteringress/fake"

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -29,7 +29,7 @@ import (
 	ingressinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress"
 	listers "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
 
-	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
+	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	istiolisters "knative.dev/pkg/client/listers/istio/v1alpha3"
 	"knative.dev/pkg/configmap"
@@ -148,7 +148,7 @@ func (r *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 	r.Logger.Info("Setting up Ingress event handlers")
 	ingressInformer := ingressinformer.Get(ctx)
 	gatewayInformer := gatewayinformer.Get(ctx)
-	podInformer := podinformer.Get(ctx)
+	endpointsInformer := endpointsinformer.Get(ctx)
 
 	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
 	ingressHandler := cache.FilteringResourceEventHandler{
@@ -181,7 +181,7 @@ func (r *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 		impl.EnqueueLabelOfNamespaceScopedResource(serving.RouteNamespaceLabelKey, serving.RouteLabelKey)(vs)
 	}
 	statusProber := NewStatusProber(r.Logger.Named("status-manager"), gatewayInformer.Lister(),
-		podInformer.Lister(), network.NewAutoTransport, resyncIngressOnVirtualServiceReady)
+		endpointsInformer.Lister(), network.NewAutoTransport, resyncIngressOnVirtualServiceReady)
 	r.StatusManager = statusProber
 	statusProber.Start(ctx.Done())
 

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -340,6 +340,7 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 					// TODO(5156): Implement HTTPS handling.
 					if port.Name == "http2" {
 						gatewayPort = strconv.Itoa(int(port.Port))
+						break
 					}
 				}
 				if gatewayPort == "" {

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -316,7 +316,7 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 			continue
 		}
 
-		// Get matching endpoint
+		// List matching endpoints
 		selector := labels.NewSelector()
 		for key, value := range gateway.Spec.Selector {
 			requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
@@ -333,18 +333,21 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 
 		for _, eps := range endpoints {
 			for _, sub := range eps.Subsets {
-				http2Port := ""
+				gatewayPort := ""
 				for _, port := range sub.Ports {
+					// Per Istio's documentation https://istio.io/docs/tasks/traffic-management/ingress/ingress-control/
+					// the portName for an unsecure gateway is "http2", a secure gateway uses "https".
+					// TODO(5156): Implement HTTPS handling.
 					if port.Name == "http2" {
-						http2Port = strconv.Itoa(int(port.Port))
+						gatewayPort = strconv.Itoa(int(port.Port))
 					}
 				}
-				if http2Port == "" {
+				if gatewayPort == "" {
 					return nil, fmt.Errorf("endpoints %q did not contain http2 port: %v", eps.Name, sub.Ports)
 				}
 
 				for _, address := range sub.Addresses {
-					podIPs = append(podIPs, net.JoinHostPort(address.IP, http2Port))
+					podIPs = append(podIPs, net.JoinHostPort(address.IP, gatewayPort))
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This heavily overlaps with #5223 but is a much smaller change.

## Proposed Changes

The status prober today lists all the pods that are part of the gateway of a VirtualService and probes their individual IPs. That has two flaws:

1. It assumes that the gateway pods always serve on port 80.
2. It potentially also probes pods that are not even ready and thus pretty much guaranteed to return failures.

This fetches endpoints instead, which have named ports that can be used to determine the correct port to use when constructing the IPs to probe. It's also guaranteed to only contain IPs of pods that are deemed ready by K8s.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Custom ports on istio-gateways are handled correctly now.
```

/assign @vagababov @JRBANCEL 
