### PR TITLE
Remove the second level map from metric collection.

### DIFF
--- a/pkg/autoscaler/aggregation/aggregation.go
+++ b/pkg/autoscaler/aggregation/aggregation.go
@@ -19,12 +19,12 @@ package aggregation
 import "time"
 
 // Accumulator is a function accumulating buckets and their time.
-type Accumulator func(time time.Time, bucket *float64Value)
+type Accumulator func(time time.Time, bucket float64)
 
 // YoungerThan only applies the accumulator to buckets that are younger than the given
 // time.
 func YoungerThan(oldest time.Time, acc Accumulator) Accumulator {
-	return func(time time.Time, bucket *float64Value) {
+	return func(time time.Time, bucket float64) {
 		if !time.Before(oldest) {
 			acc(time, bucket)
 		}
@@ -38,8 +38,8 @@ type Average struct {
 }
 
 // Accumulate accumulates the values needed to compute an average.
-func (a *Average) Accumulate(_ time.Time, bucket *float64Value) {
-	a.sum += bucket.avg()
+func (a *Average) Accumulate(_ time.Time, bucket float64) {
+	a.sum += bucket
 	a.count++
 }
 

--- a/pkg/autoscaler/aggregation/aggregation.go
+++ b/pkg/autoscaler/aggregation/aggregation.go
@@ -19,12 +19,12 @@ package aggregation
 import "time"
 
 // Accumulator is a function accumulating buckets and their time.
-type Accumulator func(time time.Time, bucket float64Bucket)
+type Accumulator func(time time.Time, bucket *float64Value)
 
 // YoungerThan only applies the accumulator to buckets that are younger than the given
 // time.
 func YoungerThan(oldest time.Time, acc Accumulator) Accumulator {
-	return func(time time.Time, bucket float64Bucket) {
+	return func(time time.Time, bucket *float64Value) {
 		if !time.Before(oldest) {
 			acc(time, bucket)
 		}
@@ -38,8 +38,8 @@ type Average struct {
 }
 
 // Accumulate accumulates the values needed to compute an average.
-func (a *Average) Accumulate(_ time.Time, bucket float64Bucket) {
-	a.sum += bucket.sum()
+func (a *Average) Accumulate(_ time.Time, bucket *float64Value) {
+	a.sum += bucket.avg()
 	a.count++
 }
 

--- a/pkg/autoscaler/aggregation/aggregation_test.go
+++ b/pkg/autoscaler/aggregation/aggregation_test.go
@@ -39,11 +39,11 @@ func TestAverage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			average := Average{}
+			bucket := &float64Value{}
 			for _, value := range tt.values {
-				bucket := float64Bucket{}
-				bucket.record("pod", value)
-				average.Accumulate(time.Now(), bucket)
+				bucket.record(value)
 			}
+			average.Accumulate(time.Now(), bucket)
 
 			if got := average.Value(); got != tt.want {
 				t.Errorf("Value() = %v, want %v", got, tt.want)
@@ -87,12 +87,12 @@ func TestYoungerThan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := make(map[time.Time]bool)
-			acc := YoungerThan(tt.oldest, func(time time.Time, bucket float64Bucket) {
+			acc := YoungerThan(tt.oldest, func(time time.Time, bucket *float64Value) {
 				got[time] = true
 			})
 			for _, t := range tt.times {
-				bucket := float64Bucket{}
-				bucket.record("pod", 1.0)
+				bucket := &float64Value{}
+				bucket.record(1.0)
 				acc(t, bucket)
 			}
 

--- a/pkg/autoscaler/aggregation/aggregation_test.go
+++ b/pkg/autoscaler/aggregation/aggregation_test.go
@@ -39,11 +39,9 @@ func TestAverage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			average := Average{}
-			bucket := &float64Value{}
 			for _, value := range tt.values {
-				bucket.record(value)
+				average.Accumulate(time.Now(), value)
 			}
-			average.Accumulate(time.Now(), bucket)
 
 			if got := average.Value(); got != tt.want {
 				t.Errorf("Value() = %v, want %v", got, tt.want)
@@ -87,12 +85,12 @@ func TestYoungerThan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := make(map[time.Time]bool)
-			acc := YoungerThan(tt.oldest, func(time time.Time, bucket *float64Value) {
+			acc := YoungerThan(tt.oldest, func(time time.Time, bucket float64) {
 				got[time] = true
 			})
 			for _, t := range tt.times {
-				bucket := &float64Value{}
-				bucket.record(1.0)
+				bucket := 0.0
+				bucket += 1
 				acc(t, bucket)
 			}
 

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -24,7 +24,14 @@ import (
 // TimedFloat64Buckets keeps buckets that have been collected at a certain time.
 type TimedFloat64Buckets struct {
 	bucketsMutex sync.RWMutex
-	buckets      map[time.Time]float64
+	// Metrics received in a certain timeframe are all summed up.
+	// This assumes that we don't take multiple readings of
+	// the same metric in the same bucket (per second currently).
+	// The only case where this might happen currently is when activator scales
+	// a revision from 0. The metrics for that bucket might be off
+	// by exactly "1" as that poke always reports a concurrency of 1.
+	// Since we're windowing metrics anyway, that slight skew is acceptable.
+	buckets map[time.Time]float64
 
 	granularity time.Duration
 }

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -48,7 +48,7 @@ func TestTimedFloat64Buckets(t *testing.T) {
 			{trunc1.Add(3 * time.Second), pod, 1.0},        // nextnextnext bucket
 		},
 		want: map[time.Time]float64{
-			trunc1:                      1.0,
+			trunc1:                      2.0,
 			trunc1.Add(1 * time.Second): 1.0,
 			trunc1.Add(3 * time.Second): 1.0,
 		},
@@ -61,7 +61,7 @@ func TestTimedFloat64Buckets(t *testing.T) {
 			{trunc5.Add(6 * time.Second), pod, 1.0}, // next bucket
 		},
 		want: map[time.Time]float64{
-			trunc5:                      1.0,
+			trunc5:                      2.0,
 			trunc5.Add(5 * time.Second): 1.0,
 		},
 	}, {
@@ -79,7 +79,7 @@ func TestTimedFloat64Buckets(t *testing.T) {
 
 			got := make(map[time.Time]float64)
 			for time, bucket := range buckets.buckets {
-				got[time] = bucket.avg()
+				got[time] = bucket
 			}
 
 			if !cmp.Equal(tt.want, got) {
@@ -98,7 +98,7 @@ func TestTimedFloat64BucketsForEachBucket(t *testing.T) {
 	trunc1 := time.Now().Truncate(granularity)
 	buckets := NewTimedFloat64Buckets(granularity)
 
-	if buckets.ForEachBucket(func(time time.Time, bucket *float64Value) {}) {
+	if buckets.ForEachBucket(func(time time.Time, bucket float64) {}) {
 		t.Fatalf("ForEachBucket unexpectedly returned non-empty result")
 	}
 	buckets.Record(trunc1, pod, 10.0)
@@ -109,10 +109,10 @@ func TestTimedFloat64BucketsForEachBucket(t *testing.T) {
 	acc1 := 0
 	acc2 := 0
 	if !buckets.ForEachBucket(
-		func(time time.Time, bucket *float64Value) {
+		func(time.Time, float64) {
 			acc1++
 		},
-		func(time time.Time, bucket *float64Value) {
+		func(time.Time, float64) {
 			acc2++
 		},
 	) {

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -42,13 +42,13 @@ func TestTimedFloat64Buckets(t *testing.T) {
 		name:        "granularity = 1s",
 		granularity: 1 * time.Second,
 		stats: []args{
-			{trunc1, pod, 1.0},
-			{trunc1.Add(100 * time.Millisecond), pod, 1.0}, // same bucket
-			{trunc1.Add(1 * time.Second), pod, 1.0},        // next bucket
-			{trunc1.Add(3 * time.Second), pod, 1.0},        // nextnextnext bucket
+			{trunc1, pod, 1.0}, // activator scale from 0.
+			{trunc1.Add(100 * time.Millisecond), pod, 10.0}, // from scraping pod/sent by activator.
+			{trunc1.Add(1 * time.Second), pod, 1.0},         // next bucket
+			{trunc1.Add(3 * time.Second), pod, 1.0},         // nextnextnext bucket
 		},
 		want: map[time.Time]float64{
-			trunc1:                      2.0,
+			trunc1:                      11.0,
 			trunc1.Add(1 * time.Second): 1.0,
 			trunc1.Add(3 * time.Second): 1.0,
 		},

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -35,6 +35,8 @@ const (
 	scrapeTickInterval = time.Second
 
 	// BucketSize is the size of the buckets of stats we create.
+	// NB: if this is more than 1s, we need to average values in the
+	// metrics buckets.
 	BucketSize = scrapeTickInterval
 )
 


### PR DESCRIPTION
Now that we're using 1s buckets to collect metrics and now that we're sampling pods for metric collection
we can get rid of the second level map, since we no longer need second degree averaging.

This simplifies the code quite a bit.
Note that while we're using maps, we need to pass pointers along (we were using maps
which are pointers in effect), but this will be removed when we switch to the
array based aggregator.

/assign @yanweiguo @markusthoemmes
/lint
