### PR TITLE
Add a missing profiling port.

### DIFF
--- a/config/networking-ns-cert.yaml
+++ b/config/networking-ns-cert.yaml
@@ -48,6 +48,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
I noticed this was missing when comparing our various Deployment yamls.