### PR TITLE
Use correct tickProvider in multiscaler to allow override in test.

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -46,8 +46,6 @@ var (
 
 	// ErrNotScraping denotes that the collector is not collecting metrics for the given resource.
 	ErrNotScraping = errors.New("the requested resource is not being scraped")
-
-	tickProvider = time.NewTicker
 )
 
 // StatsScraperFactory creates a StatsScraper for a given Metric.

--- a/pkg/autoscaler/multiscaler.go
+++ b/pkg/autoscaler/multiscaler.go
@@ -260,7 +260,7 @@ func (m *MultiScaler) updateRunner(ctx context.Context, runner *scalerRunner) {
 
 func (m *MultiScaler) runScalerTicker(ctx context.Context, runner *scalerRunner) {
 	metricKey := types.NamespacedName{Namespace: runner.decider.Namespace, Name: runner.decider.Name}
-	ticker := tickProvider(runner.decider.Spec.TickInterval)
+	ticker := m.tickProvider(runner.decider.Spec.TickInterval)
 	go func() {
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The tests override the tickProvider of the multiscaler to be able to accurately control the tick timings and not rely on wallclock time. The multiscaler however used an old global tickProvider so the tests could not override it at all, leading to unexpected ticks and races.

Example occurrence: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/6547/pull-knative-serving-unit-tests/1218067395424292866

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
