### PR TITLE
Cleanup autoscaler test.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -237,7 +237,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	case a.deciderSpec.TargetBurstCapacity >= 0:
 		excessBC = int32(math.Floor(float64(originalReadyPodsCount)*a.deciderSpec.TotalValue - observedStableValue -
 			a.deciderSpec.TargetBurstCapacity))
-		logger.Infof("PodCount=%v TotalValue=%v ObservedStableValue=%v TargetBC=%v ExcessBC=%v",
+		logger.Infof("PodCount=%v Total1PodCapacity=%v ObservedStableValue=%v TargetBC=%v ExcessBC=%v",
 			originalReadyPodsCount,
 			a.deciderSpec.TotalValue,
 			observedStableValue, a.deciderSpec.TargetBurstCapacity, excessBC)


### PR DESCRIPTION
This PR cleans up the autoscaler test, to make it a table test driven,
where possible.
Also it fixes long standing complaing that EBC test computer is hard to decipher,
so I updated the param names to make them more readable.
And a small log improvement.

/assign @yanweiguo  mattmoor @markusthoemmes 

