### PR TITLE
golang format tools

### DIFF
--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -67,7 +67,7 @@ func ServiceWithoutNamespace(name string, so ...ServiceOption) *v1alpha1.Service
 
 // DefaultService creates a service with ServiceOptions and with default values set
 func DefaultService(name, namespace string, so ...ServiceOption) *v1alpha1.Service {
-	return Service(name, namespace, append(so,WithServiceDefaults)...)
+	return Service(name, namespace, append(so, WithServiceDefaults)...)
 }
 
 // WithServiceDefaults will set the default values on the service.

--- a/test/test_images/grpc-ping/proto/ping.pb.go
+++ b/test/test_images/grpc-ping/proto/ping.pb.go
@@ -3,12 +3,15 @@
 
 package ping
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
+	fmt "fmt"
+
+	proto "github.com/golang/protobuf/proto"
+
+	math "math"
+
 	context "golang.org/x/net/context"
+
 	grpc "google.golang.org/grpc"
 )
 

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
 	ptest "knative.dev/pkg/test"
-	"knative.dev/serving/pkg/apis/serving/v1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/serving/v1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign vagababov
/cc vagababov
