### PR TITLE
Fix race in TestGlobalResyncOnUpdateDomainConfigMap test

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -309,18 +309,17 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 			}
 
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-			waitInformers := func() {}
+			revisions := revisionInformer(ctx, revision(testNamespace, testRevName))
+			waitInformers, err := controller.RunInformers(ctx.Done(), revisions.Informer())
+			if err != nil {
+				t.Fatalf("Failed to start informers: %v", err)
+			}
 			defer func() {
 				cancel()
 				reporter.Close()
 				oct.Finish()
 				waitInformers()
 			}()
-			revisions := revisionInformer(ctx, revision(testNamespace, testRevName))
-			waitInformers, err := controller.RunInformers(ctx.Done(), revisions.Informer())
-			if err != nil {
-				t.Fatalf("Failed to start informers: %v", err)
-			}
 
 			handler := (New(ctx, fakeThrottler{}, &fakeReporter{})).(*activationHandler)
 			handler.transport = &ochttp.Transport{

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -633,7 +633,11 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			rt := network.RoundTripperFunc(fakeRT.RT)
 
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-			defer cancel()
+			waitInformers := func() {}
+			defer func() {
+				cancel()
+				waitInformers()
+			}()
 
 			endpointsInformer := fakeendpointsinformer.Get(ctx)
 			serviceInformer := fakeserviceinformer.Get(ctx)
@@ -651,7 +655,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 				serviceInformer.Informer().GetIndexer().Add(svc)
 			}
 
-			controller.StartInformers(ctx.Done(), endpointsInformer.Informer())
+			waitInformers, err := controller.RunInformers(ctx.Done(), endpointsInformer.Informer())
+			if err != nil {
+				t.Fatalf("Failed to start informers: %v", err)
+			}
 
 			rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, rt, 50*time.Millisecond)
 
