### PR TITLE
Wait for scale to 0 for benchmark load-test

### DIFF
--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -117,7 +117,7 @@ func main() {
 		log.Fatalf("-flavor is a required flag.")
 	}
 	selector = labels.SelectorFromSet(labels.Set{
-		serving.ServiceLabelKey: fmt.Sprintf("load-test-%s", *flavor),
+		serving.ServiceLabelKey: "load-test-" + *flavor,
 	})
 
 	// We want this for properly handling Kubernetes container lifecycle events.

--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -36,8 +36,11 @@ import (
 	"knative.dev/serving/test/performance/metrics"
 )
 
+const namespace = "default"
+
 var (
-	flavor = flag.String("flavor", "", "The flavor of the benchmark to run.")
+	flavor   = flag.String("flavor", "", "The flavor of the benchmark to run.")
+	selector labels.Selector
 )
 
 func processResults(ctx context.Context, q *quickstore.Quickstore, results <-chan *vegeta.Result) {
@@ -60,13 +63,9 @@ func processResults(ctx context.Context, q *quickstore.Quickstore, results <-cha
 		}
 	}()
 
-	selector := labels.SelectorFromSet(labels.Set{
-		serving.ServiceLabelKey: fmt.Sprintf("load-test-%s", *flavor),
-	})
-
 	ctx, cancel := context.WithCancel(ctx)
-	deploymentStatus := metrics.FetchDeploymentStatus(ctx, "default", selector, time.Second)
-	sksMode := metrics.FetchSKSMode(ctx, "default", selector, time.Second)
+	deploymentStatus := metrics.FetchDeploymentStatus(ctx, namespace, selector, time.Second)
+	sksMode := metrics.FetchSKSMode(ctx, namespace, selector, time.Second)
 	defer cancel()
 
 	for {
@@ -117,12 +116,15 @@ func main() {
 	if *flavor == "" {
 		log.Fatalf("-flavor is a required flag.")
 	}
+	selector = labels.SelectorFromSet(labels.Set{
+		serving.ServiceLabelKey: fmt.Sprintf("load-test-%s", *flavor),
+	})
 
 	// We want this for properly handling Kubernetes container lifecycle events.
 	ctx := signals.NewContext()
 
-	// We cron every 10 minutes, so give ourselves 6 minutes to complete.
-	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
+	// We cron every 10 minutes, so give ourselves 8 minutes to complete.
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Minute)
 	defer cancel()
 
 	// Use the benchmark key created.
@@ -159,6 +161,10 @@ func main() {
 	// Make sure the target is ready before sending the large amount of requests.
 	if err := performance.ProbeTargetTillReady(url, duration); err != nil {
 		fatalf("Failed to get target ready for attacking: %v", err)
+	}
+	// Wait for scale back to 0
+	if err := performance.WaitForScaleToZero(ctx, namespace, selector, 2*time.Minute); err != nil {
+		fatalf("Failed to wait for scale-to-0: %v", err)
 	}
 
 	pacers := make([]vegeta.Pacer, 3)

--- a/test/performance/metrics/runtime.go
+++ b/test/performance/metrics/runtime.go
@@ -49,7 +49,6 @@ func FetchDeploymentStatus(
 	startTick(duration, ctx.Done(), func(t time.Time) error {
 		// Overlay the desired and ready pod counts.
 		deployments, err := dl.Deployments(namespace).List(selector)
-		dl.Deployments(namespace)
 		if err != nil {
 			log.Printf("Error listing deployments: %v", err)
 			return err

--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -125,6 +125,11 @@ function update_cluster() {
   # Update the activator hpa minReplicas to 10
   kubectl patch hpa -n knative-serving activator \
     --patch '{"spec": {"minReplicas": 10}}'
+  # Update the scale-to-zero grace period to 10s
+  kubectl patch configmap/config-autoscaler \
+    -n knative-serving \
+    --type merge \
+    -p '{"data":{"scale-to-zero-grace-period":"10s"}}'
   # According to https://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/,
   # replicas = max( ceil( cores * 1/coresPerReplica ) , ceil( nodes * 1/nodesPerReplica ) ).
   # By changing nodesPerReplica from the default 16 to 4, we make kube-dns to be able to scale to 4x replicas.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
For benchmark `load-test`, wait for scale-to-0 before sending bulk requests. And when installing serving, change `scale-to-zero-grace-period` to 10s to get scale-to-0 quicker.

> We cannot use the function provided in e2e test infra since it requires args that we do not use - https://github.com/knative/serving/blob/253e02f58dd100d4a7f0895dd073ffe9b4e6a245/test/e2e/e2e.go#L79

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
