### PR TITLE
Update zipkin-go to v0.2.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -649,7 +649,7 @@
   revision = "2ae31c8b6b30d2f4c8100c20d527b571e9c433bb"
 
 [[projects]]
-  digest = "1:5ff10da739fc2c719e3a11454e5794aa226c918cb0286cd3842aa6ae077a82a1"
+  digest = "1:ba4312bc8a900105f0c5b85d23b289d594dc88af6608ce971c8696435f43ae85"
   name = "github.com/openzipkin/zipkin-go"
   packages = [
     ".",
@@ -661,8 +661,8 @@
     "reporter/recorder",
   ]
   pruneopts = "NUT"
-  revision = "bf896b1c622eed731380e8291d9b6c02043de5e8"
-  version = "v0.1.5"
+  revision = "c29478e51bfb2e9c93e0e9f5e015e5993a490399"
+  version = "v0.2.2"
 
 [[projects]]
   digest = "1:93b1d84c5fa6d1ea52f4114c37714cddd84d5b78f151b62bb101128dd51399bf"

--- a/vendor/github.com/openzipkin/zipkin-go/context.go
+++ b/vendor/github.com/openzipkin/zipkin-go/context.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/doc.go
+++ b/vendor/github.com/openzipkin/zipkin-go/doc.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Package zipkin implements a native Zipkin instrumentation library for Go.
 

--- a/vendor/github.com/openzipkin/zipkin-go/endpoint.go
+++ b/vendor/github.com/openzipkin/zipkin-go/endpoint.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/idgenerator/idgenerator.go
+++ b/vendor/github.com/openzipkin/zipkin-go/idgenerator/idgenerator.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Package idgenerator contains several Span and Trace ID generators which can be
 used by the Zipkin tracer. Additional third party generators can be plugged in

--- a/vendor/github.com/openzipkin/zipkin-go/model/annotation.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/annotation.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/model/doc.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/doc.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Package model contains the Zipkin V2 model which is used by the Zipkin Go
 tracer implementation.

--- a/vendor/github.com/openzipkin/zipkin-go/model/endpoint.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/endpoint.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import "net"

--- a/vendor/github.com/openzipkin/zipkin-go/model/kind.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/kind.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 // Kind clarifies context of timestamp, duration and remoteEndpoint in a span.

