### PR TITLE
Do not install config/v1 for performance testing setup

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -110,7 +110,7 @@ function update_cluster() {
   local n=0
   until [ $n -ge 2 ]
   do
-    ko apply -f serving/config/ -f serving/config/v1 && break
+    ko apply -f serving/config/ && break
     n=$[$n+1]
   done
   if [ $n == 2 ]; then


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
* `config/v1` has been deleted, remove it from the script

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @mattmoor 
/cc @vagababov 
/cc @srinivashegde86 
