### PR TITLE
Use pkgTest.T interface in libraries where testing.T is used

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -17,8 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"testing"
-
 	pkgTest "knative.dev/pkg/test"
 
 	// Mysteriously required to support GCP auth (required by k8s libs). Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
@@ -57,12 +55,11 @@ const (
 )
 
 // Setup creates client to run Knative Service requests
-func Setup(t *testing.T) *Clients {
+func Setup(t pkgTest.TLegacy) *Clients {
 	t.Helper()
-	pkgTest.SetupLoggingFlags()
 	clients, err := NewClients(pkgTest.Flags.Kubeconfig, pkgTest.Flags.Cluster, ServingNamespace)
 	if err != nil {
-		t.Fatalf("Couldn't initialize clients: %v", err)
+		t.Fatal("Couldn't initialize clients", "error", err.Error())
 	}
 	return clients
 }

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -18,10 +18,12 @@ package v1
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -35,7 +37,7 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, expectedResponse string) error {
+func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
@@ -48,8 +50,7 @@ func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, 
 	return err
 }
 
-func validateDomains(
-	t *testing.T, clients *test.Clients, baseDomain *url.URL,
+func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.URL,
 	baseExpected, trafficTargets, targetsExpected []string) error {
 	var subdomains []*url.URL
 	for _, target := range trafficTargets {
@@ -104,7 +105,7 @@ func validateDomains(
 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
+func checkDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
@@ -120,7 +121,7 @@ func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, m
 }
 
 // checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
-func checkResponses(t *testing.T, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
+func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
 	// counts maps the expected response body to the number of matching requests we saw.
 	counts := make(map[string]int)
 	// badCounts maps the unexpected response body to the number of matching requests we saw.
@@ -198,7 +199,7 @@ func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, erro
 // Validates service health and vended content match for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedText string) error {
+func validateDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, expectedText string) error {
 	t.Logf("Checking that the endpoint vends the expected text: %s", expectedText)
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
@@ -217,8 +218,8 @@ func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceN
 // Validates the state of Configuration, Revision, and Route objects for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateControlPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
-	t.Log("Checking to ensure Revision is in desired state with generation: ", expectedGeneration)
+func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
+	t.Log("Checking to ensure Revision is in desired state with", "generation", expectedGeneration)
 	err := v1test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1.Revision) (bool, error) {
 		if ready, err := v1test.IsRevisionReady(r); !ready {
 			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
@@ -253,7 +254,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 		return err
 	}
 
-	t.Log("Checking to ensure Route is in desired state with generation: ", expectedGeneration)
+	t.Log("Checking to ensure Route is in desired state with", "generation", expectedGeneration)
 	err = v1test.CheckRouteState(clients.ServingClient, names.Route, v1test.AllRouteTrafficAtRevision(names))
 	if err != nil {
 		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %w", names.Route, names.Revision, err)
@@ -264,7 +265,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 
 // Validates labels on Revision, Configuration, and Route objects when created by a Service
 // see spec here: https://github.com/knative/serving/blob/master/docs/spec/spec.md#revision
-func validateLabelsPropagation(t *testing.T, objects v1test.ResourceObjects, names test.ResourceNames) error {
+func validateLabelsPropagation(t pkgTest.T, objects v1test.ResourceObjects, names test.ResourceNames) error {
 	t.Log("Validate Labels on Revision Object")
 	revision := objects.Revision
 
@@ -338,4 +339,10 @@ func validateImageDigest(imageName string, imageDigest string) (bool, error) {
 	}
 
 	return ref.Context().String() == digest.Context().String(), nil
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
 }

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -18,10 +18,12 @@ package v1alpha1
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -35,7 +37,7 @@ import (
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
-func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, expectedResponse string) error {
+func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
@@ -48,8 +50,7 @@ func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, 
 	return err
 }
 
-func validateDomains(
-	t *testing.T, clients *test.Clients, baseDomain *url.URL,
+func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.URL,
 	baseExpected, trafficTargets, targetsExpected []string) error {
 	var subdomains []*url.URL
 	for _, target := range trafficTargets {
@@ -104,7 +105,7 @@ func validateDomains(
 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
+func checkDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
@@ -120,7 +121,7 @@ func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, m
 }
 
 // checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
-func checkResponses(t *testing.T, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
+func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
 	// counts maps the expected response body to the number of matching requests we saw.
 	counts := make(map[string]int)
 	// badCounts maps the unexpected response body to the number of matching requests we saw.
@@ -198,7 +199,7 @@ func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, erro
 // Validates service health and vended content match for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedText string) error {
+func validateRunLatestDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, expectedText string) error {
 	t.Logf("Checking that the endpoint vends the expected text: %s", expectedText)
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
@@ -217,8 +218,8 @@ func validateRunLatestDataPlane(t *testing.T, clients *test.Clients, names test.
 // Validates the state of Configuration, Revision, and Route objects for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateRunLatestControlPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
-	t.Log("Checking to ensure Revision is in desired state with generation: ", expectedGeneration)
+func validateRunLatestControlPlane(t pkgTest.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
+	t.Log("Checking to ensure Revision is in desired state with", "generation", expectedGeneration)
 	err := v1a1test.CheckRevisionState(clients.ServingAlphaClient, names.Revision, func(r *v1alpha1.Revision) (bool, error) {
 		if ready, err := v1a1test.IsRevisionReady(r); !ready {
 			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
@@ -253,7 +254,7 @@ func validateRunLatestControlPlane(t *testing.T, clients *test.Clients, names te
 		return err
 	}
 
-	t.Log("Checking to ensure Route is in desired state with generation: ", expectedGeneration)
+	t.Log("Checking to ensure Route is in desired state with", "generation", expectedGeneration)
 	err = v1a1test.CheckRouteState(clients.ServingAlphaClient, names.Route, v1a1test.AllRouteTrafficAtRevision(names))
 	if err != nil {
 		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %w", names.Route, names.Revision, err)
@@ -264,7 +265,7 @@ func validateRunLatestControlPlane(t *testing.T, clients *test.Clients, names te
 
 // Validates labels on Revision, Configuration, and Route objects when created by a Service
 // see spec here: https://github.com/knative/serving/blob/master/docs/spec/spec.md#revision
-func validateLabelsPropagation(t *testing.T, objects v1a1test.ResourceObjects, names test.ResourceNames) error {
+func validateLabelsPropagation(t pkgTest.T, objects v1a1test.ResourceObjects, names test.ResourceNames) error {
 	t.Log("Validate Labels on Revision Object")
 	revision := objects.Revision
 
@@ -338,4 +339,10 @@ func validateImageDigest(imageName string, imageDigest string) (bool, error) {
 	}
 
 	return ref.Context().String() == digest.Context().String(), nil
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
 }

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -18,10 +18,12 @@ package v1beta1
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -35,7 +37,7 @@ import (
 	v1b1test "knative.dev/serving/test/v1beta1"
 )
 
-func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, expectedResponse string) error {
+func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
@@ -48,8 +50,7 @@ func waitForExpectedResponse(t *testing.T, clients *test.Clients, url *url.URL, 
 	return err
 }
 
-func validateDomains(
-	t *testing.T, clients *test.Clients, baseDomain *url.URL,
+func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.URL,
 	baseExpected, trafficTargets, targetsExpected []string) error {
 	var subdomains []*url.URL
 	for _, target := range trafficTargets {
@@ -104,7 +105,7 @@ func validateDomains(
 
 // checkDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
+func checkDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		return err
@@ -120,7 +121,7 @@ func checkDistribution(t *testing.T, clients *test.Clients, url *url.URL, num, m
 }
 
 // checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
-func checkResponses(t *testing.T, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
+func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expectedResponses []string, actualResponses []string) error {
 	// counts maps the expected response body to the number of matching requests we saw.
 	counts := make(map[string]int)
 	// badCounts maps the unexpected response body to the number of matching requests we saw.
@@ -198,7 +199,7 @@ func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, erro
 // Validates service health and vended content match for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedText string) error {
+func validateDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, expectedText string) error {
 	t.Logf("Checking that the endpoint vends the expected text: %s", expectedText)
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
@@ -217,8 +218,8 @@ func validateDataPlane(t *testing.T, clients *test.Clients, names test.ResourceN
 // Validates the state of Configuration, Revision, and Route objects for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateControlPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
-	t.Log("Checking to ensure Revision is in desired state with generation: ", expectedGeneration)
+func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
+	t.Log("Checking to ensure Revision is in desired state with", "generation", expectedGeneration)
 	err := v1b1test.CheckRevisionState(clients.ServingBetaClient, names.Revision, func(r *v1beta1.Revision) (bool, error) {
 		if ready, err := v1b1test.IsRevisionReady(r); !ready {
 			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
@@ -253,7 +254,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 		return err
 	}
 
-	t.Log("Checking to ensure Route is in desired state with generation: ", expectedGeneration)
+	t.Log("Checking to ensure Route is in desired state with", "generation", expectedGeneration)
 	err = v1b1test.CheckRouteState(clients.ServingBetaClient, names.Route, v1b1test.AllRouteTrafficAtRevision(names))
 	if err != nil {
 		return fmt.Errorf("the Route %s was not updated to route traffic to the Revision %s: %w", names.Route, names.Revision, err)
@@ -264,7 +265,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 
 // Validates labels on Revision, Configuration, and Route objects when created by a Service
 // see spec here: https://github.com/knative/serving/blob/master/docs/spec/spec.md#revision
-func validateLabelsPropagation(t *testing.T, objects v1b1test.ResourceObjects, names test.ResourceNames) error {
+func validateLabelsPropagation(t pkgTest.T, objects v1b1test.ResourceObjects, names test.ResourceNames) error {
 	t.Log("Validate Labels on Revision Object")
 	revision := objects.Revision
 
@@ -338,4 +339,10 @@ func validateImageDigest(imageName string, imageDigest string) (bool, error) {
 	}
 
 	return ref.Context().String() == digest.Context().String(), nil
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
 }

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -18,7 +18,9 @@ package runtime
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"os"
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
@@ -93,4 +95,10 @@ func splitOpts(opts ...interface{}) ([]v1alpha1testing.ServiceOption, []interfac
 
 	}
 	return serviceOpts, reqOpts, nil
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
 }

--- a/test/crd.go
+++ b/test/crd.go
@@ -21,8 +21,8 @@ package test
 import (
 	"net/url"
 	"strings"
-	"testing"
 
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 )
 
@@ -52,7 +52,7 @@ var ObjectNameForTest = helpers.ObjectNameForTest
 
 // SubServiceNameForTest generates a random service name based on the test name and
 // the given subservice name.
-func SubServiceNameForTest(t *testing.T, subsvc string) string {
+func SubServiceNameForTest(t pkgTest.T, subsvc string) string {
 	fullPrefix := strings.TrimPrefix(t.Name(), "Test") + "-" + subsvc
 	return AppendRandomString(MakeK8sNamePrefix(fullPrefix))
 }

--- a/test/prober.go
+++ b/test/prober.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-	"testing"
 
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
@@ -254,14 +253,14 @@ func RunRouteProber(logf logging.FormatLogger, clients *Clients, url *url.URL) P
 // AssertProberDefault is a helper for stopping the Prober and checking its SLI
 // against the default SLO, which requires perfect responses.
 // This takes `testing.T` so that it may be used in `defer`.
-func AssertProberDefault(t *testing.T, p Prober) {
+func AssertProberDefault(t pkgTest.T, p Prober) {
 	t.Helper()
 	if err := p.Stop(); err != nil {
-		t.Errorf("Stop() = %v", err)
+		t.Error("Stop()", "error", err.Error())
 	}
 	// Default to 100% correct (typically used in conjunction with the low probe count above)
 	if err := CheckSLO(1.0, t.Name(), p); err != nil {
-		t.Errorf("CheckSLO() = %v", err)
+		t.Error("CheckSLO()", "error", err.Error())
 	}
 }
 

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -17,8 +17,8 @@ limitations under the License.
 package upgrade
 
 import (
+	"fmt"
 	"net/url"
-	"testing"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
@@ -40,7 +40,7 @@ const (
 )
 
 // Shamelessly cribbed from conformance/service_test.
-func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
+func assertServiceResourcesUpdated(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
 	t.Helper()
 	// TODO(#1178): Remove "Wait" from all checks below this point.
 	_, err := pkgTest.WaitForEndpointState(
@@ -51,6 +51,6 @@ func assertServiceResourcesUpdated(t *testing.T, clients *test.Clients, names te
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain)
 	if err != nil {
-		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
+		t.Fatal(fmt.Sprintf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err))
 	}
 }

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/test/logging"
@@ -29,14 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	ptest "knative.dev/pkg/test"
+	pkgTest "knative.dev/pkg/test"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by names.Image.
-func CreateConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ConfigOption) (*v1.Configuration, error) {
+func CreateConfiguration(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ConfigOption) (*v1.Configuration, error) {
 	config := Configuration(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Config: config})
 	return clients.ServingClient.Configs.Create(config)
@@ -44,7 +43,7 @@ func CreateConfiguration(t *testing.T, clients *test.Clients, names test.Resourc
 
 // PatchConfig patches the existing configuration passed in with the applied mutations.
 // Returns the latest configuration object
-func PatchConfig(t *testing.T, clients *test.Clients, svc *v1.Configuration, fopt ...rtesting.ConfigOption) (*v1.Configuration, error) {
+func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1.Configuration, fopt ...rtesting.ConfigOption) (*v1.Configuration, error) {
 	newSvc := svc.DeepCopy()
 	for _, opt := range fopt {
 		opt(newSvc)
@@ -102,7 +101,7 @@ func Configuration(names test.ResourceNames, fopt ...rtesting.ConfigOption) *v1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name: names.Config,
 		},
-		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image)),
+		Spec: *ConfigurationSpec(pkgTest.ImagePath(names.Image)),
 	}
 
 	for _, opt := range fopt {

--- a/test/v1/crd.go
+++ b/test/v1/crd.go
@@ -17,9 +17,8 @@ limitations under the License.
 package v1
 
 import (
-	"testing"
-
 	"github.com/davecgh/go-spew/spew"
+	pkgTest "knative.dev/pkg/test"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -32,6 +31,6 @@ type ResourceObjects struct {
 }
 
 // LogResourceObject logs the resource object with the resource name and value
-func LogResourceObject(t *testing.T, value ResourceObjects) {
-	t.Logf("resource %s", spew.Sprint(value))
+func LogResourceObject(t pkgTest.T, value ResourceObjects) {
+	t.Log("", "resource", spew.Sprint(value))
 }

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,7 @@ import (
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 
+	pkgTest "knative.dev/pkg/test"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )
@@ -57,7 +57,7 @@ func Route(names test.ResourceNames, fopt ...rtesting.RouteOption) *v1.Route {
 }
 
 // CreateRoute creates a route in the given namespace using the route name in names
-func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (*v1.Route, error) {
+func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (*v1.Route, error) {
 	route := Route(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Route: route})
 	return clients.ServingClient.Routes.Create(route)

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"testing"
 
 	"github.com/mattbaird/jsonpatch"
 
@@ -28,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	ptest "knative.dev/pkg/test"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
@@ -90,12 +89,12 @@ func GetResourceObjects(clients *test.Clients, names test.ResourceNames) (*Resou
 // passed in through 'names'.  Names is updated with the Route and Configuration created by the Service
 // and ResourceObjects is returned with the Service, Route, and Configuration objects.
 // Returns error if the service does not come up correctly.
-func CreateServiceReady(t *testing.T, clients *test.Clients, names *test.ResourceNames, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
+func CreateServiceReady(t pkgTest.T, clients *test.Clients, names *test.ResourceNames, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
 	if names.Image == "" {
 		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
 	}
 
-	t.Logf("Creating a new Service %s.", names.Service)
+	t.Log("Creating a new Service", "service", names.Service)
 	svc, err := CreateService(t, clients, *names, fopt...)
 	if err != nil {
 		return nil, err
@@ -110,18 +109,18 @@ func CreateServiceReady(t *testing.T, clients *test.Clients, names *test.Resourc
 		names.Service = svc.Name
 	}
 
-	t.Logf("Waiting for Service %q to transition to Ready.", names.Service)
+	t.Log("Waiting for Service %q to transition to Ready.", "service", names.Service)
 	if err := WaitForServiceState(clients.ServingClient, names.Service, IsServiceReady, "ServiceIsReady"); err != nil {
 		return nil, err
 	}
 
-	t.Log("Checking to ensure Service Status is populated for Ready service", names.Service)
+	t.Log("Checking to ensure Service Status is populated for Ready service")
 	err = validateCreatedServiceStatus(clients, names)
 	if err != nil {
 		return nil, err
 	}
 
-	t.Log("Getting latest objects Created by Service", names.Service)
+	t.Log("Getting latest objects Created by Service")
 	resources, err := GetResourceObjects(clients, *names)
 	if err == nil {
 		t.Log("Successfully created Service", names.Service)
@@ -130,7 +129,7 @@ func CreateServiceReady(t *testing.T, clients *test.Clients, names *test.Resourc
 }
 
 // CreateService creates a service in namespace with the name names.Service and names.Image
-func CreateService(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ServiceOption) (*v1.Service, error) {
+func CreateService(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ServiceOption) (*v1.Service, error) {
 	service := Service(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Service: service})
 	svc, err := clients.ServingClient.Services.Create(service)
@@ -139,7 +138,7 @@ func CreateService(t *testing.T, clients *test.Clients, names test.ResourceNames
 
 // PatchService patches the existing service passed in with the applied mutations.
 // Returns the latest service object
-func PatchService(t *testing.T, clients *test.Clients, svc *v1.Service, fopt ...rtesting.ServiceOption) (*v1.Service, error) {
+func PatchService(t pkgTest.T, clients *test.Clients, svc *v1.Service, fopt ...rtesting.ServiceOption) (*v1.Service, error) {
 	newSvc := svc.DeepCopy()
 	for _, opt := range fopt {
 		opt(newSvc)
@@ -153,7 +152,7 @@ func PatchService(t *testing.T, clients *test.Clients, svc *v1.Service, fopt ...
 }
 
 // UpdateServiceRouteSpec updates a service to use the route name in names.
-func UpdateServiceRouteSpec(t *testing.T, clients *test.Clients, names test.ResourceNames, rs v1.RouteSpec) (*v1.Service, error) {
+func UpdateServiceRouteSpec(t pkgTest.T, clients *test.Clients, names test.ResourceNames, rs v1.RouteSpec) (*v1.Service, error) {
 	patches := []jsonpatch.JsonPatchOperation{{
 		Operation: "replace",
 		Path:      "/spec/traffic",
@@ -199,7 +198,7 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 // that uses the image specified by names.Image.
 func Service(names test.ResourceNames, fopt ...rtesting.ServiceOption) *v1.Service {
 	a := append([]rtesting.ServiceOption{
-		rtesting.WithInlineConfigSpec(*ConfigurationSpec(ptest.ImagePath(names.Image))),
+		rtesting.WithInlineConfigSpec(*ConfigurationSpec(pkgTest.ImagePath(names.Image))),
 	}, fopt...)
 	return rtesting.ServiceWithoutNamespace(names.Service, a...)
 }

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +30,14 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 
-	ptest "knative.dev/pkg/test"
+	pkgTest "knative.dev/pkg/test"
 	v1alpha1testing "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 )
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by names.Image.
-func CreateConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...v1alpha1testing.ConfigOption) (*v1alpha1.Configuration, error) {
+func CreateConfiguration(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...v1alpha1testing.ConfigOption) (*v1alpha1.Configuration, error) {
 	config := Configuration(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Config: config})
 	return clients.ServingAlphaClient.Configs.Create(config)
@@ -117,7 +116,7 @@ func Configuration(names test.ResourceNames, fopt ...v1alpha1testing.ConfigOptio
 		ObjectMeta: metav1.ObjectMeta{
 			Name: names.Config,
 		},
-		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image)),
+		Spec: *ConfigurationSpec(pkgTest.ImagePath(names.Image)),
 	}
 
 	for _, opt := range fopt {

--- a/test/v1alpha1/crd.go
+++ b/test/v1alpha1/crd.go
@@ -17,9 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"testing"
-
 	"github.com/davecgh/go-spew/spew"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -32,6 +31,6 @@ type ResourceObjects struct {
 }
 
 // LogResourceObject logs the resource object with the resource name and value
-func LogResourceObject(t *testing.T, value ResourceObjects) {
-	t.Logf("resource %s", spew.Sprint(value))
+func LogResourceObject(t pkgTest.T, value ResourceObjects) {
+	t.Log("", "resource", spew.Sprint(value))
 }

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -21,12 +21,12 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/ptr"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -37,7 +37,7 @@ import (
 )
 
 // CreateRoute creates a route in the given namespace using the route name in names
-func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...v1alpha1testing.RouteOption) (*v1alpha1.Route, error) {
+func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...v1alpha1testing.RouteOption) (*v1alpha1.Route, error) {
 	fopt = append(fopt, v1alpha1testing.WithSpecTraffic(v1alpha1.TrafficTarget{
 		TrafficTarget: v1.TrafficTarget{
 			Tag:               names.TrafficTarget,

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/test/logging"
@@ -30,14 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	ptest "knative.dev/pkg/test"
+	pkgTest "knative.dev/pkg/test"
 	rtesting "knative.dev/serving/pkg/testing/v1beta1"
 	"knative.dev/serving/test"
 )
 
 // CreateConfiguration create a configuration resource in namespace with the name names.Config
 // that uses the image specified by names.Image.
-func CreateConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ConfigOption) (*v1beta1.Configuration, error) {
+func CreateConfiguration(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ConfigOption) (*v1beta1.Configuration, error) {
 	config := Configuration(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Config: config})
 	return clients.ServingBetaClient.Configs.Create(config)
@@ -45,7 +44,7 @@ func CreateConfiguration(t *testing.T, clients *test.Clients, names test.Resourc
 
 // PatchConfig patches the existing configuration passed in with the applied mutations.
 // Returns the latest configuration object
-func PatchConfig(t *testing.T, clients *test.Clients, svc *v1beta1.Configuration, fopt ...rtesting.ConfigOption) (*v1beta1.Configuration, error) {
+func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1beta1.Configuration, fopt ...rtesting.ConfigOption) (*v1beta1.Configuration, error) {
 	newSvc := svc.DeepCopy()
 	for _, opt := range fopt {
 		opt(newSvc)
@@ -103,7 +102,7 @@ func Configuration(names test.ResourceNames, fopt ...rtesting.ConfigOption) *v1b
 		ObjectMeta: metav1.ObjectMeta{
 			Name: names.Config,
 		},
-		Spec: *ConfigurationSpec(ptest.ImagePath(names.Image)),
+		Spec: *ConfigurationSpec(pkgTest.ImagePath(names.Image)),
 	}
 
 	for _, opt := range fopt {

--- a/test/v1beta1/crd.go
+++ b/test/v1beta1/crd.go
@@ -17,9 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	"testing"
-
 	"github.com/davecgh/go-spew/spew"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
@@ -32,6 +31,6 @@ type ResourceObjects struct {
 }
 
 // LogResourceObject logs the resource object with the resource name and value
-func LogResourceObject(t *testing.T, value ResourceObjects) {
-	t.Logf("resource %s", spew.Sprint(value))
+func LogResourceObject(t pkgTest.T, value ResourceObjects) {
+	t.Log("", "resource", spew.Sprint(value))
 }

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -27,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"knative.dev/pkg/ptr"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -59,7 +59,7 @@ func Route(names test.ResourceNames, fopt ...rtesting.RouteOption) *v1beta1.Rout
 }
 
 // CreateRoute creates a route in the given namespace using the route name in names
-func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (*v1beta1.Route, error) {
+func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (*v1beta1.Route, error) {
 	route := Route(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Route: route})
 	return clients.ServingBetaClient.Routes.Create(route)


### PR DESCRIPTION
Allows alternate testing/logging library to use these functions.

See knative/pkg#935 for more context.

Files seem to be split on using pkgTest or ptest for
knative.dev/pkg/test. Choose pkgTest to be consistent.

Also adds TestMain() to conformance packages to run common setup functions (in this case, only setup the logging flags).

```release-note
NONE
```
