### PR TITLE
Use DownwardAPI to populate pod label into Queue-Proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -203,22 +203,23 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 }
 
 func preferPodForScaledown(logger *zap.SugaredLogger, downwardAPILabelsPath string) bool {
-	// short circuit a rejection when no label path is set
-	if downwardAPILabelsPath == "" {
+	// Short circuit a rejection when no label path file is mounted
+	if _, err := os.Stat(downwardAPILabelsPath); os.IsNotExist(err) {
 		return false
 	}
 
-	content, err := ioutil.ReadFile(downwardAPILabelsPath)
+	contentBytes, err := ioutil.ReadFile(downwardAPILabelsPath)
 	if err != nil {
 		logger.Warnf("Failed reading the labels file %v", err)
 		return false
 	}
 
-	if string(content) == "" {
+	content := string(contentBytes)
+	if content == "" {
 		return false
 	}
 
-	scaleDown, err := strconv.ParseBool(string(content))
+	scaleDown, err := strconv.ParseBool(content)
 	if err != nil {
 		logger.Errorf("Failed parsing the label value %v", err)
 		return false

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -210,7 +210,11 @@ func preferPodForScaledown(logger *zap.SugaredLogger, downwardAPILabelsPath stri
 
 	content, err := ioutil.ReadFile(downwardAPILabelsPath)
 	if err != nil {
-		logger.Errorf("Failed reading the labels file %v", err)
+		logger.Warnf("Failed reading the labels file %v", err)
+		return false
+	}
+
+	if string(content) == "" {
 		return false
 	}
 
@@ -246,10 +250,10 @@ func knativeProbeHandler(healthState *health.State, prober func() bool, isAggres
 		}
 
 		if preferPodForScaledown(logger, env.DownwardAPILabelsPath) {
-			//deliberately failing the readiness probe when pod is labelled for scale down
+			//Deliberately failing the readiness probe when pod is labelled for scale down
 			http.Error(w, failingHealthcheck, http.StatusBadRequest)
 			probeSpan.Annotate([]trace.Attribute{
-				trace.StringAttribute("queueproxy.probe.error", "failing health check")}, "error")
+				trace.StringAttribute("queueproxy.probe.error", "intentionally failing health check")}, "error")
 			return
 		}
 

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -157,4 +157,9 @@ const (
 	// KPALabelKey is the label key attached to a K8s Service to hint to the KPA
 	// which services/endpoints should trigger reconciles.
 	KPALabelKey = GroupName + "/kpa"
+
+	// PreferForScaleDownLabel is the label key set on a pod which is selected
+	// by the autoscaler as a candidate for removal. Once the label is set to "true", it
+	// signals the QueueProxy to fail readiness on the pod
+	PreferForScaleDownLabelKey = GroupName + "/prefer-for-scale-down"
 )

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/autoscaler"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
@@ -40,6 +41,7 @@ type Config struct {
 	Logging       *logging.Config
 	Tracing       *pkgtracing.Config
 	Defaults      *config.Defaults
+	Autoscaler    *autoscaler.Config
 }
 
 func FromContext(ctx context.Context) *Config {
@@ -68,6 +70,7 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 				logging.ConfigMapName():    logging.NewConfigFromConfigMap,
 				pkgtracing.ConfigName:      pkgtracing.NewTracingConfigFromConfigMap,
 				config.DefaultsConfigName:  config.NewDefaultsConfigFromConfigMap,
+				autoscaler.ConfigName:      autoscaler.NewConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -89,5 +92,6 @@ func (s *Store) Load() *Config {
 		Logging:       s.UntypedLoad((logging.ConfigMapName())).(*logging.Config).DeepCopy(),
 		Tracing:       s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config).DeepCopy(),
 		Defaults:      s.UntypedLoad(config.DefaultsConfigName).(*config.Defaults).DeepCopy(),
+		Autoscaler:    s.UntypedLoad(autoscaler.ConfigName).(*autoscaler.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/revision/config/store_test.go
+++ b/pkg/reconciler/revision/config/store_test.go
@@ -27,6 +27,7 @@ import (
 	pkgmetrics "knative.dev/pkg/metrics"
 	pkgtracing "knative.dev/pkg/tracing/config"
 	apisconfig "knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/autoscaler"
 	deployment "knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
@@ -43,6 +44,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	loggingConfig := ConfigMapFromTestFile(t, logging.ConfigMapName())
 	tracingConfig := ConfigMapFromTestFile(t, pkgtracing.ConfigName)
 	defaultConfig := ConfigMapFromTestFile(t, apisconfig.DefaultsConfigName)
+	autoscalerConfig := ConfigMapFromTestFile(t, autoscaler.ConfigName)
 
 	store.OnConfigChanged(deploymentConfig)
 	store.OnConfigChanged(networkConfig)
@@ -50,6 +52,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	store.OnConfigChanged(loggingConfig)
 	store.OnConfigChanged(tracingConfig)
 	store.OnConfigChanged(defaultConfig)
+	store.OnConfigChanged(autoscalerConfig)
 
 	config := FromContext(store.ToContext(context.Background()))
 
@@ -96,6 +99,13 @@ func TestStoreLoadWithContext(t *testing.T) {
 			t.Errorf("Unexpected defaults config (-want, +got): %v", diff)
 		}
 	})
+
+	t.Run("autoscaler", func(t *testing.T) {
+		expected, _ := autoscaler.NewConfigFromConfigMap(autoscalerConfig)
+		if diff := cmp.Diff(expected, config.Autoscaler); diff != "" {
+			t.Errorf("Unexpected autoscaler config (-want, +got): %v", diff)
+		}
+	})
 }
 
 func TestStoreImmutableConfig(t *testing.T) {
@@ -107,6 +117,7 @@ func TestStoreImmutableConfig(t *testing.T) {
 	store.OnConfigChanged(ConfigMapFromTestFile(t, logging.ConfigMapName()))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, pkgtracing.ConfigName))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, apisconfig.DefaultsConfigName))
+	store.OnConfigChanged(ConfigMapFromTestFile(t, autoscaler.ConfigName))
 
 	config := store.Load()
 
@@ -115,6 +126,8 @@ func TestStoreImmutableConfig(t *testing.T) {
 	config.Logging.LoggingConfig = "mutated"
 	ccMutated := int64(4)
 	config.Defaults.ContainerConcurrency = ccMutated
+	scaleupMutated := float64(4)
+	config.Autoscaler.MaxScaleUpRate = scaleupMutated
 
 	newConfig := store.Load()
 
@@ -129,5 +142,8 @@ func TestStoreImmutableConfig(t *testing.T) {
 	}
 	if newConfig.Defaults.ContainerConcurrency == ccMutated {
 		t.Error("Defaults config is not immutable")
+	}
+	if newConfig.Autoscaler.MaxScaleUpRate == scaleupMutated {
+		t.Error("Autoscaler config is not immutable")
 	}
 }

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -41,6 +41,7 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revisio
 		cfgs.Tracing,
 		cfgs.Network,
 		cfgs.Observability,
+		cfgs.Autoscaler,
 		cfgs.Deployment,
 	)
 
