### PR TITLE
Add port filtering for the SKS to keep only the serving port.

### DIFF
--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -23,13 +23,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
-	"knative.dev/serving/pkg/apis/networking"
-	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/serving/pkg/apis/networking"
+	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -76,13 +76,37 @@ func MakePublicEndpoints(sks *v1alpha1.ServerlessService, src *corev1.Endpoints)
 			Annotations:     resources.CopyMap(sks.GetAnnotations()),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
 		},
-		Subsets: func() (ret []corev1.EndpointSubset) {
-			for _, r := range src.Subsets {
-				ret = append(ret, *r.DeepCopy())
-			}
-			return
-		}(),
+		Subsets: FilterSubsetPorts(sks, src.Subsets),
 	}
+}
+
+// FilterSubsetPorts makes a copy of the ep.Subsets, filtering out ports
+// that are not serving (e.g. 8012 for HTTP).
+func FilterSubsetPorts(sks *v1alpha1.ServerlessService, subsets []corev1.EndpointSubset) []corev1.EndpointSubset {
+	targetPort := targetPort(sks).IntVal
+	return filterSubsetPorts(targetPort, subsets)
+}
+
+// filterSubsetPorts internal implementation that takes in port.
+func filterSubsetPorts(targetPort int32, subsets []corev1.EndpointSubset) []corev1.EndpointSubset {
+	if len(subsets) == 0 {
+		return nil
+	}
+	ret := make([]corev1.EndpointSubset, len(subsets))
+	for i, sss := range subsets {
+		sst := sss.DeepCopy()
+		// Find the port we care about and remove all others.
+		for _, p := range sst.Ports {
+			if p.Port == targetPort {
+				sst.Ports[0] = p
+				break
+			}
+		}
+		// Strip all the others.
+		sst.Ports = sst.Ports[:1]
+		ret[i] = *sst
+	}
+	return ret
 }
 
 // MakePrivateService constructs a K8s service, that is backed by the pod selector

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -88,6 +88,8 @@ func FilterSubsetPorts(sks *v1alpha1.ServerlessService, subsets []corev1.Endpoin
 }
 
 // filterSubsetPorts internal implementation that takes in port.
