### PR TITLE
Add a test that verifies that the requests, when pod is destroyed succeed

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -235,8 +235,8 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
 	})
-	if err != nil || len(pods.Items) == 0 {
-		t.Fatalf("No pods or error: %v", err)
+	if err != nil || len(pods.Items) != 1 {
+		t.Fatalf("Number of pods is not 1 or an error: %v", err)
 	}
 
 	// The request will sleep for more than 25 seconds.

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -239,7 +239,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 		t.Fatalf("No pods or error: %v", err)
 	}
 
-	// The request will leep for more than 25 seconds.
+	// The request will sleep for more than 25 seconds.
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s?sleep=25001", domain), nil)
 	if err != nil {
 		t.Fatalf("Error creating HTTP request: %v", err)


### PR DESCRIPTION

- Start the autoscale-go image.
- Send requests waiting for some time
- Kill the pod
- Observe success

Fixes #5541

/assign @tcnghia mattmoor