### PR TITLE
Fix race in activator revisionBackendsManager

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -447,6 +447,11 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 	}
 	dests := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
 	rbm.logger.Debugf("Updating Endpoints: %q (backends: %d)", revID.String(), len(dests))
+	select {
+	case <-rbm.ctx.Done():
+		return
+	default:
+	}
 	rw.destsCh <- dests
 }
 


### PR DESCRIPTION
## Proposed Changes
Check if context is done before sending endpoints to prevent panic when destsCh is closed.

Fixes #5864

/lint
/assign @vagababov