### PR TITLE
Generalize precision func and raise default to 6 digits

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -62,8 +62,9 @@ func (t *TimedFloat64Buckets) IsEmpty(now time.Time) bool {
 	return now.Sub(t.lastWrite) > t.window
 }
 
-func roundTo3Digits(f float64) float64 {
-	return math.Floor(f*1000) / 1000
+func roundToNDigits(n int, f float64) float64 {
+	p := math.Pow10(n)
+	return math.Floor(f*p) / p
 }
 
 // WindowAverage returns the average bucket value over the window.
@@ -75,7 +76,7 @@ func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
 	case d <= 0:
 		// If LastWrite equal or greater than Now
 		// return the current WindowTotal.
-		return roundTo3Digits(t.windowTotal / float64(len(t.buckets)))
+		return roundToNDigits(6 /*precision*/, t.windowTotal/float64(len(t.buckets)))
 	case d < t.window:
 		// If we haven't received metrics for some time, which is less than
 		// the window -- remove the outdated items.
@@ -85,7 +86,7 @@ func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
 		for i := stIdx + 1; i <= eIdx; i++ {
 			ret -= t.buckets[i%len(t.buckets)]
 		}
-		return roundTo3Digits(ret / float64(len(t.buckets)-(eIdx-stIdx)))
+		return roundToNDigits(6 /*precision*/, ret/float64(len(t.buckets)-(eIdx-stIdx)))
 	default: // Nothing for more than a window time, just 0.
 		return 0.
 	}

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -69,6 +69,7 @@ func roundToNDigits(n int, f float64) float64 {
 
 // WindowAverage returns the average bucket value over the window.
 func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
+	const precision = 6
 	now = now.Truncate(t.granularity)
 	t.bucketsMutex.RLock()
 	defer t.bucketsMutex.RUnlock()
@@ -76,7 +77,7 @@ func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
 	case d <= 0:
 		// If LastWrite equal or greater than Now
 		// return the current WindowTotal.
-		return roundToNDigits(6 /*precision*/, t.windowTotal/float64(len(t.buckets)))
+		return roundToNDigits(precision, t.windowTotal/float64(len(t.buckets)))
 	case d < t.window:
 		// If we haven't received metrics for some time, which is less than
 		// the window -- remove the outdated items.
@@ -86,7 +87,7 @@ func (t *TimedFloat64Buckets) WindowAverage(now time.Time) float64 {
 		for i := stIdx + 1; i <= eIdx; i++ {
 			ret -= t.buckets[i%len(t.buckets)]
 		}
-		return roundToNDigits(6 /*precision*/, ret/float64(len(t.buckets)-(eIdx-stIdx)))
+		return roundToNDigits(precision, ret/float64(len(t.buckets)-(eIdx-stIdx)))
 	default: // Nothing for more than a window time, just 0.
 		return 0.
 	}

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -454,7 +454,7 @@ func BenchmarkWindowForEach(b *testing.B) {
 	}
 }
 
-func TestRoundTo3Digits(t *testing.T) {
+func TestRoundToNDigits(t *testing.T) {
 	if got, want := roundToNDigits(6, 3.6e-17), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -455,16 +455,19 @@ func BenchmarkWindowForEach(b *testing.B) {
 }
 
 func TestRoundTo3Digits(t *testing.T) {
-	if got, want := roundTo3Digits(3.6e-17), 0.; got != want {
+	if got, want := roundToNDigits(6, 3.6e-17), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
-	if got, want := roundTo3Digits(0.0004), 0.; got != want {
+	if got, want := roundToNDigits(3, 0.0004), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
-	if got, want := roundTo3Digits(1.2345), 1.234; got != want {
+	if got, want := roundToNDigits(3, 1.2345), 1.234; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
-	if got, want := roundTo3Digits(12345), 12345.; got != want {
+	if got, want := roundToNDigits(4, 1.2345), 1.2345; got != want {
+		t.Errorf("Rounding = %v, want: %v", got, want)
+	}
+	if got, want := roundToNDigits(6, 12345), 12345.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
 


### PR DESCRIPTION
Since there may be edgecases when 3 digits is not enough.
e.g. big window (1hr) and 1 request, or there might be many pods and just one request
e.g. after a big drop off in traffic.
Hence raise it to 6 digits, which should be correct for all intents and purposes.


/lint

/assign @markusthoemmes 