### PR TITLE
Remove overhead allocations and run a parallel benchmark as well.

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package handler
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -452,47 +453,60 @@ func errMsg(msg string) string {
 }
 
 func BenchmarkHandler(b *testing.B) {
-	// Use fake Roundtripper, the buffer is used in the proxy
-	// to copy the response only.
-	fakeRT := activatortest.FakeRoundTripper{
-		RequestResponse: &activatortest.FakeResponse{
-			Code: http.StatusOK,
-		},
-	}
-	rt := pkgnet.RoundTripperFunc(fakeRT.RT)
-
-	reporter := &fakeReporter{}
-
-	t := &testing.T{}
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(&testing.T{})
 	defer cancel()
-	logger := logging.FromContext(ctx)
 	revisionInformer(ctx, revision(testNamespace, testRevName))
-	handler := (New(ctx, fakeThrottler{}, reporter)).(*activationHandler)
 
-	handler.transport = rt
-	configStore := setupConfigStore(&testing.T{}, logger)
+	configStore := setupConfigStore(&testing.T{}, logging.FromContext(ctx))
 	ctx = configStore.ToContext(ctx)
 
 	// bodyLength is in kilobytes.
 	for _, bodyLength := range [5]int{2, 16, 32, 64, 128} {
-		respBody := randomString(1024 * bodyLength)
-		fakeRT.RequestResponse.Body = respBody
-		b.Run(fmt.Sprintf("%03dk-resp-len", bodyLength), func(b *testing.B) {
+		body := []byte(randomString(1024 * bodyLength))
+
+		rt := pkgnet.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewReader(body)),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		handler := (New(ctx, fakeThrottler{}, &fakeReporter{})).(*activationHandler)
+		handler.transport = rt
+
+		request := func() *http.Request {
 			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+			req.Host = "test-host"
 			req.Header.Set(activator.RevisionHeaderNamespace, testNamespace)
 			req.Header.Set(activator.RevisionHeaderName, testRevName)
-			req.Host = "test-host"
-			for j := 0; j < b.N; j++ {
-				resp := httptest.NewRecorder()
-				handler.ServeHTTP(resp, req.WithContext(ctx))
-				if resp.Code != http.StatusOK {
-					b.Fatalf("resp.Code = %d, want: StatusOK(200)", resp.Code)
-				}
-				if got, want := resp.Body.Len(), len(respBody); got != want {
-					b.Fatalf("|body| = %d, want = %d", got, want)
-				}
+			return req
+		}
+
+		test := func(req *http.Request, b *testing.B) {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req.WithContext(ctx))
+			if resp.Code != http.StatusOK {
+				b.Fatalf("resp.Code = %d, want: StatusOK(200)", resp.Code)
 			}
+			if got, want := resp.Body.Len(), len(body); got != want {
+				b.Fatalf("|body| = %d, want = %d", got, want)
+			}
+		}
+
+		b.Run(fmt.Sprintf("%03dk-resp-len-sequential", bodyLength), func(b *testing.B) {
+			req := request()
+			for j := 0; j < b.N; j++ {
+				test(req, b)
+			}
+		})
+
+		b.Run(fmt.Sprintf("%03dk-resp-len-parallel", bodyLength), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				req := request()
+				for pb.Next() {
+					test(req, b)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

- Replace the fake roundtripper with manual and minimal response generation. That erases quite a few allocations that are specific to the testkernel itself and do not apply to the handler under test itself.
- Add a parallel version to the benchmark as well to be able to gauge behavior under concurrent load.

Output:

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-sequential-12         	  126798	      9318 ns/op	    6909 B/op	      51 allocs/op
BenchmarkHandler/002k-resp-len-parallel-12           	  546990	      3042 ns/op	    6837 B/op	      51 allocs/op
BenchmarkHandler/016k-resp-len-sequential-12         	   93540	     12477 ns/op	   21222 B/op	      51 allocs/op
BenchmarkHandler/016k-resp-len-parallel-12           	  246360	      4384 ns/op	   21165 B/op	      51 allocs/op
BenchmarkHandler/032k-resp-len-sequential-12         	   73270	     17583 ns/op	   37693 B/op	      51 allocs/op
BenchmarkHandler/032k-resp-len-parallel-12           	  177627	      6211 ns/op	   37623 B/op	      51 allocs/op
BenchmarkHandler/064k-resp-len-sequential-12         	   32152	     35663 ns/op	  136463 B/op	      52 allocs/op
BenchmarkHandler/064k-resp-len-parallel-12           	   69326	     16776 ns/op	  135927 B/op	      52 allocs/op
BenchmarkHandler/128k-resp-len-sequential-12         	   15705	     77590 ns/op	  366628 B/op	      53 allocs/op
BenchmarkHandler/128k-resp-len-parallel-12           	   23695	     44880 ns/op	  365301 B/op	      53 allocs/op
PASS
```

(saved ~9 allocs in the testkernel itself)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
