### PR TITLE
Add appropriate log keys to the activator's endpoint management.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -449,11 +449,11 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 
 	rw, err := rbm.getOrCreateRevisionWatcher(revID)
 	if err != nil {
-		logger.With(zap.Error(err)).Errorf("Failed to get revision watcher for revision %q", revID.String())
+		logger.With(zap.Error(err)).Error("Failed to get revision watcher")
 		return
 	}
 	dests := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
-	logger.Debugf("Updating Endpoints: %q (backends: %d)", revID.String(), len(dests))
+	logger.Debugf("Updating Endpoints: backends: %d", len(dests))
 	select {
 	case <-rbm.ctx.Done():
 		return

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -40,6 +40,7 @@ import (
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/network/prober"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
@@ -108,7 +109,7 @@ func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol 
 		destsCh:         destsCh,
 		serviceLister:   serviceLister,
 		podsAddressable: true, // By default we presume we can talk to pods directly.
-		logger:          logger,
+		logger:          logger.With(zap.String(logkey.Key, rev.String())),
 	}
 }
 
@@ -440,17 +441,19 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 		return
 	default:
 	}
-	rbm.logger.Debugf("Endpoints updated: %#v", newObj)
 	endpoints := newObj.(*corev1.Endpoints)
-	revID := types.NamespacedName{endpoints.Namespace, endpoints.Labels[serving.RevisionLabelKey]}
+	revID := types.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Labels[serving.RevisionLabelKey]}
+	logger := rbm.logger.With(zap.String(logkey.Key, revID.String()))
+
+	logger.Debugf("Endpoints updated: %#v", newObj)
 
 	rw, err := rbm.getOrCreateRevisionWatcher(revID)
 	if err != nil {
-		rbm.logger.With(zap.Error(err)).Errorf("Failed to get revision watcher for revision %q", revID.String())
+		logger.With(zap.Error(err)).Errorf("Failed to get revision watcher for revision %q", revID.String())
 		return
 	}
 	dests := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
-	rbm.logger.Debugf("Updating Endpoints: %q (backends: %d)", revID.String(), len(dests))
+	logger.Debugf("Updating Endpoints: %q (backends: %d)", revID.String(), len(dests))
 	select {
 	case <-rbm.ctx.Done():
 		return
@@ -475,9 +478,10 @@ func (rbm *revisionBackendsManager) endpointsDeleted(obj interface{}) {
 	default:
 	}
 	ep := obj.(*corev1.Endpoints)
-	revID := types.NamespacedName{ep.Namespace, ep.Labels[serving.RevisionLabelKey]}
+	revID := types.NamespacedName{Namespace: ep.Namespace, Name: ep.Labels[serving.RevisionLabelKey]}
+	logger := rbm.logger.With(zap.String(logkey.Key, revID.String()))
 
-	rbm.logger.Debugf("Deleting endpoint %q", revID.String())
+	logger.Debug("Deleting endpoint")
 	rbm.revisionWatchersMux.Lock()
 	defer rbm.revisionWatchersMux.Unlock()
 	rbm.deleteRevisionWatcher(revID)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* This should greatly help with debugging, especially test-debugging as it should coalesque the logs of the service under test with the logs generated in the activator's revision management and  throttler.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
