### PR TITLE
Revert  1aa8425 "Remove the istio sidecar prestop hook, it's no longer needed." 

### DIFF
--- a/third_party/istio-1.2.6/download-istio.sh
+++ b/third_party/istio-1.2.6/download-istio.sh
@@ -49,3 +49,5 @@ rm istio-${ISTIO_VERSION}-linux.tar.gz
 patch istio-crds.yaml namespace.yaml.patch
 patch istio.yaml namespace.yaml.patch
 patch istio-lean.yaml namespace.yaml.patch
+
+patch -l istio.yaml prestop-sleep.yaml.patch

--- a/third_party/istio-1.2.6/istio.yaml
+++ b/third_party/istio-1.2.6/istio.yaml
@@ -618,6 +618,12 @@ data:
       {{- else }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
       {{- end }}
+        # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "20"]
+        # PATCH #2 ends.
         ports:
         - containerPort: 15090
           protocol: TCP

--- a/third_party/istio-1.2.6/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.2.6/prestop-sleep.yaml.patch
@@ -1,0 +1,7 @@
+620a621,626
+>         # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
+>         lifecycle:
+>           preStop:
+>             exec:
+>               command: ["sleep", "20"]
+>         # PATCH #2 ends.

--- a/third_party/istio-1.3.0/download-istio.sh
+++ b/third_party/istio-1.3.0/download-istio.sh
@@ -49,3 +49,5 @@ rm istio-${ISTIO_VERSION}-linux.tar.gz
 patch istio-crds.yaml namespace.yaml.patch
 patch istio.yaml namespace.yaml.patch
 patch istio-lean.yaml namespace.yaml.patch
+
+patch -l istio.yaml prestop-sleep.yaml.patch

--- a/third_party/istio-1.3.0/istio.yaml
+++ b/third_party/istio-1.3.0/istio.yaml
@@ -604,6 +604,12 @@ data:
       {{- end }}
       containers:
       - name: istio-proxy
+        # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "20"]
+        # PATCH #2 ends.
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}

--- a/third_party/istio-1.3.0/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.3.0/prestop-sleep.yaml.patch
@@ -1,0 +1,7 @@
+606a607,612
+>         # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
+>         lifecycle:
+>           preStop:
+>             exec:
+>               command: ["sleep", "20"]
+>         # PATCH #2 ends.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Revert  1aa8425
*  Also do the same thing for Istio 1.3.0.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
