### PR TITLE
Obsolete istio.sidecar.includeOutboundIPRanges in config-network

### DIFF
--- a/config/core/configmaps/network.yaml
+++ b/config/core/configmaps/network.yaml
@@ -37,42 +37,12 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # istio.sidecar.includeOutboundIPRanges specifies the IP ranges that Istio sidecar
-    # will intercept.
+    # OBSOLETE:
+    # istio.sidecar.includeOutboundIPRanges is obsolete.
+    # The current versions have outbound network access enabled by default.
+    # If you need this option for some reason, please use global.proxy.includeIPRanges in Istio.
     #
-    # Replace this with the IP ranges of your cluster (see below for some examples).
-    # Separate multiple entries with a comma.
-    # Example: "10.4.0.0/14,10.7.240.0/20"
-    #
-    # If set to "*" Istio will intercept all traffic within
-    # the cluster as well as traffic that is going outside the cluster.
-    # Traffic going outside the cluster will be blocked unless
-    # necessary egress rules are created.
-    #
-    # If omitted or set to "", value of global.proxy.includeIPRanges
-    # provided at Istio deployment time is used. In default Knative serving
-    # deployment, global.proxy.includeIPRanges value is set to "*".
-    #
-    # If an invalid value is passed, "" is used instead.
-    #
-    # If valid set of IP address ranges are put into this value,
-    # Istio will no longer intercept traffic going to IP addresses
-    # outside the provided ranges and there is no need to specify
-    # egress rules.
-    #
-    # To determine the IP ranges of your cluster:
-    #   IBM Cloud Private: cat cluster/config.yaml | grep service_cluster_ip_range
-    #   IBM Cloud Kubernetes Service: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
-    #   Google Container Engine (GKE): gcloud container clusters describe $CLUSTER_NAME --zone=$CLUSTER_ZONE | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
-    #   Azure Kubernetes Service (AKS): "10.0.0.0/16"
-    #   Azure Container Service (ACS; deprecated): "10.244.0.0/16,10.240.0.0/16"
-    #   Azure Container Service Engine (ACS-Engine; OSS): Configurable, but defaults to "10.0.0.0/16"
-    #   Minikube: "10.0.0.1/24"
-    #
-    # For more information, visit
-    # https://istio.io/docs/tasks/traffic-management/egress/
-    #
-    istio.sidecar.includeOutboundIPRanges: "*"
+    # istio.sidecar.includeOutboundIPRanges: "*"
 
     # ingress.class specifies the default ingress class
     # to use when not dictated by Route annotation.

--- a/config/core/configmaps/network.yaml
+++ b/config/core/configmaps/network.yaml
@@ -37,7 +37,7 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # OBSOLETE:
+    # DEPRECATED:
     # istio.sidecar.includeOutboundIPRanges is obsolete.
     # The current versions have outbound network access enabled by default.
     # If you need this option for some reason, please use global.proxy.includeIPRanges in Istio.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -59,7 +59,7 @@ const (
 	// IstioOutboundIPRangesKey is the name of the configuration entry
 	// that specifies Istio outbound ip ranges.
 	//
