### PR TITLE
Better probing cancellation path

### DIFF
--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -53,7 +53,7 @@ const (
 // TODO(https://github.com/knative/serving/issues/6407):  Default timeouts may lead to hanging probes.
 var dialContext = (&net.Dialer{}).DialContext
 
-// ingressState represents the probing progress at the Ingress scope
+// ingressState represents the probing state of an Ingress
 type ingressState struct {
 	hash string
 	ing  *v1alpha1.Ingress
@@ -65,10 +65,16 @@ type ingressState struct {
 	cancel func()
 }
 
-// podState represents the probing progress at the Pod scope
+// podState represents the probing state of a Pod (for a specific Ingress)
 type podState struct {
+	// successCount is the number of successful probes
 	successCount int32
 
+	cancel func()
+}
+
+// cancelContext is a pair of a Context and its cancel function
+type cancelContext struct {
 	context context.Context
 	cancel  func()
 }
@@ -76,6 +82,7 @@ type podState struct {
 type workItem struct {
 	ingressState *ingressState
 	podState     *podState
+	context      context.Context
 	url          *url.URL
 	podIP        string
 	podPort      string
@@ -90,7 +97,6 @@ type ProbeTarget struct {
 
 // ProbeTargetLister lists all the targets that requires probing.
 type ProbeTargetLister interface {
-
 	// ListProbeTargets returns the target to be probed as a map from podIP -> port -> urls.
 	ListProbeTargets(ctx context.Context, ingress *v1alpha1.Ingress) ([]ProbeTarget, error)
 }
@@ -105,10 +111,10 @@ type Manager interface {
 type Prober struct {
 	logger *zap.SugaredLogger
 
-	// mu guards ingressStates and podStates
+	// mu guards ingressStates and podContexts
 	mu            sync.Mutex
 	ingressStates map[string]*ingressState
-	podStates     map[string]*podState
+	podContexts   map[string]*cancelContext
 
 	workQueue workqueue.RateLimitingInterface
 
@@ -129,7 +135,7 @@ func NewProber(
 	return &Prober{
 		logger:        logger,
 		ingressStates: make(map[string]*ingressState),
-		podStates:     make(map[string]*podState),
+		podContexts:   make(map[string]*cancelContext),
 		workQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.DefaultControllerRateLimiter(),
 			"ProbingQueue"),
@@ -185,15 +191,14 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 		cancel:       cancel,
 	}
 
-	workItems := make(map[string][]*workItem)
-
-	allProbeTargets, err := m.targetLister.ListProbeTargets(ctx, ing)
+	targets, err := m.targetLister.ListProbeTargets(ctx, ing)
 	if err != nil {
 		return false, err
 	}
 
 	// First, group the targets by IPs.
-	for _, target := range allProbeTargets {
+	workItems := make(map[string][]*workItem)
+	for _, target := range targets {
 		for ip := range target.PodIPs {
 			for _, url := range target.URLs {
 				workItems[ip] = append(workItems[ip], &workItem{
@@ -206,37 +211,50 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 		}
 	}
 	for ip, ipWorkItems := range workItems {
-		ctx, cancel := context.WithCancel(ingCtx)
+		// Get or create the context for that IP
+		ipCtx := func() context.Context {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			cancelCtx, ok := m.podContexts[ip]
+			if !ok {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancelCtx = &cancelContext{
+					context: ctx,
+					cancel:  cancel,
+				}
+				m.podContexts[ip] = cancelCtx
+			}
+			return cancelCtx.context
+		}()
+
+		podCtx, cancel := context.WithCancel(ingCtx)
 		podState := &podState{
 			successCount: 0,
-			context:      ctx,
 			cancel:       cancel,
 		}
 
-		// Save the podState to be able to cancel it in case of Pod deletion
-		func() {
-			m.mu.Lock()
-			defer m.mu.Unlock()
-			m.podStates[ip] = podState
+		// Quick and dirty way to join two contexts (i.e. podCtx is cancelled when either ingCtx or ipCtx are cancelled)
+		go func() {
+			select {
+			case <-podCtx.Done():
+				// This is the actual context, there is nothing to do except
+				// break to avoid leaking this goroutine.
+				break
+			case <-ipCtx.Done():
+				// Cancel podCtx
+				cancel()
+			}
 		}()
 
-		// Update states and cleanup m.podStates when probing is done or cancelled
-		go func(ip string) {
-			<-podState.context.Done()
+		// Update the states when probing is successful or cancelled
+		go func() {
+			<-podCtx.Done()
 			m.updateStates(ingressState, podState)
-
-			m.mu.Lock()
-			defer m.mu.Unlock()
-			// It is critical to check that the current podState is also the one stored in the map
-			// before deleting it because it could have been replaced if a new version of the ingress
-			// has started being probed.
-			if state, ok := m.podStates[ip]; ok && state == podState {
-				delete(m.podStates, ip)
-			}
-		}(ip)
+		}()
 
 		for _, wi := range ipWorkItems {
 			wi.podState = podState
+			wi.context = podCtx
 			m.workQueue.AddRateLimited(wi)
 			m.logger.Infof("Queuing probe for %s, IP: %s:%s (depth: %d)",
 				wi.url, wi.podIP, wi.podPort, m.workQueue.Len())
@@ -294,8 +312,9 @@ func (m *Prober) CancelPodProbing(obj interface{}) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
-		if state, ok := m.podStates[pod.Status.PodIP]; ok {
-			state.cancel()
+		if ctx, ok := m.podContexts[pod.Status.PodIP]; ok {
+			ctx.cancel()
+			delete(m.podContexts, pod.Status.PodIP)
 		}
 	}
 }
@@ -346,7 +365,7 @@ func (m *Prober) processWorkItem() bool {
 		}}
 
 	ok, err := prober.Do(
-		item.podState.context,
+		item.context,
 		transport,
 		item.url.String(),
 		prober.WithHeader(network.ProbeHeaderName, network.ProbeHeaderValue),
@@ -355,7 +374,7 @@ func (m *Prober) processWorkItem() bool {
 
 	// In case of cancellation, drop the work item
 	select {
-	case <-item.podState.context.Done():
+	case <-item.context.Done():
 		m.workQueue.Forget(obj)
 		return true
 	default:

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -114,7 +114,7 @@ type Prober struct {
 	// mu guards ingressStates and podContexts
 	mu            sync.Mutex
 	ingressStates map[string]*ingressState
-	podContexts   map[string]*cancelContext
+	podContexts   map[string]cancelContext
 
 	workQueue workqueue.RateLimitingInterface
 
@@ -135,7 +135,7 @@ func NewProber(
 	return &Prober{
 		logger:        logger,
 		ingressStates: make(map[string]*ingressState),
-		podContexts:   make(map[string]*cancelContext),
+		podContexts:   make(map[string]cancelContext),
 		workQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.DefaultControllerRateLimiter(),
 			"ProbingQueue"),
@@ -218,7 +218,7 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 			cancelCtx, ok := m.podContexts[ip]
 			if !ok {
 				ctx, cancel := context.WithCancel(context.Background())
-				cancelCtx = &cancelContext{
+				cancelCtx = cancelContext{
 					context: ctx,
 					cancel:  cancel,
 				}

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -274,10 +274,26 @@ func TestCancelPodProbing(t *testing.T) {
 	// Wait for the first probe request
 	<-requests
 
-	// Create a new version of the Ingress
-	const domain = "blabla.net"
+	// Create a new version of the Ingress (to replace the original Ingress)
+	const otherDomain = "blabla.net"
 	ing = ing.DeepCopy()
-	ing.Spec.Rules[0].Hosts[0] = domain
+	ing.Spec.Rules[0].Hosts[0] = otherDomain
+
+	// Create a different Ingress (to be probed in parallel)
+	const parallelDomain = "parallel.net"
+	func() {
+		copy := ing.DeepCopy()
+		copy.Spec.Rules[0].Hosts[0] = parallelDomain
+		copy.Name = "something"
+
+		ok, err = prober.IsReady(context.Background(), copy)
+		if err != nil {
+			t.Fatalf("IsReady failed: %v", err)
+		}
+		if ok {
+			t.Fatal("IsReady() returned true")
+		}
+	}()
 
 	// Check that probing is unsuccessful
 	select {
@@ -297,7 +313,7 @@ func TestCancelPodProbing(t *testing.T) {
 	// Drain requests for the old version
 	for req := range requests {
 		t.Logf("req.Host: %s", req.Host)
-		if strings.HasPrefix(req.Host, domain) {
+		if strings.HasPrefix(req.Host, otherDomain)  {
 			break
 		}
 	}
@@ -305,16 +321,106 @@ func TestCancelPodProbing(t *testing.T) {
 	// Cancel Pod probing
 	prober.CancelPodProbing(pod)
 
-	// Check that the requests were for the new version
+	// Check that the requests were for the new version or the other Ingress
 	close(requests)
 	for req := range requests {
-		if !strings.HasPrefix(req.Host, domain) {
-			t.Fatalf("Host = %s, want: %s", req.Host, domain)
+		if !strings.HasPrefix(req.Host, otherDomain) && !strings.HasPrefix(req.Host, parallelDomain) {
+			t.Fatalf("Host = %s, want: %s or %s", req.Host, otherDomain, parallelDomain)
 		}
 	}
 }
 
-func TestCancelIngresProbing(t *testing.T) {
+func TestPartialPodCancellation(t *testing.T) {
+	ing := ingTemplate.DeepCopy()
+	hash, err := ingress.InsertProbe(ing)
+	if err != nil {
+		t.Fatalf("Failed to insert probe: %v", err)
+	}
+
+	// Simulate a probe target returning HTTP 200 OK and the correct hash
+	requests := make(chan *http.Request, 100)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r
+		w.Header().Set(network.HashHeaderName, hash)
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %q: %v", ts.URL, err)
+	}
+	port, err := strconv.Atoi(tsURL.Port())
+	if err != nil {
+		t.Fatalf("Failed to parse port %q: %v", tsURL.Port(), err)
+	}
+
+	// pods[0] will be probed successfully, pods[1] will never be probed successfully
+	pods := []*v1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "pod0",
+			},
+			Status: v1.PodStatus{
+				PodIP: strings.Split(tsURL.Host, ":")[0],
+			},
+		}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+		},
+		Status: v1.PodStatus{
+			PodIP: "198.51.100.1",
+		},
+	}}
+
+	ready := make(chan *v1alpha1.Ingress)
+	prober := NewProber(
+		zaptest.NewLogger(t).Sugar(),
+		fakeProbeTargetLister{{
+			PodIPs: sets.NewString(pods[0].Status.PodIP, pods[1].Status.PodIP),
+			Port:   strconv.Itoa(port),
+			URLs:   []*url.URL{tsURL},
+		}},
+		func(ing *v1alpha1.Ingress) {
+			ready <- ing
+		})
+
+	done := make(chan struct{})
+	defer close(done)
+	prober.Start(done)
+
+	ok, err := prober.IsReady(context.Background(), ing)
+	if err != nil {
+		t.Fatalf("IsReady failed: %v", err)
+	}
+	if ok {
+		t.Fatal("IsReady() returned true")
+	}
+
+	// Wait for the first probe request
+	<-requests
+
+	// Check that probing is unsuccessful
+	select {
+	case <-ready:
+		t.Fatal("Probing succeeded while it should not have succeeded")
+	default:
+	}
+
+	// Cancel probing of pods[1]
+	prober.CancelPodProbing(pods[1])
+
+	// Check that probing was successful
+	select {
+	case <-ready:
+		break
+	case <-time.After(5 * time.Second):
+		t.Fatal("Probing was not successful even after waiting")
+	}
+}
+
+func TestCancelIngressProbing(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
 	// Handler keeping track of received requests and mimicking an Ingress not ready
 	requests := make(chan *http.Request, 100)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign @tcnghia 
/lint
-->

Fixes #6422 

## Proposed Changes
* A single `context.Context` per Pod IP that is used as a parent `context.Context` by each `podState` (in addition to the `ingressState` `context.Context`)
* Fix a bug where `*url.URL` are mutated instead of copied in the tests (done in #6460 )
* Probe a second `Ingress` in the cancellation test to test the change
* Add a test testing that cancelling probing of a Pod is equivalent to the probing of that Pod succeeding