### PR TITLE
Backport monitoring fixes to 0.10 release branch

### DIFF
--- a/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
@@ -39,6 +39,9 @@ metadata:
   name: node-exporter
   namespace: knative-monitoring
 spec:
+  selector:
+    matchLabels:
+      app: node-exporter
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/prometheus-operator/node-exporter.yaml
@@ -33,7 +33,7 @@ subjects:
   name: node-exporter
   namespace: knative-monitoring
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-exporter


### PR DESCRIPTION
Fixes #5809

Release Note
Change monitoring components to use apps\v1 instead of the deprecated extensions/v1beta1