### PR TITLE
Use correct port by ingress prober's Host header when istio-ingress has different target port number

### DIFF
--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -447,7 +448,7 @@ func (m *StatusProber) listGatewayURLsPerPods(gateway *v1alpha3.Gateway) (map[st
 				}
 
 				for _, addr := range sub.Addresses {
-					ingressPodAddress := fmt.Sprintf("%s:%d", addr.IP, portNumber)
+					ingressPodAddress := net.JoinHostPort(addr.IP, strconv.Itoa(int(portNumber)))
 					urlsPerPods[ingressPodAddress] = append(urlsPerPods[ingressPodAddress], fmt.Sprintf(urlTmpl, int32(server.Port.Number)))
 				}
 			}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -398,7 +398,7 @@ func (m *StatusProber) getGateway(name string) (*v1alpha3.Gateway, error) {
 
 // listGatewayPodsURLs returns a map where the keys are the Gateway Pod IPs and the values are the corresponding
 // URL templates and the Gateway Pod Port to be probed.
-func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map[string][]*probeTarget, error) {
+func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map[string][]probeTarget, error) {
 	selector := labels.NewSelector()
 	for key, value := range gateway.Spec.Selector {
 		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
@@ -423,7 +423,7 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 		return nil, fmt.Errorf("failed to list Endpoints: %v", err)
 	}
 
-	targetsPerPods := make(map[string][]*probeTarget)
+	targetsPerPods := make(map[string][]probeTarget)
 	for _, server := range gateway.Spec.Servers {
 		var urlTmpl string
 		switch server.Port.Protocol {
@@ -452,7 +452,7 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 				}
 
 				for _, addr := range sub.Addresses {
-					targetsPerPods[addr.IP] = append(targetsPerPods[addr.IP], &probeTarget{urlTmpl: fmt.Sprintf(urlTmpl, server.Port.Number), targetPort: strconv.Itoa(int(portNumber))})
+					targetsPerPods[addr.IP] = append(targetsPerPods[addr.IP], probeTarget{urlTmpl: fmt.Sprintf(urlTmpl, server.Port.Number), targetPort: strconv.Itoa(int(portNumber))})
 				}
 			}
 		}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -84,7 +84,6 @@ type workItem struct {
 	ingressState *ingressState
 	podState     *podState
 	url          string
-	port         string
 	podIP        string
 }
 
