### PR TITLE
Revert "Add e2e test to destroy activator pod in flight (#5807)"

### DIFF
--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -285,19 +285,6 @@ func WithConfigAnnotations(annotations map[string]string) ServiceOption {
 	}
 }
 
-// WithConfigLabels assigns config labels to a service
-func WithConfigLabels(labels map[string]string) ServiceOption {
-	return func(service *v1alpha1.Service) {
-		if service.Spec.DeprecatedRunLatest != nil {
-			service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta.Labels = resources.UnionMaps(
-				service.Spec.DeprecatedRunLatest.Configuration.GetTemplate().ObjectMeta.Labels, labels)
-		} else {
-			service.Spec.ConfigurationSpec.Template.ObjectMeta.Labels = resources.UnionMaps(
-				service.Spec.ConfigurationSpec.Template.ObjectMeta.Labels, labels)
-		}
-	}
-}
-
 // WithRevisionTimeoutSeconds sets revision timeout
 func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 	return func(service *v1alpha1.Service) {


### PR DESCRIPTION
This reverts commit 1d263950f9f2fea85a4dd394948a029c328af9d9.

We observes flakiness in other tests.  Reverting to confirm that this test causes such flakiness.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Revert commit 1d263950f9f2fea85a4dd394948a029c328af9d9.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
