### PR TITLE
test/apicoverage: fix artifacts for apicoverage build

### DIFF
--- a/test/apicoverage/tools/main.go
+++ b/test/apicoverage/tools/main.go
@@ -59,6 +59,7 @@ func main() {
 			log.Fatalf("Failed to create directory: %v", err)
 		}
 	}
+	tools.CleanupJunitFiles(artifactsDir)
 
 	if *buildFailed {
 		if err := tools.WriteResourcePercentages(path.Join(


### PR DESCRIPTION
Some of the junit test summary files result in test grid display that has e2e and conformance test execution results. This is not necessary for webhook-apicoverage builds where we only care about
coverage stats. This change removes un-necessary junit xml summary files artifact folder for webhook apicoverage builds.