-	// OBSOLETE: This will be completely removed once v1.4 is released.
+	// OBSOLETE: This will be completely removed in the future release.
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
 	// DeprecatedDefaultIngressClassKey  Please use DefaultIngressClassKey instead.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -196,7 +196,7 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	nc := &Config{}
 	if _, ok := configMap.Data[IstioOutboundIPRangesKey]; ok {
 		// Until next version is released, the validatoin error is enabled to notify users who configure some value.
-		return nil, fmt.Errorf("%q is obsolete as outbound network access is enabled by default now. Remove it from config-network.", IstioOutboundIPRangesKey)
+		return nil, fmt.Errorf("%q is obsolete as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
 	}
 
 	nc.DefaultIngressClass = IstioIngressClassName

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -59,7 +59,7 @@ const (
 	// IstioOutboundIPRangesKey is the name of the configuration entry
 	// that specifies Istio outbound ip ranges.
 	//
-	// OBSOLETE: This will be completely removed in the future release.
+	// DEPRECATED: This will be completely removed in the future release.
 	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
 	// DeprecatedDefaultIngressClassKey  Please use DefaultIngressClassKey instead.
@@ -199,7 +199,7 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	if _, ok := configMap.Data[IstioOutboundIPRangesKey]; ok {
 		// Until the next version is released, the validation check is enabled to notify users who configure some value.
 		logger := logging.FromContext(context.Background()).Named(configMap.Name)
-		logger.Warnf("%q is obsolete as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
+		logger.Warnf("%q is deprecated as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
 	}
 
 	nc.DefaultIngressClass = IstioIngressClassName

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -27,6 +28,7 @@ import (
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -195,8 +197,9 @@ const (
 func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	nc := &Config{}
 	if _, ok := configMap.Data[IstioOutboundIPRangesKey]; ok {
-		// Until next version is released, the validatoin error is enabled to notify users who configure some value.
-		return nil, fmt.Errorf("%q is obsolete as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
+		// Until the next version is released, the validation check is enabled to notify users who configure some value.
+		logger := logging.FromContext(context.Background()).Named(configMap.Name)
+		logger.Warnf("%q is obsolete as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
 	}
 
 	nc.DefaultIngressClass = IstioIngressClassName

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -72,30 +72,6 @@ func TestConfiguration(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "network configuration with obsoleted config",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "10.10.10.10/33",
-			},
-		},
-	}, {
-		name:    "network configuration with obsoleted config using empty value",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "",
-			},
-		},
-	}, {
 		name:    "network configuration with non-Istio ingress type",
 		wantErr: false,
 		wantConfig: &Config{

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -59,7 +59,6 @@ func TestConfiguration(t *testing.T) {
 		name:    "network configuration with no network input",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          DefaultDomainTemplate,
@@ -73,7 +72,7 @@ func TestConfiguration(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "network configuration with invalid outbound IP range",
+		name:    "network configuration with obsoleted config",
 		wantErr: true,
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -85,15 +84,8 @@ func TestConfiguration(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "network configuration with empty network",
-		wantErr: false,
-		wantConfig: &Config{
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
+		name:    "network configuration with obsoleted config using empty value",
+		wantErr: true,
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),
@@ -104,187 +96,9 @@ func TestConfiguration(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "network configuration with both valid and some invalid range",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "10.10.10.10/12,invalid",
-			},
-		},
-	}, {
-		name:    "network configuration with invalid network range",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "10.10.10.10/12,-1.1.1.1/10",
-			},
-		},
-	}, {
-		name:    "network configuration with invalid network key",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "this is not an IP range",
-			},
-		},
-	}, {
-		name:    "network configuration with invalid network",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*,*",
-			},
-		},
-	}, {
-		name:    "network configuration with incomplete network array",
-		wantErr: true,
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*,",
-			},
-		},
-	}, {
-		name:    "network configuration with invalid network string",
-		wantErr: false,
-		wantConfig: &Config{
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: ", ,",
-			},
-		},
-	}, {
-		name:    "network configuration with invalid network string",
-		wantErr: false,
-		wantConfig: &Config{
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: ",,",
-			},
-		},
-	}, {
-		name:    "network configuration with invalid network range",
-		wantErr: false,
-		wantConfig: &Config{
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: ",",
-			},
-		},
-	}, {
-		name:    "network configuration with valid CIDR network range",
-		wantErr: false,
-		wantConfig: &Config{
-			IstioOutboundIPRanges:   "10.10.10.0/24",
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "10.10.10.0/24",
-			},
-		},
-	}, {
-		name:    "network configuration with multiple valid network ranges",
-		wantErr: false,
-		wantConfig: &Config{
-			IstioOutboundIPRanges:   "10.10.10.0/24,10.240.10.0/14,192.192.10.0/16",
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "10.10.10.0/24,10.240.10.0/14,192.192.10.0/16",
-			},
-		},
-	}, {
-		name:    "network configuration with valid network",
-		wantErr: false,
-		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
-			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
-			DefaultCertificateClass: CertManagerCertificateClassName,
-			DomainTemplate:          DefaultDomainTemplate,
-			TagTemplate:             DefaultTagTemplate,
-			HTTPProtocol:            HTTPEnabled,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-			},
-		},
-	}, {
 		name:    "network configuration with non-Istio ingress type",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "foo-ingress",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          DefaultDomainTemplate,
@@ -297,15 +111,13 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
+				DefaultIngressClassKey: "foo-ingress",
 			},
 		},
 	}, {
 		name:    "network configuration with non-Cert-Manager Certificate type",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
 			DefaultCertificateClass: "foo-cert",
 			DomainTemplate:          DefaultDomainTemplate,
@@ -318,7 +130,6 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey:   "*",
 				DefaultCertificateClassKey: "foo-cert",
 			},
 		},
