### PR TITLE
Remove deprecated APIs from the 'extensions/v1beta1' group.

### DIFF
--- a/pkg/apis/networking/v1alpha1/doc.go
+++ b/pkg/apis/networking/v1alpha1/doc.go
@@ -19,6 +19,6 @@ limitations under the License.
 package v1alpha1
 
 // Ingress is heavily based on K8s Ingress
-// https://godoc.org/k8s.io/api/extensions/v1beta1#Ingress with some
+// https://godoc.org/k8s.io/api/networking/v1beta1#Ingress with some
 // highlighted modifications.  See ingress_types.go for more
 // information about the modifications that we made.

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -31,7 +31,7 @@ import (
 // by a backend. An Ingress can be configured to give services externally-reachable URLs, load
 // balance traffic, offer name based virtual hosting, etc.
 //
-// This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/extensions/v1beta1#Ingress
+// This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress
 // which some highlighted modifications.
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`

--- a/testrelease/templates/ingress.yaml
+++ b/testrelease/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "testrelease.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
@@ -33,7 +33,7 @@ subjects:
   name: node-exporter
   namespace: knative-monitoring
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-exporter


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The title says it all. `extensions/v1beta1` is deprecated for all of these, see https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Moved monitoring and test resources out of the deprecated 'extensions/v1beta1' group.
```

/assign @mattmoor 
