### PR TITLE
Fix data race and implement proper cancellation.

### DIFF
--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -277,17 +277,17 @@ func (m *Prober) Start(done <-chan struct{}) chan struct{} {
 	for i := 0; i < m.probeConcurrency; i++ {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for m.processWorkItem() {
 			}
-			wg.Done()
 		}()
 	}
 
 	// Cleanup the states periodically
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		wait.Until(m.expireOldStates, m.cleanupPeriod, done)
-		wg.Done()
 	}()
 
 	// Stop processing the queue when cancelled

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -338,15 +338,16 @@ func TestCancelPodProbing(t *testing.T) {
 
 	// Check that there are no requests for the old Ingress and the requests predate cancellation
 	for {
-		if req, ok := <-requests; ok {
+		select {
+		case req := <-requests:
 			if !strings.HasPrefix(req.Host, otherDomain) &&
 				!strings.HasPrefix(req.Host, parallelDomain) {
 				t.Fatalf("Host = %s, want: %s or %s", req.Host, otherDomain, parallelDomain)
 			} else if req.Time.Sub(cancelTime) > 0 {
 				t.Fatal("Request was made after cancellation")
 			}
-		} else {
-			break
+		default:
+			return
 		}
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign @vagababov 
/assign @tcnghia 
/lint
-->

Fixes:
1) The data race of closing a channel in a different goroutine than the goroutine sending to that channel.
The test was relying on this behavior to crash if a probe request was seen after the channel was closed. This is replaced by capturing the timestamp of the requests and comparing that to the time of the cancellation.
2) The `func (p *Prober) Start(done chan struct{})` pattern doesn't allow to know when the `Prober` is effectively done doing work when `done` is closed. This leads to `log after test is done` issues. This is changed to `func (p *Prober) Start(done chan struct{}) chan struct{}` to be able to wait for clean completion/cancellation. 