@@ -326,7 +137,6 @@ func TestConfiguration(t *testing.T) {
 		name:    "network configuration with diff domain template",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "foo-ingress",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          nonDefaultDomainTemplate,
@@ -339,9 +149,8 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
-				DomainTemplateKey:        nonDefaultDomainTemplate,
+				DefaultIngressClassKey: "foo-ingress",
+				DomainTemplateKey:      nonDefaultDomainTemplate,
 			},
 		},
 	}, {
@@ -353,9 +162,8 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
-				DomainTemplateKey:        "",
+				DefaultIngressClassKey: "foo-ingress",
+				DomainTemplateKey:      "",
 			},
 		},
 	}, {
@@ -367,8 +175,7 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
+				DefaultIngressClassKey: "foo-ingress",
 				// This is missing a closing brace.
 				DomainTemplateKey: "{{.Namespace}.{{.Name}}.{{.Domain}}",
 			},
@@ -382,8 +189,7 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
+				DefaultIngressClassKey: "foo-ingress",
 				// This is missing a closing brace.
 				DomainTemplateKey: "{{.Namespace}.{{.Name}}.{{.Domain}}",
 			},
@@ -397,8 +203,7 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
+				DefaultIngressClassKey: "foo-ingress",
 				// Paths are disallowed
 				DomainTemplateKey: "{{.Domain}}/{{.Namespace}}/{{.Name}}.",
 			},
@@ -412,8 +217,7 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
+				DefaultIngressClassKey: "foo-ingress",
 				// Bad variable
 				DomainTemplateKey: "{{.Name}}.{{.NAmespace}}.{{.Domain}}",
 			},
@@ -422,7 +226,6 @@ func TestConfiguration(t *testing.T) {
 		name:    "network configuration with Auto TLS enabled",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          DefaultDomainTemplate,
@@ -436,15 +239,13 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				AutoTLSKey:               "enabled",
+				AutoTLSKey: "enabled",
 			},
 		},
 	}, {
 		name:    "network configuration with Auto TLS disabled",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          DefaultDomainTemplate,
@@ -458,15 +259,13 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				AutoTLSKey:               "disabled",
+				AutoTLSKey: "disabled",
 			},
 		},
 	}, {
 		name:    "network configuration with HTTPProtocol disabled",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          DefaultDomainTemplate,
@@ -480,16 +279,14 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				AutoTLSKey:               "enabled",
-				HTTPProtocolKey:          "Disabled",
+				AutoTLSKey:      "enabled",
+				HTTPProtocolKey: "Disabled",
 			},
 		},
 	}, {
 		name:    "network configuration with HTTPProtocol redirected",
 		wantErr: false,
 		wantConfig: &Config{
-			IstioOutboundIPRanges:   "*",
 			DefaultIngressClass:     "istio.ingress.networking.knative.dev",
 			DefaultCertificateClass: CertManagerCertificateClassName,
 			DomainTemplate:          DefaultDomainTemplate,
@@ -503,9 +300,8 @@ func TestConfiguration(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				AutoTLSKey:               "enabled",
-				HTTPProtocolKey:          "Redirected",
+				AutoTLSKey:      "enabled",
+				HTTPProtocolKey: "Redirected",
 			},
 		},
 	}}
