### PR TITLE
 Only probe gateway endpoints in the same namespace as the gateway itself.

### DIFF
--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -406,7 +406,7 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 		selector = selector.Add(*requirement)
 	}
 
-	services, err := m.serviceLister.List(selector)
+	services, err := m.serviceLister.Services(gateway.Namespace).List(selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list Services: %v", err)
 	}
@@ -416,9 +416,9 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 	}
 	service := services[0]
 
-	endpoints, err := m.endpointsLister.List(selector)
+	endpoints, err := m.endpointsLister.Endpoints(service.Namespace).Get(service.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list Endpoints: %v", err)
+		return nil, fmt.Errorf("failed to get Endpoints: %v", err)
 	}
 
 	targetsPerPods := make(map[string][]probeTarget)
@@ -441,17 +441,15 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 			m.logger.Infof("Skipping Server %q because Service %s/%s doesn't contain a port %d", server.Port.Name, service.Namespace, service.Name, server.Port.Number)
 			continue
 		}
-		for _, eps := range endpoints {
-			for _, sub := range eps.Subsets {
-				portNumber, err := findPortNumberForName(sub, portName)
-				if err != nil {
-					m.logger.Infof("Skipping Subset %v because it doesn't contain a port %q", sub.Addresses, portName)
-					continue
-				}
+		for _, sub := range endpoints.Subsets {
+			portNumber, err := findPortNumberForName(sub, portName)
+			if err != nil {
+				m.logger.Infof("Skipping Subset %v because it doesn't contain a port %q", sub.Addresses, portName)
+				continue
+			}
 
-				for _, addr := range sub.Addresses {
-					targetsPerPods[addr.IP] = append(targetsPerPods[addr.IP], probeTarget{urlTmpl: fmt.Sprintf(urlTmpl, server.Port.Number), targetPort: strconv.Itoa(int(portNumber))})
-				}
+			for _, addr := range sub.Addresses {
+				targetsPerPods[addr.IP] = append(targetsPerPods[addr.IP], probeTarget{urlTmpl: fmt.Sprintf(urlTmpl, server.Port.Number), targetPort: strconv.Itoa(int(portNumber))})
 			}
 		}
 	}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -156,7 +156,7 @@ func (m *StatusProber) IsReady(ia v1alpha1.IngressAccessor, gw map[v1alpha1.Ingr
 
 	bytes, err := resources.ComputeIngressHash(ia)
 	if err != nil {
-		return false, fmt.Errorf("failed to compute the hash of the IngressAccessor: %v", err)
+		return false, fmt.Errorf("failed to compute the hash of the IngressAccessor: %w", err)
 	}
 	hash := fmt.Sprintf("%x", bytes)
 
@@ -190,11 +190,11 @@ func (m *StatusProber) IsReady(ia v1alpha1.IngressAccessor, gw map[v1alpha1.Ingr
 	for gatewayName, hosts := range resources.HostsPerGateway(ia, gw) {
 		gateway, err := m.getGateway(gatewayName)
 		if err != nil {
-			return false, fmt.Errorf("failed to get Gateway %q: %v", gatewayName, err)
+			return false, fmt.Errorf("failed to get Gateway %q: %w", gatewayName, err)
 		}
 		targetsPerPod, err := m.listGatewayTargetsPerPods(gateway)
 		if err != nil {
-			return false, fmt.Errorf("failed to list the probing URLs of Gateway %q: %v", gatewayName, err)
+			return false, fmt.Errorf("failed to list the probing URLs of Gateway %q: %w", gatewayName, err)
 		}
 		if len(targetsPerPod) == 0 {
 			continue
@@ -386,7 +386,7 @@ func (m *StatusProber) updateStates(ingressState *ingressState, podState *podSta
 func (m *StatusProber) getGateway(name string) (*v1alpha3.Gateway, error) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse Gateway name %q: %v", name, err)
+		return nil, fmt.Errorf("failed to parse Gateway name %q: %w", name, err)
 	}
 	if namespace == "" {
 		return nil, fmt.Errorf("unexpected unqualified Gateway name %q", name)
@@ -401,14 +401,14 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 	for key, value := range gateway.Spec.Selector {
 		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
 		if err != nil {
-			return nil, fmt.Errorf("failed to create 'Equals' requirement from %q=%q: %v", key, value, err)
+			return nil, fmt.Errorf("failed to create 'Equals' requirement from %q=%q: %w", key, value, err)
 		}
 		selector = selector.Add(*requirement)
 	}
 
 	services, err := m.serviceLister.Services(gateway.Namespace).List(selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list Services: %v", err)
+		return nil, fmt.Errorf("failed to list Services: %w", err)
 	}
 	if len(services) == 0 {
 		m.logger.Infof("Skipping Gateway %s/%s because it has no corresponding Service", gateway.Namespace, gateway.Name)
@@ -418,7 +418,7 @@ func (m *StatusProber) listGatewayTargetsPerPods(gateway *v1alpha3.Gateway) (map
 
 	endpoints, err := m.endpointsLister.Endpoints(service.Namespace).Get(service.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Endpoints: %v", err)
+		return nil, fmt.Errorf("failed to get Endpoints: %w", err)
 	}
 
 	targetsPerPods := make(map[string][]probeTarget)

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -172,12 +172,12 @@ func TestIsReadyFailureAndSuccess(t *testing.T) {
 			}},
 		},
 		endpointsLister: &fakeEndpointsLister{
-			endpoints: []*v1.Endpoints{{
+			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "gateway",
 				},
-			}},
+			},
 		},
 	}, {
 		name:     "no endpoints",
@@ -218,13 +218,13 @@ func TestIsReadyFailureAndSuccess(t *testing.T) {
 			}},
 		},
 		endpointsLister: &fakeEndpointsLister{
-			endpoints: []*v1.Endpoints{{
+			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "gateway",
 				},
 				Subsets: []v1.EndpointSubset{},
-			}},
+			},
 		},
 	}, {
 		name:     "no services",
@@ -401,7 +401,7 @@ func TestProbeLifecycle(t *testing.T) {
 			}},
 		},
 		&fakeEndpointsLister{
-			endpoints: []*v1.Endpoints{{
+			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "gateway",
@@ -418,7 +418,7 @@ func TestProbeLifecycle(t *testing.T) {
 						IP: hostname,
 					}},
 				}},
