### PR TITLE
Try to make probe ordering more consistent to see if we can reduce prober test flakes

### DIFF
--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -193,7 +193,8 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 
 	allPodIPs := sets.NewString()
 	for _, target := range allProbeTargets {
-		for ip := range target.PodIPs {
+		// Iterate through sorted Pod IPs, for a consistent order.
+		for _, ip := range target.PodIPs.List() {
 			allPodIPs.Insert(ip)
 			// Each Pod is probed using the different hosts, protocol and ports until
 			// one of the probing calls succeeds. Then, the Pod is considered ready and all pending work items


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*  Make probe ordering more consistent.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
