### PR TITLE
Label Configuration/Service as "podspecable".

### DIFF
--- a/config/200-addressable-resolvers-clusterrole.yaml
+++ b/config/200-addressable-resolvers-clusterrole.yaml
@@ -1,0 +1,36 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-addressable-resolver
+  labels:
+    serving.knative.dev/release: devel
+    # Labeled to facilitate aggregated cluster roles that act on Addressables.
+    duck.knative.dev/addressable: "true"
+
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/200-podspecable-bindings-clusterrole.yaml
+++ b/config/200-podspecable-bindings-clusterrole.yaml
@@ -1,0 +1,34 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-podspecable-binding
+  labels:
+    serving.knative.dev/release: devel
+    # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
+    duck.knative.dev/podspecable: "true"
+
+# Do not use this role directly. These rules will be added to the "podspecable-binder" role.
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - configurations
+  - services
+  verbs:
+  - list
+  - watch
+  - patch

--- a/config/300-configuration.yaml
+++ b/config/300-configuration.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
 spec:
   group: serving.knative.dev
   versions:

--- a/config/300-service.yaml
+++ b/config/300-service.yaml
@@ -20,6 +20,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
 spec:
   group: serving.knative.dev
   versions:


### PR DESCRIPTION
This also synthesizes a cluster role with each of the podspecable and addresable fragments, so that bindings on podspecable things and addressable resolution may aggregate on these same labels.  With this, we can (eventually) drop some similar logic in knative/eventing, which currently hardcodes serving stuff.

Related: https://github.com/knative/pkg/pull/917

