### PR TITLE
Add a percentage-based split test.

### DIFF
--- a/test/conformance/ingress/basic_test.go
+++ b/test/conformance/ingress/basic_test.go
@@ -22,12 +22,10 @@ import (
 	"net/http"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
 // TestBasics verifies that a no frills Ingress exposes a simple Pod/Service via the public load balancer.
@@ -37,56 +35,26 @@ func TestBasics(t *testing.T) {
 
 	name, port, cancel := CreateService(t, clients, networking.ServicePortNameHTTP1)
 	defer cancel()
-	test.CleanupOnInterrupt(cancel)
 
 	// Create a simple Ingress over the Service.
-	ing := &v1alpha1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: test.ServingNamespace,
-			Annotations: map[string]string{
-				networking.IngressClassAnnotationKey: test.ServingFlags.IngressClass,
-			},
-		},
-		Spec: v1alpha1.IngressSpec{
-			Rules: []v1alpha1.IngressRule{{
-				Hosts:      []string{name + ".example.com"},
-				Visibility: v1alpha1.IngressVisibilityExternalIP,
-				HTTP: &v1alpha1.HTTPIngressRuleValue{
-					Paths: []v1alpha1.HTTPIngressPath{{
-						Splits: []v1alpha1.IngressBackendSplit{{
-							IngressBackend: v1alpha1.IngressBackend{
-								ServiceName:      name,
-								ServiceNamespace: test.ServingNamespace,
-								ServicePort:      intstr.FromInt(port),
-							},
-						}},
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
 					}},
-				},
-			}},
-		},
-	}
-	ing, err := clients.NetworkingClient.Ingresses.Create(ing)
-	if err != nil {
-		t.Fatalf("Error creating Ingress: %v", err)
-	}
-	defer clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{})
-	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
-
-	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, ing.Name, v1a1test.IsIngressReady, t.Name()); err != nil {
-		t.Fatalf("Error waiting for ingress state: %v", err)
-	}
-	ing, err = clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error getting Ingress: %v", err)
-	}
-
-	// Create a client with a dialer based on the Ingress' public load balancer.
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: CreateDialContext(t, ing, clients),
-		},
-	}
+				}},
+			},
+		}},
+	})
+	defer cancel()
 
 	// Make a request and check the response.
 	resp, err := client.Get("http://" + name + ".example.com")

