### PR TITLE
Remove usage of deprecated grpc.FailFast function.

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -62,7 +62,7 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 			grpc.WithAuthority(domain),
 			grpc.WithInsecure(),
 			// Retrying DNS errors to avoid .xip.io issues.
-			grpc.WithDefaultCallOptions(grpc.FailFast(false)),
+			grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 		)
 	}
 	// This is a more preferred usage of the go-grpc client.
@@ -70,7 +70,7 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 		host,
 		grpc.WithInsecure(),
 		// Retrying DNS errors to avoid .xip.io issues.
-		grpc.WithDefaultCallOptions(grpc.FailFast(false)),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

`grpc.FailFast` is deprecated. One shall use `WaitForReady` instead. Your wish has been granted!

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @tanzeeb @vagababov 
