### PR TITLE
Remove remaining redundant errors in reconcilers

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -482,7 +482,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`error scaling target: inducing failure for patch deployments`),
+				`error scaling target: failed to apply scale to scale target test-revision-deployment: inducing failure for patch deployments`),
 		},
 	}, {
 		Name: "update metrics service",

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -22,12 +22,11 @@ import (
 	"net/http"
 	"time"
 
-	"go.uber.org/zap"
-
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
 
+	"github.com/pkg/errors"
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/serving/pkg/activator"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -249,8 +248,7 @@ func (ks *scaler) applyScale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, 
 	_, err = ks.dynamicClient.Resource(*gvr).Namespace(pa.Namespace).Patch(ps.Name, types.JSONPatchType,
 		patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		logger.Errorw("Error scaling target reference "+name, zap.Error(err))
-		return desiredScale, err
+		return desiredScale, errors.Wrapf(err, "failed to apply scale to scale target "+name)
 	}
 
 	logger.Debug("Successfully scaled.")
@@ -279,8 +277,7 @@ func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, sks *
 
 	ps, err := resources.GetScaleResource(pa.Namespace, pa.Spec.ScaleTargetRef, ks.psInformerFactory)
 	if err != nil {
-		logger.Errorw(fmt.Sprintf("Resource %v not found", pa.Spec.ScaleTargetRef), zap.Error(err))
-		return desiredScale, err
+		return desiredScale, errors.Wrapf(err, "failed to get scale target %v", pa.Spec.ScaleTargetRef)
 	}
 
 	currentScale := int32(1)

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -86,8 +87,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// to status with this stale state.
 	} else if _, err = c.updateStatus(config); err != nil {
 		logger.Warnw("Failed to update configuration status", zap.Error(err))
-		c.Recorder.Eventf(config, corev1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for Configuration %q: %v", config.Name, err)
+		c.Recorder.Eventf(config, corev1.EventTypeWarning, "UpdateFailed", "Failed to update status: %v", err)
 		return err
 	}
 	if reconcileErr != nil {
@@ -136,16 +136,13 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 	if errors.IsNotFound(err) {
 		lcr, err = c.createRevision(ctx, config)
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to create Revision for Configuration %q: %v", config.Name, err)
-
-			logger.Error(errMsg)
-			c.Recorder.Event(config, corev1.EventTypeWarning, "CreationFailed", errMsg)
+			c.Recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: %v", err)
 
 			// Mark the Configuration as not-Ready since creating
 			// its latest revision failed.
 			config.Status.MarkRevisionCreationFailed(err.Error())
 
-			return err
+			return perrors.Wrap(err, "failed to create Revision")
 		}
 	} else if errors.IsAlreadyExists(err) {
 		// If we get an already-exists error from latestCreatedRevision it means
@@ -154,8 +151,7 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 		config.Status.MarkRevisionCreationFailed(err.Error())
 		return nil
 	} else if err != nil {
-		logger.Errorw("Failed to reconcile Configuration: failed to get Revision", zap.Error(err))
-		return err
+		return perrors.Wrap(err, "failed to get Revision")
 	}
 
 	revName := lcr.Name
@@ -195,9 +191,7 @@ func (c *Reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 			"Latest created revision %q has failed", lcr.Name)
 
 	default:
-		err := fmt.Errorf("unrecognized condition status: %v on revision %q", rc.Status, revName)
-		logger.Errorw("Error reconciling Configuration", zap.Error(err))
-		return err
+		return fmt.Errorf("unrecognized condition status: %v on revision %q", rc.Status, revName)
 	}
 
 	return nil

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -203,10 +203,8 @@ func TestReconcile(t *testing.T) {
 				MarkRevisionCreationFailed("expected 0 <= -1 <= 1000: spec.containerConcurrency"), WithObservedGen),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision for Configuration %q: %v",
-				"validation-failure", "expected 0 <= -1 <= 1000: spec.containerConcurrency"),
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for Configuration %q: %v",
-				"validation-failure", "expected 0 <= -1 <= 1000: spec.template.spec.containerConcurrency"),
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: expected 0 <= -1 <= 1000: spec.containerConcurrency"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status: expected 0 <= -1 <= 1000: spec.template.spec.containerConcurrency"),
 		},
 		Key: "foo/validation-failure",
 	}, {
@@ -314,9 +312,8 @@ func TestReconcile(t *testing.T) {
 				MarkRevisionCreationFailed("inducing failure for create revisions"), WithObservedGen),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision for Configuration %q: %v",
-				"create-revision-failure", "inducing failure for create revisions"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create revisions"),
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: inducing failure for create revisions"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Revision: inducing failure for create revisions"),
 		},
 		Key: "foo/create-revision-failure",
 	}, {
@@ -341,8 +338,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Revision %q", "update-config-failure-00001"),
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for Configuration %q: %v",
-				"update-config-failure", "inducing failure for update configurations"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status: inducing failure for update configurations"),
 		},
 		Key: "foo/update-config-failure",
 	}, {

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
@@ -60,7 +61,6 @@ func (c *Reconciler) deleteIngressForRoute(route *v1alpha1.Route) error {
 
 func (c *Reconciler) reconcileIngress(
 	ctx context.Context, ira IngressResourceAccessors, r *v1alpha1.Route, desired netv1alpha1.IngressAccessor, optional bool) (netv1alpha1.IngressAccessor, error) {
-	logger := logging.FromContext(ctx)
 	ingress, err := ira.getIngressForRoute(r)
 	if apierrs.IsNotFound(err) {
 		if optional {
@@ -68,10 +68,8 @@ func (c *Reconciler) reconcileIngress(
 		}
 		ingress, err = ira.createIngress(desired)
 		if err != nil {
-			logger.Errorw("Failed to create Ingress", zap.Error(err))
-			c.Recorder.Eventf(r, corev1.EventTypeWarning, "CreationFailed",
-				"Failed to create Ingress for route %s/%s: %v", r.Namespace, r.Name, err)
-			return nil, err
+			c.Recorder.Eventf(r, corev1.EventTypeWarning, "CreationFailed", "Failed to create Ingress: %v", err)
+			return nil, perrors.Wrap(err, "failed to create Ingress")
 		}
 
 		c.Recorder.Eventf(r, corev1.EventTypeNormal, "Created",
@@ -90,8 +88,7 @@ func (c *Reconciler) reconcileIngress(
 
 			updated, err := ira.updateIngress(origin)
 			if err != nil {
-				logger.Errorw("Failed to update "+resources.GetIngressTypeName(ingress), zap.Error(err))
-				return nil, err
+				return nil, perrors.Wrap(err, "failed to update "+resources.GetIngressTypeName(ingress))
 			}
 			return updated, nil
 		}
@@ -103,8 +100,7 @@ func (c *Reconciler) reconcileIngress(
 func (c *Reconciler) deleteServices(namespace string, serviceNames sets.String) error {
 	for _, serviceName := range serviceNames.List() {
 		if err := c.KubeClientSet.CoreV1().Services(namespace).Delete(serviceName, nil); err != nil {
-			c.Logger.Errorw("Failed to delete service", zap.Error(err))
-			return err
+			return perrors.Wrap(err, "failed to delete Service")
 		}
 	}
 
@@ -135,10 +131,9 @@ func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1
 			// Doesn't exist, create it.
 			service, err = c.KubeClientSet.CoreV1().Services(ns).Create(desiredService)
 			if err != nil {
-				logger.Errorw("Failed to create placeholder service", zap.Error(err))
 				c.Recorder.Eventf(route, corev1.EventTypeWarning, "CreationFailed",
 					"Failed to create placeholder service %q: %v", desiredService.Name, err)
-				return nil, err
+				return nil, perrors.Wrap(err, "failed to create placeholder service")
 			}
 			logger.Infof("Created service %s", desiredService.Name)
 			c.Recorder.Eventf(route, corev1.EventTypeNormal, "Created", "Created placeholder service %q", desiredService.Name)
@@ -256,8 +251,7 @@ func (c *Reconciler) reconcileTargetRevisions(ctx context.Context, t *traffic.Co
 				}
 
 				if _, err := c.ServingClientSet.ServingV1alpha1().Revisions(route.Namespace).Patch(rev.Name, types.MergePatchType, patch); err != nil {
-					c.Logger.Errorf("Unable to set revision annotation: %v", err)
-					return err
+					return perrors.Wrap(err, "failed to set revision annotation")
 				}
 				return nil
 			})
@@ -271,10 +265,8 @@ func (c *Reconciler) reconcileCertificate(ctx context.Context, r *v1alpha1.Route
 	if apierrs.IsNotFound(err) {
 		cert, err = c.ServingClientSet.NetworkingV1alpha1().Certificates(desiredCert.Namespace).Create(desiredCert)
 		if err != nil {
-			c.Logger.Error("Failed to create Certificate", zap.Error(err))
-			c.Recorder.Eventf(r, corev1.EventTypeWarning, "CreationFailed",
-				"Failed to create Certificate for route %s/%s: %v", r.Namespace, r.Name, err)
-			return nil, err
+			c.Recorder.Eventf(r, corev1.EventTypeWarning, "CreationFailed", "Failed to create Certificate: %v", err)
+			return nil, perrors.Wrap(err, "failed to create Certificate")
 		}
 		c.Recorder.Eventf(r, corev1.EventTypeNormal, "Created",
 			"Created Certificate %s/%s", cert.Namespace, cert.Name)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -431,7 +431,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create placeholder service %q: %v",
 				"create-svc-failure", "inducing failure for create services"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create services"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create placeholder service: inducing failure for create services"),
 		},
 		Key: "default/create-svc-failure",
 	}, {
@@ -498,9 +498,8 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "ingress-create-failure"),
-			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Ingress for route %s/%s: %v",
-				"default", "ingress-create-failure", "inducing failure for create ingresses"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create ingresses"),
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Ingress: inducing failure for create ingresses"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Ingress: inducing failure for create ingresses"),
 		},
 		Key:                     "default/ingress-create-failure",
 		SkipNamespaceValidation: true,
@@ -1067,7 +1066,7 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update ingresses"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update Ingress: inducing failure for update ingresses"),
 		},
 		Key:                     "default/update-ci-failure",
 		SkipNamespaceValidation: true,
@@ -2316,7 +2315,7 @@ func TestReconcile(t *testing.T) {
 			Name: "old-service-name",
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for delete services"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to delete Service: inducing failure for delete services"),
 		},
 		Key: "default/my-route",
 	}}

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -152,13 +152,11 @@ func (r *reconciler) reconcilePublicService(ctx context.Context, sks *netv1alpha
 		srv = resources.MakePublicService(sks)
 		_, err := r.KubeClientSet.CoreV1().Services(sks.Namespace).Create(srv)
 		if err != nil {
-			logger.Errorw("Error creating K8s Service: "+sn, zap.Error(err))
-			return err
+			return errors.Wrap(err, "failed to create public K8s Service")
 		}
 		logger.Info("Created public K8s service: ", sn)
 	} else if err != nil {
-		logger.Errorw("Error getting K8s Service: "+sn, zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to get public K8s Service")
 	} else if !metav1.IsControlledBy(srv, sks) {
 		sks.Status.MarkEndpointsNotOwned("Service", sn)
 		return fmt.Errorf("SKS: %s does not own Service: %s", sks.Name, sn)
@@ -171,8 +169,7 @@ func (r *reconciler) reconcilePublicService(ctx context.Context, sks *netv1alpha
 		if !equality.Semantic.DeepEqual(want.Spec, srv.Spec) {
 			logger.Info("Public K8s Service changed; reconciling: ", sn, cmp.Diff(want.Spec, srv.Spec))
 			if _, err = r.KubeClientSet.CoreV1().Services(sks.Namespace).Update(want); err != nil {
-				logger.Errorw("Error updating public K8s Service: "+sn, zap.Error(err))
-				return err
+				return errors.Wrap(err, "failed to update public K8s Service")
 			}
 		}
 	}
@@ -190,16 +187,14 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 	)
 	activatorEps, err := r.endpointsLister.Endpoints(system.Namespace()).Get(networking.ActivatorServiceName)
 	if err != nil {
-		logger.Errorw("Error obtaining activator service endpoints", zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to get activator service endpoints")
 	}
 	logger.Debug("Activator endpoints: ", spew.Sprint(activatorEps))
 
 	psn := sks.Status.PrivateServiceName
 	pvtEps, err := r.endpointsLister.Endpoints(sks.Namespace).Get(psn)
 	if err != nil {
-		logger.Errorw("Error obtaining private service endpoints: "+psn, zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to get private K8s Service endpoints")
 	}
 	// We still might be "ready" even if in proxy mode,
 	// if proxy mode is by means of burst capacity handling.
@@ -243,13 +238,11 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 		logger.Infof("Public endpoints %s does not exist; creating.", sn)
 		sks.Status.MarkEndpointsNotReady("CreatingPublicEndpoints")
 		if _, err = r.KubeClientSet.CoreV1().Endpoints(sks.Namespace).Create(resources.MakePublicEndpoints(sks, srcEps)); err != nil {
-			logger.Errorw("Error creating K8s Endpoints: "+sn, zap.Error(err))
-			return err
+			return errors.Wrap(err, "failed to create public K8s Endpoints")
 		}
 		logger.Info("Created K8s Endpoints: ", sn)
 	} else if err != nil {
-		logger.Errorw("Error getting K8s Endpoints: "+sn, zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to get public K8s Endpoints")
 	} else if !metav1.IsControlledBy(eps, sks) {
 		sks.Status.MarkEndpointsNotOwned("Endpoints", sn)
 		return fmt.Errorf("SKS: %s does not own Endpoints: %s", sks.Name, sn)
@@ -260,8 +253,7 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 			want.Subsets = wantSubsets
 			logger.Info("Public K8s Endpoints changed; reconciling: ", sn)
 			if _, err = r.KubeClientSet.CoreV1().Endpoints(sks.Namespace).Update(want); err != nil {
-				logger.Errorw("Error updating public K8s Endpoints: "+sn, zap.Error(err))
-				return err
+				return errors.Wrap(err, "failed to update public K8s Endpoints")
 			}
 		}
 	}
@@ -330,13 +322,11 @@ func (r *reconciler) reconcilePrivateService(ctx context.Context, sks *netv1alph
 		svc = resources.MakePrivateService(sks, selector)
 		svc, err = r.KubeClientSet.CoreV1().Services(sks.Namespace).Create(svc)
 		if err != nil {
-			logger.Errorw("Error creating private K8s Service", zap.Error(err))
-			return err
+			return errors.Wrap(err, "failed to create private K8s Service")
 		}
 		logger.Info("Created private K8s service: ", svc.Name)
 	} else if err != nil {
-		logger.Errorw("Error getting K8s Service", zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to get private K8s Service")
 	} else if !metav1.IsControlledBy(svc, sks) {
 		sks.Status.MarkEndpointsNotOwned("Service", svc.Name)
 		return fmt.Errorf("SKS: %s does not own Service: %s", sks.Name, svc.Name)
@@ -351,8 +341,7 @@ func (r *reconciler) reconcilePrivateService(ctx context.Context, sks *netv1alph
 			sks.Status.MarkEndpointsNotReady("UpdatingPrivateService")
 			logger.Infof("Private K8s Service changed %s; reconciling: ", svc.Name)
 			if _, err = r.KubeClientSet.CoreV1().Services(sks.Namespace).Update(want); err != nil {
-				logger.Errorw("Error updating private K8s Service: "+svc.Name, zap.Error(err))
-				return err
+				return errors.Wrap(err, "failed to update private K8s Service")
 			}
 		}
 	}

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -243,7 +243,8 @@ func TestReconcile(t *testing.T) {
 			Object: endpointspub("update-eps", "failA", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)), // The attempted update.
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for update endpoints"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				"InternalError: failed to update public K8s Endpoints: inducing failure for update endpoints"),
 		},
 	}, {
 		Name:    "svc-fail-pub",
@@ -267,7 +268,8 @@ func TestReconcile(t *testing.T) {
 			svcpub("svc", "fail2"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for create services"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				"InternalError: failed to create public K8s Service: inducing failure for create services"),
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "svc/fail2"`),
 		},
 	}, {
@@ -293,7 +295,8 @@ func TestReconcile(t *testing.T) {
 			endpointspub("eps", "fail3", WithSubsets, withFilteredPorts(networking.BackendHTTPPort)),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for create endpoints"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				"InternalError: failed to create public K8s Endpoints: inducing failure for create endpoints"),
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "eps/fail3"`),
 		},
 	}, {
@@ -337,7 +340,8 @@ func TestReconcile(t *testing.T) {
 				markTransitioning("CreatingPublicService")),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: endpoints "activator-service" not found`),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				`InternalError: failed to get activator service endpoints: endpoints "activator-service" not found`),
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "on/cnaeps2"`),
 		},
 	}, {
@@ -360,7 +364,8 @@ func TestReconcile(t *testing.T) {
 				markTransitioning("CreatingPublicService")),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", `InternalError: endpoints "cnaeps3-private" not found`),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				`InternalError: failed to get private K8s Service endpoints: endpoints "cnaeps3-private" not found`),
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "on/cnaeps3"`),
 		},
 	}, {
@@ -425,7 +430,8 @@ func TestReconcile(t *testing.T) {
 			svcpriv("svc", "fail"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for create services"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				"InternalError: failed to create private K8s Service: inducing failure for create services"),
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "svc/fail"`),
 		},
 	}, {
@@ -544,7 +550,8 @@ func TestReconcile(t *testing.T) {
 			Object: svcpriv("update-svc", "fail9"),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for update services"),
+			Eventf(corev1.EventTypeWarning, "UpdateFailed",
+				"InternalError: failed to update private K8s Service: inducing failure for update services"),
 			Eventf(corev1.EventTypeNormal, "Updated", `Successfully updated ServerlessService "update-svc/fail9"`),
 		},
 	},
