### PR TITLE
Continue to set latest ready revision if error encountered

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -158,6 +158,9 @@ func (c *Reconciler) getSortedCreatedRevisions(ctx context.Context, config *v1.C
 		lrr, err := lister.Get(config.Status.LatestReadyRevisionName)
 		// Record the error and continue because we still want to set the LRR to the correct revision.
 		if err != nil {
+			// If the user deletes the LatestReadyRevision then this may return an error due to the
+			// dangling reference.  Proceed to calculate the next-latest ready revision so that the
+			// caller can synthesize a new Revision at the current generation to replace the one deleted.
 			logger.Errorf("Error getting latest ready revision %q: %v", config.Status.LatestReadyRevisionName, err)
 		} else {
 			start := lrr.Generation

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -156,7 +156,7 @@ func (c *Reconciler) getSortedCreatedRevisions(ctx context.Context, config *v1.C
 	})
 	if config.Status.LatestReadyRevisionName != "" {
 		lrr, err := lister.Get(config.Status.LatestReadyRevisionName)
-		// Record the error and continue because we still want to set the LRR to the correct revision
+		// Record the error and continue because we still want to set the LRR to the correct revision.
 		if err != nil {
 			logger.Errorf("Error getting latest ready revision %q: %v", config.Status.LatestReadyRevisionName, err)
 		} else {
@@ -173,10 +173,9 @@ func (c *Reconciler) getSortedCreatedRevisions(ctx context.Context, config *v1.C
 				selection.In,
 				generations,
 			)
-			if err != nil {
-				return nil, err
+			if err == nil {
+				configSelector = configSelector.Add(*inReq)
 			}
-			configSelector = configSelector.Add(*inReq)
 		}
 	}
 

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -473,7 +473,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("lrrnotexist", "foo", 2,
 				WithLatestCreated("lrrnotexist-00002"),
-				WithLatestReady("lrrnotexist-00001"), WithObservedGen, func(cfg *v1alpha1.Configuration) {
+				WithLatestReady("lrrnotexist-00001"), WithObservedGen, func(cfg *v1.Configuration) {
 					cfg.Spec.GetTemplate().Name = "lrrnotexist-00002"
 				},
 			),
@@ -488,7 +488,7 @@ func TestReconcile(t *testing.T) {
 			Object: cfg("lrrnotexist", "foo", 2,
 				WithLatestCreated("lrrnotexist-00002"),
 				WithLatestReady("lrrnotexist-00002"),
-				WithObservedGen, func(cfg *v1alpha1.Configuration) {
+				WithObservedGen, func(cfg *v1.Configuration) {
 					cfg.Spec.GetTemplate().Name = "lrrnotexist-00002"
 				},
 			),


### PR DESCRIPTION
/lint

Fixes #6588
Fixes #6876

## Proposed Changes
Currently in the config reconciler, if the LRR does not exist, we don't continue the rest of the logic to set the LRR. This PR fixes it by logging the error and continuing.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
