### PR TITLE
Move all fmt.Errorf calls from %v to %w for errors.

### DIFF
--- a/cmd/default-domain/main.go
+++ b/cmd/default-domain/main.go
@@ -53,11 +53,11 @@ const (
 func kubeClientFromFlags() (*kubernetes.Clientset, error) {
 	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("error building kubeconfig: %v", err)
+		return nil, fmt.Errorf("error building kubeconfig: %w", err)
 	}
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error building kube clientset: %v", err)
+		return nil, fmt.Errorf("error building kube clientset: %w", err)
 	}
 	return kubeClient, nil
 }
@@ -74,7 +74,7 @@ func lookupIngressGateway(kubeClient *kubernetes.Clientset) (*corev1.Service, er
 	}
 	istioConfig, err := cicfg.NewIstioFromConfigMap(istioCM)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing ConfigMap: %v", err)
+		return nil, fmt.Errorf("error parsing ConfigMap: %w", err)
 	}
 	// Parse the service name to determine which Kubernetes Service resource to fetch.
 	serviceURL := istioConfig.IngressGateways[0].ServiceURL
@@ -93,7 +93,7 @@ func lookupIngressGateway(kubeClient *kubernetes.Clientset) (*corev1.Service, er
 func lookupIngressGatewayAddress(kubeClient *kubernetes.Clientset) (*corev1.LoadBalancerIngress, error) {
 	svc, err := lookupIngressGateway(kubeClient)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up IngressGateway: %v", err)
+		return nil, fmt.Errorf("error looking up IngressGateway: %w", err)
 	}
 	// Walk the list of Ingress entries in the Service's LoadBalancer status.
 	// If one of IP address is found, return it.  Otherwise, keep one with

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -128,7 +128,7 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 		}
 		// Check that the template properly applies to ObjectMeta.
 		if err := tmpl.Execute(ioutil.Discard, metav1.ObjectMeta{}); err != nil {
-			return nil, fmt.Errorf("error executing template: %v", err)
+			return nil, fmt.Errorf("error executing template: %w", err)
 		}
 		// We store the raw template because we run deepcopy-gen on the
 		// config and that doesn't copy nicely.

