### PR TITLE
More robust WaitForServiceLatestRevision function for rolling upgrades

### DIFF
--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -77,10 +77,8 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 
 // IsRevisionPinned will check if the revision is pinned to a route.
 func IsRevisionPinned(r *v1.Revision) (bool, error) {
-	if _, ok := r.Annotations[serving.RevisionLastPinnedAnnotationKey]; !ok {
-		return false, fmt.Errorf("Revision %s not pinned", r.Name)
-	}
-	return true, nil
+	_, pinned := r.Annotations[serving.RevisionLastPinnedAnnotationKey]
+	return pinned, nil
 }
 
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -75,6 +75,14 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
+// IsRevisionPinned will check if the revision is pinned to a route.
+func IsRevisionPinned(r *v1.Revision) (bool, error) {
+	if _, ok := r.Annotations[serving.RevisionLastPinnedAnnotationKey]; !ok {
+		return false, fmt.Errorf("Revision %s not pinned", r.Name)
+	}
+	return true, nil
+}
+
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations
 // on the revision include an annotation for the generation and that the annotation is
 // set to the expected value.

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/mattbaird/jsonpatch"
+	"github.com/pkg/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -174,18 +175,24 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 	err := WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
+			// We also check that the revision is pinned, meaning it's not a stale revision.
+			// Without this it might happen that the latest created revision is later overriden by a newer one
+			// and the following check for LatestReadyRevisionName would fail.
+			if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned); revErr != nil {
+				return false, nil
+			}
 			return true, nil
 		}
 		return false, nil
 	}, "ServiceUpdatedWithRevision")
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "LatestCreatedRevisionName not updated")
 	}
 	err = WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
 	}, "ServiceReadyWithRevision")
 
-	return revisionName, err
+	return revisionName, errors.Wrapf(err, "LatestReadyRevisionName not updated with %s", revisionName)
 }
 
 // Service returns a Service object in namespace with the name names.Service

--- a/test/v1alpha1/revision.go
+++ b/test/v1alpha1/revision.go
@@ -75,6 +75,14 @@ func IsRevisionReady(r *v1alpha1.Revision) (bool, error) {
 	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
+// IsRevisionPinned will check if the revision is pinned to a route.
+func IsRevisionPinned(r *v1alpha1.Revision) (bool, error) {
+	if _, ok := r.Annotations[serving.RevisionLastPinnedAnnotationKey]; !ok {
+		return false, fmt.Errorf("Revision %s not pinned", r.Name)
+	}
+	return true, nil
+}
+
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations
 // on the revision include an annotation for the generation and that the annotation is
 // set to the expected value.

--- a/test/v1alpha1/revision.go
+++ b/test/v1alpha1/revision.go
@@ -77,10 +77,8 @@ func IsRevisionReady(r *v1alpha1.Revision) (bool, error) {
 
 // IsRevisionPinned will check if the revision is pinned to a route.
 func IsRevisionPinned(r *v1alpha1.Revision) (bool, error) {
-	if _, ok := r.Annotations[serving.RevisionLastPinnedAnnotationKey]; !ok {
-		return false, fmt.Errorf("Revision %s not pinned", r.Name)
-	}
-	return true, nil
+	_, pinned := r.Annotations[serving.RevisionLastPinnedAnnotationKey]
+	return pinned, nil
 }
 
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -30,10 +30,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/watch"
-	"knative.dev/pkg/apis/istio/v1alpha3"
-	"knative.dev/pkg/test/spoof"
 	"math/big"
 	"net"
 	"net/http"
@@ -42,8 +38,13 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/watch"
+	"knative.dev/pkg/apis/istio/v1alpha3"
+	"knative.dev/pkg/test/spoof"
+
 	"github.com/mattbaird/jsonpatch"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -59,13 +60,14 @@ import (
 
 const (
 	// Namespace is the namespace of the ingress gateway
-	Namespace            = "knative-serving"
+	Namespace = "knative-serving"
 
 	// GatewayName is the name of the ingress gateway
-	GatewayName          = "knative-ingress-gateway"
+	GatewayName = "knative-ingress-gateway"
 )
+
 var (
-	domainName           *string
+	domainName *string
 )
 
 func validateCreatedServiceStatus(clients *test.Clients, names *test.ResourceNames) error {
@@ -317,13 +319,13 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 		return false, nil
 	}, "ServiceUpdatedWithRevision")
 	if err != nil {
-		return "", errors.Wrapf(err, "LatestCreatedRevisionName not updated")
+		return "", perrors.Wrapf(err, "LatestCreatedRevisionName not updated")
 	}
 	err = WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
 	}, "ServiceReadyWithRevision")
 
