### PR TITLE
Fix copy/paste error in comment for TestShouldHaveStdinEOF

### DIFF
--- a/test/conformance/runtime/file_descriptor_test.go
+++ b/test/conformance/runtime/file_descriptor_test.go
@@ -24,7 +24,7 @@ import (
 	"knative.dev/serving/test"
 )
 
-// TestMustHaveCgroupConfigured verifies using the runtime test container that reading from the
+// TestShouldHaveStdinEOF verifies using the runtime test container that reading from the
 // stdin file descriptor results in EOF.
 func TestShouldHaveStdinEOF(t *testing.T) {
 	clients := test.Setup(t)


### PR DESCRIPTION
Just wrong function in the comment.