### PR TITLE
Add additional Stackdriver configuration fields for system metrics

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -43,7 +43,7 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 	pkglogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
-	"knative.dev/pkg/metrics"
+	pkgmetrics "knative.dev/pkg/metrics"
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/profiling"
 	"knative.dev/pkg/signals"
@@ -61,6 +61,7 @@ import (
 	"knative.dev/serving/pkg/goversion"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/logging"
+	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
 )
@@ -125,7 +126,7 @@ func main() {
 	defer cancel()
 
 	// Report stats on Go memory usage every 30 seconds.
-	msp := metrics.NewMemStatsAll()
+	msp := pkgmetrics.NewMemStatsAll()
 	msp.Start(ctx, 30*time.Second)
 	if err := view.Register(msp.DefaultViews()...); err != nil {
 		log.Fatalf("Error exporting go memstats view: %v", err)
@@ -257,7 +258,7 @@ func main() {
 	configMapWatcher.Watch(pkglogging.ConfigMapName(), pkglogging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 
 	// Watch the observability config map
-	configMapWatcher.Watch(metrics.ConfigMapName(),
+	configMapWatcher.Watch(pkgmetrics.ConfigMapName(),
 		metrics.UpdateExporterFromConfigMap(component, logger),
 		updateRequestLogFromConfigMap(logger, reqLogHandler),
 		profilingHandler.UpdateFromConfigMap)
@@ -327,5 +328,5 @@ func flush(logger *zap.SugaredLogger) {
 	logger.Sync()
 	os.Stdout.Sync()
 	os.Stderr.Sync()
-	metrics.FlushExporter()
+	pkgmetrics.FlushExporter()
 }

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -39,7 +39,7 @@ import (
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics"
+	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/pkg/profiling"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
@@ -47,6 +47,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/autoscaler/statserver"
+	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa"
 	"knative.dev/serving/pkg/reconciler/metric"
 	"knative.dev/serving/pkg/resources"
@@ -74,7 +75,7 @@ func main() {
 	ctx := signals.NewContext()
 
 	// Report stats on Go memory usage every 30 seconds.
-	msp := metrics.NewMemStatsAll()
+	msp := pkgmetrics.NewMemStatsAll()
 	msp.Start(ctx, 30*time.Second)
 	if err := view.Register(msp.DefaultViews()...); err != nil {
 		log.Fatalf("Error exporting go memstats view: %v", err)
@@ -115,7 +116,7 @@ func main() {
 	// Watch the logging config map and dynamically update logging levels.
 	cmw.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	// Watch the observability config map
-	cmw.Watch(metrics.ConfigMapName(),
+	cmw.Watch(pkgmetrics.ConfigMapName(),
 		metrics.UpdateExporterFromConfigMap(component, logger),
 		profilingHandler.UpdateFromConfigMap)
 
@@ -209,5 +210,5 @@ func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) auto
 
 func flush(logger *zap.SugaredLogger) {
 	logger.Sync()
-	metrics.FlushExporter()
+	pkgmetrics.FlushExporter()
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -37,7 +37,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
-	"knative.dev/pkg/metrics"
+	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/version"
@@ -49,6 +49,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/gc"
+	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
 
 	// config validation constructors
@@ -78,7 +79,7 @@ func main() {
 	ctx := signals.NewContext()
 
 	// Report stats on Go memory usage every 30 seconds.
-	msp := metrics.NewMemStatsAll()
+	msp := pkgmetrics.NewMemStatsAll()
 	msp.Start(ctx, 30*time.Second)
 	if err := view.Register(msp.DefaultViews()...); err != nil {
 		log.Fatalf("Error exporting go memstats view: %v", err)
@@ -115,7 +116,7 @@ func main() {
 	// Watch the observability config map and dynamically update request logs.
 	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	// Watch the observability config map
-	configMapWatcher.Watch(metrics.ConfigMapName(),
+	configMapWatcher.Watch(pkgmetrics.ConfigMapName(),
 		metrics.UpdateExporterFromConfigMap(component, logger),
 		profilingHandler.UpdateFromConfigMap)
 
@@ -170,7 +171,7 @@ func main() {
 		network.ConfigName:               network.NewConfigFromConfigMap,
 		istioconfig.IstioConfigName:      istioconfig.NewIstioFromConfigMap,
 		deployment.ConfigName:            deployment.NewConfigFromConfigMap,
-		metrics.ConfigMapName():          metricsconfig.NewObservabilityConfigFromConfigMap,
+		pkgmetrics.ConfigMapName():       metricsconfig.NewObservabilityConfigFromConfigMap,
 		logging.ConfigMapName():          logging.NewConfigFromConfigMap,
 		domainconfig.DomainConfigName:    domainconfig.NewDomainFromConfigMap,
 		defaultconfig.DefaultsConfigName: defaultconfig.NewDefaultsConfigFromConfigMap,

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -85,7 +85,7 @@ data:
   
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.
-    # Note: Using stackdriver will incur additional charges
+    # Note: Using stackdriver will incur additional charges.
     metrics.backend-destination: prometheus
 
     # metrics.request-metrics-backend-destination specifies the request metrics
@@ -93,10 +93,31 @@ data:
     # Currently supported values: prometheus, stackdriver.
     metrics.request-metrics-backend-destination: prometheus
 
-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID.
+    # This field is optional. When running on GCE, application default credentials will be
     # used if this field is not provided.
+    #
+    # To use a Stackdriver project ID that does not match the application default credentials,
+    # add a Secret named "stackdriver-service-account-key" to the "knative-serving" namespace.
+    # The Secret should contain the key of a Google Service Account with access scope of
+    # monitoring.metricDescriptors.create permissions to the project specified by
+    # metrics.stackdriver-project-id.
+    # (See https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform).
+    # Using a Stackdriver project ID that does not match the application default credentials
+    # only applies to system metrics (metrics.backend-destination).
     metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.stackdriver-gcp-location specifies the GCP zone region where Stackdriver metrics will be sent.
+    # This field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    # This field only applies to system metrics (metrics.backend-destination).
+    metrics.stackdriver-gcp-location: "<a GCP zone or region>"
+
+    # metrics.stackdriver-cluster-name specifies the cluster name that will be used to label Stackdriver metrics.
+    # The name does not have to match the cluster name that is used by the underlying cluster provider.
+    # This field is optional.
+    # This field only applies to system metrics (metrics.backend-destination).
+    metrics.stackdriver-cluster-name: "<a-cluster-name>"
 
     # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
     # Stackdriver using "global" resource type and custom metric type if the

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	pkgmetrics "knative.dev/pkg/metrics"
+)
+
+// UpdateExporterFromConfigMap sets metrics config map fields that should be uniform for knative/serving components
+// and then calls through to UpdateExporterFromConfigMap from "knative.dev/pkg/metrics".
+func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
+	return func(configMap *corev1.ConfigMap) {
+		if configMap.Data["metrics.stackdriver-gcp-secret-name"] != "" {
+			configMap.Data["metrics.stackdriver-gcp-secret-name"] = "stackdriver-service-account-key"
+			configMap.Data["metrics.stackdriver-gcp-secret-namespace"] = "knative-serving"
+		}
+		pkgmetrics.UpdateExporterFromConfigMap(component, logger)(configMap)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Add additional Stackdriver configuration fields/documentation to config-observability to allow using non-default Google application credentials to send metrics to Stackdriver on any compute platform.

Part of #5777 

## Proposed Changes

* Documents additional fields to config-observability to configure Stackdriver client metadata for metrics exporter
* Allows using a k8s Secret named "stackdriver-service-account-key" in "knative-serving" namespace to authenticate with Stackdriver
* Only hooked in for "system metrics" that metrics.backend-destination refers to (i.e. reconciler/request_count & reconciler/request_latency) are left out)
