### PR TITLE
Clean the rest of the activator code to use injected logger and informers

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -30,9 +30,7 @@ import (
 
 	// Injection related imports.
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/injection"
-	sksinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 
 	"github.com/kelseyhightower/envconfig"
@@ -147,9 +145,6 @@ func main() {
 	defer flush(logger)
 
 	kubeClient := kubeclient.Get(ctx)
-	serviceInformer := serviceinformer.Get(ctx)
-	revisionInformer := revisioninformer.Get(ctx)
-	sksInformer := sksinformer.Get(ctx)
 
 	// Run informers instead of starting them from the factory to prevent the sync hanging because of empty handler.
 	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
@@ -211,31 +206,28 @@ func main() {
 
 	var env config
 	if err := envconfig.Process("", &env); err != nil {
-		logger.Fatal("Failed to process env", err)
+		logger.Fatalw("Failed to process env", zap.Error(err))
 	}
 	podName := env.PodName
 
 	// Create and run our concurrency reporter
 	reportTicker := time.NewTicker(time.Second)
 	defer reportTicker.Stop()
-	cr := activatorhandler.NewConcurrencyReporter(logger, podName, reqCh, reportTicker.C, statCh, revisionInformer.Lister(), reporter)
+	cr := activatorhandler.NewConcurrencyReporter(ctx, podName, reqCh,
+		reportTicker.C, statCh, reporter)
 	go cr.Run(ctx.Done())
 
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
 	var ah http.Handler = activatorhandler.New(
-		logger,
-		reporter,
+		ctx,
 		throttler,
-		revisionInformer.Lister(),
-		serviceInformer.Lister(),
-		sksInformer.Lister(),
-	)
+		reporter)
 	ah = activatorhandler.NewRequestEventHandler(reqCh, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",
-		requestLogTemplateInputGetter(revisionInformer.Lister()))
+		requestLogTemplateInputGetter(revisioninformer.Get(ctx).Lister()))
 	if err != nil {
 		logger.Fatalw("Unable to create request log handler", zap.Error(err))
 	}
@@ -248,7 +240,7 @@ func main() {
 	ah = &activatorhandler.HealthHandler{HealthCheck: hc, NextHandler: ah}
 
 	// NOTE: MetricHandler is being used as the outermost handler for the purpose of measuring the request latency.
-	ah = activatorhandler.NewMetricHandler(revisionInformer.Lister(), reporter, logger, ah)
+	ah = activatorhandler.NewMetricHandler(ctx, reporter, ah)
 	ah = network.NewProbeHandler(ah)
 
 	profilingHandler := profiling.NewHandler(logger, false)

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -26,7 +26,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"knative.dev/pkg/logging"
 	. "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/system"
@@ -260,10 +259,9 @@ func newTestStats(t *testing.T, clock system.Clock) (*testStats, *ConcurrencyRep
 		reportBiChan: reportBiChan,
 	}
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-	revisions := revisionInformer(ctx, revision(testNamespace, testRevName))
+	revisionInformer(ctx, revision(testNamespace, testRevName))
 
-	cr := NewConcurrencyReporterWithClock(logging.FromContext(ctx), "activator",
-		ts.reqChan, ts.reportChan, ts.statChan,
-		revisions.Lister(), &fakeReporter{}, clock)
+	cr := NewConcurrencyReporterWithClock(ctx, "activator",
+		ts.reqChan, ts.reportChan, ts.statChan, &fakeReporter{}, clock)
 	return ts, cr, ctx, cancel
 }

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -16,27 +16,30 @@ limitations under the License.
 package handler
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/network"
 )
 
 // NewMetricHandler creates a handler collects and reports request metrics
-func NewMetricHandler(rl servinglisters.RevisionLister, r activator.StatsReporter, l *zap.SugaredLogger, next http.Handler) *MetricHandler {
+func NewMetricHandler(ctx context.Context, r activator.StatsReporter, next http.Handler) *MetricHandler {
 	handler := &MetricHandler{
 		nextHandler:    next,
-		revisionLister: rl,
+		revisionLister: revisioninformer.Get(ctx).Lister(),
 		reporter:       r,
-		logger:         l,
+		logger:         logging.FromContext(ctx),
 	}
 
 	return handler

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"knative.dev/pkg/logging"
 	. "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
@@ -104,9 +103,8 @@ func TestRequestMetricHandler(t *testing.T) {
 				ClearAll()
 			}()
 			reporter := &fakeReporter{}
-			handler := NewMetricHandler(
-				revisionInformer(ctx, revision(testNamespace, testRevName)).Lister(),
-				reporter, logging.FromContext(ctx), test.baseHandler)
+			revisionInformer(ctx, revision(testNamespace, testRevName))
+			handler := NewMetricHandler(ctx, reporter, test.baseHandler)
 
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString(""))


### PR DESCRIPTION
This is the last of such clean ups in the Activator (hopefully)


/lint
/assign mattmoor @yanweiguo 
