### PR TITLE
Remove empty SubjectAltNames

### DIFF
--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -101,7 +101,6 @@ func TestIstioProbing(t *testing.T) {
 		Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
 		PrivateKey:        "/etc/istio/ingressgateway-certs/tls.key",
 		ServerCertificate: "/etc/istio/ingressgateway-certs/tls.crt",
-		SubjectAltNames:   []string{},
 	}
 
 	cases := []struct {


### PR DESCRIPTION
This patch removes empty `SubjectAltNames`.

When updating Istio to v1.4, `TestIstioProbing` had a problem just like https://github.com/knative/serving/issues/6157. After some investigation, it turned out that it will be solved by https://github.com/knative/serving/pull/6041 very soon.

Now, it should not be necessary so this patch removes it.

/lint

Fixes #

**Release Note**

```release-note
NONE
```
