### PR TITLE
Remove the deprecated service field.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -100,10 +100,6 @@ type PodAutoscalerSpec struct {
 	// +optional
 	Reachability ReachabilityType `json:"reachability,omitempty"`
 
-	// DeprecatedServiceName holds the name of a core Kubernetes Service resource that
-	// load balances over the pods referenced by the ScaleTargetRef.
-	DeprecatedServiceName string `json:"serviceName"`
-
 	// The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.
 	ProtocolType net.ProtocolType `json:"protocolType"`
 }


### PR DESCRIPTION
It has not been set (i.e. actively removed) since at least 0.6

/assign @dgerd

