### PR TITLE
Add support for NodeSelector

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -148,6 +148,7 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.Containers = in.Containers
 	out.Volumes = in.Volumes
 	out.ImagePullSecrets = in.ImagePullSecrets
+	out.NodeSelector = in.NodeSelector
 
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
@@ -156,7 +157,6 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.TerminationGracePeriodSeconds = nil
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
-	out.NodeSelector = nil
 	out.AutomountServiceAccountToken = nil
 	out.NodeName = ""
 	out.HostNetwork = false

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -80,6 +80,9 @@ func TestVolumeSourceMask(t *testing.T) {
 func TestPodSpecMask(t *testing.T) {
 	want := &corev1.PodSpec{
 		ServiceAccountName: "default",
+		NodeSelector: map[string]string{
+			"test-selector-key": "test-selector-value",
+		},
 		ImagePullSecrets: []corev1.LocalObjectReference{{
 			Name: "foo",
 		}},
@@ -97,6 +100,9 @@ func TestPodSpecMask(t *testing.T) {
 	}
 	in := &corev1.PodSpec{
 		ServiceAccountName: "default",
+		NodeSelector: map[string]string{
+			"test-selector-key": "test-selector-value",
+		},
 		ImagePullSecrets: []corev1.LocalObjectReference{{
 			Name: "foo",
 		}},

--- a/pkg/apis/serving/v1alpha1/configuration_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/configuration_conversion_test.go
@@ -89,6 +89,9 @@ func TestConfigurationConversion(t *testing.T) {
 					Spec: RevisionSpec{
 						RevisionSpec: v1.RevisionSpec{
 							PodSpec: corev1.PodSpec{
+								NodeSelector: map[string]string{
+									"test-selector-key": "test-selector-value",
+								},
 								ServiceAccountName: "robocop",
 								ImagePullSecrets: []corev1.LocalObjectReference{{
 									Name: "foo",

--- a/pkg/apis/serving/v1alpha1/revision_conversion.go
+++ b/pkg/apis/serving/v1alpha1/revision_conversion.go
@@ -62,6 +62,7 @@ func (source *RevisionSpec) ConvertUp(ctx context.Context, sink *v1.RevisionSpec
 			Containers:         []corev1.Container{*source.DeprecatedContainer},
 			Volumes:            source.Volumes,
 			ImagePullSecrets:   source.ImagePullSecrets,
+			NodeSelector:       source.NodeSelector,
 		}
 	case len(source.Containers) == 1:
 		sink.PodSpec = source.PodSpec

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -161,6 +161,7 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, tracingC
 		ServiceAccountName:            rev.Spec.ServiceAccountName,
 		TerminationGracePeriodSeconds: rev.Spec.TimeoutSeconds,
 		ImagePullSecrets:              rev.Spec.ImagePullSecrets,
+		NodeSelector:                  rev.Spec.NodeSelector,
 	}
 
 	// Add the Knative internal volume only if /var/log collection is enabled

--- a/pkg/testing/v1alpha1/revision.go
+++ b/pkg/testing/v1alpha1/revision.go
@@ -105,6 +105,16 @@ func WithImagePullSecrets(secretName string) RevisionOption {
 	}
 }
 
+// WithNodeSelector updates the revision spec NodeSelector to
+// the provided key and value
+func WithNodeSelector(nodeSelectorKey, nodeSelectorValue string) RevisionOption {
+	return func(rev *v1alpha1.Revision) {
+		rev.Spec.NodeSelector = map[string]string{
+			nodeSelectorKey: nodeSelectorValue,
+		}
+	}
+}
+
 // MarkActive calls .Status.MarkActive on the Revision.
 func MarkActive(r *v1alpha1.Revision) {
 	r.Status.MarkActiveTrue()

--- a/test/apicoverage/image/kodata/ignoredfields.yaml
+++ b/test/apicoverage/image/kodata/ignoredfields.yaml
@@ -90,7 +90,6 @@
     - TerminationGracePeriodSeconds
     - ActiveDeadlineSeconds
     - DNSPolicy
-    - NodeSelector
     - AutomountServiceAccountToken
     - NodeName
     - HostNetwork


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1816

## Proposed Changes

* Adds support for [NodeSelector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) to Service, Configuration, and Revision

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allows a user to configure the NodeSelector which will be passed down to the Pod.
```
