### PR TITLE
Move some shared ingress utilities to pkg/network/ingress

### DIFF
--- a/pkg/network/ingress/doc.go
+++ b/pkg/network/ingress/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ingress holds utilities related to the implementation of ingress
+// controllers.
+package ingress

--- a/pkg/network/ingress/ingress.go
+++ b/pkg/network/ingress/ingress.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/network"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	net "knative.dev/serving/pkg/network"
+)
+
+// ComputeHash computes a hash of the Ingress Spec, Namespace and Name
+func ComputeHash(ia *v1alpha1.Ingress) ([16]byte, error) {
+	bytes, err := json.Marshal(ia.Spec)
+	if err != nil {
+		return [16]byte{}, fmt.Errorf("failed to serialize Ingress: %w", err)
+	}
+	bytes = append(bytes, []byte(ia.GetNamespace())...)
+	bytes = append(bytes, []byte(ia.GetName())...)
+	return md5.Sum(bytes), nil
+}
+
+// InsertProbe adds a AppendHeader rule so that any request going through a Gateway is tagged with
+// the version of the Ingress currently deployed on the Gateway.
+func InsertProbe(ia *v1alpha1.Ingress) (string, error) {
+	bytes, err := ComputeHash(ia)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute the hash of the Ingress: %w", err)
+	}
+	hash := fmt.Sprintf("%x", bytes)
+
+	for _, rule := range ia.Spec.Rules {
+		if rule.HTTP == nil {
+			return "", fmt.Errorf("rule is missing HTTP block: %+v", rule)
+		}
+		for i := range rule.HTTP.Paths {
+			if rule.HTTP.Paths[i].AppendHeaders == nil {
+				rule.HTTP.Paths[i].AppendHeaders = make(map[string]string, 1)
+			}
+			rule.HTTP.Paths[i].AppendHeaders[net.HashHeaderName] = hash
+		}
+	}
+
+	return hash, nil
+}
+
+// HostsPerVisibility takes an Ingress and a map from visibility levels to a set of string keys,
+// it then returns a map from that key space to the hosts under that visibility.
+func HostsPerVisibility(ia *v1alpha1.Ingress, visibilityToKey map[v1alpha1.IngressVisibility]sets.String) map[string]sets.String {
+	output := make(map[string]sets.String)
+	for _, rule := range ia.Spec.Rules {
+		for host := range ExpandedHosts(sets.NewString(rule.Hosts...)) {
+			for key := range visibilityToKey[rule.Visibility] {
+				if _, ok := output[key]; !ok {
+					output[key] = sets.NewString()
+				}
+				output[key].Insert(host)
+			}
+		}
+	}
+	return output
+}
+
+// ExpandedHosts sets up hosts for the short-names for cluster DNS names.
+func ExpandedHosts(hosts sets.String) sets.String {
+	expanded := sets.NewString()
+	allowedSuffixes := []string{
+		"",
+		"." + network.GetClusterDomainName(),
+		".svc." + network.GetClusterDomainName(),
+	}
+	for _, h := range hosts.List() {
+		for _, suffix := range allowedSuffixes {
+			if strings.HasSuffix(h, suffix) {
+				expanded.Insert(strings.TrimSuffix(h, suffix))
+			}
+		}
+	}
+	return expanded
+}

