### PR TITLE
Streamline logging that permits us avoiding formatting values

### DIFF
--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -55,7 +55,7 @@ type MetricHandler struct {
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	// Filter out probe and healthy requests
+	// Filter out probe and health check requests.
 	if network.IsProbe(r) {
 		h.nextHandler.ServeHTTP(w, r)
 		return

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -416,8 +416,7 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 
 	rw, err := rbm.getOrCreateRevisionWatcher(revID)
 	if err != nil {
-		rbm.logger.Errorw(fmt.Sprintf("Failed to get revision watcher for revision %q", revID.String()),
-			zap.Error(err))
+		rbm.logger.With(zap.Error(err)).Error("Failed to get revision watcher for revision %q", revID.String())
 		return
 	}
 	dests := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -19,7 +19,6 @@ package autoscaler
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -186,12 +185,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	desiredStablePodCount := int32(math.Min(math.Max(dspc, maxScaleDown), maxScaleUp))
 	desiredPanicPodCount := int32(math.Min(math.Max(dppc, maxScaleDown), maxScaleUp))
 
-	logger.Debugw(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
-		observedStableValue, spec.TargetValue),
-		zap.String("mode", "stable"))
-	logger.Debugw(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
-		observedPanicValue, spec.TargetValue),
-		zap.String("mode", "panic"))
+	logger.With(zap.String("mode", "stable")).Debugf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
+		observedStableValue, spec.TargetValue)
+	logger.With(zap.String("mode", "panic")).Debugf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
+		observedPanicValue, spec.TargetValue)
 
 	isOverPanicThreshold := observedPanicValue/readyPodsCount >= spec.PanicThreshold
 

--- a/pkg/reconciler/gc/gc.go
+++ b/pkg/reconciler/gc/gc.go
@@ -18,7 +18,6 @@ package gc
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
@@ -107,7 +106,7 @@ func (c *reconciler) reconcile(ctx context.Context, config *v1alpha1.Configurati
 		if isRevisionStale(ctx, rev, config) {
 			err := c.ServingClientSet.ServingV1alpha1().Revisions(rev.Namespace).Delete(rev.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				logger.Errorw(fmt.Sprintf("Failed to delete stale revision %q", rev.Name), zap.Error(err))
+				logger.With(zap.Error(err)).Errorf("Failed to delete stale revision %q", rev.Name)
 				continue
 			}
 		}


### PR DESCRIPTION
With this approach, it seems both more readable and definitely more
performant since we won't have to evaluate the formatted string every time
even if the log statement is not going to be logged (especially this is
important in the autoscaler debugf call).

/assign @yanweiguo @markusthoemmes