### PR TITLE
Add upgrade test for new defaults

### DIFF
--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -22,10 +22,13 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 	ptest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/serving/v1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
@@ -37,6 +40,25 @@ func TestRunLatestServicePostUpgrade(t *testing.T) {
 func TestRunLatestServicePostUpgradeFromScaleToZero(t *testing.T) {
 	t.Parallel()
 	updateService(scaleToZeroServiceName, t)
+}
+
+// TestBYORevisionPostUpgrade attempts to update the RouteSpec of a Service using BYO Revision name. This
+// test is meant to catch new defaults that break the immutability of BYO Revision name.
+func TestBYORevisionPostUpgrade(t *testing.T) {
+	t.Parallel()
+	clients := e2e.Setup(t)
+	var names test.ResourceNames
+	names.Service = byoServiceName
+
+	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{{
+			Tag:          "example-tag",
+			RevisionName: byoRevName,
+			Percent:      ptr.Int64(100),
+		}},
+	}); err != nil {
+		t.Fatalf("Failed to update Service: %v", err)
+	}
 }
 
 func updateService(serviceName string, t *testing.T) {

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -47,8 +47,9 @@ func TestRunLatestServicePostUpgradeFromScaleToZero(t *testing.T) {
 func TestBYORevisionPostUpgrade(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
-	var names test.ResourceNames
-	names.Service = byoServiceName
+	names := test.ResourceNames{
+		Service: byoServiceName,
+	}
 
 	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{
@@ -64,8 +65,9 @@ func TestBYORevisionPostUpgrade(t *testing.T) {
 func updateService(serviceName string, t *testing.T) {
 	t.Helper()
 	clients := e2e.Setup(t)
-	var names test.ResourceNames
-	names.Service = serviceName
+	names := test.ResourceNames{
+		Service: serviceName,
+	}
 
 	t.Logf("Getting service %q", names.Service)
 	svc, err := clients.ServingAlphaClient.Services.Get(names.Service, metav1.GetOptions{})

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -35,6 +35,8 @@ const (
 	// multiple "go test" invocations.
 	serviceName            = "pizzaplanet-upgrade-service"
 	scaleToZeroServiceName = "scale-to-zero-upgrade-service"
+	byoServiceName         = "byo-revision-name-upgrade-test"
+	byoRevName             = byoServiceName + "-" + "rev1"
 )
 
 // Shamelessly cribbed from conformance/service_test.


### PR DESCRIPTION
This adds a new test using BYO Revision name to make sure that the
immutability contract is not violated by adding new defaults to the
Service template.

Fixes #6077

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