@@ -885,9 +892,10 @@ func TestCheckDestsSwinging(t *testing.T) {
 
 func TestRevisionDeleted(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	waitInformers := func() {}
 	defer func() {
 		cancel()
-		time.Sleep(informerRestPeriod)
+		waitInformers()
 	}()
 
 	svc := privateSKSService(
@@ -902,7 +910,10 @@ func TestRevisionDeleted(t *testing.T) {
 	ei := fakeendpointsinformer.Get(ctx)
 	ep := ep(testRevision, 1234, "http", "128.0.0.1")
 	fakekubeclient.Get(ctx).CoreV1().Endpoints(testNamespace).Create(ep)
-	controller.StartInformers(ctx.Done(), ei.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), ei.Informer())
+	if err != nil {
+		t.Fatalf("Failed to start informers: %v", err)
+	}
 
 	rev := revision(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -633,15 +633,9 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			rt := network.RoundTripperFunc(fakeRT.RT)
 
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-			waitInformers := func() {}
-			defer func() {
-				cancel()
-				waitInformers()
-			}()
 
 			endpointsInformer := fakeendpointsinformer.Get(ctx)
 			serviceInformer := fakeserviceinformer.Get(ctx)
-
 			revisions := fakerevisioninformer.Get(ctx)
 
 			// Add the revision we're testing.
@@ -659,6 +653,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
+			defer func() {
+				cancel()
+				waitInformers()
+			}()
 
 			rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, rt, 50*time.Millisecond)
 
@@ -892,11 +890,6 @@ func TestCheckDestsSwinging(t *testing.T) {
 
 func TestRevisionDeleted(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-	waitInformers := func() {}
-	defer func() {
-		cancel()
-		waitInformers()
-	}()
 
 	svc := privateSKSService(
 		types.NamespacedName{testNamespace, testRevision},
@@ -914,6 +907,10 @@ func TestRevisionDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to start informers: %v", err)
 	}
+	defer func() {
+		cancel()
+		waitInformers()
+	}()
 
 	rev := revision(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -211,11 +211,6 @@ func TestThrottlerWithError(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-			waitInformers := func() {}
-			defer func() {
-				cancel()
-				waitInformers()
-			}()
 			updateCh := make(chan revisionDestsUpdate, 2)
 
 			params := queue.BreakerParams{
@@ -225,13 +220,16 @@ func TestThrottlerWithError(t *testing.T) {
 			}
 
 			endpoints := fakeendpointsinformer.Get(ctx)
-
 			servfake := fakeservingclient.Get(ctx)
 			revisions := fakerevisioninformer.Get(ctx)
 			waitInformers, err := controller.RunInformers(ctx.Done(), endpoints.Informer(), revisions.Informer())
 			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
+			defer func() {
+				cancel()
+				waitInformers()
+			}()
 
 			// Add the revision we're testing
 			servfake.ServingV1alpha1().Revisions(tc.revision.Namespace).Create(tc.revision)
@@ -334,11 +332,6 @@ func TestThrottlerSuccesses(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-			waitInformers := func() {}
-			defer func() {
-				cancel()
-				waitInformers()
-			}()
 			updateCh := make(chan revisionDestsUpdate, 2)
 
 			params := queue.BreakerParams{
@@ -355,6 +348,10 @@ func TestThrottlerSuccesses(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
+			defer func() {
+				cancel()
+				waitInformers()
+			}()
 
 			// Add the revision were testing
 			servfake.ServingV1alpha1().Revisions(tc.revision.Namespace).Create(tc.revision)
@@ -397,11 +394,6 @@ func TestThrottlerSuccesses(t *testing.T) {
 
 func TestMultipleActivators(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-	waitInformers := func() {}
-	defer func() {
-		cancel()
-		waitInformers()
-	}()
 
 	fake := fakekubeclient.Get(ctx)
 	endpoints := fakeendpointsinformer.Get(ctx)
@@ -412,6 +404,10 @@ func TestMultipleActivators(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to start informers: %v", err)
 	}
+	defer func() {
+		cancel()
+		waitInformers()
+	}()
 
 	rev := revision(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
 	// Add the revision were testing

--- a/pkg/reconciler/accessor/core/secret_test.go
+++ b/pkg/reconciler/accessor/core/secret_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/sync/errgroup"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,12 +101,10 @@ func (f *FakeAccessor) GetSecretLister() corev1listers.SecretLister {
 
 func TestReconcileSecretCreate(t *testing.T) {
 	ctx, cancel, _ := SetupFakeContextWithCancel(t)
-	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
+		waitInformers()
 	}()
 
 	kubeClient := fakekubeclient.Get(ctx)
@@ -122,7 +119,7 @@ func TestReconcileSecretCreate(t *testing.T) {
 		return HookComplete
 	})
 
-	accessor := setup(ctx, []*corev1.Secret{}, kubeClient, t)
+	accessor, waitInformers := setup(ctx, []*corev1.Secret{}, kubeClient, t)
 	ReconcileSecret(ctx, ownerObj, desired, accessor)
 
 	if err := h.WaitForHooks(3 * time.Second); err != nil {
@@ -132,16 +129,14 @@ func TestReconcileSecretCreate(t *testing.T) {
 
 func TestReconcileSecretUpdate(t *testing.T) {
 	ctx, cancel, _ := SetupFakeContextWithCancel(t)
-	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
+		waitInformers()
 	}()
 
 	kubeClient := fakekubeclient.Get(ctx)
-	accessor := setup(ctx, []*corev1.Secret{origin}, kubeClient, t)
+	accessor, waitInformers := setup(ctx, []*corev1.Secret{origin}, kubeClient, t)
 
 	h := NewHooks()
 	h.OnUpdate(&kubeClient.Fake, "secrets", func(obj runtime.Object) HookResult {
@@ -161,16 +156,14 @@ func TestReconcileSecretUpdate(t *testing.T) {
 
 func TestNotOwnedFailure(t *testing.T) {
 	ctx, cancel, _ := SetupFakeContextWithCancel(t)
-	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
+		waitInformers()
 	}()
 
 	kubeClient := fakekubeclient.Get(ctx)
-	accessor := setup(ctx, []*corev1.Secret{notOwnedSecret}, kubeClient, t)
+	accessor, waitInformers := setup(ctx, []*corev1.Secret{notOwnedSecret}, kubeClient, t)
 
 	_, err := ReconcileSecret(ctx, ownerObj, desired, accessor)
 	if err == nil {
@@ -182,7 +175,7 @@ func TestNotOwnedFailure(t *testing.T) {
 }
 
 func setup(ctx context.Context, secrets []*corev1.Secret,
-	kubeClient kubernetes.Interface, t *testing.T) *FakeAccessor {
+	kubeClient kubernetes.Interface, t *testing.T) (*FakeAccessor, func()) {
 
 	secretInformer := fakesecretinformer.Get(ctx)
 
@@ -192,12 +185,13 @@ func setup(ctx context.Context, secrets []*corev1.Secret,
 		secretInformer.Informer().GetIndexer().Add(secret)
 	}
 
-	if err := controller.StartInformers(ctx.Done(), secretInformer.Informer()); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), secretInformer.Informer())
+	if err != nil {
 		t.Fatalf("failed to start secret informer: %v", err)
 	}
 
 	return &FakeAccessor{
 		client:       kubeClient,
 		secretLister: secretInformer.Lister(),
-	}
+	}, waitInformers
 }

--- a/pkg/reconciler/accessor/istio/virtualservice_test.go
+++ b/pkg/reconciler/accessor/istio/virtualservice_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -93,12 +92,10 @@ func (f *FakeAccessor) GetVirtualServiceLister() istiolisters.VirtualServiceList
 func TestReconcileVirtualService_Create(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
-	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
+		waitInformers()
 	}()
 
 	sharedClient := fakesharedclient.Get(ctx)
@@ -113,7 +110,7 @@ func TestReconcileVirtualService_Create(t *testing.T) {
 		return HookComplete
 	})
 
-	accessor := setup(ctx, []*v1alpha3.VirtualService{}, sharedClient, t)
+	accessor, waitInformers := setup(ctx, []*v1alpha3.VirtualService{}, sharedClient, t)
 	ReconcileVirtualService(ctx, ownerObj, desired, accessor)
 
 	if err := h.WaitForHooks(3 * time.Second); err != nil {
@@ -124,16 +121,14 @@ func TestReconcileVirtualService_Create(t *testing.T) {
 func TestReconcileVirtualService_Update(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
-	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
+		waitInformers()
 	}()
 
 	sharedClient := fakesharedclient.Get(ctx)
-	accessor := setup(ctx, []*v1alpha3.VirtualService{origin}, sharedClient, t)
+	accessor, waitInformers := setup(ctx, []*v1alpha3.VirtualService{origin}, sharedClient, t)
 
 	h := NewHooks()
 	h.OnUpdate(&sharedClient.Fake, "virtualservices", func(obj runtime.Object) HookResult {
@@ -152,7 +147,7 @@ func TestReconcileVirtualService_Update(t *testing.T) {
 }
 
 func setup(ctx context.Context, vses []*v1alpha3.VirtualService,
-	sharedClient sharedclientset.Interface, t *testing.T) *FakeAccessor {
+	sharedClient sharedclientset.Interface, t *testing.T) (*FakeAccessor, func()) {
 
 	fake := sharedfake.NewSimpleClientset()
 	informer := informers.NewSharedInformerFactory(fake, 0)
@@ -163,12 +158,13 @@ func setup(ctx context.Context, vses []*v1alpha3.VirtualService,
 		vsInformer.Informer().GetIndexer().Add(vs)
 	}
 
-	if err := controller.StartInformers(ctx.Done(), vsInformer.Informer()); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), vsInformer.Informer())
+	if err != nil {
 		t.Fatalf("failed to start virtualservice informer: %v", err)
 	}
 
 	return &FakeAccessor{
 		client:   sharedClient,
 		vsLister: vsInformer.Lister(),
-	}
+	}, waitInformers
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1174,7 +1174,10 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	})
 
 	grp := errgroup.Group{}
-	waitInformers := func() {}
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		t.Fatalf("failed to start informers: %v", err)
+	}
 	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
@@ -1183,10 +1186,6 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 		waitInformers()
 	}()
 
-	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
-	if err != nil {
-		t.Fatalf("failed to start informers: %v", err)
-	}
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("failed to start configmap watcher: %v", err)
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -278,20 +278,20 @@ func TestReconcile(t *testing.T) {
 	// two constant objects above, which means, that all tests must share
 	// the same namespace and revision name.
 	table := TableTest{{
-		Name:                    "bad workqueue key, Part I",
-		Key:                     "too/many/parts",
+		Name: "bad workqueue key, Part I",
+		Key:  "too/many/parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "bad workqueue key, Part II",
-		Key:                     "too-few-parts",
+		Name: "bad workqueue key, Part II",
+		Key:  "too-few-parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
+		Name: "key not found",
+		Key:  "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
+		Name: "key not found",
+		Key:  "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "steady state",
@@ -1174,14 +1174,17 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	})
 
 	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Errorf("Wait() = %v", err)
 		}
+		waitInformers()
 	}()
 
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
 		t.Fatalf("failed to start informers: %v", err)
 	}
 	if err := watcher.Start(ctx.Done()); err != nil {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1038,14 +1038,6 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 	ctx, cancel, informers, ctrl, watcher := newTestSetup(t)
 
 	grp := errgroup.Group{}
-	waitInformers := func() {}
-	defer func() {
-		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
-		waitInformers()
-	}()
 
 	servingClient := fakeservingclient.Get(ctx)
 
@@ -1074,6 +1066,14 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to start informers: %v", err)
 	}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Errorf("Wait() = %v", err)
+		}
+		waitInformers()
+	}()
+
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("failed to start ingress manager: %v", err)
 	}
@@ -1131,14 +1131,6 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	ctx, cancel, informers, ctrl, watcher := newTestSetup(t)
 
 	grp := errgroup.Group{}
-	waitInformers := func() {}
-	defer func() {
-		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Errorf("Wait() = %v", err)
-		}
-		waitInformers()
-	}()
 
 	sharedClient := fakesharedclient.Get(ctx)
 
@@ -1164,6 +1156,14 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to start ingress manager: %v", err)
 	}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Errorf("Wait() = %v", err)
+		}
+		waitInformers()
+	}()
+
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("Failed to start watcher: %v", err)
 	}

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -166,22 +166,22 @@ var (
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
-		Name:                    "bad workqueue key",
-		Key:                     "too/many/parts",
+		Name: "bad workqueue key",
+		Key:  "too/many/parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
+		Name: "key not found",
+		Key:  "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
-		Name:                    "skip ingress not matching class key",
+		Name: "skip ingress not matching class key",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			addAnnotations(ingress("no-virtualservice-yet", 1234),
 				map[string]string{networking.IngressClassAnnotationKey: "fake-controller"}),
 		},
 	}, {
-		Name:                    "create VirtualService matching Ingress",
+		Name: "create VirtualService matching Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingress("no-virtualservice-yet", 1234),
@@ -234,7 +234,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "test-ns/no-virtualservice-yet",
 	}, {
-		Name:                    "observed generation is updated when error is encountered in reconciling, and ingress ready status is unknown",
+		Name: "observed generation is updated when error is encountered in reconciling, and ingress ready status is unknown",
 		SkipNamespaceValidation: true,
 		WantErr:                 true,
 		WithReactors: []clientgotesting.ReactionFunc{
@@ -305,7 +305,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "test-ns/reconcile-failed",
 	}, {
-		Name:                    "reconcile VirtualService to match desired one",
+		Name: "reconcile VirtualService to match desired one",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingress("reconcile-virtualservice", 1234),
@@ -416,7 +416,7 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcile_EnableAutoTLS(t *testing.T) {
 	table := TableTest{{
-		Name:                    "update Gateway to match newly created Ingress",
+		Name: "update Gateway to match newly created Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLS),
@@ -484,7 +484,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name:                    "No preinstalled Gateways",
+		Name: "No preinstalled Gateways",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLS),
@@ -532,7 +532,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantErr: true,
 		Key:     "test-ns/reconciling-ingress",
 	}, {
-		Name:                    "delete Ingress",
+		Name: "delete Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithFinalizers("reconciling-ingress", 1234, ingressTLS, []string{ingressFinalizer}),
@@ -553,7 +553,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name:                    "TLS Secret is not in the namespace of Istio gateway service",
+		Name: "TLS Secret is not in the namespace of Istio gateway service",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLSWithSecretNamespace("knative-serving")),
@@ -630,7 +630,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name:                    "Reconcile Target secret",
+		Name: "Reconcile Target secret",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLSWithSecretNamespace("knative-serving")),
@@ -731,7 +731,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name:                    "Reconcile with autoTLS but cluster local visibilty, mesh only",
+		Name: "Reconcile with autoTLS but cluster local visibilty, mesh only",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLSClusterLocal("reconciling-ingress", 1234, ingressTLS),
@@ -1038,11 +1038,13 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 	ctx, cancel, informers, ctrl, watcher := newTestSetup(t)
 
 	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Errorf("Wait() = %v", err)
 		}
+		waitInformers()
 	}()
 
 	servingClient := fakeservingclient.Get(ctx)
@@ -1068,8 +1070,9 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 		return HookComplete
 	})
 
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
-		t.Fatalf("failed to start ingress manager: %v", err)
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		t.Fatalf("Failed to start informers: %v", err)
 	}
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("failed to start ingress manager: %v", err)
@@ -1128,11 +1131,13 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	ctx, cancel, informers, ctrl, watcher := newTestSetup(t)
 
 	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Errorf("Wait() = %v", err)
 		}
