### PR TITLE
Add correct path info while error display

### DIFF
--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -486,7 +486,7 @@ func TestImmutableConfigurationFields(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{"spec.template"},
+			Paths:   []string{"spec.template.metadata.name"},
 			Details: "{*v1.RevisionTemplateSpec}.Spec.PodSpec.Containers[0].Image:\n\t-: \"helloworld:bar\"\n\t+: \"helloworld:foo\"\n",
 		},
 	}}

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -102,7 +102,7 @@ func (current *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og Re
 	} else if diff != "" {
 		return &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{apis.CurrentField},
+			Paths:   []string{"metadata.name"},
 			Details: diff,
 		}
 	}

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -470,7 +470,7 @@ func TestImmutableServiceFields(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{"spec.template"},
+			Paths:   []string{"spec.template.metadata.name"},
 			Details: "{*v1.RevisionTemplateSpec}.Spec.PodSpec.Containers[0].Image:\n\t-: \"helloworld:bar\"\n\t+: \"helloworld:foo\"\n",
 		},
 	}}

--- a/pkg/apis/serving/v1alpha1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation_test.go
@@ -470,7 +470,7 @@ func TestImmutableConfigurationFields(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{"spec.revisionTemplate"},
+			Paths:   []string{"spec.revisionTemplate.metadata.name"},
 			Details: "{*v1alpha1.RevisionTemplateSpec}.Spec.DeprecatedContainer.Image:\n\t-: \"helloworld:bar\"\n\t+: \"helloworld:foo\"\n",
 		},
 	}}

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -90,6 +90,7 @@ func (rt *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 // VerifyNameChange checks that if a user brought their own name previously that it
 // changes at the appropriate times.
 func (current *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og *RevisionTemplateSpec) *apis.FieldError {
+	fmt.Println("FIRST")
 	if current.Name == "" {
 		// We only check that Name changes when the DeprecatedRevisionTemplate changes.
 		return nil
@@ -108,7 +109,7 @@ func (current *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og *R
 	} else if diff != "" {
 		return &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{apis.CurrentField},
+			Paths:   []string{"metadata.name"},
 			Details: diff,
 		}
 	}

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -90,7 +90,6 @@ func (rt *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 // VerifyNameChange checks that if a user brought their own name previously that it
 // changes at the appropriate times.
 func (current *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og *RevisionTemplateSpec) *apis.FieldError {
-	fmt.Println("FIRST")
 	if current.Name == "" {
 		// We only check that Name changes when the DeprecatedRevisionTemplate changes.
 		return nil

--- a/pkg/apis/serving/v1alpha1/service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/service_validation_test.go
@@ -1090,7 +1090,7 @@ func TestImmutableServiceFields(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{"spec.runLatest.configuration.revisionTemplate"},
+			Paths:   []string{"spec.runLatest.configuration.revisionTemplate.metadata.name"},
 			Details: "{*v1alpha1.RevisionTemplateSpec}.Spec.DeprecatedContainer.Image:\n\t-: \"helloworld:bar\"\n\t+: \"helloworld:foo\"\n",
 		},
 	}}

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -440,7 +440,7 @@ func TestImmutableConfigurationFields(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{"spec.template"},
+			Paths:   []string{"spec.template.metadata.name"},
 			Details: "{*v1.RevisionTemplateSpec}.Spec.PodSpec.Containers[0].Image:\n\t-: \"helloworld:bar\"\n\t+: \"helloworld:foo\"\n",
 		},
 	}}

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -471,7 +471,7 @@ func TestImmutableServiceFields(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
-			Paths:   []string{"spec.template"},
+			Paths:   []string{"spec.template.metadata.name"},
 			Details: "{*v1.RevisionTemplateSpec}.Spec.PodSpec.Containers[0].Image:\n\t-: \"helloworld:bar\"\n\t+: \"helloworld:foo\"\n",
 		},
 	}}


### PR DESCRIPTION
## Steps
1. Create service with given name(metadata.name) in `RevisionTemplateSpec`
2. Update service only by changing spec and no changes for `RevisionTemplateSpec` metadata.name

## Actual Behavior
```
kubectl edit ksvc hello
error: services.serving.knative.dev "hello" could not be patched: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: Saw the following changes without a name change (-old +new): spec.template
*{*v1.RevisionTemplateSpec}.Spec.ContainerConcurrency:
	-: "0"
	+: "1"
```
## Expected Behavior
```
kubectl edit ksvc hello
error: services.serving.knative.dev "hello" could not be patched: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: Saw the following changes without a name change (-old +new): spec.template.metadata.name
*{*v1.RevisionTemplateSpec}.Spec.ContainerConcurrency:
	-: "0"
	+: "1"
```

## Proposed Changes

*  Add `spec.template.metadata.name` to give more concrete info to revision_validation.go

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
