### PR TITLE
Let nscert's wildcard certs create secret with domain name instead of the name of namespace

### DIFF
--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -392,7 +392,7 @@ func knCertWithStatus(namespace *corev1.Namespace, status *v1alpha1.CertificateS
 		},
 		Spec: v1alpha1.CertificateSpec{
 			DNSNames:   wildcardDNSNames,
-			SecretName: namespace.Name,
+			SecretName: defaultCertName,
 		},
 		Status: *status,
 	}

--- a/pkg/reconciler/nscert/resources/wildcard_certificate.go
+++ b/pkg/reconciler/nscert/resources/wildcard_certificate.go
@@ -37,7 +37,7 @@ func MakeWildcardCertificate(namespace *corev1.Namespace, dnsName, domain string
 		},
 		Spec: v1alpha1.CertificateSpec{
 			DNSNames:   []string{dnsName},
-			SecretName: namespace.Name,
+			SecretName: names.WildcardCertificate(dnsName),
 		},
 	}
 }

--- a/pkg/reconciler/nscert/resources/wildcard_certificate_test.go
+++ b/pkg/reconciler/nscert/resources/wildcard_certificate_test.go
@@ -50,7 +50,7 @@ func TestMakeWildcardCertificate(t *testing.T) {
 		},
 		Spec: v1alpha1.CertificateSpec{
 			DNSNames:   []string{dnsName},
-			SecretName: namespace.Name,
+			SecretName: names.WildcardCertificate(dnsName),
 		},
 	}
 


### PR DESCRIPTION
## Proposed Changes

Currently wildcard creates secret with the name of its namespace. This
causes error when the secret name is duplicated with other secret
name. In fact, it always fails when domain name is changed.

This patch changes wildcard cert to create secret name with domain
name.

/lint

Fixes https://github.com/knative/serving/issues/5538

**Release Note**

```release-note
NONE
```

/cc @rmoe @ZhiminXiang @tcnghia