+		waitInformers()
 	}()
 
 	sharedClient := fakesharedclient.Get(ctx)
@@ -1155,7 +1160,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 		return HookComplete
 	})
 
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
 		t.Fatalf("Failed to start ingress manager: %v", err)
 	}
 	if err := watcher.Start(ctx.Done()); err != nil {

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -216,14 +216,6 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	}
 
 	eg := errgroup.Group{}
-	waitInformers := func() {}
-	defer func() {
-		cancel()
-		if err := eg.Wait(); err != nil {
-			t.Fatalf("Error running controller: %v", err)
-		}
-		waitInformers()
-	}()
 
 	rev := testRevision()
 	servingClient := fakeservingclient.Get(ctx)
@@ -241,6 +233,13 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error starting informers: %v", err)
 	}
+	defer func() {
+		cancel()
+		if err := eg.Wait(); err != nil {
+			t.Fatalf("Error running controller: %v", err)
+		}
+		waitInformers()
+	}()
 
 	eg.Go(func() error {
 		return ctrl.Run(2, ctx.Done())

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -216,11 +216,13 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	}
 
 	eg := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
 			t.Fatalf("Error running controller: %v", err)
 		}
+		waitInformers()
 	}()
 
 	rev := testRevision()
@@ -235,7 +237,8 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 		return HookComplete
 	})
 
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
 		t.Fatalf("Error starting informers: %v", err)
 	}
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -561,11 +561,13 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(ctx)
 			grp := errgroup.Group{}
