### PR TITLE
Fix dataplane-probe benchmark

### DIFF
--- a/test/performance/dataplane-probe/dataplane-probe.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe.yaml
@@ -25,6 +25,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
The cronjob log shows `Failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:default:prober" cannot list resource "deployments" in API group "apps" at the cluster scope`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 