### PR TITLE
Print WindowMin insead of BucketSize in validation error

### DIFF
--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -205,7 +205,7 @@ func validate(lc *Config) (*Config, error) {
 
 	// We can't permit stable window be less than our aggregation window for correctness.
 	if lc.StableWindow < autoscaling.WindowMin {
-		return nil, fmt.Errorf("stable-window = %v, must be at least %v", lc.StableWindow, BucketSize)
+		return nil, fmt.Errorf("stable-window = %v, must be at least %v", lc.StableWindow, autoscaling.WindowMin)
 	}
 	if lc.StableWindow.Round(time.Second) != lc.StableWindow {
 		return nil, fmt.Errorf("stable-window = %v, must be specified with at most second precision", lc.StableWindow)


### PR DESCRIPTION
This patch makes a tiny change which replaces `BucketSize` with
`autoscaling.WindowMin`in validation error message.

`autoscaling.WindowMin` is used for the comparison from commit
3b33caeae013e0e8eb3c5f5f7f77e50027f3c0dc, but the error message was not updated.

/lint

**Release Note**

```release-note
NONE
```

/assign @vagababov @markusthoemmes