### PR TITLE
Fixing unkeyed loggers around metric scraping.

### DIFF
--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -61,6 +61,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.metricLister.Metrics(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The metric object is gone, so delete the collection.
+		logger.Info("Stopping to collect metrics")
 		return r.collector.Delete(namespace, name)
 	} else if err != nil {
 		return errors.Wrap(err, "failed to fetch metric "+key)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Metric collection errors are currently not correlatable with a specific key, which makes them hard to use in tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
