### PR TITLE
Log that the healthcheck is failed and the reason for it

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -246,7 +246,7 @@ func main() {
 
 	// Set up our health check based on the health of stat sink and environmental factors.
 	hc := newHealthCheck(sigCtx, logger, statSink)
-	ah = &activatorhandler.HealthHandler{HealthCheck: hc, NextHandler: ah}
+	ah = &activatorhandler.HealthHandler{HealthCheck: hc, NextHandler: ah, Logger: logger}
 
 	ah = network.NewProbeHandler(ah)
 
@@ -314,7 +314,7 @@ func newHealthCheck(sigCtx context.Context, logger *zap.SugaredLogger, statSink 
 		// When we get SIGTERM (sigCtx done), let readiness probes start failing.
 		case <-sigCtx.Done():
 			once.Do(func() {
-				logger.Info("signal context canceled")
+				logger.Info("Signal context canceled")
 			})
 			return errors.New("received SIGTERM from kubelet")
 		default:

--- a/pkg/activator/handler/healthz_handler.go
+++ b/pkg/activator/handler/healthz_handler.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"net/http"
 
+	"go.uber.org/zap"
 	"knative.dev/serving/pkg/network"
 )
 
@@ -23,11 +24,13 @@ import (
 type HealthHandler struct {
 	HealthCheck func() error
 	NextHandler http.Handler
+	Logger      *zap.SugaredLogger
 }
 
 func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if network.IsKubeletProbe(r) {
 		if err := h.HealthCheck(); err != nil {
+			h.Logger.Warnf("Healthcheck failed: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		} else {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/activator/handler/healthz_handler_test.go
+++ b/pkg/activator/handler/healthz_handler_test.go
@@ -17,9 +17,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	ktesting "knative.dev/pkg/logging/testing"
 )
 
 func TestHealthHandler(t *testing.T) {
+	logger := ktesting.TestLogger(t)
 	examples := []struct {
 		name           string
 		headers        http.Header
@@ -52,7 +55,7 @@ func TestHealthHandler(t *testing.T) {
 				wasPassed = true
 				w.WriteHeader(http.StatusOK)
 			})
-			handler := HealthHandler{HealthCheck: e.check, NextHandler: baseHandler}
+			handler := HealthHandler{HealthCheck: e.check, NextHandler: baseHandler, Logger: logger}
 
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)


### PR DESCRIPTION
This helps debugging some activator failures, when we can't observe them in-vivo

/assign @makusthoemmes @jrbancel

