### PR TITLE
Make all references to StatMessage values.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -98,7 +98,7 @@ var (
 )
 
 func statReporter(statSink *websocket.ManagedConnection, stopCh <-chan struct{},
-	statChan <-chan *autoscaler.StatMessage, logger *zap.SugaredLogger) {
+	statChan <-chan autoscaler.StatMessage, logger *zap.SugaredLogger) {
 	for {
 		select {
 		case sm := <-statChan:
@@ -176,7 +176,7 @@ func main() {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
 
-	statCh := make(chan *autoscaler.StatMessage, statReportingQueueLength)
+	statCh := make(chan autoscaler.StatMessage, statReportingQueueLength)
 	defer close(statCh)
 
 	reqCh := make(chan activatorhandler.ReqEvent, requestCountingQueueLength)

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -106,7 +106,7 @@ func main() {
 	ctx = logging.WithLogger(ctx, logger)
 
 	// statsCh is the main communication channel between the stats server and multiscaler.
-	statsCh := make(chan *autoscaler.StatMessage, statsBufferLen)
+	statsCh := make(chan autoscaler.StatMessage, statsBufferLen)
 	defer close(statsCh)
 
 	profilingHandler := profiling.NewHandler(logger, false)

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -43,7 +43,7 @@ type ConcurrencyReporter struct {
 	// Ticks with every stat report request
 	reportCh <-chan time.Time
 	// Stat reporting channel
-	statCh chan *autoscaler.StatMessage
+	statCh chan autoscaler.StatMessage
 
 	rl servinglisters.RevisionLister
 	sr activator.StatsReporter
@@ -54,7 +54,7 @@ type ConcurrencyReporter struct {
 // NewConcurrencyReporter creates a ConcurrencyReporter which listens to incoming
 // ReqEvents on reqCh and ticks on reportCh and reports stats on statCh.
 func NewConcurrencyReporter(ctx context.Context, podName string,
-	reqCh chan ReqEvent, reportCh <-chan time.Time, statCh chan *autoscaler.StatMessage,
+	reqCh chan ReqEvent, reportCh <-chan time.Time, statCh chan autoscaler.StatMessage,
 	sr activator.StatsReporter) *ConcurrencyReporter {
 	return NewConcurrencyReporterWithClock(ctx, podName, reqCh, reportCh,
 		statCh, sr, system.RealClock{})
@@ -63,7 +63,7 @@ func NewConcurrencyReporter(ctx context.Context, podName string,
 // NewConcurrencyReporterWithClock instantiates a new concurrency reporter
 // which uses the passed clock.
 func NewConcurrencyReporterWithClock(ctx context.Context, podName string, reqCh chan ReqEvent,
-	reportCh <-chan time.Time, statCh chan *autoscaler.StatMessage,
+	reportCh <-chan time.Time, statCh chan autoscaler.StatMessage,
 	sr activator.StatsReporter, clock system.Clock) *ConcurrencyReporter {
 	return &ConcurrencyReporter{
 		logger:   logging.FromContext(ctx),
@@ -86,7 +86,7 @@ func (cr *ConcurrencyReporter) reportToAutoscaler(key types.NamespacedName, conc
 
 	// Send the stat to another goroutine to transmit
 	// so we can continue bucketing stats.
-	cr.statCh <- &autoscaler.StatMessage{
+	cr.statCh <- autoscaler.StatMessage{
 		Key:  key,
 		Stat: stat,
 	}

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -61,7 +61,7 @@ func TestStats(t *testing.T) {
 	tt := []struct {
 		name          string
 		ops           []reqOp
-		expectedStats []*autoscaler.StatMessage
+		expectedStats []autoscaler.StatMessage
 	}{{
 		name: "Scale-from-zero sends stat",
 		ops: []reqOp{{
@@ -71,7 +71,7 @@ func TestStats(t *testing.T) {
 			op:  requestOpStart,
 			key: pod2,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -95,7 +95,7 @@ func TestStats(t *testing.T) {
 		}, {
 			op: requestOpTick,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -122,7 +122,7 @@ func TestStats(t *testing.T) {
 			op:  requestOpStart,
 			key: pod1,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -154,7 +154,7 @@ func TestStats(t *testing.T) {
 		}, {
 			op: requestOpTick,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -223,14 +223,14 @@ func TestStats(t *testing.T) {
 			}
 
 			// Gather reported stats
-			stats := make([]*autoscaler.StatMessage, 0, len(tc.expectedStats))
+			stats := make([]autoscaler.StatMessage, 0, len(tc.expectedStats))
 			for i := 0; i < len(tc.expectedStats); i++ {
 				sm := <-s.statChan
 				stats = append(stats, sm)
 			}
 
 			// Check the stats we got match what we wanted
-			sorter := cmpopts.SortSlices(func(a, b *autoscaler.StatMessage) bool {
+			sorter := cmpopts.SortSlices(func(a, b autoscaler.StatMessage) bool {
 				return a.Key.Name < b.Key.Name
 			})
 			if got, want := stats, tc.expectedStats; !cmp.Equal(got, want, sorter) {
@@ -244,7 +244,7 @@ func TestStats(t *testing.T) {
 type testStats struct {
 	reqChan      chan ReqEvent
 	reportChan   <-chan time.Time
-	statChan     chan *autoscaler.StatMessage
+	statChan     chan autoscaler.StatMessage
 	reportBiChan chan time.Time
 }
 
@@ -253,7 +253,7 @@ func newTestStats(t *testing.T, clock system.Clock) (*testStats, *ConcurrencyRep
 	ts := &testStats{
 		reqChan:      make(chan ReqEvent),
 		reportChan:   (<-chan time.Time)(reportBiChan),
-		statChan:     make(chan *autoscaler.StatMessage, 20),
+		statChan:     make(chan autoscaler.StatMessage, 20),
 		reportBiChan: reportBiChan,
 	}
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -39,13 +39,13 @@ type Server struct {
 	wsSrv       http.Server
 	servingCh   chan struct{}
 	stopCh      chan struct{}
-	statsCh     chan<- *autoscaler.StatMessage
+	statsCh     chan<- autoscaler.StatMessage
 	openClients sync.WaitGroup
 	logger      *zap.SugaredLogger
 }
 
 // New creates a Server which will receive autoscaler statistics and forward them to statsCh until Shutdown is called.
-func New(statsServerAddr string, statsCh chan<- *autoscaler.StatMessage, logger *zap.SugaredLogger) *Server {
+func New(statsServerAddr string, statsCh chan<- autoscaler.StatMessage, logger *zap.SugaredLogger) *Server {
 	svr := Server{
 		addr:        statsServerAddr,
 		servingCh:   make(chan struct{}),
@@ -168,7 +168,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		sm.Stat.Time = time.Now()
 
 		s.logger.Debugf("Received stat message: %+v", sm)
-		s.statsCh <- &sm
+		s.statsCh <- sm
 	}
 }
 

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestServerLifecycle(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := stats.NewTestServer(statsCh)
 
 	eg := errgroup.Group{}
@@ -54,7 +54,7 @@ func TestServerLifecycle(t *testing.T) {
 }
 
 func TestProbe(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := stats.NewTestServer(statsCh)
 
 	defer server.Shutdown(0)
@@ -76,7 +76,7 @@ func TestProbe(t *testing.T) {
 }
 
 func TestStatsReceived(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := stats.NewTestServer(statsCh)
 
 	defer server.Shutdown(0)
@@ -91,7 +91,7 @@ func TestStatsReceived(t *testing.T) {
 }
 
 func TestServerShutdown(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := stats.NewTestServer(statsCh)
 
 	go server.ListenAndServe()
@@ -136,7 +136,7 @@ func TestServerShutdown(t *testing.T) {
 }
 
 func TestServerDoesNotLeakGoroutines(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := stats.NewTestServer(statsCh)
 
 	go server.ListenAndServe()
@@ -165,8 +165,8 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	server.Shutdown(time.Second)
 }
 
-func newStatMessage(revKey types.NamespacedName, podName string, averageConcurrentRequests float64, requestCount float64) *autoscaler.StatMessage {
-	return &autoscaler.StatMessage{
+func newStatMessage(revKey types.NamespacedName, podName string, averageConcurrentRequests float64, requestCount float64) autoscaler.StatMessage {
+	return autoscaler.StatMessage{
 		Key: revKey,
 		Stat: autoscaler.Stat{
 			PodName:                   podName,
@@ -176,7 +176,7 @@ func newStatMessage(revKey types.NamespacedName, podName string, averageConcurre
 	}
 }
 
-func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, statsCh <-chan *autoscaler.StatMessage, t *testing.T) bool {
+func assertReceivedOk(sm autoscaler.StatMessage, statSink *websocket.Conn, statsCh <-chan autoscaler.StatMessage, t *testing.T) bool {
 	send(statSink, sm, t)
 	recv, ok := <-statsCh
 	if !ok {
@@ -214,7 +214,7 @@ func dial(serverURL string, t *testing.T) (*websocket.Conn, error) {
 	return statSink, err
 }
 
-func send(statSink *websocket.Conn, sm *autoscaler.StatMessage, t *testing.T) {
+func send(statSink *websocket.Conn, sm autoscaler.StatMessage, t *testing.T) {
 	var b bytes.Buffer
 	enc := gob.NewEncoder(&b)
 

--- a/pkg/autoscaler/statserver/server_testing_test.go
+++ b/pkg/autoscaler/statserver/server_testing_test.go
@@ -30,7 +30,7 @@ type TestServer struct {
 	listenAddr chan string
 }
 
-func NewTestServer(statsCh chan<- *autoscaler.StatMessage) *TestServer {
+func NewTestServer(statsCh chan<- autoscaler.StatMessage) *TestServer {
 	return &TestServer{
 		Server:     New(testAddress, statsCh, zap.NewNop().Sugar()),
 		listenAddr: make(chan string, 1),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

`Stat` is already a value everywhere so there's really no reason to make this wrapper a pointer.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
