### PR TITLE
Also report number of activators as metric

### DIFF
--- a/test/performance/benchmarks/dataplane-probe/dev.config
+++ b/test/performance/benchmarks/dataplane-probe/dev.config
@@ -113,3 +113,7 @@ metric_info_list: {
   value_key: "be1"
   label: "activator-errors-with-cc-1"
 }
+metric_info_list: {
+  value_key: "ap"
+  label: "activator-pod-count"
+}

--- a/test/performance/benchmarks/dataplane-probe/prod.config
+++ b/test/performance/benchmarks/dataplane-probe/prod.config
@@ -107,3 +107,7 @@ metric_info_list: {
   value_key: "be1"
   label: "activator-errors-with-cc-1"
 }
+metric_info_list: {
+  value_key: "ap"
+  label: "activator-pod-count"
+}

--- a/test/performance/benchmarks/load-test/continuous/main.go
+++ b/test/performance/benchmarks/load-test/continuous/main.go
@@ -27,11 +27,11 @@ import (
 	"github.com/google/mako/go/quickstore"
 	vegeta "github.com/tsenart/vegeta/lib"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"knative.dev/pkg/signals"
+	"knative.dev/pkg/test/mako"
 	pkgpacers "knative.dev/pkg/test/vegeta/pacers"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-
-	"knative.dev/pkg/test/mako"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/test/performance"
 	"knative.dev/serving/test/performance/metrics"
@@ -64,7 +64,7 @@ func processResults(ctx context.Context, q *quickstore.Quickstore, results <-cha
 	}()
 
 	ctx, cancel := context.WithCancel(ctx)
-	deploymentStatus := metrics.FetchDeploymentStatus(ctx, namespace, selector, time.Second)
+	deploymentStatus := metrics.FetchDeploymentsStatus(ctx, namespace, selector, time.Second)
 	sksMode := metrics.FetchSKSMode(ctx, namespace, selector, time.Second)
 	defer cancel()
 


### PR DESCRIPTION
This helps as an overlay over the latency graph
to show the effects of the pod rebalancing
between the activators.

E.g. https://mako.dev/run?run_key=4921325961347072&~kd=1&~id=1&~qp=1&~a=1&~qc=1&~qc1=1&~qct=1&~ac=1&~act=1&~ac1=1&~ap=1

/lint
/assign mattmoor @chizhg  