### PR TITLE
Fix TestMain usage in conformance

### DIFF
--- a/test/conformance/api/v1/main_test.go
+++ b/test/conformance/api/v1/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Knative Authors
 

--- a/test/conformance/api/v1/main_test.go
+++ b/test/conformance/api/v1/main_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	pkgTest "knative.dev/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
+}

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -18,14 +18,11 @@ package v1
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
-	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
@@ -339,10 +336,4 @@ func validateImageDigest(imageName string, imageDigest string) (bool, error) {
 	}
 
 	return ref.Context().String() == digest.Context().String(), nil
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	pkgTest.SetupLoggingFlags()
-	os.Exit(m.Run())
 }

--- a/test/conformance/api/v1alpha1/main_test.go
+++ b/test/conformance/api/v1alpha1/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Knative Authors
 

--- a/test/conformance/api/v1alpha1/main_test.go
+++ b/test/conformance/api/v1alpha1/main_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	pkgTest "knative.dev/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
+}

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -18,14 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
-	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
@@ -339,10 +336,4 @@ func validateImageDigest(imageName string, imageDigest string) (bool, error) {
 	}
 
 	return ref.Context().String() == digest.Context().String(), nil
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	pkgTest.SetupLoggingFlags()
-	os.Exit(m.Run())
 }

--- a/test/conformance/api/v1beta1/main_test.go
+++ b/test/conformance/api/v1beta1/main_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	pkgTest "knative.dev/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
+}

--- a/test/conformance/api/v1beta1/main_test.go
+++ b/test/conformance/api/v1beta1/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Knative Authors
 

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -18,14 +18,11 @@ package v1beta1
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
-	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
@@ -339,10 +336,4 @@ func validateImageDigest(imageName string, imageDigest string) (bool, error) {
 	}
 
 	return ref.Context().String() == digest.Context().String(), nil
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	pkgTest.SetupLoggingFlags()
-	os.Exit(m.Run())
 }

--- a/test/conformance/runtime/main_test.go
+++ b/test/conformance/runtime/main_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	pkgTest "knative.dev/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	pkgTest.SetupLoggingFlags()
+	os.Exit(m.Run())
+}

--- a/test/conformance/runtime/main_test.go
+++ b/test/conformance/runtime/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Knative Authors
 

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -18,9 +18,7 @@ package runtime
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
-	"os"
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
@@ -95,10 +93,4 @@ func splitOpts(opts ...interface{}) ([]v1alpha1testing.ServiceOption, []interfac
 
 	}
 	return serviceOpts, reqOpts, nil
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	pkgTest.SetupLoggingFlags()
-	os.Exit(m.Run())
 }


### PR DESCRIPTION
TestMain must be in a file matching .+_test[.]go
Does not work with in util.go or _test.go

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

```release-note
NONE
```
