### PR TITLE
Return proper EBC on uniscaler creation.

### DIFF
--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -296,7 +296,7 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 		// If TBC > Target * InitialScale (currently 1), then we know initial
 		// scale won't be enough to cover TBC and we'll be behind activator.
 		// TODO(autoscale-wg): fix this when we switch to non "1" initial scale.
-		d.Status.ExcessBurstCapacity = int32(1*d.Spec.TargetValue - tbc)
+		d.Status.ExcessBurstCapacity = int32(1*d.Spec.TotalValue - tbc)
 	}
 
 	m.runScalerTicker(ctx, runner)

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -289,14 +289,14 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 		pokeCh:  make(chan struct{}),
 	}
 	d.Status.DesiredScale = -1
-	switch x := d.Spec.TargetBurstCapacity; x {
+	switch tbc := d.Spec.TargetBurstCapacity; tbc {
 	case -1, 0:
-		d.Status.ExcessBurstCapacity = int32(x)
+		d.Status.ExcessBurstCapacity = int32(tbc)
 	default:
 		// If TBC > Target * InitialScale (currently 1), then we know initial
 		// scale won't be enough to cover TBC and we'll be behind activator.
 		// TODO(autoscale-wg): fix this when we switch to non "1" initial scale.
-		d.Status.ExcessBurstCapacity = int32(1*d.Spec.TargetValue - x)
+		d.Status.ExcessBurstCapacity = int32(1*d.Spec.TargetValue - tbc)
 	}
 
 	m.runScalerTicker(ctx, runner)

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -289,6 +289,13 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 		pokeCh:  make(chan struct{}),
 	}
 	runner.decider.Status.DesiredScale = -1
+	runner.decider.Status.ExcessBurstCapacity = func() int32 {
+		// If user asked for -1 TBC, make sure it is set that way even at creation.
+		if runner.decider.Spec.TargetBurstCapacity == -1 {
+			return -1
+		}
+		return 0
+	}()
 
 	m.runScalerTicker(ctx, runner)
 	return runner, nil

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -155,7 +155,7 @@ func NewMultiScaler(
 	}
 }
 
-// Get return the current Decider.
+// Get returns the copy of the current Decider.
 func (m *MultiScaler) Get(ctx context.Context, namespace, name string) (*Decider, error) {
 	key := types.NamespacedName{Namespace: namespace, Name: name}
 	m.scalersMutex.RLock()
@@ -167,7 +167,7 @@ func (m *MultiScaler) Get(ctx context.Context, namespace, name string) (*Decider
 	}
 	scaler.mux.RLock()
 	defer scaler.mux.RUnlock()
-	return scaler.decider, nil
+	return scaler.decider.DeepCopy(), nil
 }
 
 // Create instantiates the desired Decider.

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -142,7 +142,7 @@ func TestMultiscalerCreateTBC42(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TargetBurstCapacity = 42
-	decider.Spec.TargetValue = 25
+	decider.Spec.TotalValue = 25
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -131,6 +131,26 @@ func TestMultiScalerScaling(t *testing.T) {
 	}
 }
 
+func TestMultiscalerCreateTBC42(t *testing.T) {
+	ctx := context.Background()
+	ms, stopCh, _ := createMultiScaler(t)
+	defer close(stopCh)
+
+	decider := newDecider()
+	decider.Spec.TargetBurstCapacity = 42
+	decider.Spec.TargetValue = 25
+
+	d, err := ms.Create(ctx, decider)
+	if err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+	if got, want := d.Status.DesiredScale, int32(-1); got != want {
+		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
+	}
+	if got, want := d.Status.ExcessBurstCapacity, int32(25-42); got != want {
+		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
+	}
+}
 func TestMultiscalerCreateTBCMinus1(t *testing.T) {
 	ctx := context.Background()
 	ms, stopCh, _ := createMultiScaler(t)

--- a/pkg/autoscaler/multiscaler_test.go
+++ b/pkg/autoscaler/multiscaler_test.go
@@ -99,9 +99,13 @@ func TestMultiScalerScaling(t *testing.T) {
 	errCh := make(chan error)
 	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
 
-	d, err := ms.Create(ctx, decider)
+	_, err = ms.Create(ctx, decider)
 	if err != nil {
 		t.Fatalf("Create() = %v", err)
+	}
+	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -140,9 +144,13 @@ func TestMultiscalerCreateTBC42(t *testing.T) {
 	decider.Spec.TargetBurstCapacity = 42
 	decider.Spec.TargetValue = 25
 
-	d, err := ms.Create(ctx, decider)
+	_, err := ms.Create(ctx, decider)
 	if err != nil {
 		t.Fatalf("Create() = %v", err)
+	}
+	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -159,9 +167,13 @@ func TestMultiscalerCreateTBCMinus1(t *testing.T) {
 	decider := newDecider()
 	decider.Spec.TargetBurstCapacity = -1
 
-	d, err := ms.Create(ctx, decider)
+	_, err := ms.Create(ctx, decider)
 	if err != nil {
 		t.Fatalf("Create() = %v", err)
+	}
+	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)


### PR DESCRIPTION
When we create a new revision with tbc=-1, we want to actually
start with EBC=-1, since otherwise we start up with ebc=0
which does not put the activator in the request path.
Or to the _presumed_ value  with the initial scale.

/lint
