### PR TITLE
use constants for knative-ingress-gateway and cluster-local-gateway

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -80,6 +80,11 @@ const (
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"
+
+	// KnativeIngressGateway is the name of the ingress gateway
+	KnativeIngressGateway = "knative-ingress-gateway"
+	// ClusterLocalGateway is the name of the local gateway
+	ClusterLocalGateway = "cluster-local-gateway"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -685,7 +685,7 @@ func TestMakeIngressGateways(t *testing.T) {
 		ctx = config.ToContext(context.Background(), &config.Config{
 			Istio: &config.Istio{
 				IngressGateways: []config.Gateway{{
-					Name:       "knative-ingress-gateway",
+					Name:       networking.KnativeIngressGateway,
 					ServiceURL: fmt.Sprintf("%s.%s.svc.cluster.local", c.gatewayService.Name, c.gatewayService.Namespace),
 				}},
 			},

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -46,6 +46,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -53,7 +54,6 @@ import (
 
 var (
 	namespace = "knative-serving"
-	name      = "knative-ingress-gateway"
 )
 
 func TestIstioProbing(t *testing.T) {
@@ -63,18 +63,18 @@ func TestIstioProbing(t *testing.T) {
 	clients := e2e.Setup(t)
 
 	// Save the current Gateway to restore it after the test
-	oldGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Get(name, metav1.GetOptions{})
+	oldGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get Gateway %s/%s", namespace, name)
+		t.Fatalf("Failed to get Gateway %s/%s", namespace, networking.KnativeIngressGateway)
 	}
 	restore := func() {
-		curGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Get(name, metav1.GetOptions{})
+		curGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("Failed to get Gateway %s/%s", namespace, name)
+			t.Fatalf("Failed to get Gateway %s/%s", namespace, networking.KnativeIngressGateway)
 		}
 		curGateway.Spec.Servers = oldGateway.Spec.Servers
 		if _, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Update(curGateway); err != nil {
-			t.Fatalf("Failed to restore Gateway %s/%s: %v", namespace, name, err)
+			t.Fatalf("Failed to restore Gateway %s/%s: %v", namespace, networking.KnativeIngressGateway, err)
 		}
 	}
 	test.CleanupOnInterrupt(restore)
@@ -313,9 +313,9 @@ func hasHTTPS(servers []v1alpha3.Server) bool {
 // setupGateway updates the ingress Gateway to the provided Servers and waits until all Envoy pods have been updated.
 func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames, domain string, servers []v1alpha3.Server) {
 	// Get the current Gateway
-	curGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Get(name, metav1.GetOptions{})
+	curGateway, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get Gateway %s/%s: %v", namespace, name, err)
+		t.Fatalf("Failed to get Gateway %s/%s: %v", namespace, networking.KnativeIngressGateway, err)
 	}
 
 	// Update its Spec
@@ -325,7 +325,7 @@ func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames,
 	// Update the Gateway
 	gw, err := clients.SharedClient.NetworkingV1alpha3().Gateways(namespace).Update(newGateway)
 	if err != nil {
-		t.Fatalf("Failed to update Gateway %s/%s: %v", namespace, name, err)
+		t.Fatalf("Failed to update Gateway %s/%s: %v", namespace, networking.KnativeIngressGateway, err)
 	}
 
 	var selectors []string

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -54,6 +54,7 @@ import (
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 
 	ptest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/networking"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 )
@@ -63,7 +64,7 @@ const (
 	Namespace = "knative-serving"
 
 	// GatewayName is the name of the ingress gateway
-	GatewayName = "knative-ingress-gateway"
+	GatewayName = networking.KnativeIngressGateway
 )
 
 func validateCreatedServiceStatus(clients *test.Clients, names *test.ResourceNames) error {


### PR DESCRIPTION

## Proposed Changes

* used constants for **knative-ingress-gateway** and **cluster-local-gateway**
* modified few constants to lower case because they were not accessed from outside package

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
