### PR TITLE
Hide the methods on the private types.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -64,7 +64,7 @@ func NewConcurrencyReporter(ctx context.Context, podName string,
 	}
 }
 
-func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, concurrency int32) {
+func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, concurrency int64) {
 	ns := key.Namespace
 	revName := key.Name
 	revision, err := cr.rl.Revisions(ns).Get(revName)
@@ -74,16 +74,16 @@ func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, 
 	}
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
-	cr.sr.ReportRequestConcurrency(ns, serviceName, configurationName, revName, int64(concurrency))
+	cr.sr.ReportRequestConcurrency(ns, serviceName, configurationName, revName, concurrency)
 }
 
 // Run runs until stopCh is closed and processes events on all incoming channels
 func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
 	// Contains the number of in-flight requests per-key
-	outstandingRequestsPerKey := make(map[types.NamespacedName]int32)
+	outstandingRequestsPerKey := make(map[types.NamespacedName]int64)
 	// Contains the number of incoming requests in the current
 	// reporting period, per key.
-	incomingRequestsPerKey := make(map[types.NamespacedName]int32)
+	incomingRequestsPerKey := make(map[types.NamespacedName]int64)
 
 	for {
 		select {
@@ -128,7 +128,7 @@ func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
 			}
 			cr.statCh <- messages
 
-			incomingRequestsPerKey = make(map[types.NamespacedName]int32)
+			incomingRequestsPerKey = make(map[types.NamespacedName]int64)
 		case <-stopCh:
 			return
 		}

--- a/pkg/autoscaler/aggregation/aggregation.go
+++ b/pkg/autoscaler/aggregation/aggregation.go
@@ -18,7 +18,7 @@ package aggregation
 
 import "time"
 
-// Accumulator is a function accumulating buckets and their time..
+// Accumulator is a function accumulating buckets and their time.
 type Accumulator func(time time.Time, bucket float64Bucket)
 
 // YoungerThan only applies the accumulator to buckets that are younger than the given
@@ -39,7 +39,7 @@ type Average struct {
 
 // Accumulate accumulates the values needed to compute an average.
 func (a *Average) Accumulate(_ time.Time, bucket float64Bucket) {
-	a.sum += bucket.Sum()
+	a.sum += bucket.sum()
 	a.count++
 }
 

--- a/pkg/autoscaler/aggregation/aggregation_test.go
+++ b/pkg/autoscaler/aggregation/aggregation_test.go
@@ -41,7 +41,7 @@ func TestAverage(t *testing.T) {
 			average := Average{}
 			for _, value := range tt.values {
 				bucket := float64Bucket{}
-				bucket.Record("pod", value)
+				bucket.record("pod", value)
 				average.Accumulate(time.Now(), bucket)
 			}
 
@@ -92,7 +92,7 @@ func TestYoungerThan(t *testing.T) {
 			})
 			for _, t := range tt.times {
 				bucket := float64Bucket{}
-				bucket.Record("pod", 1.0)
+				bucket.record("pod", 1.0)
 				acc(t, bucket)
 			}
 

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -49,7 +49,7 @@ func (t *TimedFloat64Buckets) Record(time time.Time, name string, value float64)
 		bucket = float64Bucket{}
 		t.buckets[bucketKey] = bucket
 	}
-	bucket.Record(name, value)
+	bucket.record(name, value)
 }
 
 // IsEmpty returns whether or not there are no values currently stored.
@@ -94,9 +94,9 @@ type float64Value struct {
 	count float64
 }
 
-// Record adds a value to the bucket. Buckets with the same given name
+// record adds a value to the bucket. Buckets with the same given name
 // will be collapsed.
-func (b float64Bucket) Record(name string, value float64) {
+func (b float64Bucket) record(name string, value float64) {
 	current := b[name]
 	b[name] = float64Value{
 		sum:   current.sum + value,
@@ -104,9 +104,9 @@ func (b float64Bucket) Record(name string, value float64) {
 	}
 }
 
-// Sum calculates the sum over the bucket. Values of the same name in
+// sum calculates the sum over the bucket. Values of the same name in
 // the same bucket will be averaged between themselves first.
-func (b float64Bucket) Sum() float64 {
+func (b float64Bucket) sum() float64 {
 	var total float64
 	for _, value := range b {
 		total += value.sum / value.count

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -79,7 +79,7 @@ func TestTimedFloat64Buckets(t *testing.T) {
 
 			got := make(map[time.Time]float64)
 			for time, bucket := range buckets.buckets {
-				got[time] = bucket.Sum()
+				got[time] = bucket.sum()
 			}
 
 			if !cmp.Equal(tt.want, got) {
@@ -243,11 +243,11 @@ func TestFloat64Bucket(t *testing.T) {
 			bucket := float64Bucket{}
 			for name, values := range tt.stats {
 				for _, value := range values {
-					bucket.Record(name, value)
+					bucket.record(name, value)
 				}
 			}
 
-			if got := bucket.Sum(); got != tt.want {
+			if got := bucket.sum(); got != tt.want {
 				t.Errorf("Average() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -338,8 +338,10 @@ func (c *collection) stableAndPanicStats(now time.Time, buckets *aggregation.Tim
 		return 0, 0, ErrNoData
 	}
 
-	panicAverage := aggregation.Average{}
-	stableAverage := aggregation.Average{}
+	var (
+		panicAverage  aggregation.Average
+		stableAverage aggregation.Average
+	)
 	buckets.ForEachBucket(
 		aggregation.YoungerThan(now.Add(-spec.PanicWindow), panicAverage.Accumulate),
 		aggregation.YoungerThan(now.Add(-spec.StableWindow), stableAverage.Accumulate),


### PR DESCRIPTION
buckets is a private type and its methods need not be
public.
Some other minor cleanups in the metric code to reduce casting.

/assign @markusthoemmes
