### PR TITLE
Check secrets before creating pods

### DIFF
--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -24,6 +24,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	painformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
@@ -60,6 +61,7 @@ func NewController(
 
 	deploymentInformer := deploymentinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
+	secretInformer := secretinformer.Get(ctx)
 	configMapInformer := configmapinformer.Get(ctx)
 	imageInformer := imageinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
@@ -72,6 +74,7 @@ func NewController(
 		imageLister:         imageInformer.Lister(),
 		deploymentLister:    deploymentInformer.Lister(),
 		serviceLister:       serviceInformer.Lister(),
+		secretLister:        secretInformer.Lister(),
 		configMapLister:     configMapInformer.Lister(),
 		resolver: &digestResolver{
 			client:    kubeclient.Get(ctx),

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -129,10 +129,10 @@ func (c *Reconciler) createPA(ctx context.Context, rev *v1alpha1.Revision) (*av1
 func tryFetchSecret(name, ns string, optional *bool, secretLister v1.SecretLister) *apis.FieldError {
 	if optional == nil || *optional == false {
 		if _, err := secretLister.Secrets(ns).Get(name); err != nil {
-			return (&apis.FieldError{
+			return &apis.FieldError{
 				Message: err.Error(),
 				Paths:   []string{apis.CurrentField},
-			})
+			}
 		}
 	}
 	return nil

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -164,14 +164,12 @@ func verifySecrets(rev *v1alpha1.Revision, secretLister v1.SecretLister) *apis.F
 
 	// Check secrets in container envfrom
 	for i, container := range rev.Spec.Containers {
-		if len(container.EnvFrom) != 0 {
-			for j, env := range container.EnvFrom {
-				if secret := env.SecretRef; secret != nil {
-					if err := tryFetchSecret(secret.Name, rev.Namespace, secret.Optional, secretLister); err != nil {
-						apiErrs = apiErrs.Also(err.
-							ViaField("secretRef").ViaFieldIndex("envFrom", j).
-							ViaFieldIndex("containers", i).ViaField("spec"))
-					}
+		for j, env := range container.EnvFrom {
+			if secret := env.SecretRef; secret != nil {
+				if err := tryFetchSecret(secret.Name, rev.Namespace, secret.Optional, secretLister); err != nil {
+					apiErrs = apiErrs.Also(err.
+						ViaField("secretRef").ViaFieldIndex("envFrom", j).
+						ViaFieldIndex("containers", i).ViaField("spec"))
 				}
 			}
 		}

--- a/pkg/reconciler/revision/cruds_test.go
+++ b/pkg/reconciler/revision/cruds_test.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	corev1informer "k8s.io/client-go/informers/core/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	_ "knative.dev/pkg/metrics/testing"
+	"knative.dev/pkg/ptr"
+	_ "knative.dev/pkg/system/testing"
+	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+var (
+	containerName        = "my-container-name"
+
+	defaultRevision = &v1alpha1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+			UID:       "1234",
+			Labels: map[string]string{
+				serving.ConfigurationLabelKey: "cfg",
+				serving.ServiceLabelKey:       "svc",
+				serving.RouteLabelKey:         "im-a-route",
+			},
+		},
+		Spec: v1alpha1.RevisionSpec{
+			DeprecatedContainer: &corev1.Container{
+				Name:  containerName,
+				Image: "busybox",
+			},
+			RevisionSpec: v1.RevisionSpec{
+				TimeoutSeconds: ptr.Int64(45),
+			},
+		},
+	}
+)
+
+func refInt64(num int64) *int64 {
+	return &num
+}
+
+type containerOption func(*corev1.Container)
+type revisionOption func(*v1alpha1.Revision)
+
+func container(container *corev1.Container, opts ...containerOption) corev1.Container {
+	for _, option := range opts {
+		option(container)
+	}
+	return *container
+}
+
+func withReadinessProbe(handler corev1.Handler) containerOption {
+	return func(container *corev1.Container) {
+		container.ReadinessProbe = &corev1.Probe{Handler: handler}
+	}
+}
+
+func withTCPReadinessProbe() containerOption {
+	return withReadinessProbe(corev1.Handler{
+		TCPSocket: &corev1.TCPSocketAction{
+			Host: "127.0.0.1",
+			Port: intstr.FromInt(v1alpha1.DefaultUserPort),
+		},
+	})
+}
+
+func revision(opts ...revisionOption) *v1alpha1.Revision {
+	revision := defaultRevision.DeepCopy()
+	for _, option := range opts {
+		option(revision)
+	}
+	return revision
+}
+
+func TestVerifySecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *v1alpha1.Revision
+		si   corev1informer.SecretInformer
+		expectedErr string
+	}{{
+		name: "secrets (from volume source) found",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+					Name:      "asdf1",
+					MountPath: "/asdf1",
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.Spec.Volumes = []corev1.Volume{{
+					Name: "asdf1",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "asdf1",
+						},
+					},
+				}}
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
+	}, {
+		name: "secrets (from volume source) not found",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.GetContainer().Ports = []corev1.ContainerPort{{
+					ContainerPort: 8888,
+				}}
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+					Name:      "asdf1",
+					MountPath: "/asdf1",
+				}, {
+					Name:      "asdf2",
+					MountPath: "/asdf2",
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				// Adding two secrets that do not exist. We should see both of them in the error
+				revision.Spec.Volumes = []corev1.Volume{{
+					Name: "asdf1",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "asdf1",
+						},
+					},
+				}, {
+					Name: "asdf2",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "asdf2",
+						},
+					},
+				}}
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: getSecretInformer(),
+		expectedErr: `secret "asdf1" not found: spec.volumes[0].volumeSource.secretName
+secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
+	}, {
+		name: "secrets (from volume source) not found but optional is true",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+					Name:      "asdf",
+					MountPath: "/asdf",
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				// Adding two secrets that do not exist. We should see both of them in the error
+				revision.Spec.Volumes = []corev1.Volume{{
+					Name: "asdf",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "asdf",
+							Optional:   ptr.Bool(true),
+						},
+					},
+				}}
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: getSecretInformer(),
+	}, {
+		name: "secrets (from volume source projected) found",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+					Name:      "asdf1",
+					MountPath: "/asdf1",
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.Spec.Volumes = []corev1.Volume{{
+					Name: "asdf1",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf1",
+									},
+								},
+							}},
+						},
+					},
+				}}
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
+	}, {
+		name: "secrets (from volume source projected) not found",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+					Name:      "asdf1",
+					MountPath: "/asdf1",
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.Spec.Volumes = []corev1.Volume{{
+					Name: "asdf1",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf1",
+									},
+								},
+							}, {
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf2",
+									},
+								},
+							}},
+						},
+					},
+				}}
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: getSecretInformer(),
+		expectedErr: `secret "asdf1" not found: spec.volumes[0].volumeSource.projected.sources[0].secret
+secret "asdf2" not found: spec.volumes[0].volumeSource.projected.sources[1].secret`,
+	}, {
+		name: "secrets (from volume source projected) not found but optional is true",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
+					Name:      "asdf1",
+					MountPath: "/asdf1",
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.Spec.Volumes = []corev1.Volume{{
+					Name: "asdf1",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf1",
+									},
+									Optional: ptr.Bool(true),
+								},
+							}},
+						},
+					},
+				}}
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: getSecretInformer(),
+	}, {
+		name: "secrets (from EnvFrom) found",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.Containers = []corev1.Container{{
+					EnvFrom: []corev1.EnvFromSource{{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "asdf1",
+							},
+						},
+					}},
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
+	}, {
+		name: "secrets (from EnvFrom) not found",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.Containers = []corev1.Container{{
+					EnvFrom: []corev1.EnvFromSource{{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "asdf1",
+							},
+						},
+					}, {
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "asdf2",
+							},
+						},
+					}},
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: getSecretInformer(),
+		expectedErr: `secret "asdf1" not found: spec.containers[0].envFrom[0].secretRef
+secret "asdf2" not found: spec.containers[0].envFrom[1].secretRef`,
+	}, {
+		name: "secrets (from EnvFrom) not found but optional is true",
+		rev: revision(
+			func(revision *v1alpha1.Revision) {
+				revision.Spec.Containers = []corev1.Container{{
+					EnvFrom: []corev1.EnvFromSource{{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "asdf1",
+							},
+							Optional: ptr.Bool(true),
+						},
+					}},
+				}}
+				container(revision.Spec.GetContainer(),
+					withTCPReadinessProbe(),
+				)
+				revision.ObjectMeta.Labels = map[string]string{}
+			},
+		),
+		si: getSecretInformer(),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := verifySecrets(test.rev, test.si.Lister())
+			if diff := cmp.Diff(test.expectedErr, err.Error()); diff != "" {
+				t.Fatalf("verifySecrets (-wantErr, +gotErr) = %v", diff)
+			}
+		})
+	}
+}
+
+func addSecretToInformer(fake *kubefake.Clientset, secretName string, namespace string) func(si corev1informer.SecretInformer) corev1informer.SecretInformer {
+	return func(si corev1informer.SecretInformer) corev1informer.SecretInformer {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secretName,
+				Namespace:       namespace,
+			},
+			Data: map[string][]byte{
+				"test-secret": []byte("origin"),
+			},
+		}
+		fake.CoreV1().Secrets(secret.Namespace).Create(secret)
+		si.Informer().GetIndexer().Add(secret)
+		return si
+	}
+}

--- a/pkg/reconciler/revision/cruds_test.go
+++ b/pkg/reconciler/revision/cruds_test.go
@@ -25,16 +25,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	corev1informer "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/pkg/ptr"
-	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 var (
-	containerName        = "my-container-name"
+	containerName = "my-container-name"
 
 	defaultRevision = &v1alpha1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
@@ -98,9 +96,9 @@ func revision(opts ...revisionOption) *v1alpha1.Revision {
 
 func TestVerifySecrets(t *testing.T) {
 	tests := []struct {
-		name string
-		rev  *v1alpha1.Revision
-		si   corev1informer.SecretInformer
+		name        string
+		rev         *v1alpha1.Revision
+		si          corev1informer.SecretInformer
 		expectedErr string
 	}{{
 		name: "secrets (from volume source) found",
@@ -175,7 +173,6 @@ secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
 				container(revision.Spec.GetContainer(),
 					withTCPReadinessProbe(),
 				)
-				// Adding two secrets that do not exist. We should see both of them in the error
 				revision.Spec.Volumes = []corev1.Volume{{
 					Name: "asdf",
 					VolumeSource: corev1.VolumeSource{
@@ -370,8 +367,8 @@ func addSecretToInformer(fake *kubefake.Clientset, secretName string, namespace 
 	return func(si corev1informer.SecretInformer) corev1informer.SecretInformer {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            secretName,
-				Namespace:       namespace,
+				Name:      secretName,
+				Namespace: namespace,
 			},
 			Data: map[string][]byte{
 				"test-secret": []byte("origin"),

--- a/pkg/reconciler/revision/cruds_test.go
+++ b/pkg/reconciler/revision/cruds_test.go
@@ -65,7 +65,7 @@ func TestVerifySecrets(t *testing.T) {
 				},
 			},
 		},
-		si: getSecretInformer(secret("foo", "asdf1")),
+		si: secretInformer(secret("foo", "asdf1")),
 	}, {
 		name: "secrets (from volume source) not found",
 		rev: &v1alpha1.Revision{
@@ -101,7 +101,7 @@ func TestVerifySecrets(t *testing.T) {
 				},
 			},
 		},
-		si: getSecretInformer(),
+		si: secretInformer(),
 		expectedErr: `secret "asdf1" not found: spec.volumes[0].volumeSource.secretName
 secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
 	}, {
@@ -133,7 +133,7 @@ secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
 				},
 			},
 		},
