### PR TITLE
Actually pass GOGC to the activator.

### DIFF
--- a/config/activator-hpa.yaml
+++ b/config/activator-hpa.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+    minReplicas: 1
+    maxReplicas: 20
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: activator
+    metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        # Percentage of the requested CPU
+        targetAverageUtilization: 100

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -43,10 +43,6 @@ spec:
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: knative.dev/serving/cmd/activator
-        env:
-          # Run Activator with GC collection when newly generated memory is 500%
-          - name: GOGC
-            value: 500
         ports:
         - name: http1
           containerPort: 8012
@@ -106,24 +102,3 @@ spec:
             value: knative.dev/internal/serving
         securityContext:
           allowPrivilegeEscalation: false
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: activator
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: devel
-spec:
-    minReplicas: 1
-    maxReplicas: 20
-    scaleTargetRef:
-      apiVersion: apps/v1
-      kind: Deployment
-      name: activator
-    metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        # Percentage of the requested CPU
-        targetAverageUtilization: 100


### PR DESCRIPTION
This didn't actually happen because... yaml.

Also split the activator yaml into two files.

