### PR TITLE
Fix the multiscaler test flake

### DIFF
--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -140,6 +140,8 @@ type MultiScaler struct {
 
 	watcher      func(types.NamespacedName)
 	watcherMutex sync.RWMutex
+
+	tickProvider func(time.Duration) *time.Ticker
 }
 
 // NewMultiScaler constructs a MultiScaler.
@@ -152,6 +154,7 @@ func NewMultiScaler(
 		scalersStopCh:    stopCh,
 		uniScalerFactory: uniScalerFactory,
 		logger:           logger,
+		tickProvider:     time.NewTicker,
 	}
 }
 
@@ -257,7 +260,7 @@ func (m *MultiScaler) updateRunner(ctx context.Context, runner *scalerRunner) {
 
 func (m *MultiScaler) runScalerTicker(ctx context.Context, runner *scalerRunner) {
 	metricKey := types.NamespacedName{Namespace: runner.decider.Namespace, Name: runner.decider.Name}
-	ticker := time.NewTicker(runner.decider.Spec.TickInterval)
+	ticker := tickProvider(runner.decider.Spec.TickInterval)
 	go func() {
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
The flake was happening because the tick interval was quite short (5ms) and by the time
the test progressed under heavy load (some boskos are worse than others) the timeout trigger also fired.
So since both channels are active, a random one is picked, which is sometimes the wrong one.
Or the other way around due to scheduling the test timed out faster than timer would be scheduled.

Anyway, I replaced the real timer with the mock one and now I can control when we fire
the message.

```
>rt -run=TestMultiScalerScaling -count=20
PASS
ok      knative.dev/serving/pkg/autoscaler      5.070s
```

/assign @tcnghia @dgerd 