### PR TITLE
Add permissions for serving APIs to k8s's default view and edit role

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -23,3 +23,27 @@ rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
     resources: ["*"]
     verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Proposed Changes

This patch adds permissions for knative serving API to edit and view role.

The `edit` and `view` roles are k8s's default [user-facing role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles). 
So, Users should be able to assume that they can access or edit serving resources by
using these roles.

/lint

**Release Note**

```release-note
`200-clusterrole-namespaced.yaml` added clusterroles to access or edit serving resources by using view and edit clusterrole.
```
