### PR TITLE
move poll for kube-api to before logger creation

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -164,7 +164,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Error loading/parsing logging configuration: ", err)
 	}
-	
+
 	logger, atomicLevel := pkglogging.NewLoggerFromConfig(loggingConfig, component)
 	logger = logger.With(zap.String(logkey.ControllerType, component),
 		zap.String(logkey.Pod, env.PodName))


### PR DESCRIPTION
logger requires kube api to be available.

Request Prow to automatically lint any go code in this PR:

/lint

Fixes #5922

## Proposed Changes

* Move creation of logger to after the poll for kube-api to become available, since logger requires kube api to be up.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
