### PR TITLE
Do not duplicate tag check when tag is not configured

### DIFF
--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -45,19 +45,20 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 	sum := int64(0)
 	for i, tt := range traffic {
 		errs = errs.Also(tt.Validate(ctx).ViaIndex(i))
-
-		if idx, ok := trafficMap[tt.Tag]; ok {
-			// We want only single definition of the route, even if it points
-			// to the same config or revision.
-			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("Multiple definitions for %q", tt.Tag),
-				Paths: []string{
-					fmt.Sprintf("[%d].tag", i),
-					fmt.Sprintf("[%d].tag", idx),
-				},
-			})
-		} else {
-			trafficMap[tt.Tag] = i
+		if tt.Tag != "" {
+			if idx, ok := trafficMap[tt.Tag]; ok {
+				// We want only single definition of the route, even if it points
+				// to the same config or revision.
+				errs = errs.Also(&apis.FieldError{
+					Message: fmt.Sprintf("Multiple definitions for %q", tt.Tag),
+					Paths: []string{
+						fmt.Sprintf("[%d].tag", i),
+						fmt.Sprintf("[%d].tag", idx),
+					},
+				})
+			} else {
+				trafficMap[tt.Tag] = i
+			}
 		}
 		if tt.Percent != nil {
 			sum += *tt.Percent

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -348,6 +348,23 @@ func TestRouteValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "valid split without tag",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					RevisionName: "foo",
+					Percent:      ptr.Int64(90),
+				}, {
+					RevisionName: "bar",
+					Percent:      ptr.Int64(10),
+				}},
+			},
+		},
+		want: nil,
+	}, {
 		name: "missing url in status",
 		r: &Route{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Proposed Changes

The route validation, which checks duplicated tag name, fails if
multiple traffic did not have tag name as duplicated key `""` for
`trafficMap`.

To fix it, this patch skips duplicate tag check when traffic.tag empty
string.

/lint

Fixes https://github.com/knative/serving/issues/5630

**Release Note**

```release-note
NONE
```
