### PR TITLE
Correct one mistake in the comment

### DIFF
--- a/pkg/queue/stats/stats_reporter.go
+++ b/pkg/queue/stats/stats_reporter.go
@@ -143,7 +143,7 @@ func (r *Reporter) ReportRequestCount(responseCode int) error {
 	return nil
 }
 
-// ReportQueueDepth captures response time requests
+// ReportQueueDepth captures queue depth metric.
 func (r *Reporter) ReportQueueDepth(d int) error {
 	if !r.initialized {
 		return errors.New("StatsReporter is not initialized yet")


### PR DESCRIPTION
I found a mistake in the comment for function "ReportQueueDepth", so I correct it.

Detail:
"ReportQueueDepth captures response time requests" --> "ReportQueueDepth captures queue depth metric."

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->




<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