--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -61,7 +61,7 @@ func extractData(body io.Reader) (Stat, error) {
 	var parser expfmt.TextParser
 	metricFamilies, err := parser.TextToMetricFamilies(body)
 	if err != nil {
-		return emptyStat, fmt.Errorf("reading text format failed: %v", err)
+		return emptyStat, fmt.Errorf("reading text format failed: %w", err)
 	}
 
 	stat := emptyStat

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -47,7 +47,7 @@ func watchFunc(ctx context.Context, ms *MultiScaler, decider *Decider, desiredSc
 		}
 		m, err := ms.Get(ctx, decider.Namespace, decider.Name)
 		if err != nil {
-			errCh <- fmt.Errorf("Get() = %v", err)
+			errCh <- fmt.Errorf("Get() = %w", err)
 			return
 		}
 		if got, want := m.Status.DesiredScale, int32(desiredScale); got != want {

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -72,7 +72,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	}
 	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
-		return fmt.Errorf("error constructing probe request %v", err)
+		return fmt.Errorf("error constructing probe request %w", err)
 	}
 
 	req.Header.Add(network.UserAgentKey, network.KubeProbeUAPrefix+config.KubeMajor+"/"+config.KubeMinor)

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -93,7 +93,7 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 	registry := prometheus.NewRegistry()
 	for _, gv := range []*prometheus.GaugeVec{requestsPerSecondGV, proxiedRequestsPerSecondGV, averageConcurrentRequestsGV, averageProxiedConcurrentRequestsGV} {
 		if err := registry.Register(gv); err != nil {
-			return nil, fmt.Errorf("register metric failed: %v", err)
+			return nil, fmt.Errorf("register metric failed: %w", err)
 		}
 	}
 

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -98,7 +98,7 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 		}
 		gatewayName, serviceURL := k[len(prefix):], v
 		if errs := validation.IsDNS1123Subdomain(serviceURL); len(errs) > 0 {
-			return nil, fmt.Errorf("invalid gateway format: %v", errs)
+			return nil, fmt.Errorf("invalid gateway format: %w", errs)
 		}
 		gatewayNames = append(gatewayNames, gatewayName)
 		urls[gatewayName] = serviceURL

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -357,7 +357,7 @@ func (r *BaseIngressReconciler) reconcileIngress(ctx context.Context, ra Reconci
 
 	ready, err := r.StatusManager.IsReady(ia, gatewayNames)
 	if err != nil {
-		return fmt.Errorf("failed to probe IngressAccessor %s/%s: %v", ia.GetNamespace(), ia.GetName(), err)
+		return fmt.Errorf("failed to probe IngressAccessor %s/%s: %w", ia.GetNamespace(), ia.GetName(), err)
 	}
 	if ready {
 		lbs := getLBStatus(gatewayServiceURLFromContext(ctx, ia))

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -98,7 +98,7 @@ func MakeVirtualServices(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.Ingr
 	// Insert probe header
 	ia = ia.DeepCopyObject().(v1alpha1.IngressAccessor)
 	if _, err := InsertProbe(ia); err != nil {
-		return nil, fmt.Errorf("failed to insert a probe into the IngressAccessor: %v", err)
+		return nil, fmt.Errorf("failed to insert a probe into the IngressAccessor: %w", err)
 	}
 
 	vss := []*v1alpha3.VirtualService{MakeMeshVirtualService(ia)}
@@ -124,7 +124,7 @@ func MakeVirtualServices(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.Ingr
 func InsertProbe(ia v1alpha1.IngressAccessor) (string, error) {
 	bytes, err := ComputeIngressHash(ia)
 	if err != nil {
-		return "", fmt.Errorf("failed to compute the hash of the IngressAccessor: %v", err)
+		return "", fmt.Errorf("failed to compute the hash of the IngressAccessor: %w", err)
 	}
 	hash := fmt.Sprintf("%x", bytes)
 
@@ -144,7 +144,7 @@ func InsertProbe(ia v1alpha1.IngressAccessor) (string, error) {
 func ComputeIngressHash(ia v1alpha1.IngressAccessor) ([16]byte, error) {
 	bytes, err := json.Marshal(ia.GetSpec())
 	if err != nil {
-		return [16]byte{}, fmt.Errorf("failed to serialize IngressAccessor: %v", err)
+		return [16]byte{}, fmt.Errorf("failed to serialize IngressAccessor: %w", err)
 	}
 	bytes = append(bytes, []byte(ia.GetNamespace())...)
 	bytes = append(bytes, []byte(ia.GetName())...)

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -64,7 +64,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 		logger.Info("Stopping to collect metrics")
 		return r.collector.Delete(namespace, name)
 	} else if err != nil {
-		return fmt.Errorf("failed to fetch metric %s: %v", key, err)
+		return fmt.Errorf("failed to fetch metric %s: %w", key, err)
 	}
 
 	// Don't mess with informer's copy.

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -108,7 +108,7 @@ func (c *reconciler) reconcile(ctx context.Context, ns *corev1.Namespace) error 
 
 	existingCerts, err := c.knCertificateLister.Certificates(ns.Name).List(labelSelector)
 	if err != nil {
-		return fmt.Errorf("failed to list certificates: %v", err)
+		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
 	dnsName, err := wildcardDomain(cfg.Network.DomainTemplate, defaultDomain, ns.Name)

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -92,7 +92,7 @@ func DomainNameFromTemplate(ctx context.Context, r v1.ObjectMeta, name string) (
 	}
 
 	if err := templ.Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("error executing the DomainTemplate: %v", err)
+		return "", fmt.Errorf("error executing the DomainTemplate: %w", err)
 	}
 	return buf.String(), nil
 }
@@ -114,7 +114,7 @@ func HostnameFromTemplate(ctx context.Context, name string, tag string) (string,
 	networkConfig := config.FromContext(ctx).Network
 	buf := bytes.Buffer{}
 	if err := networkConfig.GetTagTemplate().Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("error executing the TagTemplate: %v", err)
+		return "", fmt.Errorf("error executing the TagTemplate: %w", err)
 	}
 	return buf.String(), nil
 }

--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -88,7 +88,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1.Route) erro
 		"RouteDomain",
 	)
 	if err != nil {
-		return fmt.Errorf("route did not get assigned an URL: %v", err)
+		return fmt.Errorf("route did not get assigned an URL: %w", err)
 	}
 
 	t.Logf("Route %s can serve the expected data at %s", route.Name, url)
@@ -100,7 +100,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1.Route) erro
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", route.Name, url, test.HelloWorldText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", route.Name, url, test.HelloWorldText, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1/single_threaded_test.go
+++ b/test/conformance/api/v1/single_threaded_test.go
@@ -79,7 +79,7 @@ func TestSingleConcurrency(t *testing.T) {
 			done := time.After(duration)
 			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
-				return fmt.Errorf("error creating http request: %v", err)
+				return fmt.Errorf("error creating http request: %w", err)
 			}
 
 			for {
@@ -89,7 +89,7 @@ func TestSingleConcurrency(t *testing.T) {
 				default:
 					res, err := client.Do(req)
 					if err != nil {
-						return fmt.Errorf("error making request %v", err)
+						return fmt.Errorf("error making request %w", err)
 					}
 					if res.StatusCode == http.StatusInternalServerError {
 						return errors.New("detected concurrent requests")

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -208,7 +208,7 @@ func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceN
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL, expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", names.Route, names.URL, expectedText, err)
 	}
 
 	return nil
@@ -221,13 +221,13 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 	t.Log("Checking to ensure Revision is in desired state with generation: ", expectedGeneration)
 	err := v1test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1.Revision) (bool, error) {
 		if ready, err := v1test.IsRevisionReady(r); !ready {
-			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %v", names.Revision, err)
+			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
 		}
 		if r.Status.ImageDigest == "" {
 			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
 		}
 		if validDigest, err := validateImageDigest(names.Image, r.Status.ImageDigest); !validDigest {
-			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %v", r.Status.ImageDigest, names.Image, err)
+			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.ImageDigest, names.Image, err)
 		}
 		return true, nil
 	})
