### PR TITLE
Delete resources before reinstalling for performance testing setup

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -122,8 +122,8 @@ function update_cluster() {
   pushd .
   cd ${GOPATH}/src/knative.dev
   echo ">> Update istio"
-  kubectl delete -f serving/third_party/$istio_version/istio-crds.yaml --ignore-not-found --timeout 60s
-  kubectl delete -f serving/third_party/$istio_version/istio-lean.yaml --ignore-not-found --timeout 60s
+  kubectl delete -f serving/third_party/$istio_version/istio-crds.yaml --ignore-not-found --timeout 100s
+  kubectl delete -f serving/third_party/$istio_version/istio-lean.yaml --ignore-not-found --timeout 100s
   wait_until_object_does_not_exist namespaces istio-system 
   kubectl apply -f serving/third_party/$istio_version/istio-crds.yaml || abort "Failed to apply istio-crds"
   kubectl apply -f serving/third_party/$istio_version/istio-lean.yaml || abort "Failed to apply istio-lean"
@@ -135,8 +135,8 @@ function update_cluster() {
     --patch '{"spec": {"replicas": 10}}'
 
   echo ">> Updating serving"
-  ko delete -f serving/config/ --ignore-not-found --timeout 60s
-  ko delete -f serving/config/v1 --ignore-not-found --timeout 60s
+  ko delete -f serving/config/ --ignore-not-found --timeout 100s
+  ko delete -f serving/config/v1 --ignore-not-found --timeout 100s
   wait_until_object_does_not_exist namespaces knative-serving
   # Retry installation for at most two times as there can sometime be a race condition when applying serving CRDs
   local n=0
@@ -180,6 +180,6 @@ EOF
   # NOTE: this assumes we have a benchmark with the same name as the cluster
   # If service creation takes long time, we will have some intially unreachable errors in the test
   cd $TEST_ROOT_PATH
-  ko delete -f $1 --ignore-not-found --timeout 60s > /dev/null 2>&1
+  ko delete -f $1 --ignore-not-found --timeout 60s
   ko apply -f $1 || abort "Failed to apply benchmarks yaml"
 }

--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -96,6 +96,8 @@ function update_cluster() {
   pushd .
   cd ${GOPATH}/src/knative.dev
   echo ">> Update istio"
+  kubectl delete -f serving/third_party/$istio_version/istio-crds.yaml > /dev/null 2>&1
+  kubectl delete -f serving/third_party/$istio_version/istio-lean.yaml > /dev/null 2>&1
   kubectl apply -f serving/third_party/$istio_version/istio-crds.yaml || abort "Failed to apply istio-crds"
   kubectl apply -f serving/third_party/$istio_version/istio-lean.yaml || abort "Failed to apply istio-lean"
 
@@ -106,6 +108,8 @@ function update_cluster() {
     --patch '{"spec": {"replicas": 10}}'
 
   echo ">> Updating serving"
+  ko delete -f serving/config/ > /dev/null 2>&1
+  ko delete -f serving/config/v1 > /dev/null 2>&1
   # Retry installation for at most two times as there can sometime be a race condition when applying serving CRDs
   local n=0
   until [ $n -ge 2 ]
@@ -148,6 +152,6 @@ EOF
   # NOTE: this assumes we have a benchmark with the same name as the cluster
   # If service creation takes long time, we will have some intially unreachable errors in the test
   cd $TEST_ROOT_PATH
-  echo "Using ko version $(ko version)"
+  ko delete -f $1 > /dev/null 2>&1
   ko apply -f $1 || abort "Failed to apply benchmarks yaml"
 }

--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -96,8 +96,8 @@ function update_cluster() {
   pushd .
   cd ${GOPATH}/src/knative.dev
   echo ">> Update istio"
-  kubectl delete -f serving/third_party/$istio_version/istio-crds.yaml > /dev/null 2>&1
-  kubectl delete -f serving/third_party/$istio_version/istio-lean.yaml > /dev/null 2>&1
+  kubectl delete -f serving/third_party/$istio_version/istio-crds.yaml --ignore-not-found --timeout 60s > /dev/null 2>&1
+  kubectl delete -f serving/third_party/$istio_version/istio-lean.yaml --ignore-not-found --timeout 60s > /dev/null 2>&1
   kubectl apply -f serving/third_party/$istio_version/istio-crds.yaml || abort "Failed to apply istio-crds"
   kubectl apply -f serving/third_party/$istio_version/istio-lean.yaml || abort "Failed to apply istio-lean"
 
@@ -108,8 +108,8 @@ function update_cluster() {
     --patch '{"spec": {"replicas": 10}}'
 
   echo ">> Updating serving"
-  ko delete -f serving/config/ > /dev/null 2>&1
-  ko delete -f serving/config/v1 > /dev/null 2>&1
+  ko delete -f serving/config/ --ignore-not-found --timeout 60s > /dev/null 2>&1
+  ko delete -f serving/config/v1 --ignore-not-found --timeout 60s > /dev/null 2>&1
   # Retry installation for at most two times as there can sometime be a race condition when applying serving CRDs
   local n=0
   until [ $n -ge 2 ]
@@ -152,6 +152,6 @@ EOF
   # NOTE: this assumes we have a benchmark with the same name as the cluster
   # If service creation takes long time, we will have some intially unreachable errors in the test
   cd $TEST_ROOT_PATH
-  ko delete -f $1 > /dev/null 2>&1
+  ko delete -f $1 --ignore-not-found --timeout 60s > /dev/null 2>&1
   ko apply -f $1 || abort "Failed to apply benchmarks yaml"
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Our Prow jobs to update serving fails because of istio version update, see https://prow.knative.dev/log?job=ci-knative-serving-update-clusters&id=1174776708444721152

For every installation, regardless whether it's recreating or update the clusters, always try to delete the previous installation first.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @srinivashegde86 
/cc @vagababov 