### PR TITLE
Make the tests more reliable by increasing timeout

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -59,7 +59,7 @@ const (
 	wantBody      = "♫ everything is awesome! ♫"
 	testNamespace = "real-namespace"
 	testRevName   = "real-name"
-	testTimeout   = 100 * time.Millisecond
+	testTimeout   = 250 * time.Millisecond
 )
 
 type fakeThrottler struct {
@@ -145,7 +145,7 @@ func TestActivationHandler(t *testing.T) {
 		wantBody:      context.DeadlineExceeded.Error() + "\n",
 		wantCode:      http.StatusServiceUnavailable,
 		wantErr:       nil,
-		throttler:     fakeThrottler{delay: 120 * time.Millisecond},
+		throttler:     fakeThrottler{delay: 300 * time.Millisecond},
 		reporterCalls: nil,
 	}, {
 		label:         "overflow",
@@ -205,7 +205,7 @@ func TestActivationHandler(t *testing.T) {
 			handler.ServeHTTP(resp, req.WithContext(ctx))
 
 			if resp.Code != test.wantCode {
-				t.Errorf("Unexpected response status. Want %d, got %d", test.wantCode, resp.Code)
+				t.Fatalf("Unexpected response status. Want %d, got %d", test.wantCode, resp.Code)
 			}
 
 			gotBody, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
On prow the tests are regularly failing because the context times out.
On my machine  succeeds every time, but I might have a less
constrained machine.
Anyway, by increasing timeouts we give the overloaded prow cluster more time
to execute the test.
Also the error is quite strange now (reporting calls are different) and you need to go up log
stack to find the actual failure (context deadline exceeded), thus change Errorf to Fatalf to make
sure the real reason for the failure is the last message.

/assign mattmoor
/lint

Examples: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/5879/pull-knative-serving-unit-tests/1187830016440799232