### PR TITLE
Use sleep 15s less than TERMINATION_DRAIN_DURATION_SECONDS in TestDestroyPodWithRequests

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -253,10 +253,11 @@ func TestDestroyPodWithRequests(t *testing.T) {
 		t.Fatalf("Number of pods is not 1 or an error: %v", err)
 	}
 
-	// The request will sleep for more than 25 seconds.
+	// The request will sleep for more than 15 seconds.
+	// NOTE: it needs to be less than TERMINATION_DRAIN_DURATION_SECONDS.
 	u, _ := url.Parse(routeURL.String())
 	q := u.Query()
-	q.Set("sleep", "25001")
+	q.Set("sleep", "15001")
 	u.RawQuery = q.Encode()
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {


### PR DESCRIPTION
## Proposed Changes

This patch changes to use 15 sec sleep in TestDestroyPodWithRequests.
Since we set `TERMINATION_DRAIN_DURATION_SECONDS` to 20s, it must be
less than that. Otherwise, containers are drained forcefully after 20s.

/lint

Fixes https://github.com/knative/serving/issues/5825

**Release Note**

```release-note
NONE
```
