### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+
 	"knative.dev/serving/pkg/apis/config"
 
 	"knative.dev/pkg/configmap"

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -18,9 +18,10 @@ package revision
 
 import (
 	"context"
-	"knative.dev/serving/pkg/apis/config"
 	"testing"
 	"time"
+
+	"knative.dev/serving/pkg/apis/config"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"golang.org/x/sync/errgroup"

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"knative.dev/serving/pkg/apis/config"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"knative.dev/serving/pkg/apis/config"
 
 	// Inject the fakes for informers this controller relies on.
 	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -550,7 +550,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo/missing-owners",
 	}, {
-		Name:    "image pull secrets",
+		Name: "image pull secrets",
 		// This test case tests that the image pull secrets from revision propagate to deployment and image
 		Objects: []runtime.Object{
 			rev("foo", "image-pull-secrets", WithImagePullSecrets("foo-secret")),

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -421,7 +421,7 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Ingress: inducing failure for create ingresses"),
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Ingress: inducing failure for create ingresses"),
 		},
-		Key:                     "default/ingress-create-failure",
+		Key: "default/ingress-create-failure",
 	}, {
 		Name: "steady state",
 		Objects: []runtime.Object{
@@ -677,7 +677,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})),
 		}},
-		Key:                     "default/new-latest-ready",
+		Key: "default/new-latest-ready",
 	}, {
 		Name: "public becomes cluster local",
 		Objects: []runtime.Object{
@@ -742,7 +742,7 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		Key:                     "default/becomes-local",
+		Key: "default/becomes-local",
 	}, {
 		Name: "cluster local becomes public",
 		Objects: []runtime.Object{
@@ -804,7 +804,7 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		Key:                     "default/becomes-public",
+		Key: "default/becomes-public",
 	}, {
 		Name: "failure updating cluster ingress",
 		// Starting from the new latest ready, induce a failure updating the cluster ingress.
@@ -881,7 +881,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update Ingress: inducing failure for update ingresses"),
 		},
-		Key:                     "default/update-ci-failure",
+		Key: "default/update-ci-failure",
 	}, {
 		Name: "reconcile service mutation",
 		Objects: []runtime.Object{
@@ -1113,7 +1113,7 @@ func TestReconcile(t *testing.T) {
 				},
 			),
 		}},
-		Key:                     "default/ingress-mutation",
+		Key: "default/ingress-mutation",
 	}, {
 		Name: "switch to a different config",
 		Objects: []runtime.Object{
@@ -1270,7 +1270,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})),
 		}},
-		Key:                     "default/pinned-becomes-ready",
+		Key: "default/pinned-becomes-ready",
 	}, {
 		Name: "traffic split becomes ready",
 		Objects: []runtime.Object{
@@ -1379,7 +1379,7 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "named-traffic-split"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "named-traffic-split"),
 		},
-		Key:                     "default/named-traffic-split",
+		Key: "default/named-traffic-split",
 	}, {
 		Name: "same revision targets",
 		Objects: []runtime.Object{
@@ -1551,7 +1551,7 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "gray-same-revision-targets"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "same-revision-targets"),
 		},
-		Key:                     "default/same-revision-targets",
+		Key: "default/same-revision-targets",
 	}, {
 		Name: "change route configuration",
 		// Start from a steady state referencing "blue", and modify the route spec to point to "green" instead.
@@ -1623,7 +1623,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}), WithRouteFinalizer),
 		}},
-		Key:                     "default/switch-configs",
+		Key: "default/switch-configs",
 	}, {
 		Name: "update single target to traffic split with unready revision",
 		// Start from a steady state referencing "blue", and modify the route spec to point to both
@@ -1685,7 +1685,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})),
 		}},
-		Key:                     "default/split",
+		Key: "default/split",
 	}, {
 		Name: "Update stale lastPinned",
 		Objects: []runtime.Object{
@@ -1940,7 +1940,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
-		Key:                     "default/becomes-ready",
+		Key: "default/becomes-ready",
 	}, {
 		Name: "check that Certificate and IngressTLS are correctly configured when creating a Route",
 		Objects: []runtime.Object{
@@ -1997,7 +1997,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created Certificate %s/%s", "default", "route-12-34"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
-		Key:                     "default/becomes-ready",
+		Key: "default/becomes-ready",
 	}, {
 		Name: "check that Certificate and IngressTLS are correctly updated when updating a Route",
 		Objects: []runtime.Object{
@@ -2080,7 +2080,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Spec for Certificate %s/%s", "default", "route-12-34"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
-		Key:                     "default/becomes-ready",
+		Key: "default/becomes-ready",
 	}, {
 		Name:    "check that Route updates status and produces event log when valid name but not owned certificate",
 		WantErr: true,
@@ -2128,7 +2128,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
 			Eventf(corev1.EventTypeWarning, "InternalError", kaccessor.NewAccessorError(fmt.Errorf("owner: %s with Type %T does not own Certificate: %q", "becomes-ready", &v1alpha1.Route{}, "route-12-34"), kaccessor.NotOwnResource).Error()),
 		},
-		Key:                     "default/becomes-ready",
+		Key: "default/becomes-ready",
 	}, {
 		Name: "check that Route is correctly updated when Certificate is not ready",
 		Objects: []runtime.Object{
@@ -2211,7 +2211,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Spec for Certificate %s/%s", "default", "route-12-34"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
-		Key:                     "default/becomes-ready",
+		Key: "default/becomes-ready",
 	}, {
 		// This test is a same with "public becomes cluster local" above, but confirm it does not create certs with autoTLS for cluster-local.
 		Name: "public becomes cluster local w/ autoTLS",
@@ -2277,7 +2277,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					},
 				})),
 		}},
