### PR TITLE
Allow the route controller to track unknown targets

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -393,7 +393,14 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, cl
 	}
 
 	// Tell our trackers to reconcile Route whenever the things referred to by our
-	// Traffic stanza change.
+	// traffic stanza change. We also track missing targets since there may be
+	// race conditions were routes are reconciled before their targets appear
+	// in the informer cache
+	for _, obj := range t.MissingTargets {
+		if err := c.tracker.Track(obj, r); err != nil {
+			return nil, err
+		}
+	}
 	for _, configuration := range t.Configurations {
 		if err := c.tracker.Track(objectRef(configuration), r); err != nil {
 			return nil, err

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -781,7 +781,14 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 			goodOldRev.Name: goodOldRev,
 			goodNewRev.Name: goodNewRev,
 		},
+		MissingTargets: []corev1.ObjectReference{{
+			APIVersion: "serving.knative.dev/v1alpha1",
+			Kind:       "Configuration",
+			Name:       missingConfig.Name,
+			Namespace:  missingConfig.Namespace,
+		}},
 	}
+
 	expectedErr := errMissingConfiguration(missingConfig.Name)
 	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
 		TrafficTarget: v1.TrafficTarget{
@@ -925,6 +932,12 @@ func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
+		MissingTargets: []corev1.ObjectReference{{
+			APIVersion: "serving.knative.dev/v1alpha1",
+			Kind:       "Revision",
+			Name:       missingRev.Name,
+			Namespace:  missingRev.Namespace,
+		}},
 	}
 	expectedErr := errMissingRevision(missingRev.Name)
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{


### PR DESCRIPTION
This prevents race conditions where if the route is reconciled
before a target is created and appearing in the controller's
informer cache the route would remain in a 'Failed' ready state
until resync - which would be 10 hours

With this change the tracker is aware of _intended_ targets and
will reconcile the route when these targets appear in the
informer cache