### PR TITLE
More tests and coverage for the throttler

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -517,9 +517,8 @@ func (t *Throttler) handleUpdate(update revisionDestsUpdate) {
 		if k8serrors.IsNotFound(err) {
 			t.logger.Debugf("Revision %q is not found. Probably it was removed", update.Rev.String())
 		} else {
-			t.logger.Errorw(
-				fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()),
-				zap.Error(err))
+			t.logger.With(zap.Error(err)).Errorf(
+				fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()))
 		}
 	} else {
 		rt.handleUpdate(t, update)

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -19,7 +19,6 @@ package net
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/rand"
 	"sort"
 	"sync"
@@ -518,7 +517,7 @@ func (t *Throttler) handleUpdate(update revisionDestsUpdate) {
 			t.logger.Debugf("Revision %q is not found. Probably it was removed", update.Rev.String())
 		} else {
 			t.logger.With(zap.Error(err)).Errorf(
-				fmt.Sprintf("Failed to get revision throttler for revision %q", update.Rev.String()))
+				"Failed to get revision throttler for revision %q", update.Rev)
 		}
 	} else {
 		rt.handleUpdate(t, update)

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -553,13 +553,7 @@ func TestMultipleActivators(t *testing.T) {
 	servfake.ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
 	revisions.Informer().GetIndexer().Add(rev)
 
-	params := queue.BreakerParams{
-		QueueDepth:      1,
-		MaxConcurrency:  defaultMaxConcurrency,
-		InitialCapacity: 0,
-	}
-
-	throttler := NewThrottler(ctx, params, "130.0.0.2:8012")
+	throttler := NewThrottler(ctx, defaultParams, "130.0.0.2:8012")
 
 	revID := types.NamespacedName{testNamespace, testRevision}
 	possibleDests := sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.23:1234")


### PR DESCRIPTION
The new code is pretty complex and unintuitive in parts, so I've added a few tests that follow paths less travelled and which more important trace the whole update path from beginning to the end.
For both limited and unlimited concurrency.
Also other minor changes (like redundant int64 storage in the revisionThrottler)

/assign @markusthoemmes 