-		Key:                     "default/becomes-local",
+		Key: "default/becomes-local",
 	}}
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
@@ -2399,7 +2399,7 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Spec for Certificate %s/%s", "default", "route-12-34"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "becomes-ready"),
 		},
-		Key:                     "default/becomes-ready",
+		Key: "default/becomes-ready",
 	}}
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		cfg := ReconcilerTestConfig(true)

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -125,7 +125,7 @@ func TestServiceGenerateName(t *testing.T) {
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -56,7 +56,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -198,10 +198,10 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		func(svc *v1alpha1.Service) {
-		svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
-	})
+			svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
+		})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -46,7 +46,7 @@ func TestSingleConcurrency(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -91,7 +91,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -165,7 +165,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -233,7 +233,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -305,7 +305,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withVolume, withSubpath); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -404,7 +404,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -55,7 +55,7 @@ func fetchRuntimeInfo(
 	})
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		serviceOpts...)
 	if err != nil {
 		return nil, nil, err

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -60,11 +60,11 @@ func TestActivatorOverload(t *testing.T) {
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		func(service *v1alpha1.Service) {
-		service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
-		service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
-	})
+			service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
+			service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
+		})
 	if err != nil {
 		t.Fatalf("Unable to create resources: %v", err)
 	}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -178,7 +178,7 @@ func setup(t *testing.T, class, metric string, target float64, targetUtilization
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		append(fopts, rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:             class,
 			autoscaling.MetricAnnotationKey:            metric,

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -173,7 +173,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
@@ -232,7 +232,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -50,7 +50,7 @@ func TestEgressTraffic(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	service, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithEnv(envVars...))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -170,7 +170,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -52,7 +52,7 @@ func TestHelloWorld(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get Gateway %s/%s", v1a1test.Namespace, v1a1test.GatewayName)
 		}
-		test.CleanupOnInterrupt(func () { v1a1test.RestoreGateway(t, clients, *oldGateway) })
+		test.CleanupOnInterrupt(func() { v1a1test.RestoreGateway(t, clients, *oldGateway) })
 		defer v1a1test.RestoreGateway(t, clients, *oldGateway)
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
@@ -118,7 +118,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 
 	t.Log("Creating a new Service")
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName("cpu"):    resource.MustParse("50m"),

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -67,10 +67,10 @@ func TestRollbackBYOName(t *testing.T) {
 
 	t.Logf("Creating a new Service with byo config name %q.", byoNameOld)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withTrafficSpecOld, func(svc *v1alpha1.Service) {
-		svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameOld
-	})
+			svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameOld
+		})
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -120,7 +120,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	defer test.TearDown(clients, names)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1alph1testing.WithEnv(envVars...),
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -197,7 +197,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	withInternalVisibility := v1alph1testing.WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withInternalVisibility,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -244,7 +244,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	defer test.TearDown(clients, testNames)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
@@ -300,7 +300,7 @@ func TestCallToPublicService(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		}))

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -77,7 +77,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 	})
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -124,7 +124,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		}},
 	})
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %w", names.Service, err)
@@ -182,13 +182,13 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		}
 		//Check subroute2 is cluster local
 		if isClusterLocal, err := isTrafficClusterLocal(r.Status.Traffic, subrouteTag2); err != nil {
-			return false,  nil
+			return false, nil
 		} else if isClusterLocal {
 			return false, nil
 		}
 		return true, nil
 	}, "Subroutes are not in correct state"); err != nil {
-		t.Fatalf("Expected subroute1 with tag %s to be not cluster local; subroute2 with tag %s to be cluster local: %w",subrouteTag1, subrouteTag2, err)
+		t.Fatalf("Expected subroute1 with tag %s to be not cluster local; subroute2 with tag %s to be cluster local: %w", subrouteTag1, subrouteTag2, err)
 	}
 
 	//Update route to private.
@@ -255,7 +255,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 		},
 	})
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		withTrafficSpec, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -396,6 +396,6 @@ func isRouteClusterLocal(rs v1alpha1.RouteStatus) bool {
 	return strings.HasSuffix(rs.URL.Host, network.GetClusterDomainName())
 }
 
-func serviceNameForRoute(subrouteTag, routeName string ) string{
+func serviceNameForRoute(subrouteTag, routeName string) string {
 	return fmt.Sprintf("%s-%s", subrouteTag, routeName)
 }

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -154,7 +154,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}),

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -153,7 +153,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 
 	t.Log("Creating a new Service")
 	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */,
+		false, /* https TODO(taragu) turn this on after helloworld test running with https */
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/test/performance/scale_from_zero_test.go
+++ b/test/performance/scale_from_zero_test.go
@@ -132,7 +132,7 @@ func createServices(t *testing.T, pc *Client, count int) ([]*v1a1test.ResourceOb
 		g.Go(func() error {
 			var err error
 			if objs[ndx], _, err = v1a1test.CreateRunLatestServiceReady(t, pc.E2EClients, testNames[ndx],
-				false /* https TODO(taragu) turn this on after helloworld test running with https */,
+				false, /* https TODO(taragu) turn this on after helloworld test running with https */
 				sos...); err != nil {
 				return fmt.Errorf("%02d: failed to create Ready service: %v", ndx, err)
 			}


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign vagababov
