### PR TITLE
Remove redundant errors 

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -381,7 +381,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "horizontalpodautoscalers"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update horizontalpodautoscalers"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update HPA: inducing failure for update horizontalpodautoscalers"),
 		},
 	}, {
 		Name: "update hpa with target usage",
@@ -421,7 +421,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantErr: true,
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create horizontalpodautoscalers"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create HPA: inducing failure for create horizontalpodautoscalers"),
 		},
 	}}
 

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -178,7 +178,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to create Cert-Manager Certificate %s: %v",
 				"foo/knCert", "inducing failure for update certificates"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update certificates"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update Cert-Manager Certificate: inducing failure for update certificates"),
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for Certificate %s: %v",
 				"foo/knCert", "inducing failure for update certificates"),
 		},

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -530,7 +530,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress-mesh"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-clusteringress"),
-			Eventf(corev1.EventTypeWarning, "InternalError", `gateway.networking.istio.io "knative-ingress-gateway" not found`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `failed to get Gateway: gateway.networking.istio.io "knative-ingress-gateway" not found`),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconciling-clusteringress"),
 		},
 		// Error should be returned when there is no preinstalled gateways.

--- a/pkg/reconciler/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/clusteringress/clusteringress_test.go
@@ -302,7 +302,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconcile-failed-mesh"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update virtualservices"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update VirtualService: inducing failure for update virtualservices"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconcile-failed"),
 		},
 		Key: "reconcile-failed",

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/tracker"
 
