### PR TITLE
Pass config defaults into revision reconciler and add test case to verify

### DIFF
--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"knative.dev/serving/pkg/apis/config"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
@@ -37,6 +38,7 @@ type Config struct {
 	Observability *metrics.ObservabilityConfig
 	Logging       *logging.Config
 	Tracing       *pkgtracing.Config
+	Defaults      *config.Defaults
 }
 
 func FromContext(ctx context.Context) *Config {
@@ -64,6 +66,7 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 				pkgmetrics.ConfigMapName(): metrics.NewObservabilityConfigFromConfigMap,
 				logging.ConfigMapName():    logging.NewConfigFromConfigMap,
 				pkgtracing.ConfigName:      pkgtracing.NewTracingConfigFromConfigMap,
+				config.DefaultsConfigName:  config.NewDefaultsConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -84,5 +87,6 @@ func (s *Store) Load() *Config {
 		Observability: s.UntypedLoad(pkgmetrics.ConfigMapName()).(*metrics.ObservabilityConfig).DeepCopy(),
 		Logging:       s.UntypedLoad((logging.ConfigMapName())).(*logging.Config).DeepCopy(),
 		Tracing:       s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config).DeepCopy(),
+		Defaults:      s.UntypedLoad(config.DefaultsConfigName).(*config.Defaults).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/revision/config/store_test.go
+++ b/pkg/reconciler/revision/config/store_test.go
@@ -113,6 +113,8 @@ func TestStoreImmutableConfig(t *testing.T) {
 	config.Deployment.QueueSidecarImage = "mutated"
 	config.Network.IstioOutboundIPRanges = "mutated"
 	config.Logging.LoggingConfig = "mutated"
+	ccMutated := int64(4)
+	config.Defaults.ContainerConcurrency = ccMutated
 
 	newConfig := store.Load()
 
@@ -124,5 +126,8 @@ func TestStoreImmutableConfig(t *testing.T) {
 	}
 	if newConfig.Logging.LoggingConfig == "mutated" {
 		t.Error("Logging config is not immutable")
+	}
+	if newConfig.Defaults.ContainerConcurrency == ccMutated {
+		t.Error("Defaults config is not immutable")
 	}
 }

--- a/pkg/reconciler/revision/config/testdata/config-defaults.yaml
+++ b/pkg/reconciler/revision/config/testdata/config-defaults.yaml
@@ -1,0 +1,1 @@
+../../../../../config/config-defaults.yaml

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	apisconfig "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/metrics"
@@ -106,6 +107,7 @@ func NewController(
 		&network.Config{},
 		&metrics.ObservabilityConfig{},
 		&deployment.Config{},
+		&apisconfig.Defaults{},
 	}
 
 	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -134,12 +134,6 @@ func getTestDeploymentConfigMap() *corev1.ConfigMap {
 	}
 }
 
-func getTestDefaultsConfig() *config.Defaults {
-	c, _ := config.NewDefaultsConfigFromConfigMap(getTestDefaultsConfigMap())
-	// ignoring error as test controller is generated
-	return c
-}
-
 func getTestDefaultsConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -147,7 +141,7 @@ func getTestDefaultsConfigMap() *corev1.ConfigMap {
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"container-concurrency": "1",
+			"container-name-template": "user-container",
 		},
 	}
 }

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -18,6 +18,7 @@ package revision
 
 import (
 	"context"
+	"knative.dev/serving/pkg/apis/config"
 	"testing"
 	"time"
 
@@ -133,6 +134,24 @@ func getTestDeploymentConfigMap() *corev1.ConfigMap {
 	}
 }
 
+func getTestDefaultsConfig() *config.Defaults {
+	c, _ := config.NewDefaultsConfigFromConfigMap(getTestDefaultsConfigMap())
+	// ignoring error as test controller is generated
+	return c
+}
+
+func getTestDefaultsConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.DefaultsConfigName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string]string{
+			"container-concurrency": "1",
+		},
+	}
+}
+
 func newTestController(t *testing.T) (
 	context.Context,
 	context.CancelFunc,
@@ -148,6 +167,7 @@ func newTestController(t *testing.T) (
 
 	configs := []*corev1.ConfigMap{
 		getTestDeploymentConfigMap(),
+		getTestDefaultsConfigMap(),
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -308,7 +308,8 @@ func TestResolutionFailed(t *testing.T) {
 // TODO(mattmoor): add coverage of a Reconcile fixing a stale logging URL
 func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 	deploymentConfig := getTestDeploymentConfig()
-	ctx, _, controller, watcher := newTestControllerWithConfig(t, deploymentConfig, &corev1.ConfigMap{
+	defaultsConfig := getTestDefaultsConfigMap()
+	ctx, _, controller, watcher := newTestControllerWithConfig(t, deploymentConfig, defaultsConfig, &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
 			Name:      metrics.ConfigMapName(),
@@ -482,7 +483,8 @@ func TestIstioOutboundIPRangesInjection(t *testing.T) {
 
 func getPodAnnotationsForConfig(t *testing.T, configMapValue string, configAnnotationOverride string) map[string]string {
 	controllerConfig := getTestDeploymentConfig()
-	ctx, _, controller, watcher := newTestControllerWithConfig(t, controllerConfig)
+	defaultsConfig := getTestDefaultsConfigMap()
+	ctx, _, controller, watcher := newTestControllerWithConfig(t, controllerConfig, defaultsConfig)
 
 	// Resolve image references to this "digest"
 	digest := "foo@sha256:deadbeef"
@@ -557,7 +559,8 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			controllerConfig := getTestDeploymentConfig()
-			ctx, informers, ctrl, watcher := newTestControllerWithConfig(t, controllerConfig)
+			defaultsConfig := getTestDefaultsConfigMap()
+			ctx, informers, ctrl, watcher := newTestControllerWithConfig(t, controllerConfig, defaultsConfig)
 
 			ctx, cancel := context.WithCancel(ctx)
 			grp := errgroup.Group{}
@@ -713,7 +716,8 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			controllerConfig := getTestDeploymentConfig()
-			ctx, informers, ctrl, watcher := newTestControllerWithConfig(t, controllerConfig)
+			defaultsConfig := getTestDefaultsConfigMap()
+			ctx, informers, ctrl, watcher := newTestControllerWithConfig(t, controllerConfig, defaultsConfig)
 
 			ctx, cancel := context.WithCancel(ctx)
 			grp := errgroup.Group{}


### PR DESCRIPTION
/lint

## Proposed Changes
* Currently we are not passing config-defaults into revision reconciler. The result is we are calling `SetDefaults(...)` but only use the hard coded values in the code, instead of using what users have set in the config-defaults config map in their cluster.

By running 52967192cf6fe19ee243ee688066c7f6f6114288 locally, I have verified that the config-defaults is not in [the context of the revision reconciler](https://github.com/knative/serving/blob/master/pkg/reconciler/revision/revision.go#L75). 

Slack convo: https://knative.slack.com/archives/CA4DNJ9A4/p1572024996068100 

/cc @nimakaviani 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
