### PR TITLE
Fix the flake in the ingress test where the order might differ

### DIFF
--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"log"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 
@@ -1077,9 +1078,13 @@ func TestListProbeTargets(t *testing.T) {
 			} else if !strings.Contains(err.Error(), test.errMessage) {
 				t.Errorf("expected error message %q but saw %v", test.errMessage, err)
 			}
-			if 0 != len(test.results)+len(results) { // consider nil map == empty map
+			if len(test.results)+len(results) > 0 { // consider nil map == empty map
+				// Sort by port number
+				sort.Slice(results, func(i, j int) bool {
+					return results[i].Port < results[j].Port
+				})
 				if diff := cmp.Diff(test.results, results); diff != "" {
-					t.Errorf("Unexpected probe targets (-want +got): %v", diff)
+					t.Errorf("Unexpected probe targets (-want +got): %s", diff)
 				}
 			}
 		})


### PR DESCRIPTION
Due to how maps are iterated the results sometimes differ.
 e.g.: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/6288/pull-knative-serving-unit-tests/1208490129887334402
So sort by port to make sure things are passing
```
>gt -count=10 -race -run=TestListProbeTargets
 PASS
> ok      knative.dev/serving/pkg/reconciler/ingress      1.018s
```

/assign @tcnghia mattmoor
