### PR TITLE
Print error from waitForActivatorEndpoints in e2e test

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -519,7 +519,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(ctx.resources, ctx.clients); err != nil {
-		t.Fatal("Never got Activator endpoints in the service")
+		t.Fatalf("Never got Activator endpoints in the service: %v", err)
 	}
 
 	// Start second load generator.
@@ -579,7 +579,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(ctx.resources, ctx.clients); err != nil {
-		t.Fatal("Never got Activator endpoints in the service")
+		t.Fatalf("Never got Activator endpoints in the service: %v", err)
 	}
 }
 

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -211,7 +211,7 @@ func TestGRPCUnaryPingViaActivator(t *testing.T) {
 	testGRPC(t,
 		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, host, domain string) {
 			if err := waitForActivatorEndpoints(resources, clients); err != nil {
-				t.Fatal("Never got Activator endpoints in the service")
+				t.Fatalf("Never got Activator endpoints in the service: %v", err)
 			}
 			unaryTest(t, resources, clients, host, domain)
 		},
@@ -225,7 +225,7 @@ func TestGRPCStreamingPingViaActivator(t *testing.T) {
 	testGRPC(t,
 		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, host, domain string) {
 			if err := waitForActivatorEndpoints(resources, clients); err != nil {
-				t.Fatal("Never got Activator endpoints in the service")
+				t.Fatalf("Never got Activator endpoints in the service: %v", err)
 			}
 			streamTest(t, resources, clients, host, domain)
 		},

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -254,7 +254,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(resources, clients); err != nil {
-		t.Fatal("Never got Activator endpoints in the service")
+		t.Fatalf("Never got Activator endpoints in the service: %v", err)
 	}
 
 	// Send request to helloworld app via httpproxy service

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -163,7 +163,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(resources, clients); err != nil {
-		t.Fatal("Never got Activator endpoints in the service")
+		t.Fatalf("Never got Activator endpoints in the service: %v", err)
 	}
 	if err := validateWebSocketConnection(t, clients, names); err != nil {
 		t.Error(err)


### PR DESCRIPTION
## Proposed Changes

This patch makes a tiny change which outputs error from
`waitForActivatorEndpoints()`.

Without this, it is difficult to do the troubleshooting.

/lint

AFTER:
```
service_to_service_test.go:257: Never got Activator endpoints in the service: endpoints "service-to-service-call-via-activator-b-disabled-nbvlgrxt-rb2xz" not found
```
**Release Note**

```release-note
NONE
```
