### PR TITLE
Enable mTLS settings

### DIFF
--- a/test/config/mtls/destinationrule.yaml
+++ b/test/config/mtls/destinationrule.yaml
@@ -1,0 +1,35 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "mtls-services"
+  namespace: "serving-tests"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "mtls-services"
+  namespace: "serving-tests-alt"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/test/config/mtls/policy.yaml
+++ b/test/config/mtls/policy.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+  namespace: "serving-tests"
+spec:
+  peers:
+  - mtls:
+      mode: STRICT
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+  namespace: "knative-serving"
+spec:
+  peers:
+  - mtls:
+      mode: PERMISSIVE

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -394,6 +394,7 @@ function test_setup() {
   if (( MESH )); then
     kubectl label namespace serving-tests istio-injection=enabled
     kubectl label namespace serving-tests-alt istio-injection=enabled
+    ko apply ${KO_FLAGS} -f test/config/mtls/ || return 1
   fi
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
   wait_until_pods_running knative-serving || return 1


### PR DESCRIPTION
## Proposed Changes

This patch adds mTLS configs and enables it during e2e test mesh mode.

I have been working on https://github.com/knative/serving/pull/5648
and Istio's issue (Istio surely had the issue), but it looks like
[this commit](https://github.com/knative/serving/commit/270c395bf985566649f3993b9d3f1c446518211d) fixed the mTLS error we have seen.

**Release Note**

```release-note
NONE
```
