### PR TITLE
Add metric ports to the private service in SKS and use it in HPA.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -131,22 +131,19 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 		}
 	}
 
-	// Only create metrics service and metric entity if we actually need to gather metrics.
-	if pa.Metric() == autoscaling.Concurrency || pa.Metric() == autoscaling.RPS {
-		metricSvc, err := c.ReconcileMetricsService(ctx, pa)
-		if err != nil {
-			return fmt.Errorf("error reconciling metrics service: %w", err)
-		}
-
-		if err := c.ReconcileMetric(ctx, pa, metricSvc); err != nil {
-			return fmt.Errorf("error reconciling metric: %w", err)
-		}
-	}
-
 	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)
 	}
+
+	// Only create metrics service and metric entity if we actually need to gather metrics.
+	pa.Status.MetricsServiceName = sks.Status.PrivateServiceName
+	if sks.Status.PrivateServiceName != "" && pa.Metric() == autoscaling.Concurrency || pa.Metric() == autoscaling.RPS {
+		if err := c.ReconcileMetric(ctx, pa, sks.Status.PrivateServiceName); err != nil {
+			return fmt.Errorf("error reconciling metric: %w", err)
+		}
+	}
+
 	// Propagate the service name regardless of the status.
 	pa.Status.ServiceName = sks.Status.ServiceName
 	if !sks.Status.IsReady() {

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -138,8 +138,8 @@ func (c *Reconciler) reconcile(ctx context.Context, key string, pa *pav1alpha1.P
 
 	// Only create metrics service and metric entity if we actually need to gather metrics.
 	pa.Status.MetricsServiceName = sks.Status.PrivateServiceName
-	if sks.Status.PrivateServiceName != "" && pa.Metric() == autoscaling.Concurrency || pa.Metric() == autoscaling.RPS {
-		if err := c.ReconcileMetric(ctx, pa, sks.Status.PrivateServiceName); err != nil {
+	if pa.Status.MetricsServiceName != "" && pa.Metric() == autoscaling.Concurrency || pa.Metric() == autoscaling.RPS {
+		if err := c.ReconcileMetric(ctx, pa, pa.Status.MetricsServiceName); err != nil {
 			return fmt.Errorf("error reconciling metric: %w", err)
 		}
 	}

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -134,6 +134,16 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),
 			}, {
+				Name:       servingv1alpha1.AutoscalingQueueMetricsPortName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       networking.AutoscalingQueueMetricsPort,
+				TargetPort: intstr.FromString(servingv1alpha1.AutoscalingQueueMetricsPortName),
+			}, {
+				Name:       servingv1alpha1.UserQueueMetricsPortName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       networking.UserQueueMetricsPort,
+				TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
+			}, {
 				// When run with the Istio mesh, Envoy blocks traffic to any ports not
 				// recognized, and has special treatment for probes, but not PreStop hooks.
 				// That results in the PreStop hook /wait-for-drain in queue-proxy not

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -595,6 +595,16 @@ func TestMakePrivateService(t *testing.T) {
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTPPort),
 				}, {
+					Name:       servingv1alpha1.AutoscalingQueueMetricsPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       networking.AutoscalingQueueMetricsPort,
+					TargetPort: intstr.FromString(servingv1alpha1.AutoscalingQueueMetricsPortName),
+				}, {
+					Name:       servingv1alpha1.UserQueueMetricsPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       networking.UserQueueMetricsPort,
+					TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
+				}, {
 					Name:       servingv1alpha1.QueueAdminPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.QueueAdminPort,
@@ -657,6 +667,16 @@ func TestMakePrivateService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+				}, {
+					Name:       servingv1alpha1.AutoscalingQueueMetricsPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       networking.AutoscalingQueueMetricsPort,
+					TargetPort: intstr.FromString(servingv1alpha1.AutoscalingQueueMetricsPortName),
+				}, {
+					Name:       servingv1alpha1.UserQueueMetricsPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       networking.UserQueueMetricsPort,
+					TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
 				}, {
 					Name:       servingv1alpha1.QueueAdminPortName,
 					Protocol:   corev1.ProtocolTCP,

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -84,13 +84,14 @@ func WithTraffic(pa *asv1a1.PodAutoscaler) {
 	pa.Status.MarkActive()
 }
 
-// WithPAStatusService annotats PA Status with the provided service name.
+// WithPAStatusService annotates PA Status with the provided service name.
 func WithPAStatusService(svc string) PodAutoscalerOption {
 	return func(pa *asv1a1.PodAutoscaler) {
 		pa.Status.ServiceName = svc
 	}
 }
 
+// WithPAMetricsService annotates PA Status with the provided service name.
 func WithPAMetricsService(svc string) PodAutoscalerOption {
 	return func(pa *asv1a1.PodAutoscaler) {
 		pa.Status.MetricsServiceName = svc

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -91,6 +91,12 @@ func WithPAStatusService(svc string) PodAutoscalerOption {
 	}
 }
 
+func WithPAMetricsService(svc string) PodAutoscalerOption {
+	return func(pa *asv1a1.PodAutoscaler) {
+		pa.Status.MetricsServiceName = svc
+	}
+}
+
 // WithBufferedTraffic updates the PA to reflect that it has received
 // and buffered traffic while it is being activated.
 func WithBufferedTraffic(reason, message string) PodAutoscalerOption {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Ref #5900

## Proposed Changes

* Add metric ports to the private service in SKS.
* Use the private service as a metric service in the HPA autoscaling implementation.

Doing the same for the KPA is the next step but vastly more complex to get "nice". This makes sure that the concept works in principle though.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Removed the additional metric service for HPA based autoscaling.
```

/assign @vagababov 