+			waitInformers := func() {}
 			defer func() {
 				cancel()
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
+				waitInformers()
 			}()
 
 			servingClient := fakeservingclient.Get(ctx)
@@ -577,7 +579,8 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 
 			h.OnUpdate(&servingClient.Fake, "revisions", test.callback(t))
 
-			if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+			waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
 			if err := watcher.Start(ctx.Done()); err != nil {
@@ -714,11 +717,13 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(ctx)
 			grp := errgroup.Group{}
+			waitInformers := func() {}
 			defer func() {
 				cancel()
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
+				waitInformers()
 			}()
 
 			kubeClient := fakekubeclient.Get(ctx)
@@ -735,7 +740,8 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 				return HookComplete
 			})
 
-			if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+			waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
 			if err := watcher.Start(ctx.Done()); err != nil {

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -561,14 +561,6 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(ctx)
 			grp := errgroup.Group{}
-			waitInformers := func() {}
-			defer func() {
-				cancel()
-				if err := grp.Wait(); err != nil {
-					t.Errorf("Wait() = %v", err)
-				}
-				waitInformers()
-			}()
 
 			servingClient := fakeservingclient.Get(ctx)
 
@@ -583,6 +575,14 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
+			defer func() {
+				cancel()
+				if err := grp.Wait(); err != nil {
+					t.Errorf("Wait() = %v", err)
+				}
+				waitInformers()
+			}()
+
 			if err := watcher.Start(ctx.Done()); err != nil {
 				t.Fatalf("Failed to start configuration manager: %v", err)
 			}
@@ -717,14 +717,6 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(ctx)
 			grp := errgroup.Group{}
-			waitInformers := func() {}
-			defer func() {
-				cancel()
-				if err := grp.Wait(); err != nil {
-					t.Errorf("Wait() = %v", err)
-				}
-				waitInformers()
-			}()
 
 			kubeClient := fakekubeclient.Get(ctx)
 
@@ -744,6 +736,14 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
+			defer func() {
+				cancel()
+				if err := grp.Wait(); err != nil {
+					t.Errorf("Wait() = %v", err)
+				}
+				waitInformers()
+			}()
+
 			if err := watcher.Start(ctx.Done()); err != nil {
 				t.Fatalf("Failed to start configuration manager: %v", err)
 			}

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -93,7 +93,11 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	})
 
 	eg := errgroup.Group{}
