### PR TITLE
Common function to process one vegeta attack result

### DIFF
--- a/test/performance/dataplane-probe/main.go
+++ b/test/performance/dataplane-probe/main.go
@@ -91,8 +91,8 @@ func main() {
 	targeter := vegeta.NewStaticTargeter(t.target)
 	attacker := vegeta.NewAttacker(vegeta.Timeout(30 * time.Second))
 
-	// Accumulate the results.
-	ar := &metrics.AggregateResult{}
+	// Create a new aggregateResult to accumulate the results.
+	ar := metrics.NewAggregateResult(int(duration.Seconds()))
 
 	// Start the attack!
 	results := attacker.Attack(targeter, rate, *duration, "load-test")

--- a/test/performance/load-test/main.go
+++ b/test/performance/load-test/main.go
@@ -45,8 +45,8 @@ var (
 )
 
 func processResults(ctx context.Context, q *quickstore.Quickstore, results <-chan *vegeta.Result) {
-	// Accumulate the results.
-	ar := &metrics.AggregateResult{}
+	// Create a new aggregateResult to accumulate the results.
+	ar := metrics.NewAggregateResult(0)
 
 	// When the benchmark completes, iterate over the accumulated rates
 	// and add them as sample points.

--- a/test/performance/metrics/request.go
+++ b/test/performance/metrics/request.go
@@ -23,17 +23,17 @@ import (
 	"knative.dev/pkg/test/mako"
 )
 
-// aggregateResult is the aggregated result of requests for better visualization.
-type aggregateResult struct {
+// AggregateResult is the aggregated result of requests for better visualization.
+type AggregateResult struct {
 	// ErrorRates is a map that saves the number of errors for each timestamp (in secs)
 	ErrorRates map[int64]int64
 	// RequestRates is a map that saves the number of requests for each timestamp (in secs)
 	RequestRates map[int64]int64
 }
 
-// NewAggregateResult returns the pointer of a new aggregateResult object.
-func NewAggregateResult(initialSize int) *aggregateResult {
-	return &aggregateResult{
+// NewAggregateResult returns the pointer of a new AggregateResult object.
+func NewAggregateResult(initialSize int) *AggregateResult {
+	return &AggregateResult{
 		ErrorRates:   make(map[int64]int64, initialSize),
 		RequestRates: make(map[int64]int64, initialSize),
 	}
@@ -42,7 +42,7 @@ func NewAggregateResult(initialSize int) *aggregateResult {
 // HandleResult will handle the attack result by:
 // 1. Adding its latency as a sample point if no error, or adding it as an error if there is
 // 2. Updating the aggregate results
-func HandleResult(q *quickstore.Quickstore, res vegeta.Result, latencyKey string, ar *aggregateResult) {
+func HandleResult(q *quickstore.Quickstore, res vegeta.Result, latencyKey string, ar *AggregateResult) {
 	// Handle the result by reporting an error or a latency sample point.
 	var isAnError int64
 	if res.Error != "" {

--- a/test/performance/metrics/request.go
+++ b/test/performance/metrics/request.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/google/mako/go/quickstore"
+	vegeta "github.com/tsenart/vegeta/lib"
+
+	"knative.dev/pkg/test/mako"
+)
+
+// AggregateResult is the aggregated result of requests for better visualization.
+type AggregateResult struct {
+	// ErrorRates is a map that saves the number of errors for each timestamp (in secs)
+	ErrorRates map[int64]int64
+	// RequestRates is a map that saves the number of requests for each timestamp (in secs)
+	RequestRates map[int64]int64
+}
+
+// HandleResult will handle the attack result by:
+// 1. Adding its latency as a sample point if no error, or adding it as an error if there is
+// 2. Updating the aggregate results
+func HandleResult(q *quickstore.Quickstore, res vegeta.Result, latencyKey string, ar *AggregateResult) {
+	// Handle the result by reporting an error or a latency sample point.
+	var isAnError int64
+	if res.Error != "" {
+		// By reporting errors like this the error strings show up on
+		// the details page for each Mako run.
+		q.AddError(mako.XTime(res.Timestamp), res.Error)
+		isAnError = 1
+	} else {
+		// Add a sample points for the target benchmark's latency stat
+		// with the latency of the request this result is for.
+		q.AddSamplePoint(mako.XTime(res.Timestamp), map[string]float64{
+			latencyKey: res.Latency.Seconds(),
+		})
+		isAnError = 0
+	}
+
+	// Update our error and request rates.
+	// We handle errors this way to force zero values into every time for
+	// which we have data, even if there is no error.
+	ar.ErrorRates[res.Timestamp.Unix()] += isAnError
+	ar.RequestRates[res.Timestamp.Unix()]++
+}

--- a/test/performance/metrics/request.go
+++ b/test/performance/metrics/request.go
@@ -23,18 +23,26 @@ import (
 	"knative.dev/pkg/test/mako"
 )
 
-// AggregateResult is the aggregated result of requests for better visualization.
-type AggregateResult struct {
+// aggregateResult is the aggregated result of requests for better visualization.
+type aggregateResult struct {
 	// ErrorRates is a map that saves the number of errors for each timestamp (in secs)
 	ErrorRates map[int64]int64
 	// RequestRates is a map that saves the number of requests for each timestamp (in secs)
 	RequestRates map[int64]int64
 }
 
+// NewAggregateResult returns the pointer of a new aggregateResult object.
+func NewAggregateResult(initialSize int) *aggregateResult {
+	return &aggregateResult{
+		ErrorRates:   make(map[int64]int64, initialSize),
+		RequestRates: make(map[int64]int64, initialSize),
+	}
+}
+
 // HandleResult will handle the attack result by:
 // 1. Adding its latency as a sample point if no error, or adding it as an error if there is
 // 2. Updating the aggregate results
-func HandleResult(q *quickstore.Quickstore, res vegeta.Result, latencyKey string, ar *AggregateResult) {
+func HandleResult(q *quickstore.Quickstore, res vegeta.Result, latencyKey string, ar *aggregateResult) {
 	// Handle the result by reporting an error or a latency sample point.
 	var isAnError int64
 	if res.Error != "" {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
It seems to be a common pattern for all benchmarks to handle one request result:
1. Add its latency as a sample point
2. Add an error if there is one
3. Collect the error rate and requests rate

So I move the logic to a common function and make it sharable for every benchmark.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
