### PR TITLE
Make sure target annotations can exceed the configured default values.

### DIFF
--- a/pkg/reconciler/autoscaling/resources/target.go
+++ b/pkg/reconciler/autoscaling/resources/target.go
@@ -45,19 +45,21 @@ func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *autoscaler.Config) 
 		tu = config.ContainerConcurrencyTargetFraction
 	}
 
+	// Use the target provided via annotation, if applicable.
+	if annotationTarget, ok := pa.Target(); ok {
+		total = annotationTarget
+		if pa.Metric() == autoscaling.Concurrency && pa.Spec.ContainerConcurrency != 0 {
+			// We pick the smaller value between container concurrency and the annotationTarget
+			// to make sure the autoscaler does not aim for a higher concurrency than the application
+			// can handle per containerConcurrency.
+			total = math.Min(annotationTarget, float64(pa.Spec.ContainerConcurrency))
+		}
+	}
+
 	if v, ok := pa.TargetUtilization(); ok {
 		tu = v
 	}
 	target = math.Max(1, total*tu)
-
-	// Use the target provided via annotation, if applicable.
-	if annotationTarget, ok := pa.Target(); ok {
-		// We pick the smaller value between the calculated target and the annotationTarget
-		// to make sure the autoscaler does not aim for a higher concurrency than the application
-		// can handle per containerConcurrency.
-		target = math.Max(1, math.Min(target, annotationTarget*tu))
-		total = math.Min(annotationTarget, total)
-	}
 
 	return target, total
 }

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -132,6 +132,11 @@ func TestResolveMetricTarget(t *testing.T) {
 		wantTgt: 1,
 		wantTot: 1,
 	}, {
+		name:    "with target annotation greater than default (ok)",
+		pa:      pa(WithTargetAnnotation("500")),
+		wantTgt: 500,
+		wantTot: 500,
+	}, {
 		name:    "with target annotation greater than container concurrency (ignore annotation for safety)",
 		pa:      pa(WithPAContainerConcurrency(1), WithTargetAnnotation("10")),
 		wantTgt: 1,
@@ -152,10 +157,10 @@ func TestResolveMetricTarget(t *testing.T) {
 		wantTgt: 150,
 		wantTot: 200,
 	}, {
-		name:    "RPS: with target annotation greater than default (ignore annotation for safety)",
+		name:    "RPS: with target annotation greater than default",
 		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("300")),
-		wantTgt: 140,
-		wantTot: 200,
+		wantTgt: 210,
+		wantTot: 300,
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5975

## Proposed Changes

Neither RPS nor concurrency based revisions can currently specify a scaling target that is higher than their respective default values. This fixes that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Concurrency and RPS can now be configured a higher target than their respective default values.
```