-		si: getSecretInformer(),
+		si: secretInformer(),
 	}, {
 		name: "secrets (from volume source projected) found",
 		rev: &v1alpha1.Revision{
@@ -168,7 +168,7 @@ secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
 				},
 			},
 		},
-		si: getSecretInformer(secret("foo", "asdf1")),
+		si: secretInformer(secret("foo", "asdf1")),
 	}, {
 		name: "secrets (from volume source projected) not found",
 		rev: &v1alpha1.Revision{
@@ -209,7 +209,7 @@ secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
 				},
 			},
 		},
-		si: getSecretInformer(),
+		si: secretInformer(),
 		expectedErr: `secret "asdf1" not found: spec.volumes[0].volumeSource.projected.sources[0].secret
 secret "asdf2" not found: spec.volumes[0].volumeSource.projected.sources[1].secret`,
 	}, {
@@ -247,7 +247,7 @@ secret "asdf2" not found: spec.volumes[0].volumeSource.projected.sources[1].secr
 				},
 			},
 		},
-		si: getSecretInformer(),
+		si: secretInformer(),
 	}, {
 		name: "secrets (from EnvFrom) found",
 		rev: &v1alpha1.Revision{
@@ -271,7 +271,7 @@ secret "asdf2" not found: spec.volumes[0].volumeSource.projected.sources[1].secr
 				},
 			},
 		},