+// Those are not arbitrary endpoints, but the endpoints we construct ourselves,
+// thus we know that at least one of the ports will always match.
 func filterSubsetPorts(targetPort int32, subsets []corev1.EndpointSubset) []corev1.EndpointSubset {
 	if len(subsets) == 0 {
 		return nil
@@ -96,14 +98,12 @@ func filterSubsetPorts(targetPort int32, subsets []corev1.EndpointSubset) []core
 	for i, sss := range subsets {
 		sst := sss.DeepCopy()
 		// Find the port we care about and remove all others.
-		for _, p := range sst.Ports {
+		for j, p := range sst.Ports {
 			if p.Port == targetPort {
-				sst.Ports[0] = p
+				sst.Ports = sst.Ports[j : j+1]
 				break
 			}
 		}
-		// Strip all the others.
-		sst.Ports = sst.Ports[:1]
 		ret[i] = *sst
 	}
 	return ret

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -240,7 +240,7 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 	eps, err := r.endpointsLister.Endpoints(sks.Namespace).Get(sn)
 
 	if apierrs.IsNotFound(err) {
-		logger.Infof("K8s endpoints %s does not exist; creating.", sn)
+		logger.Infof("Public endpoints %s does not exist; creating.", sn)
 		sks.Status.MarkEndpointsNotReady("CreatingPublicEndpoints")
 		eps, err = r.KubeClientSet.CoreV1().Endpoints(sks.Namespace).Create(resources.MakePublicEndpoints(sks, srcEps))
 		if err != nil {
@@ -254,15 +254,16 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 	} else if !metav1.IsControlledBy(eps, sks) {
 		sks.Status.MarkEndpointsNotOwned("Endpoints", sn)
 		return fmt.Errorf("SKS: %s does not own Endpoints: %s", sks.Name, sn)
-	}
-	want := eps.DeepCopy()
-	want.Subsets = srcEps.Subsets
-
-	if !equality.Semantic.DeepEqual(want.Subsets, eps.Subsets) {
-		logger.Info("Public K8s Endpoints changed; reconciling: ", sn)
-		if _, err = r.KubeClientSet.CoreV1().Endpoints(sks.Namespace).Update(want); err != nil {
-			logger.Errorw("Error updating public K8s Endpoints: "+sn, zap.Error(err))
-			return err
+	} else {
+		wantSubsets := resources.FilterSubsetPorts(sks, srcEps.Subsets)
+		if !equality.Semantic.DeepEqual(wantSubsets, eps.Subsets) {
+			want := eps.DeepCopy()
+			want.Subsets = wantSubsets
+			logger.Info("Public K8s Endpoints changed; reconciling: ", sn)
+			if _, err = r.KubeClientSet.CoreV1().Endpoints(sks.Namespace).Update(want); err != nil {
+				logger.Errorw("Error updating public K8s Endpoints: "+sn, zap.Error(err))
+				return err
+			}
 		}
 	}
 	if foundServingEndpoints {

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -82,7 +82,7 @@ func TestReconcile(t *testing.T) {
 			deploy("steady", "bar"),
 			svcpub("steady", "state"),
 			svcpriv("steady", "state", svcWithName("state-fsdf")),
-			endpointspub("steady", "state", WithSubsets),
+			endpointspub("steady", "state", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("steady", "state", WithSubsets, epsWithName("state-fsdf")),
 			activatorEndpoints(WithSubsets),
 		},
@@ -96,7 +96,7 @@ func TestReconcile(t *testing.T) {
 			deploy("steady", "bar"),
 			svcpub("steady", "to-proxy"),
 			svcpriv("steady", "to-proxy", svcWithName("to-proxy-deadbeef")),
-			endpointspub("steady", "to-proxy", withOtherSubsets),
+			endpointspub("steady", "to-proxy", withOtherSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("steady", "to-proxy", epsWithName("to-proxy-deadbeef")),
 			activatorEndpoints(WithSubsets),
 		},
@@ -105,7 +105,7 @@ func TestReconcile(t *testing.T) {
 				withProxyMode, WithPubService, WithPrivateService("to-proxy-deadbeef")),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: endpointspub("steady", "to-proxy", WithSubsets),
+			Object: endpointspub("steady", "to-proxy", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "steady/to-proxy"`),
@@ -121,12 +121,12 @@ func TestReconcile(t *testing.T) {
 			deploy("steady", "bar"),
 			svcpub("steady", "to-proxy"),
 			svcpriv("steady", "to-proxy", svcWithName("to-proxy-deadbeef")),
-			endpointspub("steady", "to-proxy", withOtherSubsets),
+			endpointspub("steady", "to-proxy", withOtherSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("steady", "to-proxy", epsWithName("to-proxy-deadbeef"), WithSubsets),
 			activatorEndpoints(WithSubsets),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: endpointspub("steady", "to-proxy", WithSubsets),
+			Object: endpointspub("steady", "to-proxy", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		}},
 	}, {
 		Name: "many-private-services",
@@ -140,7 +140,7 @@ func TestReconcile(t *testing.T) {
 			svcpriv("many", "privates", svcWithName("privates-brutality-is-here")),
 			svcpriv("many", "privates", svcWithName("privates-uncharacteristically-pretty"),
 				WithK8sSvcOwnersRemoved), // unowned, should remain.
-			endpointspub("many", "privates", WithSubsets),
+			endpointspub("many", "privates", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("many", "privates", WithSubsets, epsWithName("privates-elegance-required")),
 			activatorEndpoints(WithSubsets),
 		},
@@ -165,7 +165,7 @@ func TestReconcile(t *testing.T) {
 			deploy("public", "bar"),
 			svcpub("public", "svc-change", withTimeSelector),
 			svcpriv("public", "svc-change", svcWithName("svc-change-feedbeef")),
-			endpointspub("public", "svc-change", WithSubsets),
+			endpointspub("public", "svc-change", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("public", "svc-change", WithSubsets, epsWithName("svc-change-feedbeef")),
 			activatorEndpoints(WithSubsets),
 		},
@@ -181,14 +181,14 @@ func TestReconcile(t *testing.T) {
 			deploy("private", "baz"),
 			svcpub("private", "svc-change"),
 			svcpriv("private", "svc-change", withTimeSelector, svcWithName("svc-change-fade")),
-			endpointspub("private", "svc-change", withOtherSubsets),
+			endpointspub("private", "svc-change", withOtherSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("private", "svc-change", WithSubsets, epsWithName("svc-change-fade")),
 			activatorEndpoints(WithSubsets),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: svcpriv("private", "svc-change", svcWithName("svc-change-fade")),
 		}, {
-			Object: endpointspub("private", "svc-change", WithSubsets),
+			Object: endpointspub("private", "svc-change", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		}},
 	}, {
 		Name: "OnCreate-deployment-does-not-exist",
@@ -215,7 +215,7 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			svcpriv("on", "cde"),
 			svcpub("on", "cde"),
-			endpointspub("on", "cde", WithSubsets),
+			endpointspub("on", "cde", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: SKS("on", "cde", WithDeployRef("blah"),
@@ -241,7 +241,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "endpoints"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: endpointspub("update-eps", "failA", WithSubsets), // The attempted update.
+			Object: endpointspub("update-eps", "failA", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)), // The attempted update.
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for update endpoints"),
@@ -291,7 +291,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantCreates: []runtime.Object{
 			svcpub("eps", "fail3"),
-			endpointspub("eps", "fail3", WithSubsets),
+			endpointspub("eps", "fail3", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for create endpoints"),
@@ -309,7 +309,7 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			svcpriv("on", "cneps"),
 			svcpub("on", "cneps"),
-			endpointspub("on", "cneps", WithSubsets),
+			endpointspub("on", "cneps", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: SKS("on", "cneps", WithDeployRef("blah"),
@@ -325,7 +325,7 @@ func TestReconcile(t *testing.T) {
 			SKS("on", "cnaeps2", WithDeployRef("blah")),
 			deploy("on", "blah"),
 			endpointspriv("on", "cnaeps2", WithSubsets, epsWithName("cnaeps2-00001")),
-			endpointspub("on", "cnaeps2", WithSubsets),
+			endpointspub("on", "cnaeps2", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		},
 		WantErr: true,
 		WantCreates: []runtime.Object{
@@ -365,13 +365,13 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "on/cnaeps3"`),
 		},
 	}, {
-		Name: "OnCreate-no-activator-eps-serve",
+		Name: "OnCreate-no-activator-eps-service",
 		Key:  "on/cnaeps",
 		Objects: []runtime.Object{
 			SKS("on", "cnaeps", WithDeployRef("blah")),
 			deploy("on", "blah"),
 			endpointspriv("on", "cnaeps", WithSubsets, epsWithName("cnaeps-00001")),
-			endpointspub("on", "cnaeps", WithSubsets),
+			endpointspub("on", "cnaeps", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			activatorEndpoints(),
 		},
 		WantCreates: []runtime.Object{
@@ -439,7 +439,7 @@ func TestReconcile(t *testing.T) {
 			deploy("update-sks", "blah"),
 			svcpub("update-sks", "fail4"),
 			svcpriv("update-sks", "fail4", svcWithName("fail4-42x")),
-			endpointspub("update-sks", "fail4", WithSubsets),
+			endpointspub("update-sks", "fail4", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			endpointspriv("update-sks", "fail4", WithSubsets, epsWithName("fail4-42x")),
 			activatorEndpoints(WithSubsets),
 		},
@@ -585,7 +585,7 @@ func TestReconcile(t *testing.T) {
 				activatorEndpoints(WithSubsets),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: endpointspub("pod", "change", withOtherSubsets),
+				Object: endpointspub("pod", "change", withOtherSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			}},
 		}, {
 			Name: "proxy mode; pod change - activator",
@@ -601,7 +601,7 @@ func TestReconcile(t *testing.T) {
 				activatorEndpoints(withOtherSubsets),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: endpointspub("pod", "change", withOtherSubsets),
+				Object: endpointspub("pod", "change", withOtherSubsets, withFilteredPorts(networking.BackendHTTP2Port)),
 			}},
 		}, {
 			Name: "serving mode; serving pod comes online",
@@ -624,7 +624,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "pod/change"`),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: endpointspub("pod", "change", WithSubsets),
+				Object: endpointspub("pod", "change", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 			}},
 		}, {
 			Name: "serving mode; no backend endpoints",
@@ -647,7 +647,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "pod/change"`),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: endpointspub("pod", "change", withOtherSubsets),
+				Object: endpointspub("pod", "change", withOtherSubsets, withFilteredPorts(networking.BackendHTTP2Port)),
 			}},
 		}}
 
@@ -663,10 +663,25 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
+// Keeps only desired port.
+func withFilteredPorts(port int32) EndpointsOption {
+	return func(ep *corev1.Endpoints) {
+		for _, p := range ep.Subsets[0].Ports {
+			if p.Port == port {
+				ep.Subsets[0].Ports[0] = p
+				break
+			}
+		}
+		// Strip all the others.
+		ep.Subsets[0].Ports = ep.Subsets[0].Ports[:1]
+	}
+}
+
 // withOtherSubsets uses different IP set than functional::withSubsets.
 func withOtherSubsets(ep *corev1.Endpoints) {
 	ep.Subsets = []corev1.EndpointSubset{{
 		Addresses: []corev1.EndpointAddress{{IP: "127.0.0.2"}},
+		Ports:     []corev1.EndpointPort{{Port: 8013}, {Port: 8012}},
 	}}
 }
 

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -262,6 +262,7 @@ type EndpointsOption func(*corev1.Endpoints)
 func WithSubsets(ep *corev1.Endpoints) {
 	ep.Subsets = []corev1.EndpointSubset{{
 		Addresses: []corev1.EndpointAddress{{IP: "127.0.0.1"}},
+		Ports:     []corev1.EndpointPort{{Port: 8012}, {Port: 8013}},
 	}}
 }
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -92,6 +92,14 @@ func waitForActivatorEndpoints(resources *v1a1test.ResourceObjects, clients *tes
 		if err != nil {
 			return false, err
 		}
-		return cmp.Equal(svcEps.Subsets, aeps.Subsets), nil
+		if len(svcEps.Subsets) != len(aeps.Subsets) {
+			return false, nil
+		}
+		for i, ss := range svcEps.Subsets {
+			if !cmp.Equal(ss.Addresses, aeps.Subsets[i].Addresses) {
+				return false, nil
+			}
+		}
+		return true, nil
 	})
 }


### PR DESCRIPTION
There is no need to expose more ports than required on the public endpoints (they should only be used
to forward user requests).
This also permits us to export more ports on the private service (e.g. to go around Istio restrictions in mesh mode).
I've also significantly improved the tests and what they cover in SKS>

/lint

## Proposed Changes

* Add filtering helper 
* Filter ports
* update tests


/assign mattmoor @tcnghia 