### PR TITLE
Fix an oudated comment and some left-over code

### DIFF
--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -34,7 +34,7 @@ const (
 	retryInterval = 50 * time.Millisecond
 )
 
-// Probe wraps a corev1.Probe along with a logger and a count of consecutive, successful probes
+// Probe wraps a corev1.Probe along with a count of consecutive, successful probes
 type Probe struct {
 	*corev1.Probe
 	count int32

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -255,7 +255,6 @@ func (t *configBuilder) addRevisionTarget(tt *v1alpha1.TrafficTarget) error {
 		Protocol:      rev.GetProtocol(),
 		ServiceName:   rev.Status.ServiceName,
 	}
-	t.revisions[tt.RevisionName] = rev
 	if configName, ok := rev.Labels[serving.ConfigurationLabelKey]; ok {
 		target.TrafficTarget.ConfigurationName = configName
 		if _, err := t.getConfiguration(configName); err != nil {


### PR DESCRIPTION
Fix some nits noticed while reading through the code.

The revision cache in traffic.go is managed by configBuilder.getRevision() and
there's no need to update it again in configBuilder.addRevisionTarget() right after
calling getRevision().

/lint
