### PR TITLE
Create the beginnings of an Ingress conformance suite.

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -74,6 +74,7 @@ type ServingClients struct {
 // networking clients.
 type NetworkingClients struct {
 	ServerlessServices networkingv1alpha1.ServerlessServiceInterface
+	Ingresses          networkingv1alpha1.IngressInterface
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
@@ -144,6 +145,7 @@ func newNetworkingClients(cfg *rest.Config, namespace string) (*NetworkingClient
 	}
 	return &NetworkingClients{
 		ServerlessServices: cs.NetworkingV1alpha1().ServerlessServices(namespace),
+		Ingresses:          cs.NetworkingV1alpha1().Ingresses(namespace),
 	}, nil
 }
 

--- a/test/conformance/ingress/basic_test.go
+++ b/test/conformance/ingress/basic_test.go
@@ -1,0 +1,100 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"net/http"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+	v1a1test "knative.dev/serving/test/v1alpha1"
+)
+
+// TestBasics verifies that a no frills Ingress exposes a simple Pod/Service via the public load balancer.
+func TestBasics(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+	test.CleanupOnInterrupt(cancel)
+
+	// Create a simple Ingress over the Service.
+	ing := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Annotations: map[string]string{
+				networking.IngressClassAnnotationKey: test.ServingFlags.IngressClass,
+			},
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{{
+				Hosts:      []string{name + ".example.com"},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      name,
+								ServiceNamespace: test.ServingNamespace,
+								ServicePort:      intstr.FromInt(port),
+							},
+						}},
+					}},
+				},
+			}},
+		},
+	}
+	ing, err := clients.NetworkingClient.Ingresses.Create(ing)
+	if err != nil {
+		t.Fatalf("Error creating Ingress: %v", err)
+	}
+	defer clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{})
+	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
+
+	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, ing.Name, v1a1test.IsIngressReady, t.Name()); err != nil {
+		t.Fatalf("Error waiting for ingress state: %v", err)
+	}
+	ing, err = clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting Ingress: %v", err)
+	}
+
+	// Create a client with a dialer based on the Ingress' public load balancer.
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: CreateDialContext(t, ing, clients),
+		},
+	}
+
+	// Make a request and check the response.
+	resp, err := client.Get("http://" + name + ".example.com")
+	if err != nil {
+		t.Fatalf("Error creating Ingress: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Got non-OK status: %d", resp.StatusCode)
+	}
+}

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// CreateService creates a Kubernetes service that will respond to the protocol
+// specified with the given portName.  It returns the service name, the port on
+// which the service is listening, and a "cancel" function to clean up the
+// created resources.
+func CreateService(t *testing.T, clients *test.Clients, portName string) (string, int, context.CancelFunc) {
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 3 + rand.Intn(97)
+	t.Logf("Using port %d", port)
+
+	// Pick a high port number.
+	containerPort := int32(8000 + rand.Intn(100))
+	t.Logf("Using containerPort %d", containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("runtime"),
+				Ports: []corev1.ContainerPort{{
+					Name:          portName,
+					ContainerPort: containerPort,
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: fmt.Sprintf("%d", containerPort),
+				}},
+			}},
+		},
+	}
+	pod, err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Create(pod)
+	if err != nil {
+		t.Fatalf("Error creating Pod: %v", err)
+	}
+	cancel := func() {
+		err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Pod %s", pod.Name)
+		}
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       portName,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(int(containerPort)),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+	svc, err = clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Create(svc)
+	if err != nil {
+		cancel()
+		t.Fatalf("Error creating Service: %v", err)
+	}
+
+	return name, port, func() {
+		err := clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Service %s", pod.Name)
+		}
+		cancel()
+	}
+}
+
+// CreateDialContext looks up the endpoint information to create a "dialer" for
+// the provided Ingress' public ingress loas balancer.  It can be used to
+// contact external-visibility services with an HTTP client via:
+//
+//	client := &http.Client{
+//		Transport: &http.Transport{
+//			DialContext: CreateDialContext(t, ing, clients),
+//		},
+//	}
+func CreateDialContext(t *testing.T, ing *v1alpha1.Ingress, clients *test.Clients) func(context.Context, string, string) (net.Conn, error) {
+	if ing.Status.PublicLoadBalancer == nil || len(ing.Status.PublicLoadBalancer.Ingress) < 1 {
+		t.Fatal("Ingress does not have a public load balancer assigned.")
+	}
+
+	// TODO(mattmoor): I'm open to tricks that would let us cleanly test multiple
+	// public load balancers or LBs with multiple ingresses (below), but want to
+	// keep our simple tests simple, thus the [0]s...
+
+	// We expect an ingress LB with the form foo.bar.svc.cluster.local (though
+	// we aren't strictly sensitive to the suffix, this is just illustrative.
+	internalDomain := ing.Status.PublicLoadBalancer.Ingress[0].DomainInternal
+	parts := strings.Split(internalDomain, ".")
+	if len(parts) < 3 {
+		t.Fatalf("Too few parts in internal domain: %s", internalDomain)
+	}
+	name, namespace := parts[0], parts[1]
+
+	svc, err := clients.KubeClient.Kube.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unable to retrieve Kubernetes service %s/%s: %v", namespace, name, err)
+	}
+	if len(svc.Status.LoadBalancer.Ingress) < 1 {
+		t.Fatal("Service does not have any ingresses (not type LoadBalancer?).")
+	}
+	ingress := svc.Status.LoadBalancer.Ingress[0]
+
+	return func(_ context.Context, _ string, address string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if ingress.IP != "" {
+			return net.Dial("tcp", ingress.IP+":"+port)
+		} else if ingress.Hostname != "" {
+			return net.Dial("tcp", ingress.Hostname+":"+port)
+		} else {
+			return nil, errors.New("Service ingress does not contain dialing information.")
+		}
+	}
+}

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -21,6 +21,8 @@ package test
 
 import (
 	"flag"
+
+	"knative.dev/serving/pkg/network"
 )
 
 const (
@@ -48,8 +50,9 @@ var ServingFlags = initializeServingFlags()
 
 // ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
 type ServingEnvironmentFlags struct {
-	ResolvableDomain bool // Resolve Route controller's `domainSuffix`
-	Https            bool // Indicates where the test service will be created with https
+	ResolvableDomain bool   // Resolve Route controller's `domainSuffix`
+	Https            bool   // Indicates where the test service will be created with https
+	IngressClass     string // Indicates the class of Ingress provider to test.
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -60,6 +63,9 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 		"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
 	flag.BoolVar(&f.Https, "https", false,
 		"Set this flag to true to run all tests with https.")
+
+	flag.StringVar(&f.IngressClass, "ingressClass", network.IstioIngressClassName,
+		"Set this flag to the ingress class to test against.")
 
 	return &f
 }

--- a/test/test_images/runtime/handlers/handler.go
+++ b/test/test_images/runtime/handlers/handler.go
@@ -25,7 +25,8 @@ import (
 
 // InitHandlers initializes all handlers.
 func InitHandlers(mux *http.ServeMux) {
-	mux.HandleFunc("/", withHeaders(withRequestLog(runtimeHandler)))
+	h := network.NewProbeHandler(withHeaders(withRequestLog(runtimeHandler)))
+	mux.HandleFunc("/", h.ServeHTTP)
 	mux.HandleFunc("/healthz", withRequestLog(withKubeletProbeHeaderCheck))
 }
 

--- a/test/v1alpha1/ingress.go
+++ b/test/v1alpha1/ingress.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/test/logging"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// WaitForIngressState polls the status of the Ingress called name from client every
+// PollInterval until inState returns `true` indicating it is done, returns an
+// error or PollTimeout. desc will be used to name the metric that is emitted to
+// track how long it took for name to get into the state checked by inState.
+func WaitForIngressState(client *test.NetworkingClients, name string, inState func(r *v1alpha1.Ingress) (bool, error), desc string) error {
+	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForIngressState/%s/%s", name, desc))
+	defer span.End()
+
+	var lastState *v1alpha1.Ingress
+	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		var err error
+		lastState, err = client.Ingresses.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		return inState(lastState)
+	})
+
+	if waitErr != nil {
+		return fmt.Errorf("ingress %q is not in desired state, got: %+v: %w", name, lastState, waitErr)
+	}
+	return nil
+}
+
+// IsIngressReady will check the status conditions of the ingress and return true if the ingress is
+// ready.
+func IsIngressReady(r *v1alpha1.Ingress) (bool, error) {
+	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
+}


### PR DESCRIPTION
The intent of this is to enable us to perform much more focused testing of the semantics of Ingress resources.

Starting with a single simple test to get the ball rolling, but expect more tests to follow.

/assign @tcnghia 
cc @ilackarms @bbrowning @concaf