### PR TITLE
Special case inifite concurrency case to assign all trackers.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -244,8 +244,13 @@ func (rt *revisionThrottler) updateCapacity(throttler *Throttler, backendCount i
 		if rt.clusterIPDest != "" {
 			return 0
 		}
-		rt.resetTrackers()
-		rt.assignedTrackers = assignSlice(rt.podIPTrackers, throttler.index(), ac)
+		// Infifnite capacity, assign all.
+		if rt.containerConcurrency == 0 {
+			rt.assignedTrackers = rt.podIPTrackers
+		} else {
+			rt.resetTrackers()
+			rt.assignedTrackers = assignSlice(rt.podIPTrackers, throttler.index(), ac)
+		}
 		rt.logger.Debugf("Trackers %d/%d  %s", throttler.index(), ac, spew.Sprint(rt.assignedTrackers))
 		return len(rt.assignedTrackers)
 	}()

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -158,6 +158,18 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 	if got, want := rt.breaker.Capacity(), 15; got != want {
 		t.Errorf("Capacity = %d, want: %d", got, want)
 	}
+
+	// Inifinite capacity.
+	throttler.activatorIndex = 1
+	rt.containerConcurrency = 0
+	rt.updateCapacity(throttler, 1)
+	if got, want := rt.breaker.Capacity(), defaultMaxConcurrency; got != want {
+		t.Errorf("Capacity = %d, want: %d", got, want)
+	}
+	if got, want := len(rt.assignedTrackers), len(rt.podIPTrackers); got != want {
+		t.Errorf("Assigned tracker count = %d, want: %d, diff:\n%s", got, want,
+			cmp.Diff(rt.assignedTrackers, rt.podIPTrackers))
+	}
 }
 
 func makeTrackers(num int) []*podIPTracker {


### PR DESCRIPTION
If we have infinite capacity, then there is no reason to restrict number of the backends per
activator.

/assign @yanweiguo
/lint