@@ -194,7 +193,11 @@ func (m *StatusProber) IsReady(ia v1alpha1.IngressAccessor, gw map[v1alpha1.Ingr
 			continue
 		}
 
-		for ip, urls := range urlsPerPod {
+		for address, urls := range urlsPerPod {
+			ip := address
+			if i := strings.LastIndex(address, ":"); i != -1 {
+				ip = address[:i]
+			}
 			// Each Pod backing a Gateway is probed using the different hosts, protocol and ports until
 			// one of the probing calls succeeds. Then, the Pod is considered ready and all pending work items
 			// scheduled for that pod are cancelled.
@@ -229,18 +232,11 @@ func (m *StatusProber) IsReady(ia v1alpha1.IngressAccessor, gw map[v1alpha1.Ingr
 
 			for _, host := range hosts {
 				for _, url := range urls {
-					fullUrl := fmt.Sprintf(url, host)
-					port := ""
-					if i := strings.LastIndex(fullUrl, ":"); i != -1 {
-						port = fullUrl[i+1:]
-						fullUrl = fullUrl[:i]
-					}
 					workItem := &workItem{
 						ingressState: ingressState,
 						podState:     podState,
-						url:          fullUrl,
-						port:         port,
-						podIP:        ip,
+						url:          fmt.Sprintf(url, host),
+						podIP:        address,
 					}
 					workItems = append(workItems, workItem)
 				}
@@ -256,7 +252,7 @@ func (m *StatusProber) IsReady(ia v1alpha1.IngressAccessor, gw map[v1alpha1.Ingr
 	}()
 	for _, workItem := range workItems {
 		m.workQueue.AddRateLimited(workItem)
-		m.logger.Infof("Queuing probe for %s:%s, IP: %s (depth: %d)", workItem.url, workItem.port, workItem.podIP, m.workQueue.Len())
+		m.logger.Infof("Queuing probe for %s, IP: %s (depth: %d)", workItem.url, workItem.podIP, m.workQueue.Len())
 	}
 	return len(workItems) == 0, nil
 }
@@ -329,7 +325,7 @@ func (m *StatusProber) processWorkItem() bool {
 	if !ok {
 		m.logger.Fatalf("Unexpected work item type: want: %s, got: %s\n", reflect.TypeOf(&workItem{}).Name(), reflect.TypeOf(obj).Name())
 	}
-	m.logger.Infof("Processing probe for %s, IP: %s:%s (depth: %d)", item.url, item.podIP, item.port, m.workQueue.Len())
+	m.logger.Infof("Processing probe for %s, IP: %s (depth: %d)", item.url, item.podIP, m.workQueue.Len())
 
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -342,12 +338,7 @@ func (m *StatusProber) processWorkItem() bool {
 			// because the HTTP client validates that the hostname (not the Host header) matches the server
 			// TLS certificate Common Name or Alternative Names. Therefore, http.Request.URL is set to the
 			// hostname and it is substituted it here with the target IP.
-			if item.port != "" {
-				addr = item.podIP + ":" + item.port
-			} else {
-				// We can assume that item.port is always non-empty, but just in case.
-				addr = item.podIP
-			}
+			addr = item.podIP
 			return dialContext(ctx, network, addr)
 		}}
 
@@ -370,7 +361,7 @@ func (m *StatusProber) processWorkItem() bool {
 	if err != nil || !ok {
 		// In case of error, enqueue for retry
 		m.workQueue.AddRateLimited(obj)
-		m.logger.Errorf("Probing of %s failed, IP: %s:%s, ready: %t, error: %v (depth: %d)", item.url, item.podIP, item.port, ok, err, m.workQueue.Len())
+		m.logger.Errorf("Probing of %s failed, IP: %s, ready: %t, error: %v (depth: %d)", item.url, item.podIP, ok, err, m.workQueue.Len())
 	} else {
 		m.updateStates(item.ingressState, item.podState)
 	}
@@ -433,10 +424,10 @@ func (m *StatusProber) listGatewayURLsPerPods(gateway *v1alpha3.Gateway) (map[st
 		switch server.Port.Protocol {
 		case v1alpha3.ProtocolHTTP, v1alpha3.ProtocolHTTP2:
 			if server.TLS == nil || !server.TLS.HTTPSRedirect {
-				urlTmpl = "http://%%s:%d"
+				urlTmpl = "http://%%s:%d/"
 			}
 		case v1alpha3.ProtocolHTTPS:
-			urlTmpl = "https://%%s:%d"
+			urlTmpl = "https://%%s:%d/"
 		default:
 			m.logger.Infof("Skipping Server %q because protocol %q is not supported", server.Port.Name, server.Port.Protocol)
 			continue
@@ -456,7 +447,8 @@ func (m *StatusProber) listGatewayURLsPerPods(gateway *v1alpha3.Gateway) (map[st
 				}
 
 				for _, addr := range sub.Addresses {
-					urlsPerPods[addr.IP] = append(urlsPerPods[addr.IP], fmt.Sprintf(urlTmpl, portNumber))
+					ingressPodAddress := fmt.Sprintf("%s:%d", addr.IP, portNumber)
+					urlsPerPods[ingressPodAddress] = append(urlsPerPods[ingressPodAddress], fmt.Sprintf(urlTmpl, int32(server.Port.Number)))
 				}
 			}
 		}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -72,7 +72,7 @@ type ingressState struct {
 	cancel func()
 }
 
-// podStaTargetrepresents the probing progress at the Pod scope
+// podState represents the probing progress at the Pod scope
 type podState struct {
 	successCount int32
 
@@ -398,7 +398,7 @@ func (m *StatusProber) getGateway(name string) (*v1alpha3.Gateway, error) {
 
 // listGatewayPodsURLs returns a map where the keys are the Gateway Pod IPs and the values are the corresponding
 // URL templates and the Gateway Pod Port to be probed.
-func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map[string][]probeTarget, error) {
+func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map[string][]*probeTarget, error) {
 	selector := labels.NewSelector()
 	for key, value := range gateway.Spec.Selector {
 		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
@@ -423,7 +423,7 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 		return nil, fmt.Errorf("failed to list Endpoints: %v", err)
 	}
 
-	targetsPerPods := make(map[string][]probeTarget)
+	targetsPerPods := make(map[string][]*probeTarget)
 	for _, server := range gateway.Spec.Servers {
 		var urlTmpl string
 		switch server.Port.Protocol {
@@ -452,7 +452,7 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 				}
 
 				for _, addr := range sub.Addresses {
-					targetsPerPods[addr.IP] = append(targetsPerPods[addr.IP], probeTarget{urlTmpl: fmt.Sprintf(urlTmpl, server.Port.Number), targetPort: strconv.Itoa(int(portNumber))})
+					targetsPerPods[addr.IP] = append(targetsPerPods[addr.IP], &probeTarget{urlTmpl: fmt.Sprintf(urlTmpl, server.Port.Number), targetPort: strconv.Itoa(int(portNumber))})
 				}
 			}
 		}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -195,9 +194,9 @@ func (m *StatusProber) IsReady(ia v1alpha1.IngressAccessor, gw map[v1alpha1.Ingr
 		}
 
 		for address, urls := range urlsPerPod {
-			ip := address
-			if i := strings.LastIndex(address, ":"); i != -1 {
-				ip = address[:i]
+			ip, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return false, fmt.Errorf("failed to split host and port for %q: %v", address, err)
 			}
 			// Each Pod backing a Gateway is probed using the different hosts, protocol and ports until
 			// one of the probing calls succeeds. Then, the Pod is considered ready and all pending work items

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -457,11 +457,24 @@ func TestProbeLifecycle(t *testing.T) {
 		t.Fatalf("IsReady returned %v, want: %v", ok, false)
 	}
 
+	const expHostHeader = "foo.bar.com:80"
 	// Wait for the first request (failing) to be executed
-	<-probeRequests
+	select {
+	case req := <-probeRequests:
+		// Verify Host header as it is set to item.url in IsReady().
+		if req.Host != expHostHeader {
+			t.Fatalf("unexpected reqeust is sent, want: %s, got %s", expHostHeader, req.Host)
+		}
+	}
 
 	// Wait for the second request (success) to be executed
-	<-probeRequests
+	select {
+	case req := <-probeRequests:
+		// Verify Host header as it is set to item.url in IsReady().
+		if req.Host != expHostHeader {
+			t.Fatalf("unexpected reqeust is sent, want: %s, got %s", expHostHeader, req.Host)
+		}
+	}
 
 	// Wait for the probing to eventually succeed
 	<-ready

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -463,7 +463,7 @@ func TestProbeLifecycle(t *testing.T) {
 	case req := <-probeRequests:
 		// Verify Host header as it is set to item.url in IsReady().
 		if req.Host != expHostHeader {
-			t.Fatalf("unexpected reqeust is sent, want: %s, got %s", expHostHeader, req.Host)
+			t.Fatalf("unexpected reqeust was sent, want: %s, got %s", expHostHeader, req.Host)
 		}
 	}
 
@@ -472,7 +472,7 @@ func TestProbeLifecycle(t *testing.T) {
 	case req := <-probeRequests:
 		// Verify Host header as it is set to item.url in IsReady().
 		if req.Host != expHostHeader {
-			t.Fatalf("unexpected reqeust is sent, want: %s, got %s", expHostHeader, req.Host)
+			t.Fatalf("unexpected reqeust was sent, want: %s, got %s", expHostHeader, req.Host)
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

Currently ingress prober does not work well, when istio-ingressgateway
svc has different targetPort from its service port.

Please also refer to https://github.com/knative/serving/issues/5698 for the detail.

/lint
**Release Note**

```release-note
NONE
```


TODO:
- [x] Use correct port when istio-gateway svc has non `80` or `443` port. (But such case happen(?)).
- [x] Add unit test
