### PR TITLE
Improve TestDestroyPodInflight e2e test Istio 1.3 w/ mesh

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -45,7 +45,7 @@ import (
 const (
 	timeoutExpectedOutput  = "Slept for 0 milliseconds"
 	revisionTimeoutSeconds = 45
-	timeoutRequestDuration = 43 * time.Second
+	timeoutRequestDuration = 35 * time.Second
 )
 
 func TestDestroyPodInflight(t *testing.T) {

--- a/third_party/istio-1.3.1/download-istio.sh
+++ b/third_party/istio-1.3.1/download-istio.sh
@@ -50,4 +50,5 @@ patch istio-crds.yaml namespace.yaml.patch
 patch istio.yaml namespace.yaml.patch
 patch istio-lean.yaml namespace.yaml.patch
 
-patch -l istio.yaml prestop-sleep.yaml.patch
+# Increase termination drain duration seconds.
+patch -l istio.yaml drain-seconds.yaml.patch

--- a/third_party/istio-1.3.1/drain-seconds.yaml.patch
+++ b/third_party/istio-1.3.1/drain-seconds.yaml.patch
@@ -1,0 +1,5 @@
+781a782,785
+>         # PATCH #2: Increase termination drain duration.
+>         - name: TERMINATION_DRAIN_DURATION_SECONDS
+>           value: "20"
+>         # PATCH #2 ends.

--- a/third_party/istio-1.3.1/istio.yaml
+++ b/third_party/istio-1.3.1/istio.yaml
@@ -604,12 +604,6 @@ data:
       {{- end }}
       containers:
       - name: istio-proxy
-        # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
-        lifecycle:
-          preStop:
-            exec:
-              command: ["sleep", "20"]
-        # PATCH #2 ends.
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
@@ -785,6 +779,10 @@ data:
         - name: ISTIO_META_MESH_ID
           value: "{{ .Values.global.trustDomain }}"
         {{- end }}
+        # PATCH #2: Increase termination drain duration.
+        - name: TERMINATION_DRAIN_DURATION_SECONDS
+          value: "20"
+        # PATCH #2 ends.
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/third_party/istio-1.3.1/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.3.1/prestop-sleep.yaml.patch
@@ -1,7 +1,0 @@
-606a607,612
->         # PATCH #2: Delay Envoy lameduck a bit, since Endpoint propagation may be slow.
->         lifecycle:
->           preStop:
->             exec:
->               command: ["sleep", "20"]
->         # PATCH #2 ends.


### PR DESCRIPTION
## Proposed Changes

TestDestroyPodInflight on Istio 1.3 w/ mesh is [flaky](https://testgrid.knative.dev/serving#istio-1.3-mesh&width=20) now. To fix it, this patch changes to:

- decrase `timeoutRequestDuration` to 35 sec as 43s is not enough long. (It starts draining in 41s).
- use TERMINATION_DRAIN_DURATION_SECONDS instead of preStop sleep.

Note, TERMINATION_DRAIN_DURATION_SECONDS is introduced based on this patch
https://github.com/istio/istio/commit/ed5e9596c2a30d0b6c818b1a0b31712fb16ac7eb on upstream.

/lint

**Release Note**

```release-note
NONE
```
