### PR TITLE
Reference existing Istio Gateway to Virtualservice via annotation

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -80,6 +80,25 @@ const (
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"
+
+	// CustomExternalIPGatewayAnnotationKey is the annotation for specifing the Gateway a 
+	// VirtualService should list for external Ingress. This will append to the list of
+	// Gateways that Knative creates. The Gateway name format must be of either 
+	// {namespace}/{gateway-name} or {gateway-name}. For example,
+	//
+	//    networking.knative.dev/customGateway: some-namespace/some-gateway
+	// 
+	// Gateway name without a namespace will expect it to be in the same namespace 
+	// as the service. As a user-created custom Gateway, users are responsible for 
+	// maintaining the Gateway resource. This means that Knative will NOT be responsible 
+	// for creating, reconciling, or deleting this Gateway. Knative will just append this
+	// to the list of Gateways where the VirtualService rule should be applied to.
+	CustomExternalIPGatewayAnnotationKey = "networking.knative.dev/customExternalIPGatewayName"
+
+	// CustomClusterLocalGatewayAnnotationKey is the annotation for specifing the Gateway a 
+	// VirtualService should list for internal Ingress. Please refer to the description above
+	// for CustomExternalIPGatewayAnnotationKey for more detail.
+	CustomClusterLocalGatewayAnnotationKey = "networking.knative.dev/customClusterLocalGatewayName"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5706 

## Proposed Changes

- This enables custom gateway support for Knative services through annotations as mentioned in [the issue](https://github.com/knative/serving/issues/5706#issuecomment-539138018).

- Add a `CustomExternalIPGatewayAnnotationKey` and `CustomClusterLocalGatewayAnnotationKey` for specifying the Gateway the VirtualService will use. This will append to the list of Gateways that Knative creates. Example:

`networking.knative.dev/customExternalIPGatewayName: default/some-gateway`

- As this is a user-created custom Gateway, users are responsible for maintaining the resource. This means that Knative **will NOT** be responsible for creating, reconciling, or deleting this Gateway. Knative will just append this to the list of Gateways where the VirtualService rule should be applied to.

- The Gateway name format must be of either {namespace}/{gateway-name} or {gateway-name}, The latter expects the Gateway to be in the same namespace as the service.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
@ZhiminXiang 
