### PR TITLE
Specially wait for zipkin to be deleted in monitoring uninstallation

### DIFF
--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -44,9 +44,10 @@ kubectl delete --ignore-not-found=true -f ${SERVING_YAML} || fail_test
 wait_until_object_does_not_exist namespaces knative-serving || fail_test
 kubectl delete --ignore-not-found=true -f ${MONITORING_YAML} || fail_test
 wait_until_object_does_not_exist namespaces knative-monitoring || fail_test
-# HACK: sleep an extra 60 seconds, as we also have zipkin installed in istio-system namespace, see
+# Specially wait for zipkin to be deleted, as we have them installed in istio-system namespace, see
 # https://github.com/knative/serving/blob/4202efc0dc12052edc0630515b101cbf8068a609/config/monitoring/tracing/zipkin/100-zipkin.yaml#L19
-sleep 60
+wait_until_object_does_not_exist service zipkin istio-system
+wait_until_object_does_not_exist deployment zipkin istio-system
 
 subheader "Reinstalling Knative Serving"
 start_knative_serving "${SERVING_YAML}" || fail_test

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -44,6 +44,9 @@ kubectl delete --ignore-not-found=true -f ${SERVING_YAML} || fail_test
 wait_until_object_does_not_exist namespaces knative-serving || fail_test
 kubectl delete --ignore-not-found=true -f ${MONITORING_YAML} || fail_test
 wait_until_object_does_not_exist namespaces knative-monitoring || fail_test
+# HACK: sleep an extra 60 seconds, as we also have zipkin installed in istio-system namespace, see
+# https://github.com/knative/serving/blob/4202efc0dc12052edc0630515b101cbf8068a609/config/monitoring/tracing/zipkin/100-zipkin.yaml#L19
+sleep 60
 
 subheader "Reinstalling Knative Serving"
 start_knative_serving "${SERVING_YAML}" || fail_test


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
We occasionally get errors in the `smoke-tests`:
"Error from server (Conflict): error when creating "/tmp/tmp.LYmxo4JEIX/monitoring.yaml": Operation cannot be fulfilled on resourcequotas "gke-resource-quotas": the object has been modified; please apply your changes to the latest version and try again"

Log can be seen at https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/6456/pull-knative-serving-smoke-tests/1214576974199001088/build-log.txt

The reason seems to be we are installing zipkin monitoring before it's fully uninstalled. Since zipkin is install in `istio-system` namespace - https://github.com/knative/serving/blob/4202efc0dc12052edc0630515b101cbf8068a609/config/monitoring/tracing/zipkin/100-zipkin.yaml#L19, what we can do is to specially wait for zipkin to be uninstalled after `knative-monitoring` namespace is deleted.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/hold