-	waitInformers := func() {}
+
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		t.Fatalf("Failed to start informers: %v", err)
+	}
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
@@ -101,11 +105,6 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 		}
 		waitInformers()
 	}()
-
-	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
-	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
-	}
 
 	// Run the controller.
 	eg.Go(func() error {

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -93,14 +93,17 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	})
 
 	eg := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
 			t.Fatalf("Error running controller: %v", err)
 		}
+		waitInformers()
 	}()
 
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
 		t.Fatalf("Failed to start informers: %v", err)
 	}
 

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -951,14 +951,6 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			ctx, informers, ctrl, _, watcher, cf := newTestSetup(t)
 
 			grp := errgroup.Group{}
-			waitInformers := func() {}
-			defer func() {
-				cf()
-				if err := grp.Wait(); err != nil {
-					t.Errorf("Wait() = %v", err)
-				}
-				waitInformers()
-			}()
 
 			servingClient := fakeservingclient.Get(ctx)
 			h := NewHooks()
@@ -981,6 +973,13 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
+			defer func() {
+				cf()
+				if err := grp.Wait(); err != nil {
+					t.Errorf("Wait() = %v", err)
+				}
+				waitInformers()
+			}()
 
 			if err := watcher.Start(ctx.Done()); err != nil {
 				t.Fatalf("failed to start configuration manager: %v", err)

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -269,7 +269,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	expectedLabels := map[string]string{
 		serving.RouteLabelKey:          route.Name,
 		serving.RouteNamespaceLabelKey: route.Namespace,
-		"route":                        "test-route",
+		"route": "test-route",
 	}
 	if diff := cmp.Diff(expectedLabels, ci.Labels); diff != "" {
 		t.Errorf("Unexpected label diff (-want +got): %v", diff)
@@ -951,11 +951,13 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			ctx, informers, ctrl, _, watcher, cf := newTestSetup(t)
 
 			grp := errgroup.Group{}
+			waitInformers := func() {}
 			defer func() {
 				cf()
 				if err := grp.Wait(); err != nil {
 					t.Errorf("Wait() = %v", err)
 				}
+				waitInformers()
 			}()
 
 			servingClient := fakeservingclient.Get(ctx)
@@ -975,7 +977,8 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 				return HookComplete
 			})
 
