### PR TITLE
Allocate tracing transport only once.

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -69,10 +69,11 @@ const defaulTimeout = 2 * time.Minute
 
 // New constructs a new http.Handler that deals with revision activation.
 func New(ctx context.Context, t Throttler, sr activator.StatsReporter) http.Handler {
+	defaultTransport := pkgnet.AutoTransport
 	return &activationHandler{
 		logger:           logging.FromContext(ctx),
-		transport:        pkgnet.AutoTransport,
-		tracingTransport: &ochttp.Transport{Base: pkgnet.AutoTransport},
+		transport:        defaultTransport,
+		tracingTransport: &ochttp.Transport{Base: defaultTransport},
 		reporter:         sr,
 		throttler:        t,
 		bufferPool:       network.NewBufferPool(),

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -54,11 +54,12 @@ type Throttler interface {
 // activationHandler will wait for an active endpoint for a revision
 // to be available before proxing the request
 type activationHandler struct {
-	logger     *zap.SugaredLogger
-	transport  http.RoundTripper
-	reporter   activator.StatsReporter
-	throttler  Throttler
-	bufferPool httputil.BufferPool
+	logger           *zap.SugaredLogger
+	transport        http.RoundTripper
+	tracingTransport http.RoundTripper
+	reporter         activator.StatsReporter
+	throttler        Throttler
+	bufferPool       httputil.BufferPool
 
 	revisionLister servinglisters.RevisionLister
 }
@@ -69,12 +70,13 @@ const defaulTimeout = 2 * time.Minute
 // New constructs a new http.Handler that deals with revision activation.
 func New(ctx context.Context, t Throttler, sr activator.StatsReporter) http.Handler {
 	return &activationHandler{
-		logger:         logging.FromContext(ctx),
-		transport:      pkgnet.AutoTransport,
-		reporter:       sr,
-		throttler:      t,
-		bufferPool:     network.NewBufferPool(),
-		revisionLister: revisioninformer.Get(ctx).Lister(),
+		logger:           logging.FromContext(ctx),
+		transport:        pkgnet.AutoTransport,
+		tracingTransport: &ochttp.Transport{Base: pkgnet.AutoTransport},
+		reporter:         sr,
+		throttler:        t,
+		bufferPool:       network.NewBufferPool(),
+		revisionLister:   revisioninformer.Get(ctx).Lister(),
 	}
 }
 
@@ -142,11 +144,7 @@ func (a *activationHandler) proxyRequest(logger *zap.SugaredLogger, w http.Respo
 	proxy.BufferPool = a.bufferPool
 	proxy.Transport = a.transport
 	if config := activatorconfig.FromContext(r.Context()); config.Tracing.Backend != tracingconfig.None {
-		// When we collect metrics, we're wrapping the RoundTripper
-		// the proxy would use inside an annotating transport.
-		proxy.Transport = &ochttp.Transport{
-			Base: a.transport,
-		}
+		proxy.Transport = a.tracingTransport
 	}
 	proxy.FlushInterval = -1
 	proxy.ErrorHandler = pkgnet.ErrorHandler(logger)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This is a static value anyway as the underlying transport remains static as well. I would even favor to not even look up the config per request but that'd require more invasive changes into the handler interface I punted on for now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
