### PR TITLE
Remove remaining pointers to Stat(Message).

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -94,7 +94,7 @@ var (
 )
 
 func statReporter(statSink *websocket.ManagedConnection, stopCh <-chan struct{},
-	statChan <-chan *autoscaler.StatMessage, logger *zap.SugaredLogger) {
+	statChan <-chan autoscaler.StatMessage, logger *zap.SugaredLogger) {
 	for {
 		select {
 		case sm := <-statChan:
@@ -180,7 +180,7 @@ func main() {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
 
-	statCh := make(chan *autoscaler.StatMessage)
+	statCh := make(chan autoscaler.StatMessage)
 	defer close(statCh)
 
 	reqCh := make(chan activatorhandler.ReqEvent, requestCountingQueueLength)

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -106,7 +106,7 @@ func main() {
 	ctx = logging.WithLogger(ctx, logger)
 
 	// statsCh is the main communication channel between the stats server and multiscaler.
-	statsCh := make(chan *autoscaler.StatMessage, statsBufferLen)
+	statsCh := make(chan autoscaler.StatMessage, statsBufferLen)
 	defer close(statsCh)
 
 	profilingHandler := profiling.NewHandler(logger, false)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -327,7 +327,7 @@ func main() {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}
 
-	statChan := make(chan *autoscaler.Stat)
+	statChan := make(chan autoscaler.Stat)
 	defer close(statChan)
 	go func() {
 		for s := range statChan {

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -43,7 +43,7 @@ type ConcurrencyReporter struct {
 	// Ticks with every stat report request
 	reportCh <-chan time.Time
 	// Stat reporting channel
-	statCh chan *autoscaler.StatMessage
+	statCh chan autoscaler.StatMessage
 
 	rl servinglisters.RevisionLister
 	sr activator.StatsReporter
@@ -54,7 +54,7 @@ type ConcurrencyReporter struct {
 // NewConcurrencyReporter creates a ConcurrencyReporter which listens to incoming
 // ReqEvents on reqCh and ticks on reportCh and reports stats on statCh.
 func NewConcurrencyReporter(ctx context.Context, podName string,
-	reqCh chan ReqEvent, reportCh <-chan time.Time, statCh chan *autoscaler.StatMessage,
+	reqCh chan ReqEvent, reportCh <-chan time.Time, statCh chan autoscaler.StatMessage,
 	sr activator.StatsReporter) *ConcurrencyReporter {
 	return NewConcurrencyReporterWithClock(ctx, podName, reqCh, reportCh,
 		statCh, sr, system.RealClock{})
@@ -63,7 +63,7 @@ func NewConcurrencyReporter(ctx context.Context, podName string,
 // NewConcurrencyReporterWithClock instantiates a new concurrency reporter
 // which uses the passed clock.
 func NewConcurrencyReporterWithClock(ctx context.Context, podName string, reqCh chan ReqEvent,
-	reportCh <-chan time.Time, statCh chan *autoscaler.StatMessage,
+	reportCh <-chan time.Time, statCh chan autoscaler.StatMessage,
 	sr activator.StatsReporter, clock system.Clock) *ConcurrencyReporter {
 	return &ConcurrencyReporter{
 		logger:   logging.FromContext(ctx),
@@ -86,7 +86,7 @@ func (cr *ConcurrencyReporter) reportToAutoscaler(key types.NamespacedName, conc
 
 	// Send the stat to another goroutine to transmit
 	// so we can continue bucketing stats.
-	cr.statCh <- &autoscaler.StatMessage{
+	cr.statCh <- autoscaler.StatMessage{
 		Key:  key,
 		Stat: stat,
 	}

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -61,7 +61,7 @@ func TestStats(t *testing.T) {
 	tt := []struct {
 		name          string
 		ops           []reqOp
-		expectedStats []*autoscaler.StatMessage
+		expectedStats []autoscaler.StatMessage
 	}{{
 		name: "Scale-from-zero sends stat",
 		ops: []reqOp{{
@@ -71,7 +71,7 @@ func TestStats(t *testing.T) {
 			op:  requestOpStart,
 			key: pod2,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -95,7 +95,7 @@ func TestStats(t *testing.T) {
 		}, {
 			op: requestOpTick,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -122,7 +122,7 @@ func TestStats(t *testing.T) {
 			op:  requestOpStart,
 			key: pod1,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -154,7 +154,7 @@ func TestStats(t *testing.T) {
 		}, {
 			op: requestOpTick,
 		}},
-		expectedStats: []*autoscaler.StatMessage{{
+		expectedStats: []autoscaler.StatMessage{{
 			Key: pod1,
 			Stat: autoscaler.Stat{
 				AverageConcurrentRequests: 1,
@@ -223,14 +223,14 @@ func TestStats(t *testing.T) {
 			}
 
 			// Gather reported stats
-			stats := make([]*autoscaler.StatMessage, 0, len(tc.expectedStats))
+			stats := make([]autoscaler.StatMessage, 0, len(tc.expectedStats))
 			for i := 0; i < len(tc.expectedStats); i++ {
 				sm := <-s.statChan
 				stats = append(stats, sm)
 			}
 
 			// Check the stats we got match what we wanted
-			sorter := cmpopts.SortSlices(func(a, b *autoscaler.StatMessage) bool {
+			sorter := cmpopts.SortSlices(func(a, b autoscaler.StatMessage) bool {
 				return a.Key.Name < b.Key.Name
 			})
 			if got, want := stats, tc.expectedStats; !cmp.Equal(got, want, sorter) {
@@ -244,7 +244,7 @@ func TestStats(t *testing.T) {
 type testStats struct {
 	reqChan      chan ReqEvent
 	reportChan   <-chan time.Time
-	statChan     chan *autoscaler.StatMessage
+	statChan     chan autoscaler.StatMessage
 	reportBiChan chan time.Time
 }
 
@@ -253,7 +253,7 @@ func newTestStats(t *testing.T, clock system.Clock) (*testStats, *ConcurrencyRep
 	ts := &testStats{
 		reqChan:      make(chan ReqEvent),
 		reportChan:   (<-chan time.Time)(reportBiChan),
-		statChan:     make(chan *autoscaler.StatMessage, 20),
+		statChan:     make(chan autoscaler.StatMessage, 20),
 		reportBiChan: reportBiChan,
 	}
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -39,13 +39,13 @@ type Server struct {
 	wsSrv       http.Server
 	servingCh   chan struct{}
 	stopCh      chan struct{}
-	statsCh     chan<- *autoscaler.StatMessage
+	statsCh     chan<- autoscaler.StatMessage
 	openClients sync.WaitGroup
 	logger      *zap.SugaredLogger
 }
 
 // New creates a Server which will receive autoscaler statistics and forward them to statsCh until Shutdown is called.
-func New(statsServerAddr string, statsCh chan<- *autoscaler.StatMessage, logger *zap.SugaredLogger) *Server {
+func New(statsServerAddr string, statsCh chan<- autoscaler.StatMessage, logger *zap.SugaredLogger) *Server {
 	svr := Server{
 		addr:        statsServerAddr,
 		servingCh:   make(chan struct{}),
@@ -168,7 +168,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		sm.Stat.Time = time.Now()
 
 		s.logger.Debugf("Received stat message: %+v", sm)
-		s.statsCh <- &sm
+		s.statsCh <- sm
 	}
 }
 

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestServerLifecycle(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := newTestServer(statsCh)
 
 	eg := errgroup.Group{}
@@ -55,7 +55,7 @@ func TestServerLifecycle(t *testing.T) {
 }
 
 func TestProbe(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := newTestServer(statsCh)
 
 	defer server.Shutdown(0)
@@ -77,7 +77,7 @@ func TestProbe(t *testing.T) {
 }
 
 func TestStatsReceived(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := newTestServer(statsCh)
 
 	defer server.Shutdown(0)
@@ -92,7 +92,7 @@ func TestStatsReceived(t *testing.T) {
 }
 
 func TestServerShutdown(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := newTestServer(statsCh)
 
 	go server.listenAndServe()
@@ -137,7 +137,7 @@ func TestServerShutdown(t *testing.T) {
 }
 
 func TestServerDoesNotLeakGoroutines(t *testing.T) {
-	statsCh := make(chan *autoscaler.StatMessage)
+	statsCh := make(chan autoscaler.StatMessage)
 	server := newTestServer(statsCh)
 
 	go server.listenAndServe()
@@ -166,8 +166,8 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	server.Shutdown(time.Second)
 }
 
-func newStatMessage(revKey types.NamespacedName, podName string, averageConcurrentRequests float64, requestCount float64) *autoscaler.StatMessage {
-	return &autoscaler.StatMessage{
+func newStatMessage(revKey types.NamespacedName, podName string, averageConcurrentRequests float64, requestCount float64) autoscaler.StatMessage {
+	return autoscaler.StatMessage{
 		Key: revKey,
 		Stat: autoscaler.Stat{
 			PodName:                   podName,
@@ -177,7 +177,7 @@ func newStatMessage(revKey types.NamespacedName, podName string, averageConcurre
 	}
 }
 
-func assertReceivedOk(sm *autoscaler.StatMessage, statSink *websocket.Conn, statsCh <-chan *autoscaler.StatMessage, t *testing.T) bool {
+func assertReceivedOk(sm autoscaler.StatMessage, statSink *websocket.Conn, statsCh <-chan autoscaler.StatMessage, t *testing.T) bool {
 	send(statSink, sm, t)
 	recv, ok := <-statsCh
 	if !ok {
@@ -215,7 +215,7 @@ func dial(serverURL string, t *testing.T) (*websocket.Conn, error) {
 	return statSink, err
 }
 
-func send(statSink *websocket.Conn, sm *autoscaler.StatMessage, t *testing.T) {
+func send(statSink *websocket.Conn, sm autoscaler.StatMessage, t *testing.T) {
 	var b bytes.Buffer
 	enc := gob.NewEncoder(&b)
 
@@ -240,7 +240,7 @@ type testServer struct {
 	listenAddrCh chan string
 }
 
-func newTestServer(statsCh chan<- *autoscaler.StatMessage) *testServer {
+func newTestServer(statsCh chan<- autoscaler.StatMessage) *testServer {
 	return &testServer{
 		Server:       New(testAddress, statsCh, zap.NewNop().Sugar()),
 		listenAddrCh: make(chan string, 1),

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -116,7 +116,7 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 }
 
 // Report captures request metrics.
-func (r *PrometheusStatsReporter) Report(stat *autoscaler.Stat) {
+func (r *PrometheusStatsReporter) Report(stat autoscaler.Stat) {
 	// Requests per second is a rate over time while concurrency is not.
 	r.requestsPerSecond.Set(stat.RequestCount / r.reportingPeriod.Seconds())
 	r.proxiedRequestsPerSecond.Set(stat.ProxiedRequestCount / r.reportingPeriod.Seconds())

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -96,7 +96,7 @@ func TestReporterReport(t *testing.T) {
 	tests := []struct {
 		name                              string
 		reportingPeriod                   time.Duration
-		autoscalerStat                    *autoscaler.Stat
+		autoscalerStat                    autoscaler.Stat
 		expectedReqCount                  float64
 		expectedAverageConcurrentRequests float64
 		expectedProxiedRequestCount       float64
@@ -104,7 +104,7 @@ func TestReporterReport(t *testing.T) {
 	}{{
 		name:                              "no proxy requests",
 		reportingPeriod:                   1 * time.Second,
-		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3},
+		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3},
 		expectedReqCount:                  39,
 		expectedAverageConcurrentRequests: 3,
 		expectedProxiedRequestCount:       0,
@@ -112,7 +112,7 @@ func TestReporterReport(t *testing.T) {
 	}, {
 		name:                              "reportingPeriod=10s",
 		reportingPeriod:                   10 * time.Second,
-		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
+		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
 		expectedReqCount:                  3.9,
 		expectedAverageConcurrentRequests: 3,
 		expectedProxiedRequestCount:       1.5,
@@ -120,7 +120,7 @@ func TestReporterReport(t *testing.T) {
 	}, {
 		name:                              "reportingPeriod=2s",
 		reportingPeriod:                   2 * time.Second,
-		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
+		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
 		expectedReqCount:                  19.5,
 		expectedAverageConcurrentRequests: 3,
 		expectedProxiedRequestCount:       7.5,
@@ -128,7 +128,7 @@ func TestReporterReport(t *testing.T) {
 	}, {
 		name:                              "reportingPeriod=1s",
 		reportingPeriod:                   1 * time.Second,
-		autoscalerStat:                    &autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
+		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
 		expectedReqCount:                  39,
 		expectedAverageConcurrentRequests: 3,
 		expectedProxiedRequestCount:       15,

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -50,7 +50,7 @@ type Channels struct {
 	// Ticks with every stat report request
 	ReportChan <-chan time.Time
 	// Stat reporting channel
-	StatChan chan *autoscaler.Stat
+	StatChan chan autoscaler.Stat
 }
 
 // Stats is a structure for holding channels per pod.
@@ -114,7 +114,7 @@ func NewStats(podName string, channels Channels, startedAt time.Time) *Stats {
 			case now := <-s.ch.ReportChan:
 				updateState(now)
 
-				stat := &autoscaler.Stat{
+				stat := autoscaler.Stat{
 					Time:                             now,
 					PodName:                          s.podName,
 					AverageConcurrentRequests:        weightedAverage(timeOnConcurrency),

--- a/pkg/queue/stats_test.go
+++ b/pkg/queue/stats_test.go
@@ -33,7 +33,7 @@ func TestNoData(t *testing.T) {
 	s := newTestStats(now)
 
 	got := s.report(now)
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 0.0,
@@ -54,7 +54,7 @@ func TestSingleRequestWholeTime(t *testing.T) {
 
 	got := s.report(now)
 
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
@@ -75,7 +75,7 @@ func TestSingleRequestHalfTime(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	got := s.report(now)
 
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 0.5,
@@ -97,7 +97,7 @@ func TestVeryShortLivedRequest(t *testing.T) {
 	now = now.Add(990 * time.Millisecond) // make the second full
 	got := s.report(now)
 
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: float64(10) / float64(1000),
@@ -126,7 +126,7 @@ func TestMultipleRequestsWholeTime(t *testing.T) {
 
 	got := s.report(now)
 
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
@@ -151,7 +151,7 @@ func TestMultipleRequestsInterleaved(t *testing.T) {
 
 	got := s.report(now)
 
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.5,
@@ -169,7 +169,7 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	s.requestStart(now)
 	now = now.Add(1 * time.Second)
 	got1 := s.report(now)
-	want1 := &autoscaler.Stat{
+	want1 := autoscaler.Stat{
 		Time:                      got1.Time,
 		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
@@ -180,7 +180,7 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	s.requestEnd(now)
 	now = now.Add(500 * time.Millisecond)
 	got2 := s.report(now)
-	want2 := &autoscaler.Stat{
+	want2 := autoscaler.Stat{
 		Time:                      now,
 		PodName:                   podName,
 		AverageConcurrentRequests: 0.5,
@@ -201,7 +201,7 @@ func TestOneProxiedRequest(t *testing.T) {
 	s.proxiedStart(now)
 	now = now.Add(1 * time.Second)
 	got := s.report(now)
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                             now,
 		PodName:                          podName,
 		AverageConcurrentRequests:        1.0,
@@ -222,7 +222,7 @@ func TestOneEndedProxiedRequest(t *testing.T) {
 	s.proxiedEnd(now)
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                             now,
 		PodName:                          podName,
 		AverageConcurrentRequests:        0.5,
@@ -244,7 +244,7 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 	s.requestStart(now)
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
-	want := &autoscaler.Stat{
+	want := autoscaler.Stat{
 		Time:                             now,
 		PodName:                          podName,
 		AverageConcurrentRequests:        1.0,
@@ -268,7 +268,7 @@ func newTestStats(now time.Time) *testStats {
 	ch := Channels{
 		ReqChan:    make(chan ReqEvent),
 		ReportChan: (<-chan time.Time)(reportBiChan),
-		StatChan:   make(chan *autoscaler.Stat),
+		StatChan:   make(chan autoscaler.Stat),
 	}
 	s := NewStats(podName, ch, now)
 	t := &testStats{
@@ -294,7 +294,7 @@ func (s *testStats) proxiedEnd(now time.Time) {
 	s.ch.ReqChan <- ReqEvent{Time: now, EventType: ProxiedOut}
 }
 
-func (s *testStats) report(now time.Time) *autoscaler.Stat {
+func (s *testStats) report(now time.Time) autoscaler.Stat {
 	s.reportBiChan <- now
 	return <-s.ch.StatChan
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This should conclude my witch hunt of unneeded pointers in our stat system.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
