### PR TITLE
Update Kourier to v0.3.7

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -465,10 +465,10 @@ function test_setup() {
   if [[ -n "${KOURIER_VERSION}" ]]; then
     # we must set these override values to allow the test spoofing client to work with Kourier
     # see https://github.com/knative/pkg/blob/release-0.7/test/ingress/ingress.go#L37
-    export GATEWAY_OVERRIDE=kourier-external
+    export GATEWAY_OVERRIDE=kourier
     export GATEWAY_NAMESPACE_OVERRIDE=kourier-system
     wait_until_pods_running kourier-system || return 1
-    wait_until_service_has_external_ip kourier-system kourier-external
+    wait_until_service_has_external_ip kourier-system kourier
   fi
   if [[ -n "${AMBASSADOR_VERSION}" ]]; then
     # we must set these override values to allow the test spoofing client to work with Ambassador

--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # Download Kourier
-KOURIER_VERSION=0.3.5
+KOURIER_VERSION=0.3.6
 KOURIER_YAML=kourier-knative.yaml
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/v${KOURIER_VERSION}/deploy/${KOURIER_YAML}
 

--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -17,38 +17,8 @@
 set -ex
 
 # Download Kourier
-KOURIER_VERSION=0.3.4
+KOURIER_VERSION=0.3.5
 KOURIER_YAML=kourier-knative.yaml
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/v${KOURIER_VERSION}/deploy/${KOURIER_YAML}
 
-wget ${DOWNLOAD_URL}
-
-cat <<EOF > kourier.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kourier-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: kourier-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: kourier-system
----
-EOF
-
-cat ${KOURIER_YAML} \
-  `# Install Kourier into the kourier-system namespace` \
-  | sed 's/namespace: knative-serving/namespace: kourier-system/' \
-  `# Expose Kourier services with LoadBalancer IPs instead of ClusterIP` \
-  | sed 's/ClusterIP/LoadBalancer/' \
-  >> kourier.yaml
-
-# Clean up.
-rm ${KOURIER_YAML}
+wget -O kourier.yaml ${DOWNLOAD_URL}

--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # Download Kourier
-KOURIER_VERSION=0.3.6
+KOURIER_VERSION=0.3.7
 KOURIER_YAML=kourier-knative.yaml
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/v${KOURIER_VERSION}/deploy/${KOURIER_YAML}
 

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -119,7 +119,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.6
+        - image: quay.io/3scale/kourier:v0.3.7
           imagePullPolicy: Always
           name: kourier-control
           resources: {}

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -22,10 +22,25 @@ metadata:
   namespace: kourier-system
 spec:
   ports:
-    - name: http
+    - name: http2
       port: 80
       protocol: TCP
       targetPort: 8080
+  selector:
+    app: 3scale-kourier-gateway
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-tls
+  namespace: kourier-system
+spec:
+  ports:
+    - name: http2
+      port: 443
+      protocol: TCP
+      targetPort: 8443
   selector:
     app: 3scale-kourier-gateway
   type: LoadBalancer
@@ -69,8 +84,13 @@ spec:
             - name: config-volume
               mountPath: /tmp/config
           readinessProbe:
-            exec:
-              command: ['ash','-c','(printf "GET /__internalkouriersnapshot HTTP/1.1\r\nHost: internalkourier\r\n\r\n"; sleep 1) | nc -n localhost 8081 | grep "HTTP/1.1 200 OK"']
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: internalkourier
+              path: /__internalkouriersnapshot
+              port: 8081
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 2
       volumes:
@@ -106,7 +126,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.4
+        - image: quay.io/3scale/kourier:v0.3.5
           imagePullPolicy: Always
           name: kourier-control
           resources: {}
@@ -179,22 +199,7 @@ spec:
       targetPort: 8081
   selector:
     app: 3scale-kourier-gateway
-  type: LoadBalancer
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-external
-  namespace: kourier-system
-spec:
-  ports:
-    - name: http2
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-  selector:
-    app: 3scale-kourier-gateway
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -208,7 +213,7 @@ spec:
       targetPort: 18000
   selector:
     app: 3scale-kourier-control
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -217,12 +222,6 @@ metadata:
   namespace: kourier-system
 data:
   envoy-bootstrap.yaml: |
-    admin:
-      access_log_path: /tmp/test
-      address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 19000
     dynamic_resources:
       ads_config:
         api_type: GRPC
@@ -237,20 +236,57 @@ data:
       cluster: kourier-knative
       id: 3scale-kourier-gateway
     static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.http_connection_manager
+                  config:
+                    stat_prefix: stats_server
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                safe_regex:
+                                  google_re2: {}
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    exact_match: GET
+                              route:
+                                cluster: service_stats
+                    http_filters:
+                      - name: envoy.router
+                        config: {}
       clusters:
-        - connect_timeout: 0.2s
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
           load_assignment:
-            cluster_name: xds_cluster
+            cluster_name: service_stats
             endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: kourier-control
-                        port_value: 18000
+              lb_endpoints:
+                endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/envoy.admin
+        - name: xds_cluster
+          connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "kourier-control"
+                port_value: 18000
           http2_protocol_options: {}
-          upstream_connection_options:
-            tcp_keepalive: {}
-          lb_policy: ROUND_ROBIN
-          name: xds_cluster
           type: STRICT_DNS
+    admin:
+      access_log_path: "/dev/stdout"
+      address:
+        pipe:
+          path: /tmp/envoy.admin

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -22,22 +22,11 @@ metadata:
   namespace: kourier-system
 spec:
   ports:
-    - name: http2
+    - name: http
       port: 80
       protocol: TCP
       targetPort: 8080
-  selector:
-    app: 3scale-kourier-gateway
-  type: LoadBalancer
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-tls
-  namespace: kourier-system
-spec:
-  ports:
-    - name: http2
+    - name: https
       port: 443
       protocol: TCP
       targetPort: 8443
@@ -75,7 +64,11 @@ spec:
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
@@ -126,7 +119,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.5
+        - image: quay.io/3scale/kourier:v0.3.6
           imagePullPolicy: Always
           name: kourier-control
           resources: {}


### PR DESCRIPTION
/lint

## Proposed Changes

* Bump Kourier version to v0.3.5. This version:
  * Fixes the following tests: `test/conformance/ingress.TestIngressTLS`, `test/conformance/ingress.TestPostSplitSetHeaders`, and `test/conformance/ingress.TestPreSplitSetHeaders`.
  * Includes this fix by @nak3 https://github.com/knative/serving/pull/6450 . That PR is no longer needed because the fix is now in Kourier upstream.
  * Simplifies a bit the deployment. The patches in `third_party/kourier-latest/download-kourier.sh` are no longer needed.
  * See the full changelog here: https://github.com/3scale/kourier/blob/master/CHANGELOG.md

/cc @jmprusi 