--- a/test/conformance/ingress/percentage_test.go
+++ b/test/conformance/ingress/percentage_test.go
@@ -92,10 +92,16 @@ func TestPercentage(t *testing.T) {
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.
 	seen := make(map[string]float64, len(backends))
-	const totalRequests = 1000.0
-	// The increment to make for each request, so that the values of seen reflect the
-	// percentage of the total number of requests we are making.
-	const increment = 100.0 / totalRequests
+
+	const (
+		// The total number of requests to make (as a float to avoid conversions in later computations).
+		totalRequests = 1000.0
+		// The increment to make for each request, so that the values of seen reflect the
+		// percentage of the total number of requests we are making.
+		increment = 100.0 / totalRequests
+		// Allow the Ingress to be within 5% of the configured value.
+		margin = 5.0
+	)
 	for i := 0.0; i < totalRequests; i++ {
 		// Make a request and check the response.
 		resp, err := client.Get("http://" + name + ".example.com")
@@ -116,7 +122,6 @@ func TestPercentage(t *testing.T) {
 		seen[ri.Request.Headers.Get(headerName)] += increment
 	}
 
-	const margin = 5.0 // Allow the Ingress to be within 5% of the configured value.
 	for name, want := range weights {
 		got := seen[name]
 		switch {

--- a/test/conformance/ingress/percentage_test.go
+++ b/test/conformance/ingress/percentage_test.go
@@ -1,0 +1,127 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/types"
+)
+
+// TestPercentage verifies that an Ingress splitting over multiple backends respects
+// the given percentage distribution.
+func TestPercentage(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	// Use a post-split injected header to establish which split we are sending traffic to.
+	const headerName = "Foo-Bar-Baz"
+
+	backends := make([]v1alpha1.IngressBackendSplit, 0, 10)
+	weights := make(map[string]float64, len(backends))
+
+	// Double the percentage of the split each iteration until it would overflow, and then
+	// give the last route the remainder.
+	percent, total := 1, 0
+	for i := 0; i < 10; i++ {
+		name, port, cancel := CreateService(t, clients, networking.ServicePortNameHTTP1)
+		defer cancel()
+		backends = append(backends, v1alpha1.IngressBackendSplit{
+			IngressBackend: v1alpha1.IngressBackend{
+				ServiceName:      name,
+				ServiceNamespace: test.ServingNamespace,
+				ServicePort:      intstr.FromInt(port),
+			},
+			// Append different headers to each split, which lets us identify
+			// which backend we hit.
+			AppendHeaders: map[string]string{
+				headerName: name,
+			},
+			Percent: percent,
+		})
+		weights[name] = float64(percent)
+
+		total += percent
+		percent *= 2
+		// Cap the final non-zero bucket so that we total 100%
+		// After that, this will zero out remaining buckets.
+		if total+percent > 100 {
+			percent = 100 - total
+		}
+	}
+
+	// Create a simple Ingress over the 10 Services.
+	name := test.ObjectNameForTest(t)
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: backends,
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Create a large enough population of requests that we can reasonably assess how
+	// well the Ingress respected the percentage split.
+	seen := make(map[string]int, len(backends))
+	const totalRequests = 1000
+	for i := 0; i < totalRequests; i++ {
+		// Make a request and check the response.
+		resp, err := client.Get("http://" + name + ".example.com")
+		if err != nil {
+			t.Fatalf("Error making GET request: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Got non-OK status: %d", resp.StatusCode)
+			continue
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		ri := &types.RuntimeInfo{}
+		if err := json.Unmarshal(b, ri); err != nil {
+			t.Fatalf("Unable to parse runtime image's response payload: %v", err)
+		}
+		// Increment the bucket for the seen header.
+		seen[ri.Request.Headers.Get(headerName)]++
+	}
+
+	const margin = 3.0 // Allow the Ingress to be within 3% of the configured value.
+	for name, want := range weights {
+		got := (float64(seen[name]) * 100.0) / float64(totalRequests)
+		switch {
+		case want == 0.0 && got > 0.0:
+			// For 0% targets, we have tighter requirements.
+			t.Errorf("target %q received traffic, wanted none (0%% target).", name)
+		case want-margin > got || got > want+margin:
+			t.Errorf("target %q received %f%%, wanted %f +/- %f", name, got, want, margin)
+		}
+	}
+}

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -90,7 +90,6 @@ func CreateService(t *testing.T, clients *test.Clients, portName string) (string
 	if err != nil {
 		t.Fatalf("Error creating Pod: %v", err)
 	}
-	test.CleanupOnInterrupt(func() { clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}) })
 	cancel := func() {
 		err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
 		if err != nil {
@@ -126,9 +125,6 @@ func CreateService(t *testing.T, clients *test.Clients, portName string) (string
 		cancel()
 		t.Fatalf("Error creating Service: %v", err)
 	}
-	test.CleanupOnInterrupt(func() {
-		clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
-	})
 
 	// Wait for the Pod to show up in the Endpoints resource.
 	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
@@ -173,11 +169,11 @@ func CreateIngress(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpe
 		},
 		Spec: spec,
 	}
+	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
 	ing, err := clients.NetworkingClient.Ingresses.Create(ing)
 	if err != nil {
 		t.Fatalf("Error creating Ingress: %v", err)
 	}
-	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
 
 	return name, func() {
 		err := clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{})

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"math/rand"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,8 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/test"
+	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
 // CreateService creates a Kubernetes service that will respond to the protocol
@@ -87,6 +90,7 @@ func CreateService(t *testing.T, clients *test.Clients, portName string) (string
 	if err != nil {
 		t.Fatalf("Error creating Pod: %v", err)
 	}
+	test.CleanupOnInterrupt(func() { clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}) })
 	cancel := func() {
 		err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
 		if err != nil {
@@ -122,6 +126,9 @@ func CreateService(t *testing.T, clients *test.Clients, portName string) (string
 		cancel()
 		t.Fatalf("Error creating Service: %v", err)
 	}
+	test.CleanupOnInterrupt(func() {
+		clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+	})
 
 	// Wait for the Pod to show up in the Endpoints resource.
 	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
@@ -148,6 +155,58 @@ func CreateService(t *testing.T, clients *test.Clients, portName string) (string
 		}
 		cancel()
 	}
+}
+
+// CreateIngress creates a Knative Ingress resource
+func CreateIngress(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpec) (string, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Create a simple Ingress over the Service.
+	ing := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Annotations: map[string]string{
+				networking.IngressClassAnnotationKey: test.ServingFlags.IngressClass,
+			},
+		},
+		Spec: spec,
+	}
+	ing, err := clients.NetworkingClient.Ingresses.Create(ing)
+	if err != nil {
+		t.Fatalf("Error creating Ingress: %v", err)
+	}
+	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
+
+	return name, func() {
+		err := clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Ingress %s", ing.Name)
+		}
+	}
+}
+
+func CreateIngressReady(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpec) (string, *http.Client, context.CancelFunc) {
+	t.Helper()
+	name, cancel := CreateIngress(t, clients, spec)
+
+	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, name, v1a1test.IsIngressReady, t.Name()); err != nil {
+		cancel()
+		t.Fatalf("Error waiting for ingress state: %v", err)
+	}
+	ing, err := clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
+	if err != nil {
+		cancel()
+		t.Fatalf("Error getting Ingress: %v", err)
+	}
+
+	// Create a client with a dialer based on the Ingress' public load balancer.
+	return name, &http.Client{
+		Transport: &http.Transport{
+			DialContext: CreateDialContext(t, ing, clients),
+		},
+	}, cancel
 }
 
 // CreateDialContext looks up the endpoint information to create a "dialer" for


### PR DESCRIPTION
This also:
1. Shifts the responsibility of CleanupOnInterrupt to the utilities (less boilerplate)
2. Creates/Uses some Ingress helpers to reduce boilerplate around ObjectMeta, waiting for readiness, and http.Client setup.

cc @vagababov @ilackarms @tcnghia 