### PR TITLE
Remove unused queue metrics constant.

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -53,10 +53,6 @@ const (
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.
 	UserQueueMetricsPortName = "http-usermetric"
-
-	// ServiceQueueMetricsPortName is the name of the port that serves metrics
-	// on the Kubernetes service.
-	ServiceQueueMetricsPortName = "http-metrics"
 )
 
 var revCondSet = apis.NewLivingConditionSet(


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This constant is unused and I think has been superseded by `UserQueueMetricsPortName`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
