### PR TITLE
Backport monitoring fixes to 0.9 release branch

### DIFF
--- a/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
+++ b/config/monitoring/metrics/prometheus/100-prometheus-scrape-config.yaml
@@ -274,19 +274,15 @@ data:
       - source_labels: [__meta_kubernetes_service_name]
         target_label: service
     # Kube state metrics on https-main port
-    - job_name: kube-state-metrics-https-main
+    - job_name: kube-state-metrics-http-metrics
       honor_labels: true
-      scheme: https
       kubernetes_sd_configs:
       - role: endpoints
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tls_config:
-        insecure_skip_verify: true
       relabel_configs:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: knative-monitoring;kube-state-metrics;https-main
+        regex: knative-monitoring;kube-state-metrics;http-metrics
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace
@@ -295,18 +291,14 @@ data:
       - source_labels: [__meta_kubernetes_service_name]
         target_label: service
     # Kube state metrics on https-self port
-    - job_name: kube-state-metrics-https-self
-      scheme: https
+    - job_name: kube-state-metrics-telemetry
       kubernetes_sd_configs:
       - role: endpoints
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tls_config:
-        insecure_skip_verify: true
       relabel_configs:
       # Scrape only the the targets matching the following metadata
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: knative-monitoring;kube-state-metrics;https-self
+        regex: knative-monitoring;kube-state-metrics;telemetry
       # Rename metadata labels to be reader friendly
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace

--- a/third_party/config/monitoring/metrics/prometheus/kubernetes/kube-state-metrics.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/kubernetes/kube-state-metrics.yaml
@@ -34,7 +34,8 @@ subjects:
   name: kube-state-metrics
   namespace: knative-monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
@@ -60,9 +61,13 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources:
+  - daemonsets
+  - deployments
+  - replicasets
   - statefulsets
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
@@ -74,16 +79,24 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups: ["policy"]
   resources:
-  - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
   resources:
-  - subjectaccessreviews
-  verbs: ["create"]
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling.k8s.io"]
+  resources:
+  - verticalpodautoscalers
+  verbs: ["list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1 
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kube-state-metrics
@@ -95,14 +108,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-  namespace: knative-monitoring
+  namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: kube-state-metrics
   name: kube-state-metrics
   namespace: knative-monitoring
 spec:
+  selector:
+    matchLabels:
+      app: kube-state-metrics
   replicas: 1
   template:
     metadata:
@@ -110,92 +128,45 @@ spec:
         app: kube-state-metrics
     spec:
       serviceAccountName: kube-state-metrics
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
       containers:
-      - name: kube-rbac-proxy-main
-        image: quay.io/coreos/kube-rbac-proxy:v0.3.0
-        args:
-        - "--secure-listen-address=:8443"
-        - "--upstream=http://127.0.0.1:8081/"
-        ports:
-        - name: https-main
-          containerPort: 8443
-        resources:
-          requests:
-            memory: 20Mi
-            cpu: 10m
-          limits:
-            memory: 40Mi
-            cpu: 20m
-      - name: kube-rbac-proxy-self
-        image: quay.io/coreos/kube-rbac-proxy:v0.3.0
-        args:
-        - "--secure-listen-address=:9443"
-        - "--upstream=http://127.0.0.1:8082/"
-        ports:
-        - name: https-self
-          containerPort: 9443
-        resources:
-          requests:
-            memory: 20Mi
-            cpu: 10m
-          limits:
-            memory: 40Mi
-            cpu: 20m
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.0
-        args:
-        - "--host=127.0.0.1"
-        - "--port=8081"
-        - "--telemetry-host=127.0.0.1"
-        - "--telemetry-port=8082"
-      - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.7
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 30Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-          - /pod_nanny
-          - --container=kube-state-metrics
-          - --cpu=100m
-          - --extra-cpu=1m
-          - --memory=100Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.7.2
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: kube-state-metrics
   name: kube-state-metrics
   namespace: knative-monitoring
+  labels:
+    app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
 spec:
-  clusterIP: None
   ports:
-  - name: https-main
-    port: 8443
-    targetPort: https-main
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
     protocol: TCP
-  - name: https-self
-    port: 9443
-    targetPort: https-self
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
     protocol: TCP
   selector:
     app: kube-state-metrics

--- a/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
@@ -39,6 +39,9 @@ metadata:
   name: node-exporter
   namespace: knative-monitoring
 spec:
+  selector:
+    matchLabels:
+      app: node-exporter
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
@@ -33,7 +33,7 @@ subjects:
   name: node-exporter
   namespace: knative-monitoring
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-exporter


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #5809

**Release Note**
Change monitoring components to use `apps\v1` instead of the deprecated `extensions/v1beta1`

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
