### PR TITLE
Remove the duplicated env key in activator.yaml

### DIFF
--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -43,10 +43,6 @@ spec:
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: knative.dev/serving/cmd/activator
-        env:
-          # Run Activator with GC collection when newly generated memory is 500%
-          - name: GOGC
-            value: 500
         ports:
         - name: http1
           containerPort: 8012
@@ -85,6 +81,9 @@ spec:
             cpu: 1000m
             memory: 600Mi
         env:
+          # Run Activator with GC collection when newly generated memory is 500%.
+          - name: GOGC
+            value: 500
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -83,7 +83,7 @@ spec:
         env:
           # Run Activator with GC collection when newly generated memory is 500%.
           - name: GOGC
-            value: 500
+            value: "500"
           - name: POD_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
* There should not be duplicated keys in yaml map. Remove the duplicated `env` key in activator.yaml.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
