### PR TITLE
Add permissions for caching.internal.knative.dev to edit and view role

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -32,7 +32,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     serving.knative.dev/release: devel
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
 ---
@@ -44,6 +44,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     serving.knative.dev/release: devel
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Proposed Changes

This patch adds permissions for `caching.internal.knative.dev` to `edit`
and `view` role.

It is similar to https://github.com/knative/serving/pull/5415 but just roles are different.

**Release Note**

```release-note
NONE
```
