### PR TITLE
Prefer Pod IPs to ClusterIPs when possible

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -270,8 +270,8 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 		return
 	}
 
+	// If cluster IP is healthy and we haven't scaled down, short circuit.
 	if rw.clusterIPHealthy {
-		// If cluster IP is healthy and we haven't scaled down, short circuit.
 		rw.logger.Debugf("ClusterIP %s already probed (backends: %d)", dest, len(dests))
 		rw.sendUpdate(dest, dests)
 		return
@@ -301,7 +301,7 @@ func (rw *revisionWatcher) run(probeFrequency time.Duration) {
 	var tickCh <-chan time.Time
 	for {
 		// If we have at least one pod and either there are pods that have not been
-		// successfuly probed or clusterIP has not been probed (no pod adressability),
+		// successfuly probed or clusterIP has not been probed (no pod addressability),
 		// then we want to probe on timer.
 		rw.logger.Debugf("Dests: %+v, healthy dests: %+v, clusterIP: %v", dests, rw.healthyPods, rw.clusterIPHealthy)
 		if len(dests) > 0 && !(rw.clusterIPHealthy || dests.Equal(rw.healthyPods)) {

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -105,7 +105,7 @@ func TestRevisionWatcher(t *testing.T) {
 		probeHostResponses    map[string][]activatortest.FakeResponse
 		probeResponses        []activatortest.FakeResponse
 		initialClusterIPState bool
-		noPodAddressability   bool
+		noPodAddressability   bool // This keeps the test defs shorter.
 	}{{
 		name:  "single healthy podIP",
 		dests: []string{"128.0.0.1:1234"},
@@ -389,7 +389,7 @@ func TestRevisionWatcher(t *testing.T) {
 					t.Error("Timed out waiting for update event")
 				}
 			}
-			if got, want := rw.noPodAddressability, tc.noPodAddressability; got != want {
+			if got, want := rw.podsAddressable, !tc.noPodAddressability; got != want {
 				t.Errorf("Revision pod addressability = %v, want: %v", got, want)
 			}
 
@@ -708,13 +708,13 @@ func TestCheckDests(t *testing.T) {
 	uCh := make(chan revisionDestsUpdate, 1)
 	dCh := make(chan struct{})
 	rw := &revisionWatcher{
-		clusterIPHealthy:    true,
-		noPodAddressability: true,
-		rev:                 types.NamespacedName{testNamespace, testRevision},
-		updateCh:            uCh,
-		serviceLister:       si.Lister(),
-		logger:              TestLogger(t),
-		doneCh:              dCh,
+		clusterIPHealthy: true,
+		podsAddressable:  false,
+		rev:              types.NamespacedName{testNamespace, testRevision},
+		updateCh:         uCh,
+		serviceLister:    si.Lister(),
+		logger:           TestLogger(t),
+		doneCh:           dCh,
 	}
 	rw.checkDests(sets.NewString("10.1.1.5"))
 	select {
@@ -791,12 +791,13 @@ func TestCheckDestsSwinging(t *testing.T) {
 	uCh := make(chan revisionDestsUpdate, 1)
 	dCh := make(chan struct{})
 	rw := &revisionWatcher{
-		rev:           types.NamespacedName{testNamespace, testRevision},
-		updateCh:      uCh,
-		serviceLister: si.Lister(),
-		logger:        TestLogger(t),
-		doneCh:        dCh,
-		transport:     network.RoundTripperFunc(fakeRT.RT),
+		rev:             types.NamespacedName{testNamespace, testRevision},
+		updateCh:        uCh,
+		serviceLister:   si.Lister(),
+		logger:          TestLogger(t),
+		doneCh:          dCh,
+		podsAddressable: true,
+		transport:       network.RoundTripperFunc(fakeRT.RT),
 	}
 	// First not ready, second good, clusterIP: not ready.
 	rw.checkDests(sets.NewString("10.0.0.1:1234", "10.0.0.2:1234"))


### PR DESCRIPTION
This change switches the priority to PodIPs vs ClusterIP since we are able to do much better load balancing in Throttler than random sending.

If we cannot, e.g. mesh is enabled and prohibits us communicating with the individual pods we continue to use clusterIP as before.

/lint

/assign @markusthoemmes 