### PR TITLE
Remove usages of unkeyed loggers in reconcilers.

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -213,6 +213,7 @@ func (c *Reconciler) updateStatus(desired *v1alpha1.Route) (*v1alpha1.Route, err
 // Update the lastPinned annotation on revisions we target so they don't get GC'd.
 func (c *Reconciler) reconcileTargetRevisions(ctx context.Context, t *traffic.Config, route *v1alpha1.Route) error {
 	gcConfig := config.FromContext(ctx).GC
+	logger := logging.FromContext(ctx)
 	lpDebounce := gcConfig.StaleRevisionLastpinnedDebounce
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -222,7 +223,7 @@ func (c *Reconciler) reconcileTargetRevisions(ctx context.Context, t *traffic.Co
 			eg.Go(func() error {
 				rev, err := c.revisionLister.Revisions(route.Namespace).Get(tt.RevisionName)
 				if apierrs.IsNotFound(err) {
-					c.Logger.Infof("Unable to update lastPinned for missing revision %q", tt.RevisionName)
+					logger.Infof("Unable to update lastPinned for missing revision %q", tt.RevisionName)
 					return nil
 				} else if err != nil {
 					return err


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

These log lines currently are not logged in the context of the reconcile they're running in, which makes correlating them hard or even impossible.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
