### PR TITLE
Fix validation issue of lastModifier for configuration and routes

### DIFF
--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -43,8 +43,10 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
-			c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		if c.OwnerReferences == nil {
+			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
+				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		}
 		err := c.Spec.Template.VerifyNameChange(ctx, original.Spec.Template)
 		errs = errs.Also(err.ViaField("spec.template"))
 	}

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -43,6 +43,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
+		// Don't validate annotations(creator and lastModifier) when configuration owned by service
+		// validate only when configuration created independently.
 		if c.OwnerReferences == nil {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
 				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -820,6 +820,60 @@ func TestConfigurationAnnotationUpdate(t *testing.T) {
 			Spec: getConfigurationSpec("helloworld:foo"),
 		},
 		want: nil,
+	}, {
+		name: "no validation for lastModifier annotation even after update without spec changes as configuration owned by service",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
+	}, {
+		name: "no validation for creator annotation even after update as configuration owned by service",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u3,
+					serving.UpdaterAnnotation: u1,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -36,8 +36,10 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Route)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
-			r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		if r.OwnerReferences == nil {
+			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
+				r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -36,6 +36,8 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Route)
+		// Don't validate annotations(creator and lastModifier) when route owned by service
+		// validate only when route created independently.
 		if r.OwnerReferences == nil {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
 				r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -763,6 +763,60 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			Spec: getRouteSpec("old"),
 		},
 		want: nil,
+	}, {
+		name: "no validation for lastModifier annotation even after update without spec changes as route owned by service",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
+	}, {
+		name: "no validation for creator annotation even after update as route owned by service",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u3,
+					serving.UpdaterAnnotation: u1,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"context"
-
 	"k8s.io/apimachinery/pkg/api/equality"
 
 	"knative.dev/pkg/apis"
@@ -39,8 +38,10 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
-			c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		if c.GetOwnerReferences() == nil {
+			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
+				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		}
 		err := c.Spec.GetTemplate().VerifyNameChange(ctx,
 			original.Spec.GetTemplate())
 		errs = errs.Also(err.ViaField("spec.revisionTemplate"))

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 
 	"knative.dev/pkg/apis"
@@ -38,6 +39,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
+		// Don't validate annotations(creator and lastModifier) when configuration owned by service
+		// validate only when configuration created independently.
 		if c.GetOwnerReferences() == nil {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
 				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))

--- a/pkg/apis/serving/v1alpha1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation_test.go
@@ -793,6 +793,60 @@ func TestConfigurationAnnotationUpdate(t *testing.T) {
 			Spec: getConfigurationSpec("helloworld:foo"),
 		},
 		want: nil,
+	}, {
+		name: "no validation for lastModifier annotation even after update as configuration owned by service",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1alpha1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
+	}, {
+		name: "no validation for creator annotation even after update as configuration owned by service",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u3,
+					serving.UpdaterAnnotation: u1,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1alpha1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -31,8 +31,10 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Route)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
-			r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		if r.OwnerReferences == nil {
+			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
+				r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -31,6 +31,8 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Route)
+		// Don't validate annotations(creator and lastModifier) when route owned by service
+		// validate only when route created independently.
 		if r.OwnerReferences == nil {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
 				r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))

--- a/pkg/apis/serving/v1alpha1/route_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/route_validation_test.go
@@ -602,6 +602,60 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			Spec: getRouteSpec("old"),
 		},
 		want: nil,
+	}, {
+		name: "no validation for lastModifier annotation even after update without spec changes as route owned by service",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1alpha1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
+	}, {
+		name: "no validation for creator annotation even after update as route owned by service",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u3,
+					serving.UpdaterAnnotation: u1,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1alpha1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -43,8 +43,10 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
-			c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		if c.OwnerReferences == nil {
+			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
+				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		}
 		err := c.Spec.Template.VerifyNameChange(ctx, original.Spec.Template)
 		errs = errs.Also(err.ViaField("spec.template"))
 	}

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -43,6 +43,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Configuration)
+		// Don't validate annotations(creator and lastModifier) when configuration owned by service
+		// validate only when configuration created independently.
 		if c.OwnerReferences == nil {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
 				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -796,6 +796,60 @@ func TestConfigurationAnnotationUpdate(t *testing.T) {
 			Spec: getConfigurationSpec("helloworld:foo"),
 		},
 		want: nil,
+	}, {
+		name: "no validation for lastModifier annotation even after update as configuration owned by service",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1beta1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
+	}, {
+		name: "no validation for creator annotation even after update as configuration owned by service",
+		this: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u3,
+					serving.UpdaterAnnotation: u1,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1beta1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		prev: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getConfigurationSpec("helloworld:foo"),
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -34,6 +34,8 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Route)
+		// Don't validate annotations(creator and lastModifier) when route owned by service
+		// validate only when route created independently.
 		if r.OwnerReferences == nil {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
 				r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -34,8 +34,10 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Route)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
-			r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		if r.OwnerReferences == nil {
+			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, r.Spec, original.GetAnnotations(),
+				r.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -747,6 +747,60 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			Spec: getRouteSpec("old"),
 		},
 		want: nil,
+	}, {
+		name: "no validation for lastModifier annotation even after update as route owned by service",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u3,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1beta1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
+	}, {
+		name: "no validation for creator annotation even after update as route owned by service",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u3,
+					serving.UpdaterAnnotation: u1,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1beta1",
+					Kind:       serving.GroupName,
+				}},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		prev: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.CreatorAnnotation: u1,
+					serving.UpdaterAnnotation: u1,
+				},
+			},
+			Spec: getRouteSpec("old"),
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/5964

## Proposed Changes

* add changes to configuration and routes to validate serving.knative.dev/creator and serving.knative.dev/lastModifier when ownerReference is nil

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
