### PR TITLE
Updating pkg to master post 0.11 release.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1971,6 +1971,7 @@
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",


### PR DESCRIPTION
## Proposed Changes

- Move pkg back to master post 0.11 release.
- Update knative.dev/pkg to latest from branch master.

**Release Note**

```release-note
NONE
```

/cc @mattmoor