### PR TITLE
Also probe target for benchmark load-test before sending bulk requests

### DIFF
--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -30,7 +30,8 @@ import (
 
 	"knative.dev/pkg/test/spoof"
 
-	// Mysteriously required to support GCP auth (required by k8s libs). Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
+	// Mysteriously required to support GCP auth (required by k8s libs).
+	// Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
@@ -99,10 +100,12 @@ func ProbeTargetTillReady(target string, duration time.Duration) error {
 	if err != nil {
 		return fmt.Errorf("target %q is invalid, cannot probe: %v", target, err)
 	}
-	_, err = spoofingClient.Poll(req, func(resp *spoof.Response) (done bool, err error) {
+	if _, err = spoofingClient.Poll(req, func(resp *spoof.Response) (done bool, err error) {
 		return true, nil
-	})
-	return fmt.Errorf("failed to get target %q ready: %v", target, err)
+	}); err != nil {
+		return fmt.Errorf("failed to get target %q ready: %v", target, err)
+	}
+	return nil
 }
 
 // resolvedHeaders returns headers for the request.

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -17,6 +17,9 @@ limitations under the License.
 package performance
 
 import (
+	"fmt"
+	"log"
+	"net/http"
 	"testing"
 	"time"
 
@@ -24,6 +27,8 @@ import (
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/prometheus"
 	"knative.dev/serving/test"
+
+	"knative.dev/pkg/test/spoof"
 
 	// Mysteriously required to support GCP auth (required by k8s libs). Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -77,6 +82,27 @@ func TearDown(client *Client, names test.ResourceNames, logf logging.FormatLogge
 	if client.PromClient != nil {
 		client.PromClient.Teardown(logf)
 	}
+}
+
+// ProbeTargetTillReady will probe the target once per second for the given duration, until it's ready or error happens
+func ProbeTargetTillReady(target string, duration time.Duration) error {
+	// Make sure the target is ready before sending the large amount of requests.
+	spoofingClient := spoof.SpoofingClient{
+		Client:          &http.Client{},
+		RequestInterval: 1 * time.Second,
+		RequestTimeout:  duration,
+		Logf: func(fmt string, args ...interface{}) {
+			log.Printf(fmt, args)
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return fmt.Errorf("target %q is invalid, cannot probe: %v", target, err)
+	}
+	_, err = spoofingClient.Poll(req, func(resp *spoof.Response) (done bool, err error) {
+		return true, nil
+	})
+	return fmt.Errorf("failed to get target %q ready: %v", target, err)
 }
 
 // resolvedHeaders returns headers for the request.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
The prober for benchmark `dataplane-probe` has been proven to work, the errors are disappeared, see https://mako.dev/benchmark?benchmark_key=5142965274017792&tseconds=604800&~re1=p95000&~ret=p95000&~re=p95000&~qe=p95000, also add prober for `load-test`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
/cc @adrcunha 