### PR TITLE
[WIP] Init scale to 0

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -135,3 +135,9 @@ data:
     # Once enabled, it allows the autoscaler to prioritize pods processing
     # fewer (or zero) requests for removal when scaling down.
     enable-graceful-scaledown: "false"
+
+    # Scale to zero on deploy feature flag specifies whether we will scale a
+    # service to zero at the time of deployment.
+    # By setting this to true, services will deploy with initially
+    # zero instances created.
+    scale-to-zero-on-deploy: "false"

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -81,3 +81,9 @@ data:
     # disables this throttling and lets through as many requests as
     # the pod receives.
     container-concurrency: "0"
+
+    # scale-to-zero-on-deploy specifies whether we will scale a
+    # service to zero at the time of deployment.
+    # By setting this to true, services will deploy with initially
+    # zero instances created.
+    scale-to-zero-on-deploy: "false"

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -162,4 +162,7 @@ const (
 	// by the autoscaler as a candidate for removal. Once the label is set to "true", it
 	// signals the QueueProxy to fail readiness on the pod
 	PreferForScaleDownLabelKey = GroupName + "/prefer-for-scale-down"
+
+	// ScaleToZeroOnDeployAnnotation
+	ScaleToZeroOnDeployAnnotation = GroupName + "/scaleToZeroOnDeploy"
 )

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -58,6 +58,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 			RevisionTimeoutSeconds:    DefaultRevisionTimeoutSeconds,
 			MaxRevisionTimeoutSeconds: DefaultMaxRevisionTimeoutSeconds,
 			UserContainerNameTemplate: DefaultUserContainerName,
+			ScaleToZeroOnDeploy:       DefaultScaleToZeroOnDeploy,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -74,6 +75,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 			MaxRevisionTimeoutSeconds: 456,
 			RevisionCPURequest:        &oneTwoThree,
 			UserContainerNameTemplate: "{{.Name}}",
+			ScaleToZeroOnDeploy:       true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -85,6 +87,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 				"max-revision-timeout-seconds": "456",
 				"revision-cpu-request":         "123m",
 				"container-name-template":      "{{.Name}}",
