### PR TITLE
Add a secondary window computation.

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -54,6 +54,14 @@ func NewTimedFloat64Buckets(window, granularity time.Duration) *TimedFloat64Buck
 	}
 }
 
+// IsEmpty returns if no data has been recorded for the `window` period.
+func (t *TimedFloat64Buckets) IsEmpty(now time.Time) bool {
+	now = now.Truncate(t.granularity)
+	t.bucketsMutex.RLock()
+	defer t.bucketsMutex.RUnlock()
+	return now.Sub(t.lastWrite) > t.window
+}
+
 // WindowAverage returns the average bucket value over the window.
 func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
 	now = now.Truncate(t.granularity)

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -81,6 +81,9 @@ func TestTimedFloat64BucketsSimple(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// New implementation test.
 			buckets := NewTimedFloat64Buckets(2*time.Minute, tt.granularity)
+			if !buckets.IsEmpty(trunc1) {
+				t.Error("Unexpected non empty result")
+			}
 			for _, stat := range tt.stats {
 				buckets.Record(stat.time, stat.value)
 			}

--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -330,12 +330,12 @@ func (c *collection) currentMetric() *av1alpha1.Metric {
 func (c *collection) record(stat Stat) {
 	// Proxied requests have been counted at the activator. Subtract
 	// them to avoid double counting.
-	c.concurrencyBuckets.Record(stat.Time,
-		stat.AverageConcurrentRequests-stat.AverageProxiedConcurrentRequests)
-	c.concurrencyPanicBuckets.Record(stat.Time,
-		stat.AverageConcurrentRequests-stat.AverageProxiedConcurrentRequests)
-	c.rpsBuckets.Record(stat.Time, stat.RequestCount-stat.ProxiedRequestCount)
-	c.rpsPanicBuckets.Record(stat.Time, stat.RequestCount-stat.ProxiedRequestCount)
+	concurr := stat.AverageConcurrentRequests - stat.AverageProxiedConcurrentRequests
+	c.concurrencyBuckets.Record(stat.Time, concurr)
+	c.concurrencyPanicBuckets.Record(stat.Time, concurr)
+	rps := stat.RequestCount - stat.ProxiedRequestCount
+	c.rpsBuckets.Record(stat.Time, rps)
+	c.rpsPanicBuckets.Record(stat.Time, rps)
 }
 
 // stableAndPanicConcurrency calculates both stable and panic concurrency based on the

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -163,7 +163,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 	mtp.ch <- now
 	var gotRPS, gotConcurrency, panicRPS, panicConcurrency float64
 	// Poll to see that the async loop completed.
-	wait.PollImmediate(50*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
+	wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
 		gotConcurrency, _, _ = coll.StableAndPanicConcurrency(metricKey, now)
 		gotRPS, _, _ = coll.StableAndPanicRPS(metricKey, now)
 		return gotConcurrency == wantConcurrency && gotRPS == wantRPS, nil
@@ -192,7 +192,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 	mtp.ch <- now
 
 	// Wait for async loop to finish.
-	wait.PollImmediate(50*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
+	wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
 		gotConcurrency, _, _ = coll.StableAndPanicConcurrency(metricKey, now.Add(stableWindow).Add(-5*time.Second))
 		gotRPS, _, _ = coll.StableAndPanicRPS(metricKey, now.Add(stableWindow).Add(-5*time.Second))
 		return gotConcurrency == reportConcurrency && gotRPS == reportRPS, nil


### PR DESCRIPTION
I thought quite a lot about how to do it the best way -- and tried to invent some fancy
aggregation and online computation algorithms to track two window aggregates at the same time,
but in the end I found that it's just easier and a much more elegant thing to do is to keep
a second bucketer with shorter window. Now that the memory is always fixed and the computation
is O(1) this is actually cheaper in general

/assign @markusthoemmes

/lint

Fixes #5981

