### PR TITLE
Add NewWithContext to the pool

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pool
 
 import (
+	"context"
 	"sync"
 )
 
@@ -27,6 +28,8 @@ type impl struct {
 	// Ensure that we Wait exactly once and memoize
 	// the result.
 	waitOnce sync.Once
+
+	cancel context.CancelFunc
 
 	// We're only interested in the first result so
 	// only set it once.
@@ -47,9 +50,12 @@ func New(workers int) Interface {
 	return NewWithCapacity(workers, defaultCapacity)
 }
 
-// NewWithCapacity creates a fresh worker pool with the specified size.
-func NewWithCapacity(workers, capacity int) Interface {
+// NewWithContext creates a pool that is driven by a cancelable context.
+// Just like errgroup.Group on first error the context will be canceled as well.
+func NewWithContext(ctx context.Context, workers, capacity int) (Interface, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
 	i := &impl{
+		cancel: cancel,
 		workCh: make(chan func() error, capacity),
 	}
 
@@ -59,15 +65,48 @@ func NewWithCapacity(workers, capacity int) Interface {
 	// 3. marks work as done in our sync.WaitGroup.
 	for idx := 0; idx < workers; idx++ {
 		go func() {
-			for work := range i.workCh {
-				func() {
-					defer i.wg.Done()
-					if err := work(); err != nil {
-						i.resultOnce.Do(func() {
-							i.result = err
-						})
+			for {
+				select {
+				case <-ctx.Done():
+					break
+				case work, ok := <-i.workCh:
+					if !ok {
+						break
 					}
-				}()
+					i.exec(work)
+				}
+			}
+		}()
+	}
+	return i, ctx
+}
+
+func (i *impl) exec(w func() error) {
+	defer i.wg.Done()
+	if err := w(); err != nil {
+		i.resultOnce.Do(func() {
+			if i.cancel != nil {
+				i.cancel()
+			}
+			i.result = err
+		})
+	}
+}
+
+// NewWithCapacity creates a fresh worker pool with the specified size.
+func NewWithCapacity(workers, capacity int) Interface {
+	i := &impl{
+		workCh: make(chan func() error, capacity),
+	}
+
+	// Start a go routine for each worker, which:
+	// 1. reads off of the work channel,
+	// 2. (optionally) sets error variable
+	// 3. marks work as done in our sync.WaitGroup.
+	for idx := 0; idx < workers; idx++ {
+		go func() {
+			for work := range i.workCh {
+				i.exec(work)
 			}
 		}()
 	}
@@ -88,6 +127,10 @@ func (i *impl) Wait() error {
 	i.waitOnce.Do(func() {
 		// Wait for queued work to complete.
 		i.wg.Wait()
+		// Notify the context, that it's done now.
+		if i.cancel != nil {
+			i.cancel()
+		}
 
 		// Now we know there are definitely no new items arriving.
 		close(i.workCh)

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -95,22 +95,7 @@ func (i *impl) exec(w func() error) {
 
 // NewWithCapacity creates a fresh worker pool with the specified size.
 func NewWithCapacity(workers, capacity int) Interface {
-	i := &impl{
-		workCh: make(chan func() error, capacity),
-	}
-
-	// Start a go routine for each worker, which:
-	// 1. reads off of the work channel,
-	// 2. (optionally) sets error variable
-	// 3. marks work as done in our sync.WaitGroup.
-	for idx := 0; idx < workers; idx++ {
-		go func() {
-			for work := range i.workCh {
-				i.exec(work)
-			}
-		}()
-	}
-
+	i, _ := NewWithContext(context.Background(), workers, capacity)
 	return i
 }
 

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -233,7 +233,7 @@ func TestErrorCancelsContext(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Error("ctx is not canceled due to the first error")
 	}
-	if err := pool.Wait(); err == nil {
-		t.Fatal("pool.Wait() didn't return an error")
+	if err := pool.Wait(); err != want {
+		t.Fatalf("pool.Wait() = %v, want: %v", err, want)
 	}
 }


### PR DESCRIPTION
This mimics the behaviour of the `errgroup`
As such, if you want to receive the actual error, you
still need to `Wait()`
`Context.Err()` is (looking at the docs) reserved exclusively for `Canceled` and `DeadlineExceeded` errors.

/assign mattmoor

