### PR TITLE
Make network config key and default template const

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -106,9 +106,7 @@ const (
 	//
 	// We should consider exposing this as a configuration.
 	DefaultConnTimeout = 200 * time.Millisecond
-)
 
-var (
 	// DefaultDomainTemplate is the default golang template to use when
 	// constructing the Knative Route's Domain(host)
 	DefaultDomainTemplate = "{{.Name}}.{{.Namespace}}.{{.Domain}}"


### PR DESCRIPTION
## Proposed Changes

This patch changes `DefaultDomainTemplate`, `DefaultTagTemplate`,
`AutoTLSKey` and `HTTPProtocolKey` to const.

/lint

**Release Note**

```release-note
NONE
```
