### PR TITLE
Delay after bloating test image

### DIFF
--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -173,6 +173,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		go func() {
 			defer wg.Done()
 			fmt.Fprint(w, bloat(mb))
+			time.Sleep(time.Second)
 		}()
 	}
 }


### PR DESCRIPTION
Some systems don't prevent memory allocation, but kill any pods that exceed
memory usage after some time. So add a 1-second delay after bloating memory
in the autoscale test image.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6007 

It's done at this location because it still logs the increase in memory if possible.
