### PR TITLE
Modify AutoscalingQueueMetricsPortName as per istio naming convention

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -48,7 +48,7 @@ const (
 
 	// AutoscalingQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for autoscaler.
-	AutoscalingQueueMetricsPortName = "queue-metrics"
+	AutoscalingQueueMetricsPortName = "http-autometric"
 
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.


### PR DESCRIPTION
> https://istio.io/docs/ops/deployment/requirements/

Fixes #

**Changes**
To be on the safer side when deployed to a cluster with Istio deployed, we should follow service port naming convention as stated here -> https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

**Release Note**

```
Named service ports: Service ports must be named. The port name key/value pairs must have the following syntax: name: <protocol>[-<suffix>]. See Protocol Selection for more details.
https://istio.io/docs/ops/deployment/requirements/
```
