### PR TITLE
Use duck.CreateBytePatch and clean up dead code

### DIFF
--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logstream"
@@ -148,7 +149,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 	svcCopy := svc.DeepCopy()
 	labels.SetVisibility(&svcCopy.ObjectMeta, true)
 
-	svcpatchBytes, err := test.CreateBytePatch(svc, svcCopy)
+	svcpatchBytes, err := duck.CreateBytePatch(svc, svcCopy)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -281,7 +282,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	svcCopy := svc.DeepCopy()
 	labels.SetVisibility(&svcCopy.ObjectMeta, true)
 
-	svcpatchBytes, err := test.CreateBytePatch(svc, svcCopy)
+	svcpatchBytes, err := duck.CreateBytePatch(svc, svcCopy)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -360,7 +361,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	svc1Copy := svc1.DeepCopy()
 	labels.SetVisibility(&svcCopy.ObjectMeta, true)
 
-	svc1patchBytes, err := test.CreateBytePatch(svc1, svc1Copy)
+	svc1patchBytes, err := duck.CreateBytePatch(svc1, svc1Copy)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -20,7 +20,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/signals"
 )
 
@@ -51,15 +50,4 @@ func ListenAndServeGracefullyWithHandler(addr string, handler http.Handler) {
 
 	<-signals.SetupSignalHandler()
 	server.Shutdown(context.Background())
-}
-
-// TODO(dangerd): Remove this and use duck.CreateBytePatch after release-0.9
-// CreateBytePatch is a helper function that creates the same content as
-// CreatePatch, but returns in []byte format instead of JSONPatch.
-func CreateBytePatch(before, after interface{}) ([]byte, error) {
-	patch, err := duck.CreatePatch(before, after)
-	if err != nil {
-		return nil, err
-	}
-	return patch.MarshalJSON()
 }

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 
@@ -49,7 +50,7 @@ func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1.Configuration, fopt
 		opt(newSvc)
 	}
 	LogResourceObject(t, ResourceObjects{Config: newSvc})
-	patchBytes, err := test.CreateBytePatch(svc, newSvc)
+	patchBytes, err := duck.CreateBytePatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"knative.dev/pkg/apis/duck"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -144,7 +145,7 @@ func PatchService(t pkgTest.T, clients *test.Clients, svc *v1.Service, fopt ...r
 		opt(newSvc)
 	}
 	LogResourceObject(t, ResourceObjects{Service: newSvc})
-	patchBytes, err := test.CreateBytePatch(svc, newSvc)
+	patchBytes, err := duck.CreateBytePatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -47,7 +48,7 @@ func CreateConfiguration(t pkgTest.T, clients *test.Clients, names test.Resource
 func PatchConfigImage(clients *test.Clients, cfg *v1alpha1.Configuration, imagePath string) (*v1alpha1.Configuration, error) {
 	newCfg := cfg.DeepCopy()
 	newCfg.Spec.GetTemplate().Spec.GetContainer().Image = imagePath
-	patchBytes, err := test.CreateBytePatch(cfg, newCfg)
+	patchBytes, err := duck.CreateBytePatch(cfg, newCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/watch"
+	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/test/spoof"
 
 	"github.com/mattbaird/jsonpatch"
@@ -253,7 +254,7 @@ func PatchServiceImage(t pkgTest.T, clients *test.Clients, svc *v1alpha1.Service
 		newSvc.Spec.ConfigurationSpec.GetTemplate().Spec.GetContainer().Image = imagePath
 	}
 	LogResourceObject(t, ResourceObjects{Service: newSvc})
-	patchBytes, err := test.CreateBytePatch(svc, newSvc)
+	patchBytes, err := duck.CreateBytePatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +264,7 @@ func PatchServiceImage(t pkgTest.T, clients *test.Clients, svc *v1alpha1.Service
 // PatchService creates and applies a patch from the diff between curSvc and desiredSvc. Returns the latest service object.
 func PatchService(t pkgTest.T, clients *test.Clients, curSvc *v1alpha1.Service, desiredSvc *v1alpha1.Service) (*v1alpha1.Service, error) {
 	LogResourceObject(t, ResourceObjects{Service: desiredSvc})
-	patchBytes, err := test.CreateBytePatch(curSvc, desiredSvc)
+	patchBytes, err := duck.CreateBytePatch(curSvc, desiredSvc)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +290,7 @@ func PatchServiceTemplateMetadata(t pkgTest.T, clients *test.Clients, svc *v1alp
 	newSvc := svc.DeepCopy()
 	newSvc.Spec.ConfigurationSpec.Template.ObjectMeta = metadata
 	LogResourceObject(t, ResourceObjects{Service: newSvc})
-	patchBytes, err := test.CreateBytePatch(svc, newSvc)
+	patchBytes, err := duck.CreateBytePatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -50,7 +51,7 @@ func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1beta1.Configuration,
 		opt(newSvc)
 	}
 	LogResourceObject(t, ResourceObjects{Config: newSvc})
-	patchBytes, err := test.CreateBytePatch(svc, newSvc)
+	patchBytes, err := duck.CreateBytePatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}

--- a/test/v1beta1/service.go
+++ b/test/v1beta1/service.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/apis/duck"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -143,7 +144,7 @@ func PatchService(t pkgTest.T, clients *test.Clients, svc *v1beta1.Service, fopt
 		opt(newSvc)
 	}
 	LogResourceObject(t, ResourceObjects{Service: newSvc})
-	patchBytes, err := test.CreateBytePatch(svc, newSvc)
+	patchBytes, err := duck.CreateBytePatch(svc, newSvc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
/lint

cleans up the little left over TODO in test utils

/assign @dgerd 