### PR TITLE
Remove deadcode and duplicate imports.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -147,20 +147,6 @@ func pickP2C(tgts []*podIPTracker) (string, func()) {
 	}
 }
 
-// Returns clusterIP if it is the current valid dest. If neither clusterIP or podIPs are valid
-// dests returns error.
-func (rt *revisionThrottler) checkClusterIPDest() (string, error) {
-	rt.mux.RLock()
-	defer rt.mux.RUnlock()
-
-	if rt.clusterIPDest == "" && len(rt.podIPTrackers) == 0 {
-		return "", errors.New("made it through breaker but we have no clusterIP or podIPs. This should" +
-			" never happen" + rt.revID.String())
-	}
-
-	return rt.clusterIPDest, nil
-}
-
 func noop() {}
 
 // Returns a dest after incrementing its request count and a completion callback

--- a/pkg/reconciler/accessor/networking/certificate_test.go
+++ b/pkg/reconciler/accessor/networking/certificate_test.go
@@ -31,7 +31,6 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
-	fakeclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakecertinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/certificate/fake"
 	listers "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
@@ -96,7 +95,7 @@ func (f *FakeAccessor) GetCertificateLister() listers.CertificateLister {
 func TestReconcileCertificateCreate(t *testing.T) {
 	ctx, cancel, _ := SetupFakeContextWithCancel(t)
 
-	client := fakeclient.Get(ctx)
+	client := fakeservingclient.Get(ctx)
 
 	h := NewHooks()
 	h.OnCreate(&client.Fake, "certificates", func(obj runtime.Object) HookResult {
@@ -124,7 +123,7 @@ func TestReconcileCertificateCreate(t *testing.T) {
 func TestReconcileCertificateUpdate(t *testing.T) {
 	ctx, cancel, _ := SetupFakeContextWithCancel(t)
 
-	client := fakeclient.Get(ctx)
+	client := fakeservingclient.Get(ctx)
 	accessor, waitInformers := setup(ctx, []*v1alpha1.Certificate{origin}, client, t)
 	defer func() {
 		cancel()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Title has it all. Produced via

```
staticcheck -unused.whole-program -tags="e2e performance probe preupgrade postupgrade postdowngrade" -tests ./...
```

Ignoring unused API functions in v1beta1 and v1 for good measure and consistency.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
