### PR TITLE
Stop handling the revision with throttler when it was removed

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -226,7 +226,8 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 		// We must have scaled down.
 		rw.clusterIPHealthy = false
 		rw.logger.Debug("ClusterIP is no longer healthy.")
-		// We do not send this update, as we will send it via endpointsDeleted.
+		// Send update that we are now inactive (both params invalid).
+		rw.sendUpdate("", nil)
 		return
 	}
 

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -206,7 +206,7 @@ func (rw *revisionWatcher) probePodIPs(dests sets.String) (sets.String, bool, er
 	return healthy, !changed, err
 }
 
-func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String, deleted bool) {
+func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String) {
 	select {
 	case <-rw.doneCh:
 		// We're not closing updateCh because this would result in 1 close per revisionWatcher.
@@ -215,7 +215,7 @@ func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String, delet
 		// TODO(greghaynes) find a way to explicitly close the channel. Potentially use channel per watcher.
 		return
 	default:
-		rw.updateCh <- RevisionDestsUpdate{Rev: rw.rev, ClusterIPDest: clusterIP, Dests: dests, Deleted: deleted}
+		rw.updateCh <- RevisionDestsUpdate{Rev: rw.rev, ClusterIPDest: clusterIP, Dests: dests}
 	}
 }
 
@@ -226,8 +226,7 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 		// We must have scaled down.
 		rw.clusterIPHealthy = false
 		rw.logger.Debug("ClusterIP is no longer healthy.")
-		// Send update that we are now inactive (Deleted true).
-		rw.sendUpdate("", nil, true)
+		// We do not send this update, as we will send it via endpointsDeleted.
 		return
 	}
 
@@ -242,7 +241,7 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 	if rw.clusterIPHealthy {
 		// cluster IP is healthy and we haven't scaled down, short circuit.
 		rw.logger.Debugf("ClusterIP %s already probed (backends: %d)", dest, len(dests))
-		rw.sendUpdate(dest, dests, false)
+		rw.sendUpdate(dest, dests)
 		return
 	}
 
@@ -253,7 +252,7 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 		rw.logger.Debugf("ClusterIP is successfully probed: %s (backends: %d)", dest, len(dests))
 		rw.clusterIPHealthy = true
 		rw.healthyPods = nil
-		rw.sendUpdate(dest, dests, false)
+		rw.sendUpdate(dest, dests)
 		return
 	}
 
@@ -266,7 +265,7 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 	rw.logger.Debugf("Done probing, got %d healthy pods", len(hs))
 	if !noop {
 		rw.healthyPods = hs
-		rw.sendUpdate("" /*clusterIP not ready yet*/, hs, false)
+		rw.sendUpdate("" /*clusterIP not ready yet*/, hs)
 	}
 }
 

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -57,6 +57,7 @@ type RevisionDestsUpdate struct {
 	Rev           types.NamespacedName
 	ClusterIPDest string
 	Dests         sets.String
+	Deleted       bool
 }
 
 const (
@@ -227,8 +228,6 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 
 		rw.logger.Debug("ClusterIP is no longer healthy.")
 
-		// Send update that we are now inactive (both params invalid).
-		rw.sendUpdate("", nil)
 		return
 	}
 
