### PR TITLE
Deduplicate error logging for the stats scraper.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -194,10 +194,10 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer,
 }
 
 func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) autoscaler.StatsScraperFactory {
-	return func(metric *av1alpha1.Metric, l *zap.SugaredLogger) (autoscaler.StatsScraper, error) {
+	return func(metric *av1alpha1.Metric) (autoscaler.StatsScraper, error) {
 		podCounter := resources.NewScopedEndpointsCounter(
 			endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
-		return autoscaler.NewServiceScraper(metric, podCounter, l)
+		return autoscaler.NewServiceScraper(metric, podCounter)
 	}
 }
 

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/logging/logkey"
 	"knative.dev/serving/pkg/autoscaler/aggregation"
 
 	"go.uber.org/zap"
@@ -47,7 +46,7 @@ var (
 )
 
 // StatsScraperFactory creates a StatsScraper for a given Metric.
-type StatsScraperFactory func(*av1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error)
+type StatsScraperFactory func(*av1alpha1.Metric) (StatsScraper, error)
 
 // Stat defines a single measurement at a point in time
 type Stat struct {
@@ -128,8 +127,7 @@ func NewMetricCollector(statsScraperFactory StatsScraperFactory, logger *zap.Sug
 // it already exist.
 // Map access optimized via double-checked locking.
 func (c *MetricCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
-	l := c.logger.With(zap.String(logkey.Key, metric.Namespace+"/"+metric.Name))
-	scraper, err := c.statsScraperFactory(metric, l)
+	scraper, err := c.statsScraperFactory(metric)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -348,7 +347,7 @@ func TestMetricCollectorError(t *testing.T) {
 }
 
 func scraperFactory(scraper StatsScraper, err error) StatsScraperFactory {
-	return func(*av1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error) {
+	return func(*av1alpha1.Metric) (StatsScraper, error) {
 		return scraper, err
 	}
 }

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -23,10 +23,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	. "knative.dev/pkg/logging/testing"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/resources"
@@ -64,10 +62,8 @@ var (
 )
 
 func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
-	defer ClearAll()
-	logger := TestLogger(t)
 	client := newTestScrapeClient(testStats, []error{nil})
-	if scraper, err := serviceScraperForTest(client, logger); err != nil {
+	if scraper, err := serviceScraperForTest(client); err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	} else {
 		if scraper.url != testURL {
@@ -86,8 +82,6 @@ func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
 	client := newTestScrapeClient(testStats, []error{nil})
 	lister := kubeInformer.Core().V1().Endpoints().Lister()
 	counter := resources.NewScopedEndpointsCounter(lister, testNamespace, testService)
-	logger := TestLogger(t)
-	defer ClearAll()
 
 	testCases := []struct {
 		name        string
@@ -121,7 +115,7 @@ func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := newServiceScraperWithClient(test.metric, test.counter, test.client, logger); err != nil {
+			if _, err := newServiceScraperWithClient(test.metric, test.counter, test.client); err != nil {
 				got := err.Error()
 				want := test.expectedErr
 				if got != want {
@@ -135,11 +129,8 @@ func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
 }
 
 func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
-	defer ClearAll()
-	logger := TestLogger(t)
-
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(client, logger)
+	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
@@ -184,10 +175,8 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 }
 
 func TestScrapeReportErrorCannotFindEnoughPods(t *testing.T) {
-	defer ClearAll()
-	logger := TestLogger(t)
 	client := newTestScrapeClient(testStats[2:], []error{nil})
-	scraper, err := serviceScraperForTest(client, logger)
+	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
@@ -202,14 +191,12 @@ func TestScrapeReportErrorCannotFindEnoughPods(t *testing.T) {
 }
 
 func TestScrapeReportErrorIfAnyFails(t *testing.T) {
-	defer ClearAll()
-	logger := TestLogger(t)
 	errTest := errors.New("test")
 
 	// 1 success and 10 failures so one scrape fails permanently through retries.
 	client := newTestScrapeClient(testStats, []error{nil,
 		errTest, errTest, errTest, errTest, errTest, errTest, errTest, errTest, errTest, errTest})
-	scraper, err := serviceScraperForTest(client, logger)
+	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
@@ -224,10 +211,8 @@ func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 }
 
 func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
-	defer ClearAll()
-	logger := TestLogger(t)
 	client := newTestScrapeClient(testStats, nil)
-	scraper, err := serviceScraperForTest(client, logger)
+	scraper, err := serviceScraperForTest(client)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
@@ -244,10 +229,10 @@ func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
 	}
 }
 
-func serviceScraperForTest(sClient scrapeClient, l *zap.SugaredLogger) (*ServiceScraper, error) {
+func serviceScraperForTest(sClient scrapeClient) (*ServiceScraper, error) {
 	metric := testMetric()
 	counter := resources.NewScopedEndpointsCounter(kubeInformer.Core().V1().Endpoints().Lister(), testNamespace, testService)
-	return newServiceScraperWithClient(metric, counter, sClient, l)
+	return newServiceScraperWithClient(metric, counter, sClient)
 }
 
 func testMetric() *av1alpha1.Metric {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The stats scraper today only needs a logger to be able to log errors in the Scrape function which are logged by the caller of the Scrape function anyway. Instead of passing in a logger, we can return errors with enough context and log these instead.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
