### PR TITLE
Add IngressKeyLabel to child VirtualServices of an Ingress.

### DIFF
--- a/pkg/reconciler/accessor/istio/virtualservice.go
+++ b/pkg/reconciler/accessor/istio/virtualservice.go
@@ -38,6 +38,12 @@ type VirtualServiceAccessor interface {
 	GetVirtualServiceLister() istiolisters.VirtualServiceLister
 }
 
+func hasDesiredDiff(current, desired *v1alpha3.VirtualService) bool {
+	return !equality.Semantic.DeepEqual(current.Spec, desired.Spec) ||
+		!equality.Semantic.DeepEqual(current.Labels, desired.Labels) ||
+		!equality.Semantic.DeepEqual(current.Annotations, desired.Annotations)
+}
+
 // ReconcileVirtualService reconciles VirtiualService to the desired status.
 func ReconcileVirtualService(ctx context.Context, owner kmeta.Accessor, desired *v1alpha3.VirtualService,
 	vsAccessor VirtualServiceAccessor) (*v1alpha3.VirtualService, error) {
@@ -64,7 +70,7 @@ func ReconcileVirtualService(ctx context.Context, owner kmeta.Accessor, desired 
 		return nil, kaccessor.NewAccessorError(
 			fmt.Errorf("owner: %s with Type %T does not own VirtualService: %q", owner.GetName(), owner, name),
 			kaccessor.NotOwnResource)
-	} else if !equality.Semantic.DeepEqual(vs.Spec, desired.Spec) {
+	} else if hasDesiredDiff(vs, desired) {
 		// Don't modify the informers copy
 		existing := vs.DeepCopy()
 		existing.Spec = desired.Spec

--- a/pkg/reconciler/accessor/istio/virtualservice.go
+++ b/pkg/reconciler/accessor/istio/virtualservice.go
@@ -74,6 +74,8 @@ func ReconcileVirtualService(ctx context.Context, owner kmeta.Accessor, desired 
 		// Don't modify the informers copy
 		existing := vs.DeepCopy()
 		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		existing.Annotations = desired.Annotations
 		vs, err = vsAccessor.GetIstioClient().NetworkingV1alpha3().VirtualServices(ns).Update(existing)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update VirtualService: %w", err)

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -263,6 +263,7 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ia *v1alpha1.
 	}
 
 	// Now, remove the extra ones.
+	// TODO(https://github.com/knative/serving/issues/6363):  Switch to use networking.IngressLabelKey instead.
 	vses, err := r.virtualServiceLister.VirtualServices(resources.VirtualServiceNamespace(ia)).List(
 		labels.Set(map[string]string{
 			serving.RouteLabelKey:          ia.GetLabels()[serving.RouteLabelKey],

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -261,6 +261,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-failed",
 					Namespace: "test-ns",
 					Labels: map[string]string{
+						networking.IngressLabelKey:     "reconcile-failed",
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
@@ -315,6 +316,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice",
 					Namespace: "test-ns",
 					Labels: map[string]string{
+						networking.IngressLabelKey:     "reconcile-virtualservice",
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
@@ -327,6 +329,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice-extra",
 					Namespace: "test-ns",
 					Labels: map[string]string{
+						networking.IngressLabelKey:     "reconcile-virtualservice",
 						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
+	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/network/ingress"
@@ -59,13 +60,10 @@ func MakeIngressVirtualService(ia *v1alpha1.Ingress, gateways map[v1alpha1.Ingre
 	}
 
 	// Populate the Ingress labels.
-	if vs.Labels == nil {
-		vs.Labels = make(map[string]string)
-	}
-
-	ingressLabels := ia.GetLabels()
-	vs.Labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
-	vs.Labels[serving.RouteNamespaceLabelKey] = ingressLabels[serving.RouteNamespaceLabelKey]
+	vs.Labels = resources.FilterMap(ia.GetLabels(), func(k string) bool {
+		return k != serving.RouteLabelKey && k != serving.RouteNamespaceLabelKey
+	})
+	vs.Labels[networking.IngressLabelKey] = ia.Name
 	return vs
 }
 
@@ -87,10 +85,11 @@ func MakeMeshVirtualService(ia *v1alpha1.Ingress) *v1alpha3.VirtualService {
 			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("mesh"),
 		}, hosts),
 	}
+	// Populate the Ingress labels.
 	vs.Labels = resources.FilterMap(ia.GetLabels(), func(k string) bool {
 		return k != serving.RouteLabelKey && k != serving.RouteNamespaceLabelKey
 	})
-
+	vs.Labels[networking.IngressLabelKey] = ia.Name
 	return vs
 }
 

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -53,6 +53,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 				Name:      "test-ingress",
 				Namespace: system.Namespace(),
 				Labels: map[string]string{
+					networking.IngressLabelKey:     "test-ingress",
 					serving.RouteLabelKey:          "test-route",
 					serving.RouteNamespaceLabelKey: "test-ns",
 				},
@@ -69,6 +70,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress-mesh",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
@@ -76,6 +78,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
@@ -104,6 +107,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
@@ -132,6 +136,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress-mesh",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
@@ -160,6 +165,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress-mesh",
 			Namespace: "test-ns",
 			Labels: map[string]string{
+				networking.IngressLabelKey:     "test-ingress",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},


### PR DESCRIPTION
This is to prepare for https://github.com/knative/serving/issues/6363.  We should be able to fix https://github.com/knative/serving/issues/6363 after we roll this change out in v0.12.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Add IngressKeyLabel to child VirtualServices of an Ingress.
*  Propagate annotations and labels changes from Ingress to VirtualServices.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
