### PR TITLE
Adding standard duck label on CRD to signal this resource adheres to Addressable

### DIFF
--- a/config/300-revision.yaml
+++ b/config/300-revision.yaml
@@ -19,7 +19,6 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
-    duck.knative.dev/addressable: "true"
 spec:
   group: serving.knative.dev
   versions:

--- a/config/300-revision.yaml
+++ b/config/300-revision.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: serving.knative.dev
   versions:

--- a/config/300-route.yaml
+++ b/config/300-route.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: serving.knative.dev
   versions:

--- a/config/300-service.yaml
+++ b/config/300-service.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: serving.knative.dev
   versions:


### PR DESCRIPTION
Adding standard duck label on CRD to signal this resource adheres to Addressable

## Proposed Changes

* Label Service and Route with `duck.knative.dev/addressable=true`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Service and Route are now labeled with duck.knative.dev/addressable=true.
```
