### PR TITLE
Provide contextualized revision data on the request's context.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -242,18 +242,20 @@ func main() {
 		logger.Fatalw("Unable to create request log handler", zap.Error(err))
 	}
 	ah = reqLogHandler
-	ah = &activatorhandler.ProbeHandler{NextHandler: ah}
 
 	// NOTE: MetricHandler is being used as the outermost handler of the meaty bits. We're not interested in measuring
 	// the healthchecks or probes.
 	ah = activatorhandler.NewMetricHandler(ctx, reporter, ah)
 	ah = activatorhandler.NewContextHandler(ctx, ah)
 
-	sigCtx, sigCancel := context.WithCancel(context.Background())
+	// Network probe handlers.
+	ah = &activatorhandler.ProbeHandler{NextHandler: ah}
+	ah = network.NewProbeHandler(ah)
+
 	// Set up our health check based on the health of stat sink and environmental factors.
+	sigCtx, sigCancel := context.WithCancel(context.Background())
 	hc := newHealthCheck(sigCtx, logger, statSink)
 	ah = &activatorhandler.HealthHandler{HealthCheck: hc, NextHandler: ah, Logger: logger}
-	ah = network.NewProbeHandler(ah)
 
 	profilingHandler := profiling.NewHandler(logger, false)
 	// Watch the logging config map and dynamically update logging levels.

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -254,6 +254,7 @@ func main() {
 
 	// NOTE: MetricHandler is being used as the outermost handler for the purpose of measuring the request latency.
 	ah = activatorhandler.NewMetricHandler(ctx, reporter, ah)
+	ah = activatorhandler.NewContextHandler(ctx, ah)
 
 	profilingHandler := profiling.NewHandler(logger, false)
 	// Watch the logging config map and dynamically update logging levels.

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -38,13 +38,11 @@ type revIDKey struct{}
 // NewContextHandler creates a handler that extracts the necessary context from the request
 // and makes it available on the request's context.
 func NewContextHandler(ctx context.Context, next http.Handler) http.Handler {
-	handler := &contextHandler{
+	return &contextHandler{
 		nextHandler:    next,
 		revisionLister: revisioninformer.Get(ctx).Lister(),
 		logger:         logging.FromContext(ctx),
 	}
-
-	return handler
 }
 
 // contextHandler enriches the request's context with structured data.

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -37,8 +37,8 @@ type revIDKey struct{}
 
 // NewContextHandler creates a handler that extracts the necessary context from the request
 // and makes it available on the request's context.
-func NewContextHandler(ctx context.Context, next http.Handler) *ContextHandler {
-	handler := &ContextHandler{
+func NewContextHandler(ctx context.Context, next http.Handler) http.Handler {
+	handler := &contextHandler{
 		nextHandler:    next,
 		revisionLister: revisioninformer.Get(ctx).Lister(),
 		logger:         logging.FromContext(ctx),
@@ -47,14 +47,14 @@ func NewContextHandler(ctx context.Context, next http.Handler) *ContextHandler {
 	return handler
 }
 
-// ContextHandler enriches the request's context with structured data.
-type ContextHandler struct {
+// contextHandler enriches the request's context with structured data.
+type contextHandler struct {
 	revisionLister servinglisters.RevisionLister
 	logger         *zap.SugaredLogger
 	nextHandler    http.Handler
 }
 
-func (h *ContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
 	name := r.Header.Get(activator.RevisionHeaderName)
 	revID := types.NamespacedName{Namespace: namespace, Name: name}

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/logging/logkey"
+	"knative.dev/serving/pkg/activator"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+)
+
+type revisionKey struct{}
+type revIDKey struct{}
+
+// NewContextHandler creates a handler that extracts the necessary context from the request
+// and makes it available on the request's context.
+func NewContextHandler(ctx context.Context, next http.Handler) *ContextHandler {
+	handler := &ContextHandler{
+		nextHandler:    next,
+		revisionLister: revisioninformer.Get(ctx).Lister(),
+		logger:         logging.FromContext(ctx),
+	}
+
+	return handler
+}
+
+// ContextHandler enriches the request's context with structured data.
+type ContextHandler struct {
+	revisionLister servinglisters.RevisionLister
+	logger         *zap.SugaredLogger
+	nextHandler    http.Handler
+}
+
+func (h *ContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
+	name := r.Header.Get(activator.RevisionHeaderName)
+	revID := types.NamespacedName{Namespace: namespace, Name: name}
+	logger := h.logger.With(zap.String(logkey.Key, revID.String()))
+
+	revision, err := h.revisionLister.Revisions(namespace).Get(name)
+	if err != nil {
+		logger.Errorw("Error while getting revision", zap.Error(err))
+		sendError(err, w)
+		return
+	}
+
+	ctx := r.Context()
+	ctx = logging.WithLogger(ctx, logger)
+	ctx = context.WithValue(ctx, revisionKey{}, revision)
+	ctx = context.WithValue(ctx, revIDKey{}, revID)
+
+	h.nextHandler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+func withRevision(ctx context.Context, rev *v1alpha1.Revision) context.Context {
+	return context.WithValue(ctx, revisionKey{}, rev)
+}
+
+func revisionFrom(ctx context.Context) *v1alpha1.Revision {
+	return ctx.Value(revisionKey{}).(*v1alpha1.Revision)
+}
+
+func withRevID(ctx context.Context, revID types.NamespacedName) context.Context {
+	return context.WithValue(ctx, revIDKey{}, revID)
+}
+
+func revIDFrom(ctx context.Context) types.NamespacedName {
+	return ctx.Value(revIDKey{}).(types.NamespacedName)
+}
+
+func sendError(err error, w http.ResponseWriter) {
+	msg := fmt.Sprintf("Error getting active endpoint: %v", err)
+	if k8serrors.IsNotFound(err) {
+		http.Error(w, msg, http.StatusNotFound)
+		return
+	}
+	http.Error(w, msg, http.StatusInternalServerError)
+}

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -78,7 +78,7 @@ func TestContextHandlerError(t *testing.T) {
 	}
 
 	if got, want := resp.Body.String(), errMsg(`revision.serving.knative.dev "fooname" not found`); got != want {
-		t.Errorf("Body = %s, want %s", got, want)
+		t.Errorf("Body = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -30,9 +30,7 @@ import (
 
 func TestContextHandler(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevName}
 	revision := revision(revID.Namespace, revID.Name)
 	revisionInformer(ctx, revision)
@@ -45,8 +43,6 @@ func TestContextHandler(t *testing.T) {
 		if got := revIDFrom(r.Context()); got != revID {
 			t.Errorf("revIDFrom() = %v, want %v", got, revID)
 		}
-
-		w.WriteHeader(http.StatusOK)
 	})
 
 	handler := NewContextHandler(ctx, baseHandler)
@@ -63,16 +59,12 @@ func TestContextHandler(t *testing.T) {
 
 func TestContextHandlerError(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevName}
 	revision := revision(revID.Namespace, revID.Name)
 	revisionInformer(ctx, revision)
 
-	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
 	handler := NewContextHandler(ctx, baseHandler)
 	resp := httptest.NewRecorder()

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package handler
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	rtesting "knative.dev/pkg/reconciler/testing"
+	"knative.dev/serving/pkg/activator"
+)
+
+func TestContextHandler(t *testing.T) {
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	defer func() {
+		cancel()
+	}()
+	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevName}
+	revision := revision(revID.Namespace, revID.Name)
+	revisionInformer(ctx, revision)
+
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := revisionFrom(r.Context()); got != revision {
+			t.Errorf("revisionFrom() = %v, want %v", got, revision)
+		}
+
+		if got := revIDFrom(r.Context()); got != revID {
+			t.Errorf("revIDFrom() = %v, want %v", got, revID)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := NewContextHandler(ctx, baseHandler)
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString(""))
+	req.Header.Set(activator.RevisionHeaderNamespace, revID.Namespace)
+	req.Header.Set(activator.RevisionHeaderName, revID.Name)
+	handler.ServeHTTP(resp, req)
+
+	if got, want := resp.Code, http.StatusOK; got != want {
+		t.Errorf("StatusCode = %d, want %d, body: %s", got, want, resp.Body.String())
+	}
+}
+
+func TestContextHandlerError(t *testing.T) {
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	defer func() {
+		cancel()
+	}()
+	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevName}
+	revision := revision(revID.Namespace, revID.Name)
+	revisionInformer(ctx, revision)
+
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := NewContextHandler(ctx, baseHandler)
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString(""))
+	req.Header.Set(activator.RevisionHeaderNamespace, "foospace")
+	req.Header.Set(activator.RevisionHeaderName, "fooname")
+	handler.ServeHTTP(resp, req)
+
+	if got, want := resp.Code, http.StatusNotFound; got != want {
+		t.Errorf("StatusCode = %d, want %d", got, want)
+	}
+
+	if got, want := resp.Body.String(), errMsg(`revision.serving.knative.dev "fooname" not found`); got != want {
+		t.Errorf("Body = %s, want %s", got, want)
+	}
+}
+
+func errMsg(msg string) string {
+	return fmt.Sprintf("Error getting active endpoint: %s\n", msg)
+}

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -23,7 +23,6 @@ import (
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
 	pkghttp "knative.dev/serving/pkg/http"
-	"knative.dev/serving/pkg/network"
 )
 
 // NewMetricHandler creates a handler collects and reports request metrics
@@ -43,12 +42,6 @@ type MetricHandler struct {
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Filter out probe and health check requests.
-	if network.IsProbe(r) {
-		h.nextHandler.ServeHTTP(w, r)
-		return
-	}
-
 	revID := revIDFrom(r.Context())
 	revision := revisionFrom(r.Context())
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -20,15 +20,8 @@ import (
 	"net/http"
 	"time"
 
-	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
-
-	"knative.dev/pkg/logging"
-	"knative.dev/pkg/logging/logkey"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/network"
 )
@@ -36,10 +29,8 @@ import (
 // NewMetricHandler creates a handler collects and reports request metrics
 func NewMetricHandler(ctx context.Context, r activator.StatsReporter, next http.Handler) *MetricHandler {
 	handler := &MetricHandler{
-		nextHandler:    next,
-		revisionLister: revisioninformer.Get(ctx).Lister(),
-		reporter:       r,
-		logger:         logging.FromContext(ctx),
+		nextHandler: next,
+		reporter:    r,
 	}
 
 	return handler
@@ -47,32 +38,19 @@ func NewMetricHandler(ctx context.Context, r activator.StatsReporter, next http.
 
 // MetricHandler sends metrics via reporter
 type MetricHandler struct {
-	revisionLister servinglisters.RevisionLister
-	reporter       activator.StatsReporter
-	logger         *zap.SugaredLogger
-	nextHandler    http.Handler
+	reporter    activator.StatsReporter
+	nextHandler http.Handler
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
 	// Filter out probe and health check requests.
 	if network.IsProbe(r) {
 		h.nextHandler.ServeHTTP(w, r)
 		return
 	}
 
-	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
-	name := r.Header.Get(activator.RevisionHeaderName)
-
-	revID := types.NamespacedName{Namespace: namespace, Name: name}
-	logger := h.logger.With(zap.String(logkey.Key, revID.String()))
-
-	revision, err := h.revisionLister.Revisions(namespace).Get(name)
-	if err != nil {
-		logger.Errorw("Error while getting revision", zap.Error(err))
-		sendError(err, w)
-		return
-	}
+	revID := revIDFrom(r.Context())
+	revision := revisionFrom(r.Context())
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
 	start := time.Now()
@@ -82,10 +60,10 @@ func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := recover()
 		latency := time.Since(start)
 		if err != nil {
-			h.reporter.ReportResponseTime(namespace, serviceName, configurationName, name, http.StatusInternalServerError, latency)
+			h.reporter.ReportResponseTime(revID.Namespace, serviceName, configurationName, revID.Name, http.StatusInternalServerError, latency)
 			panic(err)
 		}
-		h.reporter.ReportResponseTime(namespace, serviceName, configurationName, name, rr.ResponseCode, latency)
+		h.reporter.ReportResponseTime(revID.Namespace, serviceName, configurationName, revID.Name, rr.ResponseCode, latency)
 	}()
 
 	h.nextHandler.ServeHTTP(rr, r)

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	rtesting "knative.dev/pkg/reconciler/testing"
-	"knative.dev/serving/pkg/network"
 )
 
 var ignoreDurationOption = cmpopts.IgnoreFields(reporterCall{}, "Duration")
@@ -45,22 +44,6 @@ func TestRequestMetricHandler(t *testing.T) {
 		wantCode      int
 		wantPanic     bool
 	}{
-		{
-			label: "kube probe request",
-			baseHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			}),
-			newHeader: map[string]string{"User-Agent": network.KubeProbeUAPrefix},
-			wantCode:  http.StatusOK,
-		},
-		{
-			label: "network probe response",
-			baseHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			}),
-			newHeader: map[string]string{network.ProbeHeaderName: "test-service"},
-			wantCode:  http.StatusOK,
-		},
 		{
 			label: "normal response",
 			baseHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/activator/handler/requestevent_handler.go
+++ b/pkg/activator/handler/requestevent_handler.go
@@ -16,8 +16,6 @@ package handler
 import (
 	"net/http"
 
-	"knative.dev/serving/pkg/activator"
-
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -55,10 +53,7 @@ type RequestEventHandler struct {
 }
 
 func (h *RequestEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
-	name := r.Header.Get(activator.RevisionHeaderName)
-
-	revisionKey := types.NamespacedName{Namespace: namespace, Name: name}
+	revisionKey := revIDFrom(r.Context())
 
 	h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqIn}
 	defer func() {

--- a/pkg/activator/handler/requestevent_handler_test.go
+++ b/pkg/activator/handler/requestevent_handler_test.go
@@ -14,13 +14,13 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/serving/pkg/activator"
 )
 
 func TestRequestEventHandler(t *testing.T) {
@@ -36,10 +36,8 @@ func TestRequestEventHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString(""))
-	req.Header.Add(activator.RevisionHeaderNamespace, namespace)
-	req.Header.Add(activator.RevisionHeaderName, revision)
-
-	handler.ServeHTTP(resp, req)
+	ctx := withRevID(context.Background(), types.NamespacedName{Namespace: namespace, Name: revision})
+	handler.ServeHTTP(resp, req.WithContext(ctx))
 
 	in := <-handler.ReqChan
 	wantIn := ReqEvent{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Many of our inner activator handlers do the same things over and over again (fetch revision, create a keyed logger etc.). This avoids quite some extra work that each of these handlers do on their own in favor of doing it once in a "context handler" and adding all the reusable data onto the request's context, which is passed down automatically.

This spares us 13 of 60 allocations we do just in the innermost handler currently.

### Old

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-12         	  100771	     11956 ns/op	    9513 B/op	      60 allocs/op
BenchmarkHandler/016k-resp-len-12         	   69216	     18579 ns/op	   38484 B/op	      60 allocs/op
BenchmarkHandler/032k-resp-len-12         	   52394	     26079 ns/op	   71210 B/op	      60 allocs/op
BenchmarkHandler/064k-resp-len-12         	   23259	     45945 ns/op	  201494 B/op	      61 allocs/op
BenchmarkHandler/128k-resp-len-12         	    9903	    101044 ns/op	  496514 B/op	      62 allocs/op
PASS
```

### New

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-12         	  119955	     10514 ns/op	    7869 B/op	      47 allocs/op
BenchmarkHandler/016k-resp-len-12         	   66926	     17647 ns/op	   36360 B/op	      47 allocs/op
BenchmarkHandler/032k-resp-len-12         	   51644	     21144 ns/op	   69509 B/op	      47 allocs/op
BenchmarkHandler/064k-resp-len-12         	   26800	     49842 ns/op	  199945 B/op	      48 allocs/op
BenchmarkHandler/128k-resp-len-12         	   12469	     96675 ns/op	  498649 B/op	      49 allocs/op
PASS
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
