### PR TITLE
Avoid update conflicts in 'TestUpdateConfigurationMetadata'.

### DIFF
--- a/test/conformance/api/v1/configuration_test.go
+++ b/test/conformance/api/v1/configuration_test.go
@@ -45,14 +45,13 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		t.Fatalf("Failed to create configuration %s", names.Config)
 	}
 
-	t.Log("The Configuration will be updated with the name of the Revision once it is created")
-	var err error
-	names.Revision, err = waitForConfigurationLatestCreatedRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
+	// Wait for the configuration to actually be ready to not race in the updates below.
+	if err := v1test.WaitForConfigurationState(clients.ServingClient, names.Config, v1test.IsConfigurationReady, "ConfigurationIsReady"); err != nil {
+		t.Fatalf("Configuration %s did not become ready: %v", names.Config, err)
 	}
 
 	cfg := fetchConfiguration(names.Config, clients, t)
+	names.Revision = cfg.Status.LatestReadyRevisionName
 
 	t.Logf("Updating labels of Configuration %s", names.Config)
 	newLabels := map[string]string{
@@ -67,7 +66,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 			cfg.Labels[k] = v
 		}
 	}
-	cfg, err = clients.ServingClient.Configs.Update(cfg)
+	cfg, err := clients.ServingClient.Configs.Update(cfg)
 	if err != nil {
 		t.Fatalf("Failed to update labels for Configuration %s: %v", names.Config, err)
 	}
@@ -138,18 +137,6 @@ func fetchConfiguration(name string, clients *test.Clients, t *testing.T) *v1.Co
 		t.Fatalf("Failed to get configuration %s: %v", name, err)
 	}
 	return cfg
-}
-
-func waitForConfigurationLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	var revisionName string
-	err := v1test.WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1.Configuration) (bool, error) {
-		if c.Status.LatestCreatedRevisionName != names.Revision {
-			revisionName = c.Status.LatestCreatedRevisionName
-			return true, nil
-		}
-		return false, nil
-	}, "ConfigurationUpdatedWithRevision")
-	return revisionName, err
 }
 
 func waitForConfigurationLabelsUpdate(clients *test.Clients, names test.ResourceNames, labels map[string]string) error {

--- a/test/conformance/api/v1alpha1/configuration_test.go
+++ b/test/conformance/api/v1alpha1/configuration_test.go
@@ -45,14 +45,13 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		t.Fatalf("Failed to create configuration %s", names.Config)
 	}
 
-	t.Log("The Configuration will be updated with the name of the Revision once it is created")
-	var err error
-	names.Revision, err = waitForConfigurationLatestCreatedRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
+	// Wait for the configuration to actually be ready to not race in the updates below.
+	if err := v1a1test.WaitForConfigurationState(clients.ServingAlphaClient, names.Config, v1a1test.IsConfigurationReady, "ConfigurationIsReady"); err != nil {
+		t.Fatalf("Configuration %s did not become ready: %v", names.Config, err)
 	}
 
 	cfg := fetchConfiguration(names.Config, clients, t)
+	names.Revision = cfg.Status.LatestReadyRevisionName
 
 	t.Logf("Updating labels of Configuration %s", names.Config)
 	newLabels := map[string]string{
@@ -67,7 +66,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 			cfg.Labels[k] = v
 		}
 	}
-	cfg, err = clients.ServingAlphaClient.Configs.Update(cfg)
+	cfg, err := clients.ServingAlphaClient.Configs.Update(cfg)
 	if err != nil {
 		t.Fatalf("Failed to update labels for Configuration %s: %v", names.Config, err)
 	}
@@ -138,18 +137,6 @@ func fetchConfiguration(name string, clients *test.Clients, t *testing.T) *v1alp
 		t.Fatalf("Failed to get configuration %s: %v", name, err)
 	}
 	return cfg
-}
-
-func waitForConfigurationLatestCreatedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	var revisionName string
-	err := v1a1test.WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
-		if c.Status.LatestCreatedRevisionName != names.Revision {
-			revisionName = c.Status.LatestCreatedRevisionName
-			return true, nil
-		}
-		return false, nil
-	}, "ConfigurationUpdatedWithRevision")
-	return revisionName, err
 }
 
 func waitForConfigurationLabelsUpdate(clients *test.Clients, names test.ResourceNames, labels map[string]string) error {

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -150,3 +150,9 @@ func CheckConfigurationState(client *test.ServingClients, name string, inState f
 	}
 	return nil
 }
+
+// IsConfigurationReady will check the status conditions of the config and return true if the config is
+// ready. This means it has at least created one revision and that has become ready.
+func IsConfigurationReady(c *v1.Configuration) (bool, error) {
+	return c.Generation == c.Status.ObservedGeneration && c.Status.IsReady(), nil
+}

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -170,3 +170,9 @@ func CheckConfigurationState(client *test.ServingAlphaClients, name string, inSt
 func ConfigurationHasCreatedRevision(c *v1alpha1.Configuration) (bool, error) {
 	return c.Status.LatestCreatedRevisionName != "", nil
 }
+
+// IsConfigurationReady will check the status conditions of the config and return true if the config is
+// ready. This means it has at least created one revision and that has become ready.
+func IsConfigurationReady(c *v1alpha1.Configuration) (bool, error) {
+	return c.Generation == c.Status.ObservedGeneration && c.Status.IsReady(), nil
+}

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -152,17 +152,8 @@ func CheckConfigurationState(client *test.ServingBetaClients, name string, inSta
 	return nil
 }
 
-// // ConfigurationHasCreatedRevision returns whether the Configuration has created a Revision.
-// func ConfigurationHasCreatedRevision(c *v1beta1.Configuration) (bool, error) {
-// 	return c.Status.LatestCreatedRevisionName != "", nil
-// }
-
-// // IsConfigRevisionCreationFailed will check the status conditions of the
-// // configuration and return true if the configuration's revision failed to
-// // create.
-// func IsConfigRevisionCreationFailed(c *v1beta1.Configuration) (bool, error) {
-// 	if cond := c.Status.GetCondition(v1beta1.ConfigurationConditionReady); cond != nil {
-// 		return cond.Status == corev1.ConditionFalse && cond.Reason == "RevisionFailed", nil
-// 	}
-// 	return false, nil
-// }
+// IsConfigurationReady will check the status conditions of the config and return true if the config is
+// ready. This means it has at least created one revision and that has become ready.
+func IsConfigurationReady(c *v1beta1.Configuration) (bool, error) {
+	return c.Generation == c.Status.ObservedGeneration && c.Status.IsReady(), nil
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This test waited for 'LatestCreatedRevision' to be set before going ahead and updating labels and annotations on the Configuration. This leads to a race with the reconciler as it will eventually also set 'LatestReadyRevision' causing the test to fail with the update.

We now wait for the Configuration to be entirely Ready, which means that it has fully reconciled the created Revision and is now in a steady state.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 