### PR TITLE
Add feature flag for graceful scaledown

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -130,3 +130,8 @@ data:
     # Scale to zero grace period is the time an inactive revision is left
     # running before it is scaled to zero (min: 30s).
     scale-to-zero-grace-period: "30s"
+
+    # Enable graceful scaledown feature flag.
+    # Once enabled, it allows the autoscaler to prioritize pods processing
+    # fewer (or zero) requests for removal when scaling down.
+    enable-graceful-scaledown: "false"

--- a/pkg/autoscaler/config.go
+++ b/pkg/autoscaler/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// Feature flags.
 	EnableScaleToZero bool
 
+	// Enable connection-aware pod scaledown
+	EnableGracefulScaledown bool
+
 	// Target concurrency knobs for different container concurrency configurations.
 	ContainerConcurrencyTargetFraction float64
 	ContainerConcurrencyTargetDefault  float64
@@ -76,11 +79,17 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key          string
 		field        *bool
 		defaultValue bool
-	}{{
-		key:          "enable-scale-to-zero",
-		field:        &lc.EnableScaleToZero,
-		defaultValue: true,
-	}} {
+	}{
+		{
+			key:          "enable-scale-to-zero",
+			field:        &lc.EnableScaleToZero,
+			defaultValue: true,
+		},
+		{
+			key:          "enable-graceful-scaledown",
+			field:        &lc.EnableGracefulScaledown,
+			defaultValue: false,
+		}} {
 		if raw, ok := data[b.key]; !ok {
 			*b.field = b.defaultValue
 		} else {

--- a/pkg/autoscaler/config_test.go
+++ b/pkg/autoscaler/config_test.go
@@ -28,6 +28,7 @@ import (
 
 var defaultConfig = Config{
 	EnableScaleToZero:                  true,
+	EnableGracefulScaledown:            false,
 	ContainerConcurrencyTargetFraction: 0.7,
 	ContainerConcurrencyTargetDefault:  100,
 	RPSTargetDefault:                   200,
@@ -91,9 +92,10 @@ func TestNewConfig(t *testing.T) {
 			return &c
 		}(defaultConfig),
 	}, {
-		name: "with toggles on",
+		name: "with default toggles set",
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
+			"enable-graceful-scaledown":               "false",
 			"max-scale-down-rate":                     "3.0",
 			"max-scale-up-rate":                       "1.01",
 			"container-concurrency-target-percentage": "0.71",
@@ -118,16 +120,19 @@ func TestNewConfig(t *testing.T) {
 	}, {
 		name: "with toggles on strange casing",
 		input: map[string]string{
-			"enable-scale-to-zero": "TRUE",
+			"enable-scale-to-zero":      "TRUE",
+			"enable-graceful-scaledown": "FALSE",
 		},
 		want: &defaultConfig,
 	}, {
-		name: "with toggles explicitly off",
+		name: "with toggles explicitly flipped",
 		input: map[string]string{
-			"enable-scale-to-zero": "false",
+			"enable-scale-to-zero":      "false",
+			"enable-graceful-scaledown": "true",
 		},
 		want: func(c Config) *Config {
 			c.EnableScaleToZero = false
+			c.EnableGracefulScaledown = true
 			return &c
 		}(defaultConfig),
 	}, {


### PR DESCRIPTION
/lint

introducing the feature flag for `GracefulScaledown` with a default value `false`. It is used in the coming PRs to enable / disable the feature.

as part of #6134 

/cc @vagababov 