### PR TITLE
Widen the default retriable conditions.

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -36,7 +36,13 @@ import (
 	"knative.dev/serving/pkg/resources"
 )
 
-var retriableConditions = strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ",")
+var retriableConditions = strings.Join([]string{
+	"5xx",
+	"connect-failure",
+	"refused-stream",
+	"cancelled",
+	"resource-exhausted",
+	"retriable-status-codes"}, ",")
 
 // VirtualServiceNamespace gives the namespace of the child
 // VirtualServices for a given Ingress.

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -36,6 +36,8 @@ import (
 	"knative.dev/serving/pkg/resources"
 )
 
+var retriableConditions = strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ",")
+
 // VirtualServiceNamespace gives the namespace of the child
 // VirtualServices for a given Ingress.
 func VirtualServiceNamespace(ia *v1alpha1.Ingress) string {
@@ -191,7 +193,7 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 		Timeout: types.DurationProto(http.Timeout.Duration),
 		Retries: &istiov1alpha3.HTTPRetry{
 			// TODO(https://github.com/knative/serving/issues/6367): Allow customization of this.
-			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
+			RetryOn:       retriableConditions,
 			Attempts:      int32(http.Retries.Attempts),
 			PerTryTimeout: types.DurationProto(http.Retries.PerTryTimeout.Duration),
 		},

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -190,6 +190,8 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 		Route:   weights,
 		Timeout: types.DurationProto(http.Timeout.Duration),
 		Retries: &istiov1alpha3.HTTPRetry{
+			// TODO(https://github.com/knative/serving/issues/6367): Allow customization of this.
+			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
 			Attempts:      int32(http.Retries.Attempts),
 			PerTryTimeout: types.DurationProto(http.Retries.PerTryTimeout.Duration),
 		},

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -306,7 +305,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
-			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
+			RetryOn:       retriableConditions,
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -445,7 +444,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
-			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
+			RetryOn:       retriableConditions,
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -476,7 +475,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
-			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
+			RetryOn:       retriableConditions,
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -529,7 +528,7 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 		}},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
-			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
+			RetryOn:       retriableConditions,
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -587,7 +586,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 		}},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
-			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
+			RetryOn:       retriableConditions,
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -305,6 +306,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
+			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -443,6 +445,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
+			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -473,6 +476,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
+			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -525,6 +529,7 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 		}},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
+			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},
@@ -582,6 +587,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 		}},
 		Timeout: types.DurationProto(defaultMaxRevisionTimeout),
 		Retries: &istiov1alpha3.HTTPRetry{
+			RetryOn:       strings.Join([]string{"5xx", "connect-failure", "refused-stream", "cancelled", "resource-exhausted", "retriable-status-codes"}, ","),
 			Attempts:      int32(networking.DefaultRetryCount),
 			PerTryTimeout: types.DurationProto(defaultMaxRevisionTimeout),
 		},


### PR DESCRIPTION
We should follow this up by fixing https://github.com/knative/serving/issues/6367 for real.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Widen the default retriable conditions.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