--- a/pkg/network/ingress/ingress_test.go
+++ b/pkg/network/ingress/ingress_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+func TestGetExpandedHosts(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		hosts sets.String
+		want  sets.String
+	}{{
+		name: "cluster local service in non-default namespace",
+		hosts: sets.NewString(
+			"service.namespace.svc.cluster.local",
+		),
+		want: sets.NewString(
+			"service.namespace",
+			"service.namespace.svc",
+			"service.namespace.svc.cluster.local",
+		),
+	}, {
+		name: "example.com service",
+		hosts: sets.NewString(
+			"foo.bar.example.com",
+		),
+		want: sets.NewString(
+			"foo.bar.example.com",
+		),
+	}, {
+		name: "default.example.com service",
+		hosts: sets.NewString(
+			"foo.default.example.com",
+		),
+		want: sets.NewString(
+			"foo.default.example.com",
+		),
+	}, {
+		name: "mix",
+		hosts: sets.NewString(
+			"foo.default.example.com",
+			"foo.default.svc.cluster.local",
+		),
+		want: sets.NewString(
+			"foo.default",
+			"foo.default.example.com",
+			"foo.default.svc",
+			"foo.default.svc.cluster.local",
+		),
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			got := ExpandedHosts(test.hosts)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("Unexpected (-want +got): %v", diff)
+			}
+		})
+	}
+}
+
+func TestInsertProbe(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress *v1alpha1.Ingress
+		want    string
+	}{{
+		name: "with rules, no append header",
+		ingress: &v1alpha1.Ingress{
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"example.com",
+					},
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "blah",
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: "b90f793b72c245476c6b4060967121ef",
+	}, {
+		name: "with rules, with append header",
+		ingress: &v1alpha1.Ingress{
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"example.com",
+					},
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "blah",
+								},
+								AppendHeaders: map[string]string{
+									"Foo": "bar",
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: "061575cdf950105126a81d6da83cda8b",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			before := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].AppendHeaders)
+			got, err := InsertProbe(test.ingress)
+			if err != nil {
+				t.Errorf("InsertProbe() = %v", err)
+			}
+			if got != test.want {
+				t.Errorf("InsertProbe() = %s, wanted %s", got, test.want)
+			}
+			after := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].AppendHeaders)
+			if before+1 != after {
+				t.Errorf("InsertProbe() left %d headers, wanted %d", after, before+1)
+			}
+		})
+	}
+}
+
+func TestHostsPerVisibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress *v1alpha1.Ingress
+		in      map[v1alpha1.IngressVisibility]sets.String
+		want    map[string]sets.String
+	}{{
+		name: "external rule",
+		ingress: &v1alpha1.Ingress{
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"example.com",
+						"foo.bar.svc.cluster.local",
+					},
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "blah",
+								},
+								AppendHeaders: map[string]string{
+									"Foo": "bar",
+								},
+							}},
+						}},
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}},
+			},
+		},
+		in: map[v1alpha1.IngressVisibility]sets.String{
+			v1alpha1.IngressVisibilityExternalIP:   sets.NewString("foo"),
+			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("bar", "baz"),
+		},
+		want: map[string]sets.String{
+			"foo": sets.NewString(
+				"example.com",
+				"foo.bar.svc.cluster.local",
+				"foo.bar.svc",
+				"foo.bar",
+			),
+		},
+	}, {
+		name: "internal rule",
+		ingress: &v1alpha1.Ingress{
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"foo.bar.svc.cluster.local",
+					},
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "blah",
+								},
+								AppendHeaders: map[string]string{
+									"Foo": "bar",
+								},
+							}},
+						}},
+					},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+				}},
+			},
+		},
+		in: map[v1alpha1.IngressVisibility]sets.String{
+			v1alpha1.IngressVisibilityExternalIP:   sets.NewString("foo"),
+			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("bar", "baz"),
+		},
+		want: map[string]sets.String{
+			"bar": sets.NewString(
+				"foo.bar.svc.cluster.local",
+				"foo.bar.svc",
+				"foo.bar",
+			),
+			"baz": sets.NewString(
+				"foo.bar.svc.cluster.local",
+				"foo.bar.svc",
+				"foo.bar",
+			),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := HostsPerVisibility(test.ingress, test.in)
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("HostsPerVisibility (-want, +got) = %s", cmp.Diff(test.want, got))
+			}
+		})
+	}
+}

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -33,6 +33,7 @@ import (
 	_ "knative.dev/pkg/client/istio/injection/informers/networking/v1alpha3/virtualservice/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
+	"knative.dev/serving/pkg/network/ingress"
 
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -176,18 +177,18 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "skip ingress not matching class key",
 		Objects: []runtime.Object{
-			addAnnotations(ingress("no-virtualservice-yet", 1234),
+			addAnnotations(ing("no-virtualservice-yet", 1234),
 				map[string]string{networking.IngressClassAnnotationKey: "fake-controller"}),
 		},
 	}, {
 		Name: "create VirtualService matching Ingress",
 
 		Objects: []runtime.Object{
-			ingress("no-virtualservice-yet", 1234),
+			ing("no-virtualservice-yet", 1234),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(insertProbe(ingress("no-virtualservice-yet", 1234))),
-			resources.MakeIngressVirtualService(insertProbe(ingress("no-virtualservice-yet", 1234)),
+			resources.MakeMeshVirtualService(insertProbe(ing("no-virtualservice-yet", 1234))),
+			resources.MakeIngressVirtualService(insertProbe(ing("no-virtualservice-yet", 1234)),
 				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + networking.KnativeIngressGateway}, nil)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -263,16 +264,16 @@ func TestReconcile(t *testing.T) {
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
-					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-failed", 1234))},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-failed", 1234))},
 				},
 				Spec: istiov1alpha3.VirtualService{},
 			},
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(insertProbe(ingress("reconcile-failed", 1234))),
+			resources.MakeMeshVirtualService(insertProbe(ing("reconcile-failed", 1234))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: resources.MakeIngressVirtualService(insertProbe(ingress("reconcile-failed", 1234)),
+			Object: resources.MakeIngressVirtualService(insertProbe(ing("reconcile-failed", 1234)),
 				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + networking.KnativeIngressGateway}, nil)),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -308,7 +309,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "reconcile VirtualService to match desired one",
 		Objects: []runtime.Object{
-			ingress("reconcile-virtualservice", 1234),
+			ing("reconcile-virtualservice", 1234),
 			&v1alpha3.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "reconcile-virtualservice",
@@ -317,7 +318,7 @@ func TestReconcile(t *testing.T) {
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
-					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
 				},
 				Spec: istiov1alpha3.VirtualService{},
 			},
