### PR TITLE
Perform multiple styles of update.

### DIFF
--- a/test/conformance/ingress/update_test.go
+++ b/test/conformance/ingress/update_test.go
@@ -90,8 +90,6 @@ func TestUpdate(t *testing.T) {
 								ServiceNamespace: test.ServingNamespace,
 								ServicePort:      intstr.FromInt(firstPort),
 							},
-							// Append different headers to each split, which lets us identify
-							// which backend we hit.
 							AppendHeaders: map[string]string{
 								updateHeaderName: sentinel,
 							},
@@ -135,8 +133,6 @@ func TestUpdate(t *testing.T) {
 								ServiceNamespace: test.ServingNamespace,
 								ServicePort:      intstr.FromInt(nextPort),
 							},
-							// Append different headers to each split, which lets us identify
-							// which backend we hit.
 							AppendHeaders: map[string]string{
 								updateHeaderName: sentinel,
 							},


### PR DESCRIPTION
The intent of this is to help Ingress authors distinguish between problems propagating different types of programming.

For instance, if the propagation of endpoints falls behind the propagation of routing information the existing test should fail, but not the new one.
