### PR TITLE
Set timeout of go test longer than timeout in scale.TestScaleToN/scale-100

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -55,7 +55,7 @@ go_test_e2e -timeout=30m \
   "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 
 # Run scale tests.
-go_test_e2e -timeout=10m \
+go_test_e2e -timeout=15m \
   ${parallelism} \
   ./test/scale || failed=1
 

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -55,7 +55,8 @@ func TestScaleToN(t *testing.T) {
 		size:    10,
 		timeout: 60 * time.Second,
 	}, {
-		size:    100,
+		size: 100,
+		// timeout should be shorter than `-timeout` option for go test.
 		timeout: 10 * time.Minute,
 	}}
 


### PR DESCRIPTION
## Proposed Changes

This patch increases timeout for `go test ./test/scale`.

Currently both `go test` command and `scale.TestScaleToN/scale-100`
code have 10 min timeout. So, if `scale.TestScaleToN/scale-100` takes
10min, it fails with `go test` command instead of scale-100's timeout.
Because of it, the test fails with following panic log:

```
  panic: test timed out after 10m0s
```

and we cannot get the error message. To make matters worse, `scale-10` is
also regarded FAIL status.

To fix it, this patch sets go test timeout to 15min which is longer
than `scale.TestScaleToN/scale-100`'s timeout.

/lint

Fixes https://github.com/knative/serving/issues/5833
(it fixes scale-10 not scale-100 https://testgrid.knative.dev/serving#istio-1.3-mesh&include-filter-by-regex=.*test/scale.TestScaleToN )

**Release Note**

```release-note
NONE
```
