### PR TITLE
Fix logstream setup for autoscale test.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -414,7 +414,7 @@ func TestAutoscaleUpCountPods(t *testing.T) {
 		name, class := name, class
 		t.Run(name, func(tt *testing.T) {
 			tt.Parallel()
-			cancel := logstream.Start(t)
+			cancel := logstream.Start(tt)
 			defer cancel()
 
 			ctx := setup(tt, class, autoscaling.Concurrency, containerConcurrency, targetUtilization)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We're currently not getting the correct logstream for these tests, which makes debugging fairly difficult.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
