### PR TITLE
Fix 'GET' strings to a constant and other minor nits

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -181,9 +181,7 @@ func TestActivationHandler(t *testing.T) {
 			reporter := &fakeReporter{}
 
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-			defer func() {
-				cancel()
-			}()
+			defer cancel()
 			revisionInformer(ctx, revision(testNamespace, testRevName))
 			handler := (New(ctx, test.throttler, reporter)).(*activationHandler)
 
@@ -210,7 +208,10 @@ func TestActivationHandler(t *testing.T) {
 				t.Errorf("Unexpected response status. Want %d, got %d", test.wantCode, resp.Code)
 			}
 
-			gotBody, _ := ioutil.ReadAll(resp.Body)
+			gotBody, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Error reading body: %v", err)
+			}
 			if string(gotBody) != test.wantBody {
 				t.Errorf("Unexpected response body. Response body %q, want %q", gotBody, test.wantBody)
 			}
@@ -229,7 +230,6 @@ func TestActivationHandler(t *testing.T) {
 			if diff := cmp.Diff(test.reporterCalls, gotCalls); diff != "" {
 				t.Errorf("Reporting calls are different (-want, +got) = %v", diff)
 			}
-
 		})
 	}
 }
@@ -243,9 +243,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	})
 
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 	revisionInformer(ctx, revision(testNamespace, testRevName))
 
 	handler := (New(ctx, fakeThrottler{}, &fakeReporter{})).(*activationHandler)

--- a/pkg/activator/handler/healthz_handler_test.go
+++ b/pkg/activator/handler/healthz_handler_test.go
@@ -55,7 +55,7 @@ func TestHealthHandler(t *testing.T) {
 			handler := HealthHandler{HealthCheck: e.check, NextHandler: baseHandler}
 
 			resp := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "http://example.com", nil)
+			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 			req.Header = e.headers
 
 			handler.ServeHTTP(resp, req)

--- a/test/performance/dataplane-probe/sla.go
+++ b/test/performance/dataplane-probe/sla.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -81,7 +82,7 @@ var (
 	}{
 		"deployment": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://deployment.default.svc.cluster.local?sleep=100",
 			},
 			stat:      "kd",
@@ -90,7 +91,7 @@ var (
 		},
 		"istio": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://istio.default.svc.cluster.local?sleep=100",
 			},
 			stat:      "id",
@@ -99,7 +100,7 @@ var (
 		},
 		"queue": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://queue-proxy.default.svc.cluster.local?sleep=100",
 			},
 			stat:      "qp",
@@ -108,7 +109,7 @@ var (
 		},
 		"queue-with-cc": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://queue-proxy-with-cc.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "qc",
@@ -118,7 +119,7 @@ var (
 		},
 		"queue-with-cc-10": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://queue-proxy-with-cc-10.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "qct",
@@ -128,7 +129,7 @@ var (
 		},
 		"queue-with-cc-1": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://queue-proxy-with-cc-1.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "qc1",
@@ -138,7 +139,7 @@ var (
 		},
 		"activator": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://activator.default.svc.cluster.local?sleep=100",
 			},
 			stat:      "a",
@@ -147,7 +148,7 @@ var (
 		},
 		"activator-with-cc": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://activator-with-cc.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "ac",
@@ -157,7 +158,7 @@ var (
 		},
 		"activator-with-cc-10": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://activator-with-cc-10.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "act",
@@ -167,7 +168,7 @@ var (
 		},
 		"activator-with-cc-1": {
 			target: vegeta.Target{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL:    "http://activator-with-cc-1.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "ac1",

--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/google/mako/go/quickstore"
@@ -154,7 +155,7 @@ func main() {
 	const duration = 2 * time.Minute
 	url := fmt.Sprintf("http://load-test-%s.default.svc.cluster.local?sleep=100", *flavor)
 	targeter := vegeta.NewStaticTargeter(vegeta.Target{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    url,
 	})
 


### PR DESCRIPTION
In benchmarks we were not using the constant.
Also other smaller nits elsewhere.

/assign @chizhg 