### PR TITLE
Fix panic in TestUpdate, ensure all probes in goroutine are canceled

### DIFF
--- a/test/conformance/ingress/update_test.go
+++ b/test/conformance/ingress/update_test.go
@@ -67,6 +67,7 @@ func TestUpdate(t *testing.T) {
 	defer cancel()
 
 	proberCancel := checkOK(t, "http://"+hostname+".example.com", client)
+	defer proberCancel()
 
 	// Give the prober a chance to get started.
 	time.Sleep(1 * time.Second)
@@ -160,8 +161,6 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 
-	// Stop the prober.
-	proberCancel()
 	// Then cleanup the final version.
 	previousVersionCancel()
 }


### PR DESCRIPTION
To avoid probe goroutines from continuing to run after test complete,
call cancel when exiting.

panic: Fail in goroutine after TestUpdate has completed

https://github.com/golang/go/issues/15976


<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
