### PR TITLE
Fix latency metrics dashboards

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
@@ -657,7 +657,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "s",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -790,7 +790,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "s",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
We currently report things in ms, but render as seconds.

After fix: https://photos.app.goo.gl/7LLL5Kvv2cNKihwz6

/assign @mdemirhan @yanweiguo 