### PR TITLE
Deprecate 'clusteringress.class' key in favor of 'ingress.class'.  

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -211,7 +211,7 @@ metadata:
 
 data:
   istio.sidecar.includeOutboundIPRanges: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
-  clusteringress.class: "istio.ingress.networking.knative.dev"
+  ingress.class: "istio.ingress.networking.knative.dev"
 ```
 
 You should keep the default value for "istio.sidecar.includeOutboundIPRanges",

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -74,7 +74,7 @@ data:
     #
     istio.sidecar.includeOutboundIPRanges: "*"
 
-    # clusteringress.class has been depreciated.   Please use ingress.class instead
+    # clusteringress.class has been depreciated.   Please use ingress.class instead.
     clusteringress.class: "istio.ingress.networking.knative.dev"
 
     # ingress.class specifies the default ingress class

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -74,7 +74,10 @@ data:
     #
     istio.sidecar.includeOutboundIPRanges: "*"
 
-    # clusteringress.class specifies the default ingress class
+    # clusteringress.class has been depreciated.   Please use ingress.class instead
+    clusteringress.class: "istio.ingress.networking.knative.dev"
+
+    # ingress.class specifies the default ingress class
     # to use when not dictated by Route annotation.
     #
     # If not specified, will use the Istio ingress.
@@ -83,7 +86,7 @@ data:
     # will result in undefined behavior.  Therefore it is best to only
     # update this value during the setup of Knative, to avoid getting
     # undefined behavior.
-    clusteringress.class: "istio.ingress.networking.knative.dev"
+    ingress.class: "istio.ingress.networking.knative.dev"
 
     # certificate.class specifies the default Certificate class
     # to use when not dictated by Route annotation.

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -74,7 +74,7 @@ data:
     #
     istio.sidecar.includeOutboundIPRanges: "*"
 
-    # clusteringress.class has been depreciated.   Please use ingress.class instead.
+    # clusteringress.class has been deprecated.   Please use ingress.class instead.
     clusteringress.class: "istio.ingress.networking.knative.dev"
 
     # ingress.class specifies the default ingress class

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -60,9 +60,12 @@ const (
 	// that specifies Istio outbound ip ranges.
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
+	// DepreciatedDefaultIngressClassKey.  Please use DefaultIngressClassKey instread
+	DepreciatedDefaultIngressClassKey = "clusteringress.class"
+
 	// DefaultIngressClassKey is the name of the configuration entry
 	// that specifies the default Ingress.
-	DefaultIngressClassKey = "clusteringress.class"
+	DefaultIngressClassKey = "ingress.class"
 
 	// DefaultCertificateClassKey is the name of the configuration entry
 	// that specifies the default Certificate.
@@ -235,7 +238,12 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	}
 
 	if ingressClass, ok := configMap.Data[DefaultIngressClassKey]; !ok {
-		nc.DefaultIngressClass = IstioIngressClassName
+		// Honor depreciated clusteringress class key in the case that ingress.class is not specified
+		if ingressClass, ok = configMap.Data[DepreciatedDefaultIngressClassKey]; !ok {
+			nc.DefaultIngressClass = IstioIngressClassName
+		} else {
+			nc.DefaultIngressClass = ingressClass
+		}
 	} else {
 		nc.DefaultIngressClass = ingressClass
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -60,7 +60,7 @@ const (
 	// that specifies Istio outbound ip ranges.
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
-	// DepreciatedDefaultIngressClassKey.  Please use DefaultIngressClassKey instead.
+	// DepreciatedDefaultIngressClassKey  Please use DefaultIngressClassKey instead.
 	DepreciatedDefaultIngressClassKey = "clusteringress.class"
 
 	// DefaultIngressClassKey is the name of the configuration entry

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -60,8 +60,8 @@ const (
 	// that specifies Istio outbound ip ranges.
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
-	// DepreciatedDefaultIngressClassKey  Please use DefaultIngressClassKey instead.
-	DepreciatedDefaultIngressClassKey = "clusteringress.class"
+	// DeprecatedDefaultIngressClassKey  Please use DefaultIngressClassKey instead.
+	DeprecatedDefaultIngressClassKey = "clusteringress.class"
 
 	// DefaultIngressClassKey is the name of the configuration entry
 	// that specifies the default Ingress.
@@ -238,8 +238,8 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	}
 
 	if ingressClass, ok := configMap.Data[DefaultIngressClassKey]; !ok {
-		// Honor depreciated clusteringress class key in the case that ingress.class is not specified
-		if ingressClass, ok = configMap.Data[DepreciatedDefaultIngressClassKey]; !ok {
+		// Honor deprecated clusteringress class key in the case that ingress.class is not specified
+		if ingressClass, ok = configMap.Data[DeprecatedDefaultIngressClassKey]; !ok {
 			nc.DefaultIngressClass = IstioIngressClassName
 		} else {
 			nc.DefaultIngressClass = ingressClass

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -60,7 +60,7 @@ const (
 	// that specifies Istio outbound ip ranges.
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
-	// DepreciatedDefaultIngressClassKey.  Please use DefaultIngressClassKey instread
+	// DepreciatedDefaultIngressClassKey.  Please use DefaultIngressClassKey instead.
 	DepreciatedDefaultIngressClassKey = "clusteringress.class"
 
 	// DefaultIngressClassKey is the name of the configuration entry

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -237,14 +237,10 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 		nc.IstioOutboundIPRanges = normalizedIpr
 	}
 
-	if ingressClass, ok := configMap.Data[DefaultIngressClassKey]; !ok {
-		// Honor deprecated clusteringress class key in the case that ingress.class is not specified
-		if ingressClass, ok = configMap.Data[DeprecatedDefaultIngressClassKey]; !ok {
-			nc.DefaultIngressClass = IstioIngressClassName
-		} else {
-			nc.DefaultIngressClass = ingressClass
-		}
-	} else {
+	nc.DefaultIngressClass = IstioIngressClassName
+	if ingressClass, ok := configMap.Data[DefaultIngressClassKey]; ok {
+		nc.DefaultIngressClass = ingressClass
+	} else if ingressClass, ok := configMap.Data[DeprecatedDefaultIngressClassKey]; ok {
 		nc.DefaultIngressClass = ingressClass
 	}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Deprecate 'clusteringress.class' key in favor of 'ingress.class'.  

Fixes #5689

## Proposed Changes

* Document that `clusteringress.class` has been deprecated as default ingress class key name in network-config.yaml.  'ingress.class` should be used instead.
* `clusteringress.class` will still be honored if `ingress.class` is not specified.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