+				"scale-to-zero-on-deploy":      "true",
 			},
 		},
 	}, {

--- a/pkg/apis/serving/v1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1/configuration_defaults_test.go
@@ -18,15 +18,18 @@ package v1
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -42,6 +45,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				Template: RevisionTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 						ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
@@ -67,6 +75,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				Template: RevisionTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						PodSpec: corev1.PodSpec{
 							Containers: []corev1.Container{{
@@ -87,6 +100,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		in: &Configuration{
 			Spec: ConfigurationSpec{
 				Template: RevisionTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						PodSpec: corev1.PodSpec{
 							Containers: []corev1.Container{{
@@ -102,6 +120,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				Template: RevisionTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						PodSpec: corev1.PodSpec{
 							Containers: []corev1.Container{{

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -18,10 +18,10 @@ package v1
 
 import (
 	"context"
-
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 )
 
@@ -32,6 +32,11 @@ func (r *Revision) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (rts *RevisionTemplateSpec) SetDefaults(ctx context.Context) {
+	cfg := config.FromContextOrDefaults(ctx)
+
+	if _, ok := rts.Annotations[autoscaling.ScaleToZeroOnDeployAnnotation]; !ok {
+		rts.WithScaleToZeroOnDeployAnno(cfg.Defaults.ScaleToZeroOnDeploy)
+	}
 	rts.Spec.SetDefaults(apis.WithinSpec(ctx))
 }
 

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -18,12 +18,14 @@ package v1
 
 import (
 	"fmt"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
@@ -194,4 +196,11 @@ func RevisionContainerExitingMessage(message string) string {
 // cannot be pulled correctly.
 func RevisionContainerMissingMessage(image string, message string) string {
 	return fmt.Sprintf("Unable to fetch image %q: %s", image, message)
+}
+
+func (rts *RevisionTemplateSpec) WithScaleToZeroOnDeployAnno(scaleToZeroOnDeploy bool) {
+	if rts.Annotations == nil {
+		rts.Annotations = make(map[string]string, 1)
+	}
+	rts.Annotations[autoscaling.ScaleToZeroOnDeployAnnotation] = strconv.FormatBool(scaleToZeroOnDeploy)
 }

--- a/pkg/apis/serving/v1/service_defaults_test.go
+++ b/pkg/apis/serving/v1/service_defaults_test.go
@@ -18,16 +18,19 @@ package v1
 
 import (
 	"context"
+	"knative.dev/serving/pkg/apis/serving"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
-	"knative.dev/serving/pkg/apis/serving"
 )
 
 func TestServiceDefaulting(t *testing.T) {
@@ -42,6 +45,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 							ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
@@ -62,6 +70,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -77,6 +90,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -105,6 +123,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -122,6 +145,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -150,6 +178,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -178,6 +211,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: RevisionTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{

--- a/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults_test.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -25,9 +26,11 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -56,6 +59,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		in: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						DeprecatedContainer: &corev1.Container{},
 					},
@@ -65,6 +73,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -85,6 +98,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		in: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						DeprecatedContainer: &corev1.Container{
 							Image: "busybox",
@@ -96,6 +114,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				Template: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -118,6 +141,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		in: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
@@ -131,6 +159,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -152,6 +185,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		in: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							ContainerConcurrency: ptr.Int64(1),
@@ -168,6 +206,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: ConfigurationSpec{
 				DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							ContainerConcurrency: ptr.Int64(1),

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -18,10 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -31,6 +32,11 @@ func (r *Revision) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (rts *RevisionTemplateSpec) SetDefaults(ctx context.Context) {
+	cfg := config.FromContextOrDefaults(ctx)
+
+	if _, ok := rts.Annotations[autoscaling.ScaleToZeroOnDeployAnnotation]; !ok {
+		rts.WithScaleToZeroOnDeployAnno(cfg.Defaults.ScaleToZeroOnDeploy)
+	}
 	rts.Spec.SetDefaults(apis.WithinSpec(ctx))
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	net "knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
@@ -355,4 +356,11 @@ func (rs *RevisionStatus) PropagateDeploymentStatus(original *appsv1.DeploymentS
 	case corev1.ConditionUnknown:
 		rs.MarkResourcesAvailableUnknown(cond.Reason, cond.Message)
 	}
+}
+
+func (rts *RevisionTemplateSpec) WithScaleToZeroOnDeployAnno(scaleToZeroOnDeploy bool) {
+	if rts.Annotations == nil {
+		rts.Annotations = make(map[string]string, 1)
+	}
+	rts.Annotations[autoscaling.ScaleToZeroOnDeployAnnotation] = strconv.FormatBool(scaleToZeroOnDeploy)
 }

--- a/pkg/apis/serving/v1alpha1/service_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/service_defaults_test.go
@@ -18,14 +18,17 @@ package v1alpha1
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -73,6 +76,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedRunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								DeprecatedContainer: &corev1.Container{},
 							},
@@ -86,6 +94,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedRunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								RevisionSpec: v1.RevisionSpec{
 									TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -110,6 +123,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedRunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								DeprecatedContainer: &corev1.Container{
 									Image: "busybox",
@@ -124,6 +142,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -157,6 +180,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedRunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								DeprecatedContainer: &corev1.Container{},
 								RevisionSpec: v1.RevisionSpec{
@@ -174,6 +202,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedRunLatest: &RunLatestType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								RevisionSpec: v1.RevisionSpec{
 									ContainerConcurrency: ptr.Int64(1),
@@ -197,6 +230,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								DeprecatedContainer: &corev1.Container{},
 							},
@@ -210,6 +248,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								RevisionSpec: v1.RevisionSpec{
 									TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -249,6 +292,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -300,6 +348,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedPinned: &PinnedType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								RevisionSpec: v1.RevisionSpec{
 									ContainerConcurrency: ptr.Int64(1),
@@ -340,6 +393,11 @@ func TestServiceDefaulting(t *testing.T) {
 					RolloutPercent: 43,
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								RevisionSpec: v1.RevisionSpec{
 									TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -378,6 +436,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -440,6 +503,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -500,6 +568,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					Template: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -557,6 +630,11 @@ func TestServiceDefaulting(t *testing.T) {
 				DeprecatedRelease: &ReleaseType{
 					Configuration: ConfigurationSpec{
 						DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+							ObjectMeta: apimachineryv1.ObjectMeta{
+								Annotations: map[string]string{
+									autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+								},
+							},
 							Spec: RevisionSpec{
 								RevisionSpec: v1.RevisionSpec{
 									ContainerConcurrency: ptr.Int64(1),
@@ -597,6 +675,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -637,6 +720,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -687,6 +775,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -743,6 +836,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: ServiceSpec{
 				ConfigurationSpec: ConfigurationSpec{
 					DeprecatedRevisionTemplate: &RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: RevisionSpec{
 							RevisionSpec: v1.RevisionSpec{
 								TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),

--- a/pkg/apis/serving/v1beta1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_defaults_test.go
@@ -18,13 +18,16 @@ package v1beta1
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	authv1 "k8s.io/api/authentication/v1"
+	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -41,6 +44,11 @@ func TestConfigurationDefaulting(t *testing.T) {
 		want: &Configuration{
 			Spec: v1.ConfigurationSpec{
 				Template: v1.RevisionTemplateSpec{
+					ObjectMeta: apimachineryv1.ObjectMeta{
+						Annotations: map[string]string{
+							autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+						},
+					},
 					Spec: v1.RevisionSpec{
 						TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 						ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),

--- a/pkg/apis/serving/v1beta1/service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/service_defaults_test.go
@@ -18,14 +18,17 @@ package v1beta1
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -43,6 +46,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
 							ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
@@ -63,6 +71,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -78,6 +91,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -106,6 +124,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -123,6 +146,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -151,6 +179,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{
@@ -179,6 +212,11 @@ func TestServiceDefaulting(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ConfigurationSpec: v1.ConfigurationSpec{
 					Template: v1.RevisionTemplateSpec{
+						ObjectMeta: apimachineryv1.ObjectMeta{
+							Annotations: map[string]string{
+								autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(config.DefaultScaleToZeroOnDeploy),
+							},
+						},
 						Spec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
 								Containers: []corev1.Container{{

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	// Enable connection-aware pod scaledown
 	EnableGracefulScaledown bool
 
+	// ScaleToZeroOnDeploy is the cluster wide feature flag for running readiness
+	// probe on deploy. If this is set to true, services will be scaled to 0 on deploy.
+	ScaleToZeroOnDeploy bool
+
 	// Target concurrency knobs for different container concurrency configurations.
 	ContainerConcurrencyTargetFraction float64
 	ContainerConcurrencyTargetDefault  float64
@@ -94,7 +98,12 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 			key:          "enable-graceful-scaledown",
 			field:        &lc.EnableGracefulScaledown,
 			defaultValue: false,
-		}} {
+		},
+		{
+			key:          "scale-to-zero-on-deploy",
+			field:        &lc.ScaleToZeroOnDeploy,
+			defaultValue: false,
+	}} {
 		if raw, ok := data[b.key]; !ok {
 			*b.field = b.defaultValue
 		} else {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -29,6 +29,7 @@ import (
 var defaultConfig = Config{
 	EnableScaleToZero:                  true,
 	EnableGracefulScaledown:            false,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 0.7,
 	ContainerConcurrencyTargetDefault:  100,
 	RPSTargetDefault:                   200,
@@ -96,6 +97,7 @@ func TestNewConfig(t *testing.T) {
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
 			"enable-graceful-scaledown":               "false",
+			"scale-to-zero-on-deploy":                 "false",
 			"max-scale-down-rate":                     "3.0",
 			"max-scale-up-rate":                       "1.01",
 			"container-concurrency-target-percentage": "0.71",
@@ -133,6 +135,21 @@ func TestNewConfig(t *testing.T) {
 		want: func(c Config) *Config {
 			c.EnableScaleToZero = false
 			c.EnableGracefulScaledown = true
+			return &c
+		}(defaultConfig),
+	}, {
+		name: "with scale to zero on deploy toggle on strange casing",
+		input: map[string]string{
+			"scale-to-zero-on-deploy": "FALSE",
+		},
+		want: &defaultConfig,
+	}, {
+		name: "with scale to zero on deploy toggle explicitly off",
+		input: map[string]string{
+			"scale-to-zero-on-deploy": "true",
+		},
+		want: func(c Config) *Config {
+			c.ScaleToZeroOnDeploy = true
 			return &c
 		}(defaultConfig),
 	}, {

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -265,6 +265,7 @@ func withMetric(m autoscalingv2beta1.MetricSpec) hpaOption {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	RPSTargetDefault:                   200.0,

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -263,6 +263,7 @@ func withPanicThresholdPercentageAnnotation(percentage string) deciderOption {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	TargetBurstCapacity:                211.0,

--- a/pkg/reconciler/autoscaling/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/resources/metric_test.go
@@ -172,6 +172,7 @@ func pa(options ...PodAutoscalerOption) *v1alpha1.PodAutoscaler {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
+	ScaleToZeroOnDeploy:              true,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	RPSTargetDefault:                   200.0,

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1006,7 +1006,7 @@ func TestMakeDeployment(t *testing.T) {
 			// Tested above so that we can rely on it here for brevity.
 			podSpec, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.ac, test.cc)
 			if err != nil {
-				t.Fatal("makePodSpec returned errror")
+				t.Fatalf("makePodSpec returned errror %v", err)
 			}
 			test.want.Spec.Template.Spec = *podSpec
 			got, err := MakeDeployment(test.rev, test.lc, test.tc, test.nc, test.oc, test.ac, test.cc)

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -117,16 +117,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		c.Recorder.Event(service, corev1.EventTypeWarning, "InternalError", reconcileErr.Error())
 		return reconcileErr
 	}
-	// TODO(mattmoor): Remove this after 0.7 cuts.
-	// If the spec has changed, then assume we need an upgrade and issue a patch to trigger
-	// the webhook to upgrade via defaulting.  Status updates do not trigger this due to the
-	// use of the /status resource.
-	if !equality.Semantic.DeepEqual(original.Spec, service.Spec) {
-		services := v1alpha1.SchemeGroupVersion.WithResource("services")
-		if err := c.MarkNeedsUpgrade(services, service.Namespace, service.Name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -243,6 +243,13 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "run-latest",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "run-latest"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "run-latest"),
@@ -262,6 +269,13 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("pinned", "foo", WithPinnedRollout("pinned-0001"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "pinned",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned"),
@@ -284,6 +298,13 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("pinned2", "foo", WithReleaseRollout("pinned2-0001"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "pinned2",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned2"),
@@ -340,6 +361,13 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "pinned3",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "pinned3"),
 		},
@@ -361,6 +389,13 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "release"),
@@ -380,6 +415,13 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("release", "foo", WithReleaseRollout("release-00001", "release-00002"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release"),
@@ -415,6 +457,13 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-nr",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr"),
 		},
@@ -446,6 +495,13 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(100),
 					},
 				})),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-nr",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr"),
@@ -492,6 +548,13 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-nr-ts",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr-ts"),
 		},
@@ -537,6 +600,13 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(42),
 					},
 				})),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-nr-ts2",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr-ts2"),
@@ -588,6 +658,13 @@ func TestReconcile(t *testing.T) {
 					},
 				}}...),
 			),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-ready-lr",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-ready-lr"),
@@ -657,6 +734,13 @@ func TestReconcile(t *testing.T) {
 					},
 				}}...),
 			),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-ready-lr",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-ready-lr"),
@@ -728,6 +812,13 @@ func TestReconcile(t *testing.T) {
 				}),
 			),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-ready",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-ready"),
 		},
@@ -750,6 +841,13 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "release-with-percent",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release-with-percent"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "release-with-percent"),
@@ -762,6 +860,13 @@ func TestReconcile(t *testing.T) {
 			route("no-updates", "foo", WithRunLatestRollout),
 			config("no-updates", "foo", WithRunLatestRollout),
 		},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "no-updates",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		Key: "foo/no-updates",
 	}, {
 		Name: "runLatest - update annotations",
@@ -788,6 +893,13 @@ func TestReconcile(t *testing.T) {
 						map[string]string{"new-key": "new-value"})
 				}),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "update-annos",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 	}, {
 		Name: "runLatest - delete annotations",
 		Objects: []runtime.Object{
@@ -809,6 +921,13 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Object: route("update-annos", "foo", WithRunLatestRollout),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "update-annos",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 	}, {
 		Name: "runLatest - update route and service",
 		Objects: []runtime.Object{
@@ -824,6 +943,13 @@ func TestReconcile(t *testing.T) {
 			Object: config("update-route-and-config", "foo", WithRunLatestRollout),
 		}, {
 			Object: route("update-route-and-config", "foo", WithRunLatestRollout),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "update-route-and-config",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 	}, {
 		Name: "runLatest - update route and service (bad existing Revision)",
@@ -858,6 +984,13 @@ func TestReconcile(t *testing.T) {
 				svc.Status.MarkRevisionNameTaken("update-route-and-config-blah")
 			}),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "update-route-and-config",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "update-route-and-config"),
 		},
@@ -876,6 +1009,13 @@ func TestReconcile(t *testing.T) {
 			Object: route("update-route-and-config-labels", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
 				"serving.knative.dev/service": "update-route-and-config-labels"})),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "update-route-and-config-labels",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 	}, {
 		Name: "runLatest - update route config labels ignoring serving.knative.dev/route",
 		Objects: []runtime.Object{
@@ -893,6 +1033,13 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Object: route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
 				"serving.knative.dev/service": "update-child-labels-ignore-route-label"})),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "update-child-labels-ignore-route-label",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 	}, {
 		Name: "runLatest - bad config update",
@@ -1069,6 +1216,13 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "all-ready",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "all-ready"),
 		},
@@ -1108,6 +1262,13 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "all-ready",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "all-ready"),
 		},
@@ -1141,6 +1302,13 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(100),
 					},
 				})),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "config-only-ready",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-only-ready"),
@@ -1177,6 +1345,13 @@ func TestReconcile(t *testing.T) {
 				WithFailedConfig("config-fails-00002", "RevisionFailed", "blah"),
 				WithServiceLatestReadyRevision("config-fails-00001")),
 		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "config-fails",
+			Patch: []byte(reconciler.ForceUpgradePatch),
+		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-fails"),
 		},
@@ -1194,6 +1369,13 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("config-fails", "foo", WithRunLatestRollout, WithInitSvcConditions,
 				WithServiceStatusRouteNotReady, WithFailedConfig(
 					"config-fails-00001", "RevisionFailed", "blah")),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "config-fails",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-fails"),
@@ -1216,6 +1398,13 @@ func TestReconcile(t *testing.T) {
 				// we expect the following changed to our status conditions.
 				WithReadyConfig("route-fails-00001"),
 				WithFailedRoute("Propagate me, please", "")),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "route-fails",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "route-fails"),
@@ -1286,6 +1475,13 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(100),
 					},
 				})),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "foo",
+			},
+			Name:  "new-owner",
+			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "new-owner"),

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -243,13 +243,6 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "run-latest",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "run-latest"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "run-latest"),
@@ -269,13 +262,6 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("pinned", "foo", WithPinnedRollout("pinned-0001"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "pinned",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned"),
@@ -298,13 +284,6 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("pinned2", "foo", WithReleaseRollout("pinned2-0001"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "pinned2",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "pinned2"),
@@ -361,13 +340,6 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "pinned3",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "pinned3"),
 		},
@@ -389,13 +361,6 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "release"),
@@ -415,13 +380,6 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("release", "foo", WithReleaseRollout("release-00001", "release-00002"),
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release"),
@@ -457,13 +415,6 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-nr",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr"),
 		},
