### PR TITLE
Validate that panic ands table window have 1s precision.

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -213,9 +213,15 @@ func validate(lc *Config) (*Config, error) {
 	if lc.StableWindow < autoscaling.WindowMin {
 		return nil, fmt.Errorf("stable-window = %v, must be at least %v", lc.StableWindow, BucketSize)
 	}
+	if lc.StableWindow.Round(time.Second) != lc.StableWindow {
+		return nil, fmt.Errorf("stable-window = %v, must be specified with at most second precision", lc.StableWindow)
+	}
 
 	if lc.PanicWindow < BucketSize || lc.PanicWindow > lc.StableWindow {
 		return nil, fmt.Errorf("panic-window = %v, must be in [%v, %v] interval", lc.PanicWindow, BucketSize, lc.StableWindow)
+	}
+	if lc.PanicWindow.Round(time.Second) != lc.PanicWindow {
+		return nil, fmt.Errorf("panic-window = %v, must be specified with at most second precision", lc.PanicWindow)
 	}
 
 	effPW := time.Duration(lc.PanicWindowPercentage / 100 * float64(lc.StableWindow))

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -214,6 +214,12 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
+		name: "stable not seconds",
+		input: map[string]string{
+			"stable-window": "61984ms",
+		},
+		wantErr: true,
+	}, {
 		name: "panic window too small",
 		input: map[string]string{
 			"panic-window": "500ms",
@@ -224,6 +230,12 @@ func TestNewConfig(t *testing.T) {
 		input: map[string]string{
 			"stable-window": "12s",
 			"panic-window":  "13s",
+		},
+		wantErr: true,
+	}, {
+		name: "panic not seconds",
+		input: map[string]string{
+			"panic-window": "4321ms",
 		},
 		wantErr: true,
 	}, {
@@ -263,6 +275,7 @@ func TestNewConfig(t *testing.T) {
 			got, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 				Data: test.input,
 			})
+			t.Logf("Error = %v", err)
 			if (err != nil) != test.wantErr {
 				t.Errorf("NewConfig() = %v, want %v", err, test.wantErr)
 			}


### PR DESCRIPTION
The autoscaler does not really work on values less than 6/2s right now
and there is no semantic reason why we would support fractional seconds
at least right now, but this restriction opens lots of windows for
optimizations in the metric collection, since we can reason about window values
being of certain form (e.g. evenly divisible by seconds).

/assign @markusthoemmes


/lint
