### PR TITLE
add changes to accessor to cover missing functionality

### DIFF
--- a/pkg/reconciler/accessor/errors_test.go
+++ b/pkg/reconciler/accessor/errors_test.go
@@ -75,12 +75,12 @@ func TestNewAccessorError(t *testing.T) {
 		reason: "",
 		want:   ": test error",
 	}, {
-		name:   "no error with reason",
+		name:   "error with no message and with reason",
 		err:    errors.New(""),
 		reason: NotOwnResource,
 		want:   "notowned: ",
 	}, {
-		name:   "no error and reason",
+		name:   "error with no message and reason",
 		err:    errors.New(""),
 		reason: "",
 		want:   ": ",

--- a/pkg/reconciler/accessor/errors_test.go
+++ b/pkg/reconciler/accessor/errors_test.go
@@ -42,7 +42,7 @@ func TestIsNotOwned(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsNotOwned(tc.err); tc.want != got {
-				t.Errorf("IsNotOwned function fails. got: %t, want: %t", tc.want, got)
+				t.Errorf("IsNotOwned(%v) = %v, want = %v", tc.err, got, tc.want)
 			}
 		})
 	}
@@ -54,7 +54,7 @@ func TestError(t *testing.T) {
 		errorReason: NotOwnResource,
 	}
 	if got, want := err.Error(), "notowned: test error"; got != want {
-		t.Errorf("Error function fails. got: %q, want: %q", got, want)
+		t.Errorf("Error() = %q, want = %q", got, want)
 	}
 }
 
@@ -88,7 +88,7 @@ func TestNewAccessorError(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := NewAccessorError(tc.err, tc.reason); got.Error() != tc.want {
-				t.Errorf("NewAccessorError function fails. got: %q, want: %q", got, tc.want)
+				t.Errorf("NewAccessorError() = %q, want = %q", got.Error(), tc.want)
 			}
 		})
 	}

--- a/pkg/reconciler/accessor/errors_test.go
+++ b/pkg/reconciler/accessor/errors_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package accessor
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -34,17 +35,14 @@ func TestIsNotOwned(t *testing.T) {
 		want: true,
 	}, {
 		name: "other error",
-		err: Error{
-			err: fmt.Errorf("test error"),
-		},
+		err:  errors.New("test error"),
 		want: false,
 	}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := IsNotOwned(tc.err)
-			if tc.want != got {
-				t.Errorf("IsNotOwned function fails. want: %t, got: %t", tc.want, got)
+			if got := IsNotOwned(tc.err); tc.want != got {
+				t.Errorf("IsNotOwned function fails. got: %t, want: %t", tc.want, got)
 			}
 		})
 	}
@@ -55,10 +53,43 @@ func TestError(t *testing.T) {
 		err:         fmt.Errorf("test error"),
 		errorReason: NotOwnResource,
 	}
-	got := err.Error()
-	want := "notowned: test error"
-	if got != want {
-		t.Errorf("Error function fails. want: %q, got: %q", want, got)
+	if got, want := err.Error(), "notowned: test error"; got != want {
+		t.Errorf("Error function fails. got: %q, want: %q", got, want)
 	}
+}
 
+func TestNewAccessorError(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		reason string
+		want   string
+	}{{
+		name:   "error with reason",
+		err:    errors.New("test error"),
+		reason: NotOwnResource,
+		want:   "notowned: test error",
+	}, {
+		name:   "error with no reason",
+		err:    errors.New("test error"),
+		reason: "",
+		want:   ": test error",
+	}, {
+		name:   "no error with reason",
+		err:    errors.New(""),
+		reason: NotOwnResource,
+		want:   "notowned: ",
+	}, {
+		name:   "no error and reason",
+		err:    errors.New(""),
+		reason: "",
+		want:   ": ",
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NewAccessorError(tc.err, tc.reason); got.Error() != tc.want {
+				t.Errorf("NewAccessorError function fails. got: %q, want: %q", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION

## Proposed Changes

* add test case for `NewAccessorError`
* modified test case for `IsNotOwned` when passing err is not a type of Error

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
