### PR TITLE
Update vendor/knative.dev/test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1823,7 +1823,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1407665e3864cc73384661a03274096b4e673f347fd9fbe71b31311c38a9617c"
+  digest = "1:e7879570d6c6708bc51f1394afa96bbed0d0a387559a771976340c28e5113142"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
@@ -1836,7 +1836,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "9ae69ebd7ca9fce84803812de3cfd0c14078e95f"
+  revision = "e381f11dc722330fe082158e2f22cd39f8fe8375"
 
 [[projects]]
   digest = "1:fef5992ddf85e9ccad899b11338339858936a10fbce96b9d5c43767669d95398"
@@ -1915,6 +1915,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/api/validation",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/labels",

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -325,6 +325,9 @@ function setup_test_cluster() {
   set -o errexit
   set -o pipefail
 
+  header "Test cluster setup"
+  kubectl get nodes
+
   header "Setting up test cluster"
 
   # Set the actual project the test cluster resides in

--- a/vendor/knative.dev/test-infra/scripts/release.sh
+++ b/vendor/knative.dev/test-infra/scripts/release.sh
@@ -212,7 +212,7 @@ function prepare_dot_release() {
     echo "Dot release will be generated for ${version_filter}"
     releases="$(echo "${releases}" | grep ^${version_filter})"
   fi
-  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r | head -1)"
+  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r -V | head -1)"
   [[ -n "${last_version}" ]] || abort "no previous release exist"
   local major_minor_version=""
   if [[ -z "${RELEASE_BRANCH}" ]]; then


### PR DESCRIPTION
Major changes:
* display E2E cluster setup during tests
* dump failed pod status when waiting for pods to come up during test setup
* fix parsing error for autogenerated code in flaky test reporter
* fix automatic dot releases for 0.10+ branches

Part of https://github.com/knative/test-infra/issues/1542

/cc @grantr 
/cc @mattmoor 