-	return revisionName, errors.Wrapf(err, "LatestReadyRevisionName not updated with %s", revisionName)
+	return revisionName, perrors.Wrapf(err, "LatestReadyRevisionName not updated with %s", revisionName)
 }
 
 // LatestService returns a Service object in namespace with the name names.Service

--- a/test/v1beta1/revision.go
+++ b/test/v1beta1/revision.go
@@ -77,10 +77,8 @@ func IsRevisionReady(r *v1beta1.Revision) (bool, error) {
 
 // IsRevisionPinned will check if the revision is pinned to a route.
 func IsRevisionPinned(r *v1beta1.Revision) (bool, error) {
-	if _, ok := r.Annotations[serving.RevisionLastPinnedAnnotationKey]; !ok {
-		return false, fmt.Errorf("Revision %s not pinned", r.Name)
-	}
-	return true, nil
+	_, pinned := r.Annotations[serving.RevisionLastPinnedAnnotationKey]
+	return pinned, nil
 }
 
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations

--- a/test/v1beta1/revision.go
+++ b/test/v1beta1/revision.go
@@ -75,6 +75,14 @@ func IsRevisionReady(r *v1beta1.Revision) (bool, error) {
 	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
+// IsRevisionPinned will check if the revision is pinned to a route.
+func IsRevisionPinned(r *v1beta1.Revision) (bool, error) {
+	if _, ok := r.Annotations[serving.RevisionLastPinnedAnnotationKey]; !ok {
+		return false, fmt.Errorf("Revision %s not pinned", r.Name)
+	}
+	return true, nil
+}
+
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations
 // on the revision include an annotation for the generation and that the annotation is
 // set to the expected value.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes the following type of issue when running rolling-upgrade tests, this issue happens randomly:
```
service_postupgrade_test.go:35: Since the Service was updated a new Revision will be created and the Service will be updated\n    service_postupgrade_test.go:35: Service pizzaplanet-upgrade-service was not updated with the Revision for image pizzaplanetv2: service \"pizzaplanet-upgrade-service\" is not in desired state, got: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:pizzaplanet-upgrade-service GenerateName: Namespace:serving-tests SelfLink:/apis/serving.knative.dev/v1alpha1/namespaces/serving-tests/services/pizzaplanet-upgrade-service UID:e0b1a3ff-007a-11ea-bfa4-02c1cbe14dfb ResourceVersion:27702 Generation:3 CreationTimestamp:2019-11-06 04:50:34 -0500 EST DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[serving.knative.dev/creator:kube:admin serving.knative.dev/forceUpgrade:true serving.knative.dev/lastModifier:kube:admin] OwnerReferences:[] Initializers:nil Finalizers:[] ClusterName:} Spec:{DeprecatedGeneration:0 DeprecatedRunLatest:<nil> DeprecatedPinned:<nil> DeprecatedManual:<nil> DeprecatedRelease:<nil> ConfigurationSpec:{DeprecatedGeneration:0 DeprecatedBuild:nil DeprecatedRevisionTemplate:<nil> Template:&ObjectMeta{Name:,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{autoscaling.knative.dev/minScale: 1,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,}} RouteSpec:{DeprecatedGeneration:0 Traffic:[{DeprecatedName: TrafficTarget:{Tag: RevisionName: ConfigurationName: LatestRevision:0xc0007a1048 Percent:0xc0007a1070 URL:}}]}} Status:{Status:{ObservedGeneration:3 Conditions:[{Type:ConfigurationsReady Status:True Severity: LastTransitionTime:{Inner:2019-11-06 04:53:45 -0500 EST} Reason: Message:} {Type:Ready Status:True Severity: LastTransitionTime:{Inner:2019-11-06 04:53:46 -0500 EST} Reason: Message:} {Type:RoutesReady Status:True Severity: LastTransitionTime:{Inner:2019-11-06 04:53:46 -0500 EST} Reason: Message:}]} RouteStatusFields:{URL:http://pizzaplanet-upgrade-service.serving-tests.apps.ocf-rollup-19-ocf-ocp-4.0-aws-rolling-upgrade.openshift-aws.rhocf-dev.com DeprecatedDomain: DeprecatedDomainInternal: Address:0xc000382760 Traffic:[{DeprecatedName: TrafficTarget:{Tag: RevisionName:pizzaplanet-upgrade-service-lqckw ConfigurationName: LatestRevision:0xc0007a109b Percent:0xc0007a10a0 URL:}}]} ConfigurationStatusFields:{LatestReadyRevisionName:pizzaplanet-upgrade-service-lqckw LatestCreatedRevisionName:pizzaplanet-upgrade-service-lqckw}}}: timed out waiting for the condition
```

