### PR TITLE
Retry route inconsistencies on 'TestDestroyPodWithRequests'.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -93,14 +93,13 @@ func TestDestroyPodInflight(t *testing.T) {
 		t.Fatalf("Error obtaining Revision's name %v", err)
 	}
 
-	_, err = pkgTest.WaitForEndpointState(
+	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
 		domain,
 		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(timeoutExpectedOutput))),
 		"TimeoutAppServesText",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve the expected text \"%s\": %v", names.Route, domain, test.HelloWorldText, err)
 	}
 
@@ -232,14 +231,13 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	}
 	domain := objects.Route.Status.URL.Host
 
-	_, err = pkgTest.WaitForEndpointState(
+	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
 		domain,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"RouteServes",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
+		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at domain %s didn't serve correctly: %v", names.Route, domain, err)
 	}
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -232,6 +232,17 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	}
 	domain := objects.Route.Status.URL.Host
 
+	_, err = pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		domain,
+		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		"RouteServes",
+		test.ServingFlags.ResolvableDomain)
+	if err != nil {
+		t.Fatalf("The endpoint for Route %s at domain %s didn't serve correctly: %v", names.Route, domain, err)
+	}
+
 	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
 	})

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -71,6 +71,7 @@ func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, 
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
+// TODO(5573): Remove this.
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This test lacks the general `WaitForEndpointState` helper, which we're still using in all places.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
