### PR TITLE
Expose QueueAdminPort to private Service of the Revision

### DIFF
--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -110,6 +110,8 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),
 			}, {
+				// Expose the QueueAdminPort in order to allow PreStop hooks to be called.
+				// This is important for graceful shutdown of user-container.
 				Name:       servingv1alpha1.QueueAdminPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.QueueAdminPort,

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -20,6 +20,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -108,6 +109,11 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// This one is matching the public one, since this is the
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),
+			}, {
+				Name:       servingv1alpha1.QueueAdminPortName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       networking.QueueAdminPort,
+				TargetPort: intstr.FromInt(networking.QueueAdminPort),
 			}},
 			Selector: selector,
 		},

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -110,8 +110,13 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),
 			}, {
-				// Expose the QueueAdminPort in order to allow PreStop hooks to be called.
-				// This is important for graceful shutdown of user-container.
+				// When run with the Istio mesh, Envoy blocks traffic to any ports not
+				// recognized, and has special treatment for probes, but not PreStop hooks.
+				// That results in the PreStop hook /wait-for-drain in queue-proxy not
+				// reachable, thus triggering SIGTERM immediately during shutdown and
+				// causing requests to be dropped.
+				//
+				// So we expose this port here to work around this Istio bug.
 				Name:       servingv1alpha1.QueueAdminPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.QueueAdminPort,

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
+	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 var (
@@ -503,6 +504,11 @@ func TestMakePrivateService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTPPort),
+				}, {
+					Name:       servingv1alpha1.QueueAdminPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       networking.QueueAdminPort,
+					TargetPort: intstr.FromInt(networking.QueueAdminPort),
 				}},
 			},
 		},
@@ -561,6 +567,11 @@ func TestMakePrivateService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+				}, {
+					Name:       servingv1alpha1.QueueAdminPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       networking.QueueAdminPort,
+					TargetPort: intstr.FromInt(networking.QueueAdminPort),
 				}},
 			},
 		},


### PR DESCRIPTION
We observe in our `pull-knative-serving-istio-*-mesh` test grids that the PreStop hook `/wait-for-drain` was not reachable by the kubelet, causing SIGTERM to be immediately sent to the `user-container`.  This is due to port 8022 not referred by any Service causing Istio sidecar to not add a listener for that port.

Before https://github.com/knative/serving/pull/4148 we used to include a reference to :8022 in readiness probes, which Istio pilot takes into account unlike lifecycle hooks.  Ignoring lifecycle hooks seems like an Istio bug and should also be fixed upstream.

We also need an E2E to test this particular case (see https://github.com/knative/serving/issues/5541).  Currently we only hit this issue due to the overshoot correction of TestAutoscaleSustaining.
<!--
Request Prow to automatically lint any go code in this PR:

-->
/lint



## Proposed Changes

*  Expose QueueAdminPort to private Service
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix a bug in graceful shutdown of user-container, due to PreStop hook being unreachable.
```
