### PR TITLE
Enable field imagePullSecrets for PodSpec

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -147,6 +147,7 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.ServiceAccountName = in.ServiceAccountName
 	out.Containers = in.Containers
 	out.Volumes = in.Volumes
+	out.ImagePullSecrets = in.ImagePullSecrets
 
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
@@ -163,7 +164,6 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.HostIPC = false
 	out.ShareProcessNamespace = nil
 	out.SecurityContext = nil
-	out.ImagePullSecrets = nil
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.Affinity = nil

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -80,6 +80,9 @@ func TestVolumeSourceMask(t *testing.T) {
 func TestPodSpecMask(t *testing.T) {
 	want := &corev1.PodSpec{
 		ServiceAccountName: "default",
+		ImagePullSecrets: []corev1.LocalObjectReference{{
+			Name: "foo",
+		}},
 		Containers: []corev1.Container{{
 			Image: "helloworld",
 		}},
@@ -94,6 +97,9 @@ func TestPodSpecMask(t *testing.T) {
 	}
 	in := &corev1.PodSpec{
 		ServiceAccountName: "default",
+		ImagePullSecrets: []corev1.LocalObjectReference{{
+			Name: "foo",
+		}},
 		Containers: []corev1.Container{{
 			Image: "helloworld",
 		}},

--- a/pkg/apis/serving/v1alpha1/configuration_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_conversion_test.go
@@ -90,6 +90,9 @@ func TestConfigurationConversion(t *testing.T) {
 						RevisionSpec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								ServiceAccountName: "robocop",
+								ImagePullSecrets: []corev1.LocalObjectReference{{
+									Name: "foo",
+								}},
 								Containers: []corev1.Container{{
 									Image: "busybox",
 									VolumeMounts: []corev1.VolumeMount{{

--- a/pkg/apis/serving/v1alpha1/revision_conversion.go
+++ b/pkg/apis/serving/v1alpha1/revision_conversion.go
@@ -61,6 +61,7 @@ func (source *RevisionSpec) ConvertUp(ctx context.Context, sink *v1.RevisionSpec
 			ServiceAccountName: source.ServiceAccountName,
 			Containers:         []corev1.Container{*source.DeprecatedContainer},
 			Volumes:            source.Volumes,
+			ImagePullSecrets:   source.ImagePullSecrets,
 		}
 	case len(source.Containers) == 1:
 		sink.PodSpec = source.PodSpec

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -160,6 +160,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, tracingC
 		Volumes:                       append([]corev1.Volume{varLogVolume}, rev.Spec.Volumes...),
 		ServiceAccountName:            rev.Spec.ServiceAccountName,
 		TerminationGracePeriodSeconds: rev.Spec.TimeoutSeconds,
+		ImagePullSecrets:              rev.Spec.ImagePullSecrets,
 	}
 
 	// Add the Knative internal volume only if /var/log collection is enabled

--- a/pkg/reconciler/revision/resources/imagecache.go
+++ b/pkg/reconciler/revision/resources/imagecache.go
@@ -48,7 +48,7 @@ func MakeImageCache(rev *v1alpha1.Revision) *caching.Image {
 		Spec: caching.ImageSpec{
 			Image:              image,
 			ServiceAccountName: rev.Spec.ServiceAccountName,
-			// We don't support ImagePullSecrets today.
+			ImagePullSecrets:   rev.Spec.ImagePullSecrets,
 		},
 	}
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -132,12 +132,15 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 		return nil
 	}
 
+	var imagePullSecrets []string
+	for _, s := range rev.Spec.ImagePullSecrets {
+		imagePullSecrets = append(imagePullSecrets, s.Name)
+	}
 	cfgs := config.FromContext(ctx)
 	opt := k8schain.Options{
 		Namespace:          rev.Namespace,
 		ServiceAccountName: rev.Spec.ServiceAccountName,
-		// ImagePullSecrets: Not possible via RevisionSpec, since we
-		// don't expose such a field.
+		ImagePullSecrets:   imagePullSecrets,
 	}
 	digest, err := c.resolver.Resolve(rev.Spec.GetContainer().Image,
 		opt, cfgs.Deployment.RegistriesSkippingTagResolving)

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
@@ -91,6 +92,16 @@ func WithLastPinned(t time.Time) RevisionOption {
 func WithRevStatus(st v1alpha1.RevisionStatus) RevisionOption {
 	return func(rev *v1alpha1.Revision) {
 		rev.Status = st
+	}
+}
+
+// WithImagePullSecrets updates the revision spec ImagePullSecrets to
+// the provided secrets
+func WithImagePullSecrets(secretName string) RevisionOption {
+	return func(rev *v1alpha1.Revision) {
+		rev.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{
+			Name: secretName,
+		}}
 	}
 }
 

--- a/test/apicoverage/image/kodata/ignoredfields.yaml
+++ b/test/apicoverage/image/kodata/ignoredfields.yaml
@@ -98,7 +98,6 @@
     - HostIPC
     - ShareProcessNamespace
     - SecurityContext
-    - ImagePullSecrets
     - Hostname
     - Subdomain
     - Affinity


### PR DESCRIPTION
/lint

Part of #5866

## Proposed Changes
* Enable users to specify imagePullSecrets in their service yaml

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Users will now be able to specify imagePullSecrets in their service yaml.
```
