### PR TITLE
Allows to override the ingress endpoint for conformance/ingress tests

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -701,6 +701,11 @@ func CreateDialContext(t *testing.T, ing *v1alpha1.Ingress, clients *test.Client
 		if err != nil {
 			return nil, err
 		}
+		// Allow "ingressendpoint" flag to override the discovered ingress IP/hostname,
+		// this is required in minikube-like environments.
+		if pkgTest.Flags.IngressEndpoint != "" {
+			return net.Dial("tcp", pkgTest.Flags.IngressEndpoint+":"+port)
+		}
 		if ingress.IP != "" {
 			return net.Dial("tcp", ingress.IP+":"+port)
 		}


### PR DESCRIPTION
/lint

## Proposed Changes

* Allow overriding the ingress endpoint when running conformance/ingress tests passing the proper flag: `-ingressendpoint=127.0.0.1`

**Release Note**

```release-note
NONE
```
