### PR TITLE
Parse sub 1% values as fractions.

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -71,8 +71,8 @@ func ValidateQueueSidecarAnnotation(annotations map[string]string) *apis.FieldEr
 	if err != nil {
 		return apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(QueueSideCarResourcePercentageAnnotation)
 	}
-	if value <= 0.1 || value > 100 {
-		return apis.ErrOutOfBoundsValue(value, 0.1, 100.0, QueueSideCarResourcePercentageAnnotation)
+	if value <= 0.001 || value > 100 {
+		return apis.ErrOutOfBoundsValue(value, 0.001, 100.0, QueueSideCarResourcePercentageAnnotation)
 	}
 	return nil
 }

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -185,7 +185,7 @@ func TestValidateQueueSidecarAnnotation(t *testing.T) {
 			QueueSideCarResourcePercentageAnnotation: "200",
 		},
 		expectErr: &apis.FieldError{
-			Message: "expected 0.1 <= 200 <= 100",
+			Message: "expected 0.001 <= 200 <= 100",
 			Paths:   []string{QueueSideCarResourcePercentageAnnotation},
 		},
 	}, {

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -67,6 +67,7 @@ const (
 	UpdaterAnnotation = GroupName + "/lastModifier"
 
 	// QueueSideCarResourcePercentageAnnotation is the percentage of user container resources to be used for queue-proxy
-	// It has to be in [0.1,100]
+	// For usability, if the value is less than `1` the value is treated as a fraction.
+	// The range of fractional values is [0.001, 1) the range of percentages is [1, 100].
 	QueueSideCarResourcePercentageAnnotation = "queue.sidecar." + GroupName + "/resourcePercentage"
 )

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -866,7 +866,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			},
 		},
 		want: (&apis.FieldError{
-			Message: "expected 0.1 <= 200 <= 100",
+			Message: "expected 0.001 <= 200 <= 100",
 			Paths:   []string{serving.QueueSideCarResourcePercentageAnnotation},
 		}).ViaField("metadata.annotations"),
 	}, {

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -440,7 +440,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		want: apis.ErrInvalidValue("not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
 			"metadata.generateName"),
 	}, {
-		name: "Queue sidecar resource percentage annotation more than 100",
+		name: "Queue sidecar resource percentage annotation greater than 100",
 		rts: &RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -454,7 +454,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			},
 		},
 		want: (&apis.FieldError{
-			Message: "expected 0.1 <= 200 <= 100",
+			Message: "expected 0.001 <= 200 <= 100",
 			Paths:   []string{serving.QueueSideCarResourcePercentageAnnotation},
 		}).ViaField("metadata.annotations"),
 	}, {

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -818,7 +818,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			},
 		},
 		want: (&apis.FieldError{
-			Message: "expected 0.1 <= 200 <= 100",
+			Message: "expected 0.001 <= 200 <= 100",
 			Paths:   []string{serving.QueueSideCarResourcePercentageAnnotation},
 		}).ViaField("metadata.annotations"),
 	}, {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -137,7 +137,11 @@ func computeResourceRequirements(resourceQuantity *resource.Quantity, fraction f
 
 func fractionFromPercentage(m map[string]string, k string) (float64, bool) {
 	value, err := strconv.ParseFloat(m[k], 64)
-	return float64(value / 100), err == nil
+	// value is 0 in case of error.
+	if value < 1 {
+		return value, err == nil
+	}
+	return value / 100, err == nil
 }
 
 func makeQueueProbe(in *corev1.Probe) *corev1.Probe {


### PR DESCRIPTION
I have seen users put `0.2` as the value for this annotation, since many users think in form of fractions.
So instead let's view the values less than 1 as fractions. We already do this for some of the Autoscaling annotations, where it has been so for historical reasons.
Update the tests, add coverage for the convertor.

/assign mattmoor @dgerd 
