### PR TITLE
Set prober target port from gateway instead of endpoint

### DIFF
--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -91,9 +91,10 @@ type workItem struct {
 
 // ProbeTarget contains the URLs to probes for a set of Pod IPs serving out of the same port.
 type ProbeTarget struct {
-	PodIPs sets.String
-	Port   string
-	URLs   []*url.URL
+	PodIPs  sets.String
+	PodPort string
+	Port    string
+	URLs    []*url.URL
 }
 
 // ProbeTargetLister lists all the targets that requires probing.
@@ -205,7 +206,7 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 					ingressState: ingressState,
 					url:          url,
 					podIP:        ip,
-					podPort:      target.Port,
+					podPort:      target.PodPort,
 				})
 			}
 		}

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -112,9 +112,9 @@ func TestProbeLifecycle(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs: sets.NewString(hostname),
-			Port:   strconv.Itoa(port),
-			URLs:   []*url.URL{tsURL},
+			PodIPs:  sets.NewString(hostname),
+			PodPort: strconv.Itoa(port),
+			URLs:    []*url.URL{tsURL},
 		}},
 		func(ing *v1alpha1.Ingress) {
 			ready <- ing
@@ -261,9 +261,9 @@ func TestCancelPodProbing(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs: sets.NewString(hostname),
-			Port:   strconv.Itoa(port),
-			URLs:   []*url.URL{tsURL},
+			PodIPs:  sets.NewString(hostname),
+			PodPort: strconv.Itoa(port),
+			URLs:    []*url.URL{tsURL},
 		}},
 		func(ing *v1alpha1.Ingress) {
 			ready <- ing
@@ -400,9 +400,9 @@ func TestPartialPodCancellation(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs: sets.NewString(pods[0].Status.PodIP, pods[1].Status.PodIP),
-			Port:   strconv.Itoa(port),
-			URLs:   []*url.URL{tsURL},
+			PodIPs:  sets.NewString(pods[0].Status.PodIP, pods[1].Status.PodIP),
+			PodPort: strconv.Itoa(port),
+			URLs:    []*url.URL{tsURL},
 		}},
 		func(ing *v1alpha1.Ingress) {
 			ready <- ing
@@ -470,9 +470,9 @@ func TestCancelIngressProbing(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs: sets.NewString(hostname),
-			Port:   strconv.Itoa(port),
-			URLs:   []*url.URL{tsURL},
+			PodIPs:  sets.NewString(hostname),
+			PodPort: strconv.Itoa(port),
+			URLs:    []*url.URL{tsURL},
 		}},
 		func(ing *v1alpha1.Ingress) {
 			ready <- ing
@@ -543,8 +543,9 @@ func (l fakeProbeTargetLister) ListProbeTargets(ctx context.Context, ing *v1alph
 	targets := []ProbeTarget{}
 	for _, target := range l {
 		newTarget := ProbeTarget{
-			PodIPs: target.PodIPs,
-			Port:   target.Port,
+			PodIPs:  target.PodIPs,
+			PodPort: target.PodPort,
+			Port:    target.Port,
 		}
 		for _, url := range target.URLs {
 			newURL := *url

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -80,9 +80,10 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 		}
 		for _, target := range targets {
 			qualifiedTarget := status.ProbeTarget{
-				PodIPs: target.PodIPs,
-				Port:   target.Port,
-				URLs:   make([]*url.URL, len(gatewayHosts[gatewayName])),
+				PodIPs:  target.PodIPs,
+				PodPort: target.PodPort,
+				Port:    target.Port,
+				URLs:    make([]*url.URL, len(gatewayHosts[gatewayName])),
 			}
 			// Use sorted hosts list for consistent ordering.
 			for i, host := range gatewayHosts[gatewayName].List() {
@@ -159,9 +160,10 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1alpha3.Gateway) (
 				continue
 			}
 			target := status.ProbeTarget{
-				PodIPs: sets.NewString(),
-				Port:   strconv.Itoa(int(portNumber)),
-				URLs:   []*url.URL{tURL},
+				PodIPs:  sets.NewString(),
+				PodPort: strconv.Itoa(int(portNumber)),
+				Port:    strconv.Itoa(int(server.Port.Number)),
+				URLs:    []*url.URL{tURL},
 			}
 			for _, addr := range sub.Addresses {
 				target.PodIPs.Insert(addr.IP)

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -506,7 +506,7 @@ func TestListProbeTargets(t *testing.T) {
 			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
 		}},
 	}, {
-		name: "Different port between ednpoint and gateway service",
+		name: "Different port between endpoint and gateway service",
 		ingressGateways: []config.Gateway{{
 			Name:      "gateway",
 			Namespace: "default",

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -428,7 +428,7 @@ func TestListProbeTargets(t *testing.T) {
 						Hosts: []string{"*"},
 						Port: &istiov1alpha3.Port{
 							Name:     "http",
-							Number:   80,
+							Number:   8080,
 							Protocol: "HTTP",
 						},
 					}, {
@@ -454,10 +454,10 @@ func TestListProbeTargets(t *testing.T) {
 				Subsets: []v1.EndpointSubset{{
 					Ports: []v1.EndpointPort{{
 						Name: "bogus",
-						Port: 8080,
+						Port: 8081,
 					}, {
 						Name: "real",
-						Port: 80,
+						Port: 8080,
 					}},
 					Addresses: []v1.EndpointAddress{{
 						IP: "1.1.1.1",
@@ -477,10 +477,10 @@ func TestListProbeTargets(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Ports: []v1.ServicePort{{
 						Name: "bogus",
-						Port: 8080,
+						Port: 8081,
 					}, {
 						Name: "real",
-						Port: 80,
+						Port: 8080,
 					}},
 				},
 			}},
@@ -501,9 +501,9 @@ func TestListProbeTargets(t *testing.T) {
 		},
 		results: []status.ProbeTarget{{
 			PodIPs:  sets.NewString("1.1.1.1"),
-			PodPort: "80",
-			Port:    "80",
-			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
+			PodPort: "8080",
+			Port:    "8080",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:8080"}},
 		}},
 	}, {
 		name: "Different port between endpoint and gateway service",

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -500,9 +500,104 @@ func TestListProbeTargets(t *testing.T) {
 			},
 		},
 		results: []status.ProbeTarget{{
-			PodIPs: sets.NewString("1.1.1.1"),
-			Port:   "80",
-			URLs:   []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
+			PodIPs:  sets.NewString("1.1.1.1"),
+			PodPort: "80",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
+		}},
+	}, {
+		name: "Different port between ednpoint and gateway service",
+		ingressGateways: []config.Gateway{{
+			Name:      "gateway",
+			Namespace: "default",
+		}},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: istiov1alpha3.Gateway{
+					Servers: []*istiov1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: &istiov1alpha3.Port{
+							Name:     "http",
+							Number:   80,
+							Protocol: "HTTP",
+						},
+					}, {
+						Hosts: []string{"*"},
+						Port: &istiov1alpha3.Port{
+							Name:     "https",
+							Number:   443,
+							Protocol: "HTTPS",
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "bogus",
+						Port: 8081,
+					}, {
+						Name: "real",
+						Port: 8080, // Different port number between Endpoint and Gateway Service.
+					}},
+					Addresses: []v1.EndpointAddress{{
+						IP: "1.1.1.1",
+					}},
+				}},
+			}},
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+					Labels: map[string]string{
+						"gwt": "istio",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "bogus",
+						Port: 8081,
+					}, {
+						Name: "real",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"foo.bar.com",
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}},
+			},
+		},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.NewString("1.1.1.1"),
+			PodPort: "8080",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
 		}},
 	}, {
 		name: "one gateway, https redirect",
@@ -896,13 +991,15 @@ func TestListProbeTargets(t *testing.T) {
 			},
 		},
 		results: []status.ProbeTarget{{
-			PodIPs: sets.NewString("1.1.1.1"),
-			Port:   "80",
-			URLs:   []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
+			PodIPs:  sets.NewString("1.1.1.1"),
+			PodPort: "80",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
 		}, {
-			PodIPs: sets.NewString("2.2.2.2", "2.2.2.3"),
-			Port:   "90",
-			URLs:   []*url.URL{{Scheme: "http", Host: "foo.bar.com:90"}},
+			PodIPs:  sets.NewString("2.2.2.2", "2.2.2.3"),
+			PodPort: "90",
+			Port:    "90",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:90"}},
 		}},
 	}, {
 		name: "local gateways",
@@ -1047,8 +1144,9 @@ func TestListProbeTargets(t *testing.T) {
 			},
 		},
 		results: []status.ProbeTarget{{
-			PodIPs: sets.NewString("2.2.2.2", "2.2.2.3"),
-			Port:   "80",
+			PodIPs:  sets.NewString("2.2.2.2", "2.2.2.3"),
+			PodPort: "80",
+			Port:    "80",
 			URLs: []*url.URL{
 				{Scheme: "http", Host: "foo.bar:80"},
 				{Scheme: "http", Host: "foo.bar.svc:80"},


### PR DESCRIPTION
## Proposed Changes

Currently target port to probe is set from endpoint's port.
It does not work when endpoint has different port number from gateway.

To fix it, this patch sets prober target port from gateway instead of
endpoint.

/lint

**Release Note**

```release-note
NONE
```

/cc @savitaashture @markusthoemmes @tcnghia @JRBANCEL 