### PR TITLE
Minimize usages of SkipNamespaceValidation throughout our tests.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -262,21 +262,17 @@ func TestReconcile(t *testing.T) {
 	// two constant objects above, which means, that all tests must share
 	// the same namespace and revision name.
 	table := TableTest{{
-		Name:                    "bad workqueue key, Part I",
-		Key:                     "too/many/parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key, Part I",
+		Key:  "too/many/parts",
 	}, {
-		Name:                    "bad workqueue key, Part II",
-		Key:                     "too-few-parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key, Part II",
+		Key:  "too-few-parts",
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
-		SkipNamespaceValidation: true,
+		Name: "key not found",
+		Key:  "foo/not-found",
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
-		SkipNamespaceValidation: true,
+		Name: "key not found",
+		Key:  "foo/not-found",
 	}, {
 		Name: "steady state",
 		Key:  key,

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -166,23 +166,20 @@ var (
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
-		Name:                    "bad workqueue key",
-		Key:                     "too/many/parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key",
+		Key:  "too/many/parts",
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
-		SkipNamespaceValidation: true,
+		Name: "key not found",
+		Key:  "foo/not-found",
 	}, {
-		Name:                    "skip ingress not matching class key",
-		SkipNamespaceValidation: true,
+		Name: "skip ingress not matching class key",
 		Objects: []runtime.Object{
 			addAnnotations(ingress("no-virtualservice-yet", 1234),
 				map[string]string{networking.IngressClassAnnotationKey: "fake-controller"}),
 		},
 	}, {
-		Name:                    "create VirtualService matching Ingress",
-		SkipNamespaceValidation: true,
+		Name: "create VirtualService matching Ingress",
+
 		Objects: []runtime.Object{
 			ingress("no-virtualservice-yet", 1234),
 		},
@@ -234,9 +231,8 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "test-ns/no-virtualservice-yet",
 	}, {
-		Name:                    "observed generation is updated when error is encountered in reconciling, and ingress ready status is unknown",
-		SkipNamespaceValidation: true,
-		WantErr:                 true,
+		Name:    "observed generation is updated when error is encountered in reconciling, and ingress ready status is unknown",
+		WantErr: true,
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "virtualservices"),
 		},
@@ -305,8 +301,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "test-ns/reconcile-failed",
 	}, {
-		Name:                    "reconcile VirtualService to match desired one",
-		SkipNamespaceValidation: true,
+		Name: "reconcile VirtualService to match desired one",
 		Objects: []runtime.Object{
 			ingress("reconcile-virtualservice", 1234),
 			&v1alpha3.VirtualService{
@@ -484,8 +479,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name:                    "No preinstalled Gateways",
-		SkipNamespaceValidation: true,
+		Name: "No preinstalled Gateways",
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLS),
 			originSecret("istio-system", "secret0"),

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -50,13 +50,11 @@ func TestNewController(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
-		Name:                    "bad workqueue key, Part I",
-		Key:                     "too/many/parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key, Part I",
+		Key:  "too/many/parts",
 	}, {
-		Name:                    "bad workqueue key, Part II",
-		Key:                     "too-few-parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key, Part II",
+		Key:  "too-few-parts",
 	}, {
 		Name: "update status",
 		Key:  "status/update",

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -148,9 +148,8 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo",
 	}, {
-		Name:                    "certificate not created for excluded namespace",
-		Key:                     "foo",
-		SkipNamespaceValidation: true,
+		Name: "certificate not created for excluded namespace",
+		Key:  "foo",
 		Objects: []runtime.Object{
 			kubeExcludedNamespace("foo"),
 		},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -170,8 +170,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key: "default/becomes-ready",
-		// TODO(lichuqiang): config namespace validation in resource scope.
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "custom ingress route becomes ready, ingress unknown",
 		Objects: []runtime.Object{
@@ -225,8 +223,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key: "default/becomes-ready",
-		// TODO(lichuqiang): config namespace validation in resource scope.
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "cluster local route becomes ready, ingress unknown",
 		Objects: []runtime.Object{
@@ -284,8 +280,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key: "default/becomes-ready",
-		// TODO(lichuqiang): config namespace validation in resource scope.
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "simple route becomes ready",
 		Objects: []runtime.Object{
@@ -428,7 +422,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Ingress: inducing failure for create ingresses"),
 		},
 		Key:                     "default/ingress-create-failure",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "steady state",
 		Objects: []runtime.Object{
@@ -685,7 +678,6 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		Key:                     "default/new-latest-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "public becomes cluster local",
 		Objects: []runtime.Object{
@@ -751,7 +743,6 @@ func TestReconcile(t *testing.T) {
 				})),
 		}},
 		Key:                     "default/becomes-local",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "cluster local becomes public",
 		Objects: []runtime.Object{
@@ -814,7 +805,6 @@ func TestReconcile(t *testing.T) {
 				})),
 		}},
 		Key:                     "default/becomes-public",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "failure updating cluster ingress",
 		// Starting from the new latest ready, induce a failure updating the cluster ingress.
@@ -892,7 +882,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update Ingress: inducing failure for update ingresses"),
 		},
 		Key:                     "default/update-ci-failure",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "reconcile service mutation",
 		Objects: []runtime.Object{
@@ -1125,7 +1114,6 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		Key:                     "default/ingress-mutation",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "switch to a different config",
 		Objects: []runtime.Object{
@@ -1283,7 +1271,6 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		Key:                     "default/pinned-becomes-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "traffic split becomes ready",
 		Objects: []runtime.Object{
@@ -1393,7 +1380,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "named-traffic-split"),
 		},
 		Key:                     "default/named-traffic-split",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "same revision targets",
 		Objects: []runtime.Object{
@@ -1566,7 +1552,6 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "same-revision-targets"),
 		},
 		Key:                     "default/same-revision-targets",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "change route configuration",
 		// Start from a steady state referencing "blue", and modify the route spec to point to "green" instead.