@@ -568,7 +575,7 @@ func TestReconcile(t *testing.T) {
 				Object: svcpub("update-svc", "fail8"),
 			}},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: inducing failure for update services"),
+				Eventf(corev1.EventTypeWarning, "UpdateFailed", "InternalError: failed to update public K8s Service: inducing failure for update services"),
 			},
 		}, {
 			Name: "pod change",

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -952,7 +952,8 @@ func TestReconcile(t *testing.T) {
 				}),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "Failed to parse image reference: spec.template.spec.containers[0].image\nimage: \"#\", error: could not parse reference"),
+			Eventf(corev1.EventTypeWarning, "InternalError",
+				"failed to reconcile Configuration: Failed to parse image reference: spec.template.spec.containers[0].image\nimage: \"#\", error: could not parse reference"),
 		},
 	}, {
 		Name: "runLatest - route creation failure",
@@ -978,7 +979,7 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "create-route-failure"),
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Route %q: %v",
 				"create-route-failure", "inducing failure for create routes"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create routes"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Route: inducing failure for create routes"),
 		},
 	}, {
 		Name: "runLatest - configuration creation failure",
@@ -1003,7 +1004,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Configuration %q: %v",
 				"create-config-failure", "inducing failure for create configurations"),
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create configurations"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Configuration: inducing failure for create configurations"),
 		},
 	}, {
 		Name: "runLatest - update route failure",
@@ -1023,7 +1024,7 @@ func TestReconcile(t *testing.T) {
 			Object: route("update-route-failure", "foo", WithRunLatestRollout),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update routes"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile Route: inducing failure for update routes"),
 		},
 	}, {
 		Name: "runLatest - update config failure",
@@ -1045,7 +1046,7 @@ func TestReconcile(t *testing.T) {
 			Object: config("update-config-failure", "foo", WithRunLatestRollout),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update configurations"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile Configuration: inducing failure for update configurations"),
 		},
 	}, {
 		Name: "runLatest - failure updating service status",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

A followup for #5598. This removes redundant error logging in the remaining places. No semantic change intended.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