@@ -495,13 +446,6 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(100),
 					},
 				})),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-nr",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr"),
@@ -548,13 +492,6 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-nr-ts",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr-ts"),
 		},
@@ -600,13 +537,6 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(42),
 					},
 				})),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-nr-ts2",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-nr-ts2"),
@@ -658,13 +588,6 @@ func TestReconcile(t *testing.T) {
 					},
 				}}...),
 			),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-ready-lr",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-ready-lr"),
@@ -734,13 +657,6 @@ func TestReconcile(t *testing.T) {
 					},
 				}}...),
 			),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-ready-lr",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-ready-lr"),
@@ -812,13 +728,6 @@ func TestReconcile(t *testing.T) {
 				}),
 			),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-ready",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "release-ready"),
 		},
@@ -841,13 +750,6 @@ func TestReconcile(t *testing.T) {
 				// The first reconciliation will initialize the status conditions.
 				WithInitSvcConditions),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "release-with-percent",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Configuration %q", "release-with-percent"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Route %q", "release-with-percent"),
@@ -860,13 +762,6 @@ func TestReconcile(t *testing.T) {
 			route("no-updates", "foo", WithRunLatestRollout),
 			config("no-updates", "foo", WithRunLatestRollout),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "no-updates",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		Key: "foo/no-updates",
 	}, {
 		Name: "runLatest - update annotations",
@@ -893,13 +788,6 @@ func TestReconcile(t *testing.T) {
 						map[string]string{"new-key": "new-value"})
 				}),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "update-annos",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 	}, {
 		Name: "runLatest - delete annotations",
 		Objects: []runtime.Object{
@@ -921,13 +809,6 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Object: route("update-annos", "foo", WithRunLatestRollout),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "update-annos",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 	}, {
 		Name: "runLatest - update route and service",
 		Objects: []runtime.Object{
@@ -943,13 +824,6 @@ func TestReconcile(t *testing.T) {
 			Object: config("update-route-and-config", "foo", WithRunLatestRollout),
 		}, {
 			Object: route("update-route-and-config", "foo", WithRunLatestRollout),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "update-route-and-config",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 	}, {
 		Name: "runLatest - update route and service (bad existing Revision)",
@@ -984,13 +858,6 @@ func TestReconcile(t *testing.T) {
 				svc.Status.MarkRevisionNameTaken("update-route-and-config-blah")
 			}),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "update-route-and-config",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "update-route-and-config"),
 		},
@@ -1009,13 +876,6 @@ func TestReconcile(t *testing.T) {
 			Object: route("update-route-and-config-labels", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
 				"serving.knative.dev/service": "update-route-and-config-labels"})),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "update-route-and-config-labels",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 	}, {
 		Name: "runLatest - update route config labels ignoring serving.knative.dev/route",
 		Objects: []runtime.Object{
@@ -1033,13 +893,6 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Object: route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
 				"serving.knative.dev/service": "update-child-labels-ignore-route-label"})),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "update-child-labels-ignore-route-label",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 	}, {
 		Name: "runLatest - bad config update",
@@ -1216,13 +1069,6 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "all-ready",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "all-ready"),
 		},
