### PR TITLE
Set timeout for ingress prober

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -81,7 +81,6 @@ const (
 	queueDepthN            = "queue_depth"
 
 	healthURLTemplate = "http://127.0.0.1:%d"
-	tcpProbeTimeout   = 100 * time.Millisecond
 	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
 	// started as early as possible while still wanting to give the container some breathing
 	// room to get up and running.

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -48,10 +48,11 @@ const (
 	stateExpiration = 5 * time.Minute
 	// cleanupPeriod defines how often states are cleaned up
 	cleanupPeriod = 1 * time.Minute
+	//probeTimeout defines the maximum amount of time a request will wait
+	probeTimeout = 1 * time.Second
 )
 
-// TODO(https://github.com/knative/serving/issues/6407):  Default timeouts may lead to hanging probes.
-var dialContext = (&net.Dialer{}).DialContext
+var dialContext = (&net.Dialer{Timeout: probeTimeout}).DialContext
 
 // ingressState represents the probing progress at the Ingress scope
 type ingressState struct {


### PR DESCRIPTION
Fixes #6407

## Proposed Changes

* Set timeout for `dialContext`.
* Remove unused variable.