### PR TITLE
Remove panic-window configmap entry and other cleanups

### DIFF
--- a/config/config-autoscaler.yaml
+++ b/config/config-autoscaler.yaml
@@ -84,6 +84,7 @@ data:
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.
+    # Stable window must be in whole seconds.
     stable-window: "60s"
 
     # When observed average concurrency during the panic window reaches
@@ -91,13 +92,9 @@ data:
     # enters panic mode. When operating in panic mode, the autoscaler
     # scales on the average concurrency over the panic window which is
     # panic-window-percentage of the stable-window.
+    # When computing the panic window it will be rounded to the closest
+    # whole second.
     panic-window-percentage: "10.0"
-
-    # Absolute panic window duration.
-    # Deprecated in favor of panic-window-percentage.
-    # Existing revisions will continue to scale based on panic-window
-    # but new revisions will default to panic-window-percentage.
-    panic-window: "6s"
 
     # The percentage of the container concurrency target at which to
     # enter panic mode when reached within the panic window.

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -60,9 +60,7 @@ type Config struct {
 	StableWindow             time.Duration
 	PanicWindowPercentage    float64
 	PanicThresholdPercentage float64
-	// Deprecated in favor of PanicWindowPercentage.
-	PanicWindow  time.Duration
-	TickInterval time.Duration
+	TickInterval             time.Duration
 
 	ScaleToZeroGracePeriod time.Duration
 }
