### PR TITLE
WaitForEndpointState in ObservedConcurrencyTest

### DIFF
--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -165,20 +165,20 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
 
-	baseUrl := objs.Route.Status.URL.URL()
+	baseURL := objs.Route.Status.URL.URL()
 
 	// See https://github.com/knative/serving/issues/5573 for why we need this
 	if _, err = pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
-		baseUrl,
+		baseURL,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"ObservedConcurrency",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatalf("Error probing %s: %v", baseUrl, err)
+		t.Fatalf("Error probing %s: %v", baseURL, err)
 	}
 
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, baseUrl.Hostname(), test.ServingFlags.ResolvableDomain)
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, baseURL.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {
 		t.Fatalf("Error creating spoofing client: %v", err)
 	}
@@ -193,7 +193,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 
 	t.Logf("Running %d concurrent requests for %v", concurrency, duration)
 
-	url := fmt.Sprintf("http://%s/?timeout=1000", baseUrl.Hostname())
+	url := fmt.Sprintf("http://%s/?timeout=1000", baseURL.Hostname())
 	eg.Go(func() error {
 		return generateTraffic(t, client, url, concurrency, duration, responseChannel)
 	})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Related to https://github.com/knative/serving/issues/5573

Fixes the problem that the test might proceed before the route is actually ready and then we're getting 
 error code 404. I hit this problem several times this week.

## Proposed Changes

* Wait for the endpoint to return status 200 before proceeding with the test
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
