### PR TITLE
Update DEVELOPMENT.md to use istio 1.3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,11 +145,11 @@ Kubernetes cluster in your designated environment, if necessary.
 ### Deploy Istio
 
 ```shell
-kubectl apply -f ./third_party/istio-1.2-latest/istio-crds.yaml
+kubectl apply -f ./third_party/istio-1.3-latest/istio-crds.yaml
 while [[ $(kubectl get crd gateways.networking.istio.io -o jsonpath='{.status.conditions[?(@.type=="Established")].status}') != 'True' ]]; do
   echo "Waiting on Istio CRDs"; sleep 1
 done
-kubectl apply -f ./third_party/istio-1.2-latest/istio-lean.yaml
+kubectl apply -f ./third_party/istio-1.3-latest/istio-lean.yaml
 ```
 
 Follow the
@@ -162,7 +162,7 @@ installed, please install it with following commands. You could also adjust
 parameters if needed.
 
 ```shell
-kubectl apply -f ./third_party/istio-1.2-latest/istio-knative-extras.yaml
+kubectl apply -f ./third_party/istio-1.3-latest/istio-knative-extras.yaml
 ```
 
 > If you want to customize the `istio*.yaml` files you can refer to
@@ -323,8 +323,8 @@ You can delete all of the service components with:
 ko delete --ignore-not-found=true \
   -f config/monitoring/100-namespace.yaml \
   -f config/ \
-  -f ./third_party/istio-1.2-latest/istio.yaml \
-  -f ./third_party/istio-1.2-latest/istio-crds.yaml \
+  -f ./third_party/istio-1.3-latest/istio-lean.yaml \
+  -f ./third_party/istio-1.3-latest/istio-crds.yaml \
   -f ./third_party/cert-manager-0.9.1/cert-manager-crds.yaml \
   -f ./third_party/cert-manager-0.9.1/cert-manager.yaml
 ```


### PR DESCRIPTION
## Proposed Changes

This patch updates DEVELOPMENT.md to use istio 1.3. It is
basically same with https://github.com/knative/serving/pull/4512/files
except for third_party/* as they are already updated.

**Release Note**

```release-note
NONE
```

/cc @tcnghia @ZhiminXiang


