### PR TITLE
Remove Deleted field in the backend update

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -58,7 +58,6 @@ type revisionDestsUpdate struct {
 	Rev           types.NamespacedName
 	ClusterIPDest string
 	Dests         sets.String
-	Deleted       bool
 }
 
 const (
@@ -430,7 +429,6 @@ func (rbm *revisionBackendsManager) deleteRevisionWatcher(rev types.NamespacedNa
 	if rw, ok := rbm.revisionWatchers[rev]; ok {
 		rw.cancel()
 		delete(rbm.revisionWatchers, rev)
-		rbm.updateCh <- revisionDestsUpdate{Rev: rev, Deleted: true}
 	}
 }
 

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -865,16 +865,8 @@ func TestRevisionDeleted(t *testing.T) {
 	fakekubeclient.Get(ctx).CoreV1().Endpoints(testNamespace).Delete(ep.Name, &metav1.DeleteOptions{})
 	select {
 	case r := <-rbm.updates():
-		if got, want := r.Deleted, true; got != want {
-			t.Errorf("Deleted = %t, want true", got)
-		}
-		if got, want := r.ClusterIPDest, ""; got != want {
-			t.Errorf(`ClusterIP = %s, want ""`, got)
-		}
-		if got, want := len(r.Dests), 0; got != want {
-			t.Errorf("DestsLen = %d, want: 0", got)
-		}
-	case <-time.After(time.Second * 2):
-		t.Errorf("Timedout waiting for initial response")
+		t.Errorf("Unexpected update: %#v", r)
+	case <-time.After(time.Millisecond * 200):
+		// Wait to make sure the callbacks are executed.
 	}
 }

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -457,10 +457,6 @@ func (t *Throttler) revisionDeleted(obj interface{}) {
 }
 
 func (t *Throttler) handleUpdate(update revisionDestsUpdate) {
-	if update.Deleted {
-		// Nothing to do as revisionDeleted is already called by DeleteFunc of Informer.
-		return
-	}
 	if rt, err := t.getOrCreateRevisionThrottler(update.Rev); err != nil {
 		if k8serrors.IsNotFound(err) {
 			t.logger.Debugf("Revision %q is not found. Probably it was removed", update.Rev.String())


### PR DESCRIPTION
But there is no reason to have the field to mark the update as ignored,
rather we can just *not* issue the update in the first place!

/assign @nak3 @markusthoemmes
/lint
