### PR TITLE
Return average rather than sum and integration in the collector.

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -54,8 +54,8 @@ func NewTimedFloat64Buckets(window, granularity time.Duration) *TimedFloat64Buck
 	}
 }
 
-// WindowTotal returns the sum of all valid buckets.
-func (t *TimedFloat64Buckets) WindowTotal(now time.Time) float64 {
+// WindowAverage returns the average bucket value over the window.
+func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
 	now = now.Truncate(t.granularity)
 	t.bucketsMutex.RLock()
 	defer t.bucketsMutex.RUnlock()
@@ -63,7 +63,7 @@ func (t *TimedFloat64Buckets) WindowTotal(now time.Time) float64 {
 	case d <= 0:
 		// If LastWrite equal or greater than Now
 		// return the current WindowTotal.
-		return t.windowTotal
+		return t.windowTotal / float64(len(t.buckets))
 	case d < t.window:
 		// If we haven't received metrics for some time, which is less than
 		// the window -- remove the outdated items.
@@ -73,7 +73,7 @@ func (t *TimedFloat64Buckets) WindowTotal(now time.Time) float64 {
 		for i := stIdx + 1; i <= eIdx; i++ {
 			ret -= t.buckets[i%len(t.buckets)]
 		}
-		return ret
+		return ret / float64(len(t.buckets)-(eIdx-stIdx))
 	default: // Nothing for more than a window time, just 0.
 		return 0.
 	}

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -132,7 +132,7 @@ func TestTimedFloat64BucketsManyReps(t *testing.T) {
 	}
 }
 
-func TestTimedFloat64BucketsWindowTotal(t *testing.T) {
+func TestTimedFloat64BucketsWindowAverage(t *testing.T) {
 	now := time.Now()
 	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
 
@@ -140,27 +140,28 @@ func TestTimedFloat64BucketsWindowTotal(t *testing.T) {
 		buckets.Record(now.Add(time.Duration(i)*time.Second), float64(i+1))
 	}
 
-	if got, want := buckets.WindowTotal(now.Add(4*time.Second)), 15.; got != want {
-		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	if got, want := buckets.WindowAverage(now.Add(4*time.Second)), 15./5; got != want {
+		t.Errorf("WindowAverage = %v, want: %v", got, want)
 	}
 	// Check when `now` lags behind.
-	if got, want := buckets.WindowTotal(now.Add(3600*time.Millisecond)), 15.; got != want {
-		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	if got, want := buckets.WindowAverage(now.Add(3600*time.Millisecond)), 15./5; got != want {
+		t.Errorf("WindowAverage = %v, want: %v", got, want)
 	}
 
 	// Check with short hole.
-	if got, want := buckets.WindowTotal(now.Add(6*time.Second)), 15.-1-2; got != want {
-		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	if got, want := buckets.WindowAverage(now.Add(6*time.Second)), (15.-1-2)/(5-2); got != want {
+		t.Errorf("WindowAverage = %v, want: %v", got, want)
 	}
+
 	// Check with a long hole.
-	if got, want := buckets.WindowTotal(now.Add(10*time.Second)), 0.; got != want {
-		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	if got, want := buckets.WindowAverage(now.Add(10*time.Second)), 0.; got != want {
+		t.Errorf("WindowAverage = %v, want: %v", got, want)
 	}
 
 	// Check write with holes.
 	buckets.Record(now.Add(6*time.Second), 91)
-	if got, want := buckets.WindowTotal(now.Add(6*time.Second)), 15.-1-2+91; got != want {
-		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	if got, want := buckets.WindowAverage(now.Add(6*time.Second)), (15.-1-2+91)/5; got != want {
+		t.Errorf("WindowAverage = %v, want: %v", got, want)
 	}
 
 }
@@ -185,8 +186,8 @@ func TestTimedFloat64BucketsHoles(t *testing.T) {
 	if got, want := sum, 15.; got != want {
 		t.Errorf("Sum = %v, want: %v", got, want)
 	}
-	if got, want := buckets.WindowTotal(now.Add(4*time.Second)), 15.; got != want {
-		t.Errorf("WindowTotal = %v, want: %v", got, want)
+	if got, want := buckets.WindowAverage(now.Add(4*time.Second)), 15./5; got != want {
+		t.Errorf("WindowAverage = %v, want: %v", got, want)
 	}
 	// Now write at 9th second. Which means that seconds
 	// 5[0], 6[1], 7[2] become 0.


### PR DESCRIPTION
Switch the logic I had for total sum computation to actually return average over the number of buckets since this is the metric we care about.
Also introduce its usage in the collector.

Next: the short window. I am still thinking about the API for that.

/assign @markusthoemmes mattmoor @dgerd 