### PR TITLE
Hide RBM fully and fix the bug with activator Throttler stop.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -351,7 +351,7 @@ func newRevisionBackendsManagerWithProbeFrequency(ctx context.Context, tr http.R
 			DeleteFunc: rbm.endpointsDeleted,
 		},
 	})
-	// Make sure we close the update channel when we're done,
+	// We close the update channel when we're done,
 	// to make sure Throttler will stop.
 	go func() {
 		select {

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -54,7 +54,7 @@ import (
 const (
 	testNamespace      = "test-namespace"
 	testRevision       = "test-revision"
-	informerRestPeriod = 2 * time.Second
+	informerRestPeriod = 500 * time.Millisecond
 )
 
 func revision(revID types.NamespacedName, protocol networking.ProtocolType) *v1alpha1.Revision {

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -326,7 +326,7 @@ func (t *Throttler) run(updateCh <-chan revisionDestsUpdate) {
 	for update := range updateCh {
 		t.handleUpdate(update)
 	}
-	t.logger.Info("The Throttler has stopped!")
+	t.logger.Info("The Throttler has stopped.")
 }
 
 // Try waits for capacity and then executes function, passing in a l4 dest to send a request

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -326,6 +326,7 @@ func (t *Throttler) run(updateCh <-chan revisionDestsUpdate) {
 	for update := range updateCh {
 		t.handleUpdate(update)
 	}
+	t.logger.Info("The Throttler has stopped!")
 }
 
 // Try waits for capacity and then executes function, passing in a l4 dest to send a request


### PR DESCRIPTION
Currently activator background loop never stops, since nothing closes the channel that it listens to.
This change will close that channel.
In addition, this would stop pushing updates to the revision watcher, once ctx.Done() has fired, to avoid
redundant work on shutdown.
Finally, RBM struct itself somehow escaped being hidden, so now it will.

/assign mattmoor

/lint
