### PR TITLE
Fix verbose logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1959,6 +1959,7 @@
     "k8s.io/code-generator/cmd/defaulter-gen",
     "k8s.io/code-generator/cmd/informer-gen",
     "k8s.io/code-generator/cmd/lister-gen",
+    "k8s.io/klog",
     "k8s.io/kubernetes/pkg/version",
     "k8s.io/metrics/pkg/apis/custom_metrics",
     "knative.dev/caching/pkg/apis/caching",

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -59,6 +59,7 @@ const (
 // Setup creates client to run Knative Service requests
 func Setup(t *testing.T) *Clients {
 	t.Helper()
+	pkgTest.SetupLoggingFlags()
 	clients, err := NewClients(pkgTest.Flags.Kubeconfig, pkgTest.Flags.Cluster, ServingNamespace)
 	if err != nil {
 		t.Fatalf("Couldn't initialize clients: %v", err)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -52,6 +52,7 @@ func SetupAlternativeNamespace(t *testing.T) *test.Clients {
 
 // SetupWithNamespace creates the client objects needed in the e2e tests under the specified namespace.
 func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
+	pkgTest.SetupLoggingFlags()
 	clients, err := test.NewClients(
 		pkgTest.Flags.Kubeconfig,
 		pkgTest.Flags.Cluster,

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -21,9 +21,6 @@ package test
 
 import (
 	"flag"
-
-	"knative.dev/pkg/test"
-	"knative.dev/pkg/test/logging"
 )
 
 const (
@@ -33,9 +30,6 @@ const (
 	// AlternativeServingNamespace is a different namepace to run cross-
 	// namespace tests in.
 	AlternativeServingNamespace = "serving-tests-alt"
-
-	// E2EMetricExporter is the name for the metrics exporter logger
-	E2EMetricExporter = "e2e-metrics"
 
 	// Environment propagation conformance test objects
 
@@ -58,22 +52,14 @@ type ServingEnvironmentFlags struct {
 	Https            bool // Indicates where the test service will be created with https
 }
 
-// initializeServingFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
-// go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
 func initializeServingFlags() *ServingEnvironmentFlags {
 	var f ServingEnvironmentFlags
 
+	// Only define and set flags here. Flag values cannot be read at package init time.
 	flag.BoolVar(&f.ResolvableDomain, "resolvabledomain", false,
 		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
 	flag.BoolVar(&f.Https, "https", false,
 		"Set this flag to true to run all tests with https.")
-
-	flag.Set("alsologtostderr", "true")
-	logging.InitializeLogger(test.Flags.LogVerbose)
-
-	if test.Flags.EmitMetrics {
-		logging.InitializeMetricExporter(E2EMetricExporter)
-	}
 
 	return &f
 }

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -59,6 +59,7 @@ type Client struct {
 
 // Setup creates all the clients that we need to interact with in our tests
 func Setup(t *testing.T, monitoring ...int) (*Client, error) {
+	pkgTest.SetupLoggingFlags()
 	clients, err := test.NewClients(pkgTest.Flags.Kubeconfig, pkgTest.Flags.Cluster, test.ServingNamespace)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In #5398 we missed that flags cannot be set until after they are parsed.
As golang/testing is now doing the parsing just before calling our test function,
to change values they must now be called during the test (or before if we
were to use TestMain -- a future improvement planned). So split the flag setup
into definition and value setting, then call it in the tests that use ServingFlags.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5949
