### PR TITLE
Delete istio pods before reinstalling for performance testing

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -32,7 +32,7 @@ function update_knative() {
   cd ${GOPATH}/src/knative.dev
   echo ">> Update istio"
   # istio-pilot pod occasionally gets overloaded and dies, delete all pods from
-  # istio before reintalling it
+  # istio before reintalling it to get them freshly recreated
   kubectl delete pods --all -n istio-system
   kubectl apply -f serving/third_party/$istio_version/istio-crds.yaml || abort "Failed to apply istio-crds"
   kubectl apply -f serving/third_party/$istio_version/istio-lean.yaml || abort "Failed to apply istio-lean"

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -31,9 +31,10 @@ function update_knative() {
   pushd .
   cd ${GOPATH}/src/knative.dev
   echo ">> Update istio"
-  # istio-pilot pod occasionally gets overloaded and dies, delete all pods from
-  # istio before reintalling it to get them freshly recreated
-  kubectl delete pods --all -n istio-system
+  # Some istio pods occasionally get overloaded and die, delete all deployments
+  # and services from istio before reintalling it, to get them freshly recreated
+  kubectl delete deployments --all -n istio-system
+  kubectl delete services --all -n istio-system
   kubectl apply -f serving/third_party/$istio_version/istio-crds.yaml || abort "Failed to apply istio-crds"
   kubectl apply -f serving/third_party/$istio_version/istio-lean.yaml || abort "Failed to apply istio-lean"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
* Since `istio-pilot` pod occasionally gets overloaded and dies, delete all istio pods before reinstalling to get them freshly recreated.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
/cc @mattmoor 
