### PR TITLE
Enable alert for dataplane-probe benchmark

### DIFF
--- a/test/performance/dataplane-probe/main.go
+++ b/test/performance/dataplane-probe/main.go
@@ -143,10 +143,8 @@ LOOP:
 		})
 	}
 
-	// Commit this benchmark run to Mako!
-	out, err := q.Store()
-	if err != nil {
-		fatalf("q.Store error: %v: %v", out, err)
+	// Commit data to Mako and handle the result.
+	if err := mc.StoreAndHandleResult(); err != nil {
+		fatalf("Failed to store and handle benchmarking result: %v", err)
 	}
-	log.Printf("Done! Run: %s\n", out.GetRunChartLink())
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
dataplane-probe benchmark has been running quite stably, we should be able to enable its alert.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 