### PR TITLE
Scale crash looping Revisions with minScale to zero.

### DIFF
--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -445,6 +445,9 @@ func TestReconcile(t *testing.T) {
 				WithLogURL, AllUnknownConditions,
 				MarkResourcesUnavailable("ImagePullBackoff", "can't pull it")),
 		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: pa("foo", "pull-backoff", WithReachability(asv1a1.ReachabilityUnreachable)),
+		}},
 		Key: "foo/pull-backoff",
 	}, {
 		Name: "surface pod errors",


### PR DESCRIPTION
For a (very) detailed walkthough of the problem, see the linked issue.
This fixes things by having the Revision controller mark failed Revisions
as Unreachable, since we should not be routing traffic to them.

Fixes: https://github.com/knative/serving/issues/5529