@@ -236,16 +236,16 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 	}
 	err = v1test.CheckRevisionState(clients.ServingClient, names.Revision, v1test.IsRevisionAtExpectedGeneration(expectedGeneration))
 	if err != nil {
-		return fmt.Errorf("revision %s did not have an expected annotation with generation %s: %v", names.Revision, expectedGeneration, err)
+		return fmt.Errorf("revision %s did not have an expected annotation with generation %s: %w", names.Revision, expectedGeneration, err)
 	}
 
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1test.CheckConfigurationState(clients.ServingClient, names.Config, func(c *v1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %v", names.Config, names.Revision, err)
+			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %w", names.Config, names.Revision, err)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
+			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %w", names.Config, names.Revision, err)
 		}
 		return true, nil
 	})
@@ -256,7 +256,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 	t.Log("Checking to ensure Route is in desired state with generation: ", expectedGeneration)
 	err = v1test.CheckRouteState(clients.ServingClient, names.Route, v1test.AllRouteTrafficAtRevision(names))
 	if err != nil {
-		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
+		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %w", names.Route, names.Revision, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -88,7 +88,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1alpha1.Route
 		"RouteDomain",
 	)
 	if err != nil {
-		return fmt.Errorf("route did not get assigned an URL : %v", err)
+		return fmt.Errorf("route did not get assigned an URL : %w", err)
 	}
 
 	t.Logf("Route %s can serve the expected data at %s", route.Name, url)
