### PR TITLE
Fix data race introduced during refactoring of status.go

### DIFF
--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -191,12 +191,11 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 		cancel:       cancel,
 	}
 
+	// Get the probe targets and group them by IP
 	targets, err := m.targetLister.ListProbeTargets(ctx, ing)
 	if err != nil {
 		return false, err
 	}
-
-	// First, group the targets by IPs.
 	workItems := make(map[string][]*workItem)
 	for _, target := range targets {
 		for ip := range target.PodIPs {
@@ -210,6 +209,9 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 			}
 		}
 	}
+
+	ingressState.pendingCount = int32(len(workItems))
+
 	for ip, ipWorkItems := range workItems {
 		// Get or create the context for that IP
 		ipCtx := func() context.Context {
@@ -260,7 +262,7 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 				wi.url, wi.podIP, wi.podPort, m.workQueue.Len())
 		}
 	}
-	ingressState.pendingCount += int32(len(workItems))
+
 	func() {
 		m.mu.Lock()
 		defer m.mu.Unlock()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign @vagababov 
/assign @tcnghia 
/lint
-->

Fixes the following data race:
```
==================
WARNING: DATA RACE
Write at 0x00c0005413d8 by goroutine 57:
  sync/atomic.AddInt32()
      /usr/lib/google-golang/src/runtime/race_amd64.s:269 +0xb
  knative.dev/serving/pkg/network/status.(*Prober).updateStates()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status.go:400 +0x98
  knative.dev/serving/pkg/network/status.(*Prober).processWorkItem()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status.go:389 +0xb3f
  knative.dev/serving/pkg/network/status.(*Prober).Start.func1()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status.go:277 +0x38

Previous write at 0x00c0005413d8 by goroutine 92:
  knative.dev/serving/pkg/network/status.(*Prober).IsReady()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status.go:263 +0x1264
  knative.dev/serving/pkg/network/status.TestPartialPodCancellation()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status_test.go:393 +0xac3
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:909 +0x199

Goroutine 57 (running) created at:
  knative.dev/serving/pkg/network/status.(*Prober).Start()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status.go:276 +0x4f
  knative.dev/serving/pkg/network/status.TestPartialPodCancellation()
      /usr/local/google/home/bancel/go/src/knative.dev/serving/pkg/network/status/status_test.go:391 +0xa7d
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:909 +0x199

Goroutine 92 (running) created at:
  testing.(*T).Run()
      /usr/lib/google-golang/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/lib/google-golang/src/testing/testing.go:1204 +0xa6
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/lib/google-golang/src/testing/testing.go:1202 +0x521
  testing.(*M).Run()
      /usr/lib/google-golang/src/testing/testing.go:1119 +0x309
  main.main()
      _testmain.go:52 +0x223
==================
```

It was introduced somewhere when `status.go` was moved and reshaped.
The problem is that `pendingCount` is set after work items are enqueued (L260) which makes it possible for `pendingCount` to be modified (concurrently and in an unsafe manner) before it is even set to anything meaningful.
