### PR TITLE
Change example of tagTemplate in config-network to the same value of default

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -122,7 +122,7 @@ data:
     # when constructing the DNS name for "tags" within the traffic blocks
     # of Routes and Configuration.  This is used in conjunction with the
     # domainTemplate above to determine the full URL for the tag.
-    tagTemplate: "{{.Name}}-{{.Tag}}"
+    tagTemplate: "{{.Tag}}-{{.Name}}"
 
     # Controls whether TLS certificates are automatically provisioned and
     # installed in the Knative ingress to terminate external TLS connection.


### PR DESCRIPTION
## Proposed Changes

As https://github.com/knative/serving/issues/6178 reported, the actual default value of `tagTemplate` is:

https://github.com/knative/serving/blob/b8a17ae4bac00a9749ba65b822db697cd582df50/pkg/network/network.go#L119

which is opposite from the example in `config-network`. As mentioned
in https://github.com/knative/serving/issues/3492, the example value should be defaults to avoid confusion.

This patch fixes the example.

/lint

Fixes https://github.com/knative/serving/issues/6178

**Release Note**

```release-note
NONE
```

cc @ahmetb 