### PR TITLE
Add e2e to validate the graceful scaledown behavior

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/networking"
@@ -73,6 +74,18 @@ func autoscalerCM(clients *test.Clients) (*autoscaler.Config, error) {
 		return nil, err
 	}
 	return autoscaler.NewConfigFromMap(autoscalerCM.Data)
+}
+
+// rawCM returns the raw knative config map for the given name
+func rawCM(clients *test.Clients, name string) (*corev1.ConfigMap, error) {
+	return clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Get(
+		name,
+		metav1.GetOptions{})
+}
+
+// patchCM updates the existing config map with the supplied value.
+func patchCM(clients *test.Clients, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Update(cm)
 }
 
 // WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -88,9 +88,9 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 // x == size; ensuring that each connection lands on a separate pod
 func uniqueHostConnections(t *testing.T, names test.ResourceNames, size int) (*sync.Map, error) {
 	clients := Setup(t)
-	uniqueHostConns := sync.Map{}
+	uniqueHostConns := &sync.Map{}
 
-	ctx, done := context.WithCancel(context.Background())
+	ctx, _ := context.WithTimeout(context.Background(), uniqueHostConnTimeout)
 	gr, gctx := errgroup.WithContext(ctx)
 	for i := 0; i < size; i++ {
 		gr.Go(func() error {
@@ -129,15 +129,10 @@ func uniqueHostConnections(t *testing.T, names test.ResourceNames, size int) (*s
 		})
 	}
 
-	timer := time.AfterFunc(uniqueHostConnTimeout, func() {
-		done()
-	})
-	defer timer.Stop()
-
 	if err := gr.Wait(); err != nil {
 		return nil, err
 	}
-	return &uniqueHostConns, nil
+	return uniqueHostConns, nil
 }
 
 // deleteHostConnections closes and removees x number of open websocket connections

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/sync/errgroup"
+
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/util/wait"
+	pkgTest "knative.dev/pkg/test"
+	ingress "knative.dev/pkg/test/ingress"
+	"knative.dev/serving/test"
+)
+
+const (
+	connectRetryInterval  = 1 * time.Second
+	connectTimeout        = 1 * time.Minute
+	uniqueHostConnTimeout = 3 * time.Minute
+)
+
+// connect attempts to establish WebSocket connection with the Service.
+// It will retry until reaching `connectTimeout` duration.
+func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Conn, error) {
+	var (
+		err     error
+		address string
+	)
+
+	if test.ServingFlags.ResolvableDomain {
+		address = domain
+	} else if pkgTest.Flags.IngressEndpoint != "" {
+		address = pkgTest.Flags.IngressEndpoint
+	} else if address, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube); err != nil {
+		return nil, err
+	}
+
+	u := url.URL{Scheme: "ws", Host: address, Path: "/"}
+	var conn *websocket.Conn
+	waitErr := wait.PollImmediate(connectRetryInterval, connectTimeout, func() (bool, error) {
+		t.Logf("Connecting using websocket: url=%s, host=%s", u.String(), domain)
+		c, resp, err := websocket.DefaultDialer.Dial(u.String(), http.Header{"Host": {domain}})
+		if err == nil {
+			t.Log("WebSocket connection established.")
+			conn = c
+			return true, nil
+		}
+		if resp == nil {
+			// We don't have an HTTP response, probably TCP errors.
+			t.Logf("Connection failed: %v", err)
+			return false, nil
+		}
+
+		body, readErr := ioutil.ReadAll(resp.Body)
+		if readErr != nil {
+			t.Logf("Connection failed: %v. Failed to read HTTP response: %v", err, readErr)
+			return false, nil
+		}
+		t.Logf("HTTP connection failed: %v. Response=%+v. ResponseBody=%q", err, resp, body)
+		return false, nil
+	})
+	return conn, waitErr
+}
+
+// uniqueHostConnections returns a map of open websocket connections to x number of pods where
+// x == size; ensuring that each connection lands on a separate pod
+func uniqueHostConnections(t *testing.T, names test.ResourceNames, size int) (*sync.Map, error) {
+	clients := Setup(t)
+	uniqueHostConns := sync.Map{}
+
+	ctx, done := context.WithCancel(context.Background())
+	gr, gctx := errgroup.WithContext(ctx)
+	for i := 0; i < size; i++ {
+		gr.Go(func() error {
+			for {
+				select {
+				case <-gctx.Done():
+					return errors.New("Timed out trying to find unique host connections.")
+
+				default:
+					conn, err := connect(t, clients, names.URL.Hostname())
+					if err != nil {
+						return err
+					}
+
+					if err = conn.WriteMessage(websocket.TextMessage, []byte("hostname")); err != nil {
+						return err
+					}
+
+					_, recv, err := conn.ReadMessage()
+					if err != nil {
+						return err
+					}
+
+					host := string(recv)
+					if host == "" {
+						return errors.New("No host name is received from the server.")
+					}
+
+					if _, ok := uniqueHostConns.LoadOrStore(host, conn); !ok {
+						return nil
+					} else {
+						conn.Close()
+					}
+				}
+			}
+		})
+	}
+
+	timer := time.AfterFunc(uniqueHostConnTimeout, func() {
+		done()
+	})
+	defer timer.Stop()
+
+	if err := gr.Wait(); err != nil {
+		return nil, err
+	}
+	return &uniqueHostConns, nil
+}
+
+// deleteHostConnections closes and removees x number of open websocket connections
+// from the hostConnMap where x == size
+func deleteHostConnections(hostConnMap *sync.Map, size int) error {
+	hostConnMap.Range(func(key, value interface{}) bool {
+		if size <= 0 {
+			return false
+		}
+
+		if conn, ok := value.(*websocket.Conn); ok {
+			conn.Close()
+			hostConnMap.Delete(key)
+			size -= 1
+			return true
+		}
+		return false
+	})
+
+	if size != 0 {
+		return errors.New("Failed to close connections")
+	}
+
+	return nil
+}