+	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -392,7 +393,6 @@ func (r *BaseIngressReconciler) reconcileCertSecrets(ctx context.Context, ia v1a
 
 func (r *BaseIngressReconciler) reconcileVirtualServices(ctx context.Context, ia v1alpha1.IngressAccessor,
 	desired []*v1alpha3.VirtualService) error {
-	logger := logging.FromContext(ctx)
 	// First, create all needed VirtualServices.
 	kept := sets.NewString()
 	for _, d := range desired {
@@ -410,8 +410,7 @@ func (r *BaseIngressReconciler) reconcileVirtualServices(ctx context.Context, ia
 			serving.RouteLabelKey:          ia.GetLabels()[serving.RouteLabelKey],
 			serving.RouteNamespaceLabelKey: ia.GetLabels()[serving.RouteNamespaceLabelKey]}).AsSelector())
 	if err != nil {
-		logger.Errorw("Failed to get VirtualServices", zap.Error(err))
-		return err
+		return perrors.Wrap(err, "failed to get VirtualServices")
 	}
 	for _, vs := range vses {
 		n, ns := vs.Name, vs.Namespace
@@ -419,8 +418,7 @@ func (r *BaseIngressReconciler) reconcileVirtualServices(ctx context.Context, ia
 			continue
 		}
 		if err = r.SharedClientSet.NetworkingV1alpha3().VirtualServices(ns).Delete(n, &metav1.DeleteOptions{}); err != nil {
-			logger.Errorw("Failed to delete VirtualService", zap.Error(err))
-			return err
+			return perrors.Wrap(err, "failed to delete VirtualService")
 		}
 	}
 	return nil
@@ -493,13 +491,11 @@ func (r *BaseIngressReconciler) ensureFinalizer(ra ReconcilerAccessor, ia v1alph
 func (r *BaseIngressReconciler) reconcileGateway(ctx context.Context, ia v1alpha1.IngressAccessor, gw config.Gateway, desired []v1alpha3.Server) error {
 	// TODO(zhiminx): Need to handle the scenario when deleting ClusterIngress. In this scenario,
 	// the Gateway servers of the ClusterIngress need also be removed from Gateway.
-	logger := logging.FromContext(ctx)
 	gateway, err := r.GatewayLister.Gateways(gw.Namespace).Get(gw.Name)
 	if err != nil {
-		// Not like VirtualService, A default gateway needs to be existed.
+		// Not like VirtualService, A default gateway needs to be existent.
 		// It should be installed when installing Knative.
-		logger.Errorw("Failed to get Gateway.", zap.Error(err))
-		return err
+		return perrors.Wrap(err, "failed to get Gateway")
 	}
 
 	existing := resources.GetServers(gateway, ia)
@@ -520,8 +516,7 @@ func (r *BaseIngressReconciler) reconcileGateway(ctx context.Context, ia v1alpha
 	copy := gateway.DeepCopy()
 	copy = resources.UpdateGateway(copy, desired, existing)
 	if _, err := r.SharedClientSet.NetworkingV1alpha3().Gateways(copy.Namespace).Update(copy); err != nil {
-		logger.Errorw("Failed to update Gateway", zap.Error(err))
-		return err
+		return perrors.Wrap(err, "failed to update Gateway")
 	}
 	r.Recorder.Eventf(ia, corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", gateway.Namespace, gateway.Name)
 	return nil

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -493,7 +493,7 @@ func (r *BaseIngressReconciler) reconcileGateway(ctx context.Context, ia v1alpha
 	// the Gateway servers of the ClusterIngress need also be removed from Gateway.
 	gateway, err := r.GatewayLister.Gateways(gw.Namespace).Get(gw.Name)
 	if err != nil {
-		// Not like VirtualService, A default gateway needs to be existent.
+		// Unlike VirtualService, a default gateway needs to be existent.
 		// It should be installed when installing Knative.
 		return perrors.Wrap(err, "failed to get Gateway")
 	}

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Knative certificate %s/%s: inducing failure for create certificates", "foo", defaultCertName),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create certificates"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create namespace certificate: inducing failure for create certificates"),
 		},
 	}}
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -152,7 +152,6 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 }
 
 func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) error {
-	logger := commonlogging.FromContext(ctx)
 	if rev.GetDeletionTimestamp() != nil {
 		return nil
 	}
@@ -194,7 +193,6 @@ func (c *Reconciler) reconcile(ctx context.Context, rev *v1alpha1.Revision) erro
 
 	for _, phase := range phases {
 		if err := phase.f(ctx, rev); err != nil {
-			logger.Errorw("Failed to reconcile", zap.String("phase", phase.name), zap.Error(err))
 			return err
 		}
 	}

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -137,7 +137,7 @@ func TestReconcile(t *testing.T) {
 				MarkDeploying("Deploying")),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create podautoscalers"),
+			Eventf(corev1.EventTypeWarning, "InternalError", `failed to create PA "create-pa-failure": inducing failure for create podautoscalers`),
 		},
 		Key: "foo/create-pa-failure",
 	}, {
@@ -163,7 +163,8 @@ func TestReconcile(t *testing.T) {
 				MarkDeploying("Deploying")),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create deployments"),
+			Eventf(corev1.EventTypeWarning, "InternalError",
+				`failed to create deployment "create-user-deploy-failure-deployment": inducing failure for create deployments`),
 		},
 		Key: "foo/create-user-deploy-failure",
 	}, {
@@ -237,7 +238,8 @@ func TestReconcile(t *testing.T) {
 			Object: deploy(t, "foo", "failure-update-deploy"),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update deployments"),
+			Eventf(corev1.EventTypeWarning, "InternalError",
+				`failed to update deployment "failure-update-deploy-deployment": inducing failure for update deployments`),
 		},
 		Key: "foo/failure-update-deploy",
 	}, {
@@ -383,7 +385,7 @@ func TestReconcile(t *testing.T) {
 			Object: pa("foo", "fix-mutated-pa-fail", WithReachability(asv1a1.ReachabilityUnknown)),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update podautoscalers"),
+			Eventf(corev1.EventTypeWarning, "InternalError", `failed to update PA "fix-mutated-pa-fail": inducing failure for update podautoscalers`),
 		},
 		Key: "foo/fix-mutated-pa-fail",
 	}, {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We do lots of redundant error logging as our main reconciler handler always logs the errors it gets. If we properly return contextualized errors, that should suffice to give us good error logging without calling it explicitly everywhere, polluting the code with redundant text and more importantly, polluting the log with no added benefits.

This is Part 1, a few reconcilers are still missing but I wanted to get feedback if we even want to do this.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Error log messages have been consolidated.
```

/assign @mattmoor @vagababov 
