### PR TITLE
Remove autoscaler.Stat from the queue-proxy.

### DIFF
--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"knative.dev/serving/pkg/autoscaler"
 )
 
 const (
@@ -116,12 +115,12 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 }
 
 // Report captures request metrics.
-func (r *PrometheusStatsReporter) Report(stat autoscaler.Stat) {
+func (r *PrometheusStatsReporter) Report(acr float64, apcr float64, rc float64, prc float64) {
 	// Requests per second is a rate over time while concurrency is not.
-	r.requestsPerSecond.Set(stat.RequestCount / r.reportingPeriod.Seconds())
-	r.proxiedRequestsPerSecond.Set(stat.ProxiedRequestCount / r.reportingPeriod.Seconds())
-	r.averageConcurrentRequests.Set(stat.AverageConcurrentRequests)
-	r.averageProxiedConcurrentRequests.Set(stat.AverageProxiedConcurrentRequests)
+	r.requestsPerSecond.Set(rc / r.reportingPeriod.Seconds())
+	r.proxiedRequestsPerSecond.Set(prc / r.reportingPeriod.Seconds())
+	r.averageConcurrentRequests.Set(acr)
+	r.averageProxiedConcurrentRequests.Set(apcr)
 }
 
 // Handler returns an uninstrumented http.Handler used to serve stats registered by this

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"knative.dev/serving/pkg/autoscaler"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -94,45 +93,68 @@ func TestNewPrometheusStatsReporter_negative(t *testing.T) {
 func TestReporterReport(t *testing.T) {
 	t.Helper()
 	tests := []struct {
-		name                              string
-		reportingPeriod                   time.Duration
-		autoscalerStat                    autoscaler.Stat
-		expectedReqCount                  float64
-		expectedAverageConcurrentRequests float64
-		expectedProxiedRequestCount       float64
-		expectedProxiedConcurrency        float64
+		name            string
+		reportingPeriod time.Duration
+
+		concurrency        float64
+		proxiedConcurrency float64
+		reqCount           float64
+		proxiedReqCount    float64
+
+		expectedReqCount            float64
+		expectedProxiedRequestCount float64
+		expectedConcurrency         float64
+		expectedProxiedConcurrency  float64
 	}{{
-		name:                              "no proxy requests",
-		reportingPeriod:                   1 * time.Second,
-		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3},
-		expectedReqCount:                  39,
-		expectedAverageConcurrentRequests: 3,
-		expectedProxiedRequestCount:       0,
-		expectedProxiedConcurrency:        0,
+		name:            "no proxy requests",
+		reportingPeriod: 1 * time.Second,
+
+		reqCount:    39,
+		concurrency: 3,
+
+		expectedReqCount:            39,
+		expectedConcurrency:         3,
+		expectedProxiedRequestCount: 0,
+		expectedProxiedConcurrency:  0,
 	}, {
-		name:                              "reportingPeriod=10s",
-		reportingPeriod:                   10 * time.Second,
-		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
-		expectedReqCount:                  3.9,
-		expectedAverageConcurrentRequests: 3,
-		expectedProxiedRequestCount:       1.5,
-		expectedProxiedConcurrency:        2,
+		name:            "reportingPeriod=10s",
+		reportingPeriod: 10 * time.Second,
+
+		reqCount:           39,
+		concurrency:        3,
+		proxiedReqCount:    15,
+		proxiedConcurrency: 2,
+
+		expectedReqCount:            3.9,
+		expectedConcurrency:         3,
+		expectedProxiedRequestCount: 1.5,
+		expectedProxiedConcurrency:  2,
 	}, {
-		name:                              "reportingPeriod=2s",
-		reportingPeriod:                   2 * time.Second,
-		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
-		expectedReqCount:                  19.5,
-		expectedAverageConcurrentRequests: 3,
-		expectedProxiedRequestCount:       7.5,
-		expectedProxiedConcurrency:        2,
+		name:            "reportingPeriod=2s",
+		reportingPeriod: 2 * time.Second,
+
+		reqCount:           39,
+		concurrency:        3,
+		proxiedReqCount:    15,
+		proxiedConcurrency: 2,
+
+		expectedReqCount:            19.5,
+		expectedConcurrency:         3,
+		expectedProxiedRequestCount: 7.5,
+		expectedProxiedConcurrency:  2,
 	}, {
-		name:                              "reportingPeriod=1s",
-		reportingPeriod:                   1 * time.Second,
-		autoscalerStat:                    autoscaler.Stat{RequestCount: 39, AverageConcurrentRequests: 3, ProxiedRequestCount: 15, AverageProxiedConcurrentRequests: 2},
-		expectedReqCount:                  39,
-		expectedAverageConcurrentRequests: 3,
-		expectedProxiedRequestCount:       15,
-		expectedProxiedConcurrency:        2,
+		name:            "reportingPeriod=1s",
+		reportingPeriod: 1 * time.Second,
+
+		reqCount:           39,
+		concurrency:        3,
+		proxiedReqCount:    15,
+		proxiedConcurrency: 2,
+
+		expectedReqCount:            39,
+		expectedConcurrency:         3,
+		expectedProxiedRequestCount: 15,
+		expectedProxiedConcurrency:  2,
 	},
 	}
 
@@ -142,9 +164,9 @@ func TestReporterReport(t *testing.T) {
 			if err != nil {
 				t.Errorf("Something went wrong with creating a reporter, '%v'.", err)
 			}
-			reporter.Report(test.autoscalerStat)
+			reporter.Report(test.concurrency, test.proxiedConcurrency, test.reqCount, test.proxiedReqCount)
 			checkData(t, requestsPerSecondGV, test.expectedReqCount)
-			checkData(t, averageConcurrentRequestsGV, test.expectedAverageConcurrentRequests)
+			checkData(t, averageConcurrentRequestsGV, test.expectedConcurrency)
 			checkData(t, proxiedRequestsPerSecondGV, test.expectedProxiedRequestCount)
 			checkData(t, averageProxiedConcurrentRequestsGV, test.expectedProxiedConcurrency)
 		})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

It really only becomes a `Stat` once the scraper parses the data properly. All the interim products are not really an `autoscaler.Stat`, so this resolves that coupling. It also gets rid of an unneeded goroutine in the queue-proxy's main method.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
