### PR TITLE
Generalize and release the default-domain Job.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -237,7 +237,7 @@ export K8S_CLUSTER_REGION="my-cluster-region"
 ./hack/dev-patch-config-gke.sh my-k8s-cluster-name
 
 # Run post-install job to setup nice XIP.IO domain name.  This only works
-# if your Kubernetes LoadBalancer has an IP address.
+# if your Kubernetes LoadBalancer has an IPv4 address.
 ko delete -f config/post-install --ignore-not-found
 ko apply -f config/post-install
 ```

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -20,14 +20,13 @@ metadata:
   labels:
     app: "default-domain"
     serving.knative.dev/release: devel
-    networking.knative.dev/ingress-provider: istio
 spec:
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
+      labels:
+        app: "default-domain"
+        serving.knative.dev/release: devel
     spec:
-      # Piggyback on the controller's service account.
       serviceAccountName: controller
       containers:
       - name: default-domain
@@ -35,24 +34,39 @@ spec:
         # and substituted here.
         image: knative.dev/serving/cmd/default-domain
         args: ["-magic-dns=xip.io"]
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe: &probe
+          httpGet:
+            port: 8080
+        livenessProbe: *probe
         env:
-          - name: SYSTEM_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        # We don't actually read these volume mounts, but using them
-        # to make sure the pod starts after the ConfigMaps exist.
-        volumeMounts:
-        - name: config-domain
-          mountPath: /etc/config-domain
-        - name: config-istio
-          mountPath: /etc/config-istio
-      volumes:
-        - name: config-domain
-          configMap:
-            name: config-domain
-        - name: config-istio
-          configMap:
-            name: config-istio
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       restartPolicy: Never
   backoffLimit: 10
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-domain-service
+  namespace: knative-serving
+  labels:
+    app: default-domain
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    app: default-domain
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  type: ClusterIP

--- a/test/config/100-istio-default-domain.yaml
+++ b/test/config/100-istio-default-domain.yaml
@@ -1,1 +1,0 @@
-../../config/post-install/100-istio-default-domain.yaml

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -679,7 +679,7 @@ func CreateDialContext(t *testing.T, ing *v1alpha1.Ingress, clients *test.Client
 	// keep our simple tests simple, thus the [0]s...
 
 	// We expect an ingress LB with the form foo.bar.svc.cluster.local (though
-	// we aren't strictly sensitive to the suffix, this is just illustrative.
+	// we aren't strictly sensitive to the suffix, this is just illustrative).
 	internalDomain := ing.Status.PublicLoadBalancer.Ingress[0].DomainInternal
 	parts := strings.SplitN(internalDomain, ".", 3)
 	if len(parts) < 3 {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -397,11 +397,6 @@ function test_setup() {
   # Clean up kail so it doesn't interfere with job shutting down
   trap "kill $kail_pid || true" EXIT
 
-  # Omit istio-specific setup logic when we aren't using istio.
-  if [[ -z "${ISTIO_VERSION}" ]]; then
-    KO_FLAGS="${KO_FLAGS} --selector=networking.knative.dev/ingress-provider!=istio"
-  fi
-
   echo ">> Creating test resources (test/config/)"
   ko apply ${KO_FLAGS} -f test/config/ || return 1
   if (( MESH )); then


### PR DESCRIPTION
As originally written the `default-domain` job worked in a very Istio-specific way.  This change generalizes it using similar techniques to what we do in `./test/conformance/ingress` to establish the external address of the Ingress provider, and using that to configure the `xip.io` default domain.

This also moves the Job from `config/post-install` (which we didn't release) to `config/core/post-install` which will include it in all of the yamls we ship once https://github.com/knative/serving/pull/6431 lands.
