### PR TITLE
Add e2e test to destroy activator pod in flight

### DIFF
--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -285,6 +285,19 @@ func WithConfigAnnotations(annotations map[string]string) ServiceOption {
 	}
 }
 
+// WithConfigLabels assigns config labels to a service
+func WithConfigLabels(labels map[string]string) ServiceOption {
+	return func(service *v1alpha1.Service) {
+		if service.Spec.DeprecatedRunLatest != nil {
+			service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta.Labels = resources.UnionMaps(
+				service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta.Labels, labels)
+		} else {
+			service.Spec.ConfigurationSpec.Template.ObjectMeta.Labels = resources.UnionMaps(
+				service.Spec.ConfigurationSpec.Template.ObjectMeta.Labels, labels)
+		}
+	}
+}
+
 // WithRevisionTimeoutSeconds sets revision timeout
 func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 	return func(service *v1alpha1.Service) {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -55,9 +55,7 @@ var testToDestroy = []struct {
 	name   string
 	rmFunc func(*test.Clients) error
 }{
-	// Destroy pod which is receiving the requests.
 	{"pod", killRevisionPods},
-	// Destroy activator pods.
 	{"activator", killActivatorPods},
 }
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -73,12 +73,12 @@ func killActivatorPods(clients *test.Clients) error {
 
 func TestDestroyPodInflight(t *testing.T) {
 	// Not running in parallel as this test delete activator pods
-	cancel := logstream.Start(t)
-	defer cancel()
 	clients := Setup(t)
 
 	for _, tc := range testToDestroy {
 		t.Run(tc.name, func(t *testing.T) {
+			cancel := logstream.Start(t)
+			defer cancel()
 			testDestroyPodInflight(t, clients, tc.rmFunc)
 		})
 	}
@@ -222,12 +222,12 @@ func TestDestroyPodTimely(t *testing.T) {
 
 func TestDestroyPodWithRequests(t *testing.T) {
 	// Not running in parallel as this test delete activator pods
-	cancel := logstream.Start(t)
-	defer cancel()
 	clients := Setup(t)
 
 	for _, tc := range testToDestroy {
 		t.Run(tc.name, func(t *testing.T) {
+			cancel := logstream.Start(t)
+			defer cancel()
 			testDestroyPodWithRequests(t, clients, tc.rmFunc)
 		})
 	}


### PR DESCRIPTION
## Proposed Changes

This patch adds test case, which is destroy activator pods, to
`TestDestroyPodWithRequests` and `TestDestroyPodInflight`.

/lint

Fixes https://github.com/knative/serving/issues/5806

**Release Note**

```release-note
NONE
```
