### PR TITLE
Fix dataplane probe benchmark

### DIFF
--- a/test/performance/dataplane-probe/dataplane-probe.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe.yaml
@@ -28,6 +28,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["serverlessservices"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
* Fix dataplane probe benchmark by adding the missed permissions

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 