### PR TITLE
Add missing configmaps for kourier e2e tests

### DIFF
--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # Download Kourier
-KOURIER_VERSION=0.3.1
+KOURIER_VERSION=0.3.3
 KOURIER_YAML=kourier-knative.yaml
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/v${KOURIER_VERSION}/deploy/${KOURIER_YAML}
 

--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -29,6 +29,18 @@ kind: Namespace
 metadata:
   name: kourier-system
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: kourier-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: kourier-system
+---
 EOF
 
 cat ${KOURIER_YAML} \

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -4,6 +4,18 @@ metadata:
   name: kourier-system
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: kourier-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: kourier-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: kourier

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -106,7 +106,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.1
+        - image: quay.io/3scale/kourier:v0.3.3
           imagePullPolicy: Always
           name: kourier-control
           resources: {}


### PR DESCRIPTION
/lint

## Proposed Changes

Recently Kourier has been migrated to use the knative controller and because in tests it's running in a different namespace than knative-serving it crashes due to missing configmaps. 

To avoid the controller crashing, we are creating two empty configmaps (config-observability,config-logging)  in the same namespace as kourier.

**Release Note**

```release-note
NONE
```
