### PR TITLE
Add a conformance test for Retry attempts in Ingress.

### DIFF
--- a/test/conformance/ingress/retry_test.go
+++ b/test/conformance/ingress/retry_test.go
@@ -122,9 +122,9 @@ func TestRetry(t *testing.T) {
 				}
 				defer resp.Body.Close()
 				if want, got := current, resp.StatusCode; got != want {
-					t.Errorf("unexpected status: %d, wanted %d", got, want)
+					t.Errorf("Status = %d, wanted %d", got, want)
+					DumpResponse(t, resp)
 				}
-				DumpResponse(t, resp)
 				// Swap things.
 				current, next = next, current
 			}

--- a/test/conformance/ingress/retry_test.go
+++ b/test/conformance/ingress/retry_test.go
@@ -1,0 +1,140 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestRetry verifies that an Ingress configured to retry N times properly masks transient failures.
+func TestRetry(t *testing.T) {
+	for i := 2; i < 12; i++ {
+		i := i
+		t.Run(fmt.Sprintf("period=%d,attempts=%d", i, i), func(t *testing.T) {
+			t.Parallel()
+			clients := test.Setup(t)
+			// When the period matches, then it shouldn't fail.
+			name, port, cancel := CreateFlakyService(t, clients, i)
+			defer cancel()
+
+			domain := name + ".example.com"
+
+			// Create a simple Ingress over the Service.
+			_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{domain},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Retries: retries(i),
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      name,
+									ServiceNamespace: test.ServingNamespace,
+									ServicePort:      intstr.FromInt(port),
+								},
+							}},
+						}},
+					},
+				}},
+			})
+			defer cancel()
+
+			for j := 0; j < 5; j++ {
+				resp, err := client.Get("http://" + domain)
+				if err != nil {
+					t.Errorf("Error making GET request: %v", err)
+					continue
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("Got non-OK status: %d", resp.StatusCode)
+					DumpResponse(t, resp)
+				}
+			}
+		})
+
+		t.Run(fmt.Sprintf("period=%d,attempts=%d", i, i-1), func(t *testing.T) {
+			t.Parallel()
+			clients := test.Setup(t)
+			// When the period matches, then it shouldn't fail.
+			name, port, cancel := CreateFlakyService(t, clients, i)
+			defer cancel()
+
+			domain := name + ".example.com"
+
+			// Create a simple Ingress over the Service.
+			_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{domain},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Retries: retries(i - 1),
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      name,
+									ServiceNamespace: test.ServingNamespace,
+									ServicePort:      intstr.FromInt(port),
+								},
+							}},
+						}},
+					},
+				}},
+			})
+			defer cancel()
+
+			// When the period is one more than the number of attempts (retries+1), then what we should see is:
+			//   500 {count=4}
+			//   200 {count=5}
+			//   500 {count=9}
+			//   200 {count=10}
+			//   500 {count=14}
+			//   200 {count=15}
+			current, next := http.StatusInternalServerError, http.StatusOK
+			for j := 0; j < 5; j++ {
+				resp, err := client.Get("http://" + domain)
+				if err != nil {
+					t.Errorf("Error making GET request: %v", err)
+					continue
+				}
+				defer resp.Body.Close()
+				if want, got := current, resp.StatusCode; got != want {
+					t.Errorf("unexpected status: %d, wanted %d", got, want)
+				}
+				DumpResponse(t, resp)
+				// Swap things.
+				current, next = next, current
+			}
+		})
+	}
+}
+
+func retries(attempts int) *v1alpha1.HTTPRetry {
+	return &v1alpha1.HTTPRetry{
+		// retries is one less than the number of attempts
+		Attempts: attempts - 1,
+	}
+}

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -187,6 +187,80 @@ func CreateTimeoutService(t *testing.T, clients *test.Clients) (string, int, con
 	return name, port, createPodAndService(t, clients, pod, svc)
 }
 
+// CreateFlakyService creates a Kubernetes service where the backing pod will
+// succeed only every Nth request.
+func CreateFlakyService(t *testing.T, clients *test.Clients, period int) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("flaky"),
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameHTTP1,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}, {
+					Name:  "PERIOD",
+					Value: strconv.Itoa(period),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/",
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameHTTP1,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(int(containerPort)),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(t, clients, pod, svc)
+}
+
 // CreateWebsocketService creates a Kubernetes service that will upgrade the connection
 // to use websockets and echo back the received messages with the provided suffix.
 func CreateWebsocketService(t *testing.T, clients *test.Clients, suffix string) (string, int, context.CancelFunc) {

--- a/test/test_images/flaky/README.md
+++ b/test/test_images/flaky/README.md
@@ -1,0 +1,15 @@
+# Flaky test image
+
+The image contains a simple Go webserver, `main.go`, that will only succeed every Nth request.
+The value of N is specified in the PERIOD environment variable.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/flaky/main.go
+++ b/test/test_images/flaky/main.go
@@ -43,10 +43,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	// Increment the request count per non-probe request.
 	val := atomic.AddUint64(&count, 1)
 
-	switch val % period {
-	case 0:
-		w.WriteHeader(http.StatusOK)
-	default:
+	if val%period > 0 {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.Write([]byte(fmt.Sprintf("count = %d", val)))

--- a/test/test_images/flaky/main.go
+++ b/test/test_images/flaky/main.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+
+	"knative.dev/serving/pkg/network"
+	"knative.dev/serving/test"
+)
+
+var (
+	period uint64
+	count  uint64
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Always succeed probes.
+	if network.IsKubeletProbe(r) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Increment the request count per non-probe request.
+	val := atomic.AddUint64(&count, 1)
+
+	switch val % period {
+	case 0:
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	w.Write([]byte(fmt.Sprintf("count = %d", val)))
+}
+
+func main() {
+	p, err := strconv.Atoi(os.Getenv("PERIOD"))
+	if err != nil {
+		log.Fatal("Must specify PERIOD environment variable.")
+	} else if p < 1 {
+		log.Fatalf("Period must be positive, got: %d", p)
+	}
+	period = uint64(p)
+	h := network.NewProbeHandler(http.HandlerFunc(handler))
+	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+}

--- a/test/test_images/flaky/service.yaml
+++ b/test/test_images/flaky/service.yaml
@@ -9,6 +9,6 @@ spec:
       containers:
       - image: knative.dev/serving/test/test_images/flaky
         env:
-        # Succeed every third request.
+        # Succeed every Nth request.
         - name: PERIOD
           value: "5"

--- a/test/test_images/flaky/service.yaml
+++ b/test/test_images/flaky/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: flaky-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/flaky
+        env:
+        # Succeed every third request.
+        - name: PERIOD
+          value: "5"


### PR DESCRIPTION
This adds a set of tests that verifies that the Ingress implementation properly retries server-side flakiness using the new "flaky" test image, which returns success once per period.

@tcnghia When I run this with Istio locally it fails, but passes with Contour and the semantics appear to be correct.