### PR TITLE
Improve the error message when invalid combination

### DIFF
--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -146,7 +146,7 @@ func (tt *TrafficTarget) validateLatestRevision(ctx context.Context) *apis.Field
 		if pinned == lr {
 			// The senses for whether to pin to a particular revision or
 			// float forward to the latest revision must match.
-			return apis.ErrGeneric(fmt.Sprintf("May not set revisionName %q when latestRevision is %t", tt.RevisionName, lr), "latestRevision")
+			return apis.ErrGeneric(fmt.Sprintf("may not set revisionName %q when latestRevision is %t", tt.RevisionName, lr), "latestRevision")
 		}
 	}
 	return nil

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -146,7 +146,7 @@ func (tt *TrafficTarget) validateLatestRevision(ctx context.Context) *apis.Field
 		if pinned == lr {
 			// The senses for whether to pin to a particular revision or
 			// float forward to the latest revision must match.
-			return apis.ErrInvalidValue(lr, "latestRevision")
+			return apis.ErrGeneric(fmt.Sprintf("May not set revisionName %q when latestRevision is %t", tt.RevisionName, lr), "latestRevision")
 		}
 	}
 	return nil

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -100,7 +100,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrGeneric(`May not set revisionName "bar" when latestRevision is true`, "latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "bar" when latestRevision is true`, "latestRevision"),
 	}, {
 		name: "valid with revisionName and latestRevision (status)",
 		tt: &TrafficTarget{
@@ -153,7 +153,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid with configurationName and default configurationName",
 		tt: &TrafficTarget{
@@ -190,7 +190,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
 		},
-		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid without revisionName in status",
 		tt: &TrafficTarget{

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -100,7 +100,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrInvalidValue(true, "latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "bar" when latestRevision is true`, "latestRevision"),
 	}, {
 		name: "valid with revisionName and latestRevision (status)",
 		tt: &TrafficTarget{
@@ -153,7 +153,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrInvalidValue(false, "latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid with configurationName and default configurationName",
 		tt: &TrafficTarget{
@@ -190,7 +190,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
 		},
-		want: apis.ErrInvalidValue(false, "latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid without revisionName in status",
 		tt: &TrafficTarget{

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -194,7 +194,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue(true, "spec.traffic[0].latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "valid" when latestRevision is true`, "spec.traffic[0].latestRevision"),
 	}, {
 		name: "invalid container concurrency",
 		r: &Service{

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -194,7 +194,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrGeneric(`May not set revisionName "valid" when latestRevision is true`, "spec.traffic[0].latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "valid" when latestRevision is true`, "spec.traffic[0].latestRevision"),
 	}, {
 		name: "invalid container concurrency",
 		r: &Service{

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -170,7 +170,7 @@ func (rt *ReleaseType) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if numRevisions < 2 && rt.RolloutPercent != 0 {
-		errs = errs.Also(apis.ErrGeneric("May not set rolloutPercent for a single revision", "rolloutPercent"))
+		errs = errs.Also(apis.ErrGeneric("may not set rolloutPercent for a single revision", "rolloutPercent"))
 	}
 
 	if rt.RolloutPercent < 0 || rt.RolloutPercent > 99 {

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -170,7 +170,7 @@ func (rt *ReleaseType) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if numRevisions < 2 && rt.RolloutPercent != 0 {
-		errs = errs.Also(apis.ErrInvalidValue(rt.RolloutPercent, "rolloutPercent"))
+		errs = errs.Also(apis.ErrGeneric("May not set rolloutPercent for a single revision", "rolloutPercent"))
 	}
 
 	if rt.RolloutPercent < 0 || rt.RolloutPercent > 99 {

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -494,7 +494,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue(10, "spec.release.rolloutPercent"),
+		want: apis.ErrGeneric("May not set rolloutPercent for a single revision", "spec.release.rolloutPercent"),
 	}, {
 		name: "invalid name - dots",
 		s: &Service{

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -494,7 +494,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrGeneric("May not set rolloutPercent for a single revision", "spec.release.rolloutPercent"),
+		want: apis.ErrGeneric("may not set rolloutPercent for a single revision", "spec.release.rolloutPercent"),
 	}, {
 		name: "invalid name - dots",
 		s: &Service{

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -101,7 +101,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrGeneric(`May not set revisionName "bar" when latestRevision is true`, "latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "bar" when latestRevision is true`, "latestRevision"),
 	}, {
 		name: "valid with revisionName and latestRevision (status)",
 		tt: &v1.TrafficTarget{
@@ -154,7 +154,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid with configurationName and default configurationName",
 		tt: &v1.TrafficTarget{
@@ -191,7 +191,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		wc: func(ctx context.Context) context.Context {
 			return v1.WithDefaultConfigurationName(apis.WithinSpec(ctx))
 		},
-		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid without revisionName in status",
 		tt: &v1.TrafficTarget{

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -101,7 +101,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:        ptr.Int64(12),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrInvalidValue(true, "latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "bar" when latestRevision is true`, "latestRevision"),
 	}, {
 		name: "valid with revisionName and latestRevision (status)",
 		tt: &v1.TrafficTarget{
@@ -154,7 +154,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			Percent:           ptr.Int64(37),
 		},
 		wc:   apis.WithinSpec,
-		want: apis.ErrInvalidValue(false, "latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid with configurationName and default configurationName",
 		tt: &v1.TrafficTarget{
@@ -191,7 +191,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 		wc: func(ctx context.Context) context.Context {
 			return v1.WithDefaultConfigurationName(apis.WithinSpec(ctx))
 		},
-		want: apis.ErrInvalidValue(false, "latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "" when latestRevision is false`, "latestRevision"),
 	}, {
 		name: "invalid without revisionName in status",
 		tt: &v1.TrafficTarget{

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -195,7 +195,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue(true, "spec.traffic[0].latestRevision"),
+		want: apis.ErrGeneric(`May not set revisionName "valid" when latestRevision is true`, "spec.traffic[0].latestRevision"),
 	}, {
 		name: "invalid container concurrency",
 		r: &Service{

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -195,7 +195,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrGeneric(`May not set revisionName "valid" when latestRevision is true`, "spec.traffic[0].latestRevision"),
+		want: apis.ErrGeneric(`may not set revisionName "valid" when latestRevision is true`, "spec.traffic[0].latestRevision"),
 	}, {
 		name: "invalid container concurrency",
 		r: &Service{


### PR DESCRIPTION
## Proposed Changes

This PR is basically same idea with the fix of https://github.com/knative/serving/issues/5382.

When invalid combination is configured, the ErrInvalidValue is printed for now.
It is not accurate message and will mislead users.

To fix it, this patch prints accurate message with ErrGeneric.

BEFORE:
```
invalid value: true: spec.traffic[0].latestRevision
```

AFTER:
```
May not set revisionName "hello-example-dk7nd" when latestRevision is true: spec.traffic[0].latestRevision
```

for following combination.

```
  traffic:
  - latestRevision: true
    revisionName: hello-example-dk7nd
    percent: 100
```

Also, ref: https://github.com/knative/pkg/pull/638

/lint


**Release Note**

```release-note
NONE
```
