### PR TITLE
Use short name 'kingress' instead of 'ing' to avoid collision.

### DIFF
--- a/config/300-ingress.yaml
+++ b/config/300-ingress.yaml
@@ -33,7 +33,7 @@ spec:
     - knative-internal
     - networking
     shortNames:
-    - ing
+    - kingress
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Use short name 'kingress' instead of 'ing' to avoid collision with K8s's Ingress object.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