--- a/vendor/github.com/openzipkin/zipkin-go/model/span.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/span.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/model/span_id.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/span_id.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/model/traceid.go
+++ b/vendor/github.com/openzipkin/zipkin-go/model/traceid.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/noop.go
+++ b/vendor/github.com/openzipkin/zipkin-go/noop.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (
@@ -21,5 +35,7 @@ func (*noopSpan) Annotate(time.Time, string) {}
 func (*noopSpan) Tag(string, string) {}
 
 func (*noopSpan) Finish() {}
+
+func (*noopSpan) FinishedWithDuration(duration time.Duration) {}
 
 func (*noopSpan) Flush() {}

--- a/vendor/github.com/openzipkin/zipkin-go/propagation/propagation.go
+++ b/vendor/github.com/openzipkin/zipkin-go/propagation/propagation.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Package propagation holds the required function signatures for Injection and
 Extraction as used by the Zipkin Tracer.

--- a/vendor/github.com/openzipkin/zipkin-go/reporter/recorder/recorder.go
+++ b/vendor/github.com/openzipkin/zipkin-go/reporter/recorder/recorder.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Package recorder implements a reporter to record spans in v2 format.
 */

--- a/vendor/github.com/openzipkin/zipkin-go/reporter/reporter.go
+++ b/vendor/github.com/openzipkin/zipkin-go/reporter/reporter.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Package reporter holds the Reporter interface which is used by the Zipkin
 Tracer to send finished spans.

--- a/vendor/github.com/openzipkin/zipkin-go/reporter/serializer.go
+++ b/vendor/github.com/openzipkin/zipkin-go/reporter/serializer.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"encoding/json"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+// SpanSerializer describes the methods needed for allowing to set Span encoding
+// type for the various Zipkin transports.
+type SpanSerializer interface {
+	Serialize([]*model.SpanModel) ([]byte, error)
+	ContentType() string
+}
+
+// JSONSerializer implements the default JSON encoding SpanSerializer.
+type JSONSerializer struct{}
+
+// Serialize takes an array of Zipkin SpanModel objects and returns a JSON
+// encoding of it.
+func (JSONSerializer) Serialize(spans []*model.SpanModel) ([]byte, error) {
+	return json.Marshal(spans)
+}
+
+// ContentType returns the ContentType needed for this encoding.
+func (JSONSerializer) ContentType() string {
+	return "application/json"
+}

--- a/vendor/github.com/openzipkin/zipkin-go/sample.go
+++ b/vendor/github.com/openzipkin/zipkin-go/sample.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (
@@ -13,12 +27,12 @@ import (
 type Sampler func(id uint64) bool
 
 // NeverSample will always return false. If used by a service it will not allow
-// the service to start traces but will still allow the service to participate 
+// the service to start traces but will still allow the service to participate
 // in traces started upstream.
 func NeverSample(_ uint64) bool { return false }
 
 // AlwaysSample will always return true. If used by a service it will always start
-// traces if no upstream trace has been propagated. If an incoming upstream trace 
+// traces if no upstream trace has been propagated. If an incoming upstream trace
 // is not sampled the service will adhere to this and only propagate the context.
 func AlwaysSample(_ uint64) bool { return true }
 

--- a/vendor/github.com/openzipkin/zipkin-go/span.go
+++ b/vendor/github.com/openzipkin/zipkin-go/span.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (
@@ -30,6 +44,12 @@ type Span interface {
 	// becomes the user's responsibility to get the Span reported (by using
 	// span.Flush).
 	Finish()
+
+	// Finish the Span with duration and send to Reporter. If DelaySend option was used at
+	// Span creation time, FinishedWithDuration will not send the Span to the Reporter. It then
+	// becomes the user's responsibility to get the Span reported (by using
+	// span.Flush).
+	FinishedWithDuration(duration time.Duration)
 
 	// Flush the Span to the Reporter (regardless of being finished or not).
 	// This can be used if the DelaySend SpanOption was set or when dealing with

--- a/vendor/github.com/openzipkin/zipkin-go/span_implementation.go
+++ b/vendor/github.com/openzipkin/zipkin-go/span_implementation.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (
@@ -65,6 +79,15 @@ func (s *spanImpl) Tag(key, value string) {
 func (s *spanImpl) Finish() {
 	if atomic.CompareAndSwapInt32(&s.mustCollect, 1, 0) {
 		s.Duration = time.Since(s.Timestamp)
+		if s.flushOnFinish {
+			s.tracer.reporter.Send(s.SpanModel)
+		}
+	}
+}
+
+func (s *spanImpl) FinishedWithDuration(d time.Duration) {
+	if atomic.CompareAndSwapInt32(&s.mustCollect, 1, 0) {
+		s.Duration = d
 		if s.flushOnFinish {
 			s.tracer.reporter.Send(s.SpanModel)
 		}

--- a/vendor/github.com/openzipkin/zipkin-go/span_options.go
+++ b/vendor/github.com/openzipkin/zipkin-go/span_options.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/tags.go
+++ b/vendor/github.com/openzipkin/zipkin-go/tags.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 // Tag holds available types

--- a/vendor/github.com/openzipkin/zipkin-go/tracer.go
+++ b/vendor/github.com/openzipkin/zipkin-go/tracer.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (

--- a/vendor/github.com/openzipkin/zipkin-go/tracer_options.go
+++ b/vendor/github.com/openzipkin/zipkin-go/tracer_options.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenZipkin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package zipkin
 
 import (


### PR DESCRIPTION
## Proposed Changes

Update zipkin-go to v0.2.2 to pickup recent fix of unbounded goroutine
creation when the zipkin backend is down.

Follow up on knative/pkg#715

/lint

**Release Note**

NONE
