### PR TITLE
Set to 20 for the maximum number of ksvc to be created in-flight for TestScaleToN/scale-100

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -52,7 +52,7 @@ func abortOnTimeout(ctx context.Context) spoof.ResponseChecker {
 	}
 }
 
-func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies Latencies) {
+func ScaleToWithin(t *testing.T, scale, maxInflight int, duration time.Duration, latencies Latencies) {
 	clients := Setup(t)
 
 	cleanupCh := make(chan test.ResourceNames, scale)
@@ -75,7 +75,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 	width := int(math.Ceil(math.Log10(float64(scale))))
 
 	t.Log("Creating new Services")
-	wg := pool.NewWithCapacity(50 /* maximum in-flight creates */, scale /* capacity */)
+	wg := pool.NewWithCapacity(maxInflight /* maximum in-flight creates */, scale /* capacity */)
 	for i := 0; i < scale; i++ {
 		// https://golang.org/doc/faq#closures_and_goroutines
 		i := i

--- a/test/performance/scale_test.go
+++ b/test/performance/scale_test.go
@@ -154,7 +154,7 @@ func TestScaleToN(t *testing.T) {
 				results = append(results, l.Results(t)...)
 			}()
 
-			e2e.ScaleToWithin(t, size, 30*time.Minute, l)
+			e2e.ScaleToWithin(t, size, 50, 30*time.Minute, l)
 		})
 	}
 

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -43,6 +43,8 @@ const (
 	shortModeMaxScale = 10
 	// Timeout for each worker task
 	workerTimeout = 5 * time.Minute
+	// The maximum number of ksvc to be created in-flight
+	maxInflight = 20
 )
 
 // While redundant, we run two versions of this by default:
@@ -59,7 +61,7 @@ func TestScaleToN(t *testing.T) {
 			if testing.Short() && size > shortModeMaxScale {
 				t.Skip("Skipping test in short mode")
 			}
-			ScaleToWithin(t, size, workerTimeout, &nopLatencies{t})
+			ScaleToWithin(t, size, maxInflight, workerTimeout, &nopLatencies{t})
 		})
 	}
 }


### PR DESCRIPTION
## Proposed Changes

`TestScaleToN/scale-100` e2e test creates `50` Ksvc are created at the same time.

Due to this, it causes CPU high load and pods takes a little bit long time to be ready.
Especially it looks like mesh-1.3's istio-proxy always does not meet the time.
(Please also refer to @JRBANCEL 's https://github.com/knative/serving/issues/5335#issuecomment-545138042)

To fix it, this patch changes the maximum in-flight pods creation to
`20` from `50` in TestScaleToN tests.

/lint

Fixes https://github.com/knative/serving/issues/5890

Note, https://github.com/knative/serving/pull/5988 verified setting `20` passes all tests with 1.3-mesh.

**Release Note**

```release-note
NONE
```

/cc @tcnghia @JRBANCEL 
