### PR TITLE
Consistently use Duration helpers to get correct units.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,7 +26,7 @@ Start by creating [a GitHub account](https://github.com/join), then setup
 You must install these tools:
 
 1. [`go`](https://golang.org/doc/install): The language `Knative Serving` is
-   built in (1.12rc1 or later)
+   built in (1.13 or later)
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
 1. [`dep`](https://github.com/golang/dep): For managing external Go
    dependencies.

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -168,8 +168,7 @@ func (r *Reporter) ReportResponseTime(ns, service, config, rev string, responseC
 		return err
 	}
 
-	// convert time.Duration in nanoseconds to milliseconds
-	pkgmetrics.Record(ctx, responseTimeInMsecM.M(float64(d/time.Millisecond)))
+	pkgmetrics.Record(ctx, responseTimeInMsecM.M(float64(d.Milliseconds())))
 	return nil
 }
 

--- a/pkg/queue/stats/stats_reporter.go
+++ b/pkg/queue/stats/stats_reporter.go
@@ -166,8 +166,7 @@ func (r *Reporter) ReportResponseTime(responseCode int, d time.Duration) error {
 		return err
 	}
 
-	// convert time.Duration in nanoseconds to milliseconds
-	pkgmetrics.Record(ctx, r.latencyMetric.M(float64(d/time.Millisecond)))
+	pkgmetrics.Record(ctx, r.latencyMetric.M(float64(d.Milliseconds())))
 	return nil
 }
 

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -118,7 +118,6 @@ func NewStatsReporter(reconciler string) (StatsReporter, error) {
 // ReportServiceReady reports the time it took a service to become Ready
 func (r *reporter) ReportServiceReady(namespace, service string, d time.Duration) error {
 	key := fmt.Sprintf("%s/%s", namespace, service)
-	v := int64(d / time.Millisecond)
 	ctx, err := tag.New(
 		r.ctx,
 		tag.Insert(keyTagKey, key))
@@ -127,6 +126,6 @@ func (r *reporter) ReportServiceReady(namespace, service string, d time.Duration
 	}
 
 	metrics.Record(ctx, serviceReadyCountStat.M(1))
-	metrics.Record(ctx, serviceReadyLatencyStat.M(v))
+	metrics.Record(ctx, serviceReadyLatencyStat.M(d.Milliseconds()))
 	return nil
 }

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -110,10 +110,9 @@ func TestDestroyPodInflight(t *testing.T) {
 	}
 
 	// The timeout app sleeps for the time passed via the timeout query parameter in milliseconds
-	timeoutRequestDurationInMillis := int64(timeoutRequestDuration / time.Millisecond)
 	u, _ := url.Parse(routeURL.String())
 	q := u.Query()
-	q.Set("timeout", fmt.Sprintf("%d", timeoutRequestDurationInMillis))
+	q.Set("timeout", fmt.Sprintf("%d", timeoutRequestDuration.Milliseconds()))
 	u.RawQuery = q.Encode()
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -132,7 +131,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		if res.StatusCode != http.StatusOK {
 			return fmt.Errorf("Expected response to have status 200, had %d", res.StatusCode)
 		}
-		expectedBody := fmt.Sprintf("Slept for %d milliseconds", timeoutRequestDurationInMillis)
+		expectedBody := fmt.Sprintf("Slept for %d milliseconds", timeoutRequestDuration.Milliseconds())
 		gotBody := string(res.Body)
 		if gotBody != expectedBody {
 			return fmt.Errorf("Unexpected body, expected: %q got: %q", expectedBody, gotBody)

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -121,6 +121,6 @@ func TestTimeToServeLatency(t *testing.T) {
 // Performs perf testing on a long running app.
 // It uses the timeout app that sleeps for the specified amount of time.
 func TestTimeToServeLatencyLongRunning(t *testing.T) {
-	q := fmt.Sprintf("timeout=%d", sleepTime/time.Millisecond)
+	q := fmt.Sprintf("timeout=%d", sleepTime.Milliseconds())
 	timeToServe(t, "timeout", q, sleepReqTimeout)
 }

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -217,7 +217,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 			t.Logf("Never scaled to %d", i)
 		} else {
 			t.Logf("Took %v to scale to %d", toConcurrency, i)
-			tc = append(tc, perf.CreatePerfTestCase(float32(toConcurrency/time.Millisecond), fmt.Sprintf("to%d(ms)", i), t.Name()))
+			tc = append(tc, perf.CreatePerfTestCase(float32(toConcurrency.Milliseconds()), fmt.Sprintf("to%d(ms)", i), t.Name()))
 		}
 	}
 	tc = append(tc, perf.CreatePerfTestCase(float32(failedRequests), "failed requests", t.Name()))

--- a/test/performance/scale_revision_by_load_test.go
+++ b/test/performance/scale_revision_by_load_test.go
@@ -194,7 +194,7 @@ func scaleRevisionByLoad(t *testing.T, numClients int) []junit.TestCase {
 	// Add scale metrics.
 	for _, ev := range scaleEvents {
 		t.Logf("Scaled: %d -> %d in %v", ev.oldScale, ev.newScale, ev.timestamp.Sub(attackStartTime))
-		tc = append(tc, perf.CreatePerfTestCase(float32(ev.timestamp.Sub(attackStartTime)/time.Second), fmt.Sprintf("scale-from-%02d-to-%02d(seconds)", ev.oldScale, ev.newScale), t.Name()))
+		tc = append(tc, perf.CreatePerfTestCase(float32(ev.timestamp.Sub(attackStartTime).Seconds()), fmt.Sprintf("scale-from-%02d-to-%02d(seconds)", ev.oldScale, ev.newScale), t.Name()))
 	}
 
 	// Add latency metrics.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Consistently use Duration helpers to get correct units.
* This also bumps the documented minimum go version to 1.13 as the `Milliseconds` helper was introduced there.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
