### PR TITLE
As a continuation to #5720 remove the vestiges of the autoscaler config.

### DIFF
--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -23,7 +23,6 @@ import (
 	"knative.dev/pkg/logging"
 	pkgmetrics "knative.dev/pkg/metrics"
 	pkgtracing "knative.dev/pkg/tracing/config"
-	"knative.dev/serving/pkg/autoscaler"
 	deployment "knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
@@ -38,7 +37,6 @@ type Config struct {
 	Observability *metrics.ObservabilityConfig
 	Logging       *logging.Config
 	Tracing       *pkgtracing.Config
-	Autoscaler    *autoscaler.Config
 }
 
 func FromContext(ctx context.Context) *Config {
@@ -64,7 +62,6 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 				deployment.ConfigName:      deployment.NewConfigFromConfigMap,
 				network.ConfigName:         network.NewConfigFromConfigMap,
 				pkgmetrics.ConfigMapName(): metrics.NewObservabilityConfigFromConfigMap,
-				autoscaler.ConfigName:      autoscaler.NewConfigFromConfigMap,
 				logging.ConfigMapName():    logging.NewConfigFromConfigMap,
 				pkgtracing.ConfigName:      pkgtracing.NewTracingConfigFromConfigMap,
 			},
@@ -87,6 +84,5 @@ func (s *Store) Load() *Config {
 		Observability: s.UntypedLoad(pkgmetrics.ConfigMapName()).(*metrics.ObservabilityConfig).DeepCopy(),
 		Logging:       s.UntypedLoad((logging.ConfigMapName())).(*logging.Config).DeepCopy(),
 		Tracing:       s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config).DeepCopy(),
-		Autoscaler:    s.UntypedLoad(autoscaler.ConfigName).(*autoscaler.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +31,7 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+
 	cachinglisters "knative.dev/caching/pkg/client/listers/caching/v1alpha1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -35,7 +35,6 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler"
@@ -733,8 +732,7 @@ func ReconcilerTestConfig() *config.Config {
 		Observability: &metrics.ObservabilityConfig{
 			LoggingURLTemplate: "http://logger.io/${REVISION_UID}",
 		},
-		Logging:    &logging.Config{},
-		Tracing:    &tracingconfig.Config{},
-		Autoscaler: &autoscaler.Config{},
+		Logging: &logging.Config{},
+		Tracing: &tracingconfig.Config{},
 	}
 }


### PR DESCRIPTION
Since revision controller no longer uses Autoscaler config at all
remove it from the stored, watched and maintained config, saving
resources for everybody.

/lint
/assign @markusthoemmes @evankanderson 