### PR TITLE
Add container and pod labels to revision and activator metrics

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -176,7 +176,7 @@ func main() {
 		logger.Fatalw("Timed out attempting to get k8s version", zap.Error(err))
 	}
 
-	reporter, err := activator.NewStatsReporter()
+	reporter, err := activator.NewStatsReporter(env.PodName)
 	if err != nil {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -581,7 +581,7 @@ func pushRequestLogHandler(currentHandler http.Handler, env config) http.Handler
 
 func pushRequestMetricHandler(currentHandler http.Handler, countMetric *stats.Int64Measure,
 	latencyMetric *stats.Float64Measure, queueDepthMetric *stats.Int64Measure, breaker *queue.Breaker, env config) http.Handler {
-	r, err := queuestats.NewStatsReporter(env.ServingNamespace, env.ServingService, env.ServingConfiguration, env.ServingRevision, countMetric, latencyMetric, queueDepthMetric)
+	r, err := queuestats.NewStatsReporter(env.ServingNamespace, env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, countMetric, latencyMetric, queueDepthMetric)
 	if err != nil {
 		logger.Errorw("Error setting up request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -101,8 +101,10 @@ spec:
             value: config-logging
           - name: CONFIG_OBSERVABILITY_NAME
             value: config-observability
+          # Currently used for Stackdriver only.
+          # knative.dev/internal/serving is the one for activator metrics.
           - name: METRICS_DOMAIN
-            value: knative.dev/serving
+            value: knative.dev/internal/serving
         securityContext:
           allowPrivilegeEscalation: false
 ---

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -101,8 +101,7 @@ spec:
             value: config-logging
           - name: CONFIG_OBSERVABILITY_NAME
             value: config-observability
-          # Currently used for Stackdriver only.
-          # knative.dev/internal/serving is the one for activator metrics.
+          # Used for Stackdriver only.
           - name: METRICS_DOMAIN
             value: knative.dev/internal/serving
         securityContext:

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -92,8 +92,7 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
-        # Currently used for Stackdriver only.
-        # knative.dev/serving is the one for autoscaler metrics.
+        # Used for Stackdriver only.
         - name: METRICS_DOMAIN
           value: knative.dev/serving
         securityContext:

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -92,6 +92,8 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        # Currently used for Stackdriver only.
+        # knative.dev/serving is the one for autoscaler metrics.
         - name: METRICS_DOMAIN
           value: knative.dev/serving
         securityContext:

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -110,6 +110,3 @@ data:
     # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
     # The HTTP context root for profiling is then /debug/pprof/.
     profiling.enable: "false"
-  metrics.request-metrics-backend-destination: stackdriver
-  metrics.backend-destination: stackdriver
-  metrics.allow-stackdriver-custom-metrics: "false"

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -110,3 +110,6 @@ data:
     # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
     # The HTTP context root for profiling is then /debug/pprof/.
     profiling.enable: "false"
+  metrics.request-metrics-backend-destination: stackdriver
+  metrics.backend-destination: stackdriver
+  metrics.allow-stackdriver-custom-metrics: "false"

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
-        # Currently used for Stackdriver only.
+        # Used for Stackdriver only.
         # knative.dev/internal/serving is the one for revision metrics.
         - name: METRICS_DOMAIN
           value: knative.dev/internal/serving

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -61,7 +61,9 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        # Currently used for Stackdriver only.
+        # knative.dev/internal/serving is the one for revision metrics.
         - name: METRICS_DOMAIN
-          value: knative.dev/serving
+          value: knative.dev/internal/serving
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -41,7 +41,7 @@ func TestActivatorReporter(t *testing.T) {
 	}
 
 	var err error
-	if r, err = NewStatsReporter(); err != nil {
+	if r, err = NewStatsReporter("testpod"); err != nil {
 		t.Fatalf("Failed to create a new reporter: %v", err)
 	}
 	// Without this `go test ... -count=X`, where X > 1, fails, since
@@ -54,6 +54,8 @@ func TestActivatorReporter(t *testing.T) {
 		metricskey.LabelServiceName:       "testsvc",
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+		"pod_name":                        "testpod",
+		"container_name":                  "activator",
 	}
 	expectSuccess(t, func() error {
 		return r.ReportRequestConcurrency("testns", "testsvc", "testconfig", "testrev", 100)
@@ -70,6 +72,8 @@ func TestActivatorReporter(t *testing.T) {
 		metricskey.LabelServiceName:       "testsvc",
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+		"pod_name":                        "testpod",
+		"container_name":                  "activator",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 		"num_tries":                       "6",
@@ -88,6 +92,8 @@ func TestActivatorReporter(t *testing.T) {
 		metricskey.LabelServiceName:       "testsvc",
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+		"pod_name":                        "testpod",
+		"container_name":                  "activator",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 	}
@@ -101,7 +107,7 @@ func TestActivatorReporter(t *testing.T) {
 }
 
 func TestActivatorReporterEmptyServiceName(t *testing.T) {
-	r, err := NewStatsReporter()
+	r, err := NewStatsReporter("testpod")
 	defer unregister()
 
 	if err != nil {
@@ -114,6 +120,8 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+		"pod_name":                        "testpod",
+		"container_name":                  "activator",
 	}
 	expectSuccess(t, func() error {
 		return r.ReportRequestConcurrency("testns", "" /*service=*/, "testconfig", "testrev", 100)
@@ -126,6 +134,8 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+		"pod_name":                        "testpod",
+		"container_name":                  "activator",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 		"num_tries":                       "6",
@@ -141,6 +151,8 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+		"pod_name":                        "testpod",
+		"container_name":                  "activator",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 	}

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -31,6 +31,8 @@ var (
 	ServiceTagKey        = tag.MustNewKey(metricskey.LabelServiceName)
 	ConfigTagKey         = tag.MustNewKey(metricskey.LabelConfigurationName)
 	RevisionTagKey       = tag.MustNewKey(metricskey.LabelRevisionName)
+	PodTagKey            = tag.MustNewKey("pod_name")
+	ContainerTagKey      = tag.MustNewKey("container_name")
 	ResponseCodeKey      = tag.MustNewKey("response_code")
 	ResponseCodeClassKey = tag.MustNewKey("response_code_class")
 	NumTriesKey          = tag.MustNewKey("num_tries")

--- a/pkg/queue/stats/stats_reporter.go
+++ b/pkg/queue/stats/stats_reporter.go
@@ -51,7 +51,7 @@ type Reporter struct {
 }
 
 // NewStatsReporter creates a reporter that collects and reports queue proxy metrics.
-func NewStatsReporter(ns, service, config, rev string, countMetric *stats.Int64Measure,
+func NewStatsReporter(ns, service, config, rev, pod string, countMetric *stats.Int64Measure,
 	latencyMetric *stats.Float64Measure, queueSizeMetric *stats.Int64Measure) (*Reporter, error) {
 	if ns == "" {
 		return nil, errors.New("namespace must not be empty")
@@ -63,7 +63,7 @@ func NewStatsReporter(ns, service, config, rev string, countMetric *stats.Int64M
 		return nil, errors.New("revision must not be empty")
 	}
 
-	keys := append(metrics.CommonRevisionKeys, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey)
+	keys := append(metrics.CommonRevisionKeys, metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey)
 	// Create view to see our measurements.
 	if err := view.Register(
 		&view.View{
@@ -101,6 +101,8 @@ func NewStatsReporter(ns, service, config, rev string, countMetric *stats.Int64M
 		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
 		tag.Insert(metrics.ConfigTagKey, config),
 		tag.Insert(metrics.RevisionTagKey, rev),
+		tag.Insert(metrics.PodTagKey, pod),
+		tag.Insert(metrics.ContainerTagKey, "queue-proxy"),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/queue/stats/stats_reporter_test.go
+++ b/pkg/queue/stats/stats_reporter_test.go
@@ -32,6 +32,7 @@ const (
 	testSvc     = "helloworld-go-service"
 	testConf    = "helloworld-go"
 	testRev     = "helloworld-go-00001"
+	testPod     = "helloworld-go-00001-abcd"
 	countName   = "request_count"
 	qdepthName  = "queue_depth"
 	latencyName = "request_latencies"
@@ -85,7 +86,7 @@ func TestNewStatsReporterNegative(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := NewStatsReporter(test.namespace, testSvc, test.config, test.revision,
+			if _, err := NewStatsReporter(test.namespace, testSvc, test.config, test.revision, testPod,
 				countMetric, latencyMetric, queueSizeMetric); err.Error() != test.result.Error() {
 				t.Errorf("%+v, got: '%+v'", test.errorMsg, err)
 			}
@@ -105,7 +106,7 @@ func TestReporterReport(t *testing.T) {
 		t.Error("Reporter.ReportRequestCount() expected an error for Report call before init. Got success.")
 	}
 
-	r, err := NewStatsReporter(testNs, testSvc, testConf, testRev, countMetric, latencyMetric, queueSizeMetric)
+	r, err := NewStatsReporter(testNs, testSvc, testConf, testRev, testPod, countMetric, latencyMetric, queueSizeMetric)
 	if err != nil {
 		t.Fatalf("Unexpected error from NewStatsReporter() = %v", err)
 	}
@@ -114,6 +115,8 @@ func TestReporterReport(t *testing.T) {
 		metricskey.LabelServiceName:       testSvc,
 		metricskey.LabelConfigurationName: testConf,
 		metricskey.LabelRevisionName:      testRev,
+		"pod_name":                        testPod,
+		"container_name":                  "queue-proxy",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 	}
@@ -143,7 +146,7 @@ func TestReporterReport(t *testing.T) {
 	unregisterViews(r)
 
 	// Test reporter with empty service name
-	r, err = NewStatsReporter(testNs, "" /*service name*/, testConf, testRev, countMetric, latencyMetric, queueSizeMetric)
+	r, err = NewStatsReporter(testNs, "" /*service name*/, testConf, testRev, testPod, countMetric, latencyMetric, queueSizeMetric)
 	if err != nil {
 		t.Fatalf("Unexpected error from NewStatsReporter() = %v", err)
 	}
@@ -152,6 +155,8 @@ func TestReporterReport(t *testing.T) {
 		metricskey.LabelServiceName:       "unknown",
 		metricskey.LabelConfigurationName: testConf,
 		metricskey.LabelRevisionName:      testRev,
+		"pod_name":                        testPod,
+		"container_name":                  "queue-proxy",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5691

## Proposed Changes

* Add container and pod as labels to activator and revision metrics.
* Switch to write to `knative.dev/internal/serving` metrics for activator and revision metrics, which support container and pod labels.

