### PR TITLE
Add BufferPool implementation to the activator and queue-proxy handler.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -444,7 +444,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, req
 	httpProxy := httputil.NewSingleHostReverseProxy(target)
 	httpProxy.Transport = buildTransport(env, logger)
 	httpProxy.ErrorHandler = pkgnet.ErrorHandler(logger)
-
+	httpProxy.BufferPool = network.NewBufferPool()
 	httpProxy.FlushInterval = -1
 	activatorutil.SetupHeaderPruning(httpProxy)
 

--- a/pkg/network/bufferpool.go
+++ b/pkg/network/bufferpool.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"net/http/httputil"
+	"sync"
+)
+
+// bufferPool implements the BufferPool interface to be used in
+// httputil.ReverseProxy. It stores pointers to to slices to
+// further avoid allocations, see https://staticcheck.io/docs/checks#SA6002.
+type bufferPool struct {
+	pool *sync.Pool
+}
+
+// NewBufferPool creates a new BytePool.
+func NewBufferPool() httputil.BufferPool {
+	return &bufferPool{
+		pool: &sync.Pool{},
+	}
+}
+
+// Get gets a []byte from the bufferPool, or creates a new one if none are
+// available in the pool.
+func (b *bufferPool) Get() []byte {
+	buf := b.pool.Get()
+	if buf == nil {
+		// Use the default buffer size as defined in the ReverseProxy itself.
+		return make([]byte, 32*1024)
+	}
+
+	return *buf.(*[]byte)
+}
+
+// Put returns the given Buffer to the bufferPool.
+func (b *bufferPool) Put(buffer []byte) {
+	b.pool.Put(&buffer)
+}

--- a/pkg/network/bufferpool.go
+++ b/pkg/network/bufferpool.go
@@ -28,7 +28,9 @@ type bufferPool struct {
 	pool *sync.Pool
 }
 
-// NewBufferPool creates a new BytePool.
+// NewBufferPool creates a new BytePool. This is only safe to use in the context
+// of a httputil.ReverseProxy, as the buffers returned via Put are not cleaned
+// explicitly.
 func NewBufferPool() httputil.BufferPool {
 	return &bufferPool{
 		pool: &sync.Pool{},

--- a/pkg/network/bufferpool_test.go
+++ b/pkg/network/bufferpool_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	pkgnet "knative.dev/pkg/network"
+)
+
+func TestBufferPool(t *testing.T) {
+	pool := NewBufferPool()
+	// Transparently creates a new buffer
+	buf := pool.Get()
+	if got, want := len(buf), 32*1024; got != want {
+		t.Errorf("len(buf) = %d, want %d", got, want)
+	}
+}
+
+// TestBufferPoolInReverseProxy asserts correctness of the pool in context
+// of the httputil.ReverseProxy. It makes sure that the behavior around
+// slice "cleanup" is correct and that slices returned to the pool do not
+// pollute later requests.
+func TestBufferPoolInReverseProxy(t *testing.T) {
+	want := "The testmessage successfully made its way through the roundtripper."
+
+	url := &url.URL{}
+	proxy := httputil.NewSingleHostReverseProxy(url)
+
+	pool := NewBufferPool()
+	proxy.BufferPool = pool
+	proxy.Transport = pkgnet.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		recorder := httptest.NewRecorder()
+		recorder.WriteString(want)
+		return recorder.Result(), nil
+	})
+
+	pool.Put([]byte("I'm polluting this pool with a buffer that's not empty."))
+	pool.Put([]byte("I'm adding a little less."))
+	pool.Put([]byte("And I'm even adding more info than the first message did, for sanity."))
+
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, url.String(), nil)
+	proxy.ServeHTTP(recorder, req)
+
+	if got := recorder.Body.String(); got != want {
+		t.Errorf("res.Body = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This adds pooling of the buffers needed to reverse proxy every request from the activator to reduce the burden on memory allocation and likewise on garbage collection.

**Note:** This implementation currently does not explicitly clean the slices as they are returned to the pool. The ReverseProxy's implementation of copyBuffer doesn't seem to require a cleaned buffer to be returned.

### Prior Art:
- https://github.com/cloudfoundry/gorouter/blob/master/proxy/buffer_pool.go (This is loosely based on this implementation, with a few tweaks)
- https://github.com/oxtoacart/bpool (based on channels etc. I opted to use sync.Pool manually as that seemed to be the intended solution by Golang's creators. See https://blog.questionable.services/article/using-buffer-pools-with-go/#postscript for more info on the thought process on their side. We could potentially swap to this implementation)
- https://github.com/valyala/bytebufferpool (part of fasthttp but the ByteBuffer types make it annoying to use in our use-case, especially with allocations in mind)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Reduced memory churn in the activator by pooling byte slices.
```

/assign @vagababov 