-			}},
+			},
 		},
 		&fakeServiceLister{
 			services: []*v1.Service{{
@@ -576,7 +576,7 @@ func TestCancellation(t *testing.T) {
 			}},
 		},
 		&fakeEndpointsLister{
-			endpoints: []*v1.Endpoints{{
+			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "gateway",
@@ -590,7 +590,7 @@ func TestCancellation(t *testing.T) {
 						Port: int32(port),
 					}},
 				}},
-			}},
+			},
 		},
 		&fakeServiceLister{
 			services: []*v1.Service{{
@@ -717,11 +717,20 @@ func (l *fakeGatewayNamespaceLister) Get(name string) (*v1alpha3.Gateway, error)
 }
 
 type fakeEndpointsLister struct {
-	endpoints []*v1.Endpoints
+	endpoints *v1.Endpoints
 	fails     bool
 }
 
-func (l *fakeEndpointsLister) List(selector labels.Selector) (ret []*v1.Endpoints, err error) {
+func (l *fakeEndpointsLister) List(selector labels.Selector) ([]*v1.Endpoints, error) {
+	log.Panic("not implemented")
+	return nil, nil
+}
+
+func (l *fakeEndpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
+	return l
+}
+
+func (l *fakeEndpointsLister) Get(name string) (*v1.Endpoints, error) {
 	if l.fails {
 		return nil, errors.New("failed to get Endpoints")
 	}
@@ -729,17 +738,12 @@ func (l *fakeEndpointsLister) List(selector labels.Selector) (ret []*v1.Endpoint
 	return l.endpoints, nil
 }
 
-func (l *fakeEndpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
-	log.Panic("not implemented")
-	return nil
-}
-
 type fakeServiceLister struct {
 	services []*v1.Service
 	fails    bool
 }
 
-func (l *fakeServiceLister) List(selector labels.Selector) (ret []*v1.Service, err error) {
+func (l *fakeServiceLister) List(selector labels.Selector) ([]*v1.Service, error) {
 	if l.fails {
 		return nil, errors.New("failed to get Services")
 	}
@@ -748,11 +752,15 @@ func (l *fakeServiceLister) List(selector labels.Selector) (ret []*v1.Service, e
 }
 
 func (l *fakeServiceLister) Services(namespace string) corev1listers.ServiceNamespaceLister {
-	log.Panic("not implemented")
-	return nil
+	return l
 }
 
 func (l *fakeServiceLister) GetPodServices(pod *v1.Pod) ([]*v1.Service, error) {
+	log.Panic("not implemented")
+	return nil, nil
+}
+
+func (l *fakeServiceLister) Get(name string) (*v1.Service, error) {
 	log.Panic("not implemented")
 	return nil, nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

If Istio (or derivatives of it) has multiple control-planes installed in a cluster, there will be multiple gateways, for example 2 istio-ingressgateways. The labels on the service/endpoints for both of these will be identical though. Not qualifying the namespace to look for the service/endpoints pair causes us to pick up ingressgateway pods for both control planes in this example.

This instead qualifies the List/Get operations with the namespace of the respective gateway to make sure that the right resources are returned.
