### PR TITLE
Remove the Istio sidecar prestop hook (no longer needed).

### DIFF
--- a/third_party/istio-1.2.6/download-istio.sh
+++ b/third_party/istio-1.2.6/download-istio.sh
@@ -49,5 +49,3 @@ rm istio-${ISTIO_VERSION}-linux.tar.gz
 patch istio-crds.yaml namespace.yaml.patch
 patch istio.yaml namespace.yaml.patch
 patch istio-lean.yaml namespace.yaml.patch
-
-patch -l istio.yaml prestop-sleep.yaml.patch

--- a/third_party/istio-1.2.6/istio.yaml
+++ b/third_party/istio-1.2.6/istio.yaml
@@ -618,12 +618,6 @@ data:
       {{- else }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
       {{- end }}
-        # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
-        lifecycle:
-          preStop:
-            exec:
-              command: ["sleep", "20"]
-        # PATCH #2 ends.
         ports:
         - containerPort: 15090
           protocol: TCP

--- a/third_party/istio-1.2.6/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.2.6/prestop-sleep.yaml.patch
@@ -1,7 +1,0 @@
-620a621,626
->         # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
->         lifecycle:
->           preStop:
->             exec:
->               command: ["sleep", "20"]
->         # PATCH #2 ends.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Remove the Istio sidecar prestop hook (no longer needed).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
