### PR TITLE
Add a window total rolling computation.

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -28,7 +28,7 @@ import (
 type TimedFloat64Buckets struct {
 	bucketsMutex sync.RWMutex
 	buckets      []float64
-	// The total sum of valid buckets within the window.
+	// The total sum of all valid buckets within the window.
 	windowTotal float64
 	lastWrite   time.Time
 

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -28,7 +28,9 @@ import (
 type TimedFloat64Buckets struct {
 	bucketsMutex sync.RWMutex
 	buckets      []float64
-	lastWrite    time.Time
+	// The total sum of valid buckets within the window.
+	windowTotal float64
+	lastWrite   time.Time
 
 	granularity time.Duration
 	window      time.Duration
@@ -49,6 +51,31 @@ func NewTimedFloat64Buckets(window, granularity time.Duration) *TimedFloat64Buck
 		buckets:     make([]float64, nb),
 		granularity: granularity,
 		window:      window,
+	}
+}
+
+// WindowTotal returns the sum of all valid buckets.
+func (t *TimedFloat64Buckets) WindowTotal(now time.Time) float64 {
+	now = now.Truncate(t.granularity)
+	t.bucketsMutex.RLock()
+	defer t.bucketsMutex.RUnlock()
+	switch d := now.Sub(t.lastWrite); {
+	case d <= 0:
+		// If LastWrite equal or greater than Now
+		// return the current WindowTotal.
+		return t.windowTotal
+	case d < t.window:
+		// If we haven't received metrics for some time, which is less than
+		// the window -- remove the outdated items.
+		stIdx := t.timeToIndex(t.lastWrite)
+		eIdx := t.timeToIndex(now)
+		ret := t.windowTotal
+		for i := stIdx + 1; i <= eIdx; i++ {
+			ret -= t.buckets[i%len(t.buckets)]
+		}
+		return ret
+	default: // Nothing for more than a window time, just 0.
+		return 0.
 	}
 }
 
@@ -78,6 +105,7 @@ func (t *TimedFloat64Buckets) Record(now time.Time, name string, value float64) 
 			for i := range t.buckets {
 				t.buckets[i] = 0
 			}
+			t.windowTotal = 0
 		} else {
 			// In theory we might lose buckets between stats gathering.
 			// Thus we need to clean not only the current index, but also
@@ -85,13 +113,16 @@ func (t *TimedFloat64Buckets) Record(now time.Time, name string, value float64) 
 			// due to possible wrap-around, so they are not merged together.
 			oldIdx := t.timeToIndex(t.lastWrite)
 			for i := oldIdx + 1; i <= writeIdx; i++ {
-				t.buckets[i%len(t.buckets)] = 0
+				idx := i % len(t.buckets)
+				t.windowTotal -= t.buckets[idx]
+				t.buckets[idx] = 0
 			}
 		}
 		// Update the last write time.
 		t.lastWrite = bucketTime
 	}
 	t.buckets[writeIdx%len(t.buckets)] += value
+	t.windowTotal += value
 }
 
 // ForEachBucket calls the given Accumulator function for each bucket.

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -133,6 +133,39 @@ func TestTimedFloat64BucketsManyReps(t *testing.T) {
 	}
 }
 
+func TestTimedFloat64BucketsWindowTotal(t *testing.T) {
+	now := time.Now()
+	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
+
+	for i := time.Duration(0); i < 5; i++ {
+		buckets.Record(now.Add(i*time.Second), pod, float64(i+1))
+	}
+
+	if got, want := buckets.WindowTotal(now.Add(4*time.Second)), 15.; got != want {
+		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	}
+	// Check when `now` lags behind.
+	if got, want := buckets.WindowTotal(now.Add(3600*time.Millisecond)), 15.; got != want {
+		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	}
+
+	// Check with short hole.
+	if got, want := buckets.WindowTotal(now.Add(6*time.Second)), 15.-1-2; got != want {
+		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	}
+	// Check with a long hole.
+	if got, want := buckets.WindowTotal(now.Add(10*time.Second)), 0.; got != want {
+		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	}
+
+	// Check write with holes.
+	buckets.Record(now.Add(6*time.Second), pod, 91)
+	if got, want := buckets.WindowTotal(now.Add(6*time.Second)), 15.-1-2+91; got != want {
+		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	}
+
+}
+
 func TestTimedFloat64BucketsHoles(t *testing.T) {
 	now := time.Now()
 	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
@@ -152,6 +185,9 @@ func TestTimedFloat64BucketsHoles(t *testing.T) {
 	}
 	if got, want := sum, 15.; got != want {
 		t.Errorf("Sum = %v, want: %v", got, want)
+	}
+	if got, want := buckets.WindowTotal(now.Add(4*time.Second)), 15.; got != want {
+		t.Errorf("WindowTotal = %v, want: %v", got, want)
 	}
 	// Now write at 9th second. Which means that seconds
 	// 5[0], 6[1], 7[2] become 0.

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -137,8 +137,8 @@ func TestTimedFloat64BucketsWindowTotal(t *testing.T) {
 	now := time.Now()
 	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
 
-	for i := time.Duration(0); i < 5; i++ {
-		buckets.Record(now.Add(i*time.Second), pod, float64(i+1))
+	for i := 0; i < 5; i++ {
+		buckets.Record(now.Add(time.Duration(i)*time.Second), pod, float64(i+1))
 	}
 
 	if got, want := buckets.WindowTotal(now.Add(4*time.Second)), 15.; got != want {


### PR DESCRIPTION
This is the next step in making autoscaler constant time operation.
Currently to compute the total concurrency over the window, we're executing an O(N) operation in seconds, where
N is window width.
Obviously with larger windows (and we do not restrict them right now) this becomes a noticeable operation (given that it's
executing per revision as well).

So now we're computing the running total and sometimes subtract the holes, should the happen (rare occurrence).
Usage is in the follow up PRs.

/lint
Part of #5981.
/assign @dgerd @markusthoemmes mattmoor