### PR TITLE
Share some of the common logic for issuing requests.

### DIFF
--- a/test/conformance/ingress/basic_test.go
+++ b/test/conformance/ingress/basic_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package ingress
 
 import (
-	"net/http"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -56,13 +55,5 @@ func TestBasics(t *testing.T) {
 	})
 	defer cancel()
 
-	// Make a request and check the response.
-	resp, err := client.Get("http://" + name + ".example.com")
-	if err != nil {
-		t.Fatalf("Error creating Ingress: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Got non-OK status: %d", resp.StatusCode)
-	}
+	RuntimeRequest(t, client, "http://"+name+".example.com")
 }

--- a/test/conformance/ingress/hosts_test.go
+++ b/test/conformance/ingress/hosts_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package ingress
 
 import (
-	"net/http"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -66,14 +65,6 @@ func TestMultipleHosts(t *testing.T) {
 	defer cancel()
 
 	for _, host := range hosts {
-		// Make a request and check the response.
-		resp, err := client.Get("http://" + host)
-		if err != nil {
-			t.Fatalf("Error creating Ingress: %v", err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Got non-OK status: %d", resp.StatusCode)
-		}
+		RuntimeRequest(t, client, "http://"+host)
 	}
 }

--- a/test/conformance/ingress/path_test.go
+++ b/test/conformance/ingress/path_test.go
@@ -19,16 +19,12 @@ limitations under the License.
 package ingress
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/test"
-	"knative.dev/serving/test/types"
 )
 
 // TestPath verifies that an Ingress properly dispatches to backends based on the path of the URL.
@@ -134,20 +130,9 @@ func TestPath(t *testing.T) {
 
 	for path, want := range tests {
 		t.Run(path, func(t *testing.T) {
-			// Make a request and check the response.
-			resp, err := client.Get("http://" + name + ".example.com" + path)
-			if err != nil {
-				t.Fatalf("Error creating Ingress: %v", err)
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				t.Errorf("Got non-OK status: %d", resp.StatusCode)
-			}
-
-			b, err := ioutil.ReadAll(resp.Body)
-			ri := &types.RuntimeInfo{}
-			if err := json.Unmarshal(b, ri); err != nil {
-				t.Fatalf("Unable to parse runtime image's response payload: %v", err)
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com"+path)
+			if ri == nil {
+				return
 			}
 
 			got := ri.Request.Headers.Get(headerName)

--- a/test/conformance/ingress/percentage_test.go
+++ b/test/conformance/ingress/percentage_test.go
@@ -19,17 +19,13 @@ limitations under the License.
 package ingress
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"math"
-	"net/http"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/test"
-	"knative.dev/serving/test/types"
 )
 
 // TestPercentage verifies that an Ingress splitting over multiple backends respects
@@ -103,21 +99,9 @@ func TestPercentage(t *testing.T) {
 		margin = 5.0
 	)
 	for i := 0.0; i < totalRequests; i++ {
-		// Make a request and check the response.
-		resp, err := client.Get("http://" + name + ".example.com")
-		if err != nil {
-			t.Fatalf("Error making GET request: %v", err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Got non-OK status: %d", resp.StatusCode)
+		ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+		if ri == nil {
 			continue
-		}
-
-		b, err := ioutil.ReadAll(resp.Body)
-		ri := &types.RuntimeInfo{}
-		if err := json.Unmarshal(b, ri); err != nil {
-			t.Fatalf("Unable to parse runtime image's response payload: %v", err)
 		}
 		seen[ri.Request.Headers.Get(headerName)] += increment
 	}

--- a/test/conformance/ingress/timeout_test.go
+++ b/test/conformance/ingress/timeout_test.go
@@ -106,5 +106,6 @@ func checkTimeout(t *testing.T, client *http.Client, name string, code int, init
 	defer resp.Body.Close()
 	if resp.StatusCode != code {
 		t.Errorf("Unexpected status code: %d, wanted %d", resp.StatusCode, code)
+		DumpResponse(t, resp)
 	}
 }


### PR DESCRIPTION
Factors a small library for making a GET request to produce a RuntimeInfo.

Also add a small debug dumping utility on failures, the hope of consolidating some of this is to have a common point for instrumenting as we chase 404s.

