### PR TITLE
Remove all occurrences of github.com/pkg/errors in our code.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1886,7 +1886,6 @@
     "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd",
     "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider",
     "github.com/mattbaird/jsonpatch",
-    "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_model/go",

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -31,7 +32,6 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/pkg/errors"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"

--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -17,11 +17,11 @@ limitations under the License.
 package autoscaler
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -17,12 +17,12 @@ limitations under the License.
 package autoscaler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"

--- a/pkg/queue/readiness/probe_encoding.go
+++ b/pkg/queue/readiness/probe_encoding.go
@@ -18,8 +18,7 @@ package readiness
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -27,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	vegeta "github.com/tsenart/vegeta/lib"
 	"golang.org/x/sync/errgroup"
 	"knative.dev/pkg/system"

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/network"
@@ -389,7 +387,7 @@ func isTrafficClusterLocal(tt []v1alpha1.TrafficTarget, tag string) (bool, error
 			return strings.HasSuffix(traffic.TrafficTarget.URL.Host, network.GetClusterDomainName()), nil
 		}
 	}
-	return false, errors.Errorf("Unable to find traffic target with tag %s", tag)
+	return false, fmt.Errorf("Unable to find traffic target with tag %s", tag)
 }
 
 func isRouteClusterLocal(rs v1alpha1.RouteStatus) bool {

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/mattbaird/jsonpatch"
-	"github.com/pkg/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -186,13 +185,13 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 		return false, nil
 	}, "ServiceUpdatedWithRevision")
 	if err != nil {
-		return "", errors.Wrapf(err, "LatestCreatedRevisionName not updated")
+		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
 	err = WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
 	}, "ServiceReadyWithRevision")
 
-	return revisionName, errors.Wrapf(err, "LatestReadyRevisionName not updated with %s", revisionName)
+	return revisionName, fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
 }
 
 // Service returns a Service object in namespace with the name names.Service

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -301,7 +301,7 @@ func PatchServiceTemplateMetadata(t *testing.T, clients *test.Clients, svc *v1al
 // before returning the name of the revision.
 func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
 	var revisionName string
-	err := WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+	if err := WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
 			// We also check that the revision is pinned, meaning it's not a stale revision.
@@ -313,15 +313,16 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 			return true, nil
 		}
 		return false, nil
-	}, "ServiceUpdatedWithRevision")
-	if err != nil {
+	}, "ServiceUpdatedWithRevision"); err != nil {
 		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
-	err = WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+	if err := WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
-	}, "ServiceReadyWithRevision")
+	}, "ServiceReadyWithRevision"); err != nil {
+		return "", fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
+	}
 
-	return revisionName, fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
+	return revisionName, nil
 }
 
 // LatestService returns a Service object in namespace with the name names.Service

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -44,7 +44,6 @@ import (
 	"knative.dev/pkg/test/spoof"
 
 	"github.com/mattbaird/jsonpatch"
-	perrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -316,13 +315,13 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 		return false, nil
 	}, "ServiceUpdatedWithRevision")
 	if err != nil {
-		return "", perrors.Wrapf(err, "LatestCreatedRevisionName not updated")
+		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
 	err = WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
 	}, "ServiceReadyWithRevision")
 
-	return revisionName, perrors.Wrapf(err, "LatestReadyRevisionName not updated with %s", revisionName)
+	return revisionName, fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
 }
 
 // LatestService returns a Service object in namespace with the name names.Service

--- a/test/v1beta1/service.go
+++ b/test/v1beta1/service.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/mattbaird/jsonpatch"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -185,13 +184,13 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 		return false, nil
 	}, "ServiceUpdatedWithRevision")
 	if err != nil {
-		return "", errors.Wrapf(err, "LatestCreatedRevisionName not updated")
+		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
 	err = WaitForServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
 	}, "ServiceReadyWithRevision")
 
-	return revisionName, errors.Wrapf(err, "LatestReadyRevisionName not updated with %s", revisionName)
+	return revisionName, fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
 }
 
 // Service returns a Service object in namespace with the name names.Service

--- a/test/v1beta1/service.go
+++ b/test/v1beta1/service.go
@@ -170,7 +170,7 @@ func UpdateServiceRouteSpec(t *testing.T, clients *test.Clients, names test.Reso
 // before returning the name of the revision.
 func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
 	var revisionName string
-	err := WaitForServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
+	if err := WaitForServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
 			// We also check that the revision is pinned, meaning it's not a stale revision.
@@ -182,15 +182,16 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 			return true, nil
 		}
 		return false, nil
-	}, "ServiceUpdatedWithRevision")
-	if err != nil {
+	}, "ServiceUpdatedWithRevision"); err != nil {
 		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
-	err = WaitForServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
+	if err := WaitForServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == revisionName), nil
-	}, "ServiceReadyWithRevision")
+	}, "ServiceReadyWithRevision"); err != nil {
+		return "", fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
+	}
 
-	return revisionName, fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
+	return revisionName, nil
 }
 
 // Service returns a Service object in namespace with the name names.Service


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We want to use go1.13's native capabilities everywhere.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
