### PR TITLE
Simplify queue-proxy prometheus reporter.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -335,9 +335,7 @@ func main() {
 	defer close(statChan)
 	go func() {
 		for s := range statChan {
-			if err := promStatReporter.Report(s); err != nil {
-				logger.Errorw("Error while sending stat", zap.Error(err))
-			}
+			promStatReporter.Report(s)
 		}
 	}()
 

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -142,12 +142,7 @@ func TestReporterReport(t *testing.T) {
 			if err != nil {
 				t.Errorf("Something went wrong with creating a reporter, '%v'.", err)
 			}
-			if !reporter.initialized {
-				t.Error("Reporter should be initialized")
-			}
-			if err := reporter.Report(test.autoscalerStat); err != nil {
-				t.Error(err)
-			}
+			reporter.Report(test.autoscalerStat)
 			checkData(t, requestsPerSecondGV, test.expectedReqCount)
 			checkData(t, averageConcurrentRequestsGV, test.expectedAverageConcurrentRequests)
 			checkData(t, proxiedRequestsPerSecondGV, test.expectedProxiedRequestCount)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- The labels of the reporter are actually immutable so we can look up the corresponding gauges when launching the stats reporter, making the actual metric reporting a simple `Set` operation for each value.
- The 'initialized' state is a noop. It's never false in our usages. If we really care about preventing false usage throught using the struct directly, we should hide the implementation behind an interface.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
