### PR TITLE
Avoid tracing allocations if tracing is disabled anyway.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -206,7 +206,7 @@ func knativeProbeHandler(healthState *health.State, prober func() bool, isAggres
 			return
 		}
 
-		probeSpan := (*trace.Span)(nil)
+		var probeSpan *trace.Span
 		if tracingEnabled {
 			_, probeSpan = trace.StartSpan(r.Context(), "probe")
 			defer probeSpan.End()

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -155,15 +155,18 @@ type config struct {
 }
 
 // Make handler a closure for testing.
-func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, next http.Handler) http.HandlerFunc {
+func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEnabled bool, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if network.IsKubeletProbe(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		proxyCtx, proxySpan := trace.StartSpan(r.Context(), "proxy")
-		defer proxySpan.End()
+		if tracingEnabled {
+			proxyCtx, proxySpan := trace.StartSpan(r.Context(), "proxy")
+			r = r.WithContext(proxyCtx)
+			defer proxySpan.End()
+		}
 
 		// Metrics for autoscaling.
 		in, out := queue.ReqIn, queue.ReqOut
@@ -179,7 +182,7 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, next http
 		// Enforce queuing and concurrency limits.
 		if breaker != nil {
 			if err := breaker.Maybe(r.Context(), func() {
-				next.ServeHTTP(w, r.WithContext(proxyCtx))
+				next.ServeHTTP(w, r)
 			}); err != nil {
 				switch err {
 				case context.DeadlineExceeded, queue.ErrRequestQueueFull:
@@ -189,12 +192,12 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, next http
 				}
 			}
 		} else {
-			next.ServeHTTP(w, r.WithContext(proxyCtx))
+			next.ServeHTTP(w, r)
 		}
 	}
 }
 
-func knativeProbeHandler(healthState *health.State, prober func() bool, isAggressive bool, next http.Handler) http.HandlerFunc {
+func knativeProbeHandler(healthState *health.State, prober func() bool, isAggressive bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ph := network.KnativeProbeHeader(r)
 
@@ -203,8 +206,11 @@ func knativeProbeHandler(healthState *health.State, prober func() bool, isAggres
 			return
 		}
 
-		_, probeSpan := trace.StartSpan(r.Context(), "probe")
-		defer probeSpan.End()
+		probeSpan := (*trace.Span)(nil)
+		if tracingEnabled {
+			_, probeSpan = trace.StartSpan(r.Context(), "probe")
+			defer probeSpan.End()
+		}
 
 		if ph != queue.Name {
 			http.Error(w, fmt.Sprintf(badProbeTemplate, ph), http.StatusBadRequest)
@@ -451,6 +457,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, req
 
 	breaker := buildBreaker(env)
 	metricsSupported := supportsMetrics(env, logger)
+	tracingEnabled := env.TracingConfigBackend != tracingconfig.None
 
 	// Create queue handler chain.
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
@@ -459,7 +466,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, req
 		composedHandler = pushRequestMetricHandler(httpProxy, appRequestCountM, appResponseTimeInMsecM,
 			queueDepthM, breaker, env)
 	}
-	composedHandler = proxyHandler(reqChan, breaker, composedHandler)
+	composedHandler = proxyHandler(reqChan, breaker, tracingEnabled, composedHandler)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
 	composedHandler = queue.TimeToFirstByteTimeoutHandler(composedHandler,
 		time.Duration(env.RevisionTimeoutSeconds)*time.Second, "request timeout")
@@ -471,7 +478,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, req
 	}
 	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
 
-	composedHandler = knativeProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), composedHandler)
+	composedHandler = knativeProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
 	composedHandler = network.NewProbeHandler(composedHandler)
 
 	return pkgnet.NewServer(":"+strconv.Itoa(env.QueueServingPort), composedHandler)

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -76,7 +76,7 @@ func TestHandlerReqEvent(t *testing.T) {
 	params := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
 	breaker := queue.NewBreaker(params)
 	reqChan := make(chan queue.ReqEvent, 10)
-	h := proxyHandler(reqChan, breaker, proxy)
+	h := proxyHandler(reqChan, breaker, true /*tracingEnabled*/, proxy)
 
 	writer := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -137,7 +137,7 @@ func TestProbeHandler(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 			req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 
-			h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, nil)
+			h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
 			h(writer, req)
 
 			if got, want := writer.Code, tc.wantCode; got != want {
@@ -411,10 +411,10 @@ func TestQueueTraceSpans(t *testing.T) {
 					Base: pkgnet.AutoTransport,
 				}
 
-				h := proxyHandler(reqChan, breaker, proxy)
+				h := proxyHandler(reqChan, breaker, true /*tracingEnabled*/, proxy)
 				h(writer, req)
 			} else {
-				h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, nil)
+				h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
 				req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 				h(writer, req)
 			}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

If tracing is disabled we don't need to allocate spans and contexts at all. It saves 6 allocations in the activator per request. I'll post benchmark data once #6533 merges.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
