### PR TITLE
Undo part of #6495

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -38,12 +38,7 @@ LATEST_SERVING_RELEASE_VERSION=$(git describe --match "v[0-9]*" --abbrev=0)
 function install_latest_release() {
   header "Installing Knative latest public release"
   local url="https://github.com/knative/serving/releases/download/${LATEST_SERVING_RELEASE_VERSION}"
-  local yaml="serving-core.yaml"
-
-  # serving.yaml contains the Istio integration, which we don't need for other ingress controllers.
-  if [[ -n "${ISTIO_VERSION}" ]]; then
-    yaml="serving.yaml"
-  fi
+  local yaml="serving.yaml"
 
   local RELEASE_YAML="$(mktemp)"
   wget "${url}/${yaml}" -O "${RELEASE_YAML}" \


### PR DESCRIPTION
Since we don't actually run the upgrade tests for anything but Istio, this change effectively reverts the change and removes the logic that isn't exercised today to (hopefully) unbreak things.
