### PR TITLE
Use cluster-admin to run benchmark cronjobs

### DIFF
--- a/test/performance/dataplane-probe/dataplane-probe.yaml
+++ b/test/performance/dataplane-probe/dataplane-probe.yaml
@@ -17,21 +17,6 @@ kind: ServiceAccount
 metadata:
   name: prober
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prober
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.internal.knative.dev"]
-    resources: ["serverlessservices"]
-    verbs: ["get", "list", "watch"]
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -42,7 +27,7 @@ subjects:
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: prober
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1beta1

--- a/test/performance/deployment-probe/benchmark.yaml
+++ b/test/performance/deployment-probe/benchmark.yaml
@@ -17,29 +17,17 @@ kind: ServiceAccount
 metadata:
   name: prober
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: service-creator
-rules:
-  - apiGroups: [""]
-    resources: ["pods", "nodes"]
-    verbs: ["create", "update", "get", "list", "watch", "delete", "deletecollection"]
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["*"]
-    verbs: ["create", "update", "get", "list", "watch", "deletecollection"]
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: service-creator
+  name: prober
 subjects:
   - kind: ServiceAccount
     name: prober
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: service-creator
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1beta1

--- a/test/performance/load-test/load-test.yaml
+++ b/test/performance/load-test/load-test.yaml
@@ -17,21 +17,6 @@ kind: ServiceAccount
 metadata:
   name: loader
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: load-testing
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.internal.knative.dev"]
-    resources: ["serverlessservices"]
-    verbs: ["get", "list", "watch"]
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -42,7 +27,7 @@ subjects:
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: load-testing
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1beta1


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
It seems there is no reason to restrict permissions of the service account that runs benchmarking jobs, bind it with `cluster-admin` role.
I ran the `load-test` benchmark and it worked, run link - https://mako.dev/run?run_key=6549552056238080&~l=1&~es=1&~rs=1&~dp=1&~ap=1&~sks=1

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
/cc @mattmoor 
