### PR TITLE
Do not expose kourier-internal and controller services

### DIFF
--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -46,8 +46,6 @@ EOF
 cat ${KOURIER_YAML} \
   `# Install Kourier into the kourier-system namespace` \
   | sed 's/namespace: knative-serving/namespace: kourier-system/' \
-  `# Expose Kourier services with LoadBalancer IPs instead of ClusterIP` \
-  | sed 's/ClusterIP/LoadBalancer/' \
   >> kourier.yaml
 
 # Clean up.

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -179,7 +179,6 @@ spec:
       targetPort: 8081
   selector:
     app: 3scale-kourier-gateway
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
@@ -208,7 +207,6 @@ spec:
       targetPort: 18000
   selector:
     app: 3scale-kourier-control
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -179,6 +179,7 @@ spec:
       targetPort: 8081
   selector:
     app: 3scale-kourier-gateway
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -193,7 +194,7 @@ spec:
       targetPort: 8080
   selector:
     app: 3scale-kourier-gateway
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -207,6 +208,7 @@ spec:
       targetPort: 18000
   selector:
     app: 3scale-kourier-control
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Proposed Changes

This patch removes type LoadBalancer from kourier-internal and
controller. These should not be necessary to be exposed.

/lint

**Release Note**

```release-note
NONE
```

BEFORE

```
$ kubectl get svc -n kourier-system 
NAME               TYPE           CLUSTER-IP      EXTERNAL-IP                                                                    PORT(S)           AGE
kourier            LoadBalancer   172.20.9.56     a75a3c4f6f10245fe9cb29194d17df4c-2042427866.ap-southeast-1.elb.amazonaws.com   80:31521/TCP      3h29m
kourier-control    LoadBalancer   172.20.26.244   a11c23501c9464dd789e6ed1e76580a6-1994205324.ap-southeast-1.elb.amazonaws.com   18000:30035/TCP   3h29m
kourier-external   LoadBalancer   172.20.10.170   ae4011262614547119343a73f48535c5-1908226611.ap-southeast-1.elb.amazonaws.com   80:31212/TCP      3h29m
kourier-internal   LoadBalancer   172.20.4.95     a64593473c7354ca0b8e4552880b2222-323914506.ap-southeast-1.elb.amazonaws.com    80:31230/TCP      3h29m
```


AFTER
```
$ kubectl get svc -n kourier-system 
NAME               TYPE           CLUSTER-IP      EXTERNAL-IP                                                                    PORT(S)        AGE
kourier            LoadBalancer   172.20.2.170    ae9d007e5fd454309a18c0113a08f038-100056802.ap-southeast-1.elb.amazonaws.com    80:31904/TCP   22m
kourier-control    ClusterIP      172.20.13.242   <none>                                                                         18000/TCP      22m
kourier-external   LoadBalancer   172.20.26.141   abb507731d64344bfafdf552caaf7f7b-2127070299.ap-southeast-1.elb.amazonaws.com   80:32418/TCP   22m
kourier-internal   ClusterIP      172.20.9.74     <none>                                                                         80/TCP         22m
```

/cc @bbrowning @jmprusi @davidor