@@ -1262,13 +1108,6 @@ func TestReconcile(t *testing.T) {
 					},
 				})),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "all-ready",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "all-ready"),
 		},
@@ -1302,13 +1141,6 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(100),
 					},
 				})),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "config-only-ready",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-only-ready"),
@@ -1345,13 +1177,6 @@ func TestReconcile(t *testing.T) {
 				WithFailedConfig("config-fails-00002", "RevisionFailed", "blah"),
 				WithServiceLatestReadyRevision("config-fails-00001")),
 		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "config-fails",
-			Patch: []byte(reconciler.ForceUpgradePatch),
-		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-fails"),
 		},
@@ -1369,13 +1194,6 @@ func TestReconcile(t *testing.T) {
 			Object: DefaultService("config-fails", "foo", WithRunLatestRollout, WithInitSvcConditions,
 				WithServiceStatusRouteNotReady, WithFailedConfig(
 					"config-fails-00001", "RevisionFailed", "blah")),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "config-fails",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "config-fails"),
@@ -1398,13 +1216,6 @@ func TestReconcile(t *testing.T) {
 				// we expect the following changed to our status conditions.
 				WithReadyConfig("route-fails-00001"),
 				WithFailedRoute("Propagate me, please", "")),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "route-fails",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "route-fails"),
