### PR TITLE
Translate to tcp probe in queue-proxy when exec probe was used for readinessprobe in user-container

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -612,7 +612,7 @@ func TestMakePodSpec(t *testing.T) {
 					withExecReadinessProbe([]string{"echo", "hello"})),
 				queueContainer(
 					withEnvVar("CONTAINER_CONCURRENCY", "0"),
-					withEnvVar("SERVING_READINESS_PROBE", "{}"),
+					withEnvVar("SERVING_READINESS_PROBE", `{"tcpSocket":{"port":8080,"host":"127.0.0.1"}}`),
 				),
 			}),
 	}, {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -356,7 +356,12 @@ func applyReadinessProbeDefaults(p *corev1.Probe, port int32) {
 		p.TCPSocket.Host = localAddress
 		p.TCPSocket.Port = intstr.FromInt(int(port))
 	case p.Exec != nil:
-		//User-defined ExecProbe will still be run on user-container.
+		// User-defined ExecProbe will still be run on user-container.
+		// Use TCP probe in queue-proxy.
+		p.TCPSocket = &corev1.TCPSocketAction{
+			Host: localAddress,
+			Port: intstr.FromInt(int(port)),
+		}
 		p.Exec = nil
 	}
 

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -38,27 +38,28 @@ var testCases = []struct {
 	name string
 	// handler to be used for readiness probe in user container.
 	handler corev1.Handler
-}{
-	{
-		"httpGet",
-		corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/healthz",
-			},
+}{{
+	"httpGet",
+	corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/healthz",
 		},
 	},
-	{
-		"exec",
-		corev1.Handler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"/ko-app/runtime", "probe"},
-			},
+}, {
+	"tcpSocket",
+	corev1.Handler{
+		TCPSocket: &corev1.TCPSocketAction{},
+	},
+}, {
+	"exec",
+	corev1.Handler{
+		Exec: &corev1.ExecAction{
+			Command: []string{"/ko-app/runtime", "probe"},
 		},
 	},
-}
+}}
 
 func TestProbeRuntime(t *testing.T) {
-	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()
 

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -30,40 +30,39 @@ import (
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
-// testCases for table-driven testing.
-var testCases = []struct {
-	// name of the test case, which will be inserted in names of routes, configurations, etc.
-	// Use a short name here to avoid hitting the 63-character limit in names
-	// (e.g., "service-to-service-call-svc-cluster-local-uagkdshh-frkml-service" is too long.)
-	name string
-	// handler to be used for readiness probe in user container.
-	handler corev1.Handler
-}{{
-	"httpGet",
-	corev1.Handler{
-		HTTPGet: &corev1.HTTPGetAction{
-			Path: "/healthz",
-		},
-	},
-}, {
-	"tcpSocket",
-	corev1.Handler{
-		TCPSocket: &corev1.TCPSocketAction{},
-	},
-}, {
-	"exec",
-	corev1.Handler{
-		Exec: &corev1.ExecAction{
-			Command: []string{"/ko-app/runtime", "probe"},
-		},
-	},
-}}
-
 func TestProbeRuntime(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
 	clients := test.Setup(t)
+
+	var testCases = []struct {
+		// name of the test case, which will be inserted in names of routes, configurations, etc.
+		// Use a short name here to avoid hitting the 63-character limit in names
+		// (e.g., "service-to-service-call-svc-cluster-local-uagkdshh-frkml-service" is too long.)
+		name string
+		// handler to be used for readiness probe in user container.
+		handler corev1.Handler
+	}{{
+		"httpGet",
+		corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/healthz",
+			},
+		},
+	}, {
+		"tcpSocket",
+		corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{},
+		},
+	}, {
+		"exec",
+		corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"/ko-app/runtime", "probe"},
+			},
+		},
+	}}
 
 	for _, tc := range testCases {
 		tc := tc

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -14,6 +14,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 	"os"
@@ -23,12 +24,23 @@ import (
 )
 
 func main() {
-
 	// We expect PORT to be defined in a Knative environment
 	// and don't want to mask this failure in a test image.
 	port, isSet := os.LookupEnv("PORT")
 	if !isSet {
 		log.Fatal("Environment variable PORT is not set.")
+	}
+
+	// This is an option for exec readiness probe test.
+	flag.Parse()
+	args := flag.Args()
+	if len(args) > 0 && args[0] == "probe" {
+		url := "http://localhost:" + port
+		_, err := http.Get(url)
+		if err != nil {
+			log.Fatalf("failed to probe %v", err)
+		}
+		return
 	}
 
 	mux := http.NewServeMux()

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -36,8 +36,7 @@ func main() {
 	args := flag.Args()
 	if len(args) > 0 && args[0] == "probe" {
 		url := "http://localhost:" + port
-		_, err := http.Get(url)
-		if err != nil {
+		if _, err := http.Get(url); err != nil {
 			log.Fatalf("Failed to probe %v", err)
 		}
 		return

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -38,7 +38,7 @@ func main() {
 		url := "http://localhost:" + port
 		_, err := http.Get(url)
 		if err != nil {
-			log.Fatalf("failed to probe %v", err)
+			log.Fatalf("Failed to probe %v", err)
 		}
 		return
 	}


### PR DESCRIPTION
## Proposed Changes

When users defined exec probe for readinessprobe, it becomes `nil` and
get unexpected error. To make matters worse, the pod never becomes ready.

This patch changes to translates exec probe in user-container to tcp
probe as per following code comment.

https://github.com/knative/serving/blob/3174fcedbabd3fb3e1e5bde3f2188049ed38e796/pkg/queue/readiness/probe.go#L65-L66

/lint

Fixes https://github.com/knative/serving/issues/5711

**Release Note**

```release-note
NONE
```
