### PR TITLE
Deprecate and stop using custom values for secret schema.

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -51,14 +51,9 @@ func (s *IngressSpec) SetDefaults(ctx context.Context) {
 
 // SetDefaults populates default values in IngressTLS
 func (t *IngressTLS) SetDefaults(ctx context.Context) {
-	// Default Secret key for ServerCertificate is `tls.crt`.
-	if t.ServerCertificate == "" {
-		t.ServerCertificate = "tls.crt"
-	}
-	// Default Secret key for PrivateKey is `tls.key`.
-	if t.PrivateKey == "" {
-		t.PrivateKey = "tls.key"
-	}
+	// Deprecated, do not use.
+	t.DeprecatedServerCertificate = ""
+	t.DeprecatedPrivateKey = ""
 }
 
 // SetDefaults populates default values in IngressRule

--- a/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
@@ -54,53 +54,6 @@ func TestIngressDefaulting(t *testing.T) {
 			},
 		},
 	}, {
-		name: "tls-defaulting",
-		in: &Ingress{
-			Spec: IngressSpec{
-				TLS: []IngressTLS{{
-					SecretNamespace: "secret-space",
-					SecretName:      "secret-name",
-				}},
-			},
-		},
-		want: &Ingress{
-			Spec: IngressSpec{
-				TLS: []IngressTLS{{
-					SecretNamespace: "secret-space",
-					SecretName:      "secret-name",
-					// Default secret keys are filled in.
-					ServerCertificate: "tls.crt",
-					PrivateKey:        "tls.key",
-				}},
-				Visibility: IngressVisibilityExternalIP,
-			},
-		},
-	}, {
-		name: "tls-not-defaulting",
-		in: &Ingress{
-			Spec: IngressSpec{
-				TLS: []IngressTLS{{
-					SecretNamespace:   "secret-space",
-					SecretName:        "secret-name",
-					ServerCertificate: "custom.tls.cert",
-					PrivateKey:        "custom.tls.key",
-				}},
-				Visibility: IngressVisibilityExternalIP,
-			},
-		},
-		want: &Ingress{
-			Spec: IngressSpec{
-				TLS: []IngressTLS{{
-					SecretNamespace: "secret-space",
-					SecretName:      "secret-name",
-					// Default secret keys are kept intact.
-					ServerCertificate: "custom.tls.cert",
-					PrivateKey:        "custom.tls.key",
-				}},
-				Visibility: IngressVisibilityExternalIP,
-			},
-		},
-	}, {
 		name: "split-timeout-retry-defaulting",
 		in: &Ingress{
 			Spec: IngressSpec{

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -143,12 +143,12 @@ type IngressTLS struct {
 	// ServerCertificate identifies the certificate filename in the secret.
 	// Defaults to `tls.crt`.
 	// +optional
-	ServerCertificate string `json:"serverCertificate,omitempty"`
+	DeprecatedServerCertificate string `json:"serverCertificate,omitempty"`
 
 	// PrivateKey identifies the private key filename in the secret.
 	// Defaults to `tls.key`.
 	// +optional
-	PrivateKey string `json:"privateKey,omitempty"`
+	DeprecatedPrivateKey string `json:"privateKey,omitempty"`
 }
 
 // IngressRule represents the rules mapping the paths under a specified host to

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -115,11 +115,9 @@ var (
 	}}
 
 	ingressTLS = []v1alpha1.IngressTLS{{
-		Hosts:             []string{"host-tls.example.com"},
-		SecretName:        "secret0",
-		SecretNamespace:   "istio-system",
-		ServerCertificate: "tls.crt",
-		PrivateKey:        "tls.key",
+		Hosts:           []string{"host-tls.example.com"},
+		SecretName:      "secret0",
+		SecretNamespace: "istio-system",
 	}}
 
 	// The gateway server according to ingressTLS.

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -189,8 +189,8 @@ func MakeTLSServers(ia *v1alpha1.Ingress, gatewayServiceNamespace string, origin
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: tls.ServerCertificate,
-				PrivateKey:        tls.PrivateKey,
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 				CredentialName:    credentialName,
 			},
 		}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -65,33 +65,31 @@ var gateway = v1alpha3.Gateway{
 	},
 }
 
