### PR TITLE
Fix the issue which kcert ends up with Failed status when cm Cert is InProgress

### DIFF
--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -165,12 +165,11 @@ func (c *Reconciler) reconcile(ctx context.Context, knCert *v1alpha1.Certificate
 	case cmCertReadyCondition.Status == cmmeta.ConditionFalse:
 		if strings.EqualFold(cmCertReadyCondition.Reason, inProgressReason) {
 			knCert.Status.MarkNotReady(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
-			if err := c.setHTTP01Challenges(knCert, cmCert); err != nil {
-				return err
-			}
 		} else {
 			knCert.Status.MarkFailed(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
-			knCert.Status.HTTP01Challenges = []v1alpha1.HTTP01Challenge{}
+		}
+		if err := c.setHTTP01Challenges(knCert, cmCert); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -455,7 +455,7 @@ func TestReconcile_HTTP01Challenges(t *testing.T) {
 							Type:     v1alpha1.CertificateConditionReady,
 							Status:   corev1.ConditionUnknown,
 							Severity: apis.ConditionSeverityError,
-							Reason:   inProgressReason,
+							Reason:   "InProgress",
 						}},
 					},
 				}),


### PR DESCRIPTION
Fix the issue which kcert ends up with Failed status when cert manager certificate becomes "Failed" with "InProgress" reason as we should consider this case as "Unknow" in our context.