### PR TITLE
fix scale-from-zero errors

### DIFF
--- a/test/performance/benchmarks/scale-from-zero/continuous/main.go
+++ b/test/performance/benchmarks/scale-from-zero/continuous/main.go
@@ -55,7 +55,7 @@ const (
 	serviceName              = "perftest-scalefromzero"
 	helloWorldExpectedOutput = "Hello World!"
 	helloWorldImage          = "helloworld"
-	waitToServe              = 10 * time.Minute
+	waitToServe              = 1 * time.Minute
 )
 
 func clientsFromConfig() (*test.Clients, error) {
@@ -191,14 +191,15 @@ func testScaleFromZero(clients *test.Clients, count int) {
 	}
 	q, qclose, ctx := mc.Quickstore, mc.ShutDownFunc, mc.Context
 	defer qclose(ctx)
-	// Wrap fatalf in a helper or our sidecar will live forever.
-	fatalf := func(f string, args ...interface{}) {
-		qclose(ctx)
-		log.Fatalf(f, args...)
-	}
 
 	// Create the services once.
 	objs, cleanup, err := createServices(clients, count)
+	// Wrap fatalf in a helper or our sidecar will live forever, also wrap cleanup.
+	fatalf := func(f string, args ...interface{}) {
+		cleanup()
+		qclose(ctx)
+		log.Fatalf(f, args...)
+	}
 	if err != nil {
 		fatalf("Failed to create services: %v", err)
 	}

--- a/test/performance/benchmarks/scale-from-zero/continuous/main.go
+++ b/test/performance/benchmarks/scale-from-zero/continuous/main.go
@@ -55,7 +55,7 @@ const (
 	serviceName              = "perftest-scalefromzero"
 	helloWorldExpectedOutput = "Hello World!"
 	helloWorldImage          = "helloworld"
-	waitToServe              = 1 * time.Minute
+	waitToServe              = 2 * time.Minute
 )
 
 func clientsFromConfig() (*test.Clients, error) {

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -92,8 +92,14 @@ EOF
 }
 
 function update_benchmark() {
-  echo ">> Applying all the yamls for benchmark $1"
+  echo ">> Deleting all the yamls for benchmark $1"
   ko delete -f ${BENCHMARK_ROOT_PATH}/$1/continuous --ignore-not-found=true
+  echo ">> Deleting all Knative serving resources"
+  kubectl delete route --all
+  kubectl delete configuration --all
+  kubectl delete ksvc --all
+
+  echo ">> Applying all the yamls for benchmark $1"
   ko apply -f ${BENCHMARK_ROOT_PATH}/$1/continuous || abort "failed to apply benchmarks yaml $1"
 }
 

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -94,9 +94,7 @@ EOF
 function update_benchmark() {
   echo ">> Deleting all the yamls for benchmark $1"
   ko delete -f ${BENCHMARK_ROOT_PATH}/$1/continuous --ignore-not-found=true
-  echo ">> Deleting all Knative serving resources"
-  kubectl delete route --all
-  kubectl delete configuration --all
+  echo ">> Deleting all Knative serving services"
   kubectl delete ksvc --all
 
   echo ">> Applying all the yamls for benchmark $1"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Fix some errors for the `scale-from-zero` benchmark
1. When the Prow job updates the cluster, if one benchmarking job is still running, the resources created in the test won't be deleted, so adding the following commands to make sure they are cleaned up:
```
kubectl delete route --all
kubectl delete configuration --all
kubectl delete ksvc --all
```
2. Also change a bit in the test code to make sure `cleanup` will be called if the benchmark job finishes.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
