### PR TITLE
Receive SIGTERM in main routine and signal to HealthHandler to let readiness probe start failing

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -244,7 +244,7 @@ func main() {
 	sigCtx, sigCancel := context.WithCancel(context.Background())
 
 	// Set up our health check based on the health of stat sink and environmental factors.
-	hc := newHealthCheck(logger, statSink, sigCtx)
+	hc := newHealthCheck(sigCtx, logger, statSink)
 	ah = &activatorhandler.HealthHandler{HealthCheck: hc, NextHandler: ah}
 
 	ah = network.NewProbeHandler(ah)
@@ -306,7 +306,7 @@ func main() {
 	logger.Info("Servers shutdown.")
 }
 
-func newHealthCheck(logger *zap.SugaredLogger, statSink *websocket.ManagedConnection, sigCtx context.Context) func() error {
+func newHealthCheck(sigCtx context.Context, logger *zap.SugaredLogger, statSink *websocket.ManagedConnection) func() error {
 	once := sync.Once{}
 	return func() error {
 		select {


### PR DESCRIPTION
## Proposed Changes

Current activator's shutdown process is:

1. SIGTERM is sent by kubelet.
2. Readiness probe (HealthHandler) catch/find the signal when getting probe HTTP request.
3. The probe starts failing to stop traffic.
4. 30s after step2, server shutdown starts.

However, if HealthHandler did not receive the probe request(step2
above), the shutdown process stops. On Istio mesh env, as activator
stops receiving the probe because sidecar is shutdown earlier, the 
process stuck.

To fix it, this patch changes the shutdown process as below:

1. SIGTERM is sent by kubelet.
2. Activator's main routine catches the signal.
3. The routine sends a signal to HealthHandler to let readiness probe start failing.
4. 30s after step2, server shutdown starts.

/lint

Fixes https://github.com/knative/serving/issues/5542

**Release Note**

```release-note
Fix activator's taking long time for shutdown on mesh env.
```
