### PR TITLE
Resolve the Gateway's listening ports via a lookup in the Service definition.

### DIFF
--- a/pkg/reconciler/clusteringress/clusteringress.go
+++ b/pkg/reconciler/clusteringress/clusteringress.go
@@ -26,6 +26,7 @@ import (
 	gatewayinformer "knative.dev/pkg/client/injection/informers/istio/v1alpha3/gateway"
 	virtualserviceinformer "knative.dev/pkg/client/injection/informers/istio/v1alpha3/virtualservice"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
+	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/tracker"
@@ -85,6 +86,7 @@ func (c *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 	clusterIngressInformer := clusteringressinformer.Get(ctx)
 	gatewayInformer := gatewayinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
+	serviceInformer := serviceinformer.Get(ctx)
 
 	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
 	clusterIngressHandler := cache.FilteringResourceEventHandler{
@@ -116,8 +118,13 @@ func (c *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 		// Reconcile when a VirtualService becomes ready
 		impl.EnqueueLabelOfClusterScopedResource(networking.ClusterIngressLabelKey)(vs)
 	}
-	statusProber := ing.NewStatusProber(c.Logger.Named("status-manager"), gatewayInformer.Lister(),
-		endpointsInformer.Lister(), network.NewAutoTransport, resyncIngressOnVirtualServiceReady)
+	statusProber := ing.NewStatusProber(
+		c.Logger.Named("status-manager"),
+		gatewayInformer.Lister(),
+		endpointsInformer.Lister(),
+		serviceInformer.Lister(),
+		network.NewAutoTransport,
+		resyncIngressOnVirtualServiceReady)
 	c.BaseIngressReconciler.StatusManager = statusProber
 	statusProber.Start(ctx.Done())
 

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -29,6 +29,7 @@ import (
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/clusteringress/fake"
 

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -31,6 +31,7 @@ import (
 
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
+	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	istiolisters "knative.dev/pkg/client/listers/istio/v1alpha3"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -149,6 +150,7 @@ func (r *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 	ingressInformer := ingressinformer.Get(ctx)
 	gatewayInformer := gatewayinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
+	serviceInformer := serviceinformer.Get(ctx)
 
 	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
 	ingressHandler := cache.FilteringResourceEventHandler{
@@ -180,8 +182,13 @@ func (r *Reconciler) Init(ctx context.Context, cmw configmap.Watcher, impl *cont
 		// Reconcile when a VirtualService becomes ready
 		impl.EnqueueLabelOfNamespaceScopedResource(serving.RouteNamespaceLabelKey, serving.RouteLabelKey)(vs)
 	}
-	statusProber := NewStatusProber(r.Logger.Named("status-manager"), gatewayInformer.Lister(),
-		endpointsInformer.Lister(), network.NewAutoTransport, resyncIngressOnVirtualServiceReady)
+	statusProber := NewStatusProber(
+		r.Logger.Named("status-manager"),
+		gatewayInformer.Lister(),
+		endpointsInformer.Lister(),
+		serviceInformer.Lister(),
+		network.NewAutoTransport,
+		resyncIngressOnVirtualServiceReady)
 	r.StatusManager = statusProber
 	statusProber.Start(ctx.Done())
 

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -336,7 +336,7 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 		}
 		if len(services) == 0 {
 			// Allow an empty services list to not unnecessarily interrupt.
-			break
+			continue
 		}
 		service := services[0]
 

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -332,10 +332,10 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 
 		services, err := m.serviceLister.List(selector)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list Service: %v", err)
+			return nil, fmt.Errorf("failed to list Services: %v", err)
 		}
 		if len(services) == 0 {
-			// Skip gateways where we cannot find a corresponding service
+			m.logger.Infof("Skip Gateway %s/%s because it has no corresponding Service", gateway.Namespace, gateway.Name)
 			continue
 		}
 		service := services[0]

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -336,7 +336,7 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 		}
 		if len(services) == 0 {
 			// Allow an empty services list to not unnecessarily interrupt.
-			return podIPs, nil
+			break
 		}
 		service := services[0]
 

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -335,7 +335,8 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 			return nil, fmt.Errorf("failed to list Service: %v", err)
 		}
 		if len(services) == 0 {
-			return nil, errors.New("did not find a Service")
+			// Allow an empty services list to not unnecessarily interrupt.
+			return podIPs, nil
 		}
 		service := services[0]
 
@@ -351,7 +352,6 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 				continue
 			}
 
-			// Resolve the current gateway server's port to a name defined in the gateway's service.
 			portName, err := findNameForPortNumber(service, int32(server.Port.Number))
 			if err != nil {
 				return nil, fmt.Errorf("failed to find port name: %v", err)

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -335,7 +335,7 @@ func (m *StatusProber) listVirtualServicePodIPs(vs *v1alpha3.VirtualService) ([]
 			return nil, fmt.Errorf("failed to list Service: %v", err)
 		}
 		if len(services) == 0 {
-			// Allow an empty services list to not unnecessarily interrupt.
+			// Skip gateways where we cannot find a corresponding service
 			continue
 		}
 		service := services[0]

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -102,34 +102,6 @@ func TestIsReadyFailures(t *testing.T) {
 		},
 		serviceLister: &fakeServiceLister{fails: true},
 	}, {
-		name: "empty service list",
-		vsSpec: v1alpha3.VirtualServiceSpec{
-			Gateways: []string{"default/gateway"},
-			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
-		},
-		gatewayLister: &fakeGatewayLister{
-			gateways: []*v1alpha3.Gateway{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "gateway",
-				},
-				Spec: v1alpha3.GatewaySpec{
-					Servers: []v1alpha3.Server{{
-						Hosts: []string{"*"},
-						Port: v1alpha3.Port{
-							Number:   80,
-							Protocol: v1alpha3.ProtocolHTTP,
-						},
-					}},
-					Selector: map[string]string{
-						"gwt": "istio",
-					},
-				},
-			}},
-		},
-		serviceLister:   &fakeServiceLister{},
-		endpointsLister: &fakeEndpointsLister{fails: true},
-	}, {
 		name: "endpoints error",
 		vsSpec: v1alpha3.VirtualServiceSpec{
 			Gateways: []string{"default/gateway"},

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -50,6 +50,7 @@ func TestIsReadyFailures(t *testing.T) {
 		vsSpec          v1alpha3.VirtualServiceSpec
 		gatewayLister   istiolisters.GatewayLister
 		endpointsLister corev1listers.EndpointsLister
+		serviceLister   corev1listers.ServiceLister
 	}{{
 		name: "multiple probes",
 		vsSpec: v1alpha3.VirtualServiceSpec{
@@ -73,6 +74,61 @@ func TestIsReadyFailures(t *testing.T) {
 			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
 		},
 		gatewayLister: &fakeGatewayLister{fails: true},
+	}, {
+		name: "service error",
+		vsSpec: v1alpha3.VirtualServiceSpec{
+			Gateways: []string{"default/gateway"},
+			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
+		},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: v1alpha3.Port{
+							Number:   80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		serviceLister: &fakeServiceLister{fails: true},
+	}, {
+		name: "empty service list",
+		vsSpec: v1alpha3.VirtualServiceSpec{
+			Gateways: []string{"default/gateway"},
+			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
+		},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: v1alpha3.Port{
+							Number:   80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		serviceLister:   &fakeServiceLister{},
+		endpointsLister: &fakeEndpointsLister{fails: true},
 	}, {
 		name: "endpoints error",
 		vsSpec: v1alpha3.VirtualServiceSpec{
@@ -99,6 +155,14 @@ func TestIsReadyFailures(t *testing.T) {
 				},
 			}},
 		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+			}},
+		},
 		endpointsLister: &fakeEndpointsLister{fails: true},
 	}}
 
@@ -108,6 +172,7 @@ func TestIsReadyFailures(t *testing.T) {
 				zaptest.NewLogger(t).Sugar(),
 				test.gatewayLister,
 				test.endpointsLister,
+				test.serviceLister,
 				network.NewAutoTransport,
 				func(vs *v1alpha3.VirtualService) {})
 			copy := vs.DeepCopy()
@@ -177,7 +242,7 @@ func TestProbeLifecycle(t *testing.T) {
 					Servers: []v1alpha3.Server{{
 						Hosts: []string{"*"},
 						Port: v1alpha3.Port{
-							Number:   port,
+							Number:   80,
 							Protocol: v1alpha3.ProtocolHTTP,
 						},
 					}},
@@ -194,10 +259,34 @@ func TestProbeLifecycle(t *testing.T) {
 					Name:      "gateway",
 				},
 				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "bogus",
+						Port: 8080,
+					}, {
+						Name: "real",
+						Port: int32(port),
+					}},
 					Addresses: []v1.EndpointAddress{{
 						IP: hostname,
 					}},
 				}},