@@ -1475,13 +1286,6 @@ func TestReconcile(t *testing.T) {
 						Percent:      ptr.Int64(100),
 					},
 				})),
-		}},
-		WantPatches: []clientgotesting.PatchActionImpl{{
-			ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "foo",
-			},
-			Name:  "new-owner",
-			Patch: []byte(reconciler.ForceUpgradePatch),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "new-owner"),

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1
 
 import (
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -180,5 +182,18 @@ func WithRevisionLabel(key, value string) RevisionOption {
 			config.Labels = make(map[string]string)
 		}
 		config.Labels[key] = value
+	}
+}
+
+// WithScaleToZeroOnDeploy updates the scaleToZeroOnDeploy annotation to
+// the provided value
+func WithScaleToZeroOnDeploy(b bool) RevisionOption {
+	return func(rev *v1.Revision) {
+		ans := rev.Annotations
+		if ans == nil {
+			ans = make(map[string]string, 1)
+		}
+		ans[autoscaling.ScaleToZeroOnDeployAnnotation] = strconv.FormatBool(b)
+		rev.SetAnnotations(ans)
 	}
 }

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -50,6 +50,7 @@ func ServiceWithoutNamespace(name string, so ...ServiceOption) *v1.Service {
 			Name: name,
 		},
 	}