@@ -157,10 +155,6 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		field:        &lc.StableWindow,
 		defaultValue: 60 * time.Second,
 	}, {
-		key:          "panic-window",
-		field:        &lc.PanicWindow,
-		defaultValue: 6 * time.Second,
-	}, {
 		key:          "scale-to-zero-grace-period",
 		field:        &lc.ScaleToZeroGracePeriod,
 		defaultValue: 30 * time.Second,
@@ -215,13 +209,6 @@ func validate(lc *Config) (*Config, error) {
 	}
 	if lc.StableWindow.Round(time.Second) != lc.StableWindow {
 		return nil, fmt.Errorf("stable-window = %v, must be specified with at most second precision", lc.StableWindow)
-	}
-
-	if lc.PanicWindow < BucketSize || lc.PanicWindow > lc.StableWindow {
-		return nil, fmt.Errorf("panic-window = %v, must be in [%v, %v] interval", lc.PanicWindow, BucketSize, lc.StableWindow)
-	}
-	if lc.PanicWindow.Round(time.Second) != lc.PanicWindow {
-		return nil, fmt.Errorf("panic-window = %v, must be specified with at most second precision", lc.PanicWindow)
 	}
 
 	effPW := time.Duration(lc.PanicWindowPercentage / 100 * float64(lc.StableWindow))

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -36,7 +36,6 @@ var defaultConfig = Config{
 	MaxScaleUpRate:                     1000,
 	MaxScaleDownRate:                   2,
 	StableWindow:                       time.Minute,
-	PanicWindow:                        6 * time.Second,
 	ScaleToZeroGracePeriod:             30 * time.Second,
 	TickInterval:                       2 * time.Second,
 	PanicWindowPercentage:              10.0,
@@ -61,7 +60,6 @@ func TestNewConfig(t *testing.T) {
 			"container-concurrency-target-default":    "10.0",
 			"target-burst-capacity":                   "0",
 			"stable-window":                           "5m",
-			"panic-window":                            "10s",
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
@@ -72,7 +70,6 @@ func TestNewConfig(t *testing.T) {
 			c.MaxScaleUpRate = 1.001
 			c.TargetBurstCapacity = 0
 			c.StableWindow = 5 * time.Minute
-			c.PanicWindow = 10 * time.Second
 			return &c
 		}(defaultConfig),
 	}, {
@@ -104,7 +101,6 @@ func TestNewConfig(t *testing.T) {
 			"requests-per-second-target-default":      "10.11",
 			"target-burst-capacity":                   "12345",
 			"stable-window":                           "5m",
-			"panic-window":                            "11s",
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
@@ -117,7 +113,6 @@ func TestNewConfig(t *testing.T) {
 			c.MaxScaleDownRate = 3
 			c.MaxScaleUpRate = 1.01
 			c.StableWindow = 5 * time.Minute
-			c.PanicWindow = 11 * time.Second
 			return &c
 		}(defaultConfig),
 	}, {
@@ -217,25 +212,6 @@ func TestNewConfig(t *testing.T) {
 		name: "stable not seconds",
 		input: map[string]string{
 			"stable-window": "61984ms",
-		},
-		wantErr: true,
-	}, {
-		name: "panic window too small",
-		input: map[string]string{
-			"panic-window": "500ms",
-		},
-		wantErr: true,
-	}, {
-		name: "panic window too big",
-		input: map[string]string{
-			"stable-window": "12s",
-			"panic-window":  "13s",
-		},
-		wantErr: true,
-	}, {
-		name: "panic not seconds",
-		input: map[string]string{
-			"panic-window": "4321ms",
 		},
 		wantErr: true,
 	}, {

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -272,7 +272,6 @@ var config = &autoscaler.Config{
 	MaxScaleUpRate:                     10.0,
 	StableWindow:                       60 * time.Second,
 	PanicThresholdPercentage:           200,
-	PanicWindow:                        6 * time.Second,
 	PanicWindowPercentage:              10,
 	TickInterval:                       2 * time.Second,
 	ScaleToZeroGracePeriod:             30 * time.Second,

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -270,7 +270,6 @@ var config = &autoscaler.Config{
 	TargetUtilization:                  1.0,
 	StableWindow:                       60 * time.Second,
 	PanicThresholdPercentage:           200,
-	PanicWindow:                        6 * time.Second,
 	PanicWindowPercentage:              10,
 	TickInterval:                       2 * time.Second,
 	ScaleToZeroGracePeriod:             30 * time.Second,

--- a/pkg/reconciler/autoscaling/resources/metric.go
+++ b/pkg/reconciler/autoscaling/resources/metric.go
@@ -48,7 +48,7 @@ func MakeMetric(ctx context.Context, pa *v1alpha1.PodAutoscaler, metricSvc strin
 		// Fall back to cluster config.
 		panicWindowPercentage = config.PanicWindowPercentage
 	}
-	panicWindow := time.Duration(float64(stableWindow) * panicWindowPercentage / 100.0)
+	panicWindow := time.Duration(float64(stableWindow) * panicWindowPercentage / 100.0).Round(time.Second)
 	if panicWindow < autoscaler.BucketSize {
 		panicWindow = autoscaler.BucketSize
 	}

--- a/pkg/reconciler/autoscaling/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/resources/metric_test.go
@@ -64,6 +64,14 @@ func TestMakeMetric(t *testing.T) {
 			withScrapeTarget("dansen"),
 			withStableWindow(time.Minute), withPanicWindow(30*time.Second),
 			withPanicWindowPercentageAnnotation("50")),
+	}, {
+		name: "with panic window percentage+rounding",
+		pa:   pa(WithPanicWindowPercentageAnnotation("51")),
+		msn:  "dansen",
+		want: metric(
+			withScrapeTarget("dansen"),
+			withStableWindow(time.Minute), withPanicWindow(31*time.Second),
+			withPanicWindowPercentageAnnotation("51")),
 	}}
 
 	for _, tc := range cases {
@@ -171,7 +179,6 @@ var config = &autoscaler.Config{
 	MaxScaleUpRate:                     10.0,
 	StableWindow:                       60 * time.Second,
 	PanicThresholdPercentage:           200,
-	PanicWindow:                        6 * time.Second,
 	PanicWindowPercentage:              10,
 	TickInterval:                       2 * time.Second,
 	ScaleToZeroGracePeriod:             30 * time.Second,


### PR DESCRIPTION
1. remove the configmap entry for the panic-window, it's long unsed
2. make sure when we compute the panic-window from percentage it's rounded to the whole second
3. update comments in the configmap.

/assign mattmoor @markusthoemmes


/lint