-		si: getSecretInformer(secret("foo", "asdf1")),
+		si: secretInformer(secret("foo", "asdf1")),
 	}, {
 		name: "secrets (from EnvFrom) not found",
 		rev: &v1alpha1.Revision{
@@ -301,7 +301,7 @@ secret "asdf2" not found: spec.volumes[0].volumeSource.projected.sources[1].secr
 				},
 			},
 		},
-		si: getSecretInformer(),
+		si: secretInformer(),
 		expectedErr: `secret "asdf1" not found: spec.containers[0].envFrom[0].secretRef
 secret "asdf2" not found: spec.containers[0].envFrom[1].secretRef`,
 	}, {
@@ -328,7 +328,7 @@ secret "asdf2" not found: spec.containers[0].envFrom[1].secretRef`,
 				},
 			},
 		},
-		si: getSecretInformer(),
+		si: secretInformer(),
 	}}
 
 	for _, test := range tests {
@@ -353,7 +353,7 @@ func secret(namespace, name string) *corev1.Secret {
 	}
 }
 
-func getSecretInformer(objs ...runtime.Object) corev1informer.SecretInformer {
+func secretInformer(objs ...runtime.Object) corev1informer.SecretInformer {
 	fake := kubefake.NewSimpleClientset(objs...)
 	informer := k8sinformers.NewSharedInformerFactory(fake, 0)
 	si := informer.Core().V1().Secrets()

--- a/pkg/reconciler/revision/cruds_test.go
+++ b/pkg/reconciler/revision/cruds_test.go
@@ -26,55 +26,9 @@ import (
 	corev1informer "k8s.io/client-go/informers/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/ptr"
-	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
-
-var (
-	containerName = "my-container-name"
-)
-
-type containerOption func(*corev1.Container)
-type revisionOption func(*v1alpha1.Revision)
-
-func container(container *corev1.Container, opts ...containerOption) corev1.Container {
-	for _, option := range opts {
-		option(container)
-	}
-	return *container
-}
-
-func revision(opts ...revisionOption) *v1alpha1.Revision {
-	defaultRevision := &v1alpha1.Revision{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-			Name:      "bar",
-			UID:       "1234",
-			Labels: map[string]string{
-				serving.ConfigurationLabelKey: "cfg",
-				serving.ServiceLabelKey:       "svc",
-				serving.RouteLabelKey:         "im-a-route",
-			},
-		},
-		Spec: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				TimeoutSeconds: ptr.Int64(45),
-				PodSpec: corev1.PodSpec{
-					InitContainers: nil,
-					Containers: []corev1.Container{{
-						Name:  "containerName",
-						Image: "busybox",
-					}},
-				},
-			},
-		},
-	}
-	for _, option := range opts {
-		option(defaultRevision)
-	}
-	return defaultRevision
-}
 
 func TestVerifySecrets(t *testing.T) {
 	tests := []struct {
@@ -84,254 +38,295 @@ func TestVerifySecrets(t *testing.T) {
 		expectedErr string
 	}{{
 		name: "secrets (from volume source) found",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
-					Name:      "asdf1",
-					MountPath: "/asdf1",
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.Spec.Volumes = []corev1.Volume{{
-					Name: "asdf1",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "asdf1",
-						},
-					},
-				}}
-				revision.ObjectMeta.Labels = map[string]string{}
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
 			},
-		),
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "asdf1",
+								MountPath: "/asdf1",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: "asdf1",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "asdf1",
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
 	}, {
 		name: "secrets (from volume source) not found",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.GetContainer().Ports = []corev1.ContainerPort{{
-					ContainerPort: 8888,
-				}}
-				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
-					Name:      "asdf1",
-					MountPath: "/asdf1",
-				}, {
-					Name:      "asdf2",
-					MountPath: "/asdf2",
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				// Adding two secrets that do not exist. We should see both of them in the error
-				revision.Spec.Volumes = []corev1.Volume{{
-					Name: "asdf1",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "asdf1",
-						},
-					},
-				}, {
-					Name: "asdf2",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "asdf2",
-						},
-					},
-				}}
-				revision.ObjectMeta.Labels = map[string]string{}
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
 			},
-		),
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "asdf1",
+								MountPath: "/asdf1",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: "asdf1",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "asdf1",
+								},
+							},
+						}, {
+							Name: "asdf2",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "asdf2",
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 		si: getSecretInformer(),
 		expectedErr: `secret "asdf1" not found: spec.volumes[0].volumeSource.secretName
 secret "asdf2" not found: spec.volumes[1].volumeSource.secretName`,
 	}, {
 		name: "secrets (from volume source) not found but optional is true",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
-					Name:      "asdf",
-					MountPath: "/asdf",
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.Spec.Volumes = []corev1.Volume{{
-					Name: "asdf",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "asdf",
-							Optional:   ptr.Bool(true),
-						},
-					},
-				}}
-				revision.ObjectMeta.Labels = map[string]string{}
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
 			},
-		),
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "asdf",
+								MountPath: "/asdf",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: "asdf",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "asdf",
+									Optional:   ptr.Bool(true),
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 		si: getSecretInformer(),
 	}, {
 		name: "secrets (from volume source projected) found",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
-					Name:      "asdf1",
-					MountPath: "/asdf1",
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.Spec.Volumes = []corev1.Volume{{
-					Name: "asdf1",
-					VolumeSource: corev1.VolumeSource{
-						Projected: &corev1.ProjectedVolumeSource{
-							Sources: []corev1.VolumeProjection{{
-								Secret: &corev1.SecretProjection{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "asdf1",
-									},
-								},
-							}},
-						},
-					},
-				}}
-				revision.ObjectMeta.Labels = map[string]string{}
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
 			},
-		),
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "asdf1",
+								MountPath: "/asdf1",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: "asdf1",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "asdf1",
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
 	}, {
 		name: "secrets (from volume source projected) not found",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
-					Name:      "asdf1",
-					MountPath: "/asdf1",
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.Spec.Volumes = []corev1.Volume{{
-					Name: "asdf1",
-					VolumeSource: corev1.VolumeSource{
-						Projected: &corev1.ProjectedVolumeSource{
-							Sources: []corev1.VolumeProjection{{
-								Secret: &corev1.SecretProjection{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "asdf1",
-									},
-								},
-							}, {
-								Secret: &corev1.SecretProjection{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "asdf2",
-									},
-								},
-							}},
-						},
-					},
-				}}
-				revision.ObjectMeta.Labels = map[string]string{}
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
 			},
-		),
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "asdf1",
+								MountPath: "/asdf1",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: "asdf1",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "asdf1",
+											},
+										},
+									}, {
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "asdf2",
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 		si: getSecretInformer(),
 		expectedErr: `secret "asdf1" not found: spec.volumes[0].volumeSource.projected.sources[0].secret
 secret "asdf2" not found: spec.volumes[0].volumeSource.projected.sources[1].secret`,
 	}, {
 		name: "secrets (from volume source projected) not found but optional is true",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.GetContainer().VolumeMounts = []corev1.VolumeMount{{
-					Name:      "asdf1",
-					MountPath: "/asdf1",
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.Spec.Volumes = []corev1.Volume{{
-					Name: "asdf1",
-					VolumeSource: corev1.VolumeSource{
-						Projected: &corev1.ProjectedVolumeSource{
-							Sources: []corev1.VolumeProjection{{
-								Secret: &corev1.SecretProjection{
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "asdf1",
+								MountPath: "/asdf1",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: "asdf1",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "asdf1",
+											},
+											Optional: ptr.Bool(true),
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+		si: getSecretInformer(),
+	}, {
+		name: "secrets (from EnvFrom) found",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							EnvFrom: []corev1.EnvFromSource{{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf1",
+									},
+								},
+							}},
+						}},
+					},
+				},
+			},
+		},
+		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
+	}, {
+		name: "secrets (from EnvFrom) not found",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							EnvFrom: []corev1.EnvFromSource{{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf1",
+									},
+								},
+							}, {
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "asdf2",
+									},
+								},
+							}},
+						}},
+					},
+				},
+			},
+		},
+		si: getSecretInformer(),
+		expectedErr: `secret "asdf1" not found: spec.containers[0].envFrom[0].secretRef
+secret "asdf2" not found: spec.containers[0].envFrom[1].secretRef`,
+	}, {
+		name: "secrets (from EnvFrom) not found but optional is true",
+		rev: &v1alpha1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.RevisionSpec{
+				RevisionSpec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							EnvFrom: []corev1.EnvFromSource{{
+								SecretRef: &corev1.SecretEnvSource{
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "asdf1",
 									},
 									Optional: ptr.Bool(true),
 								},
 							}},
-						},
+						}},
 					},
-				}}
-				revision.ObjectMeta.Labels = map[string]string{}
+				},
 			},
-		),
-		si: getSecretInformer(),
-	}, {
-		name: "secrets (from EnvFrom) found",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.Containers = []corev1.Container{{
-					EnvFrom: []corev1.EnvFromSource{{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "asdf1",
-							},
-						},
-					}},
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.ObjectMeta.Labels = map[string]string{}
-			},
-		),
-		si: addSecretToInformer(kubefake.NewSimpleClientset(), "asdf1", "foo")(getSecretInformer()),
-	}, {
-		name: "secrets (from EnvFrom) not found",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.Containers = []corev1.Container{{
-					EnvFrom: []corev1.EnvFromSource{{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "asdf1",
-							},
-						},
-					}, {
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "asdf2",
-							},
-						},
-					}},
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.ObjectMeta.Labels = map[string]string{}
-			},
-		),
-		si: getSecretInformer(),
-		expectedErr: `secret "asdf1" not found: spec.containers[0].envFrom[0].secretRef
-secret "asdf2" not found: spec.containers[0].envFrom[1].secretRef`,
-	}, {
-		name: "secrets (from EnvFrom) not found but optional is true",
-		rev: revision(
-			func(revision *v1alpha1.Revision) {
-				revision.Spec.Containers = []corev1.Container{{
-					EnvFrom: []corev1.EnvFromSource{{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "asdf1",
-							},
-							Optional: ptr.Bool(true),
-						},
-					}},
-				}}
-				container(revision.Spec.GetContainer(),
-					//withTCPReadinessProbe(),
-				)
-				revision.ObjectMeta.Labels = map[string]string{}
-			},
-		),
+		},
 		si: getSecretInformer(),
 	}}
 

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -47,7 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	. "knative.dev/pkg/reconciler/testing"
 )
 

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -43,7 +43,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 		// Deployment does not exist. Create it.
 		rev.Status.MarkResourcesAvailableUnknown(v1alpha1.Deploying, "")
 		rev.Status.MarkContainerHealthyUnknown(v1alpha1.Deploying, "")
-		deployment, err = c.createDeployment(ctx, rev)
+		deployment, err = c.createDeployment(ctx, rev, c.secretLister)
 		if err != nil {
 			return fmt.Errorf("failed to create deployment %q: %w", deploymentName, err)
 		}
@@ -56,7 +56,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 		return fmt.Errorf("revision: %q does not own Deployment: %q", rev.Name, deploymentName)
 	} else {
 		// The deployment exists, but make sure that it has the shape that we expect.
-		deployment, err = c.checkAndUpdateDeployment(ctx, rev, deployment)
+		deployment, err = c.checkAndUpdateDeployment(ctx, rev, deployment, c.secretLister)
 		if err != nil {
 			return fmt.Errorf("failed to update deployment %q: %w", deploymentName, err)
 		}

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -176,7 +176,7 @@ var (
 
 	defaultPodSpec = &corev1.PodSpec{
 		Volumes:                       []corev1.Volume{varLogVolume},
-		TerminationGracePeriodSeconds: refInt64(45),
+		TerminationGracePeriodSeconds: ptr.Int64(45),
 	}
 
 	defaultDeployment = &appsv1.Deployment{

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -58,6 +58,7 @@ type Reconciler struct {
 	podAutoscalerLister palisters.PodAutoscalerLister
 	imageLister         cachinglisters.ImageLister
 	deploymentLister    appsv1listers.DeploymentLister
+	secretLister        corev1listers.SecretLister
 	serviceLister       corev1listers.ServiceLister
 	configMapLister     corev1listers.ConfigMapLister
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/serving/pkg/apis/config"
-
 	// Inject the fakes for informers this controller relies on.
 	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
 	fakeimageinformer "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake"
@@ -34,6 +32,7 @@ import (
 	fakedeploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakepainformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
@@ -59,6 +58,7 @@ import (
 	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
@@ -117,6 +117,7 @@ func newTestControllerWithConfig(t *testing.T, deploymentConfig *deployment.Conf
 
 	ctx, informers := SetupFakeContext(t)
 	configMapWatcher := &configmap.ManualWatcher{Namespace: system.Namespace()}
+
 	controller := NewController(ctx, configMapWatcher)
 
 	controller.Reconciler.(*Reconciler).resolver = &nopResolver{}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/serving/pkg/apis/config"
+
 	// Inject the fakes for informers this controller relies on.
 	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
 	fakeimageinformer "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake"
@@ -58,7 +60,6 @@ import (
 	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
@@ -117,7 +118,6 @@ func newTestControllerWithConfig(t *testing.T, deploymentConfig *deployment.Conf
 
 	ctx, informers := SetupFakeContext(t)
 	configMapWatcher := &configmap.ManualWatcher{Namespace: system.Namespace()}
-
 	controller := NewController(ctx, configMapWatcher)
 
 	controller.Reconciler.(*Reconciler).resolver = &nopResolver{}


### PR DESCRIPTION
/lint

Fixes #5103

## Proposed Changes

* Check secrets before creating pods

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
If secrets listed in a service cannot be fetched, the service will not be able to be successfully created or updated.
```
