### PR TITLE
Remove redundant and unused values from queue stats reporting.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -346,7 +346,7 @@ func main() {
 	reportTicker := time.NewTicker(reportingPeriod)
 	defer reportTicker.Stop()
 
-	queue.NewStats(env.ServingPod, queue.Channels{
+	queue.NewStats(queue.Channels{
 		ReqChan:    reqChan,
 		ReportChan: reportTicker.C,
 		StatChan:   statChan,

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -104,7 +104,6 @@ func NewStats(ch Channels, startedAt time.Time) {
 				updateState(now)
 
 				stat := autoscaler.Stat{
-					Time:                             now,
 					AverageConcurrentRequests:        weightedAverage(timeOnConcurrency),
 					AverageProxiedConcurrentRequests: weightedAverage(timeOnProxiedConcurrency),
 					RequestCount:                     requestCount,

--- a/pkg/queue/stats_test.go
+++ b/pkg/queue/stats_test.go
@@ -24,17 +24,12 @@ import (
 	"knative.dev/serving/pkg/autoscaler"
 )
 
-const (
-	podName = "pod"
-)
-
 func TestNoData(t *testing.T) {
 	now := time.Now()
 	s := newTestStats(now)
 
 	got := s.report(now)
 	want := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: 0.0,
 		RequestCount:              0,
 	}
@@ -54,7 +49,6 @@ func TestSingleRequestWholeTime(t *testing.T) {
 	got := s.report(now)
 
 	want := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              1,
 	}
@@ -74,7 +68,6 @@ func TestSingleRequestHalfTime(t *testing.T) {
 	got := s.report(now)
 
 	want := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: 0.5,
 		RequestCount:              1,
 	}
@@ -95,7 +88,6 @@ func TestVeryShortLivedRequest(t *testing.T) {
 	got := s.report(now)
 
 	want := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: float64(10) / float64(1000),
 		RequestCount:              1,
 	}
@@ -123,7 +115,6 @@ func TestMultipleRequestsWholeTime(t *testing.T) {
 	got := s.report(now)
 
 	want := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              3,
 	}
@@ -147,7 +138,6 @@ func TestMultipleRequestsInterleaved(t *testing.T) {
 	got := s.report(now)
 
 	want := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: 1.5,
 		RequestCount:              2,
 	}
@@ -164,7 +154,6 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	got1 := s.report(now)
 	want1 := autoscaler.Stat{
-		Time:                      got1.Time,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              1,
 	}
@@ -174,7 +163,6 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got2 := s.report(now)
 	want2 := autoscaler.Stat{
-		Time:                      now,
 		AverageConcurrentRequests: 0.5,
 		RequestCount:              0,
 	}
@@ -194,7 +182,6 @@ func TestOneProxiedRequest(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	got := s.report(now)
 	want := autoscaler.Stat{
-		Time:                             now,
 		AverageConcurrentRequests:        1.0,
 		AverageProxiedConcurrentRequests: 1.0,
 		RequestCount:                     1,
@@ -214,7 +201,6 @@ func TestOneEndedProxiedRequest(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
 	want := autoscaler.Stat{
-		Time:                             now,
 		AverageConcurrentRequests:        0.5,
 		AverageProxiedConcurrentRequests: 0.5,
 		RequestCount:                     1,
@@ -235,7 +221,6 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 	now = now.Add(500 * time.Millisecond)
 	got := s.report(now)
 	want := autoscaler.Stat{
-		Time:                             now,
 		AverageConcurrentRequests:        1.0,
 		AverageProxiedConcurrentRequests: 0.5,
 		RequestCount:                     2,

--- a/pkg/queue/stats_test.go
+++ b/pkg/queue/stats_test.go
@@ -35,7 +35,6 @@ func TestNoData(t *testing.T) {
 	got := s.report(now)
 	want := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: 0.0,
 		RequestCount:              0,
 	}
@@ -56,7 +55,6 @@ func TestSingleRequestWholeTime(t *testing.T) {
 
 	want := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              1,
 	}
@@ -77,7 +75,6 @@ func TestSingleRequestHalfTime(t *testing.T) {
 
 	want := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: 0.5,
 		RequestCount:              1,
 	}
@@ -99,7 +96,6 @@ func TestVeryShortLivedRequest(t *testing.T) {
 
 	want := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: float64(10) / float64(1000),
 		RequestCount:              1,
 	}
@@ -128,7 +124,6 @@ func TestMultipleRequestsWholeTime(t *testing.T) {
 
 	want := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              3,
 	}
@@ -153,7 +148,6 @@ func TestMultipleRequestsInterleaved(t *testing.T) {
 
 	want := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: 1.5,
 		RequestCount:              2,
 	}
@@ -171,7 +165,6 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	got1 := s.report(now)
 	want1 := autoscaler.Stat{
 		Time:                      got1.Time,
-		PodName:                   podName,
 		AverageConcurrentRequests: 1.0,
 		RequestCount:              1,
 	}
@@ -182,7 +175,6 @@ func TestOneRequestAcrossReportings(t *testing.T) {
 	got2 := s.report(now)
 	want2 := autoscaler.Stat{
 		Time:                      now,
-		PodName:                   podName,
 		AverageConcurrentRequests: 0.5,
 		RequestCount:              0,
 	}
@@ -203,7 +195,6 @@ func TestOneProxiedRequest(t *testing.T) {
 	got := s.report(now)
 	want := autoscaler.Stat{
 		Time:                             now,
-		PodName:                          podName,
 		AverageConcurrentRequests:        1.0,
 		AverageProxiedConcurrentRequests: 1.0,
 		RequestCount:                     1,
@@ -224,7 +215,6 @@ func TestOneEndedProxiedRequest(t *testing.T) {
 	got := s.report(now)
 	want := autoscaler.Stat{
 		Time:                             now,
-		PodName:                          podName,
 		AverageConcurrentRequests:        0.5,
 		AverageProxiedConcurrentRequests: 0.5,
 		RequestCount:                     1,
@@ -246,7 +236,6 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 	got := s.report(now)
 	want := autoscaler.Stat{
 		Time:                             now,
-		PodName:                          podName,
 		AverageConcurrentRequests:        1.0,
 		AverageProxiedConcurrentRequests: 0.5,
 		RequestCount:                     2,
@@ -259,7 +248,7 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 
 // Test type to hold the bi-directional time channels
 type testStats struct {
-	Stats
+	ch           Channels
 	reportBiChan chan time.Time
 }
 
@@ -270,9 +259,9 @@ func newTestStats(now time.Time) *testStats {
 		ReportChan: (<-chan time.Time)(reportBiChan),
 		StatChan:   make(chan autoscaler.Stat),
 	}
-	s := NewStats(podName, ch, now)
+	NewStats(ch, now)
 	t := &testStats{
-		Stats:        *s,
+		ch:           ch,
 		reportBiChan: reportBiChan,
 	}
 	return t


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

1. The *Stats value returned by `NewStats` is used nowhere, so we might as well just get rid of it.
2. The PodName is reported via other means (see Prometheus reporter) and thus does not need to be part of the stats reporter itself.
3. The Time value isn't used at all, nor does it matter at this point.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
