### PR TITLE
Remove k8s resource in e2e test

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -217,6 +217,7 @@ func setup(t *testing.T, class, metric string, target, targetUtilization float64
 			}),
 		}, fopts...)...)
 	if err != nil {
+		test.TearDown(clients, names)
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -61,16 +61,16 @@ func TestDestroyPodInflight(t *testing.T) {
 		Route:  svcName,
 		Image:  "timeout",
 	}
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
 
+	t.Log("Creating a new Route and Configuration")
 	if _, err := v1a1test.CreateConfiguration(t, clients, names, v1a1opts.WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds)); err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
 	if _, err := v1a1test.CreateRoute(t, clients, names); err != nil {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
-
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
 
 	t.Log("When the Revision can have traffic routed to it, the Route is marked as Ready")
 	if err := v1a1test.WaitForRouteState(clients.ServingAlphaClient, names.Route, v1a1test.IsRouteReady, "RouteIsReady"); err != nil {


### PR DESCRIPTION
## Proposed Changes

* Remove k8s resource in autoscale test if `steup` function meet error.
* Set `defer` function before `t.Fatalf` called. Otherwise the `defer` function may not be called.

