### PR TITLE
Actually handle revision get error.

### DIFF
--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -131,6 +131,9 @@ func TestReconcileTargetValidRevision(t *testing.T) {
 
 	// Verify last pinned annotation is updated correctly
 	newRev, err := fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(r.Namespace).Get(rev.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting revision: %v", err)
+	}
 	afterTimestamp, err := getLastPinnedTimestamp(t, newRev)
 	if err != nil {
 		t.Fatalf("Error getting last pinned timestamps: %v", err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Actually handle an the revision get error instead of ignoring it and potentially panic in the following lines.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @taragu @vagababov 
