### PR TITLE
Remove timing based test for the TimeToFirstByteTimeoutHandler.

### DIFF
--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -124,13 +124,13 @@ func TestTimeoutWriterAllowsForAdditionalWrites(t *testing.T) {
 		w: recorder,
 	}
 
-	handler.WriteHeader(200)
+	handler.WriteHeader(http.StatusOK)
 	handler.TimeoutAndWriteError("error")
 	if _, err := io.WriteString(handler, "test"); err != nil {
 		t.Fatalf("handler.Write() = %v, want no error", err)
 	}
 
-	if got, want := recorder.Code, 200; got != want {
+	if got, want := recorder.Code, http.StatusOK; got != want {
 		t.Errorf("recorder.Status = %d, want %d", got, want)
 	}
 	if got, want := recorder.Body.String(), "test"; got != want {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Failed in https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/5966/pull-knative-serving-unit-tests/1192510136782950400. We don't need to have a timing based test so... remove the timer!

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
