### PR TITLE
Validate StatusCode before the Header for clearer debugging.

### DIFF
--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -345,9 +345,8 @@ func (m *StatusProber) processWorkItem() bool {
 		transport,
 		item.url,
 		prober.WithHeader(network.ProbeHeaderName, network.ProbeHeaderValue),
-		prober.ExpectsHeader(network.HashHeaderName, item.ingressState.hash),
 		prober.ExpectsStatusCodes([]int{http.StatusOK}),
-	)
+		prober.ExpectsHeader(network.HashHeaderName, item.ingressState.hash))
 
 	// In case of cancellation, drop the work item
 	select {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Today, if Envoy returns an error and doesn't proxy the request to Activator/Queue-Proxy, the response won't have the expected `K-Network-Hash` header and the error message will be `unexpected header "K-Network-Hash": want "83f7f105ee78be5a8990dbdc88aff7a7", got ""` which is not useful. By validating the StatusCode first, the error message will provide us with the error code from Envoy.

This has absolutely no functional changes.
