### PR TITLE
Create SKS before KPA in autoscaler GlobalResync test.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1055,13 +1055,14 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
 	kpa := revisionresources.MakePA(rev)
-	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
-
 	sks := aresources.MakeSKS(kpa, nv1a1.SKSOperationModeServe)
 	sks.Status.PrivateServiceName = "bogus"
+
 	fakeservingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(testNamespace).Create(sks)
 	fakesksinformer.Get(ctx).Informer().GetIndexer().Add(sks)
+
+	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	// Wait for decider to be created.
 	if decider, err := pollDeciders(fakeDeciders, testNamespace, testRevision, nil); err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Ref #6490

This test runs a "proper" controller process so we don't control when a reconcilation is kicked off. Creating the KPA first therefore leads to a race where reconcilation might happen before the test creates a dummy SKS with a dummy PrivateServiceName filled in. That will never resolve itself because we don't run an SKS controller here so nothing will fill in the missing PrivateServiceName and no decider will ever be created.

Creating the SKS first should deterministically solve this as the reconciler should now see the SKS we created in any case.

Example occurrence: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1216996136678592512

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @mattmoor 
