### PR TITLE
Fix the package name, which is currently incorrect.

### DIFF
--- a/pkg/activator/net/doc.go
+++ b/pkg/activator/net/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package net contains the Activator components that govern Activator's
+// request throttling, routing, and reflect the cluster network state.
+package net

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package activator
+package net
 
 import (
 	"net"

--- a/pkg/activator/net/helpers_test.go
+++ b/pkg/activator/net/helpers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package activator
+package net
 
 import (
 	"testing"

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package activator
+package net
 
 import (
 	"context"

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package activator
+package net
 
 import (
 	"errors"

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package activator
+package net
 
 import (
 	"context"

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package activator
+package net
 
 import (
 	"context"


### PR DESCRIPTION
The package name should generally match the directory name.
This was flying under the radar because it has always been aliased.
Also add a doc.go file for the package level docs.

/assign @markusthoemmes mattmoor