--- a/test/test_images/wsserver-hostname/README.md
+++ b/test/test_images/wsserver-hostname/README.md
@@ -1,0 +1,11 @@
+# Hostname WebSocket test image
+
+A simple WebSocket server adapted from
+https://github.com/gorilla/WebSocket/blob/master/examples/echo/server.go . The
+server simply returns the name of the host it runs on and keeps the connection
+open.
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/wsserver-hostname/main.go
+++ b/test/test_images/wsserver-hostname/main.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/websocket"
+	"knative.dev/serving/pkg/network"
+	"knative.dev/serving/test"
+)
+
+var upgrader = websocket.Upgrader{
+	// Allow any origin, since we are spoofing requests anyway.
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if network.IsKubeletProbe(r) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("Error upgrading websocket:", err)
+		return
+	}
+	defer conn.Close()
+	log.Println("Connection upgraded to WebSocket. Entering receive loop.")
+	for {
+		messageType, message, err := conn.ReadMessage()
+		if err != nil {
+			// We close abnormally, because we're just closing the connection in the client,
+			// which is okay. There's no value delaying closure of the connection unnecessarily.
+			if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
+				log.Println("Client disconnected.")
+			} else {
+				log.Println("Handler exiting on error:", err)
+			}
+			return
+		}
+
+		host, err := os.Hostname()
+		if err != nil {
+			log.Println("os.Hostname() returning an error:", err)
+		}
+
+		// Write the host name and keep the connection open
+		if err = conn.WriteMessage(messageType, []byte(host)); err != nil {
+			log.Println("Failed to write message:", err)
+			return
+		}
+		log.Printf("Successfully wrote: %q", message)
+	}
+}
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+	h := network.NewProbeHandler(http.HandlerFunc(handler))
+	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+}

--- a/test/test_images/wsserver-hostname/service.yaml
+++ b/test/test_images/wsserver-hostname/service.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: websocket-hostname-server
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: knative.dev/serving/test/test_images/wsserver-hostname


### PR DESCRIPTION
This PR introduces an e2e test that validates the behavior for graceful scale down in the presence of open websocket connections to a subset of pods.

as part of #6134

/lint