@@ -557,9 +353,8 @@ func TestAnnotationsInDomainTemplate(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
-				DomainTemplateKey:        `{{.Name}}.{{ index .Annotations "sub"}}.{{.Domain}}`,
+				DefaultIngressClassKey: "foo-ingress",
+				DomainTemplateKey:      `{{.Name}}.{{ index .Annotations "sub"}}.{{.Domain}}`,
 			},
 		},
 		data: DomainTemplateValues{
@@ -578,9 +373,8 @@ func TestAnnotationsInDomainTemplate(t *testing.T) {
 				Name:      ConfigName,
 			},
 			Data: map[string]string{
-				IstioOutboundIPRangesKey: "*",
-				DefaultIngressClassKey:   "foo-ingress",
-				DomainTemplateKey:        `{{.Name}}.{{.Namespace}}.{{.Domain}}`,
+				DefaultIngressClassKey: "foo-ingress",
+				DomainTemplateKey:      `{{.Name}}.{{.Namespace}}.{{.Domain}}`,
 			},
 		},
 		data: DomainTemplateValues{

--- a/pkg/reconciler/revision/config/store_test.go
+++ b/pkg/reconciler/revision/config/store_test.go
@@ -122,7 +122,6 @@ func TestStoreImmutableConfig(t *testing.T) {
 	config := store.Load()
 
 	config.Deployment.QueueSidecarImage = "mutated"
-	config.Network.IstioOutboundIPRanges = "mutated"
 	config.Logging.LoggingConfig = "mutated"
 	ccMutated := int64(4)
 	config.Defaults.ContainerConcurrency = ccMutated
@@ -133,9 +132,6 @@ func TestStoreImmutableConfig(t *testing.T) {
 
 	if newConfig.Deployment.QueueSidecarImage == "mutated" {
 		t.Error("Controller config is not immutable")
-	}
-	if newConfig.Network.IstioOutboundIPRanges == "mutated" {
-		t.Error("Network config is not immutable")
 	}
 	if newConfig.Logging.LoggingConfig == "mutated" {
 		t.Error("Logging config is not immutable")

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -239,19 +239,6 @@ func MakeDeployment(rev *v1.Revision,
 	// out via annotation) we should explicitly disable that here to avoid redundant Image
 	// resources.
 
-	// Inject the IP ranges for istio sidecar configuration.
-	// We will inject this value only if all of the following are true:
-	// - the config map contains a non-empty value
-	// - the user doesn't specify this annotation in configuration's pod template
-	// - configured values are valid CIDR notation IP addresses
-	// If these conditions are not met, this value will be left untouched.
-	// * is a special value that is accepted as a valid.
-	// * intercepts calls to all IPs: in cluster as well as outside the cluster.
-	if _, ok := podTemplateAnnotations[IstioOutboundIPRangeAnnotation]; !ok {
-		if len(networkConfig.IstioOutboundIPRanges) > 0 {
-			podTemplateAnnotations[IstioOutboundIPRangeAnnotation] = networkConfig.IstioOutboundIPRanges
-		}
-	}
 	podSpec, err := makePodSpec(rev, loggingConfig, tracingConfig, observabilityConfig, autoscalerConfig, deploymentConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PodSpec: %w", err)

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -919,32 +919,6 @@ func TestMakeDeployment(t *testing.T) {
 		cc:   &deployment.Config{},
 		want: makeDeployment(),
 	}, {
-		name: "with outbound IP range configured",
-		rev: revision(
-			withoutLabels,
-			func(revision *v1.Revision) {
-				container(revision.Spec.GetContainer(),
-					withReadinessProbe(corev1.Handler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Host: "127.0.0.1",
-							Port: intstr.FromInt(12345),
-						},
-					}),
-				)
-			},
-		),
-		lc: &logging.Config{},
-		tc: &tracingconfig.Config{},
-		nc: &network.Config{
-			IstioOutboundIPRanges: "*",
-		},
-		oc: &metrics.ObservabilityConfig{},
-		ac: &autoscalerconfig.Config{},
-		cc: &deployment.Config{},
-		want: makeDeployment(func(deploy *appsv1.Deployment) {
-			deploy.Spec.Template.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "*"
-		}),
-	}, {
 		name: "with sidecar annotation override",
 		rev: revision(withoutLabels, func(revision *v1.Revision) {
 			revision.ObjectMeta.Annotations = map[string]string{
@@ -968,36 +942,6 @@ func TestMakeDeployment(t *testing.T) {
 		want: makeDeployment(func(deploy *appsv1.Deployment) {
 			deploy.ObjectMeta.Annotations[sidecarIstioInjectAnnotation] = "false"
 			deploy.Spec.Template.ObjectMeta.Annotations[sidecarIstioInjectAnnotation] = "false"
-		}),
-	}, {
-		name: "with outbound IP range override",
-		rev: revision(
-			withoutLabels,
-			func(revision *v1.Revision) {
-				revision.ObjectMeta.Annotations = map[string]string{
-					IstioOutboundIPRangeAnnotation: "10.4.0.0/14,10.7.240.0/20",
-				}
-				container(revision.Spec.GetContainer(),
-					withReadinessProbe(corev1.Handler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Host: "127.0.0.1",
-							Port: intstr.FromInt(12345),
-						},
-					}),
-				)
-			},
-		),
-		lc: &logging.Config{},
-		tc: &tracingconfig.Config{},
-		nc: &network.Config{
-			IstioOutboundIPRanges: "*",
-		},
-		oc: &metrics.ObservabilityConfig{},
-		ac: &autoscalerconfig.Config{},
-		cc: &deployment.Config{},
-		want: makeDeployment(func(deploy *appsv1.Deployment) {
-			deploy.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
-			deploy.Spec.Template.ObjectMeta.Annotations[IstioOutboundIPRangeAnnotation] = "10.4.0.0/14,10.7.240.0/20"
 		}),
 	}}
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -439,84 +439,6 @@ func TestNoQueueSidecarImageUpdateFail(t *testing.T) {
 	}
 }
 
-// This covers *error* paths in receiveNetworkConfig, since "" is not a valid value.
-func TestIstioOutboundIPRangesInjection(t *testing.T) {
-	var annotations map[string]string
-
-	// A valid IP range
-	in := "  10.10.10.0/24\r,,\t,\n,,"
-	want := "10.10.10.0/24"
-	annotations = getPodAnnotationsForConfig(t, in, "")
-	if got := annotations[resources.IstioOutboundIPRangeAnnotation]; want != got {
-		t.Fatalf("%v annotation expected to be %v, but is %v.", resources.IstioOutboundIPRangeAnnotation, want, got)
-	}
-
-	// Multiple valid ranges with whitespaces
-	in = " \t\t10.10.10.0/24,  ,,\t\n\r\n,10.240.10.0/14\n,   192.192.10.0/16"
-	want = "10.10.10.0/24,10.240.10.0/14,192.192.10.0/16"
-	annotations = getPodAnnotationsForConfig(t, in, "")
-	if got := annotations[resources.IstioOutboundIPRangeAnnotation]; want != got {
-		t.Fatalf("%v annotation expected to be %v, but is %v.", resources.IstioOutboundIPRangeAnnotation, want, got)
-	}
-
-	// An invalid IP range
-	in = "10.10.10.10/33"
-	annotations = getPodAnnotationsForConfig(t, in, "")
-	if got, ok := annotations[resources.IstioOutboundIPRangeAnnotation]; !ok {
-		t.Fatalf("Expected to have no %v annotation for invalid option %v. But found value %v", resources.IstioOutboundIPRangeAnnotation, want, got)
-	}
-
-	// Configuration has an annotation override - its value must be preserved
-	want = "10.240.10.0/14"
-	annotations = getPodAnnotationsForConfig(t, "", want)
-	if got := annotations[resources.IstioOutboundIPRangeAnnotation]; got != want {
-		t.Fatalf("%v annotation is expected to have %v but got %v", resources.IstioOutboundIPRangeAnnotation, want, got)
-	}
-	annotations = getPodAnnotationsForConfig(t, "10.10.10.0/24", want)
-	if got := annotations[resources.IstioOutboundIPRangeAnnotation]; got != want {
-		t.Fatalf("%v annotation is expected to have %v but got %v", resources.IstioOutboundIPRangeAnnotation, want, got)
-	}
-}
-
-func getPodAnnotationsForConfig(t *testing.T, configMapValue string, configAnnotationOverride string) map[string]string {
-	controllerConfig := getTestDeploymentConfig()
-	ctx, _, controller, watcher := newTestControllerWithConfig(t, controllerConfig, nil, func(r *Reconciler) {
-		// Resolve image references to this "digest"
-		digest := "foo@sha256:deadbeef"
-
-		r.resolver = &fixedResolver{digest}
-	})
-
-	watcher.OnChange(&corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      network.ConfigName,
-			Namespace: system.Namespace(),
-		},
-		Data: map[string]string{
-			network.IstioOutboundIPRangesKey: configMapValue,
-		}})
-
-	rev := testRevision()
-	config := testConfiguration()
-	if len(configAnnotationOverride) > 0 {
-		rev.ObjectMeta.Annotations = map[string]string{resources.IstioOutboundIPRangeAnnotation: configAnnotationOverride}
-	}
-
-	rev.OwnerReferences = append(
-		rev.OwnerReferences,
-		*kmeta.NewControllerRef(config),
-	)
-
-	createRevision(t, ctx, controller, rev)
-
-	expectedDeploymentName := fmt.Sprintf("%s-deployment", rev.Name)
-	deployment, err := fakekubeclient.Get(ctx).AppsV1().Deployments(testNamespace).Get(expectedDeploymentName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get serving deployment: %v", err)
-	}
-	return deployment.Spec.Template.ObjectMeta.Annotations
-}
-
 func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 	// Test that changes to the ConfigMap result in the desired changes on an existing
 	// revision.
@@ -633,34 +555,6 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 		configMapToUpdate *corev1.ConfigMap
 		callback          func(*testing.T) func(runtime.Object) HookResult
 	}{{
-		name: "Update Istio Outbound IP Ranges", // Should update metadata on Deployment
-		configMapToUpdate: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      network.ConfigName,
-				Namespace: system.Namespace(),
-			},
-			Data: map[string]string{
-				"istio.sidecar.includeOutboundIPRanges": "10.0.0.1/24",
-			},
-		},
-		callback: func(t *testing.T) func(runtime.Object) HookResult {
-			return func(obj runtime.Object) HookResult {
-				deployment := obj.(*appsv1.Deployment)
-				t.Logf("Deployment updated: %v", deployment.Name)
-
-				expected := "10.0.0.1/24"
-				annotations := deployment.Spec.Template.ObjectMeta.Annotations
-				got := annotations[resources.IstioOutboundIPRangeAnnotation]
-
-				if got != expected {
-					t.Logf("No update occurred; expected: %s got: %s", expected, got)
-					return HookIncomplete
-				}
-
-				return HookComplete
-			}
-		},
-	}, {
 		name: "Disable /var/log Collection", // Should set ENABLE_VAR_LOG_COLLECTION to false
 		configMapToUpdate: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -41,7 +41,6 @@ import (
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
-	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 	"knative.dev/serving/pkg/reconciler/revision/resources"
 
@@ -742,7 +741,6 @@ var _ pkgreconciler.ConfigStore = (*testConfigStore)(nil)
 func ReconcilerTestConfig() *config.Config {
 	return &config.Config{
 		Deployment: getTestDeploymentConfig(),
-		Network:    &network.Config{IstioOutboundIPRanges: "*"},
 		Observability: &metrics.ObservabilityConfig{
 			LoggingURLTemplate: "http://logger.io/${REVISION_UID}",
 		},


### PR DESCRIPTION
## Proposed Changes

This patch makes `istio.sidecar.includeOutboundIPRanges` in
`config-network` obsolete.

Since current versions have outbound network access enabled by
default, we do not need this option and should remove it from
Serving's settings.

With said, users might use this option instead of Istio's global
config. Hence, we produce validation warning message
until the next release.

Part of https://github.com/knative/serving/issues/6543

/lint

#### The validation warning by this patch:

```
{"level":"warn","ts":1579690558.7121727,"logger":"fallback.config-network","caller":"network/network.go:194","msg":"\"istio.sidecar.includeOutboundIPRanges\" is obsolete as outbound network access is enabled by default now. Remove it from config-network"}
```

**Release Note**

```release-note
istio.sidecar.includeOutboundIPRanges in config-network is obsolete as outbound network access enabled by default. Remove it from config-network otherwise get validation error.
```
