### PR TITLE
Update kube-state-metrics yaml

### DIFF
--- a/third_party/config/monitoring/metrics/prometheus/kubernetes/kube-state-metrics.yaml
+++ b/third_party/config/monitoring/metrics/prometheus/kubernetes/kube-state-metrics.yaml
@@ -39,7 +39,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
-  namespace: knative-monitoring
 rules:
 - apiGroups: [""]
   resources:
@@ -100,7 +99,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kube-state-metrics
-  namespace: knative-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -108,7 +106,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-  namespace: kube-system
+  namespace: knative-monitoring
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes #6558

## Proposed Changes

* kube-state-metrics can not get k8s resource due to wrong service-account.