@@ -100,7 +100,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1alpha1.Route
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", route.Name, url, test.HelloWorldText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", route.Name, url, test.HelloWorldText, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -78,7 +78,7 @@ func TestSingleConcurrency(t *testing.T) {
 			done := time.After(duration)
 			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
-				return fmt.Errorf("error creating http request: %v", err)
+				return fmt.Errorf("error creating http request: %w", err)
 			}
 
 			for {
@@ -88,7 +88,7 @@ func TestSingleConcurrency(t *testing.T) {
 				default:
 					res, err := client.Do(req)
 					if err != nil {
-						return fmt.Errorf("error making request %v", err)
+						return fmt.Errorf("error making request %w", err)
 					}
 					if res.StatusCode == http.StatusInternalServerError {
 						return errors.New("detected concurrent requests")

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -208,7 +208,7 @@ func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL.String(), expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", names.Route, names.URL.String(), expectedText, err)
 	}
 
 	return nil
@@ -221,13 +221,13 @@ func validateRunLatestControlPlane(t *testing.T, clients *test.Clients, names te
 	t.Log("Checking to ensure Revision is in desired state with generation: ", expectedGeneration)
 	err := v1a1test.CheckRevisionState(clients.ServingAlphaClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
 		if ready, err := v1a1test.IsRevisionReady(r); !ready {
-			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %v", names.Revision, err)
+			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
 		}
 		if r.Status.ImageDigest == "" {
 			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
 		}
 		if validDigest, err := validateImageDigest(names.Image, r.Status.ImageDigest); !validDigest {
-			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %v", r.Status.ImageDigest, names.Image, err)
+			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.ImageDigest, names.Image, err)
 		}
 		return true, nil
 	})
@@ -236,16 +236,16 @@ func validateRunLatestControlPlane(t *testing.T, clients *test.Clients, names te
 	}
 	err = v1a1test.CheckRevisionState(clients.ServingAlphaClient, names.Revision, v1a1test.IsRevisionAtExpectedGeneration(expectedGeneration))
 	if err != nil {
-		return fmt.Errorf("revision %s did not have an expected annotation with generation %s: %v", names.Revision, expectedGeneration, err)
+		return fmt.Errorf("revision %s did not have an expected annotation with generation %s: %w", names.Revision, expectedGeneration, err)
 	}
 
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1a1test.CheckConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %v", names.Config, names.Revision, err)
+			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %w", names.Config, names.Revision, err)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
+			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %w", names.Config, names.Revision, err)
 		}
 		return true, nil
 	})
