### PR TITLE
Use Gateway port instead of Endpoints port

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -299,7 +299,6 @@ func CanProbeGateway(gateway *v1alpha3.Gateway) bool {
 	for _, server := range gateway.Spec.Servers {
 		if len(server.Hosts) == 1 &&
 			server.Hosts[0] == "*" &&
-			server.Port.Number == 80 &&
 			server.Port.Protocol == v1alpha3.ProtocolHTTP {
 			return true
 		}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -704,7 +704,7 @@ func TestCanProbeGateway(t *testing.T) {
 				}},
 			},
 		},
-		canProbe: false,
+		canProbe: true,
 	}, {
 		name: "wildcard TCP on port 80",
 		gateway: &v1alpha3.Gateway{
@@ -727,7 +727,7 @@ func TestCanProbeGateway(t *testing.T) {
 					Hosts: []string{"*"},
 					Port: v1alpha3.Port{
 						Number:   100,
-						Protocol: v1alpha3.ProtocolHTTP,
+						Protocol: v1alpha3.ProtocolHTTPS,
 					},
 				}},
 			},

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -100,42 +100,6 @@ func TestIsReadyFailures(t *testing.T) {
 			}},
 		},
 		endpointsLister: &fakeEndpointsLister{fails: true},
-	}, {
-		name: "missing port",
-		vsSpec: v1alpha3.VirtualServiceSpec{
-			Gateways: []string{"default/gateway"},
-			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
-		},
-		gatewayLister: &fakeGatewayLister{
-			gateways: []*v1alpha3.Gateway{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "gateway",
-				},
-				Spec: v1alpha3.GatewaySpec{
-					Servers: []v1alpha3.Server{{
-						Hosts: []string{"*"},
-						Port: v1alpha3.Port{
-							Number:   80,
-							Protocol: v1alpha3.ProtocolHTTP,
-						},
-					}},
-					Selector: map[string]string{
-						"gwt": "istio",
-					},
-				},
-			}},
-		},
-		endpointsLister: &fakeEndpointsLister{
-			endpoints: []*v1.Endpoints{{
-				Subsets: []v1.EndpointSubset{{
-					Ports: []v1.EndpointPort{{
-						Name: "foo",
-						Port: 80,
-					}},
-				}},
-			}},
-		},
 	}}
 
 	for _, test := range tests {
@@ -213,7 +177,7 @@ func TestProbeLifecycle(t *testing.T) {
 					Servers: []v1alpha3.Server{{
 						Hosts: []string{"*"},
 						Port: v1alpha3.Port{
-							Number:   80,
+							Number:   port,
 							Protocol: v1alpha3.ProtocolHTTP,
 						},
 					}},
@@ -232,10 +196,6 @@ func TestProbeLifecycle(t *testing.T) {
 				Subsets: []v1.EndpointSubset{{
 					Addresses: []v1.EndpointAddress{{
 						IP: hostname,
-					}},
-					Ports: []v1.EndpointPort{{
-						Name: "http2",
-						Port: int32(port),
 					}},
 				}},
 			}},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Follow up on https://github.com/knative/serving/pull/5531.

Using Endpoints instead of Pods to figure out which IPs to probe is a good change except that we cannot use the Endpoints ports because they are uncorrelated with what is defined in the Gateway. Envoy listens to the ports defined in the Gateway ([unless it doesn't :frowning_face:](https://github.com/Maistra/istio/commit/ca7f4aebb567ca445bd2a9abda722f824f948c3a)).

[More context](https://knative.slack.com/archives/CA9RHBGJX/p1568384517170800).

## Proposed Changes
* Use the ports defined in the Gateway
