### PR TITLE
split defaulting for RevTemplateSpec and rev.Spec

### DIFF
--- a/pkg/apis/serving/v1alpha1/configuration_defaults.go
+++ b/pkg/apis/serving/v1alpha1/configuration_defaults.go
@@ -48,5 +48,5 @@ func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
 		}
 	}
 
-	cs.GetTemplate().Spec.SetDefaults(ctx)
+	cs.GetTemplate().SetDefaults(ctx)
 }

--- a/pkg/apis/serving/v1alpha1/revision_defaults.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults.go
@@ -29,6 +29,11 @@ func (r *Revision) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
 }
 
+// SetDefaults implements apis.Defaultable
+func (rts *RevisionTemplateSpec) SetDefaults(ctx context.Context) {
+	rts.Spec.SetDefaults(apis.WithinSpec(ctx))
+}
+
 func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	if v1.IsUpgradeViaDefaulting(ctx) {
 		v1 := v1.RevisionSpec{}


### PR DESCRIPTION
/lint

## Proposed Changes

provides parity with how defaulting is done for v1
and makes it easier to add additional defaulting
to ObjectMeta in the template if necessary.

