### PR TITLE
Fixes gRPC e2e test when using "--ingressendpoint"

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -21,6 +21,7 @@ package e2e
 import (
 	"context"
 	"io"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
@@ -57,9 +58,16 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 	if host != domain {
 		// The host to connect and the domain accepted differ.
 		// We need to do grpc.WithAuthority(...) here.
+
+		// We need to remove the port part in the domain to use it as the authority
+		authority, _, err := net.SplitHostPort(domain)
+		if err != nil {
+			return nil, err
+		}
+
 		return grpc.Dial(
 			host,
-			grpc.WithAuthority(domain),
+			grpc.WithAuthority(authority),
 			grpc.WithInsecure(),
 			// Retrying DNS errors to avoid .xip.io issues.
 			grpc.WithDefaultCallOptions(grpc.FailFast(false)),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This PR fixes an issue when running the e2e tests with "--ingressendpoint" specified. 

## Proposed Changes

* Removes the port part of the domain when is used as the gRPC "authority". 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
