### PR TITLE
Run E2E tests sequentially in 1.3.x

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -44,8 +44,8 @@ header "Running tests"
 failed=0
 
 # Run tests serially in the mesh scenario
-parallelism=""
-(( ISTIO_MESH )) && parallelism="-parallel 1"
+parallelism="-parallel 1"
+#(( ISTIO_MESH )) && parallelism="-parallel 1"
 
 # Run conformance and e2e tests.
 go_test_e2e -timeout=30m \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -43,9 +43,12 @@ header "Running tests"
 
 failed=0
 
-# Run tests serially in the mesh scenario
-parallelism="-parallel 1"
-#(( ISTIO_MESH )) && parallelism="-parallel 1"
+# Run tests serially in the mesh scenario or for Istio 1.3.x
+parallelism=""
+(( ISTIO_MESH )) && parallelism="-parallel 1"
+if [[ ${ISTIO_VERSION} =~ 1.3.* ]]; then
+  parallelism="-parallel 1"
+fi
 
 # Run conformance and e2e tests.
 go_test_e2e -timeout=30m \


### PR DESCRIPTION
There is a regression in Istio 1.3.x where under a lot of config changes, Envoy returns HTTP 503 NR.
This has nothing to do with Knative. As such, we should run the 1.3.x E2E tests sequentially until this is fixed by Istio.

** TODO
* [ ] Create minimal repro and report the issue to Istio