### PR TITLE
Fix race in activator's revisionWatcher

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -68,11 +68,12 @@ const (
 // revisionWatcher watches the podIPs and ClusterIP of the service for a revision. It implements the logic
 // to supply revisionDestsUpdate events on updateCh
 type revisionWatcher struct {
-	doneCh   <-chan struct{}
+	stopCh   <-chan struct{}
 	cancel   context.CancelFunc
 	rev      types.NamespacedName
 	protocol networking.ProtocolType
 	updateCh chan<- revisionDestsUpdate
+	done     chan struct{}
 
 	// Stores the list of pods that have been successfully probed.
 	healthyPods sets.String
@@ -95,11 +96,12 @@ func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol 
 	logger *zap.SugaredLogger) *revisionWatcher {
 	ctx, cancel := context.WithCancel(ctx)
 	return &revisionWatcher{
-		doneCh:          ctx.Done(),
+		stopCh:          ctx.Done(),
 		cancel:          cancel,
 		rev:             rev,
 		protocol:        protocol,
 		updateCh:        updateCh,
+		done:            make(chan struct{}),
 		healthyPods:     sets.NewString(),
 		transport:       transport,
 		destsCh:         destsCh,
@@ -218,7 +220,7 @@ func (rw *revisionWatcher) probePodIPs(dests sets.String) (sets.String, bool, er
 
 func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String) {
 	select {
-	case <-rw.doneCh:
+	case <-rw.stopCh:
 		return
 	default:
 		rw.updateCh <- revisionDestsUpdate{Rev: rw.rev, ClusterIPDest: clusterIP, Dests: dests}
@@ -293,7 +295,7 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 }
 
 func (rw *revisionWatcher) run(probeFrequency time.Duration) {
-	defer close(rw.destsCh)
+	defer close(rw.done)
 
 	var dests sets.String
 	timer := time.NewTicker(probeFrequency)
@@ -314,7 +316,7 @@ func (rw *revisionWatcher) run(probeFrequency time.Duration) {
 		}
 
 		select {
-		case <-rw.doneCh:
+		case <-rw.stopCh:
 			return
 		case x := <-rw.destsCh:
 			dests = x
@@ -386,7 +388,7 @@ func newRevisionBackendsManagerWithProbeFrequency(ctx context.Context, tr http.R
 		rbm.revisionWatchersMux.Lock()
 		defer rbm.revisionWatchersMux.Unlock()
 		for _, rw := range rbm.revisionWatchers {
-			<-rw.destsCh
+			<-rw.done
 		}
 	}()
 
@@ -447,7 +449,11 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 	}
 	dests := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
 	rbm.logger.Debugf("Updating Endpoints: %q (backends: %d)", revID.String(), len(dests))
-	rw.destsCh <- dests
+	select {
+	case <-rbm.ctx.Done():
+		return
+	case rw.destsCh <- dests:
+	}
 }
 
 // deleteRevisionWatcher deletes the revision watcher for rev if it exists. It expects

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -407,19 +407,19 @@ func TestRevisionWatcher(t *testing.T) {
 				t.Errorf("revisionDests updates = %v, want: %v, diff (-want, +got):\n %s", got, want, cmp.Diff(want, got))
 			}
 
-			assertChClosed(t, destsCh)
+			assertChClosed(t, rw.done)
 		})
 	}
 }
 
-func assertChClosed(t *testing.T, ch chan sets.String) {
+func assertChClosed(t *testing.T, ch chan struct{}) {
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("the channel was not closed")
 		}
 	}()
 	select {
-	case ch <- nil:
+	case ch <- struct{}{}:
 		// Panics if the channel is closed
 	default:
 		// Prevents from blocking forever if the channel is not closed
@@ -719,7 +719,7 @@ func TestCheckDests(t *testing.T) {
 		updateCh:         uCh,
 		serviceLister:    si.Lister(),
 		logger:           TestLogger(t),
-		doneCh:           dCh,
+		stopCh:           dCh,
 	}
 	rw.checkDests(sets.NewString("10.1.1.5"))
 	select {
@@ -800,7 +800,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 		updateCh:        uCh,
 		serviceLister:   si.Lister(),
 		logger:          TestLogger(t),
-		doneCh:          dCh,
+		stopCh:          dCh,
 		podsAddressable: true,
 		transport:       network.RoundTripperFunc(fakeRT.RT),
 	}


### PR DESCRIPTION
## Proposed Changes
The destsCh channel in revisionWatcher is currently used by revisionBackendsManager
for both for sending incoming endpoints to it and as a signal that this
revisionWatcher has finished running.

Since destsCh is getting closed from the receiving side in revisionWatcher.run(),
this may cause panic for sending on a closed channel in
revisionBackendsManager.endpointsUpdated().

Fix this by introducing new channel for notifying revisionBackendsManager that this
revisionWatcher has finished running.

Fixes #5864

cc @greghaynes @JRBANCEL @vagababov

/lint
/assign JRBANCEL