### PR TITLE
Allow to use manual KCert

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1960,7 +1960,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		Key:                     "default/becomes-ready",
 		SkipNamespaceValidation: true,
 	}, {
-		Name: "check that cutom cert is used when creating a Route",
+		Name: "check that custom cert is used when creating a Route",
 		Objects: []runtime.Object{
 			customCert("default", "becomes-ready.default.example.com"),
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
@@ -2401,7 +2401,7 @@ func customCert(namespace, domain string) *netv1alpha1.Certificate {
 	return &netv1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      fmt.Sprintf(domain),
+			Name:      domain,
 			Annotations: map[string]string{
 				networking.CertificateClassAnnotationKey: "my-custom",
 			},


### PR DESCRIPTION
After this patch, if there is a KCert which does not have an
annotation (`certificate.class: cert-manager`) and has a matching
domain, Knative uses it instead of generating new KCert.

For example, users can provision manual TLS by following KCert for `my-custom-route.example.com` domain.

```
apiVersion: networking.internal.knative.dev/v1alpha1
kind: Certificate
metadata:
  name: test
  namespace: default
  networking.internal.knative.dev/certificate.class: "my-kcert"
spec:
  dnsNames:
  - 'my-custom-route.example.com'
  secretName: my-company-tls
```

This also becomes a first part of the FIRST proposal of https://github.com/knative/serving/issues/5706#issuecomment-539138018

/lint

Fixes #

**Release Note**

```release-note
If there is a KCert which does not have an annotation (`networking.internal.knative.dev/certificate.class: cert-manager.certificate.networking.internal.knative.dev`) and has a matching domain, Knative uses it.
```

/cc @Joon-L @ZhiminXiang @tcnghia 