### PR TITLE
Move metricKey out of the stats scraper and make Stat a non-pointer.

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -259,7 +259,7 @@ func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, logger *zap.S
 				scrapeTicker.Stop()
 				return
 			case <-scrapeTicker.C:
-				message, err := c.getScraper().Scrape()
+				stat, err := c.getScraper().Scrape()
 				if err != nil {
 					copy := metric.DeepCopy()
 					switch {
@@ -273,8 +273,8 @@ func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, logger *zap.S
 					logger.Errorw("Failed to scrape metrics", zap.Error(err))
 					c.updateMetric(copy)
 				}
-				if message != nil {
-					c.record(message.Stat)
+				if stat != (Stat{}) {
+					c.record(stat)
 				}
 			}
 		}

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -70,6 +70,8 @@ type Stat struct {
 	ProxiedRequestCount float64
 }
 
+var emptyStat = Stat{}
+
 // StatMessage wraps a Stat with identifying information so it can be routed
 // to the correct receiver.
 type StatMessage struct {
@@ -273,7 +275,7 @@ func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, logger *zap.S
 					logger.Errorw("Failed to scrape metrics", zap.Error(err))
 					c.updateMetric(copy)
 				}
-				if stat != (Stat{}) {
+				if stat != emptyStat {
 					c.record(stat)
 				}
 			}

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -54,13 +54,13 @@ func TestMetricCollectorCRUD(t *testing.T) {
 
 	scraper := &testScraper{
 		s: func() (Stat, error) {
-			return Stat{}, nil
+			return emptyStat, nil
 		},
 		url: "just-right",
 	}
 	scraper2 := &testScraper{
 		s: func() (Stat, error) {
-			return Stat{}, nil
+			return emptyStat, nil
 		},
 		url: "slightly-off",
 	}
@@ -197,7 +197,7 @@ func TestMetricCollectorRecord(t *testing.T) {
 	}
 	scraper := &testScraper{
 		s: func() (Stat, error) {
-			return Stat{}, nil
+			return emptyStat, nil
 		},
 	}
 	factory := scraperFactory(scraper, nil)
@@ -235,7 +235,7 @@ func TestMetricCollectorError(t *testing.T) {
 		name: "Failed to get endpoints scraper error",
 		scraper: &testScraper{
 			s: func() (Stat, error) {
-				return Stat{}, ErrFailedGetEndpoints
+				return emptyStat, ErrFailedGetEndpoints
 			},
 		},
 		metric: &av1alpha1.Metric{
@@ -262,7 +262,7 @@ func TestMetricCollectorError(t *testing.T) {
 		name: "Did not receive stat scraper error",
 		scraper: &testScraper{
 			s: func() (Stat, error) {
-				return Stat{}, ErrDidNotReceiveStat
+				return emptyStat, ErrDidNotReceiveStat
 			},
 		},
 		metric: &av1alpha1.Metric{
@@ -289,7 +289,7 @@ func TestMetricCollectorError(t *testing.T) {
 		name: "Other scraper error",
 		scraper: &testScraper{
 			s: func() (Stat, error) {
-				return Stat{}, errors.New("foo")
+				return emptyStat, errors.New("foo")
 			},
 		},
 		metric: &av1alpha1.Metric{

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -53,14 +53,14 @@ func TestMetricCollectorCRUD(t *testing.T) {
 	logger := TestLogger(t)
 
 	scraper := &testScraper{
-		s: func() (*StatMessage, error) {
-			return nil, nil
+		s: func() (Stat, error) {
+			return Stat{}, nil
 		},
 		url: "just-right",
 	}
 	scraper2 := &testScraper{
-		s: func() (*StatMessage, error) {
-			return nil, nil
+		s: func() (Stat, error) {
+			return Stat{}, nil
 		},
 		url: "slightly-off",
 	}
@@ -119,17 +119,14 @@ func TestMetricCollectorScraper(t *testing.T) {
 	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	wantConcurrency := 10.0
 	wantRPS := 20.0
-	stat := &StatMessage{
-		Key: metricKey,
-		Stat: Stat{
-			Time:                      &now,
-			PodName:                   "testPod",
-			AverageConcurrentRequests: wantConcurrency,
-			RequestCount:              wantRPS,
-		},
+	stat := Stat{
+		Time:                      &now,
+		PodName:                   "testPod",
+		AverageConcurrentRequests: wantConcurrency,
+		RequestCount:              wantRPS,
 	}
 	scraper := &testScraper{
-		s: func() (*StatMessage, error) {
+		s: func() (Stat, error) {
 			return stat, nil
 		},
 	}
@@ -199,8 +196,8 @@ func TestMetricCollectorRecord(t *testing.T) {
 		ProxiedRequestCount:              20, // this should be subtracted from the above.
 	}
 	scraper := &testScraper{
-		s: func() (*StatMessage, error) {
-			return nil, nil
+		s: func() (Stat, error) {
+			return Stat{}, nil
 		},
 	}
 	factory := scraperFactory(scraper, nil)
@@ -237,8 +234,8 @@ func TestMetricCollectorError(t *testing.T) {
 	}{{
 		name: "Failed to get endpoints scraper error",
 		scraper: &testScraper{
-			s: func() (*StatMessage, error) {
-				return nil, ErrFailedGetEndpoints
+			s: func() (Stat, error) {
+				return Stat{}, ErrFailedGetEndpoints
 			},
 		},
 		metric: &av1alpha1.Metric{
@@ -264,8 +261,8 @@ func TestMetricCollectorError(t *testing.T) {
 	}, {
 		name: "Did not receive stat scraper error",
 		scraper: &testScraper{
-			s: func() (*StatMessage, error) {
-				return nil, ErrDidNotReceiveStat
+			s: func() (Stat, error) {
+				return Stat{}, ErrDidNotReceiveStat
 			},
 		},
 		metric: &av1alpha1.Metric{
@@ -291,8 +288,8 @@ func TestMetricCollectorError(t *testing.T) {
 	}, {
 		name: "Other scraper error",
 		scraper: &testScraper{
-			s: func() (*StatMessage, error) {
-				return nil, errors.New("foo")
+			s: func() (Stat, error) {
+				return Stat{}, errors.New("foo")
 			},
 		},
 		metric: &av1alpha1.Metric{
@@ -349,10 +346,10 @@ func scraperFactory(scraper StatsScraper, err error) StatsScraperFactory {
 }
 
 type testScraper struct {
-	s   func() (*StatMessage, error)
+	s   func() (Stat, error)
 	url string
 }
 
-func (s *testScraper) Scrape() (*StatMessage, error) {
+func (s *testScraper) Scrape() (Stat, error) {
 	return s.s()
 }

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -281,7 +281,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 		AverageConcurrentRequests: 1,
 		RequestCount:              1,
 	}
-	ms.Poke(testPAKey, testStat)
+	ms.Poke(metricKey, testStat)
 
 	// Verify that we see a "tick"
 	if err := verifyTick(errCh); err != nil {

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/types"
 
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
@@ -62,14 +61,14 @@ var (
 // StatsScraper defines the interface for collecting Revision metrics
 type StatsScraper interface {
 	// Scrape scrapes the Revision queue metric endpoint.
-	Scrape() (*StatMessage, error)
+	Scrape() (Stat, error)
 }
 
 // scrapeClient defines the interface for collecting Revision metrics for a given
 // URL. Internal used only.
 type scrapeClient interface {
 	// Scrape scrapes the given URL.
-	Scrape(url string) (*Stat, error)
+	Scrape(url string) (Stat, error)
 }
 
 // cacheDisabledClient is a http client with cache disabled. It is shared by
@@ -87,11 +86,9 @@ var cacheDisabledClient = &http.Client{
 // https://kubernetes.io/docs/concepts/services-networking/network-policies/
 // for details.
 type ServiceScraper struct {
-	sClient   scrapeClient
-	counter   resources.ReadyPodCounter
-	namespace string
-	metricKey types.NamespacedName
-	url       string
+	sClient scrapeClient
+	counter resources.ReadyPodCounter
+	url     string
 }
 
 // NewServiceScraper creates a new StatsScraper for the Revision which
@@ -123,11 +120,9 @@ func newServiceScraperWithClient(
 	}
 
 	return &ServiceScraper{
-		sClient:   sClient,
-		counter:   counter,
-		url:       urlFromTarget(metric.Spec.ScrapeTarget, metric.ObjectMeta.Namespace),
-		metricKey: types.NamespacedName{Namespace: metric.Namespace, Name: metric.Name},
-		namespace: metric.Namespace,
+		sClient: sClient,
+		counter: counter,
+		url:     urlFromTarget(metric.Spec.ScrapeTarget, metric.ObjectMeta.Namespace),
 	}, nil
 }
 
@@ -139,18 +134,18 @@ func urlFromTarget(t, ns string) string {
 
 // Scrape calls the destination service then sends it
 // to the given stats channel.
-func (s *ServiceScraper) Scrape() (*StatMessage, error) {
+func (s *ServiceScraper) Scrape() (Stat, error) {
 	readyPodsCount, err := s.counter.ReadyCount()
 	if err != nil {
-		return nil, ErrFailedGetEndpoints
+		return Stat{}, ErrFailedGetEndpoints
 	}
 
 	if readyPodsCount == 0 {
-		return nil, nil
+		return Stat{}, nil
 	}
 
 	sampleSize := populationMeanSampleSize(readyPodsCount)
-	statCh := make(chan *Stat, sampleSize)
+	statCh := make(chan Stat, sampleSize)
 	scrapedPods := &sync.Map{}
 
 	grp := errgroup.Group{}
@@ -173,7 +168,7 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 
 	// Return the inner error, if any.
 	if err := grp.Wait(); err != nil {
-		return nil, errors.Wrap(err, "unsuccessful scrape, sampleSize="+strconv.Itoa(sampleSize))
+		return Stat{}, errors.Wrap(err, "unsuccessful scrape, sampleSize="+strconv.Itoa(sampleSize))
 	}
 	close(statCh)
 
@@ -207,31 +202,26 @@ func (s *ServiceScraper) Scrape() (*StatMessage, error) {
 	// customer pods per scraping. The pod name is set to a unique value, i.e.
 	// scraperPodName so in autoscaler all stats are either from activator or
 	// scraper.
-	extrapolatedStat := Stat{
+	return Stat{
 		Time:                             &now,
 		PodName:                          scraperPodName,
 		AverageConcurrentRequests:        avgConcurrency * frpc,
 		AverageProxiedConcurrentRequests: avgProxiedConcurrency * frpc,
 		RequestCount:                     reqCount * frpc,
 		ProxiedRequestCount:              proxiedReqCount * frpc,
-	}
-
-	return &StatMessage{
-		Stat: extrapolatedStat,
-		Key:  s.metricKey,
 	}, nil
 }
 
 // tryScrape runs a single scrape and checks if this pod wasn't already scraped
 // against the given already scraped pods.
-func (s *ServiceScraper) tryScrape(scrapedPods *sync.Map) (*Stat, error) {
+func (s *ServiceScraper) tryScrape(scrapedPods *sync.Map) (Stat, error) {
 	stat, err := s.sClient.Scrape(s.url)
 	if err != nil {
-		return nil, err
+		return Stat{}, err
 	}
 
 	if _, exists := scrapedPods.LoadOrStore(stat.PodName, struct{}{}); exists {
-		return nil, ErrDidNotReceiveStat
+		return Stat{}, ErrDidNotReceiveStat
 	}
 
 	return stat, nil

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -137,11 +137,11 @@ func urlFromTarget(t, ns string) string {
 func (s *ServiceScraper) Scrape() (Stat, error) {
 	readyPodsCount, err := s.counter.ReadyCount()
 	if err != nil {
-		return Stat{}, ErrFailedGetEndpoints
+		return emptyStat, ErrFailedGetEndpoints
 	}
 
 	if readyPodsCount == 0 {
-		return Stat{}, nil
+		return emptyStat, nil
 	}
 
 	sampleSize := populationMeanSampleSize(readyPodsCount)
@@ -168,7 +168,7 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 
 	// Return the inner error, if any.
 	if err := grp.Wait(); err != nil {
-		return Stat{}, errors.Wrap(err, "unsuccessful scrape, sampleSize="+strconv.Itoa(sampleSize))
+		return emptyStat, errors.Wrap(err, "unsuccessful scrape, sampleSize="+strconv.Itoa(sampleSize))
 	}
 	close(statCh)
 
@@ -217,11 +217,11 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 func (s *ServiceScraper) tryScrape(scrapedPods *sync.Map) (Stat, error) {
 	stat, err := s.sClient.Scrape(s.url)
 	if err != nil {
-		return Stat{}, err
+		return emptyStat, err
 	}
 
 	if _, exists := scrapedPods.LoadOrStore(stat.PodName, struct{}{}); exists {
-		return Stat{}, ErrDidNotReceiveStat
+		return emptyStat, ErrDidNotReceiveStat
 	}
 
 	return stat, nil

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -214,7 +214,7 @@ func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scraper.Scrape() returned error: %v", err)
 	}
-	if stat != (Stat{}) {
+	if stat != emptyStat {
 		t.Error("Received unexpected Stat.")
 	}
 }

--- a/pkg/autoscaler/stats_scraper_test.go
+++ b/pkg/autoscaler/stats_scraper_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/resources"
@@ -37,8 +36,7 @@ const (
 )
 
 var (
-	testPAKey = types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}
-	testStats = []*Stat{
+	testStats = []Stat{
 		{
 			PodName:                          "pod-1",
 			AverageConcurrentRequests:        3.0,
@@ -65,13 +63,8 @@ func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	client := newTestScrapeClient(testStats, []error{nil})
 	if scraper, err := serviceScraperForTest(client); err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	} else {
-		if scraper.url != testURL {
-			t.Errorf("scraper.url=%v, want %v", scraper.url, testURL)
-		}
-		if scraper.metricKey != testPAKey {
-			t.Errorf("scraper.metricKey=%v, want %v", scraper.metricKey, testPAKey)
-		}
+	} else if scraper.url != testURL {
+		t.Errorf("scraper.url=%v, want %v", scraper.url, testURL)
 	}
 }
 
@@ -145,32 +138,29 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 		t.Fatalf("unexpected error from scraper.Scrape(): %v", err)
 	}
 
-	if got.Key != testPAKey {
-		t.Errorf("StatMessage.Key=%v, want %v", got.Key, testPAKey)
+	if got.Time.Before(now) {
+		t.Errorf("stat.Time=%v, want bigger than %v", got.Time, now)
 	}
-	if got.Stat.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want bigger than %v", got.Stat.Time, now)
-	}
-	if got.Stat.PodName != scraperPodName {
-		t.Errorf("StatMessage.Stat.PodName=%v, want %v", got.Stat.PodName, scraperPodName)
+	if got.PodName != scraperPodName {
+		t.Errorf("stat.PodName=%v, want %v", got.PodName, scraperPodName)
 	}
 	// (3.0 + 5.0 + 3.0) / 3.0 * 3 = 11
-	if got.Stat.AverageConcurrentRequests != 11.0 {
-		t.Errorf("StatMessage.Stat.AverageConcurrentRequests=%v, want %v",
-			got.Stat.AverageConcurrentRequests, 11.0)
+	if got.AverageConcurrentRequests != 11.0 {
+		t.Errorf("stat.AverageConcurrentRequests=%v, want %v",
+			got.AverageConcurrentRequests, 11.0)
 	}
 	// ((5 + 7 + 5) / 3.0) * 3 = 17
-	if got.Stat.RequestCount != 17 {
-		t.Errorf("StatMessage.Stat.RequestCount=%v, want %v", got.Stat.RequestCount, 15)
+	if got.RequestCount != 17 {
+		t.Errorf("stat.RequestCount=%v, want %v", got.RequestCount, 15)
 	}
 	// (2.0 + 4.0 + 2.0) / 3.0 * 3 = 8
-	if got.Stat.AverageProxiedConcurrentRequests != 8.0 {
-		t.Errorf("StatMessage.Stat.AverageProxiedConcurrentRequests=%v, want %v",
-			got.Stat.AverageProxiedConcurrentRequests, 8.0)
+	if got.AverageProxiedConcurrentRequests != 8.0 {
+		t.Errorf("stat.AverageProxiedConcurrentRequests=%v, want %v",
+			got.AverageProxiedConcurrentRequests, 8.0)
 	}
 	// ((4 + 6 + 4) / 3.0) * 3 = 14
-	if got.Stat.ProxiedRequestCount != 14 {
-		t.Errorf("StatMessage.Stat.ProxiedCount=%v, want %v", got.Stat.ProxiedRequestCount, 12)
+	if got.ProxiedRequestCount != 14 {
+		t.Errorf("stat.ProxiedCount=%v, want %v", got.ProxiedRequestCount, 12)
 	}
 }
 
@@ -222,10 +212,10 @@ func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
 
 	stat, err := scraper.Scrape()
 	if err != nil {
-		t.Fatalf(" scraper.Scrape() returned error: %v", err)
+		t.Fatalf("scraper.Scrape() returned error: %v", err)
 	}
-	if stat != nil {
-		t.Error("Received unexpected StatMessage.")
+	if stat != (Stat{}) {
+		t.Error("Received unexpected Stat.")
 	}
 }
 
@@ -250,7 +240,7 @@ func testMetric() *av1alpha1.Metric {
 	}
 }
 
-func newTestScrapeClient(stats []*Stat, errs []error) scrapeClient {
+func newTestScrapeClient(stats []Stat, errs []error) scrapeClient {
 	return &fakeScrapeClient{
 		stats: stats,
 		errs:  errs,
@@ -259,13 +249,13 @@ func newTestScrapeClient(stats []*Stat, errs []error) scrapeClient {
 
 type fakeScrapeClient struct {
 	i     int
-	stats []*Stat
+	stats []Stat
 	errs  []error
 	mutex sync.Mutex
 }
 
 // Scrape return the next item in the stats and error array of fakeScrapeClient.
-func (c *fakeScrapeClient) Scrape(url string) (*Stat, error) {
+func (c *fakeScrapeClient) Scrape(url string) (Stat, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	ans := c.stats[c.i%len(c.stats)]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Move metricKey out of the stats scraper. This is a first step towards disentangling the scraping system from the rest of the system.
* Make all Stats a non-pointer as the object is always very small.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
