### PR TITLE
Define autoscaleSleep variable with default value 500

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -56,6 +56,7 @@ const (
 	containerConcurrency = 6.0
 	targetUtilization    = 0.7
 	successRateSLO       = 0.999
+	autoscaleSleep       = 500
 )
 
 type testContext struct {
@@ -72,7 +73,7 @@ func getVegetaTarget(kubeClientset *kubernetes.Clientset, domain, endpointOverri
 	if resolvable {
 		return vegeta.Target{
 			Method: http.MethodGet,
-			URL:    fmt.Sprintf("http://%s?sleep=100", domain),
+			URL:    fmt.Sprintf("http://%s?sleep=%d", domain, autoscaleSleep),
 		}, nil
 	}
 
@@ -91,7 +92,7 @@ func getVegetaTarget(kubeClientset *kubernetes.Clientset, domain, endpointOverri
 	h.Set("Host", domain)
 	return vegeta.Target{
 		Method: http.MethodGet,
-		URL:    fmt.Sprintf("http://%s?sleep=100", endpoint),
+		URL:    fmt.Sprintf("http://%s?sleep=%d", endpoint, autoscaleSleep),
 		Header: h,
 	}, nil
 }


### PR DESCRIPTION
On some environments the round trip times for requests coming to Knative services might be longer (200ms and more) and the current value for delay on server side together with the number of threads that are sending requests can't maintain the required load and tests such as TestAutoscaleSustaining and TestTargetBurstCapacity are failing because the number of pods for the knative service is too low. 
This PR increases the sleep time on server side but also makes is possible to override the value externally via -ldflags.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
