### PR TITLE
Call API when removing route's finalizer

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -365,6 +365,11 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 
+	// Delete the Ingress resources for this Route.
+	logger.Info("Cleaning up Ingress")
+	if err := c.deleteIngressForRoute(r); err != nil {
+		return err
+	}
 	// remove our finalizer if it is found
 	for i, v := range r.Finalizers {
 		if v == routeFinalizer {
@@ -375,10 +380,7 @@ func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) e
 			break
 		}
 	}
-
-	// Delete the Ingress resources for this Route.
-	logger.Info("Cleaning up Ingress")
-	return c.deleteIngressForRoute(r)
+	return nil
 }
 
 // configureTraffic attempts to configure traffic based on the RouteSpec.  If there are missing

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -365,22 +365,23 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 
+	// If our Finalizer is first, delete the ClusterIngress for this Route
+	// and remove the finalizer.
+	if len(r.Finalizers) == 0 || r.Finalizers[0] != routeFinalizer {
+		return nil
+	}
+
 	// Delete the Ingress resources for this Route.
 	logger.Info("Cleaning up Ingress")
 	if err := c.deleteIngressForRoute(r); err != nil {
 		return err
 	}
-	// remove our finalizer if it is found
-	for i, v := range r.Finalizers {
-		if v == routeFinalizer {
-			r.Finalizers = append(r.Finalizers[:i], r.Finalizers[i+1:]...)
-			if _, err := c.ServingClientSet.ServingV1alpha1().Routes(r.Namespace).Update(r); err != nil {
-				return err
-			}
-			break
-		}
-	}
-	return nil
+
+	// Update the Route to remove the Finalizer.
+	logger.Info("Removing Finalizer")
+	r.Finalizers = r.Finalizers[1:]
+	_, err := c.ServingClientSet.ServingV1alpha1().Routes(r.Namespace).Update(r)
+	return err
 }
 
 // configureTraffic attempts to configure traffic based on the RouteSpec.  If there are missing

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -369,6 +369,9 @@ func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) e
 	for i, v := range r.Finalizers {
 		if v == routeFinalizer {
 			r.Finalizers = append(r.Finalizers[:i], r.Finalizers[i+1:]...)
+			if _, err := c.ServingClientSet.ServingV1alpha1().Routes(r.Namespace).Update(r); err != nil {
+				return err
+			}
 			break
 		}
 	}

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -365,7 +365,7 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, tr
 func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) error {
 	logger := logging.FromContext(ctx)
 
-	// If our Finalizer is first, delete the ClusterIngress for this Route
+	// If our Finalizer is first, delete the Ingress for this Route
 	// and remove the finalizer.
 	if len(r.Finalizers) == 0 || r.Finalizers[0] != routeFinalizer {
 		return nil


### PR DESCRIPTION
## Proposed Changes

When Route object deleted the finalizer, we need to call API but we
are missing it. Due to it, old route which had the finalizer will not be
removed by reconciler.

This patch fixes the issue by calling the API after removed finalizer

/lint

Fixes https://github.com/knative/serving/issues/5714

**Release Note**

```release-note
NONE
```

/cc @wtam2018 @tcnghia @mattmoor 
