### PR TITLE
Remove 'HasCapacity' from breaker as it's no longer used.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -674,5 +674,4 @@ func (ib *infiniteBreaker) Maybe(ctx context.Context, thunk func()) error {
 	}
 }
 
-func (ib *infiniteBreaker) HasCapacity() bool                      { return ib.Capacity() > 0 }
 func (ib *infiniteBreaker) Reserve(context.Context) (func(), bool) { return noop, true }

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -639,9 +639,6 @@ func TestInfiniteBreaker(t *testing.T) {
 	if _, ok := b.Reserve(context.Background()); ok != true {
 		t.Error("Reserve failed, must always succeed")
 	}
-	if got, want := b.HasCapacity(), false; got != want {
-		t.Errorf("HasCapacity = %v, want: %v", got, want)
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -652,9 +649,6 @@ func TestInfiniteBreaker(t *testing.T) {
 	b.UpdateConcurrency(1)
 	if got, want := b.Capacity(), 1; got != want {
 		t.Errorf("Cap=%d, want: %d", got, want)
-	}
-	if got, want := b.HasCapacity(), true; got != want {
-		t.Errorf("HasCapacity = %v, want: %v", got, want)
 	}
 
 	// Verify we call the thunk when we have achieved capacity.

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -67,11 +67,6 @@ func NewBreaker(params BreakerParams) *Breaker {
 	}
 }
 
-// HasCapacity returns if the breaker can accept a request.
-func (b *Breaker) HasCapacity() bool {
-	return b.sem.hasCapacity()
-}
-
 // Reserve reserves an execution slot in the breaker, to permit
 // richer semantics in the caller.
 // The caller on success must execute the callback when done with work.
@@ -269,9 +264,4 @@ func (s *semaphore) Capacity() int {
 	defer s.mux.RUnlock()
 
 	return s.effectiveCapacity()
-}
-
-// A helper returning whether current capacity is positive.
-func (s *semaphore) hasCapacity() bool {
-	return len(s.queue) > 0
 }

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -281,17 +281,6 @@ func TestSemaphoreAcquireHasCapacity(t *testing.T) {
 	}
 }
 
-func TestSemaphoreHasCapacity(t *testing.T) {
-	sem := newSemaphore(1, 1)
-	if !sem.hasCapacity() {
-		t.Error("Has no capacity")
-	}
-	sem.acquire(context.Background())
-	if sem.hasCapacity() {
-		t.Error("Has capacity")
-	}
-}
-
 func TestSemaphoreRelease(t *testing.T) {
 	sem := newSemaphore(1, 1)
 	sem.acquire(context.Background())


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This is now effectively dead-code as it has been replaced by `Reserve` usages that guarantee consistency.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
