### PR TITLE
Update the total computation during window update.

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -174,6 +174,7 @@ func (t *TimedFloat64Buckets) ResizeWindow(w time.Duration) {
 	}
 	numBuckets := int(math.Ceil(float64(w) / float64(t.granularity)))
 	newBuckets := make([]float64, numBuckets)
+	newTotal := 0.
 
 	// We need write lock here.
 	// So that we can copy the existing buckets into the new array.
@@ -187,8 +188,13 @@ func (t *TimedFloat64Buckets) ResizeWindow(w time.Duration) {
 		oi := tIdx % oldNumBuckets
 		ni := tIdx % numBuckets
 		newBuckets[ni] = t.buckets[oi]
+		// In case we're shringking, make sure the total
+		// window sum will match. This is no-op in case if
+		// window is getting bigger.
+		newTotal += t.buckets[oi]
 		tIdx--
 	}
 	t.window = w
 	t.buckets = newBuckets
+	t.windowTotal = newTotal
 }


### PR DESCRIPTION
The previous change missed the possible edge case that total sum needs to be recomputed
whenever the window changes.
This problem might occur only when window shrinks and therefore average can never to to 0
and scale to 0 will never occur, which is a problem.
Basically whenever the window size changes we have to sum the buckets that are still relevant while discarding the ones that are expunged. Obviously in case of window getting bigger this is a redundant busy work, but in general this should not happen _often_, if ever.

Why do we permit online updates to the window width is a different question, which
we might want to revisit in future, but right now it's there...


/lint
/assign @dgerd @markusthoemmes 