-var servers = []*istiov1alpha3.Server{
-	{
-		Hosts: []string{"host1.example.com"},
-		Port: &istiov1alpha3.Port{
-			Name:     "test-ns/ingress:0",
-			Number:   443,
-			Protocol: "HTTPS",
-		},
-		Tls: &istiov1alpha3.Server_TLSOptions{
-			Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-			ServerCertificate: "tls.crt",
-			PrivateKey:        "tls.key",
-		},
-	}, {
-		Hosts: []string{"host2.example.com"},
-		Port: &istiov1alpha3.Port{
-			Name:     "test-ns/non-ingress:0",
-			Number:   443,
-			Protocol: "HTTPS",
-		},
-		Tls: &istiov1alpha3.Server_TLSOptions{
-			Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-			ServerCertificate: "tls.crt",
-			PrivateKey:        "tls.key",
-		},
+var servers = []*istiov1alpha3.Server{{
+	Hosts: []string{"host1.example.com"},
+	Port: &istiov1alpha3.Port{
+		Name:     "test-ns/ingress:0",
+		Number:   443,
+		Protocol: "HTTPS",
 	},
-}
+	Tls: &istiov1alpha3.Server_TLSOptions{
+		Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
+		ServerCertificate: corev1.TLSCertKey,
+		PrivateKey:        corev1.TLSPrivateKeyKey,
+	},
+}, {
+	Hosts: []string{"host2.example.com"},
+	Port: &istiov1alpha3.Port{
+		Name:     "test-ns/non-ingress:0",
+		Number:   443,
+		Protocol: "HTTPS",
+	},
+	Tls: &istiov1alpha3.Server_TLSOptions{
+		Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
+		ServerCertificate: corev1.TLSCertKey,
+		PrivateKey:        corev1.TLSPrivateKeyKey,
+	},
+}}
 
 var httpServer = istiov1alpha3.Server{
 	Hosts: []string{"*"},
@@ -139,8 +137,8 @@ var modifiedDefaultTLSServer = istiov1alpha3.Server{
 	},
 	Tls: &istiov1alpha3.Server_TLSOptions{
 		Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-		ServerCertificate: "tls.crt",
-		PrivateKey:        "tls.key",
+		ServerCertificate: corev1.TLSCertKey,
+		PrivateKey:        corev1.TLSPrivateKeyKey,
 	},
 }
 
@@ -149,11 +147,9 @@ var ingressSpec = v1alpha1.IngressSpec{
 		Hosts: []string{"host1.example.com"},
 	}},
 	TLS: []v1alpha1.IngressTLS{{
-		Hosts:             []string{"host1.example.com"},
-		SecretName:        "secret0",
-		SecretNamespace:   system.Namespace(),
-		ServerCertificate: "tls.crt",
-		PrivateKey:        "tls.key",
+		Hosts:           []string{"host1.example.com"},
+		SecretName:      "secret0",
+		SecretNamespace: system.Namespace(),
 	}},
 }
 
@@ -176,8 +172,8 @@ func TestGetServers(t *testing.T) {
 		},
 		Tls: &istiov1alpha3.Server_TLSOptions{
 			Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-			ServerCertificate: "tls.crt",
-			PrivateKey:        "tls.key",
+			ServerCertificate: corev1.TLSCertKey,
+			PrivateKey:        corev1.TLSPrivateKeyKey,
 		},
 	}}
 
@@ -226,8 +222,8 @@ func TestMakeTLSServers(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 				CredentialName:    targetSecret(&secret, &ingressResource),
 			},
 		}},
@@ -246,8 +242,8 @@ func TestMakeTLSServers(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 				CredentialName:    "secret0",
 			},
 		}},
@@ -266,8 +262,8 @@ func TestMakeTLSServers(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 				CredentialName:    "secret0",
 			},
 		}},
@@ -354,8 +350,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}},
 		newServers: []*istiov1alpha3.Server{{
@@ -367,8 +363,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}},
 		original: gateway,
@@ -384,8 +380,8 @@ func TestUpdateGateway(t *testing.T) {
 					},
 					Tls: &istiov1alpha3.Server_TLSOptions{
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-						ServerCertificate: "tls.crt",
-						PrivateKey:        "tls.key",
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
 					},
 				}, {
 					Hosts: []string{"host2.example.com"},
@@ -396,8 +392,8 @@ func TestUpdateGateway(t *testing.T) {
 					},
 					Tls: &istiov1alpha3.Server_TLSOptions{
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-						ServerCertificate: "tls.crt",
-						PrivateKey:        "tls.key",
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
 					},
 				}},
 			},
