### PR TITLE
Skip tag uniqeness check if no traffic target tag was provided

### DIFF
--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -46,6 +46,14 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 	for i, tt := range traffic {
 		errs = errs.Also(tt.Validate(ctx).ViaIndex(i))
 
+		if tt.Percent != nil {
+			sum += *tt.Percent
+		}
+
+		if tt.Tag == "" {
+			continue
+		}
+
 		if idx, ok := trafficMap[tt.Tag]; ok {
 			// We want only single definition of the route, even if it points
 			// to the same config or revision.
@@ -58,9 +66,6 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 			})
 		} else {
 			trafficMap[tt.Tag] = i
-		}
-		if tt.Percent != nil {
-			sum += *tt.Percent
 		}
 	}
 

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -348,6 +348,23 @@ func TestRouteValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "valid split without tags",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					RevisionName: "foo",
+					Percent:      ptr.Int64(90),
+				}, {
+					RevisionName: "bar",
+					Percent:      ptr.Int64(10),
+				}},
+			},
+		},
+		want: nil,
+	}, {
 		name: "missing url in status",
 		r: &Route{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Proposed Changes

Currently v1 route validation rejects multiple traffic targets with empty
tags. Since traffic target tags are optional this behavior is incorrect.

This patch disables tag uniqueness checks for traffic targets with empty
tags. This also aligns with v1alpha1 traffic target validation.

/lint
