### PR TITLE
Add process uptime to the queue.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -330,7 +330,9 @@ func main() {
 	}
 
 	// Setup reporters and processes to handle stat reporting.
-	promStatReporter, err := queue.NewPrometheusStatsReporter(env.ServingNamespace, env.ServingConfiguration, env.ServingRevision, env.ServingPod, reportingPeriod)
+	promStatReporter, err := queue.NewPrometheusStatsReporter(
+		env.ServingNamespace, env.ServingConfiguration, env.ServingRevision,
+		env.ServingPod, reportingPeriod)
 	if err != nil {
 		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
 	}

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -54,6 +54,9 @@ var (
 	averageProxiedConcurrentRequestsGV = newGV(
 		"queue_average_proxied_concurrent_requests",
 		"Number of proxied requests currently being handled by this pod")
+	processUptimeGV = newGV(
+		"process_uptime",
+		"The number of seconds that the process has been up")
 )
 
 func newGV(n, h string) *prometheus.GaugeVec {
@@ -67,11 +70,13 @@ func newGV(n, h string) *prometheus.GaugeVec {
 type PrometheusStatsReporter struct {
 	handler         http.Handler
 	reportingPeriod time.Duration
+	startTime       time.Time
 
 	requestsPerSecond                prometheus.Gauge
 	proxiedRequestsPerSecond         prometheus.Gauge
 	averageConcurrentRequests        prometheus.Gauge
 	averageProxiedConcurrentRequests prometheus.Gauge
+	processUptime                    prometheus.Gauge
 }
 
 // NewPrometheusStatsReporter creates a reporter that collects and reports queue metrics.
@@ -90,7 +95,10 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 	}
 
 	registry := prometheus.NewRegistry()
-	for _, gv := range []*prometheus.GaugeVec{requestsPerSecondGV, proxiedRequestsPerSecondGV, averageConcurrentRequestsGV, averageProxiedConcurrentRequestsGV} {
+	for _, gv := range []*prometheus.GaugeVec{
+		requestsPerSecondGV, proxiedRequestsPerSecondGV,
+		averageConcurrentRequestsGV, averageProxiedConcurrentRequestsGV,
+		processUptimeGV} {
 		if err := registry.Register(gv); err != nil {
 			return nil, fmt.Errorf("register metric failed: %w", err)
 		}
@@ -106,21 +114,25 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 	return &PrometheusStatsReporter{
 		handler:         promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
 		reportingPeriod: reportingPeriod,
+		startTime:       time.Now(),
 
 		requestsPerSecond:                requestsPerSecondGV.With(labels),
 		proxiedRequestsPerSecond:         proxiedRequestsPerSecondGV.With(labels),
 		averageConcurrentRequests:        averageConcurrentRequestsGV.With(labels),
 		averageProxiedConcurrentRequests: averageProxiedConcurrentRequestsGV.With(labels),
+		processUptime:                    processUptimeGV.With(labels),
 	}, nil
 }
 
 // Report captures request metrics.
 func (r *PrometheusStatsReporter) Report(acr float64, apcr float64, rc float64, prc float64) {
 	// Requests per second is a rate over time while concurrency is not.
-	r.requestsPerSecond.Set(rc / r.reportingPeriod.Seconds())
-	r.proxiedRequestsPerSecond.Set(prc / r.reportingPeriod.Seconds())
+	rp := r.reportingPeriod.Seconds()
+	r.requestsPerSecond.Set(rc / rp)
+	r.proxiedRequestsPerSecond.Set(prc / rp)
 	r.averageConcurrentRequests.Set(acr)
 	r.averageProxiedConcurrentRequests.Set(apcr)
+	r.processUptime.Set(time.Since(r.startTime).Seconds())
 }
 
 // Handler returns an uninstrumented http.Handler used to serve stats registered by this

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -32,6 +32,10 @@ const (
 	config    = "helloworld-go"
 	revision  = "helloworld-go-00001"
 	pod       = "helloworld-go-00001-deployment-8ff587cc9-7g9gc"
+
+	// Except for uptime everything else is integers, so this precision is
+	// good enough for the tests.
+	precision = 0.1
 )
 
 func TestNewPrometheusStatsReporter_negative(t *testing.T) {
@@ -175,10 +179,6 @@ func TestReporterReport(t *testing.T) {
 		})
 	}
 }
-
-// Except for uptime everything else is integers, so this precision is
-// good enough for the tests.
-const precision = 0.1
 
 func checkData(t *testing.T, gv *prometheus.GaugeVec, want float64) {
 	t.Helper()


### PR DESCRIPTION
This is the first step in getting autoscaler to try to avoid young pods, in order not to
suggest lower scale, due to the fact that new pods are not full yet with requests.
We can query the age of the pod from a pod lister, but this is easier and generically more useful way I think to query the data.
Next use this data in the autoscaler.

Example:
```
curl http://10.24.15.204:9090/metrics
# HELP process_uptime The number of seconds that the process has been up
# TYPE process_uptime gauge
process_uptime{destination_configuration="s1",destination_namespace="default",destination_pod="s1-tdgpn-deployment-86f6459cf8-mc9mw",destination_revision="s1-tdgpn"} 2937.000279171
```

/assign @yanweiguo @markusthoemmes 

