### PR TITLE
Enhance error messages around image to tag resolving.

### DIFF
--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -18,6 +18,7 @@ package revision
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -142,6 +143,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1alpha1.Revision
 	digest, err := c.resolver.Resolve(rev.Spec.GetContainer().Image,
 		opt, cfgs.Deployment.RegistriesSkippingTagResolving)
 	if err != nil {
+		err = fmt.Errorf("failed to resolve image to digest: %w", err)
 		rev.Status.MarkContainerHealthyFalse(v1alpha1.ContainerMissing,
 			v1alpha1.RevisionContainerMissingMessage(
 				rev.Spec.GetContainer().Image, err.Error()))

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -261,11 +261,11 @@ func (r *fixedResolver) Resolve(_ string, _ k8schain.Options, _ sets.String) (st
 }
 
 type errorResolver struct {
-	error string
+	err error
 }
 
 func (r *errorResolver) Resolve(_ string, _ k8schain.Options, _ sets.String) (string, error) {
-	return "", errors.New(r.error)
+	return "", r.err
 }
 
 func TestResolutionFailed(t *testing.T) {
@@ -273,8 +273,8 @@ func TestResolutionFailed(t *testing.T) {
 	defer cancel()
 
 	// Unconditionally return this error during resolution.
-	errorMessage := "I am the expected error message, hear me ROAR!"
-	controller.Reconciler.(*Reconciler).resolver = &errorResolver{errorMessage}
+	innerError := errors.New("I am the expected error message, hear me ROAR!")
+	controller.Reconciler.(*Reconciler).resolver = &errorResolver{innerError}
 
 	rev := testRevision()
 	config := testConfiguration()
@@ -295,7 +295,7 @@ func TestResolutionFailed(t *testing.T) {
 			Status: corev1.ConditionFalse,
 			Reason: "ContainerMissing",
 			Message: v1alpha1.RevisionContainerMissingMessage(
-				rev.Spec.GetContainer().Image, errorMessage),
+				rev.Spec.GetContainer().Image, "failed to resolve image to digest: "+innerError.Error()),
 			LastTransitionTime: got.LastTransitionTime,
 			Severity:           apis.ConditionSeverityError,
 		}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -273,7 +273,7 @@ func TestResolutionFailed(t *testing.T) {
 	defer cancel()
 
 	// Unconditionally return this error during resolution.
-	innerError := errors.New("I am the expected error message, hear me ROAR!")
+	innerError := errors.New("i am the expected error message, hear me ROAR!")
 	controller.Reconciler.(*Reconciler).resolver = &errorResolver{innerError}
 
 	rev := testRevision()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5410

## Proposed Changes

We currently surface the plain error returned from the tag resolution without further explanation. This adds wrapping around those errors to explain in which step it fails and adds wrapping around the outer layer to make sure the user gets enough context to be able to tell what exactly failed.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Added more expressive error messages around image to tag resolving.
```

/assign @dgerd 
