### PR TITLE
Move common tag keys to serving/pkg/metrics

### DIFF
--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"errors"
 
-	"knative.dev/pkg/metrics"
+	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/serving/pkg/metrics"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -73,16 +74,6 @@ var (
 		"panic_mode",
 		"1 if autoscaler is in panic mode, 0 otherwise",
 		stats.UnitDimensionless)
-
-	// Create the tag keys that will be used to add tags to our measurements.
-	// Tag keys must conform to the restrictions described in
-	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
-	// - length between 1 and 255 inclusive
-	// - characters are printable US-ASCII
-	namespaceTagKey = tag.MustNewKey(metricskey.LabelNamespaceName)
-	serviceTagKey   = tag.MustNewKey(metricskey.LabelServiceName)
-	configTagKey    = tag.MustNewKey(metricskey.LabelConfigurationName)
-	revisionTagKey  = tag.MustNewKey(metricskey.LabelRevisionName)
 )
 
 func init() {
@@ -98,67 +89,67 @@ func register() {
 			Description: "Number of pods autoscaler wants to allocate",
 			Measure:     desiredPodCountM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Number of pods autoscaler requested from Kubernetes",
 			Measure:     requestedPodCountM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Number of pods that are allocated currently",
 			Measure:     actualPodCountM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Average of requests count over the stable window",
 			Measure:     stableRequestConcurrencyM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Current excess burst capacity over average request count over the stable window",
 			Measure:     excessBurstCapacityM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Average of requests count over the panic window",
 			Measure:     panicRequestConcurrencyM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "The desired number of concurrent requests for each pod",
 			Measure:     targetRequestConcurrencyM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "1 if autoscaler is in panic mode, 0 otherwise",
 			Measure:     panicM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Average requests-per-second over the stable window",
 			Measure:     stableRPSM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "Average requests-per-second over the panic window",
 			Measure:     panicRPSM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 		&view.View{
 			Description: "The desired requests-per-second for each pod",
 			Measure:     targetRPSM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{namespaceTagKey, serviceTagKey, configTagKey, revisionTagKey},
+			TagKeys:     metrics.CommonRevisionKeys,
 		},
 	); err != nil {
 		panic(err)
@@ -194,7 +185,7 @@ func valueOrUnknown(v string) string {
 }
 
 // NewStatsReporter creates a reporter that collects and reports autoscaler metrics
-func NewStatsReporter(podNamespace string, service string, config string, revision string) (*Reporter, error) {
+func NewStatsReporter(ns, service, config, revision string) (*Reporter, error) {
 	r := &Reporter{}
 
 	// Our tags are static. So, we can get away with creating a single context
@@ -202,10 +193,10 @@ func NewStatsReporter(podNamespace string, service string, config string, revisi
 	// can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(namespaceTagKey, podNamespace),
-		tag.Insert(serviceTagKey, valueOrUnknown(service)),
-		tag.Insert(configTagKey, config),
-		tag.Insert(revisionTagKey, revision))
+		tag.Insert(metrics.NamespaceTagKey, ns),
+		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
+		tag.Insert(metrics.ConfigTagKey, config),
+		tag.Insert(metrics.RevisionTagKey, revision))
 	if err != nil {
 		return nil, err
 	}
@@ -276,6 +267,6 @@ func (r *Reporter) report(m stats.Measurement) error {
 		return errors.New("StatsReporter is not initialized yet")
 	}
 
-	metrics.Record(r.ctx, m)
+	pkgmetrics.Record(r.ctx, m)
 	return nil
 }

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"go.opencensus.io/tag"
+	"knative.dev/pkg/metrics/metricskey"
+)
+
+// Create the tag keys that will be used to add tags to our measurements.
+// Tag keys must conform to the restrictions described in
+// go.opencensus.io/tag/validate.go. Currently those restrictions are:
+// - length between 1 and 255 inclusive
+// - characters are printable US-ASCII
+var (
+	NamespaceTagKey      = tag.MustNewKey(metricskey.LabelNamespaceName)
+	ServiceTagKey        = tag.MustNewKey(metricskey.LabelServiceName)
+	ConfigTagKey         = tag.MustNewKey(metricskey.LabelConfigurationName)
+	RevisionTagKey       = tag.MustNewKey(metricskey.LabelRevisionName)
+	ResponseCodeKey      = tag.MustNewKey("response_code")
+	ResponseCodeClassKey = tag.MustNewKey("response_code_class")
+	NumTriesKey          = tag.MustNewKey("num_tries")
+
+	CommonRevisionKeys = []tag.Key{NamespaceTagKey, ServiceTagKey, ConfigTagKey, RevisionTagKey}
+)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Refactor stats reporter of activator, autoscaler and queue-proxy. Store the tag keys to `serving/pkg/metrics` as they are static and shared by these 3 components.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
