### PR TITLE
Drop istio-specific annotations on Deployments/Namespaces.

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -17,5 +17,6 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
+    # TODO(mattmoor): We should not require any istio annotations.
     istio-injection: enabled
     serving.knative.dev/release: devel

--- a/config/400-autoscaler-hpa-service.yaml
+++ b/config/400-autoscaler-hpa-service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,23 +16,20 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    role: webhook
+    app: autoscaler-hpa
     serving.knative.dev/release: devel
-  name: webhook
+    autoscaling.knative.dev/autoscaler-provider: hpa
+  name: autoscaler-hpa
   namespace: knative-serving
 spec:
   ports:
-    - name: https-webhook
-      port: 443
-      targetPort: 8443
-    # These exist because if they aren't here Envoy fails to come up.
-    - name: http-profiling
-      port: 8008
-      protocol: TCP
-      targetPort: 8008
-    - name: http-metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    protocol: TCP
+    targetPort: 8008
   selector:
-    role: webhook
+    app: autoscaler-hpa

--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -26,5 +26,9 @@ spec:
     port: 9090
     protocol: TCP
     targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    protocol: TCP
+    targetPort: 8008
   selector:
     app: controller

--- a/config/400-sutoscaler-service.yaml
+++ b/config/400-sutoscaler-service.yaml
@@ -30,6 +30,10 @@ spec:
     port: 9090
     protocol: TCP
     targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    protocol: TCP
+    targetPort: 8008
   - name: https-custom-metrics
     port: 443
     protocol: TCP

--- a/config/activator.yaml
+++ b/config/activator.yaml
@@ -28,7 +28,6 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "true"
       labels:
         app: activator
         role: activator

--- a/config/autoscaler-hpa.yaml
+++ b/config/autoscaler-hpa.yaml
@@ -27,8 +27,6 @@ spec:
       app: autoscaler-hpa
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: autoscaler-hpa
         serving.knative.dev/release: devel

--- a/config/autoscaler.yaml
+++ b/config/autoscaler.yaml
@@ -28,11 +28,6 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "true"
-        # traffic.sidecar.istio.io/excludeInboundPorts: 8443 didn't work as
-        # expected and still firewalled the given port off. Using a whitelist
-        # instead works as expected.
-        traffic.sidecar.istio.io/includeInboundPorts: "8080,9090"
       labels:
         app: autoscaler
         serving.knative.dev/release: devel

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -74,9 +74,6 @@ data:
     #
     istio.sidecar.includeOutboundIPRanges: "*"
 
-    # clusteringress.class has been deprecated.   Please use ingress.class instead.
-    clusteringress.class: "istio.ingress.networking.knative.dev"
-
     # ingress.class specifies the default ingress class
     # to use when not dictated by Route annotation.
     #

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -26,8 +26,6 @@ spec:
       app: controller
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: controller
         serving.knative.dev/release: devel

--- a/config/networking-certmanager.yaml
+++ b/config/networking-certmanager.yaml
@@ -27,8 +27,6 @@ spec:
       app: networking-certmanager
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: networking-certmanager
         serving.knative.dev/release: devel

--- a/config/networking-istio.yaml
+++ b/config/networking-istio.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        # This must be outside of the mesh to probe the gateways.
         sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio

--- a/config/networking-ns-cert.yaml
+++ b/config/networking-ns-cert.yaml
@@ -27,8 +27,6 @@ spec:
       app: networking-ns-cert
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: networking-ns-cert
     spec:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -29,7 +29,6 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "false"
       labels:
         app: webhook
         role: webhook


### PR DESCRIPTION
A lot of the manual sidecar labeling goes back to a time where Istio was much less mature, we always enabled the mesh, and Istio wasn't optional.

This also has a couple other minor cleanups e.g. deleting clusteringress.class from config-network.

/hold

I'd like to make sure @tcnghia is on-board with this.