### PR TITLE
Run Istio tests having mutations after scale tests.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -54,6 +54,11 @@ go_test_e2e -timeout=30m \
   ${parallelism} \
   "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 
+# Run scale tests.
+go_test_e2e -timeout=10m \
+  ${parallelism} \
+  ./test/scale || failed=1
+
 # Istio E2E tests mutate the cluster and must be ran separately
 # TODO(https://github.com/knative/test-infra/issues/1398): use proper flags instead of binary GLOO/no GLOO
 if [[ -z "${GLOO_VERSION}" ]]; then
@@ -61,11 +66,6 @@ if [[ -z "${GLOO_VERSION}" ]]; then
     ./test/e2e/istio \
     "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
-
-# Run scale tests.
-go_test_e2e -timeout=10m \
-  ${parallelism} \
-  ./test/scale || failed=1
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state


### PR DESCRIPTION
This seems to make the scale test less flaky.  We should push for a
fix upstream but in the mean time we do this to reduce flakiness.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Run Istio tests having cluster mutations after scale tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