+			}},
+		},
+		&fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "bogus",
+						Port: 8080,
+					}, {
+						Name: "real",
+						Port: 80,
+					}},
+				},
 			}},
 		},
 		network.NewAutoTransport,
@@ -322,7 +411,7 @@ type fakeEndpointsLister struct {
 
 func (l *fakeEndpointsLister) List(selector labels.Selector) (ret []*v1.Endpoints, err error) {
 	if l.fails {
-		return nil, errors.New("failed to get Pod")
+		return nil, errors.New("failed to get Endpoints")
 	}
 	// TODO(bancel): use selector
 	return l.endpoints, nil
@@ -331,4 +420,27 @@ func (l *fakeEndpointsLister) List(selector labels.Selector) (ret []*v1.Endpoint
 func (l *fakeEndpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
 	log.Panic("not implemented")
 	return nil
+}
+
+type fakeServiceLister struct {
+	services []*v1.Service
+	fails    bool
+}
+
+func (l *fakeServiceLister) List(selector labels.Selector) (ret []*v1.Service, err error) {
+	if l.fails {
+		return nil, errors.New("failed to get Services")
+	}
+	// TODO(bancel): use selector
+	return l.services, nil
+}
+
+func (l *fakeServiceLister) Services(namespace string) corev1listers.ServiceNamespaceLister {
+	log.Panic("not implemented")
+	return nil
+}
+
+func (l *fakeServiceLister) GetPodServices(pod *v1.Pod) ([]*v1.Service, error) {
+	log.Panic("not implemented")
+	return nil, nil
 }

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -136,6 +136,108 @@ func TestIsReadyFailures(t *testing.T) {
 			}},
 		},
 		endpointsLister: &fakeEndpointsLister{fails: true},
+	}, {
+		name: "service port not found",
+		vsSpec: v1alpha3.VirtualServiceSpec{
+			Gateways: []string{"default/gateway"},
+			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
+		},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: v1alpha3.Port{
+							Number:   80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "bogus",
+						Port: 8080,
+					}},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpoints: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+			}},
+		},
+	}, {
+		name: "service port not found",
+		vsSpec: v1alpha3.VirtualServiceSpec{
+			Gateways: []string{"default/gateway"},
+			Hosts:    []string{"foobar" + resources.ProbeHostSuffix},
+		},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1alpha3.GatewaySpec{
+					Servers: []v1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: v1alpha3.Port{
+							Number:   80,
+							Protocol: v1alpha3.ProtocolHTTP,
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "real",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpoints: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "bogus",
+						Port: 8080,
+					}},
+				}},
+			}},
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Disclaimer:** This is not needed for upstream Istio. It is however needed for Openshift's mid-/downstream [Maistra](https://github.com/Maistra/istio/commit/ca7f4aebb567ca445bd2a9abda722f824f948c3a). It's trying to find a common enough ground between the two to prevent deviation downstream. Let's discuss if it makes sense.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

In upstream Istio, the gateway pods listen to the port specified in the Gateway definition. In Maistra however, the listening port is defined via the Gateway's Service definition.

This looks up the listening port via looking up the port number from the Gateway definition in the Service definition and then essentially using the Service's target port as the actual listening port. In the upstream Istio case, that should always be identical. In Maistra, the target port will define the actual listening port.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

/assign @JRBANCEL @mattmoor 
