### PR TITLE
Limit our use of PrependGenerateNameReactor.

### DIFF
--- a/pkg/reconciler/testing/v1alpha1/factory.go
+++ b/pkg/reconciler/testing/v1alpha1/factory.go
@@ -94,9 +94,12 @@ func MakeFactory(ctor Ctor) Factory {
 				return false, nil, nil
 			},
 		)
+		// This is needed by the Configuration controller tests, which
+		// use GenerateName to produce Revisions.
 		PrependGenerateNameReactor(&client.Fake)
+		// This is needed by the ServerlessService controller tests, which
+		// use GenerateName to produce K8s Services.
 		PrependGenerateNameReactor(&kubeClient.Fake)
-		PrependGenerateNameReactor(&dynamicClient.Fake)
 
 		// Set up our Controller from the fakes.
 		c := ctor(ctx, &ls, configmap.NewStaticWatcher())


### PR DESCRIPTION
This breaks in 1.14, and is going to mean carrying a patch to the testing
libraries for the near term.  I've eliminated the use of this entirely in
`eventing[-contrib]`, but we actually use this a few places today.
