### PR TITLE
Remove pointers to time.Time.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/zap"
 
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/resources"
 
@@ -47,7 +46,7 @@ type Autoscaler struct {
 	// State in panic mode. Carries over multiple Scale calls. Guarded
 	// by the stateMux.
 	stateMux     sync.Mutex
-	panicTime    *time.Time
+	panicTime    time.Time
 	maxPanicPods int32
 
 	// specMux guards the current DeciderSpec and the PodCounter.
@@ -85,9 +84,9 @@ func New(
 		// is reconciled before SKS has even chance of creating the service/endpoints.
 		curC = 0
 	}
-	var pt *time.Time
+	var pt time.Time
 	if curC > 1 {
-		pt = ptr.Time(time.Now())
+		pt = time.Now()
 		// A new instance of autoscaler is created in panic mode.
 		reporter.ReportPanic(1)
 	} else {
@@ -198,25 +197,25 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 
 	a.stateMux.Lock()
 	defer a.stateMux.Unlock()
-	if a.panicTime == nil && isOverPanicThreshold {
+	if a.panicTime.IsZero() && isOverPanicThreshold {
 		// Begin panicking when we cross the threshold in the panic window.
 		logger.Info("PANICKING")
-		a.panicTime = &now
+		a.panicTime = now
 		a.reporter.ReportPanic(1)
-	} else if a.panicTime != nil && !isOverPanicThreshold && a.panicTime.Add(spec.StableWindow).Before(now) {
+	} else if !a.panicTime.IsZero() && !isOverPanicThreshold && a.panicTime.Add(spec.StableWindow).Before(now) {
 		// Stop panicking after the surge has made its way into the stable metric.
 		logger.Info("Un-panicking.")
-		a.panicTime = nil
+		a.panicTime = time.Time{}
 		a.maxPanicPods = 0
 		a.reporter.ReportPanic(0)
 	}
 
-	if a.panicTime != nil {
+	if !a.panicTime.IsZero() {
 		logger.Debug("Operating in panic mode.")
 		// We do not scale down while in panic mode. Only increases will be applied.
 		if desiredPanicPodCount > a.maxPanicPods {
 			logger.Infof("Increasing pods from %d to %d.", originalReadyPodsCount, desiredPanicPodCount)
-			a.panicTime = &now
+			a.panicTime = now
 			a.maxPanicPods = desiredPanicPodCount
 		} else if desiredPanicPodCount < a.maxPanicPods {
 			logger.Debugf("Skipping decrease from %d to %d.", a.maxPanicPods, desiredPanicPodCount)

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -436,7 +436,7 @@ func TestStartInPanicMode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error creating test autoscaler: %v", err)
 		}
-		if a.panicTime != nil {
+		if !a.panicTime.IsZero() {
 			t.Errorf("Create at scale %d had panic mode on", i)
 		}
 		if got, want := int(a.maxPanicPods), i; got != want {
@@ -450,7 +450,7 @@ func TestStartInPanicMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating test autoscaler: %v", err)
 	}
-	if a.panicTime == nil {
+	if a.panicTime.IsZero() {
 		t.Error("Create at scale 2 had panic mode off")
 	}
 	if got, want := int(a.maxPanicPods), 2; got != want {

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -52,7 +52,7 @@ type StatsScraperFactory func(*av1alpha1.Metric) (StatsScraper, error)
 // Stat defines a single measurement at a point in time
 type Stat struct {
 	// The time the data point was received by autoscaler.
-	Time *time.Time
+	Time time.Time
 
 	// The unique identity of this pod.  Used to count how many pods
 	// are contributing to the metrics.
@@ -308,8 +308,8 @@ func (c *collection) record(stat Stat) {
 
 	// Proxied requests have been counted at the activator. Subtract
 	// them to avoid double counting.
-	c.concurrencyBuckets.Record(*stat.Time, stat.PodName, stat.AverageConcurrentRequests-stat.AverageProxiedConcurrentRequests)
-	c.rpsBuckets.Record(*stat.Time, stat.PodName, stat.RequestCount-stat.ProxiedRequestCount)
+	c.concurrencyBuckets.Record(stat.Time, stat.PodName, stat.AverageConcurrentRequests-stat.AverageProxiedConcurrentRequests)
+	c.rpsBuckets.Record(stat.Time, stat.PodName, stat.RequestCount-stat.ProxiedRequestCount)
 
 	// Delete outdated stats taking stat.Time as current time.
 	now := stat.Time

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -120,7 +120,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 	wantConcurrency := 10.0
 	wantRPS := 20.0
 	stat := Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   "testPod",
 		AverageConcurrentRequests: wantConcurrency,
 		RequestCount:              wantRPS,
@@ -182,13 +182,13 @@ func TestMetricCollectorRecord(t *testing.T) {
 	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	want := 10.0
 	outdatedStat := Stat{
-		Time:                      &oldTime,
+		Time:                      oldTime,
 		PodName:                   "testPod",
 		AverageConcurrentRequests: 100,
 		RequestCount:              100,
 	}
 	stat := Stat{
-		Time:                             &now,
+		Time:                             now,
 		PodName:                          "testPod",
 		AverageConcurrentRequests:        want + 10,
 		AverageProxiedConcurrentRequests: 10, // this should be subtracted from the above.

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -274,9 +274,8 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 		t.Error("Failed to set scale for metric to 0")
 	}
 
-	now := time.Now()
 	testStat := Stat{
-		Time:                      &now,
+		Time:                      time.Now(),
 		PodName:                   "test-pod",
 		AverageConcurrentRequests: 1,
 		RequestCount:              1,

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -193,7 +193,6 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 	avgProxiedConcurrency = avgProxiedConcurrency / successCount
 	reqCount = reqCount / successCount
 	proxiedReqCount = proxiedReqCount / successCount
-	now := time.Now()
 
 	// Assumption: A particular pod can stand for other pods, i.e. other pods
 	// have similar concurrency and QPS.
@@ -203,7 +202,7 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 	// scraperPodName so in autoscaler all stats are either from activator or
 	// scraper.
 	return Stat{
-		Time:                             &now,
+		Time:                             time.Now(),
 		PodName:                          scraperPodName,
 		AverageConcurrentRequests:        avgConcurrency * frpc,
 		AverageProxiedConcurrentRequests: avgProxiedConcurrency * frpc,

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -165,8 +165,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error(err)
 			continue
 		}
-		now := time.Now()
-		sm.Stat.Time = &now
+		sm.Stat.Time = time.Now()
 
 		s.logger.Debugf("Received stat message: %+v", sm)
 		s.statsCh <- &sm

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -182,7 +182,7 @@ func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, stat
 	if !ok {
 		t.Fatalf("statistic not received")
 	}
-	if recv.Stat.Time == nil {
+	if recv.Stat.Time == (time.Time{}) {
 		t.Fatalf("Stat time is nil")
 	}
 	ignoreTimeField := cmpopts.IgnoreFields(autoscaler.StatMessage{}, "Stat.Time")

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -115,7 +115,7 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 				updateState(now)
 
 				stat := &autoscaler.Stat{
-					Time:                             &now,
+					Time:                             now,
 					PodName:                          s.podName,
 					AverageConcurrentRequests:        weightedAverage(timeOnConcurrency),
 					AverageProxiedConcurrentRequests: weightedAverage(timeOnProxiedConcurrency),

--- a/pkg/queue/stats_test.go
+++ b/pkg/queue/stats_test.go
@@ -34,7 +34,7 @@ func TestNoData(t *testing.T) {
 
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 0.0,
 		RequestCount:              0,
@@ -55,7 +55,7 @@ func TestSingleRequestWholeTime(t *testing.T) {
 	got := s.report(now)
 
 	want := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              1,
@@ -76,7 +76,7 @@ func TestSingleRequestHalfTime(t *testing.T) {
 	got := s.report(now)
 
 	want := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 0.5,
 		RequestCount:              1,
@@ -98,7 +98,7 @@ func TestVeryShortLivedRequest(t *testing.T) {
 	got := s.report(now)
 
 	want := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: float64(10) / float64(1000),
 		RequestCount:              1,
@@ -127,7 +127,7 @@ func TestMultipleRequestsWholeTime(t *testing.T) {
 	got := s.report(now)
 
 	want := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              3,
@@ -152,7 +152,7 @@ func TestMultipleRequestsInterleaved(t *testing.T) {
 	got := s.report(now)
 
 	want := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.5,
 		RequestCount:              2,
@@ -181,7 +181,7 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got2 := s.report(now)
 	want2 := &autoscaler.Stat{
-		Time:                      &now,
+		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 0.5,
 		RequestCount:              0,
@@ -202,7 +202,7 @@ func TestOneProxiedRequest(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                             &now,
+		Time:                             now,
 		PodName:                          podName,
 		AverageConcurrentRequests:        1.0,
 		AverageProxiedConcurrentRequests: 1.0,
@@ -223,7 +223,7 @@ func TestOneEndedProxiedRequest(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                             &now,
+		Time:                             now,
 		PodName:                          podName,
 		AverageConcurrentRequests:        0.5,
 		AverageProxiedConcurrentRequests: 0.5,
@@ -245,7 +245,7 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
 	want := &autoscaler.Stat{
-		Time:                             &now,
+		Time:                             now,
 		PodName:                          podName,
 		AverageConcurrentRequests:        1.0,
 		AverageProxiedConcurrentRequests: 0.5,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

```golang
// A Time represents an instant in time with nanosecond precision.
//
// Programs using times should typically store and pass them as values,
// not pointers. That is, time variables and struct fields should be of
// type time.Time, not *time.Time.
```

'nuff said 🙂 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
