### PR TITLE
Add more tests to RMB to cover service failures.

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -940,3 +940,91 @@ func TestRevisionDeleted(t *testing.T) {
 		// Wait to make sure the callbacks are executed.
 	}
 }
+
+func TestServiceProblem(t *testing.T) {
+	// Tests when the service is not available.
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+
+	ei := fakeendpointsinformer.Get(ctx)
+	eps := ep(testRevision, 1234, "http", "128.0.0.1")
+	fakekubeclient.Get(ctx).CoreV1().Endpoints(testNamespace).Create(eps)
+	waitInformers, err := controller.RunInformers(ctx.Done(), ei.Informer())
+	if err != nil {
+		t.Fatalf("Failed to start informers: %v", err)
+	}
+	defer func() {
+		cancel()
+		waitInformers()
+	}()
+
+	rev := revision(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
+	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	ri := fakerevisioninformer.Get(ctx)
+	ri.Informer().GetIndexer().Add(rev)
+
+	// This will make sure we go to the cluster IP probing.
+	fakeRT := activatortest.FakeRoundTripper{
+		ExpectHost: testRevision,
+		ProbeHostResponses: map[string][]activatortest.FakeResponse{
+			// To ensure that if we fail, when we get into the second iteration
+			// of probing if the test is not yet complete, we store 2 items here.
+			"128.0.0.1:1234": {{
+				Err: errors.New("clusterIP transport error"),
+			}, {
+				Err: errors.New("clusterIP transport error"),
+			}, {
+				Err: errors.New("clusterIP transport error"),
+			}},
+		},
+	}
+	rt := network.RoundTripperFunc(fakeRT.RT)
+
+	rbm := newRevisionBackendsManager(ctx, rt)
+	// Make some movements to generate a checkDests call.
+	ei.Informer().GetIndexer().Add(eps)
+	select {
+	case x := <-rbm.updates():
+		// We can't probe endpoints (see RT above) and we can't get to probe
+		// cluster IP. But if the service is accessible then we will and probing will
+		// succeed since RT has no rules for that.
+		t.Errorf("Unexpected update, should have had none: %v", x)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Now let's create two!
+	for _, num := range []string{"11", "12"} {
+		svc := privateSKSService(
+			types.NamespacedName{testNamespace, testRevision},
+			"129.0.0."+num,
+			[]corev1.ServicePort{{Name: "http", Port: 1234}},
+		)
+		// Modify the name so both can be created.
+		svc.Name = svc.Name + num
+		fakekubeclient.Get(ctx).CoreV1().Services(testNamespace).Create(svc)
+		si := fakeserviceinformer.Get(ctx)
+		si.Informer().GetIndexer().Add(svc)
+	}
+
+	// Make sure fake probe failures ensue.
+	fakeRT.ProbeHostResponses = map[string][]activatortest.FakeResponse{
+		// To ensure that if we fail, when we get into the second iteration
+		// of probing if the test is not yet complete, we store 2 items here.
+		"128.0.0.1:1234": {{
+			Err: errors.New("clusterIP transport error"),
+		}, {
+			Err: errors.New("clusterIP transport error"),
+		}, {
+			Err: errors.New("clusterIP transport error"),
+		}},
+	}
+	eps = ep(testRevision, 1234, "http", "128.0.0.44")
+	ei.Informer().GetIndexer().Add(eps)
+	select {
+	case x := <-rbm.updates():
+		// We can't probe endpoints (see RT above) and we can't get to probe
+		// cluster IP. But if the service is accessible then we will and probing will
+		// succeed since RT has no rules for that.
+		t.Errorf("Unexpected update, should have had none: %v", x)
+	case <-time.After(200 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
We had this hole in the tests where erors from the service were not
covered.
So fix that deficiency.

/assign mattmoor @markusthoemmes
/lint
