### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_accessors_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_accessors_test.go
@@ -58,7 +58,7 @@ func TestIngressAccessorMethods(t *testing.T) {
 	}
 
 	ia := ci
-	for i, _ := range ci.Spec.Rules {
+	for i := range ci.Spec.Rules {
 		ci.Spec.Rules[i].Hosts = append(ci.Spec.Rules[i].Hosts, "exampletest.com")
 	}
 	ia.SetSpec(ci.Spec)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -242,4 +242,3 @@ func getContext() context.Context {
 	cfg := ReconcilerTestConfig(false)
 	return config.ToContext(context.Background(), cfg)
 }
-


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign mattmoor
