### PR TITLE
Do not remove default TLS server modified by users in gateway

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -280,10 +280,7 @@ func UpdateGateway(gateway *v1alpha3.Gateway, want []v1alpha3.Server, existing [
 
 func isDefaultServer(server *v1alpha3.Server) bool {
 	if server.Port.Name == "https" {
-		if len(server.Hosts) > 0 && server.Hosts[0] == "*" {
-			return true
-		}
-		return false
+		return len(server.Hosts) > 0 && server.Hosts[0] == "*"
 	}
 	return server.Port.Name == "http"
 }

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -279,7 +279,13 @@ func UpdateGateway(gateway *v1alpha3.Gateway, want []v1alpha3.Server, existing [
 }
 
 func isDefaultServer(server *v1alpha3.Server) bool {
-	return server.Port.Name == "http" || server.Port.Name == "https"
+	if server.Port.Name == "https" {
+		if len(server.Hosts) > 0 && server.Hosts[0] == "*" {
+			return true
+		}
+		return false
+	}
+	return server.Port.Name == "http"
 }
 
 func isPlaceHolderServer(server *v1alpha3.Server) bool {

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -58,31 +58,35 @@ var selector = map[string]string{
 
 var gateway = v1alpha3.Gateway{
 	Spec: v1alpha3.GatewaySpec{
-		Servers: []v1alpha3.Server{{
-			Hosts: []string{"host1.example.com"},
-			Port: v1alpha3.Port{
-				Name:     "test-ns/ingress:0",
-				Number:   443,
-				Protocol: v1alpha3.ProtocolHTTPS,
-			},
-			TLS: &v1alpha3.TLSOptions{
-				Mode:              v1alpha3.TLSModeSimple,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
-			},
-		}, {
-			Hosts: []string{"host2.example.com"},
-			Port: v1alpha3.Port{
-				Name:     "test-ns/non-ingress:0",
-				Number:   443,
-				Protocol: v1alpha3.ProtocolHTTPS,
-			},
-			TLS: &v1alpha3.TLSOptions{
-				Mode:              v1alpha3.TLSModeSimple,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
-			},
-		}},
+		Servers: servers,
+	},
+}
+
+var servers = []v1alpha3.Server{
+	{
+		Hosts: []string{"host1.example.com"},
+		Port: v1alpha3.Port{
+			Name:     "test-ns/ingress:0",
+			Number:   443,
+			Protocol: v1alpha3.ProtocolHTTPS,
+		},
+		TLS: &v1alpha3.TLSOptions{
+			Mode:              v1alpha3.TLSModeSimple,
+			ServerCertificate: "tls.crt",
+			PrivateKey:        "tls.key",
+		},
+	}, {
+		Hosts: []string{"host2.example.com"},
+		Port: v1alpha3.Port{
+			Name:     "test-ns/non-ingress:0",
+			Number:   443,
+			Protocol: v1alpha3.ProtocolHTTPS,
+		},
+		TLS: &v1alpha3.TLSOptions{
+			Mode:              v1alpha3.TLSModeSimple,
+			ServerCertificate: "tls.crt",
+			PrivateKey:        "tls.key",
+		},
 	},
 }
 
@@ -98,6 +102,42 @@ var httpServer = v1alpha3.Server{
 var gatewayWithPlaceholderServer = v1alpha3.Gateway{
 	Spec: v1alpha3.GatewaySpec{
 		Servers: []v1alpha3.Server{placeholderServer},
+	},
+}
+
+var gatewayWithDefaultWildcardTLSServer = v1alpha3.Gateway{
+	Spec: v1alpha3.GatewaySpec{
+		Servers: []v1alpha3.Server{{
+			Hosts: []string{"*"},
+			Port: v1alpha3.Port{
+				Name:     "https",
+				Number:   443,
+				Protocol: v1alpha3.ProtocolHTTPS,
+			},
+			TLS: &v1alpha3.TLSOptions{
+				Mode: v1alpha3.TLSModePassThrough,
+			}},
+		},
+	},
+}
+
+var gatewayWithModifiedWildcardTLSServer = v1alpha3.Gateway{
+	Spec: v1alpha3.GatewaySpec{
+		Servers: []v1alpha3.Server{modifiedDefaultTLSServer},
+	},
+}
+
+var modifiedDefaultTLSServer = v1alpha3.Server{
+	Hosts: []string{"added.by.user.example.com"},
+	Port: v1alpha3.Port{
+		Name:     "https",
+		Number:   443,
+		Protocol: v1alpha3.ProtocolHTTPS,
+	},
+	TLS: &v1alpha3.TLSOptions{
+		Mode:              v1alpha3.TLSModeSimple,
+		ServerCertificate: "tls.crt",
+		PrivateKey:        "tls.key",
 	},
 }
 
@@ -459,6 +499,50 @@ func TestUpdateGateway(t *testing.T) {
 						PrivateKey:        "tls.key",
 					},
 				}},
+			},
+		},
+	}, {
+		name:            "Delete wildcard servers from gateway",
+		existingServers: []v1alpha3.Server{},
+		newServers:      servers,
+		original:        gatewayWithDefaultWildcardTLSServer,
+		// The wildcard server should be deleted.
+		expected: gateway,
+	}, {
+		name:            "Do not delete modified wildcard servers from gateway",
+		existingServers: []v1alpha3.Server{},
+		newServers: []v1alpha3.Server{{
+			Hosts: []string{"host1.example.com"},
+			Port: v1alpha3.Port{
+				Name:     "clusteringress:0",
+				Number:   443,
+				Protocol: v1alpha3.ProtocolHTTPS,
+			},
+			TLS: &v1alpha3.TLSOptions{
+				Mode:              v1alpha3.TLSModeSimple,
+				ServerCertificate: "tls.crt",
+				PrivateKey:        "tls.key",
+			},
+		}},
+		original: gatewayWithModifiedWildcardTLSServer,
+		expected: v1alpha3.Gateway{
+			Spec: v1alpha3.GatewaySpec{
+				Servers: []v1alpha3.Server{
+					{
+						Hosts: []string{"host1.example.com"},
+						Port: v1alpha3.Port{
+							Name:     "clusteringress:0",
+							Number:   443,
+							Protocol: v1alpha3.ProtocolHTTPS,
+						},
+						TLS: &v1alpha3.TLSOptions{
+							Mode:              v1alpha3.TLSModeSimple,
+							ServerCertificate: "tls.crt",
+							PrivateKey:        "tls.key",
+						},
+					},
+					modifiedDefaultTLSServer,
+				},
 			},
 		},
 	}}


### PR DESCRIPTION
## Proposed Changes

This patch changes to stop removing default TLS servers modified by
users. In other words, if the TLS server is matches to both:

- `port.name` is `https`
- `hosts` is `'*'`

it will be removed as it conflicts with other hosts.

/lint

Fixes https://github.com/knative/serving/issues/5622

**Release Note**

```release-note
NONE
```

/cc @ZhiminXiang @tcnghia