### PR TITLE
Add sideEffects to webhooks

### DIFF
--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -26,6 +26,7 @@ webhooks:
       name: webhook
       namespace: knative-serving
   failurePolicy: Fail
+  sideEffects: None
   name: config.webhook.serving.knative.dev
   namespaceSelector:
     matchExpressions:

--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -26,4 +26,5 @@ webhooks:
       name: webhook
       namespace: knative-serving
   failurePolicy: Fail
+  sideEffects: None
   name: webhook.serving.knative.dev

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -26,4 +26,5 @@ webhooks:
       name: webhook
       namespace: knative-serving
   failurePolicy: Fail
+  sideEffects: None
   name: validation.webhook.serving.knative.dev


### PR DESCRIPTION
`admissionregistration.k8s.io/v1 webhooks` require `sideEffects` to be
explicitly set to `None` or `NoneOnDryRun` otherwise will be rejected

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
