### PR TITLE
Adjust digest validation for image templating mechanism.

### DIFF
--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -327,6 +327,9 @@ func validateReleaseServiceShape(objs *v1test.ResourceObjects) error {
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	imageDigestRegex := fmt.Sprintf("%s/%s@sha256:[0-9a-f]{64}", pkgTest.Flags.DockerRepo, imageName)
+	fullName := pkgTest.ImagePath(imageName)
+	// Remove the tag portion from the fullName to be able to append the sha instead.
+	repository := strings.Split(fullName, ":")[0]
+	imageDigestRegex := repository + "@sha256:[0-9a-f]{64}"
 	return regexp.MatchString(imageDigestRegex, imageDigest)
 }

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -22,10 +22,10 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
@@ -327,9 +327,15 @@ func validateReleaseServiceShape(objs *v1a1test.ResourceObjects) error {
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	fullName := pkgTest.ImagePath(imageName)
-	// Remove the tag portion from the fullName to be able to append the sha instead.
-	repository := strings.Split(fullName, ":")[0]
-	imageDigestRegex := repository + "@sha256:[0-9a-f]{64}"
-	return regexp.MatchString(imageDigestRegex, imageDigest)
+	ref, err := name.ParseReference(pkgTest.ImagePath(imageName))
+	if err != nil {
+		return false, err
+	}
+
+	digest, err := name.NewDigest(imageDigest)
+	if err != nil {
+		return false, err
+	}
+
+	return ref.Context().String() == digest.Context().String(), nil
 }

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -327,6 +327,9 @@ func validateReleaseServiceShape(objs *v1a1test.ResourceObjects) error {
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	imageDigestRegex := fmt.Sprintf("%s/%s@sha256:[0-9a-f]{64}", pkgTest.Flags.DockerRepo, imageName)
+	fullName := pkgTest.ImagePath(imageName)
+	// Remove the tag portion from the fullName to be able to append the sha instead.
+	repository := strings.Split(fullName, ":")[0]
+	imageDigestRegex := repository + "@sha256:[0-9a-f]{64}"
 	return regexp.MatchString(imageDigestRegex, imageDigest)
 }

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -22,10 +22,10 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
@@ -327,9 +327,15 @@ func validateReleaseServiceShape(objs *v1b1test.ResourceObjects) error {
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	fullName := pkgTest.ImagePath(imageName)
-	// Remove the tag portion from the fullName to be able to append the sha instead.
-	repository := strings.Split(fullName, ":")[0]
-	imageDigestRegex := repository + "@sha256:[0-9a-f]{64}"
-	return regexp.MatchString(imageDigestRegex, imageDigest)
+	ref, err := name.ParseReference(pkgTest.ImagePath(imageName))
+	if err != nil {
+		return false, err
+	}
+
+	digest, err := name.NewDigest(imageDigest)
+	if err != nil {
+		return false, err
+	}
+
+	return ref.Context().String() == digest.Context().String(), nil
 }

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -327,6 +327,9 @@ func validateReleaseServiceShape(objs *v1b1test.ResourceObjects) error {
 }
 
 func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	imageDigestRegex := fmt.Sprintf("%s/%s@sha256:[0-9a-f]{64}", pkgTest.Flags.DockerRepo, imageName)
+	fullName := pkgTest.ImagePath(imageName)
+	// Remove the tag portion from the fullName to be able to append the sha instead.
+	repository := strings.Split(fullName, ":")[0]
+	imageDigestRegex := repository + "@sha256:[0-9a-f]{64}"
 	return regexp.MatchString(imageDigestRegex, imageDigest)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We can no longer rely on the image format to be static since we introduced a templating mechanism. This adjusts the relevant validation functions to also take that into account.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
