### PR TITLE
Add the public interface to the new probe requests logs functionality in Queue-proxy

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -40,7 +40,7 @@ data:
     # logging.enable-var-log-collection defaults to false.
     # The fluentd daemon set will be set up to collect /var/log if
     # this flag is true.
-    logging.enable-var-log-collection: false
+    logging.enable-var-log-collection: "false"
 
     # logging.revision-url-template provides a template to use for producing the
     # logging URL that is injected into the status of each Revision.
@@ -49,7 +49,8 @@ data:
     logging.revision-url-template: |
       http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
 
-    # If non-empty, this enables queue proxy writing request logs to stdout.
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
     # The value determines the shape of the request logs and it must be a valid go text/template.
     # It is important to keep this as a single line. Multiple lines are parsed as separate entities
     # by most collection agents and will split the request logs into multiple records.
@@ -78,6 +79,10 @@ data:
     #
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
 
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+  
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.
     # Note: Using stackdriver will incur additional charges

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -81,6 +81,7 @@ data:
 
     # If true, this enables queue proxy writing request logs for probe requests to stdout.
     # It uses the same template for user requests, i.e. logging.request-log-template.
+    # Not yet used // TODO(yanweiguo) remove once other parts are ready.
     logging.enable-probe-request-log: "false"
   
     # metrics.backend-destination field specifies the system metrics destination.

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -40,6 +40,9 @@ type ObservabilityConfig struct {
 	// RequestLogTemplate is the go template to use to shape the request logs.
 	RequestLogTemplate string
 
+	// EnableProbeRequestLog enables queue-proxy to write health check probe request logs.
+	EnableProbeRequestLog bool
+
 	// RequestMetricsBackend specifies the request metrics destination, e.g. Prometheus,
 	// Stackdriver.
 	RequestMetricsBackend string
@@ -68,6 +71,10 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 			return nil, err
 		}
 		oc.RequestLogTemplate = rlt
+	}
+
+	if eprl, ok := configMap.Data["logging.enable-probe-request-log"]; ok {
+		oc.EnableProbeRequestLog = strings.ToLower(eprl) == "true"
 	}
 
 	if mb, ok := configMap.Data["metrics.request-metrics-backend-destination"]; ok {

--- a/pkg/metrics/config_test.go
+++ b/pkg/metrics/config_test.go
@@ -54,6 +54,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			LoggingURLTemplate:     "https://logging.io",
 			EnableVarLogCollection: true,
 			RequestLogTemplate:     `{"requestMethod": "{{.Request.Method}}"}`,
+			EnableProbeRequestLog:  true,
 			RequestMetricsBackend:  "stackdriver",
 		},
 		config: &corev1.ConfigMap{
@@ -64,6 +65,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			Data: map[string]string{
 				"logging.enable-var-log-collection":           "true",
 				"logging.revision-url-template":               "https://logging.io",
+				"logging.enable-probe-request-log":            "true",
 				"logging.write-request-logs":                  "true",
 				"logging.request-log-template":                `{"requestMethod": "{{.Request.Method}}"}`,
 				"metrics.request-metrics-backend-destination": "stackdriver",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #5068. Introduces a new flag in ConfigMap to enable request logs for probe requests.

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

