### PR TITLE
Stop assuming that !Gloo=Istio and that mesh is Istio only.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,7 +45,7 @@ failed=0
 
 # Run tests serially in the mesh scenario
 parallelism=""
-(( ISTIO_MESH )) && parallelism="-parallel 1"
+(( MESH )) && parallelism="-parallel 1"
 
 # Run conformance and e2e tests.
 go_test_e2e -timeout=30m \
@@ -60,8 +60,7 @@ go_test_e2e -timeout=10m \
   ./test/scale || failed=1
 
 # Istio E2E tests mutate the cluster and must be ran separately
-# TODO(https://github.com/knative/test-infra/issues/1398): use proper flags instead of binary GLOO/no GLOO
-if [[ -z "${GLOO_VERSION}" ]]; then
+if [[ -n "${ISTIO_VERSION}" ]]; then
   go_test_e2e -timeout=10m \
     ./test/e2e/istio \
     "--resolvabledomain=$(use_resolvable_domain)" || failed=1


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/test-infra/issues/1398

## Proposed Changes
* Do not assume `mesh` is only for Istio: rename `ISTIO_MESH` to `MESH`
* Do not assume that it is either `Istio` or `Gloo`, we might support other meshes/gateways later

Matching `knative.dev/test-infra` PR: https://github.com/knative/test-infra/pull/1453 