### PR TITLE
Mark LoadBalancerReady False when VirtualService failed to be reconciled

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -29,6 +29,8 @@ var ingressCondSet = apis.NewLivingConditionSet(
 	IngressConditionLoadBalancerReady,
 )
 
+var VirtualServiceNotReconciledReason = "ReconcileVirtualServiceFailed"
+
 // GetGroupVersionKind returns SchemeGroupVersion of an Ingress
 func (i *Ingress) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Ingress")
@@ -73,9 +75,14 @@ func (is *IngressStatus) MarkLoadBalancerReady(lbs []LoadBalancerIngressStatus, 
 
 // MarkLoadBalancerPending marks the "IngressConditionLoadBalancerReady" condition to unknown to
 // reflect that the load balancer is not ready yet.
-func (is *IngressStatus) MarkLoadBalancerPending() {
+func (is *IngressStatus) MarkLoadBalancerNotReady() {
 	ingressCondSet.Manage(is).MarkUnknown(IngressConditionLoadBalancerReady, "Uninitialized",
 		"Waiting for VirtualService to be ready")
+}
+
+// MarkLoadBalancerFailed marks the "IngressConditionLoadBalancerReady" condition to false.
+func (is *IngressStatus) MarkLoadBalancerFailed(reason, message string) {
+	ingressCondSet.Manage(is).MarkFalse(IngressConditionLoadBalancerReady, reason, message)
 }
 
 // MarkIngressNotReady marks the "IngressConditionReady" condition to unknown.

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -29,7 +29,9 @@ var ingressCondSet = apis.NewLivingConditionSet(
 	IngressConditionLoadBalancerReady,
 )
 
-var VirtualServiceNotReconciledReason = "ReconcileVirtualServiceFailed"
+// VirtualServiceNotReconciled is used for the reason of MarkLoadBalancerFailed
+// when VirtualService is failed to be reconciled.
+var VirtualServiceNotReconciled = "ReconcileVirtualServiceFailed"
 
 // GetGroupVersionKind returns SchemeGroupVersion of an Ingress
 func (i *Ingress) GetGroupVersionKind() schema.GroupVersionKind {

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -75,7 +75,7 @@ func (is *IngressStatus) MarkLoadBalancerReady(lbs []LoadBalancerIngressStatus, 
 	ingressCondSet.Manage(is).MarkTrue(IngressConditionLoadBalancerReady)
 }
 
-// MarkLoadBalancerPending marks the "IngressConditionLoadBalancerReady" condition to unknown to
+// MarkLoadBalancerNotReady marks the "IngressConditionLoadBalancerReady" condition to unknown to
 // reflect that the load balancer is not ready yet.
 func (is *IngressStatus) MarkLoadBalancerNotReady() {
 	ingressCondSet.Manage(is).MarkUnknown(IngressConditionLoadBalancerReady, "Uninitialized",

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -83,9 +83,13 @@ func TestIngressTypicalFlow(t *testing.T) {
 	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
 
 	// Then ingress is pending.
-	r.MarkLoadBalancerPending()
+	r.MarkLoadBalancerNotReady()
 	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionLoadBalancerReady, t)
 	apitestv1.CheckConditionOngoing(r.duck(), IngressConditionReady, t)
+
+	r.MarkLoadBalancerFailed("some reason", "some message")
+	apitestv1.CheckConditionFailed(r.duck(), IngressConditionLoadBalancerReady, t)
+	apitestv1.CheckConditionFailed(r.duck(), IngressConditionLoadBalancerReady, t)
 
 	// Then ingress has address.
 	r.MarkLoadBalancerReady(

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -168,6 +168,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ia *v1alpha1.Ingress)
 	logger.Infof("Creating/Updating VirtualServices")
 	ia.Status.ObservedGeneration = ia.GetGeneration()
 	if err := r.reconcileVirtualServices(ctx, ia, vses); err != nil {
+		ia.Status.MarkLoadBalancerFailed(v1alpha1.VirtualServiceNotReconciledReason, err.Error())
 		return err
 	}
 
@@ -218,7 +219,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ia *v1alpha1.Ingress)
 		privateLbs := getLBStatus(privateGatewayServiceURLFromContext(ctx))
 		ia.Status.MarkLoadBalancerReady(lbs, publicLbs, privateLbs)
 	} else {
-		ia.Status.MarkLoadBalancerPending()
+		ia.Status.MarkLoadBalancerNotReady()
 	}
 
 	// TODO(zhiminx): Mark Route status to indicate that Gateway is configured.

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -168,7 +168,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ia *v1alpha1.Ingress)
 	logger.Infof("Creating/Updating VirtualServices")
 	ia.Status.ObservedGeneration = ia.GetGeneration()
 	if err := r.reconcileVirtualServices(ctx, ia, vses); err != nil {
-		ia.Status.MarkLoadBalancerFailed(v1alpha1.VirtualServiceNotReconciledReason, err.Error())
+		ia.Status.MarkLoadBalancerFailed(v1alpha1.VirtualServiceNotReconciled, err.Error())
 		return err
 	}
 

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -279,7 +279,7 @@ func TestReconcile(t *testing.T) {
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{{
 							Type:     v1alpha1.IngressConditionLoadBalancerReady,
-							Reason:   v1alpha1.VirtualServiceNotReconciledReason,
+							Reason:   v1alpha1.VirtualServiceNotReconciled,
 							Severity: apis.ConditionSeverityError,
 							Message:  "failed to update VirtualService: inducing failure for update virtualservices",
 							Status:   corev1.ConditionFalse,

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -278,14 +278,17 @@ func TestReconcile(t *testing.T) {
 				v1alpha1.IngressStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{{
-							Type:   v1alpha1.IngressConditionLoadBalancerReady,
-							Status: corev1.ConditionTrue,
+							Type:     v1alpha1.IngressConditionLoadBalancerReady,
+							Reason:   v1alpha1.VirtualServiceNotReconciledReason,
+							Severity: apis.ConditionSeverityError,
+							Message:  "failed to update VirtualService: inducing failure for update virtualservices",
+							Status:   corev1.ConditionFalse,
 						}, {
 							Type:   v1alpha1.IngressConditionNetworkConfigured,
 							Status: corev1.ConditionTrue,
 						}, {
 							Type:     v1alpha1.IngressConditionReady,
-							Status:   corev1.ConditionUnknown,
+							Status:   corev1.ConditionFalse,
 							Severity: apis.ConditionSeverityError,
 							Reason:   notReconciledReason,
 							Message:  notReconciledMessage,


### PR DESCRIPTION
## Proposed Changes

Currently `LoadBalancerReady` is not updated even when VirtualService failed to be reconciled.

This patch updates LoadBalancerReady with reason and message by using
returned error message.

Also, `MarkLoadBalancerPending()` is changed to `MarkLoadBalancerNotReady()`
by following https://github.com/knative/serving/issues/5076.

/lint

**Release Note**

```release-note
NONE
```

AFTER THIS PATCH:

```
status:
  conditions:
  - lastTransitionTime: "2019-11-16T11:41:46Z"
    message: 'failed to create VirtualService: admission webhook "pilot.validation.istio.io"
      denied the request: configuration is invalid: regex match ''^service-to-service-call-via-activator-both-disabled-vktmmxev\.serving-tests(\.svc(\.cluster\.local)?)?(?::\d{1,5})?$''
      cannot be greater than 100 bytes'
    reason: ReconcileVirtualServiceFailed
    status: "False"
    type: LoadBalancerReady
  - lastTransitionTime: "2019-11-16T11:08:23Z"
    status: Unknown
    type: NetworkConfigured
  - lastTransitionTime: "2019-11-16T11:41:46Z"
    message: Ingress reconciliation failed
    reason: ReconcileIngressFailed
    status: "False"
    type: Ready
```
