### PR TITLE
Over provision istio pilot in performance testing setup

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -103,10 +103,12 @@ function update_cluster() {
   kubectl apply -f serving/third_party/$istio_version/istio-crds.yaml || abort "Failed to apply istio-crds"
   kubectl apply -f serving/third_party/$istio_version/istio-lean.yaml || abort "Failed to apply istio-lean"
 
-  # Overprovision the Istio gateways.
+  # Overprovision the Istio gateways and pilot.
   kubectl patch hpa -n istio-system istio-ingressgateway \
     --patch '{"spec": {"minReplicas": 10, "maxReplicas": 10}}'
   kubectl patch deploy -n istio-system cluster-local-gateway \
+    --patch '{"spec": {"replicas": 10}}'
+  kubectl patch deploy -n istio-system istio-pilot \
     --patch '{"spec": {"replicas": 10}}'
 
   echo ">> Updating serving"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
The `istio-pilot` pod is occasionally dead due to the large amount of requests, overprovision it to 10 to mitigate.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
/cc @mattmoor 
