### PR TITLE
Use the correct zap sugared logger syntax

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -143,7 +143,7 @@ func main() {
 
 	// Start all of the informers and wait for them to sync.
 	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
-		logger.Fatalw("Failed to start informers", err)
+		logger.Fatalw("Failed to start informers", zap.Error(err))
 	}
 
 	go controller.StartAll(ctx.Done(), controllers...)

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -106,7 +106,7 @@ func main() {
 	logger = logger.With(zap.String(logkey.ControllerType, component))
 
 	if err := version.CheckMinimumVersion(kubeClient.Discovery()); err != nil {
-		logger.Fatalw("Version check failed", err)
+		logger.Fatalw("Version check failed", zap.Error(err))
 	}
 
 	profilingHandler := profiling.NewHandler(logger, false)


### PR DESCRIPTION
Fatalw needs either a zap.Field or `key, value` pairs in the variadic args.

Fixes #5746  

/lint

## Proposed Changes

* Update Fatalw to correct syntax in webhook and autoscaler