### PR TITLE
Fix log format

### DIFF
--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -109,7 +109,7 @@ func CreateServiceReady(t pkgTest.T, clients *test.Clients, names *test.Resource
 		names.Service = svc.Name
 	}
 
-	t.Log("Waiting for Service %q to transition to Ready.", "service", names.Service)
+	t.Log("Waiting for Service to transition to Ready.", "service", names.Service)
 	if err := WaitForServiceState(clients.ServingClient, names.Service, IsServiceReady, "ServiceIsReady"); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed Changes

This makes a super tiny change to fix invalid log format.

```
    service.go:112: Waiting for Service %q to transition to Ready. service projected-config-map-volume-tfxwzfio
```

This PR changes the format with same manner with other lines like:

https://github.com/knative/serving/blob/1fdc974221061f67d343c72f4bbfd10344ccfb69/test/v1alpha1/service.go#L143


/lint


**Release Note**

```release-note
NONE
```
