### PR TITLE
Report activator stats in a batched way.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -224,9 +224,8 @@ func TestStats(t *testing.T) {
 
 			// Gather reported stats
 			stats := make([]autoscaler.StatMessage, 0, len(tc.expectedStats))
-			for i := 0; i < len(tc.expectedStats); i++ {
-				sm := <-s.statChan
-				stats = append(stats, sm)
+			for len(stats) < len(tc.expectedStats) {
+				stats = append(stats, <-s.statChan...)
 			}
 
 			// Check the stats we got match what we wanted
@@ -244,7 +243,7 @@ func TestStats(t *testing.T) {
 type testStats struct {
 	reqChan      chan ReqEvent
 	reportChan   <-chan time.Time
-	statChan     chan autoscaler.StatMessage
+	statChan     chan []autoscaler.StatMessage
 	reportBiChan chan time.Time
 }
 
@@ -253,7 +252,7 @@ func newTestStats(t *testing.T, clock system.Clock) (*testStats, *ConcurrencyRep
 	ts := &testStats{
 		reqChan:      make(chan ReqEvent),
 		reportChan:   (<-chan time.Time)(reportBiChan),
-		statChan:     make(chan autoscaler.StatMessage, 20),
+		statChan:     make(chan []autoscaler.StatMessage, 20),
 		reportBiChan: reportBiChan,
 	}
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We now spawn a goroutine for every message we receive via the statchannel in the activator. That currently scales with the number of revisions active and proxying via the activator so in really bad cases, we could be spawning hundreds of goroutines per second.

This change simply sends the stats of all revisions in a batch. They are collected at the same time anyway, so we don't loose anything by doing it but we keep the amount of goroutines spawned to 1 per second (excluding scale-from-zero operations which still cause one goroutine per message).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
