### PR TITLE
Enable side-car injection on serving-tests and serving-tests-alt for mesh tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -391,6 +391,10 @@ function test_setup() {
 
   echo ">> Creating test resources (test/config/)"
   ko apply ${KO_FLAGS} -f test/config/ || return 1
+  if (( MESH )); then
+    kubectl label namespace serving-tests istio-injection=enabled
+    kubectl label namespace serving-tests-alt istio-injection=enabled
+  fi
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
   wait_until_pods_running knative-serving || return 1
   if [[ -n "${ISTIO_VERSION}" ]]; then


### PR DESCRIPTION
## Proposed Changes

* This patch adds label `istio-injection=enabled` to serving-tests{-alt} to run mesh tests with istio-proxy.

/lint

Fixes https://github.com/knative/serving/issues/6166

**Release Note**

```release-note
NONE
```
