### PR TITLE
Fix exposing cluster local names to the external gateway.

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -183,7 +183,11 @@ func makeServiceSpec(ingress *netv1alpha1.Ingress, isPrivate bool) (*corev1.Serv
 func GetDesiredServiceNames(ctx context.Context, route *v1alpha1.Route) (sets.String, error) {
 	traffic := route.Spec.Traffic
 
-	names := sets.String{}
+	// We always want create the route with the service name.
+	// If the traffic stanza only contains revision targets, then
+	// this will not be added below, and as a consequence we'll create
+	// a public route to it.
+	names := sets.NewString(route.Name)
 
 	for _, t := range traffic {
 		serviceName, err := domains.HostnameFromTemplate(ctx, route.Name, t.Tag)

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -381,36 +381,50 @@ func TestGetDesiredServiceNames(t *testing.T) {
 		traffic RouteOption
 		want    sets.String
 		wantErr bool
-	}{
-		{
-			name: "no traffic defined",
-		},
-		{
-			name:    "only default traffic",
-			traffic: WithSpecTraffic(v1alpha1.TrafficTarget{TrafficTarget: v1.TrafficTarget{}}),
-			want:    sets.NewString("myroute"),
-		},
-		{
-			name: "traffic targets with tag",
-			traffic: WithSpecTraffic(v1alpha1.TrafficTarget{
-				TrafficTarget: v1.TrafficTarget{},
-			}, v1alpha1.TrafficTarget{
-				TrafficTarget: v1.TrafficTarget{
-					Tag: "hello",
-				},
-			}, v1alpha1.TrafficTarget{
-				TrafficTarget: v1.TrafficTarget{
-					Tag: "hello",
-				},
-			}, v1alpha1.TrafficTarget{
-				TrafficTarget: v1.TrafficTarget{
-					Tag: "bye",
-				},
+	}{{
+		name: "no traffic defined",
+		want: sets.NewString("myroute"),
+	}, {
+		name:    "only default traffic",
+		traffic: WithSpecTraffic(v1alpha1.TrafficTarget{TrafficTarget: v1.TrafficTarget{}}),
+		want:    sets.NewString("myroute"),
+	}, {
+		name: "traffic targets with default and tags",
+		traffic: WithSpecTraffic(v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{},
+		}, v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
+				Tag: "hello",
 			},
-			),
-			want: sets.NewString("myroute", "hello-myroute", "bye-myroute"),
+		}, v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
+				Tag: "hello",
+			},
+		}, v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
+				Tag: "bye",
+			},
 		},
-	}
+		),
+		want: sets.NewString("myroute", "hello-myroute", "bye-myroute"),
+	}, {
+		name: "traffic targets with NO default and tags",
+		traffic: WithSpecTraffic(v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
+				Tag: "hello",
+			},
+		}, v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
+				Tag: "hello",
+			},
+		}, v1alpha1.TrafficTarget{
+			TrafficTarget: v1.TrafficTarget{
+				Tag: "bye",
+			},
+		},
+		),
+		want: sets.NewString("myroute", "hello-myroute", "bye-myroute"),
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := testConfig()

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -28,14 +28,13 @@ import (
 	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 	v1alph1testing "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"knative.dev/serving/pkg/apis/autoscaling"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 )
 
 const (
@@ -152,7 +151,8 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		t.Fatalf("The httpproxy response = %q, want: %q.", string(response.Body), helloworldResponse)
 	}
 
-	// As a final check (since we know they are both up), check that if we can access the helloworld app externally.
+	// As a final check (since we know they are both up), check that if we can
+	// (or cannot) access the helloworld app externally.
 	response, err = sendRequest(t, clients, test.ServingFlags.ResolvableDomain, helloworldURL)
 	if err != nil {
 		if test.ServingFlags.ResolvableDomain {
@@ -224,7 +224,7 @@ func TestServiceToServiceCall(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cancel := logstream.Start(t)
 			defer cancel()
-			testProxyToHelloworld(t, clients, helloworldURL, true, false)
+			testProxyToHelloworld(t, clients, helloworldURL, true /*inject*/, false /*accessible externally*/)
 		})
 	}
 }
@@ -259,7 +259,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	}
 
 	// Send request to helloworld app via httpproxy service
-	testProxyToHelloworld(t, clients, resources.Route.Status.URL.URL(), injectA, false)
+	testProxyToHelloworld(t, clients, resources.Route.Status.URL.URL(), injectA, false /*accessible externally*/)
 }
 
 // Same test as TestServiceToServiceCall but before sending requests
@@ -328,7 +328,7 @@ func TestCallToPublicService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cancel := logstream.Start(t)
 			defer cancel()
-			testProxyToHelloworld(t, clients, tc.url, false, tc.accessibleExternally)
+			testProxyToHelloworld(t, clients, tc.url, false /*inject*/, tc.accessibleExternally)
 		})
 	}
 }


### PR DESCRIPTION
Currently the code was not adding the service/config target (default
placeholder service) if the whole
traffic routing stanza was revision tags only.
This created a problem that the `clusterLocal` names were only
 `tag` target names, if the service was marked `cluster-local`.
Thus, when we created the rules for ingress  `` (empty tag), it translated into
`serviceName` target, that was not part of the cluster local list, hence
exposing it on the cluster-ingress gateway.

/assign @tcnghia @mattmoor 