@@ -415,7 +414,7 @@ func (rbm *RevisionBackendsManager) deleteRevisionWatcher(rev types.NamespacedNa
 	if rw, ok := rbm.revisionWatchers[rev]; ok {
 		close(rw.ch)
 		delete(rbm.revisionWatchers, rev)
-		rbm.updateCh <- RevisionDestsUpdate{Rev: rev}
+		rbm.updateCh <- RevisionDestsUpdate{Rev: rev, Deleted: true}
 	}
 }
 

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -856,7 +856,7 @@ func TestRevisionDeleted(t *testing.T) {
 	select {
 	case r := <-rbm.UpdateCh():
 		if got, want := r.Deleted, true; got != want {
-			t.Errorf(`Deleted = %t, want true`, got)
+			t.Errorf("Deleted = %t, want true", got)
 		}
 		if got, want := r.ClusterIPDest, ""; got != want {
 			t.Errorf(`ClusterIP = %s, want ""`, got)

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -855,6 +855,9 @@ func TestRevisionDeleted(t *testing.T) {
 	fakekubeclient.Get(ctx).CoreV1().Endpoints(testNamespace).Delete(ep.Name, &metav1.DeleteOptions{})
 	select {
 	case r := <-rbm.UpdateCh():
+		if got, want := r.Deleted, true; got != want {
+			t.Errorf(`Deleted = %t, want true`, got)
+		}
 		if got, want := r.ClusterIPDest, ""; got != want {
 			t.Errorf(`ClusterIP = %s, want ""`, got)
 		}

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -380,7 +380,8 @@ func (t *Throttler) handleUpdate(update RevisionDestsUpdate) {
 	if update.Deleted {
 		// Nothing to do as revisionDeleted is already called by DeleteFunc of Informer.
 		return
-	} else if rt, err := t.getOrCreateRevisionThrottler(update.Rev); err != nil {
+	}
+	if rt, err := t.getOrCreateRevisionThrottler(update.Rev); err != nil {
 		if k8serrors.IsNotFound(err) {
 			t.logger.Debugf("Revision %q is not found. Probably it was removed", update.Rev.String())
 		} else {

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -25,6 +25,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -380,7 +381,12 @@ func (t *Throttler) handleUpdate(update RevisionDestsUpdate) {
 		// Nothing to do as revisionDeleted is already called by DeleteFunc of Informer.
 		return
 	} else if rt, err := t.getOrCreateRevisionThrottler(update.Rev); err != nil {
-		t.logger.Errorw(fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()))
+		if k8serrors.IsNotFound(err) {
+			t.logger.Debugf("Revision %q is not found. Probably it was removed", update.Rev.String())
+		} else {
+			t.logger.Errorw(fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()),
+				zap.Error(err))
+		}
 	} else {
 		rt.handleUpdate(t, update)
 	}

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -377,7 +377,7 @@ func (t *Throttler) revisionDeleted(obj interface{}) {
 
 func (t *Throttler) handleUpdate(update RevisionDestsUpdate) {
 	if rt, err := t.getOrCreateRevisionThrottler(update.Rev); err != nil {
-		t.logger.Errorw(fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()),
+		t.logger.Warnw(fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()),
 			zap.Error(err))
 	} else {
 		rt.handleUpdate(t, update)

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -25,6 +25,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -359,7 +360,11 @@ func (t *Throttler) revisionUpdated(obj interface{}) {
 	t.logger.Debugf("Revision update %q", revID.String())
 
 	if _, err := t.getOrCreateRevisionThrottler(revID); err != nil {
-		t.logger.Errorw("Failed to get revision throttler for revision "+revID.String(), zap.Error(err))
+		if k8serrors.IsNotFound(err) {
+			t.logger.Debugf("Revision %q is not found. Probably it was removed", revID.String())
+		} else {
+			t.logger.Errorw("Failed to get revision throttler for revision "+revID.String(), zap.Error(err))
+		}
 	}
 }
 
@@ -377,8 +382,12 @@ func (t *Throttler) revisionDeleted(obj interface{}) {
 
 func (t *Throttler) handleUpdate(update RevisionDestsUpdate) {
 	if rt, err := t.getOrCreateRevisionThrottler(update.Rev); err != nil {
-		t.logger.Warnw(fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()),
-			zap.Error(err))
+		if k8serrors.IsNotFound(err) {
+			t.logger.Debugf("Revision %q is not found. Probably it was removed", update.Rev.String())
+		} else {
+			t.logger.Errorw(fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()),
+				zap.Error(err))
+		}
 	} else {
 		rt.handleUpdate(t, update)
 	}


### PR DESCRIPTION
## Proposed Changes

This patch makes a tiny change, which changes the throttler's update error
log to warning from error level.

Whenever we delete ksvc, `handleUpdate()` outputs error as `Failed to
get revision throttler for revision`. This is no problem as we deleted
ksvc and the revision. Also, `handleUpdate()` is called again, even if
it failed so we should output the message with warning level.

/lint

**Release Note**

```release-note
NONE
```
