### PR TITLE
Fix the bug with CC rounding in Activator and fix tests

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -330,6 +330,9 @@ func assignSlice(trackers []*podTracker, selfIndex, numActivators, cc int) []*po
 	x := append(trackers[:0:0], trackers[bi:ei]...)
 	if remnants > 0 {
 		tail := trackers[len(trackers)-remnants:]
+		// We shuffle the tail, to ensure that pods in the tail get better
+		// load distribution, since we sort the pods above, this puts more requests
+		// on the very first tail pod, than on the others.
 		rand.Shuffle(remnants, func(i, j int) {
 			tail[i], tail[j] = tail[j], tail[i]
 		})
@@ -338,7 +341,6 @@ func assignSlice(trackers []*podTracker, selfIndex, numActivators, cc int) []*po
 		// This is basically: x = append(x, trackers[len(trackers)-remnants:]...)
 		// But we need to update the capacity.
 		for _, t := range tail {
-			// minOneOrValue ensures that infinity tracker will never scale to 0.
 			t.UpdateConcurrency(dcc)
 			x = append(x, t)
 		}


### PR DESCRIPTION
1. Fix a bug wherein we were rounding down the CC for individual pod break, which caused us to lose units, compared to the overall activator capacity. E.g. with #A=7, #P=10, CC=10, each activator gets 100/7 = 14 slots, but the tail 3 items get only 10/7=1 slot, making 13 in total. Now during load tests when activators are actually saturated this causes activator to return an error, which is not desired.
2. Since we're kind of overprovisioning the tail now, shuffle the pods in the tail to achieve better distribution of requests over the pods.
3. Fix the tests where we were actually ignoring eveything, thus just comparing the counts :-( *in shame kube*


/lint

/assign mattmoor @markusthoemmes 