### PR TITLE
[WIP] Add a dummy liveness probe to the queue-proxy

### DIFF
--- a/pkg/queue/constants.go
+++ b/pkg/queue/constants.go
@@ -26,4 +26,13 @@ const (
 	// Main usage is to delay the termination of user-container until all
 	// accepted requests have been processed.
 	RequestQueueDrainPath = "/wait-for-drain"
+
+	// DummyProbePath is used to expose a liveness probe on the queue-proxy
+	// that is not intended to establish any sort of healthiness, but to
+	// work around a bug in Istio.
+	// When run with the Istio mesh, Envoy blocks traffic to any ports not
+	// recognized, and has special treatment for probes, but not PreStop hooks.
+	// So we use this dummy path to expose an otherwise useless probe to
+	// workaround the bug.  See: #5540
+	DummyProbePath = "/dummy-probe"
 )

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -83,6 +83,7 @@ var (
 			PeriodSeconds:  1,
 			TimeoutSeconds: 10,
 		},
+		LivenessProbe:   dummyLivenessProbe,
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{
 			Name:  "SERVING_NAMESPACE",

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -112,6 +112,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Env: env(nil),
@@ -154,6 +155,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTP2Port),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -193,6 +195,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -232,6 +235,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Env: env(map[string]string{
@@ -272,6 +276,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Env: env(map[string]string{
@@ -308,6 +313,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Env: env(map[string]string{
@@ -340,6 +346,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Env: env(map[string]string{
@@ -375,6 +382,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			Resources:       createQueueResources(make(map[string]string), &corev1.Container{}),
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Env: env(map[string]string{
@@ -477,6 +485,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			},
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -534,6 +543,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			},
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -590,6 +600,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			},
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -646,6 +657,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			},
 			Ports:           append(queueNonServingPorts, queueHTTPPort),
 			ReadinessProbe:  defaultKnativeQReadinessProbe,
+			LivenessProbe:   dummyLivenessProbe,
 			SecurityContext: queueSecurityContext,
 			// These changed based on the Revision and configs passed in.
 			Image: "alpine",
@@ -756,6 +768,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 			PeriodSeconds:  1,
 			TimeoutSeconds: 10,
 		},
+		LivenessProbe: dummyLivenessProbe,
 		// These changed based on the Revision and configs passed in.
 		Env: env(map[string]string{
 			"SERVING_READINESS_PROBE": string(wantProbeJSON),
@@ -850,6 +863,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 			PeriodSeconds:  2,
 			TimeoutSeconds: 10,
 		},
+		LivenessProbe: dummyLivenessProbe,
 		// These changed based on the Revision and configs passed in.
 		Env: env(map[string]string{
 			"USER_PORT":               strconv.Itoa(userPort),
@@ -922,6 +936,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				PeriodSeconds:  1,
 				TimeoutSeconds: 10,
 			},
+			LivenessProbe: dummyLivenessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env:             env(map[string]string{"USER_PORT": strconv.Itoa(userPort)}),
 			SecurityContext: queueSecurityContext,
@@ -969,6 +984,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				PeriodSeconds:  1,
 				TimeoutSeconds: 1,
 			},
+			LivenessProbe: dummyLivenessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env:             env(map[string]string{}),
 			SecurityContext: queueSecurityContext,
@@ -1029,6 +1045,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				FailureThreshold:    7,
 				InitialDelaySeconds: 3,
 			},
+			LivenessProbe: dummyLivenessProbe,
 			// These changed based on the Revision and configs passed in.
 			Env:             env(map[string]string{"USER_PORT": strconv.Itoa(userPort)}),
 			SecurityContext: queueSecurityContext,


### PR DESCRIPTION
This is an alternative fix to what @tcnghia found in https://github.com/knative/serving/pull/5540.

When run with the Istio mesh, Envoy is configured to proxy traffic into the pod and blocks traffic
on any unrecognized ports.  Istio has logic for special casing ports in probes, but apparently not
lifecycle hooks, so when we switched to exec probes the way we shutdown user containers stopped
working with the mesh.

To workaround this, we expose a simple dummy liveness (so that it doesn't affect coldstart) probe
that always returns 200 and serves no purpose other than to trick Istio and workaround the bug.

/test pull-knative-serving-istio-1.1-mesh
/test pull-knative-serving-istio-1.2-mesh