### PR TITLE
Fix a transposed resource block in the default tests.

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -279,11 +279,11 @@ func TestRevisionDefaulting(t *testing.T) {
 					Containers: []corev1.Container{{
 						Name: config.DefaultUserContainerName,
 						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
+							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("200M"),
 							},
-							Requests: corev1.ResourceList{
+							Limits: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("300m"),
 								corev1.ResourceMemory: resource.MustParse("400M"),
 							},


### PR DESCRIPTION
I believe this test doesn't fail today because of the `ignoreUnexportedFields` in the `cmp.Diff`, but for some reason is starts failing with the K8s 1.15 libs (I'm still not sure why!).