### PR TITLE
Add default request metrics backend in observability config 

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -89,7 +89,7 @@ data:
     metrics.backend-destination: prometheus
 
     # metrics.request-metrics-backend-destination specifies the request metrics
-    # destination. It enables queue proxy to send request metrics. 
+    # destination. It enables queue proxy to send request metrics.
     # Currently supported values: prometheus (the default), stackdriver.
     metrics.request-metrics-backend-destination: prometheus
 

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -89,8 +89,8 @@ data:
     metrics.backend-destination: prometheus
 
     # metrics.request-metrics-backend-destination specifies the request metrics
-    # destination. If non-empty, it enables queue proxy to send request metrics.
-    # Currently supported values: prometheus, stackdriver.
+    # destination. It enables queue proxy to send request metrics. 
+    # Currently supported values: prometheus (the default), stackdriver.
     metrics.request-metrics-backend-destination: prometheus
 
     # metrics.stackdriver-project-id field specifies the stackdriver project ID. This

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	defaultLogURLTemplate = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
+	defaultLogURLTemplate        = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
+	defaultRequestMetricsBackend = "prometheus"
 )
 
 // ObservabilityConfig contains the configuration defined in the observability ConfigMap.
@@ -79,6 +80,8 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 
 	if mb, ok := configMap.Data["metrics.request-metrics-backend-destination"]; ok {
 		oc.RequestMetricsBackend = mb
+	} else {
+		oc.RequestMetricsBackend = defaultRequestMetricsBackend
 	}
 
 	if prof, ok := configMap.Data["profiling.enable"]; ok {

--- a/pkg/metrics/config_test.go
+++ b/pkg/metrics/config_test.go
@@ -78,7 +78,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			EnableVarLogCollection: false,
 			LoggingURLTemplate:     defaultLogURLTemplate,
 			RequestLogTemplate:     "",
-			RequestMetricsBackend:  "",
+			RequestMetricsBackend:  "prometheus",
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5919

## Proposed Changes

* Add default request metrics backend in observability config to make it consistent with the default example value in config-observability.yaml
* Make request metrics available when using default monitoring yaml.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add default request metrics backend in observability config to make it consistent with the default example value in config-observability.yaml
```

**The default example in config-observability.yaml**
https://github.com/knative/serving/blob/ec657e71ac290fcba0e397153330e2a85a1dac02/config/config-observability.yaml#L91-L94