### PR TITLE
Fix ineffective break in pool.

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -65,16 +65,8 @@ func NewWithContext(ctx context.Context, workers, capacity int) (Interface, cont
 	// 3. marks work as done in our sync.WaitGroup.
 	for idx := 0; idx < workers; idx++ {
 		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case work, ok := <-i.workCh:
-					if !ok {
-						return
-					}
-					i.exec(work)
-				}
+			for work := range i.workCh {
+				i.exec(work)
 			}
 		}()
 	}

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -68,10 +68,10 @@ func NewWithContext(ctx context.Context, workers, capacity int) (Interface, cont
 			for {
 				select {
 				case <-ctx.Done():
-					break
+					return
 				case work, ok := <-i.workCh:
 					if !ok {
-						break
+						return
 					}
 					i.exec(work)
 				}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The break statements apply to the select in this case, not as intended to the outer for-loop.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
