### PR TITLE
Deflake the TestNewConfigurationCallsSyncHandler test

### DIFF
--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -102,7 +102,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	}()
 
 	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
-		t.Fatalf("failed to start cluster ingress manager: %v", err)
+		t.Fatalf("Failed to start informers: %v", err)
 	}
 
 	// Run the controller.

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -1023,7 +1023,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			})
 
 			if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
-				t.Fatalf("failed to start cluster ingress manager: %v", err)
+				t.Fatalf("Failed to start informers: %v", err)
 			}
 
 			if err := watcher.Start(ctx.Done()); err != nil {


### PR DESCRIPTION
This is a new attempt at deflaking the picky TestNewConfigurationCallsSyncHandler test.
Since basically the whole premise of the test is to verify that we create revision when
configuration is reconciled, so let's just do that, without additional movements.
Also fix the strigs across a few tests.

/assign @dgerd mattmoor
/lint
