### PR TITLE
set default readiness timeoutSeconds and failureThreshold

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -93,6 +93,12 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 		if rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold == 0 {
 			rs.PodSpec.Containers[idx].ReadinessProbe.SuccessThreshold = 1
 		}
+		if rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds == 0 {
+			rs.PodSpec.Containers[idx].ReadinessProbe.TimeoutSeconds = 1
+		}
+		if rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold == 0 {
+			rs.PodSpec.Containers[idx].ReadinessProbe.FailureThreshold = 3
+		}
 
 		vms := rs.PodSpec.Containers[idx].VolumeMounts
 		for i := range vms {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5732

## Proposed Changes

* Set default value of readiness timeoutSeconds to 1, same as the kubernetes default value https://github.com/knative/serving/blob/75f0f8775f99357d6a3d23bf478cc87c4d577987/vendor/k8s.io/api/core/v1/types.go#L2018-L2022
* Set default value of readiness failureThreshold to 3, same as the kubernetes default value https://github.com/knative/serving/blob/75f0f8775f99357d6a3d23bf478cc87c4d577987/vendor/k8s.io/api/core/v1/types.go#L2031-L2034
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set default readiness timeoutSeconds and failureThreshold.
```