-			if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+			waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+			if err != nil {
 				t.Fatalf("Failed to start informers: %v", err)
 			}
 

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -52,11 +52,13 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	ctrl := NewController(ctx, configmap.NewStaticWatcher())
 
 	grp := errgroup.Group{}
+	waitInformers := func() {}
 	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Fatalf("Error waiting for contoller to terminate: %v", err)
 		}
+		waitInformers()
 	}()
 
 	kubeClnt := fakekubeclient.Get(ctx)
@@ -78,7 +80,8 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 		t.Fatalf("Error creating private endpoints: %v", err)
 	}
 
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
 		t.Fatalf("Error starting informers: %v", err)
 	}
 

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -52,14 +52,6 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	ctrl := NewController(ctx, configmap.NewStaticWatcher())
 
 	grp := errgroup.Group{}
-	waitInformers := func() {}
-	defer func() {
-		cancel()
-		if err := grp.Wait(); err != nil {
-			t.Fatalf("Error waiting for contoller to terminate: %v", err)
-		}
-		waitInformers()
-	}()
 
 	kubeClnt := fakekubeclient.Get(ctx)
 
@@ -84,6 +76,13 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error starting informers: %v", err)
 	}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Fatalf("Error waiting for contoller to terminate: %v", err)
+		}
+		waitInformers()
+	}()
 
 	grp.Go(func() error {
 		return ctrl.Run(1, ctx.Done())


### PR DESCRIPTION
Use RunInformers instead of StartInformers to address flakiness of
TestGlobalResyncOnUpdateDomainConfigMap due to race condition.

Fixes #5351

This PR depends on knative/pkg#758

/hold
/lint

This PR is RFC and if review goes well can be followed up by another switching all serving tests to use `RunInformers` instead of `StartInformers`.