### PR TITLE
Make autoscaling approvers part of activator approvers.

### DIFF
--- a/pkg/activator/OWNERS
+++ b/pkg/activator/OWNERS
@@ -1,10 +1,13 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
+- autoscaling-approvers
 - networking-approvers
 
 reviewers:
+- autoscaling-reviewers
 - networking-reviewers
 
 labels:
+- area/autoscale
 - area/networking


### PR DESCRIPTION
Activator currently is maitained mostly by the autoscaling WG members
and it does play more and more into how we scale/load etc the system
so it makes sense.
Also I think this is how it was in pre-historical times :-)

/assign @markusthoemmes

