### PR TITLE
Make tests faster by leveraging new waitInformers method

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -302,7 +302,7 @@ func TestThrottlerWithError(t *testing.T) {
 				time.Sleep(200 * time.Millisecond)
 			}
 
-			to := 20 * time.Millisecond
+			to := 90 * time.Millisecond
 			if tc.ctxTimeout > 0 {
 				to = tc.ctxTimeout
 			}
@@ -452,7 +452,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 			// Wait for throttler to complete processing updates and exit
 			wg.Wait()
 
-			tryContext, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			tryContext, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel2()
 
 			gotTries := tryThrottler(throttler, tc.trys, tryContext)
@@ -630,7 +630,7 @@ func TestMultipleActivators(t *testing.T) {
 	}
 
 	// Test with 2 activators, 3 endpoints we can send 1 request and the second times out.
-	tryContext, cancel2 := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	tryContext, cancel2 := context.WithTimeout(context.Background(), 90*time.Millisecond)
 	defer cancel2()
 
 	results := tryThrottler(throttler, []types.NamespacedName{revID, revID}, tryContext)
@@ -662,7 +662,7 @@ func tryThrottler(throttler *Throttler, trys []types.NamespacedName, ctx context
 			if err := throttler.Try(ctx, revID, func(dest string) error {
 				ret[i] = tryResult{dest: dest}
 				select {
-				case <-time.After(15 * time.Millisecond): // Proxy simulation.
+				case <-time.After(60 * time.Millisecond): // Proxy simulation.
 				case <-ctx.Done():
 					// Timeout.
 				}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1068,12 +1068,12 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	if decider, err := pollDeciders(fakeDeciders, testNamespace, testRevision, nil); err != nil {
 		t.Fatalf("Failed to get decider: %v", err)
 	} else if got, want := decider.Spec.TargetValue, defaultConcurrencyTarget*defaultTU; got != want {
-		t.Fatalf("TargetValue = %v, want %v", got, want)
+		t.Fatalf("TargetValue = %f, want %f", got, want)
 	}
 
-	concurrencyTargetAfterUpdate := 100.0
+	const concurrencyTargetAfterUpdate = 100.0
 	data := defaultConfigMapData()
-	data["container-concurrency-target-default"] = fmt.Sprintf("%v", concurrencyTargetAfterUpdate)
+	data["container-concurrency-target-default"] = fmt.Sprintf("%f", concurrencyTargetAfterUpdate)
 	watcher.OnChange(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      autoscaler.ConfigName,
@@ -1089,7 +1089,7 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	if decider, err := pollDeciders(fakeDeciders, testNamespace, testRevision, cond); err != nil {
 		t.Fatalf("Failed to get decider: %v", err)
 	} else if got, want := decider.Spec.TargetValue, concurrencyTargetAfterUpdate*defaultTU; got != want {
-		t.Fatalf("TargetValue = %v, want %v", got, want)
+		t.Fatalf("TargetValue = %f, want %f", got, want)
 	}
 }
 


### PR DESCRIPTION
This permits removing the 500ms wait at the end of the tests
for deflaking purposes, since now we can actually wait for it to finish.

/assign @markusthoemmes 