@@ -1639,7 +1624,6 @@ func TestReconcile(t *testing.T) {
 					}), WithRouteFinalizer),
 		}},
 		Key:                     "default/switch-configs",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "update single target to traffic split with unready revision",
 		// Start from a steady state referencing "blue", and modify the route spec to point to both
@@ -1702,7 +1686,6 @@ func TestReconcile(t *testing.T) {
 					})),
 		}},
 		Key:                     "default/split",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "Update stale lastPinned",
 		Objects: []runtime.Object{
@@ -1958,7 +1941,6 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "check that Certificate and IngressTLS are correctly configured when creating a Route",
 		Objects: []runtime.Object{
@@ -2016,7 +1998,6 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "check that Certificate and IngressTLS are correctly updated when updating a Route",
 		Objects: []runtime.Object{
@@ -2100,7 +2081,6 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		Name:    "check that Route updates status and produces event log when valid name but not owned certificate",
 		WantErr: true,
@@ -2149,7 +2129,6 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "InternalError", kaccessor.NewAccessorError(fmt.Errorf("owner: %s with Type %T does not own Certificate: %q", "becomes-ready", &v1alpha1.Route{}, "route-12-34"), kaccessor.NotOwnResource).Error()),
 		},
 		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		Name: "check that Route is correctly updated when Certificate is not ready",
 		Objects: []runtime.Object{
@@ -2233,7 +2212,6 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
 	}, {
 		// This test is a same with "public becomes cluster local" above, but confirm it does not create certs with autoTLS for cluster-local.
 		Name: "public becomes cluster local w/ autoTLS",
@@ -2300,7 +2278,6 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				})),
 		}},
 		Key:                     "default/becomes-local",
-		SkipNamespaceValidation: true,
 	}}
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
@@ -2423,7 +2400,6 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
 		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
 	}}
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		cfg := ReconcilerTestConfig(true)

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -60,17 +60,14 @@ func TestNewController(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
-		Name:                    "bad workqueue key, Part I",
-		Key:                     "too/many/parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key, Part I",
+		Key:  "too/many/parts",
 	}, {
-		Name:                    "bad workqueue key, Part II",
-		Key:                     "too-few-parts",
-		SkipNamespaceValidation: true,
+		Name: "bad workqueue key, Part II",
+		Key:  "too-few-parts",
 	}, {
-		Name:                    "key not found",
-		Key:                     "foo/not-found",
-		SkipNamespaceValidation: true,
+		Name: "key not found",
+		Key:  "foo/not-found",
 	}, {
 		Name: "steady state",
 		Key:  "steady/state",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This used to be prominent because of the cluster-scoped ClusterIngress. We no longer have that though, so this removes most of its usages.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
