### PR TITLE
Wait for Addresses, not just Subsets.

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -129,7 +129,12 @@ func CreateService(t *testing.T, clients *test.Clients, portName string) (string
 		if err != nil {
 			return true, err
 		}
-		return len(ep.Subsets) == 1, nil
+		for _, subset := range ep.Subsets {
+			if len(subset.Addresses) == 0 {
+				return false, nil
+			}
+		}
+		return len(ep.Subsets) > 0, nil
 	})
 	if waitErr != nil {
 		cancel()


### PR DESCRIPTION
Subsets is populated quickly with `notReadyAddresses`, so this refines the check to also check that each of the `subsets` has a non-empty `addresses` field.
