### PR TITLE
Some cleanups to the kpa code

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -42,9 +42,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// podCounts keep record of the number of pods
-// for each revision
+// podCounts keeps record of various numbers of pods
+// for each revision.
 type podCounts struct {
+	want        int
 	ready       int
 	notReady    int
 	pending     int
@@ -140,7 +141,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 		if _, err = c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe); err != nil {
 			return fmt.Errorf("error reconciling SKS: %w", err)
 		}
-		return computeStatus(pa, scaleUnknown, podCounts{})
+		return computeStatus(pa, podCounts{want: scaleUnknown})
 	}
 
 	pa.Status.MetricsServiceName = sks.Status.PrivateServiceName
@@ -214,13 +215,14 @@ func (c *Reconciler) reconcile(ctx context.Context, pa *pav1alpha1.PodAutoscaler
 	logger.Infof("PA scale got=%d, want=%d, ebc=%d", ready, want, decider.Status.ExcessBurstCapacity)
 
 	pc := podCounts{
+		want:        int(want),
 		ready:       ready,
 		notReady:    notReady,
 		pending:     pending,
 		terminating: terminating,
 	}
 	logger.Infof("Observed pod counts=%#v", pc)
-	return computeStatus(pa, want, pc)
+	return computeStatus(pa, pc)
 }
 
 func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAutoscaler, k8sSvc string) (*autoscaler.Decider, error) {
@@ -243,24 +245,23 @@ func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAut
 			return nil, fmt.Errorf("error updating decider: %w", err)
 		}
 	}
-
 	return decider, nil
 }
 
-func computeStatus(pa *pav1alpha1.PodAutoscaler, want int32, pc podCounts) error {
-	pa.Status.DesiredScale, pa.Status.ActualScale = &want, ptr.Int32(int32(pc.ready))
+func computeStatus(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
+	pa.Status.DesiredScale, pa.Status.ActualScale = ptr.Int32(int32(pc.want)), ptr.Int32(int32(pc.ready))
 
-	if err := reportMetrics(pa, want, pc); err != nil {
+	if err := reportMetrics(pa, pc); err != nil {
 		return fmt.Errorf("error reporting metrics: %w", err)
 	}
 
-	computeActiveCondition(pa, want, pc.ready)
+	computeActiveCondition(pa, pc.want, pc.ready)
 
 	pa.Status.ObservedGeneration = pa.Generation
 	return nil
 }
 
-func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, pc podCounts) error {
+func reportMetrics(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
 	var serviceLabel string
 	var configLabel string
 	if pa.Labels != nil {
@@ -277,8 +278,8 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, pc podCounts) error
 	reporter.ReportPendingPodCount(int64(pc.pending))
 	reporter.ReportTerminatingPodCount(int64(pc.terminating))
 	// Negative "want" values represent an empty metrics pipeline and thus no specific request is being made.
-	if want >= 0 {
-		reporter.ReportRequestedPodCount(int64(want))
+	if pc.want >= 0 {
+		reporter.ReportRequestedPodCount(int64(pc.want))
 	}
 	return nil
 }
@@ -296,7 +297,7 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, want int32, pc podCounts) error
 //    | -1   | >= min | inactive   | inactive   |
 //    | -1   | >= min | activating | active     |
 //    | -1   | >= min | active     | active     |
-func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want int32, got int) {
+func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, want, got int) {
 	minReady := activeThreshold(pa)
 
 	switch {


### PR DESCRIPTION
This is a followup to the #6476 PR.
The main change is that 'want' is pushed into the podCounts
to pack them together, which, imo, improves readability, by
removing at least some parameters.
Also optimize the code in the test for reuse

/assign @nimakaviani @markusthoemmes 