### PR TITLE
greghaynes@ has changed jobs and no longer works on Knative

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,13 +16,11 @@ aliases:
   - vagababov
 
   autoscaling-approvers:
-  - greghaynes
   - josephburnett
   - markusthoemmes
   - mdemirhan
   - vagababov
   autoscaling-reviewers:
-  - greghaynes
   - josephburnett
   - markusthoemmes
   - mdemirhan

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,12 +16,10 @@ aliases:
   - vagababov
 
   autoscaling-approvers:
-  - josephburnett
   - markusthoemmes
   - mdemirhan
   - vagababov
   autoscaling-reviewers:
-  - josephburnett
   - markusthoemmes
   - mdemirhan
   - taragu


### PR DESCRIPTION
Thus remove him from the approvers for knative.

While doing this I also noticed that Joe hasn't been active contributor for a while as well, so remove him as well.


/assign @evankanderson @mattmoor 