@@ -413,8 +409,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}},
 		newServers: []*istiov1alpha3.Server{},
@@ -431,8 +427,8 @@ func TestUpdateGateway(t *testing.T) {
 					},
 					Tls: &istiov1alpha3.Server_TLSOptions{
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-						ServerCertificate: "tls.crt",
-						PrivateKey:        "tls.key",
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
 					},
 				}},
 			},
@@ -450,8 +446,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}, {
 			Hosts: []string{"host2.example.com"},
@@ -462,8 +458,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}},
 		newServers: []*istiov1alpha3.Server{},
@@ -481,8 +477,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}},
 		original: gatewayWithPlaceholderServer,
@@ -498,8 +494,8 @@ func TestUpdateGateway(t *testing.T) {
 					},
 					Tls: &istiov1alpha3.Server_TLSOptions{
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-						ServerCertificate: "tls.crt",
-						PrivateKey:        "tls.key",
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
 					},
 				}},
 			},
@@ -523,8 +519,8 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			Tls: &istiov1alpha3.Server_TLSOptions{
 				Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-				ServerCertificate: "tls.crt",
-				PrivateKey:        "tls.key",
+				ServerCertificate: corev1.TLSCertKey,
+				PrivateKey:        corev1.TLSPrivateKeyKey,
 			},
 		}},
 		original: gatewayWithModifiedWildcardTLSServer,
@@ -540,8 +536,8 @@ func TestUpdateGateway(t *testing.T) {
 						},
 						Tls: &istiov1alpha3.Server_TLSOptions{
 							Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-							ServerCertificate: "tls.crt",
-							PrivateKey:        "tls.key",
+							ServerCertificate: corev1.TLSCertKey,
+							PrivateKey:        corev1.TLSPrivateKeyKey,
 						},
 					},
 					&modifiedDefaultTLSServer,
@@ -601,8 +597,8 @@ func TestMakeIngressGateways(t *testing.T) {
 					},
 					Tls: &istiov1alpha3.Server_TLSOptions{
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-						ServerCertificate: "tls.crt",
-						PrivateKey:        "tls.key",
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
 						CredentialName:    targetSecret(&secret, &ingressResource),
 					},
 				}, {
@@ -649,8 +645,8 @@ func TestMakeIngressGateways(t *testing.T) {
 					},
 					Tls: &istiov1alpha3.Server_TLSOptions{
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
-						ServerCertificate: "tls.crt",
-						PrivateKey:        "tls.key",
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
 						CredentialName:    secret.Name,
 					},
 				}, {

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -153,15 +153,11 @@ func newTestIngress(t *testing.T, r *v1alpha1.Route, trafficOpts ...func(tc *tra
 		opt(tc)
 	}
 
-	tls := []netv1alpha1.IngressTLS{
-		{
-			Hosts:             []string{"test-route.test-ns.example.com"},
-			PrivateKey:        "tls.key",
-			SecretName:        "test-secret",
-			SecretNamespace:   "test-ns",
-			ServerCertificate: "tls.crt",
-		},
-	}
+	tls := []netv1alpha1.IngressTLS{{
+		Hosts:           []string{"test-route.test-ns.example.com"},
+		SecretName:      "test-secret",
+		SecretNamespace: "test-ns",
+	}}
 	ingress, err := resources.MakeIngress(getContext(), r, tc, tls, sets.NewString(), "foo-ingress")
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -725,14 +725,10 @@ func TestMakeIngress_WithTLS(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	ingressClass := "foo-ingress"
 	r := Route(ns, "test-route", WithRouteUID("1234-5678"), WithURL)
-	tls := []netv1alpha1.IngressTLS{
-		{
-			Hosts:             []string{"*.default.domain.com"},
-			PrivateKey:        "tls.key",
-			SecretName:        "secret",
-			ServerCertificate: "tls.crt",
-		},
-	}
+	tls := []netv1alpha1.IngressTLS{{
+		Hosts:      []string{"*.default.domain.com"},
+		SecretName: "secret",
+	}}
 	expected := &netv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",


### PR DESCRIPTION
We require the schema specified for `type: kubernetes.io/tls`

Fixes: https://github.com/knative/serving/issues/6322

