### PR TITLE
Convert tag.Insert to tag.Upsert

### DIFF
--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -66,8 +66,8 @@ type Reporter struct {
 func NewStatsReporter(pod string) (*Reporter, error) {
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(metrics.PodTagKey, pod),
-		tag.Insert(metrics.ContainerTagKey, Name),
+		tag.Upsert(metrics.PodTagKey, pod),
+		tag.Upsert(metrics.ContainerTagKey, Name),
 	)
 	if err != nil {
 		return nil, err
@@ -124,10 +124,10 @@ func (r *Reporter) ReportRequestConcurrency(ns, service, config, rev string, v i
 	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(metrics.NamespaceTagKey, ns),
-		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Insert(metrics.ConfigTagKey, config),
-		tag.Insert(metrics.RevisionTagKey, rev))
+		tag.Upsert(metrics.NamespaceTagKey, ns),
+		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
+		tag.Upsert(metrics.ConfigTagKey, config),
+		tag.Upsert(metrics.RevisionTagKey, rev))
 	if err != nil {
 		return err
 	}
@@ -145,13 +145,13 @@ func (r *Reporter) ReportRequestCount(ns, service, config, rev string, responseC
 	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(metrics.NamespaceTagKey, ns),
-		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Insert(metrics.ConfigTagKey, config),
-		tag.Insert(metrics.RevisionTagKey, rev),
-		tag.Insert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Insert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)),
-		tag.Insert(metrics.NumTriesKey, strconv.Itoa(numTries)))
+		tag.Upsert(metrics.NamespaceTagKey, ns),
+		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
+		tag.Upsert(metrics.ConfigTagKey, config),
+		tag.Upsert(metrics.RevisionTagKey, rev),
+		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
+		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)),
+		tag.Upsert(metrics.NumTriesKey, strconv.Itoa(numTries)))
 	if err != nil {
 		return err
 	}
@@ -169,12 +169,12 @@ func (r *Reporter) ReportResponseTime(ns, service, config, rev string, responseC
 	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(metrics.NamespaceTagKey, ns),
-		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Insert(metrics.ConfigTagKey, config),
-		tag.Insert(metrics.RevisionTagKey, rev),
-		tag.Insert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Insert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
+		tag.Upsert(metrics.NamespaceTagKey, ns),
+		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
+		tag.Upsert(metrics.ConfigTagKey, config),
+		tag.Upsert(metrics.RevisionTagKey, rev),
+		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
+		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
 	if err != nil {
 		return err
 	}

--- a/pkg/autoscaler/stats_reporter.go
+++ b/pkg/autoscaler/stats_reporter.go
@@ -193,10 +193,10 @@ func NewStatsReporter(ns, service, config, revision string) (*Reporter, error) {
 	// can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(metrics.NamespaceTagKey, ns),
-		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Insert(metrics.ConfigTagKey, config),
-		tag.Insert(metrics.RevisionTagKey, revision))
+		tag.Upsert(metrics.NamespaceTagKey, ns),
+		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
+		tag.Upsert(metrics.ConfigTagKey, config),
+		tag.Upsert(metrics.RevisionTagKey, revision))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/queue/stats/stats_reporter.go
+++ b/pkg/queue/stats/stats_reporter.go
@@ -97,12 +97,12 @@ func NewStatsReporter(ns, service, config, rev, pod string, countMetric *stats.I
 	// Note that service name can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(metrics.NamespaceTagKey, ns),
-		tag.Insert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Insert(metrics.ConfigTagKey, config),
-		tag.Insert(metrics.RevisionTagKey, rev),
-		tag.Insert(metrics.PodTagKey, pod),
-		tag.Insert(metrics.ContainerTagKey, "queue-proxy"),
+		tag.Upsert(metrics.NamespaceTagKey, ns),
+		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
+		tag.Upsert(metrics.ConfigTagKey, config),
+		tag.Upsert(metrics.RevisionTagKey, rev),
+		tag.Upsert(metrics.PodTagKey, pod),
+		tag.Upsert(metrics.ContainerTagKey, "queue-proxy"),
 	)
 	if err != nil {
 		return nil, err
@@ -133,8 +133,8 @@ func (r *Reporter) ReportRequestCount(responseCode int) error {
 	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Insert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
+		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
+		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
 	if err != nil {
 		return err
 	}
@@ -162,8 +162,8 @@ func (r *Reporter) ReportResponseTime(responseCode int, d time.Duration) error {
 	// Note that service names can be an empty string, so it needs a special treatment.
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Insert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
+		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
+		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -108,7 +108,7 @@ type reporter struct {
 func NewStatsReporter(reconciler string) (StatsReporter, error) {
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(reconcilerTagKey, reconciler))
+		tag.Upsert(reconcilerTagKey, reconciler))
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (r *reporter) ReportServiceReady(namespace, service string, d time.Duration
 	key := fmt.Sprintf("%s/%s", namespace, service)
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(keyTagKey, key))
+		tag.Upsert(keyTagKey, key))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

`tag.Insert` says:

> If k already exists in the tag map, mutator doesn’t update the value.

`tag.Upsert` says:
> It inserts the value if k doesn’t exist already. It mutates the value if k already exists.

I think we *always* want to set these keys, so we should use `tag.Upsert`, since `tag.New` [will copy values from the surrounding context](https://github.com/census-instrumentation/opencensus-go/blob/master/tag/map.go#L190).

## Proposed Changes

* Switch all locations from `tag.Insert` to `tag.Upsert` in serving.

**Release Note**

```release-note
NONE
```

/assign @yanweiguo 