### PR TITLE
[WIP] PoC for distinct endpoint subsets of activator and application in one service.

### DIFF
--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -74,7 +74,7 @@ func endpointsToDests(endpoints *corev1.Endpoints, portName string) (sets.String
 // getServicePort takes a service and a protocol and returns the port number of
 // the port named for that protocol. If the port is not found then ok is false.
 func getServicePort(protocol networking.ProtocolType, svc *corev1.Service) (port int, ok bool) {
-	wantName := networking.ServicePortName(protocol)
+	wantName := networking.ServicePortName(protocol) + "-proxy"
 	for _, p := range svc.Spec.Ports {
 		if p.Name == wantName {
 			port, ok = int(p.Port), true

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -53,38 +53,38 @@ if (( HTTP )); then
   use_https="--https"
 fi
 
-# Run conformance and e2e tests.
-go_test_e2e -timeout=30m \
-  $(go list ./test/conformance/... | grep -v certificate) \
-  ./test/e2e \
-  ${parallelism} \
-  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+# # Run conformance and e2e tests.
+# go_test_e2e -timeout=30m \
+#   $(go list ./test/conformance/... | grep -v certificate) \
+#   ./test/e2e \
+#   ${parallelism} \
+#   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
-# Certificate conformance tests must be run separately
-# because they need cert-manager specific configurations.
-kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
-add_trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/nonhttp01 "$(certificate_class)" || failed=1
-kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
+# # Certificate conformance tests must be run separately
+# # because they need cert-manager specific configurations.
+# kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
+# add_trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+# go_test_e2e -timeout=10m \
+#   ./test/conformance/certificate/nonhttp01 "$(certificate_class)" || failed=1
+# kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
 
-kubectl apply -f ./test/config/autotls/certmanager/http01/
-add_trap "kubectl delete -f ./test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/http01 "$(certificate_class)" || failed=1
-kubectl delete -f ./test/config/autotls/certmanager/http01/
+# kubectl apply -f ./test/config/autotls/certmanager/http01/
+# add_trap "kubectl delete -f ./test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+# go_test_e2e -timeout=10m \
+#   ./test/conformance/certificate/http01 "$(certificate_class)" || failed=1
+# kubectl delete -f ./test/config/autotls/certmanager/http01/
 
 # Run scale tests.
-go_test_e2e -timeout=10m \
+go_test_e2e -timeout=30m \
   ${parallelism} \
   ./test/scale || failed=1
 
-# Istio E2E tests mutate the cluster and must be ran separately
-if [[ -n "${ISTIO_VERSION}" ]]; then
-  go_test_e2e -timeout=10m \
-    ./test/e2e/istio \
-    "--resolvabledomain=$(use_resolvable_domain)" || failed=1
-fi
+# # Istio E2E tests mutate the cluster and must be ran separately
+# if [[ -n "${ISTIO_VERSION}" ]]; then
+#   go_test_e2e -timeout=10m \
+#     ./test/e2e/istio \
+#     "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+# fi
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -298,7 +298,7 @@ func numberOfReadyPods(ctx *testContext) (float64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to get endpoints %s: %w", sks.Status.PrivateServiceName, err)
 	}
-	return float64(resources.ReadyAddressCount(eps)), nil
+	return float64(resources.ReadyAddressCountApplication(eps)), nil
 }
 
 func checkPodScale(ctx *testContext, targetPods, minPods, maxPods float64, duration time.Duration) error {
@@ -612,7 +612,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	// Now read the service endpoints and make sure there are 2 endpoints there.
 	// We poll, since network programming takes times, but the timeout is set for
 	// uniformness with one above.
-	if err := wait.Poll(250*time.Millisecond, 2*cfg.StableWindow, func() (bool, error) {
+	/*if err := wait.Poll(250*time.Millisecond, 2*cfg.StableWindow, func() (bool, error) {
 		svcEps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
 			ctx.resources.Revision.Status.ServiceName, metav1.GetOptions{})
 		if err != nil {
@@ -622,7 +622,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 		return resources.ReadyAddressCount(svcEps) == 2, nil
 	}); err != nil {
 		t.Errorf("Never achieved subset of size 2: %v", err)
-	}
+	}*/
 }
 
 func TestTargetBurstCapacityMinusOne(t *testing.T) {
@@ -673,7 +673,7 @@ func TestFastScaleToZero(t *testing.T) {
 	epsL, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
 			serving.RevisionLabelKey, ctx.resources.Revision.Name,
-			networking.ServiceTypeKey, networking.ServiceTypePrivate,
+			networking.ServiceTypeKey, networking.ServiceTypePublic,
 		),
 	})
 	if err != nil || len(epsL.Items) == 0 {
@@ -695,7 +695,7 @@ func TestFastScaleToZero(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
-		return resources.ReadyAddressCount(eps) == 0, nil
+		return resources.ReadyAddressCountApplication(eps) == 0, nil
 	}); err != nil {
 		t.Fatalf("Did not observe %q to actually be emptied", epsN)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -131,14 +131,11 @@ func waitForActivatorEndpoints(resources *v1a1test.ResourceObjects, clients *tes
 		if err != nil {
 			return false, err
 		}
-		if len(svcEps.Subsets) != len(aeps.Subsets) {
-			return false, nil
-		}
-		for i, ss := range svcEps.Subsets {
-			if !cmp.Equal(ss.Addresses, aeps.Subsets[i].Addresses) {
-				return false, nil
+		for _, ss := range svcEps.Subsets {
+			if cmp.Equal(ss.Addresses, aeps.Subsets[0].Addresses) {
+				return true, nil
 			}
 		}
-		return true, nil
+		return false, nil
 	})
 }

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -52,7 +52,7 @@ const (
 //   interesting burst of deployments, but low enough to complete in a reasonable window.
 func TestScaleToN(t *testing.T) {
 	// Run each of these variations.
-	tests := []int{10, 100}
+	tests := []int{100, 200}
 
 	for _, size := range tests {
 		t.Run(fmt.Sprintf("scale-%d", size), func(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This is hackedyhacky currently, just to find out if this works through various meshes in principle.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
