### PR TITLE
Use an SLO approach in TestAutoscalingSustaining

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -122,7 +122,7 @@ func generateTraffic(
 			ctx.t.Log("Stopping generateTraffic")
 			successRate := float64(1)
 			if totalRequests > 0 {
-				successRate := float64(successfulRequests) / float64(totalRequests)
+				successRate = float64(successfulRequests) / float64(totalRequests)
 			}
 			if successRate < successRateSLO {
 				return fmt.Errorf("request success rate under SLO: total = %d, errors = %d, rate = %f, SLO = %f",

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -120,7 +120,10 @@ func generateTraffic(
 		select {
 		case <-stopChan:
 			ctx.t.Log("Stopping generateTraffic")
-			successRate := float32(successfulRequests)/float32(totalRequests)
+			successRate := float64(1)
+			if totalRequests > 0 {
+				successRate := float64(successfulRequests) / float64(totalRequests)
+			}
 			if successRate < successRateSLO {
 				return fmt.Errorf("request success rate under SLO: total = %d, errors = %d, rate = %f, SLO = %f",
 					totalRequests, totalRequests-successfulRequests, successRate, successRateSLO)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -55,6 +55,7 @@ const (
 	// but not high enough to generate scheduling problems.
 	containerConcurrency = 6.0
 	targetUtilization    = 0.7
+	successRateSLO       = 0.999
 )
 
 type testContext struct {
@@ -119,9 +120,10 @@ func generateTraffic(
 		select {
 		case <-stopChan:
 			ctx.t.Log("Stopping generateTraffic")
-			if successfulRequests != totalRequests {
-				return fmt.Errorf("error making requests for scale up: total = %d, errors = %d, expected 0",
-					totalRequests, totalRequests-successfulRequests)
+			successRate := float32(successfulRequests)/float32(totalRequests)
+			if successRate < successRateSLO {
+				return fmt.Errorf("request success rate under SLO: total = %d, errors = %d, rate = %f, SLO = %f",
+					totalRequests, totalRequests-successfulRequests, successRate, successRateSLO)
 			}
 			return nil
 		case res, ok := <-results:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign @tcnghia 
/lint
-->

TestAutoscalingSustaining is flaky because it executes requests in parallel (60 goroutines) as fast as possible and fails if a single requests is not successful. This seems too aggressive in mesh scenario.

From what I have seen, around 0.02% of the requests occasionally fail leading to flakyness. This introduces a SLO (0.999) based approach that we also use in other tests.
