### PR TITLE
Fail fast if failed generating yamls

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -119,11 +119,10 @@ function build_knative_from_source() {
   fi
 
   # Generate manifests, capture environment variables pointing to the YAML files.
-  local FULL_OUTPUT="$( \
+  local FULL_OUTPUT
+  FULL_OUTPUT="$( \
       source $(dirname $0)/../hack/generate-yamls.sh ${REPO_ROOT_DIR} ${YAML_LIST} ; \
       set | grep _YAML=/)"
-  # Fail if generate-yamls.sh failed
-  (( $? )) && return 1
   local LOG_OUTPUT="$(echo "${FULL_OUTPUT}" | grep -v _YAML=/)"
   local ENV_OUTPUT="$(echo "${FULL_OUTPUT}" | grep '^[_0-9A-Z]\+_YAML=/')"
   [[ -z "${LOG_OUTPUT}" || -z "${ENV_OUTPUT}" ]] && fail_test "Error generating manifests"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -122,6 +122,8 @@ function build_knative_from_source() {
   local FULL_OUTPUT="$( \
       source $(dirname $0)/../hack/generate-yamls.sh ${REPO_ROOT_DIR} ${YAML_LIST} ; \
       set | grep _YAML=/)"
+  # Fail if generate-yamls.sh failed
+  (( $? )) && return 1
   local LOG_OUTPUT="$(echo "${FULL_OUTPUT}" | grep -v _YAML=/)"
   local ENV_OUTPUT="$(echo "${FULL_OUTPUT}" | grep '^[_0-9A-Z]\+_YAML=/')"
   [[ -z "${LOG_OUTPUT}" || -z "${ENV_OUTPUT}" ]] && fail_test "Error generating manifests"


### PR DESCRIPTION
It shouldn't run e2e tests if failed generating serving yamls. Example: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.1-mesh/1174030278339858432

/cc @adrcunha 
/cc @mattmoor 