### PR TITLE
Initial Slicing Implementation in Activator.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -252,31 +252,31 @@ func (rt *revisionThrottler) updateThrottleState(throttler *Throttler, backendCo
 }
 
 // pickIndices picks the indices for the slicing.
-func pickIndices(lt, selfIndex, numActivators int) (bi, ei int) {
-	if numActivators > lt {
+func pickIndices(numTrackers, selfIndex, numActivators int) (beginIndex, endIndex int) {
+	if numActivators > numTrackers {
 		// 1. We have fewer pods than than activators. Assign the pod in round robin fashion.
 		// NB: when we implement subsetting this will be less of a problem.
-		// e.g. lt=3, #ac = 5; for si = 3 => 3 % 3 = 0, or for si = 5 => 5%3 = 2
-		bi = selfIndex % lt
-		ei = bi + 1
+		// e.g. lt=3, #ac = 5; for selfIdx = 3 => 3 % 3 = 0, or for si = 5 => 5%3 = 2
+		beginIndex = selfIndex % numTrackers
+		endIndex = beginIndex + 1
 		return
 	}
 	// 2. We have at least as many pods as activators. Assign equal slices
 	// to the Activators. If the numbers don't divide evenly, assign the remnants
 	// to first k Activators, where k = #trackers % #activators
-	sliceSize := lt / numActivators
-	remnants := lt % numActivators
+	sliceSize := numTrackers / numActivators
+	remnants := numTrackers % numActivators
 	if selfIndex < remnants {
 		// 2.1. We get one more pod!
 		// The first k activators get `sliceSize+1` pods assigned.
-		bi = selfIndex * (sliceSize + 1)
-		ei = bi + sliceSize + 1
+		beginIndex = selfIndex * (sliceSize + 1)
+		endIndex = beginIndex + sliceSize + 1
 		return
 	}
 
 	// 2.2. equally divided or smaller slice.
-	bi = remnants + selfIndex*sliceSize
-	ei = bi + sliceSize
+	beginIndex = remnants + selfIndex*sliceSize
+	endIndex = beginIndex + sliceSize
 	return
 }
 

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -228,7 +228,7 @@ func (rt *revisionThrottler) updateCapacity(throttler *Throttler, backendCount i
 }
 
 func (rt *revisionThrottler) updateThrottleState(throttler *Throttler, backendCount int, trackers []*podIPTracker, clusterIPDest string) {
-	rt.logger.Infof("Updating Revision Throttler with: clusterIP = %s, trackers = %d, backends = %d",
+	rt.logger.Infof("Updating Revision Throttler with: clusterIP = %q, trackers = %d, backends = %d",
 		clusterIPDest, len(trackers), backendCount)
 
 	// Update trackers / clusterIP before capacity. Otherwise we can race updating our breaker when
@@ -251,16 +251,66 @@ func (rt *revisionThrottler) updateThrottleState(throttler *Throttler, backendCo
 	}
 }
 
+// pickIndices picks the indices for the slicing.
+func pickIndices(lt, selfIndex, numActivators int) (bi, ei int) {
+	if numActivators > lt {
+		// 1. We have fewer pods than than activators. Assign the pod in round robin fashion.
+		// NB: when we implement subsetting this will be less of a problem.
+		// e.g. lt=3, #ac = 5; for si = 3 => 3 % 3 = 0, or for si = 5 => 5%3 = 2
+		bi = selfIndex % lt
+		ei = bi + 1
+		return
+	}
+	// 2. We have at least as many pods as activators. Assign equal slices
+	// to the Activators. If the numbers don't divide evenly, assign the remnants
+	// to first k Activators, where k = #trackers % #activators
+	sliceSize := lt / numActivators
+	remnants := lt % numActivators
+	if selfIndex < remnants {
+		// 2.1. We get one more pod!
+		// The first k activators get `sliceSize+1` pods assigned.
+		bi = selfIndex * (sliceSize + 1)
+		ei = bi + sliceSize + 1
+		return
+	}
+
+	// 2.2. equally divided or smaller slice.
+	bi = remnants + selfIndex*sliceSize
+	ei = bi + sliceSize
+	return
+}
+
+// assignSlice picks a subset of the individual pods to send requests to
+// for this Activator instance. This only matters in case of direct
+// to pod IP routing, and is irrelevant, when ClusterIP is used.
+func assignSlice(trackers []*podIPTracker, selfIndex, numActivators int) []*podIPTracker {
+	// When we're unassigned, doesn't matter what we return.
+	if selfIndex == -1 {
+		return trackers
+	}
+	lt := len(trackers)
+	if lt == 1 {
+		return trackers
+	}
+	// Sort, so we get more or less stable results.
+	sort.Slice(trackers, func(i, j int) bool {
+		return trackers[i].dest < trackers[j].dest
+	})
+	bi, ei := pickIndices(lt, selfIndex, numActivators)
+	return trackers[bi:ei]
+}
+
 // This function will never be called in parallel but try can be called in parallel to this so we need
 // to lock on updating concurrency / trackers
 func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionDestsUpdate) {
-	rt.logger.Debugf("Handling update w/ %d ready and dests: %v", len(update.Dests), update.Dests)
+	rt.logger.Debugf("Handling update w/ ClusterIP=%q, %d ready and dests: %v",
+		update.ClusterIPDest, len(update.Dests), update.Dests)
 
 	// ClusterIP is not yet ready, so we want to send requests directly to the pods.
 	// NB: this will not be called in parallel, thus we can build a new podIPTrackers
 	// array before taking out a lock.
 	if update.ClusterIPDest == "" {
-		// Create a map for fast lookup of existing trackers
+		// Create a map for fast lookup of existing trackers.
 		trackersMap := make(map[string]*podIPTracker, len(rt.podIPTrackers))
 		for _, tracker := range rt.podIPTrackers {
 			trackersMap[tracker.dest] = tracker
@@ -268,7 +318,8 @@ func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionD
 
 		trackers := make([]*podIPTracker, 0, len(update.Dests))
 
-		// Loop over dests, reuse existing tracker if we have one otherwise create new
+		// Loop over dests, reuse existing tracker if we have one otherwise create
+		// a new one.
 		for newDest := range update.Dests {
 			tracker, ok := trackersMap[newDest]
 			if !ok {
@@ -277,6 +328,7 @@ func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionD
 			trackers = append(trackers, tracker)
 		}
 
+		trackers = assignSlice(trackers, throttler.index(), throttler.activatorCount())
 		rt.updateThrottleState(throttler, len(update.Dests), trackers, "" /*clusterIP*/)
 		return
 	}
@@ -464,6 +516,10 @@ func (t *Throttler) activatorEndpointsUpdated(newObj interface{}) {
 	atomic.StoreInt32(&t.numActivators, int32(activatorCount))
 	atomic.StoreInt32(&t.activatorIndex, int32(idx))
 	t.updateAllThrottlerCapacity()
+}
+
+func (t *Throttler) index() int {
+	return int(atomic.LoadInt32(&t.activatorIndex))
 }
 
 func (t *Throttler) activatorCount() int {

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -285,11 +285,8 @@ func pickIndices(numTrackers, selfIndex, numActivators int) (beginIndex, endInde
 // to pod IP routing, and is irrelevant, when ClusterIP is used.
 func assignSlice(trackers []*podIPTracker, selfIndex, numActivators int) []*podIPTracker {
 	// When we're unassigned, doesn't matter what we return.
-	if selfIndex == -1 {
-		return trackers
-	}
 	lt := len(trackers)
-	if lt == 1 {
+	if selfIndex == -1 || lt <= 1 {
 		return trackers
 	}
 	// Sort, so we get more or less stable results.

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -761,6 +761,12 @@ func TestAssignSlice(t *testing.T) {
 			dest: "3",
 		},
 	}
+	t.Run("notrackers", func(t *testing.T) {
+		got := assignSlice([]*podIPTracker{}, 0, 1)
+		if !reflect.DeepEqual(got, []*podIPTracker{}) {
+			t.Errorf("Got=%v, want: %v", got, trackers)
+		}
+	})
 	t.Run("idx=-1", func(t *testing.T) {
 		got := assignSlice(trackers, -1, 1)
 		if !reflect.DeepEqual(got, trackers) {

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -18,7 +18,6 @@ package net
 
 import (
 	"context"
-	"reflect"
 	"regexp"
 	"sync"
 	"sync/atomic"
@@ -26,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -763,27 +763,31 @@ func TestAssignSlice(t *testing.T) {
 	}
 	t.Run("notrackers", func(t *testing.T) {
 		got := assignSlice([]*podIPTracker{}, 0, 1)
-		if !reflect.DeepEqual(got, []*podIPTracker{}) {
-			t.Errorf("Got=%v, want: %v", got, trackers)
+		if !cmp.Equal(got, []*podIPTracker{}, cmpopts.IgnoreUnexported(podIPTracker{})) {
+			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
+				cmp.Diff([]*podIPTracker{}, got, cmpopts.IgnoreUnexported(podIPTracker{})))
 		}
 	})
 	t.Run("idx=-1", func(t *testing.T) {
 		got := assignSlice(trackers, -1, 1)
-		if !reflect.DeepEqual(got, trackers) {
-			t.Errorf("Got=%v, want: %v", got, trackers)
+		if !cmp.Equal(got, trackers, cmpopts.IgnoreUnexported(podIPTracker{})) {
+			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
+				cmp.Diff(trackers, got, cmpopts.IgnoreUnexported(podIPTracker{})))
 		}
 	})
 	t.Run("idx=1", func(t *testing.T) {
 		cp := append(trackers[:0:0], trackers...)
 		got := assignSlice(cp, 1, 3)
-		if !reflect.DeepEqual(got, trackers[0:1]) {
-			t.Errorf("Got=%v, want: %v", got, trackers[0:1])
+		if !cmp.Equal(got, trackers[0:1], cmpopts.IgnoreUnexported(podIPTracker{})) {
+			t.Errorf("Got=%v, want: %v; diff: %s", got, trackers[0:1],
+				cmp.Diff(trackers[0:1], got, cmpopts.IgnoreUnexported(podIPTracker{})))
 		}
 	})
 	t.Run("len=1", func(t *testing.T) {
 		got := assignSlice(trackers[0:1], 1, 3)
-		if !reflect.DeepEqual(got, trackers[0:1]) {
-			t.Errorf("Got=%v, want: %v", got, trackers[0:1])
+		if !cmp.Equal(got, trackers[0:1], cmpopts.IgnoreUnexported(podIPTracker{})) {
+			t.Errorf("Got=%v, want: %v; diff: %s", got, trackers[0:1],
+				cmp.Diff(trackers[0:1], got, cmpopts.IgnoreUnexported(podIPTracker{})))
 		}
 	})
 }


### PR DESCRIPTION
This PR implements the initial slicing in the activator, permitting each of the
activators to own a slice of the downstream pods and route the requests to them.
Note, that as of now it will only work when cluster IP is not yet ready.
That last piece is coming in the next PR.

Also some tweaks to the tests to increase coverage.


/lint
/assign @markusthoemmes 