@@ -61,6 +62,7 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 		cfgs.Tracing,
 		cfgs.Network,
 		cfgs.Observability,
+		cfgs.Autoscaler,
 		cfgs.Deployment,
 	)
 

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -38,6 +38,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
@@ -395,6 +396,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc   *logging.Config
 		tc   *tracingconfig.Config
 		oc   *metrics.ObservabilityConfig
+		ac   *autoscaler.Config
 		cc   *deployment.Config
 		want *corev1.PodSpec
 	}{{
@@ -413,6 +415,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -456,6 +459,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -495,6 +499,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -519,6 +524,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -543,6 +549,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -562,6 +569,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -586,6 +594,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -605,6 +614,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -630,6 +640,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -662,6 +673,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -689,6 +701,7 @@ func TestMakePodSpec(t *testing.T) {
 		oc: &metrics.ObservabilityConfig{
 			EnableVarLogCollection: true,
 		},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -732,6 +745,7 @@ func TestMakePodSpec(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: podSpec(
 			[]corev1.Container{
@@ -773,7 +787,7 @@ func TestMakePodSpec(t *testing.T) {
 			quantityComparer := cmp.Comparer(func(x, y resource.Quantity) bool {
 				return x.Cmp(y) == 0
 			})
-			got, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.cc)
+			got, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.ac, test.cc)
 			if err != nil {
 				t.Fatal("makePodSpec returned errror")
 			}
@@ -793,7 +807,7 @@ func TestMakePodSpec(t *testing.T) {
 			}
 			test.rev.Spec.DeprecatedContainer = nil
 
-			got, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.cc)
+			got, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.ac, test.cc)
 			if err != nil {
 				t.Fatal("makePodSpec returned errror")
 			}
@@ -810,6 +824,7 @@ func TestMissingProbeError(t *testing.T) {
 		&tracingconfig.Config{},
 		&network.Config{},
 		&metrics.ObservabilityConfig{},
+		&autoscaler.Config{},
 		&deployment.Config{},
 	)
 
@@ -826,6 +841,7 @@ func TestMakeDeployment(t *testing.T) {
 		tc   *tracingconfig.Config
 		nc   *network.Config
 		oc   *metrics.ObservabilityConfig
+		ac   *autoscaler.Config
 		cc   *deployment.Config
 		want *appsv1.Deployment
 	}{{
@@ -848,6 +864,7 @@ func TestMakeDeployment(t *testing.T) {
 		tc:   &tracingconfig.Config{},
 		nc:   &network.Config{},
 		oc:   &metrics.ObservabilityConfig{},
+		ac:   &autoscaler.Config{},
 		cc:   &deployment.Config{},
 		want: makeDeployment(),
 	}, {
@@ -870,6 +887,7 @@ func TestMakeDeployment(t *testing.T) {
 		tc:   &tracingconfig.Config{},
 		nc:   &network.Config{},
 		oc:   &metrics.ObservabilityConfig{},
+		ac:   &autoscaler.Config{},
 		cc:   &deployment.Config{},
 		want: makeDeployment(),
 	}, {
@@ -893,6 +911,7 @@ func TestMakeDeployment(t *testing.T) {
 			IstioOutboundIPRanges: "*",
 		},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.Spec.Template.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "*"
@@ -916,6 +935,7 @@ func TestMakeDeployment(t *testing.T) {
 		tc: &tracingconfig.Config{},
 		nc: &network.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.ObjectMeta.Annotations[sidecarIstioInjectAnnotation] = "false"
@@ -945,6 +965,7 @@ func TestMakeDeployment(t *testing.T) {
 			IstioOutboundIPRanges: "*",
 		},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
@@ -955,12 +976,12 @@ func TestMakeDeployment(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Tested above so that we can rely on it here for brevity.
-			podSpec, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.cc)
+			podSpec, err := makePodSpec(test.rev, test.lc, test.tc, test.oc, test.ac, test.cc)
 			if err != nil {
 				t.Fatal("makePodSpec returned errror")
 			}
 			test.want.Spec.Template.Spec = *podSpec
-			got, err := MakeDeployment(test.rev, test.lc, test.tc, test.nc, test.oc, test.cc)
+			got, err := MakeDeployment(test.rev, test.lc, test.tc, test.nc, test.oc, test.ac, test.cc)
 			if err != nil {
 				t.Fatalf("got unexpected error: %v", err)
 			}

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
@@ -187,7 +188,7 @@ func makeQueueProbe(in *corev1.Probe) *corev1.Probe {
 
 // makeQueueContainer creates the container spec for the queue sidecar.
 func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig,
-	deploymentConfig *deployment.Config) (*corev1.Container, error) {
+	autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) (*corev1.Container, error) {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -224,6 +224,10 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, t
 		volumeMounts = append(volumeMounts, internalVolumeMount)
 	}
 
+	if autoscalerConfig.EnableGracefulScaledown {
+		volumeMounts = append(volumeMounts, labelVolumeMount)
+	}
+
 	rp := rev.Spec.GetContainer().ReadinessProbe.DeepCopy()
 
 	applyReadinessProbeDefaults(rp, userPort)
@@ -324,6 +328,9 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, t
 		}, {
 			Name:  "INTERNAL_VOLUME_PATH",
 			Value: internalVolumePath,
+		}, {
+			Name:  "DOWNWARD_API_LABELS_PATH",
+			Value: fmt.Sprintf("%s/%s", podInfoVolumePath, metadataLabelsPath),
 		}, {
 			Name:  "SERVING_READINESS_PROBE",
 			Value: probeJSON,

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -1132,6 +1132,7 @@ var defaultEnv = map[string]string{
 	"ENABLE_VAR_LOG_COLLECTION":             "false",
 	"VAR_LOG_VOLUME_NAME":                   varLogVolumeName,
 	"INTERNAL_VOLUME_PATH":                  internalVolumePath,
+	"DOWNWARD_API_LABELS_PATH":              fmt.Sprintf("%s/%s", podInfoVolumePath, metadataLabelsPath),
 	"ENABLE_PROFILING":                      "false",
 	"SERVING_ENABLE_PROBE_REQUEST_LOG":      "false",
 }
@@ -1141,8 +1142,7 @@ func probeJSON(container *corev1.Container) string {
 		return fmt.Sprintf(testProbeJSONTemplate, v1alpha1.DefaultUserPort)
 	}
 
-	ports := container.Ports
-	if len(ports) > 0 && ports[0].ContainerPort != 0 {
+	if ports := container.Ports; len(ports) > 0 && ports[0].ContainerPort != 0 {
 		return fmt.Sprintf(testProbeJSONTemplate, ports[0].ContainerPort)
 	}
 	return fmt.Sprintf(testProbeJSONTemplate, v1alpha1.DefaultUserPort)

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/network"
@@ -82,6 +83,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc   *logging.Config
 		tc   *tracingconfig.Config
 		oc   *metrics.ObservabilityConfig
+		ac   *autoscaler.Config
 		cc   *deployment.Config
 		want *corev1.Container
 	}{{
@@ -102,6 +104,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -141,6 +144,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -179,6 +183,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -219,6 +224,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -258,6 +264,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -293,6 +300,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -327,6 +335,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			RequestLogTemplate:    "test template",
 			EnableProbeRequestLog: true,
 		},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -362,6 +371,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		oc: &metrics.ObservabilityConfig{
 			RequestMetricsBackend: "prometheus",
 		},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -394,6 +404,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{EnableProfiling: true},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{},
 		want: &corev1.Container{
 			// These are effectively constant
@@ -420,7 +431,7 @@ func TestMakeQueueContainer(t *testing.T) {
 					}},
 				}
 			}
-			got, err := makeQueueContainer(test.rev, test.lc, test.tc, test.oc, test.cc)
+			got, err := makeQueueContainer(test.rev, test.lc, test.tc, test.oc, test.ac, test.cc)
 
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error")
@@ -446,6 +457,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		lc   *logging.Config
 		tc   *tracingconfig.Config
 		oc   *metrics.ObservabilityConfig
+		ac   *autoscaler.Config
 		cc   *deployment.Config
 		want *corev1.Container
 	}{{
@@ -484,6 +496,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -543,6 +556,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -599,6 +613,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -653,6 +668,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		lc: &logging.Config{},
 		tc: &tracingconfig.Config{},
 		oc: &metrics.ObservabilityConfig{},
+		ac: &autoscaler.Config{},
 		cc: &deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -678,7 +694,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := makeQueueContainer(test.rev, test.lc, test.tc, test.oc, test.cc)
+			got, err := makeQueueContainer(test.rev, test.lc, test.tc, test.oc, test.ac, test.cc)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error")
 			}
@@ -761,6 +777,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 	lc := &logging.Config{}
 	tc := &tracingconfig.Config{}
 	oc := &metrics.ObservabilityConfig{}
+	ac := &autoscaler.Config{}
 	cc := &deployment.Config{}
 	want := &corev1.Container{
 		// These are effectively constant
@@ -783,7 +800,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		SecurityContext: queueSecurityContext,
 	}
 
-	got, err := makeQueueContainer(rev, lc, tc, oc, cc)
+	got, err := makeQueueContainer(rev, lc, tc, oc, ac, cc)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -854,6 +871,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 	lc := &logging.Config{}
 	tc := &tracingconfig.Config{}
 	oc := &metrics.ObservabilityConfig{}
+	ac := &autoscaler.Config{}
 	cc := &deployment.Config{}
 	want := &corev1.Container{
 		// These are effectively constant
@@ -877,7 +895,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		SecurityContext: queueSecurityContext,
 	}
 
-	got, err := makeQueueContainer(rev, lc, tc, oc, cc)
+	got, err := makeQueueContainer(rev, lc, tc, oc, ac, cc)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -1058,6 +1076,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			lc := &logging.Config{}
 			tc := &tracingconfig.Config{}
 			oc := &metrics.ObservabilityConfig{}
+			ac := &autoscaler.Config{}
 			cc := &deployment.Config{}
 			testRev := &v1alpha1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1076,7 +1095,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				Value: string(wantProbeJSON),
 			})
 
-			got, err := makeQueueContainer(testRev, lc, tc, oc, cc)
+			got, err := makeQueueContainer(testRev, lc, tc, oc, ac, cc)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error")
 			}
@@ -1122,7 +1141,8 @@ func probeJSON(container *corev1.Container) string {
 		return fmt.Sprintf(testProbeJSONTemplate, v1alpha1.DefaultUserPort)
 	}
 
-	if ports := container.Ports; len(ports) > 0 && ports[0].ContainerPort != 0 {
+	ports := container.Ports
+	if len(ports) > 0 && ports[0].ContainerPort != 0 {
 		return fmt.Sprintf(testProbeJSONTemplate, ports[0].ContainerPort)
 	}
 	return fmt.Sprintf(testProbeJSONTemplate, v1alpha1.DefaultUserPort)

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -42,6 +42,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/revision/resources"
 
 	. "knative.dev/pkg/reconciler/testing"
+	"knative.dev/serving/pkg/autoscaler"
 	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
 	. "knative.dev/serving/pkg/testing"
 	. "knative.dev/serving/pkg/testing/v1alpha1"
@@ -763,7 +764,8 @@ func ReconcilerTestConfig() *config.Config {
 		Observability: &metrics.ObservabilityConfig{
 			LoggingURLTemplate: "http://logger.io/${REVISION_UID}",
 		},
-		Logging: &logging.Config{},
-		Tracing: &tracingconfig.Config{},
+		Logging:    &logging.Config{},
+		Tracing:    &tracingconfig.Config{},
+		Autoscaler: &autoscaler.Config{},
 	}
 }

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -700,7 +700,7 @@ func deploy(t *testing.T, namespace, name string, opts ...interface{}) *appsv1.D
 	// before calling MakeDeployment within Reconcile.
 	rev.SetDefaults(context.Background())
 	deployment, err := resources.MakeDeployment(rev, cfg.Logging, cfg.Tracing, cfg.Network,
-		cfg.Observability, cfg.Deployment,
+		cfg.Observability, cfg.Autoscaler, cfg.Deployment,
 	)
 
 	if err != nil {

--- a/vendor/knative.dev/pkg/network/prober/prober.go
+++ b/vendor/knative.dev/pkg/network/prober/prober.go
@@ -118,7 +118,8 @@ func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...
 
 	for _, op := range ops {
 		if vo, ok := op.(Verifier); ok {
-			if ok, err := vo(resp, body); err != nil || !ok {
+			ok, err := vo(resp, body)
+			if err != nil || !ok {
 				return false, err
 			}
 		}

--- a/vendor/knative.dev/pkg/network/prober/prober.go
+++ b/vendor/knative.dev/pkg/network/prober/prober.go
@@ -118,8 +118,7 @@ func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...
 
 	for _, op := range ops {
 		if vo, ok := op.(Verifier); ok {
-			ok, err := vo(resp, body)
-			if err != nil || !ok {
+			if ok, err := vo(resp, body); err != nil || !ok {
 				return false, err
 			}
 		}


### PR DESCRIPTION
This PR adds a DownwardAPI volume source to the queue proxy container and uses the corresponding volume in the queue proxy to access the value for `kubernetes.io/prefer-for-scale-down` and fail the readiness probe if it is set to `true`.

/lint

as part of #6134

/cc @vagababov @markusthoemmes @dgerd 