@@ -329,17 +330,17 @@ func TestReconcile(t *testing.T) {
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
-					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconcile-virtualservice", 1234))},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
 				},
 				Spec: istiov1alpha3.VirtualService{},
 			},
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: resources.MakeIngressVirtualService(insertProbe(ingress("reconcile-virtualservice", 1234)),
+			Object: resources.MakeIngressVirtualService(insertProbe(ing("reconcile-virtualservice", 1234)),
 				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + networking.KnativeIngressGateway}, nil)),
 		}},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(insertProbe(ingress("reconcile-virtualservice", 1234))),
+			resources.MakeMeshVirtualService(insertProbe(ing("reconcile-virtualservice", 1234))),
 		},
 		WantDeletes: []clientgotesting.DeleteActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
@@ -860,7 +861,7 @@ func secret(namespace, name string, labels map[string]string) *corev1.Secret {
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ingress("reconciling-ingress", 1234))},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconciling-ingress", 1234))},
 		},
 		Data: map[string][]byte{
 			"test-secret": []byte("abcd"),
@@ -951,7 +952,7 @@ func ingressWithStatus(name string, generation int64, status v1alpha1.IngressSta
 	}
 }
 
-func ingress(name string, generation int64) *v1alpha1.Ingress {
+func ing(name string, generation int64) *v1alpha1.Ingress {
 	return ingressWithStatus(name, generation, v1alpha1.IngressStatus{})
 }
 
@@ -1123,7 +1124,7 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 
 func insertProbe(ia *v1alpha1.Ingress) *v1alpha1.Ingress {
 	ia = ia.DeepCopy()
-	resources.InsertProbe(ia)
+	ingress.InsertProbe(ia)
 	return ia
 }
 

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -157,7 +157,7 @@ var ingressSpec = v1alpha1.IngressSpec{
 	}},
 }
 
