### PR TITLE
Shorten the window time for the autoscale test.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -185,6 +185,9 @@ func setup(t *testing.T, class, metric string, target float64, targetUtilization
 			autoscaling.MetricAnnotationKey:            metric,
 			autoscaling.TargetAnnotationKey:            strconv.FormatFloat(target, 'f', -1, 64),
 			autoscaling.TargetUtilizationPercentageKey: strconv.FormatFloat(targetUtilization*100, 'f', -1, 64),
+			// We run the test for 60s, so make window a bit shorter,
+			// so that we're operating in sustained mode and the pod actions stopped happening.
+			autoscaling.WindowAnnotationKey: "50s",
 		}), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("512Mi"),


### PR DESCRIPTION
We were using 60s window and 60s test, which means that the end of the test corresponds
to the end of the of the observation and panic periods, that can bring to flakes
from time to time, where some weird timing issue causes us to measure over/under provisioned values.

Also make sure the apply `fopts` on top of the default values. Currently we were doing that in the wrong order and the default would override the test provided opt.

```
>go test ./test/e2e -timeout=90m -tags="e2e" -run=TestAutoscale -test.count=12 | tee /tmp/e2e
ok      knative.dev/serving/test/e2e    1522.771s
```

/hold
/assign @markusthoemmes  @yanweiguo 

