### PR TITLE
Fix invalid error format

### DIFF
--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -89,7 +89,7 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 		}
 		gatewayName, serviceURL := k[len(prefix):], v
 		if errs := validation.IsDNS1123Subdomain(serviceURL); len(errs) > 0 {
-			return nil, fmt.Errorf("invalid gateway format: %w", errs)
+			return nil, fmt.Errorf("invalid gateway format: %v", errs)
 		}
 		gatewayNames = append(gatewayNames, gatewayName)
 		urls[gatewayName] = serviceURL


### PR DESCRIPTION
This patch makes a tiny change.

`IsDNS1123Subdomain()` returns `[]string` instead of `error` so `%w` does not work for `fmt.Errorf`.

https://github.com/knative/serving/blob/641c75689aea9256fea0c142ba0f808abd2ee31c/vendor/k8s.io/apimachinery/pkg/util/validation/validation.go#L141

`invalid gateway format: %!w` is printed currently.

BEFORE:
```
error: configmaps "config-istio" could not be patched: admission webhook "config.webhook.serving.knative.dev" denied the request: validation failed: invalid gateway format: %!w([]string=[a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')])
```

AFTER:
```
error: configmaps "config-istio" could not be patched: admission webhook "config.webhook.serving.knative.dev" denied the request: validation failed: invalid gateway format: [a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]
```

/lint

**Release Note**

```release-note
NONE
```

/cc @markusthoemmes @vagababov 