### PR TITLE
Move webhooks to separate paths.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -86,9 +86,7 @@ func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		"webhook.serving.knative.dev",
 
 		// The path on which to serve the webhook.
-		// TODO(mattmoor): This can be changed after 0.11 once
-		// we have release reconciliation-based webhooks.
-		"/",
+		"/defaulting",
 
 		// The resources to validate and default.
 		types,
@@ -110,9 +108,7 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 		"validation.webhook.serving.knative.dev",
 
 		// The path on which to serve the webhook.
-		// TODO(mattmoor): This can be changed after 0.11 once
-		// we have release reconciliation-based webhooks.
-		"/",
+		"/resource-validation",
 
 		// The resources to validate and default.
 		types,


### PR DESCRIPTION
The upgrade test will hopefully be fine now.

Related: https://github.com/knative/serving/issues/6037

(note: there is stuff to cleanup in eventing and pkg as well)