### PR TITLE
Reconcile ingress when annotation is updated

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -76,11 +76,13 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, r *v1alpha1.Route, de
 		// It is notable that one reason for differences here may be defaulting.
 		// When that is the case, the Update will end up being a nop because the
 		// webhook will bring them into alignment and no new reconciliation will occur.
-		if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) {
+		// Also, compare annotation in case ingress.Class is updated.
+		if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) ||
+			!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) {
 			// Don't modify the informers copy
 			origin := ingress.DeepCopy()
 			origin.Spec = desired.Spec
-
+			origin.Annotations = desired.Annotations
 			updated, err := c.ServingClientSet.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(origin)
 			if err != nil {
 				return nil, fmt.Errorf("failed to update Ingress: %w", err)


### PR DESCRIPTION
## Proposed Changes

Although `ingress.class` in config-network updates ingress annotation,
reconciler does not work by the difference of annotation.

To fix it, this patch changes to reconcile ingress when annotation is
updated.

/lint

Fixes https://github.com/knative/serving/issues/6568

**Release Note**

```release-note
Ingress is reconciled when its annotation is updated.
```
