### PR TITLE
Provide option to run e2e and conformance tests with HTTPS

### DIFF
--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -67,7 +67,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */)
+		true /* https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -67,7 +67,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */)
+		test.ServingFlags.Https)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -125,7 +125,7 @@ func TestServiceGenerateName(t *testing.T) {
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -125,7 +125,7 @@ func TestServiceGenerateName(t *testing.T) {
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Logf("Creating new service with generateName %s", generateName)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -56,7 +56,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1a1opts.WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -56,7 +56,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1a1opts.WithResourceRequirements(resources))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -54,7 +54,7 @@ func TestRunLatestService(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */)
+		true /* https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -198,7 +198,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		func(svc *v1alpha1.Service) {
 			svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
 		})
@@ -269,7 +269,7 @@ func TestReleaseService(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */)
+		true /* https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -534,7 +534,7 @@ func TestAnnotationPropagation(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */)
+		true /* https */)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -54,7 +54,7 @@ func TestRunLatestService(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */)
+		test.ServingFlags.Https)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -198,7 +198,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		func(svc *v1alpha1.Service) {
 			svc.Spec.ConfigurationSpec.GetTemplate().Name = revName
 		})
@@ -269,7 +269,7 @@ func TestReleaseService(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */)
+		test.ServingFlags.Https)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -534,7 +534,7 @@ func TestAnnotationPropagation(t *testing.T) {
 
 	// Setup initial Service
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */)
+		test.ServingFlags.Https)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -46,7 +46,7 @@ func TestSingleConcurrency(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -46,7 +46,7 @@ func TestSingleConcurrency(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -91,7 +91,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -165,7 +165,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -233,7 +233,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -305,7 +305,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withVolume, withSubpath); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -404,7 +404,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -91,7 +91,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -165,7 +165,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -233,7 +233,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withVolume, withOptionalBadVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -305,7 +305,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withVolume, withSubpath); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
@@ -404,7 +404,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Setup initial Service
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withVolume); err != nil {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -78,7 +78,7 @@ func TestProbeRuntime(t *testing.T) {
 
 			t.Log("Creating a new Service")
 			resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-				false, /* https TODO(taragu) turn this on after helloworld test running with https */
+				true /* https */,
 				v1a1opts.WithReadinessProbe(
 					&corev1.Probe{
 						Handler: tc.handler,

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -78,7 +78,7 @@ func TestProbeRuntime(t *testing.T) {
 
 			t.Log("Creating a new Service")
 			resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-				true /* https */,
+				test.ServingFlags.Https,
 				v1a1opts.WithReadinessProbe(
 					&corev1.Probe{
 						Handler: tc.handler,

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -55,7 +55,7 @@ func fetchRuntimeInfo(
 	})
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
-		false /* https */,
+		test.ServingFlags.Https,
 		serviceOpts...)
 	if err != nil {
 		return nil, nil, err

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -55,7 +55,7 @@ func fetchRuntimeInfo(
 	})
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		serviceOpts...)
 	if err != nil {
 		return nil, nil, err

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -55,7 +55,7 @@ func fetchRuntimeInfo(
 	})
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
-		true /* https */,
+		false /* https */,
 		serviceOpts...)
 	if err != nil {
 		return nil, nil, err

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -342,15 +342,6 @@ function use_resolvable_domain() {
   echo "false"
 }
 
-# Check if we should use --https.
-function use_https() {
-  if (( HTTPS )); then
-    echo "--https"
-  else
-    echo ""
-  fi
-}
-
 # Check if we should specify --ingressClass
 function ingress_class() {
   if [[ -z "${INGRESS_CLASS}" ]]; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -47,8 +47,11 @@ failed=0
 parallelism=""
 use_https=""
 (( MESH )) && parallelism="-parallel 1"
-(( HTTPS )) && parallelism="-parallel 1"
-(( HTTPS )) && use_https="--https"
+
+if (( HTTP )); then
+  parallelism="-parallel 1"
+  use_https="--https"
+fi
 
 # Run conformance and e2e tests.
 go_test_e2e -timeout=30m \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -43,16 +43,19 @@ header "Running tests"
 
 failed=0
 
-# Run tests serially in the mesh scenario
+# Run tests serially in the mesh and https scenarios
 parallelism=""
+use_https=""
 (( MESH )) && parallelism="-parallel 1"
+(( HTTPS )) && parallelism="-parallel 1"
+(( HTTPS )) && use_https="--https"
 
 # Run conformance and e2e tests.
 go_test_e2e -timeout=30m \
   ./test/conformance/... \
   ./test/e2e \
   ${parallelism} \
-  "--resolvabledomain=$(use_resolvable_domain)" "$(use_https)" "$(ingress_class)" || failed=1
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 # Run scale tests.
 go_test_e2e -timeout=10m \
@@ -63,7 +66,7 @@ go_test_e2e -timeout=10m \
 if [[ -n "${ISTIO_VERSION}" ]]; then
   go_test_e2e -timeout=10m \
     ./test/e2e/istio \
-    "--resolvabledomain=$(use_resolvable_domain)" "$(use_https)" || failed=1
+    "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
 
 # Dump cluster state in case of failure

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -77,7 +77,7 @@ TIMEOUT=10m
 header "Running preupgrade tests"
 
 go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 header "Starting prober test"
 
@@ -85,7 +85,7 @@ header "Starting prober test"
 rm -f /tmp/prober-signal
 
 go_test_e2e -tags=probe -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" &
+  --resolvabledomain=$(use_resolvable_domain) &
 PROBER_PID=$!
 echo "Prober PID is ${PROBER_PID}"
 
@@ -93,13 +93,13 @@ install_head
 
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 install_latest_release
 
 header "Running postdowngrade tests"
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) "$(use_https)" || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 # The prober is blocking on /tmp/prober-signal to know when it should exit.
 #

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -60,7 +60,7 @@ func TestActivatorOverload(t *testing.T) {
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		func(service *v1alpha1.Service) {
 			service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
 			service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -60,7 +60,7 @@ func TestActivatorOverload(t *testing.T) {
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		func(service *v1alpha1.Service) {
 			service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
 			service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -180,7 +180,7 @@ func setup(t *testing.T, class, metric string, target float64, targetUtilization
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		append([]rtesting.ServiceOption{
 			rtesting.WithConfigAnnotations(map[string]string{
 				autoscaling.ClassAnnotationKey:             class,

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -180,7 +180,7 @@ func setup(t *testing.T, class, metric string, target float64, targetUtilization
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		append([]rtesting.ServiceOption{
 			rtesting.WithConfigAnnotations(map[string]string{
 				autoscaling.ClassAnnotationKey:             class,

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -173,7 +173,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
@@ -232,7 +232,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -173,7 +173,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
@@ -232,7 +232,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1a1opts.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -50,7 +50,7 @@ func TestEgressTraffic(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	service, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1a1opts.WithEnv(envVars...))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -50,7 +50,7 @@ func TestEgressTraffic(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	service, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1a1opts.WithEnv(envVars...))
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -170,7 +170,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -170,7 +170,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -118,7 +118,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 
 	t.Log("Creating a new Service")
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		test.ServingFlags.Https,
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName("cpu"):    resource.MustParse("50m"),

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -90,7 +90,7 @@ func TestIstioProbing(t *testing.T) {
 		test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 		defer test.TearDown(clients, names)
 		objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-			false /* https TODO(taragu) turn this on after helloworld test running with https */)
+			true /* https */)
 		if err != nil {
 			t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 		}
@@ -265,7 +265,7 @@ func TestIstioProbing(t *testing.T) {
 			// Create the service and wait for it to be ready
 			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 			defer test.TearDown(clients, names)
-			_, _, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names, false /* https */)
+			_, _, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names, true /* https */)
 			if err != nil {
 				t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 			}

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -90,7 +90,7 @@ func TestIstioProbing(t *testing.T) {
 		test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 		defer test.TearDown(clients, names)
 		objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-			true /* https */)
+			test.ServingFlags.Https)
 		if err != nil {
 			t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 		}
@@ -265,7 +265,7 @@ func TestIstioProbing(t *testing.T) {
 			// Create the service and wait for it to be ready
 			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 			defer test.TearDown(clients, names)
-			_, _, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names, true /* https */)
+			_, _, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names, test.ServingFlags.Https)
 			if err != nil {
 				t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 			}

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -63,7 +63,7 @@ func TestMultipleNamespace(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources,
-		true /* https */); err != nil {
+		test.ServingFlags.Https); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
 
@@ -74,7 +74,7 @@ func TestMultipleNamespace(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources,
-		true /* https */); err != nil {
+		test.ServingFlags.Https); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
 
@@ -127,7 +127,7 @@ func TestConflictingRouteService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */); err != nil {
+		test.ServingFlags.Https); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
 }

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -63,7 +63,7 @@ func TestMultipleNamespace(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
+		true /* https */); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
 
@@ -74,7 +74,7 @@ func TestMultipleNamespace(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
+		true /* https */); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
 
@@ -127,7 +127,7 @@ func TestConflictingRouteService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
+		true /* https */); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
 }

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -67,7 +67,7 @@ func TestRollbackBYOName(t *testing.T) {
 
 	t.Logf("Creating a new Service with byo config name %q.", byoNameOld)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withTrafficSpecOld, func(svc *v1alpha1.Service) {
 			svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameOld
 		})

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -67,7 +67,7 @@ func TestRollbackBYOName(t *testing.T) {
 
 	t.Logf("Creating a new Service with byo config name %q.", byoNameOld)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withTrafficSpecOld, func(svc *v1alpha1.Service) {
 			svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameOld
 		})

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -119,7 +119,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	defer test.TearDown(clients, names)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1alph1testing.WithEnv(envVars...),
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -197,7 +197,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	withInternalVisibility := v1alph1testing.WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withInternalVisibility,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -248,7 +248,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	defer test.TearDown(clients, testNames)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
@@ -304,7 +304,7 @@ func TestCallToPublicService(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		}))

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -119,7 +119,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	defer test.TearDown(clients, names)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1alph1testing.WithEnv(envVars...),
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -197,7 +197,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	withInternalVisibility := v1alph1testing.WithServiceLabel(
 		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withInternalVisibility,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
@@ -248,7 +248,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	defer test.TearDown(clients, testNames)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
@@ -304,7 +304,7 @@ func TestCallToPublicService(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		v1alph1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		}))

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -75,7 +75,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 	})
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -122,7 +122,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		}},
 	})
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %w", names.Service, err)
@@ -253,7 +253,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 		},
 	})
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		withTrafficSpec, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -75,7 +75,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 	})
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -122,7 +122,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		}},
 	})
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %w", names.Service, err)
@@ -253,7 +253,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 		},
 	})
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		withTrafficSpec, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -189,7 +189,7 @@ func TestWebSocket(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */); err != nil {
+		true /* https */); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
@@ -217,7 +217,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		true /* https */,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}),
@@ -251,7 +251,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with HTTPS */
+		true /* https */,
 		func(s *v1alpha1.Service) {
 			s.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{
 				Name:  "SUFFIX",

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -189,7 +189,7 @@ func TestWebSocket(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	if _, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */); err != nil {
+		test.ServingFlags.Https); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
@@ -217,7 +217,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}),
@@ -251,7 +251,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
 	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		true /* https */,
+		test.ServingFlags.Https,
 		func(s *v1alpha1.Service) {
 			s.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{
 				Name:  "SUFFIX",

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -65,7 +65,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 
 	t.Log("Creating a new Service")
 	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https only enabled for e2e and conformance testts */)
+		false /* https only enabled for e2e and conformance tests */)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -65,7 +65,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 
 	t.Log("Creating a new Service")
 	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https TODO(taragu) turn this on after helloworld test running with https */)
+		false /* https only enabled for e2e and conformance testts */)
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -153,7 +153,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 
 	t.Log("Creating a new Service")
 	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false, /* https TODO(taragu) turn this on after helloworld test running with https */
+		false /* https only enabled for e2e and conformance testts */,
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -153,7 +153,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 
 	t.Log("Creating a new Service")
 	objs, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		false /* https only enabled for e2e and conformance testts */,
+		false /* https only enabled for e2e and conformance tests */,
 		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),


### PR DESCRIPTION
/lint

Part of #5148

## Proposed Changes
Provide option to run e2e and conformance tests with HTTPS if `--https` flag is provided.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @JRBANCEL 