### PR TITLE
Do not create -mesh VirtualService in case we don't need one.

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -253,8 +253,6 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ia *v1alpha1.
 	// First, create all needed VirtualServices.
 	kept := sets.NewString()
 	for _, d := range desired {
-		json, _ := json.MarshalIndent(d, "", "  ")
-		fmt.Println(string(json))
 		if _, err := istioaccessor.ReconcileVirtualService(ctx, ia, d, r); err != nil {
 			if kaccessor.IsNotOwned(err) {
 				ia.Status.MarkResourceNotOwned("VirtualService", d.Name)

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -253,6 +253,8 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ia *v1alpha1.
 	// First, create all needed VirtualServices.
 	kept := sets.NewString()
 	for _, d := range desired {
+		json, _ := json.MarshalIndent(d, "", "  ")
+		fmt.Println(string(json))
 		if _, err := istioaccessor.ReconcileVirtualService(ctx, ia, d, r); err != nil {
 			if kaccessor.IsNotOwned(err) {
 				ia.Status.MarkResourceNotOwned("VirtualService", d.Name)

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -58,6 +58,9 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+				Hosts: []string{
+					"test-route.test-ns.svc.cluster.local",
+				},
 				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				HTTP:       &v1alpha1.HTTPIngressRuleValue{},
 			}}},
@@ -78,6 +81,34 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			},
 		}},
 	}, {
+		name:     "ingress only",
+		gateways: makeGatewayMap([]string{"gateway"}, []string{"private-gateway"}),
+		ci: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ingress",
+				Namespace: system.Namespace(),
+				Labels: map[string]string{
+					serving.RouteLabelKey:          "test-route",
+					serving.RouteNamespaceLabelKey: "test-ns",
+				},
+			},
+			Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+				Hosts: []string{
+					"test-route.test-ns.example.com",
+				},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP:       &v1alpha1.HTTPIngressRuleValue{},
+			}}},
+		},
+		expected: []metav1.ObjectMeta{{
+			Name:      "test-ingress",
+			Namespace: system.Namespace(),
+			Labels: map[string]string{
+				serving.RouteLabelKey:          "test-route",
+				serving.RouteNamespaceLabelKey: "test-ns",
+			},
+		}},
+	}, {
 		name:     "mesh only",
 		gateways: nil,
 		ci: &v1alpha1.Ingress{
@@ -89,7 +120,13 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 					serving.RouteNamespaceLabelKey: "test-ns",
 				},
 			},
-			Spec: v1alpha1.IngressSpec{},
+			Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+				Hosts: []string{
+					"test-route.test-ns.svc.cluster.local",
+				},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP:       &v1alpha1.HTTPIngressRuleValue{},
+			}}},
 		},
 		expected: []metav1.ObjectMeta{{
 			Name:      "test-ingress-mesh",
@@ -111,7 +148,13 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 					serving.RouteNamespaceLabelKey: "test-ns",
 				},
 			},
-			Spec: v1alpha1.IngressSpec{},
+			Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+				Hosts: []string{
+					"test-route.test-ns.svc.cluster.local",
+				},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP:       &v1alpha1.HTTPIngressRuleValue{},
+			}}},
 		},
 		expected: []metav1.ObjectMeta{{
 			Name:      "test-ingress-mesh",
@@ -150,7 +193,14 @@ func TestMakeMeshVirtualServiceSpec_CorrectGateways(t *testing.T) {
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
 		},
-		Spec: v1alpha1.IngressSpec{},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{{
+				Hosts: []string{
+					"test-route.test-ns.svc.cluster.local",
+				},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP:       &v1alpha1.HTTPIngressRuleValue{},
+			}}},
 	}
 	expected := []string{"mesh"}
 	gateways := MakeMeshVirtualService(ci).Spec.Gateways


### PR DESCRIPTION
Strictly speaking we don't encounter this issue when using Knative,
since we always expose things to the mesh.  However, this allows less
coupling, thus allow conformance testing to be a bit more targeted.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Do not create -mesh VirtualService in case we don't need one.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
