### PR TITLE
Add benchmarks for the request log handler and reduce contention.

### DIFF
--- a/pkg/http/request_log_test.go
+++ b/pkg/http/request_log_test.go
@@ -38,13 +38,12 @@ var (
 		PodIP:         "ip",
 	}
 	defaultInputGetter = RequestLogTemplateInputGetterFromRevision(defaultRevInfo)
+	baseHandler        = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 )
 
 func TestRequestLogHandler(t *testing.T) {
-	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
 	tests := []struct {
 		name                  string
 		url                   string
@@ -156,9 +155,6 @@ func TestPanickingHandler(t *testing.T) {
 }
 
 func TestFailedTemplateExecution(t *testing.T) {
-	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
 	buf := bytes.NewBufferString("")
 	handler, err := NewRequestLogHandler(
 		baseHandler, buf, "{{.Request.Something}}", defaultInputGetter, false)
@@ -177,10 +173,6 @@ func TestFailedTemplateExecution(t *testing.T) {
 }
 
 func TestSetTemplate(t *testing.T) {
-	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
 	url, body := "http://example.com/testpage", "test"
 	tests := []struct {
 		name     string
@@ -247,9 +239,6 @@ func TestSetTemplate(t *testing.T) {
 }
 
 func BenchmarkRequestLogHandlerNoTemplate(b *testing.B) {
-	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
 	handler, err := NewRequestLogHandler(baseHandler, ioutil.Discard, "", defaultInputGetter, false)
 	if err != nil {
 		b.Fatalf("Failed to create handler: %v", err)
@@ -281,10 +270,6 @@ func BenchmarkRequestLogHandlerNoTemplate(b *testing.B) {
 }
 
 func BenchmarkRequestLogHandlerDefaultTemplate(b *testing.B) {
-	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
 	// Taken from config-observability.yaml
 	tpl := `{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}`
 	handler, err := NewRequestLogHandler(baseHandler, ioutil.Discard, tpl, defaultInputGetter, false)

--- a/pkg/http/request_log_test.go
+++ b/pkg/http/request_log_test.go
@@ -243,27 +243,20 @@ func BenchmarkRequestLogHandlerNoTemplate(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create handler: %v", err)
 	}
-	request := func() *http.Request {
-		return httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-	}
-
 	resp := httptest.NewRecorder()
-	test := func(req *http.Request, b *testing.B) {
-		handler.ServeHTTP(resp, req)
-	}
 
-	b.Run(fmt.Sprintf("sequential"), func(b *testing.B) {
-		req := request()
+	b.Run(fmt.Sprint("sequential"), func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 		for j := 0; j < b.N; j++ {
-			test(req, b)
+			handler.ServeHTTP(resp, req)
 		}
 	})
 
-	b.Run(fmt.Sprintf("parallel"), func(b *testing.B) {
+	b.Run(fmt.Sprint("parallel"), func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
-			req := request()
+			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 			for pb.Next() {
-				test(req, b)
+				handler.ServeHTTP(resp, req)
 			}
 		})
 	})
@@ -276,27 +269,20 @@ func BenchmarkRequestLogHandlerDefaultTemplate(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create handler: %v", err)
 	}
-	request := func() *http.Request {
-		return httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-	}
-
 	resp := httptest.NewRecorder()
-	test := func(req *http.Request, b *testing.B) {
-		handler.ServeHTTP(resp, req)
-	}
 
-	b.Run(fmt.Sprintf("sequential"), func(b *testing.B) {
-		req := request()
+	b.Run(fmt.Sprint("sequential"), func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 		for j := 0; j < b.N; j++ {
-			test(req, b)
+			handler.ServeHTTP(resp, req)
 		}
 	})
 
-	b.Run(fmt.Sprintf("parallel"), func(b *testing.B) {
+	b.Run(fmt.Sprint("parallel"), func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
-			req := request()
+			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 			for pb.Next() {
-				test(req, b)
+				handler.ServeHTTP(resp, req)
 			}
 		})
 	})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Added a benchmark that uses a template and no template.
*  Use unsafe.Pointer instead of RWMutex for the template to get the least possible contention. We don't care about consistency of the template variable at all. We only want it to be picked up after it is set eventually. Using an atomically handled pointer is quicker than an RWMutex in this case.

### RWMutex

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/http
BenchmarkRequestLogHandlerNoTemplate/sequential-12         	19548554	        58.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkRequestLogHandlerNoTemplate/parallel-12           	24365936	        52.3 ns/op	       0 B/op	       0 allocs/op
PASS
```

### unsafe.Pointer

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/http
BenchmarkRequestLogHandlerNoTemplate/sequential-12         	100000000	        10.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkRequestLogHandlerNoTemplate/parallel-12           	612916347	         2.22 ns/op	       0 B/op	       0 allocs/op
PASS
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
