### PR TITLE
Skip creating certificate and ingressTLS for cluster-local service

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -306,14 +306,14 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 	if !config.FromContext(ctx).Network.AutoTLS {
 		return tls, nil
 	}
-	tagToDomainMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), clusterLocalServiceNames)
+	domainToTagMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), clusterLocalServiceNames)
 	if err != nil {
 		return nil, err
 	}
 
-	for domain := range tagToDomainMap {
+	for domain := range domainToTagMap {
 		if domains.IsClusterLocal(domain) {
-			delete(tagToDomainMap, domain)
+			delete(domainToTagMap, domain)
 		}
 	}
 
@@ -329,7 +329,7 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 		return nil, err
 	}
 
-	desiredCerts := resources.MakeCertificates(r, tagToDomainMap, certClass(ctx, r))
+	desiredCerts := resources.MakeCertificates(r, domainToTagMap, certClass(ctx, r))
 	for _, desiredCert := range desiredCerts {
 		dnsNames := sets.NewString(desiredCert.Spec.DNSNames...)
 		// Look for a matching wildcard cert before provisioning a new one. This saves the

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -303,7 +303,7 @@ func (c *Reconciler) reconcileIngressResources(ctx context.Context, r *v1alpha1.
 
 func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, traffic *traffic.Config, clusterLocalServiceNames sets.String) ([]netv1alpha1.IngressTLS, error) {
 	tls := []netv1alpha1.IngressTLS{}
-	if !config.FromContext(ctx).Network.AutoTLS {
+	if !config.FromContext(ctx).Network.AutoTLS || r.Labels[config.VisibilityLabelKey] == config.VisibilityClusterLocal {
 		return tls, nil
 	}
 	tagToDomainMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), clusterLocalServiceNames)

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -303,7 +303,7 @@ func (c *Reconciler) reconcileIngressResources(ctx context.Context, r *v1alpha1.
 
 func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, traffic *traffic.Config, clusterLocalServiceNames sets.String) ([]netv1alpha1.IngressTLS, error) {
 	tls := []netv1alpha1.IngressTLS{}
-	if !config.FromContext(ctx).Network.AutoTLS || r.Labels[config.VisibilityLabelKey] == config.VisibilityClusterLocal {
+	if !config.FromContext(ctx).Network.AutoTLS {
 		return tls, nil
 	}
 	tagToDomainMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), clusterLocalServiceNames)
@@ -311,9 +311,9 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 		return nil, err
 	}
 
-	for tag, domain := range tagToDomainMap {
+	for domain := range tagToDomainMap {
 		if domains.IsClusterLocal(domain) {
-			delete(tagToDomainMap, tag)
+			delete(tagToDomainMap, domain)
 		}
 	}
 

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2731,7 +2731,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		SkipNamespaceValidation: true,
 	}, {
 		// This test is a same with "public becomes cluster local" above, but confirm it does not create certs with autoTLS for cluster-local.
-		Name: "public becomes cluster local",
+		Name: "public becomes cluster local w/ autoTLS",
 		Objects: []runtime.Object{
 			route("default", "becomes-local", WithConfigTarget("config"),
 				WithRouteLabel(config.VisibilityLabelKey, config.VisibilityClusterLocal),


### PR DESCRIPTION
## Proposed Changes

This patch changes to skip creating certificate and ingressTLS for
cluster-local service, when `serving.knative.dev/visibility` is set to
the Route.

/lint

Fixes https://github.com/knative/serving/issues/5611

**Release Note**

```release-note
NONE
```

/cc @ZhiminXiang @tcnghia
