### PR TITLE
Disable mTLS on Istio 1.3

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -337,7 +337,12 @@ function test_setup() {
   echo ">> Creating test resources (test/config/)"
   ko apply ${KO_FLAGS} -f test/config/ || return 1
   if (( ISTIO_MESH )); then 
-    ko apply ${KO_FLAGS} -f test/config/mtls/ || return 1
+    if [[ ${ISTIO_VERSION} =~ 1.3.* ]]; then
+      # TODO: Enable mTLS with Istio 1.3 once https://github.com/knative/serving/issues/5725 is identified.
+      continue
+    else
+      ko apply ${KO_FLAGS} -f test/config/mtls/ || return 1
+    fi
   fi
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
   wait_until_pods_running knative-serving || return 1


### PR DESCRIPTION
## Proposed Changes

This patch disables mTLS on Istio 1.3. Currently mTLS with Istio 1.3 fails the e2e tests. The issue is tracked by https://github.com/knative/serving/issues/5725.

/lint

Fixes https://github.com/knative/serving/issues/5723

**Release Note**

```release-note
NONE
```
