### PR TITLE
config/v1 is missed in cleanup section.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -321,7 +321,7 @@ You can delete all of the service components with:
 ```shell
 ko delete --ignore-not-found=true \
   -f config/monitoring/100-namespace.yaml \
-  -f config/ \
+  -f config/ -f config/v1 \
   -f ./third_party/istio-1.2-latest/istio.yaml \
   -f ./third_party/istio-1.2-latest/istio-crds.yaml \
   -f ./third_party/cert-manager-0.9.1/cert-manager-crds.yaml \


### PR DESCRIPTION
Signed-off-by: Yu Wei <yuweiw@cn.ibm.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5553 

## Proposed Changes

* `ko delete -f config/v1` should be invoked in cleanup section. Updated development doc.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
