### PR TITLE
Switch to 'Set' semantic for header manipulations.

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -158,7 +158,7 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 		if len(split.AppendHeaders) > 0 {
 			h = &istiov1alpha3.Headers{
 				Request: &istiov1alpha3.Headers_HeaderOperations{
-					Add: split.AppendHeaders,
+					Set: split.AppendHeaders,
 				},
 			}
 		}
@@ -180,7 +180,7 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 	if len(http.AppendHeaders) > 0 {
 		h = &istiov1alpha3.Headers{
 			Request: &istiov1alpha3.Headers_HeaderOperations{
-				Add: http.AppendHeaders,
+				Set: http.AppendHeaders,
 			},
 		}
 	}

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -290,7 +290,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Weight: 100,
 			Headers: &istiov1alpha3.Headers{
 				Request: &istiov1alpha3.Headers_HeaderOperations{
-					Add: map[string]string{
+					Set: map[string]string{
 						"ugh": "blah",
 					},
 				},
@@ -298,7 +298,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		}},
 		Headers: &istiov1alpha3.Headers{
 			Request: &istiov1alpha3.Headers_HeaderOperations{
-				Add: map[string]string{
+				Set: map[string]string{
 					"foo": "bar",
 				},
 			},
@@ -428,7 +428,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Weight: 100,
 			Headers: &istiov1alpha3.Headers{
 				Request: &istiov1alpha3.Headers_HeaderOperations{
-					Add: map[string]string{
+					Set: map[string]string{
 						"ugh": "blah",
 					},
 				},
@@ -436,7 +436,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		}},
 		Headers: &istiov1alpha3.Headers{
 			Request: &istiov1alpha3.Headers_HeaderOperations{
-				Add: map[string]string{
+				Set: map[string]string{
 					"foo": "bar",
 				},
 			},
@@ -466,7 +466,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		}},
 		Headers: &istiov1alpha3.Headers{
 			Request: &istiov1alpha3.Headers_HeaderOperations{
-				Add: map[string]string{
+				Set: map[string]string{
 					"foo": "baz",
 				},
 			},

--- a/test/conformance/ingress/headers_test.go
+++ b/test/conformance/ingress/headers_test.go
@@ -75,8 +75,6 @@ func TestPreSplitSetHeaders(t *testing.T) {
 	})
 
 	t.Run("Check with passing header", func(t *testing.T) {
-		t.Skip("https://github.com/knative/serving/issues/6303")
-
 		ri := RuntimeRequest(t, client, "http://"+name+".example.com", func(req *http.Request) {
 			// Specify a value for the header to verify that implementations
 			// use set vs. append semantics.
@@ -155,8 +153,6 @@ func TestPostSplitSetHeaders(t *testing.T) {
 	})
 
 	t.Run("Check with passing header", func(t *testing.T) {
-		t.Skip("https://github.com/knative/serving/issues/6303")
-
 		// Make enough requests that the likelihood of us seeing each variation is high,
 		// but don't check the distribution of requests, as that isn't the point of this
 		// particular test.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6303 

## Proposed Changes

*  Switch to 'Set' semantic for header manipulations.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
