### PR TITLE
Log 'no longer exists' on info level.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -62,7 +62,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	original, err := c.PALister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
-		logger.Debug("PA no longer exists")
+		logger.Info("PA in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -69,7 +69,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	original, err := c.PALister.PodAutoscalers(namespace).Get(name)
 	if errors.IsNotFound(err) {
-		logger.Debug("PA no longer exists")
+		logger.Info("PA in work queue no longer exists")
 		if err := c.deciders.Delete(ctx, namespace, name); err != nil {
 			return err
 		}

--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -78,7 +78,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	original, err := c.knCertificateLister.Certificates(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
-		logger.Errorf("Knative Certificate %s in work queue no longer exists", key)
+		logger.Info("Knative Certificate in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -70,7 +70,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := c.configurationLister.Configurations(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		// The resource no longer exists, in which case we stop processing.
-		logger.Error("Configuration in work queue no longer exists")
+		logger.Info("Configuration in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.ingressLister.Ingresses(ns).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("ingress %q in work queue no longer exists", key)
+		logger.Info("Ingress in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -77,7 +77,7 @@ func (c *reconciler) Reconcile(ctx context.Context, key string) error {
 
 	namespace, err := c.nsLister.Get(ns)
 	if apierrs.IsNotFound(err) {
-		logger.Errorf("Namespace %s in work queue no longer exists %s", key, err)
+		logger.Info("Namespace in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -88,7 +88,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := c.revisionLister.Revisions(namespace).Get(name)
 	// The resource may no longer exist, in which case we stop processing.
 	if apierrs.IsNotFound(err) {
-		logger.Errorf("revision %q in work queue no longer exists", key)
+		logger.Info("Revision in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -104,7 +104,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := c.routeLister.Routes(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Error("Route in work queue no longer exists")
+		logger.Info("Route in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -81,7 +81,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.sksLister.ServerlessServices(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("SKS resource in work queue no longer exists")
+		logger.Info("SKS resource in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -79,7 +79,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := c.serviceLister.Services(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Error("Service in work queue no longer exists")
+		logger.Info("Service in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- This is not really an error as it happens frequently if we "just" delete entities. Info level should suffice to inform about this happening.
- Also removed string interpolation of the key in places where we had that as the key should already be part of the structured log anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