@@ -256,7 +256,7 @@ func validateRunLatestControlPlane(t *testing.T, clients *test.Clients, names te
 	t.Log("Checking to ensure Route is in desired state with generation: ", expectedGeneration)
 	err = v1a1test.CheckRouteState(clients.ServingAlphaClient, names.Route, v1a1test.AllRouteTrafficAtRevision(names))
 	if err != nil {
-		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
+		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %w", names.Route, names.Revision, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -88,7 +88,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1beta1.Route)
 		"RouteDomain",
 	)
 	if err != nil {
-		return fmt.Errorf("route did not get assigned a domain: %v", err)
+		return fmt.Errorf("route did not get assigned a domain: %w", err)
 	}
 
 	t.Logf("Route %s can serve the expected data at %s", route.Name, url)
@@ -100,7 +100,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1beta1.Route)
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", route.Name, url, test.HelloWorldText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", route.Name, url, test.HelloWorldText, err)
 	}
 
 	return nil

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -79,7 +79,7 @@ func TestSingleConcurrency(t *testing.T) {
 			done := time.After(duration)
 			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 			if err != nil {
-				return fmt.Errorf("error creating http request: %v", err)
+				return fmt.Errorf("error creating http request: %w", err)
 			}
 
 			for {
@@ -89,7 +89,7 @@ func TestSingleConcurrency(t *testing.T) {
 				default:
 					res, err := client.Do(req)
 					if err != nil {
-						return fmt.Errorf("error making request %v", err)
+						return fmt.Errorf("error making request %w", err)
 					}
 					if res.StatusCode == http.StatusInternalServerError {
 						return errors.New("detected concurrent requests")

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -208,7 +208,7 @@ func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceN
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL, expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", names.Route, names.URL, expectedText, err)
 	}
 
 	return nil
@@ -221,13 +221,13 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 	t.Log("Checking to ensure Revision is in desired state with generation: ", expectedGeneration)
 	err := v1b1test.CheckRevisionState(clients.ServingBetaClient, names.Revision, func(r *v1beta1.Revision) (bool, error) {
 		if ready, err := v1b1test.IsRevisionReady(r); !ready {
-			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %v", names.Revision, err)
+			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
 		}
 		if r.Status.ImageDigest == "" {
 			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
 		}
 		if validDigest, err := validateImageDigest(names.Image, r.Status.ImageDigest); !validDigest {
-			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %v", r.Status.ImageDigest, names.Image, err)
+			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.ImageDigest, names.Image, err)
 		}
 		return true, nil
 	})
@@ -236,16 +236,16 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 	}
 	err = v1b1test.CheckRevisionState(clients.ServingBetaClient, names.Revision, v1b1test.IsRevisionAtExpectedGeneration(expectedGeneration))
 	if err != nil {
-		return fmt.Errorf("revision %s did not have an expected annotation with generation %s: %v", names.Revision, expectedGeneration, err)
+		return fmt.Errorf("revision %s did not have an expected annotation with generation %s: %w", names.Revision, expectedGeneration, err)
 	}
 
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1b1test.CheckConfigurationState(clients.ServingBetaClient, names.Config, func(c *v1beta1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %v", names.Config, names.Revision, err)
+			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %w", names.Config, names.Revision, err)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
+			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %w", names.Config, names.Revision, err)
 		}
 		return true, nil
 	})
@@ -256,7 +256,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 	t.Log("Checking to ensure Route is in desired state with generation: ", expectedGeneration)
 	err = v1b1test.CheckRouteState(clients.ServingBetaClient, names.Route, v1b1test.AllRouteTrafficAtRevision(names))
 	if err != nil {
-		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
+		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %w", names.Route, names.Revision, err)
 	}
 
 	return nil

