### PR TITLE
Add `devel` label to HPA for activator.

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -110,8 +110,10 @@ spec:
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-    name: activator
-    namespace: knative-serving
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
 spec:
     minReplicas: 1
     maxReplicas: 20


### PR DESCRIPTION
I noticed this when comparing the set of released YAML vs a partial filter from my local working directory.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE.
```
