### PR TITLE
Remove unneeded buffering in queue's stats channel.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -60,11 +60,6 @@ import (
 )
 
 const (
-	// Add a little buffer space between request handling and stat
-	// reporting so that latency in the stat pipeline doesn't
-	// interfere with request handling.
-	statReportingQueueLength = 10
-
 	// Add enough buffer to not block request serving on stats collection
 	requestCountingQueueLength = 100
 
@@ -331,7 +326,7 @@ func main() {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
 
-	statChan := make(chan *autoscaler.Stat, statReportingQueueLength)
+	statChan := make(chan *autoscaler.Stat)
 	defer close(statChan)
 	go func() {
 		for s := range statChan {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Values are written only once every second and the reporting to the prometheus endpoint is as simple as setting an atomic Int64 so buffering should not be needed on that channel.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