+	s.SetDefaults(context.Background())
 	for _, opt := range so {
 		opt(s)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1 "k8s.io/api/core/v1"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
@@ -31,7 +32,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/networking"

--- a/test/e2e/init_scale_zero_test.go
+++ b/test/e2e/init_scale_zero_test.go
@@ -1,0 +1,261 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/test/logstream"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/test"
+	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1a1testing "knative.dev/serving/pkg/testing/v1alpha1"
+)
+
+var (
+	scaleToZeroOnDeployFalse = map[string]string{
+		autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(false),
+	}
+	scaleToZeroOnDeployTrue = map[string]string{
+		autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(true),
+	}
+)
+
+// TestInitScaleZeroServiceLevel tests setting of annotation scaleToZeroOnDeploy on
+// the revision level
+func TestInitScaleZeroServiceLevel(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	defer test.TearDown(clients, names)
+
+	updatedConfigAutoscalerCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-autoscaler")
+	defer restoreCM(t, clients, updatedConfigAutoscalerCM)
+
+	t.Log("Creating a new Service with scale to zero on deploy being true and verifying that no pods are created")
+	createServiceAndCheckPods(t, clients, &names, false /* podsCreated */, v1a1testing.WithConfigAnnotations(scaleToZeroOnDeployTrue))
+
+	names = test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	t.Log("Creating a new Service with scale to zero on deploy being false and verifying that pods are created")
+	createServiceAndCheckPods(t, clients, &names, true /* podsCreated */, v1a1testing.WithConfigAnnotations(scaleToZeroOnDeployFalse))
+}
+
+// TestInitScaleZeroClusterLevel tests setting of scaleToZeroOnDeploy flags in both
+// config-defaults and config-autoscaler on the cluster level.
+func TestInitScaleZeroClusterLevel(t *testing.T) {
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	tests := []struct {
+		name                      string
+		// configDefaultsFlag indicates if the scale to zero on deploy flag is set to true
+		// or false in the config-defaults config map.
+		configDefaultsFlag        bool
+		// configAutoscalerFlag indicates if the scale to zero on deploy flag is set to true
+		// or false in the config-autoscaler config map.
+		configAutoscalerFlag      bool
+		// serviceScaleToZeroUnset indicates whether pods will be created when the scale to zero
+		// on deploy flag is unset on the test service created.
+		serviceScaleToZeroUnset bool
+		// serviceScaleToZeroFalse indicates whether pods will be created when the scale to zero
+		// on deploy flag is set to false on the test service created.
+		serviceScaleToZeroFalse bool
+		// serviceScaleToZeroTrue indicates whether pods will be created when the scale to zero
+		// on deploy flag is set to true on the test service created.
+		serviceScaleToZeroTrue  bool
+	}{{
+		name: "both config-defaults config-autoscaler true",
+		configDefaultsFlag: true,
+		configAutoscalerFlag: true,
+		serviceScaleToZeroUnset: false,
+		serviceScaleToZeroFalse: true,
+		serviceScaleToZeroTrue: false,
+	}, {
+		name: "config-autoscaler false but config-defaults true",
+		configDefaultsFlag:        true,
+		configAutoscalerFlag:      false,
+		serviceScaleToZeroUnset: true,
+		serviceScaleToZeroFalse: true,
+		serviceScaleToZeroTrue:  true,
+	}, {
+		name: "config-defaults false but config-autoscaler true",
+		configDefaultsFlag: false,
+		configAutoscalerFlag: true,
+		serviceScaleToZeroUnset: true,
+		serviceScaleToZeroFalse: true,
+		serviceScaleToZeroTrue: false,
+	}, {
+		name: "both config-defaults config-autoscaler false",
+		configDefaultsFlag: false,
+		configAutoscalerFlag: false,
+		serviceScaleToZeroUnset: true,
+		serviceScaleToZeroFalse: true,
+		serviceScaleToZeroTrue: true,
+	}}
+	for _, tc := range tests {
+		func() {
+			t.Logf("Setting feature flag to %v on config-defaults ConfigMap and %v on config-autoscaler ConfigMap.", tc.configDefaultsFlag, tc.configAutoscalerFlag)
+			if tc.configDefaultsFlag {
+				updatedConfigDefaultsCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-defaults")
+				defer restoreCM(t, clients, updatedConfigDefaultsCM)
+			}
+			if tc.configAutoscalerFlag {
+				updatedConfigAutoscalerCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-autoscaler")
+				defer restoreCM(t, clients, updatedConfigAutoscalerCM)
+			}
+
+			namesScaleToZeroUnset := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   "helloworld",
+			}
+			namesScaleToZeroFalse := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   "helloworld",
+			}
+			namesScaleToZeroTrue := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   "helloworld",
+			}
+			defer test.TearDown(clients, namesScaleToZeroUnset)
+			t.Logf("Creating a new Service without scale to zero on deploy being set and verifying that podsCreated is %v.", tc.serviceScaleToZeroUnset)
+			createServiceAndCheckPods(t, clients, &namesScaleToZeroUnset, tc.serviceScaleToZeroUnset /* podsCreated */)
+
+			defer test.TearDown(clients, namesScaleToZeroFalse)
+			t.Logf("Creating a new Service with scale to zero on deploy being false and verifying that podsCreated is %v.", tc.serviceScaleToZeroFalse)
+			createServiceAndCheckPods(t, clients, &namesScaleToZeroFalse, tc.serviceScaleToZeroFalse /* podsCreated */, v1a1testing.WithConfigAnnotations(scaleToZeroOnDeployFalse))
+
+			defer test.TearDown(clients, namesScaleToZeroTrue)
+			t.Logf("Creating a new Service with check scale to zero on deploy being true and verifying that podsCreated is %v.", tc.serviceScaleToZeroTrue)
+			createServiceAndCheckPods(t, clients, &namesScaleToZeroTrue, tc.serviceScaleToZeroTrue /* podsCreated */, v1a1testing.WithConfigAnnotations(scaleToZeroOnDeployTrue))
+		}()
+	}
+}
+
+// TestInitScaleZeroMinScaleClusterLevel tests setting of annotation scaleToZeroOnDeploy on
+// the config-defaults and config-autoscaler with minScale > 0
+func TestInitScaleZeroMinScaleClusterLevel(t *testing.T) {
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	defer test.TearDown(clients, names)
+
+	updatedConfigDefaultsCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-defaults")
+	updatedConfigAutoscalerCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-autoscaler")
+	defer restoreCM(t, clients, updatedConfigDefaultsCM)
+	defer restoreCM(t, clients, updatedConfigAutoscalerCM)
+
+	t.Log("Creating a new Service with minScale greater than 0 and verifying that pods are created.")
+	createServiceAndCheckPods(t, clients, &names, true /* podsCreated */, v1a1testing.WithConfigAnnotations(map[string]string{
+		autoscaling.MinScaleAnnotationKey: "1",
+	}))
+}
+
+// TestInitScaleZeroMinScaleServiceLevel tests setting of annotation scaleToZeroOnDeploy on
+// the service level with minScale > 0
+func TestInitScaleZeroMinScaleServiceLevel(t *testing.T) {
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+
+	defer test.TearDown(clients, names)
+
+	updatedConfigAutoscalerCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-autoscaler")
+	defer restoreCM(t, clients, updatedConfigAutoscalerCM)
+
+	t.Log("Creating a new Service with scale to zero on deploy being true and minScale greater than 0; verify that pods are created")
+	createServiceAndCheckPods(t, clients, &names, true /* podsCreated */, v1a1testing.WithConfigAnnotations(map[string]string{
+		autoscaling.MinScaleAnnotationKey:         "1",
+		autoscaling.ScaleToZeroOnDeployAnnotation: strconv.FormatBool(true),
+	}))
+}
+
+func restoreCM(t *testing.T, clients *test.Clients, oldCM *v1.ConfigMap) {
+	if _, err := patchCM(clients, oldCM); err != nil {
+		t.Fatalf("Error restoring ConfigMap %q: %v", oldCM.Name, err)
+	}
+	t.Logf("Successfully restored ConfigMap %s", oldCM.Name)
+}
+
+func setScaleToZeroOnDeployOnCluster(t *testing.T, clients *test.Clients, configMapName string) *v1.ConfigMap {
+	t.Logf("Fetch %s ConfigMap", configMapName)
+	original, err := rawCM(clients, configMapName)
+	if err != nil || original == nil {
+		t.Fatalf("Error fetching %s: %v", configMapName, err)
+	}
+	var newCM *v1.ConfigMap
+	original.Data["scale-to-zero-on-deploy"] = "true"
+	if newCM, err = patchCM(clients, original); err != nil {
+		t.Fatalf("Failed to update %s: %v", configMapName, err)
+	}
+	t.Logf("Successfully updated %s configMap.", configMapName)
+
+	newCM.Data["scale-to-zero-on-deploy"] = "false"
+	test.CleanupOnInterrupt(func() { restoreCM(t, clients, newCM) })
+	return newCM
+}
+
+// Returns true if pods are created; false if otherwise.
+func createServiceAndCheckPods(t *testing.T, clients *test.Clients, names *test.ResourceNames, podsCreated bool, fopt ...v1a1testing.ServiceOption) {
+	t.Helper()
+	test.CleanupOnInterrupt(func() {
+		test.TearDown(clients, *names)
+	})
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
+		false,
+		fopt...)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
+	podList, err := pods.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
+	})
+	if err != nil {
+		t.Fatalf("Failed to list all pods: %v: %v", names.Service, err)
+	}
+	if gotPods := len(podList.Items); podsCreated != (gotPods > 0) {
+		t.Fatalf("Expect podsCreated to be %v, but got %d pods.", podsCreated, gotPods)
+	}
+}


### PR DESCRIPTION
/lint

Part of #4098

## Proposed Changes
* Create user-facing knob `/checkValidityOnDeploy` annotation for the service level
* Create cluster-level knob `check-validity-on-deploy`

**Release Note**

```release-note
Operators can enable initial-scale-to-0 by setting the value of annotation /checkValidityOnDeploy to false.
End users can turn on initial-scale-to-0 by setting the annotation check-validity-on-deploy to false on ServiceSpec or RevisionSpec.
```

Future TODOs:
* e2e test with check-validity-on-deploy being false
* update documentation

/cc @nimakaviani 