### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -178,7 +178,6 @@ func getUserPort(rev *v1alpha1.Revision) int32 {
 		return ports[0].ContainerPort
 	}
 
-
 	return v1alpha1.DefaultUserPort
 }
 

--- a/test/performance/benchmarks/scale-from-zero/continuous/main.go
+++ b/test/performance/benchmarks/scale-from-zero/continuous/main.go
@@ -21,12 +21,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	v1 "k8s.io/api/apps/v1"
 	"log"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	v1 "k8s.io/api/apps/v1"
 
 	"github.com/google/mako/go/quickstore"
 	"k8s.io/apimachinery/pkg/labels"
@@ -186,7 +187,7 @@ func runScaleFromZero(ctx context.Context, clients *test.Clients, idx int, ro *v
 	})
 
 	watcher, err := clients.KubeClient.Kube.AppsV1().Deployments(testNamespace).Watch(
-		metav1.ListOptions{LabelSelector:selector.String()})
+		metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		m := fmt.Sprintf("%02d: unable to watch the deployment for the service: %v", idx, err)
 		log.Println(m)
@@ -233,7 +234,7 @@ func runScaleFromZero(ctx context.Context, clients *test.Clients, idx int, ro *v
 			}
 		case <-sdch:
 			return time.Since(start), dd, nil
-		case err := <- errch:
+		case err := <-errch:
 			return 0, 0, err
 		}
 	}


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign vagababov