--- a/test/conformance/runtime/filesystem_test.go
+++ b/test/conformance/runtime/filesystem_test.go
@@ -69,7 +69,7 @@ func testFiles(t *testing.T, clients *test.Clients, paths map[string]types.FileI
 
 		if file.Perm != "" {
 			if err := verifyPermissionsString(riFile.Perm, file.Perm); err != nil {
-				return fmt.Errorf("%s has invalid permissions string %s: %v", path, riFile.Perm, err)
+				return fmt.Errorf("%s has invalid permissions string %s: %w", path, riFile.Perm, err)
 			}
 		}
 	}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -106,7 +106,7 @@ func generateTraffic(
 	target, err := getVegetaTarget(
 		ctx.clients.KubeClient.Kube, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("error creating vegeta target: %v", err)
+		return fmt.Errorf("error creating vegeta target: %w", err)
 	}
 
 	results := attacker.Attack(vegeta.NewStaticTargeter(target), pacer, duration, "load-test")

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -275,7 +275,7 @@ func TestIstioProbing(t *testing.T) {
 				g.Go(func() error {
 					u, err := url.Parse(fmt.Sprintf(tmpl, names.Service+"."+domain))
 					if err != nil {
-						return fmt.Errorf("failed to parse URL: %v", err)
+						return fmt.Errorf("failed to parse URL: %w", err)
 					}
 					if _, err := pkgTest.WaitForEndpointStateWithTimeout(
 						clients.KubeClient,
@@ -286,7 +286,7 @@ func TestIstioProbing(t *testing.T) {
 						test.ServingFlags.ResolvableDomain,
 						1*time.Minute,
 						transportOptions...); err != nil {
-						return fmt.Errorf("failed to probe %s: %v", u, err)
+						return fmt.Errorf("failed to probe %s: %w", u, err)
 					}
 					return nil
 				})
@@ -417,7 +417,7 @@ func setupHTTPS(t *testing.T, kubeClient *pkgTest.KubeClient, hosts []string) sp
 func generateCertificate(hosts []string) ([]byte, []byte, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate private key: %v", err)
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
 	}
 
 	notBefore := time.Now().Add(-5 * time.Minute)
@@ -426,7 +426,7 @@ func generateCertificate(hosts []string) ([]byte, []byte, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate serial number: %v", err)
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
 	template := x509.Certificate{
@@ -452,17 +452,17 @@ func generateCertificate(hosts []string) ([]byte, []byte, error) {
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create the certificate: %v", err)
+		return nil, nil, fmt.Errorf("failed to create the certificate: %w", err)
 	}
 
 	var certBuf bytes.Buffer
 	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return nil, nil, fmt.Errorf("failed to encode the certificate: %v", err)
+		return nil, nil, fmt.Errorf("failed to encode the certificate: %w", err)
 	}
 
 	var keyBuf bytes.Buffer
 	if err := pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
-		return nil, nil, fmt.Errorf("failed to encode the private key: %v", err)
+		return nil, nil, fmt.Errorf("failed to encode the private key: %w", err)
 	}
 
 	return certBuf.Bytes(), keyBuf.Bytes(), nil

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -40,7 +40,7 @@ func checkResponse(t *testing.T, clients *test.Clients, names test.ResourceNames
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, names.URL.String(), expectedText, err)
+		return fmt.Errorf("the endpoint for Route %s at %s didn't serve the expected text %q: %w", names.Route, names.URL.String(), expectedText, err)
 	}
 
 	return nil

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -53,7 +53,7 @@ func generateTraffic(t *testing.T, client *spoof.SpoofingClient, url string, con
 			done := time.After(duration)
 			req, err := http.NewRequest(http.MethodGet, url, nil)
 			if err != nil {
-				return fmt.Errorf("error creating http request: %v", err)
+				return fmt.Errorf("error creating http request: %w", err)
 			}
 			for {
 				select {
@@ -71,7 +71,7 @@ func generateTraffic(t *testing.T, client *spoof.SpoofingClient, url string, con
 	}
 
 	if err := group.Wait(); err != nil {
-		return fmt.Errorf("error making requests for scale up: %v", err)
+		return fmt.Errorf("error making requests for scale up: %w", err)
 	}
 	return nil
 }

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -102,12 +102,12 @@ func ProbeTargetTillReady(target string, duration time.Duration) error {
 	}
 	req, err := http.NewRequest(http.MethodGet, target, nil)
 	if err != nil {
-		return fmt.Errorf("target %q is invalid, cannot probe: %v", target, err)
+		return fmt.Errorf("target %q is invalid, cannot probe: %w", target, err)
 	}
 	if _, err = spoofingClient.Poll(req, func(resp *spoof.Response) (done bool, err error) {
 		return true, nil
 	}); err != nil {
-		return fmt.Errorf("failed to get target %q ready: %v", target, err)
+		return fmt.Errorf("failed to get target %q ready: %w", target, err)
 	}
 	return nil
 }

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -132,7 +132,7 @@ func createServices(t *testing.T, pc *Client, count int) ([]*v1a1test.ResourceOb
 		g.Go(func() error {
 			var err error
 			if objs[ndx], err = v1a1test.CreateRunLatestServiceReady(t, pc.E2EClients, testNames[ndx], sos...); err != nil {
-				return fmt.Errorf("%02d: failed to create Ready service: %v", ndx, err)
+				return fmt.Errorf("%02d: failed to create Ready service: %w", ndx, err)
 			}
 			return nil
 		})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Regexed via `fmt.Errorf\((.*)%v",(.*) err\)`. Correctly wraps all errors generated by `fmt.Errorf`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
