### PR TITLE
Update Kourier to v0.3.4

### DIFF
--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # Download Kourier
-KOURIER_VERSION=0.3.3
+KOURIER_VERSION=0.3.4
 KOURIER_YAML=kourier-knative.yaml
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/v${KOURIER_VERSION}/deploy/${KOURIER_YAML}
 

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -56,7 +56,7 @@ spec:
         - args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.2
+          image: quay.io/3scale/kourier-gateway:v0.1.3
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -106,7 +106,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.3
+        - image: quay.io/3scale/kourier:v0.3.4
           imagePullPolicy: Always
           name: kourier-control
           resources: {}


### PR DESCRIPTION
/lint

## Proposed Changes

* Bump Kourier version to v0.3.4. This version updates the envoy version used in the Kourier gateway image to v1.12.2, which fixes some CVEs.