-var ingress = v1alpha1.Ingress{
+var ingressResource = v1alpha1.Ingress{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "ingress",
 		Namespace: "test-ns",
@@ -166,7 +166,7 @@ var ingress = v1alpha1.Ingress{
 }
 
 func TestGetServers(t *testing.T) {
-	servers := GetServers(&gateway, &ingress)
+	servers := GetServers(&gateway, &ingressResource)
 	expected := []*istiov1alpha3.Server{{
 		Hosts: []string{"host1.example.com"},
 		Port: &istiov1alpha3.Port{
@@ -213,7 +213,7 @@ func TestMakeTLSServers(t *testing.T) {
 		wantErr                 bool
 	}{{
 		name: "secret namespace is the different from the gateway service namespace",
-		ci:   &ingress,
+		ci:   &ingressResource,
 		// gateway service namespace is "istio-system", while the secret namespace is system.Namespace()("knative-testing").
 		gatewayServiceNamespace: "istio-system",
 		originSecrets:           originSecrets,
@@ -228,12 +228,12 @@ func TestMakeTLSServers(t *testing.T) {
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
 				ServerCertificate: "tls.crt",
 				PrivateKey:        "tls.key",
-				CredentialName:    targetSecret(&secret, &ingress),
+				CredentialName:    targetSecret(&secret, &ingressResource),
 			},
 		}},
 	}, {
 		name: "secret namespace is the same as the gateway service namespace",
-		ci:   &ingress,
+		ci:   &ingressResource,
 		// gateway service namespace and the secret namespace are both in system.Namespace().
 		gatewayServiceNamespace: system.Namespace(),
 		originSecrets:           originSecrets,
@@ -253,7 +253,7 @@ func TestMakeTLSServers(t *testing.T) {
 		}},
 	}, {
 		name:                    "port name is created with ingress namespace-name",
-		ci:                      &ingress,
+		ci:                      &ingressResource,
 		gatewayServiceNamespace: system.Namespace(),
 		originSecrets:           originSecrets,
 		expected: []*istiov1alpha3.Server{{
@@ -273,7 +273,7 @@ func TestMakeTLSServers(t *testing.T) {
 		}},
 	}, {
 		name:                    "error to make servers because of incorrect originSecrets",
-		ci:                      &ingress,
+		ci:                      &ingressResource,
 		gatewayServiceNamespace: "istio-system",
 		originSecrets:           map[string]*corev1.Secret{},
 		wantErr:                 true,
@@ -570,7 +570,7 @@ func TestMakeIngressGateways(t *testing.T) {
 		wantErr        bool
 	}{{
 		name:          "happy path: secret namespace is the different from the gateway service namespace",
-		ia:            &ingress,
+		ia:            &ingressResource,
 		originSecrets: originSecrets,
 		gatewayService: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -585,7 +585,7 @@ func TestMakeIngressGateways(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            fmt.Sprintf("ingress-%d", adler32.Checksum([]byte("istio-system/istio-ingressgateway"))),
 				Namespace:       "test-ns",
-				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(&ingress)},
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(&ingressResource)},
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
@@ -603,7 +603,7 @@ func TestMakeIngressGateways(t *testing.T) {
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
 						ServerCertificate: "tls.crt",
 						PrivateKey:        "tls.key",
-						CredentialName:    targetSecret(&secret, &ingress),
+						CredentialName:    targetSecret(&secret, &ingressResource),
 					},
 				}, {
 					Hosts: []string{"host1.example.com"},
@@ -617,7 +617,7 @@ func TestMakeIngressGateways(t *testing.T) {
 		}},
 	}, {
 		name:          "happy path: secret namespace is the same as the gateway service namespace",
-		ia:            &ingress,
+		ia:            &ingressResource,
 		originSecrets: originSecrets,
 		// The namespace of gateway service is the same as the secrets.
 		gatewayService: &corev1.Service{
@@ -633,7 +633,7 @@ func TestMakeIngressGateways(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            fmt.Sprintf("ingress-%d", adler32.Checksum([]byte(system.Namespace()+"/istio-ingressgateway"))),
 				Namespace:       "test-ns",
-				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(&ingress)},
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(&ingressResource)},
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
@@ -665,7 +665,7 @@ func TestMakeIngressGateways(t *testing.T) {
 		}},
 	}, {
 		name:          "error to make gateway because of incorrect originSecrets",
-		ia:            &ingress,
+		ia:            &ingressResource,
 		originSecrets: map[string]*corev1.Secret{},
 		gatewayService: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -33,7 +31,7 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	net "knative.dev/serving/pkg/network"
+	"knative.dev/serving/pkg/network/ingress"
 	"knative.dev/serving/pkg/reconciler/ingress/resources/names"
 	"knative.dev/serving/pkg/resources"
 )
@@ -57,7 +55,7 @@ func MakeIngressVirtualService(ia *v1alpha1.Ingress, gateways map[v1alpha1.Ingre
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ia)},
 			Annotations:     ia.GetAnnotations(),
 		},
-		Spec: *makeVirtualServiceSpec(ia, gateways, expandedHosts(getHosts(ia))),
+		Spec: *makeVirtualServiceSpec(ia, gateways, ingress.ExpandedHosts(getHosts(ia))),
 	}
 
 	// Populate the Ingress labels.
@@ -83,7 +81,7 @@ func MakeMeshVirtualService(ia *v1alpha1.Ingress) *v1alpha3.VirtualService {
 		Spec: *makeVirtualServiceSpec(ia, map[v1alpha1.IngressVisibility]sets.String{
 			v1alpha1.IngressVisibilityExternalIP:   sets.NewString("mesh"),
 			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("mesh"),
-		}, expandedHosts(keepLocalHostnames(getHosts(ia)))),
+		}, ingress.ExpandedHosts(keepLocalHostnames(getHosts(ia)))),
 	}
 	vs.Labels = resources.FilterMap(ia.GetLabels(), func(k string) bool {
 		return k != serving.RouteLabelKey && k != serving.RouteNamespaceLabelKey
@@ -96,7 +94,7 @@ func MakeMeshVirtualService(ia *v1alpha1.Ingress) *v1alpha3.VirtualService {
 func MakeVirtualServices(ia *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String) ([]*v1alpha3.VirtualService, error) {
 	// Insert probe header
 	ia = ia.DeepCopy()
-	if _, err := InsertProbe(ia); err != nil {
+	if _, err := ingress.InsertProbe(ia); err != nil {
 		return nil, fmt.Errorf("failed to insert a probe into the Ingress: %w", err)
 	}
 
@@ -116,51 +114,6 @@ func MakeVirtualServices(ia *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisi
 	}
 
 	return vss, nil
-}
-
-// InsertProbe adds a AppendHeader rule so that any request going through a Gateway is tagged with
-// the version of the Ingress currently deployed on the Gateway.
-func InsertProbe(ia *v1alpha1.Ingress) (string, error) {
-	bytes, err := ComputeIngressHash(ia)
-	if err != nil {
-		return "", fmt.Errorf("failed to compute the hash of the Ingress: %w", err)
-	}
-	hash := fmt.Sprintf("%x", bytes)
-
-	for _, rule := range ia.Spec.Rules {
-		for i := range rule.HTTP.Paths {
-			if rule.HTTP.Paths[i].AppendHeaders == nil {
-				rule.HTTP.Paths[i].AppendHeaders = make(map[string]string, 1)
-			}
-			rule.HTTP.Paths[i].AppendHeaders[net.HashHeaderName] = hash
-		}
-	}
-
-	return hash, nil
-}
-
-// ComputeIngressHash computes a hash of the Ingress Spec, Namespace and Name
-func ComputeIngressHash(ia *v1alpha1.Ingress) ([16]byte, error) {
-	bytes, err := json.Marshal(ia.Spec)
-	if err != nil {
-		return [16]byte{}, fmt.Errorf("failed to serialize Ingress: %w", err)
-	}
-	bytes = append(bytes, []byte(ia.GetNamespace())...)
-	bytes = append(bytes, []byte(ia.GetName())...)
-	return md5.Sum(bytes), nil
-}
-
-// HostsPerGateway returns the set of hosts that each Gateway handles
-func HostsPerGateway(ia *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String) map[string][]string {
-	output := make(map[string][]string)
-	for _, rule := range ia.Spec.Rules {
-		for host := range expandedHosts(sets.NewString(rule.Hosts...)) {
-			for gateway := range gateways[rule.Visibility] {
-				output[gateway] = append(output[gateway], host)
-			}
-		}
-	}
-	return output
 }
 
 func makeVirtualServiceSpec(ia *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, hosts sets.String) *istiov1alpha3.VirtualService {
@@ -249,23 +202,6 @@ func keepLocalHostnames(hosts sets.String) sets.String {
 		}
 	}
 	return retained
-}
-
-func expandedHosts(hosts sets.String) sets.String {
-	expanded := sets.NewString()
-	allowedSuffixes := []string{
-		"",
-		"." + network.GetClusterDomainName(),
-		".svc." + network.GetClusterDomainName(),
-	}
-	for _, h := range hosts.List() {
-		for _, suffix := range allowedSuffixes {
-			if strings.HasSuffix(h, suffix) {
-				expanded.Insert(strings.TrimSuffix(h, suffix))
-			}
-		}
-	}
-	return expanded
 }
 
 func makeMatch(host string, pathRegExp string, gateways sets.String) *istiov1alpha3.HTTPMatchRequest {

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -559,59 +559,6 @@ func TestGetHosts_Duplicate(t *testing.T) {
 	}
 }
 
-func TestGetExpandedHosts(t *testing.T) {
-	for _, test := range []struct {
-		name  string
-		hosts sets.String
-		want  sets.String
-	}{{
-		name: "cluster local service in non-default namespace",
-		hosts: sets.NewString(
-			"service.namespace.svc.cluster.local",
-		),
-		want: sets.NewString(
-			"service.namespace",
-			"service.namespace.svc",
-			"service.namespace.svc.cluster.local",
-		),
-	}, {
-		name: "example.com service",
-		hosts: sets.NewString(
-			"foo.bar.example.com",
-		),
-		want: sets.NewString(
-			"foo.bar.example.com",
-		),
-	}, {
-		name: "default.example.com service",
-		hosts: sets.NewString(
-			"foo.default.example.com",
-		),
-		want: sets.NewString(
-			"foo.default.example.com",
-		),
-	}, {
-		name: "mix",
-		hosts: sets.NewString(
-			"foo.default.example.com",
-			"foo.default.svc.cluster.local",
-		),
-		want: sets.NewString(
-			"foo.default",
-			"foo.default.example.com",
-			"foo.default.svc",
-			"foo.default.svc.cluster.local",
-		),
-	}} {
-		t.Run(test.name, func(t *testing.T) {
-			got := expandedHosts(test.hosts)
-			if diff := cmp.Diff(got, test.want); diff != "" {
-				t.Errorf("Unexpected (-want +got): %v", diff)
-			}
-		})
-	}
-}
-
 func makeGatewayMap(publicGateways []string, privateGateways []string) map[v1alpha1.IngressVisibility]sets.String {
 	return map[v1alpha1.IngressVisibility]sets.String{
 		v1alpha1.IngressVisibilityExternalIP:   sets.NewString(publicGateways...),

--- a/pkg/reconciler/ingress/status_test.go
+++ b/pkg/reconciler/ingress/status_test.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/network/ingress"
 
 	"go.uber.org/zap/zaptest"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
@@ -39,7 +40,6 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	istiolisters "knative.dev/pkg/client/istio/listers/networking/v1alpha3"
 	"knative.dev/serving/pkg/network"
-	"knative.dev/serving/pkg/reconciler/ingress/resources"
 )
 
 var (
@@ -319,7 +319,7 @@ func TestProbeLifecycle(t *testing.T) {
 	}
 
 	ia := iaTemplate.DeepCopy()
-	hash, err := resources.InsertProbe(ia)
+	hash, err := ingress.InsertProbe(ia)
 	if err != nil {
 		t.Fatalf("failed to insert probe: %v", err)
 	}


### PR DESCRIPTION
This also adds direct unit test coverage of what wasn't previously covered.

This is a precursor to trying to factor apart the probing logic from the Istio ingress implementation (these are the things from within `pkg/reconciler/ingress` that `status.go` depends on).