### PR TITLE
Relax TestDestroyPodWithRequests test to allow it to start with more than 1 pod.

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -252,8 +252,8 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
 	})
-	if err != nil || len(pods.Items) != 1 {
-		t.Fatalf("Number of pods is not 1 or an error: %v", err)
+	if err != nil || len(pods.Items) == 0 {
+		t.Fatalf("No pods or error: %v", err)
 	}
 
 	// The request will sleep for more than 15 seconds.

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -185,6 +185,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	if err != nil || len(pods.Items) == 0 {
 		t.Fatalf("No pods or error: %v", err)
 	}
+	t.Logf("Saw %d pods", len(pods.Items))
 
 	podToDelete := pods.Items[0].Name
 	t.Logf("Deleting pod %q", podToDelete)
@@ -255,6 +256,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	if err != nil || len(pods.Items) == 0 {
 		t.Fatalf("No pods or error: %v", err)
 	}
+	t.Logf("Saw %d pods", len(pods.Items))
 
 	// The request will sleep for more than 15 seconds.
 	// NOTE: it needs to be less than TERMINATION_DRAIN_DURATION_SECONDS.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6371

## Proposed Changes

*  Relax TestDestroyPodWithRequests test to allow it to start with more than 1 pod.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
