### PR TITLE
Hot fix for performance testing

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -146,16 +146,17 @@ data:
   environment: prod
   repository: serving
   additionalTags: "istio=$istio_version_escaped"
-  benchmarkChannels:
-    Serving dataplane probe:
-    - name: networking
-      identity: CA9RHBGJX
-    Serving deployment probe:
-    - name: serving-api
-      identity: CA4DNJ9A4
-    Serving load testing:
-    - name: autoscaling
-      identity: C94SPR60H
+  slackConfig: |
+    benchmarkChannels:
+      "Serving dataplane probe":
+      - name: networking
+        identity: CA9RHBGJX
+      "Serving deployment probe":
+      - name: serving-api
+        identity: CA4DNJ9A4
+      "Serving load testing":
+      - name: autoscaling
+        identity: C94SPR60H
 EOF
 
   echo ">> Applying all the yamls"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
I accidentally lost the `slackConfig` key when I made the last PR, this PR fixes it. I have verified on my local benchmark that it's working correctly now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @adrcunha 
