### PR TITLE
Drop istio-specific port on private service.

### DIFF
--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -56,11 +56,15 @@ var (
 		Name:          requestQueueHTTPPortName,
 		ContainerPort: int32(networking.BackendHTTP2Port),
 	}
+
+	// When run with the Istio mesh, Envoy blocks traffic to any ports not
+	// recognized, and has special treatment for probes, but not PreStop hooks.
+	// That results in the PreStop hook /wait-for-drain in queue-proxy not
+	// reachable, thus triggering SIGTERM immediately during shutdown and
+	// causing requests to be dropped.
+	//
+	// So we DON'T expose this port here to work around this Istio bug.
 	queueNonServingPorts = []corev1.ContainerPort{{
-		// Provides health checks and lifecycle hooks.
-		Name:          v1alpha1.QueueAdminPortName,
-		ContainerPort: int32(networking.QueueAdminPort),
-	}, {
 		Name:          v1alpha1.AutoscalingQueueMetricsPortName,
 		ContainerPort: int32(networking.AutoscalingQueueMetricsPort),
 	}, {

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -143,18 +143,6 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.UserQueueMetricsPort,
 				TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
-			}, {
-				// When run with the Istio mesh, Envoy blocks traffic to any ports not
-				// recognized, and has special treatment for probes, but not PreStop hooks.
-				// That results in the PreStop hook /wait-for-drain in queue-proxy not
-				// reachable, thus triggering SIGTERM immediately during shutdown and
-				// causing requests to be dropped.
-				//
-				// So we expose this port here to work around this Istio bug.
-				Name:       servingv1alpha1.QueueAdminPortName,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.QueueAdminPort,
-				TargetPort: intstr.FromInt(networking.QueueAdminPort),
 			}},
 			Selector: selector,
 		},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Istio intercepts the traffic of all advertised ports on the containers. If we don't advertise a port, it shouldn't detect it and leave it alone.

The QueueAdminPort should only be called from things local to the container anyway, so that should be okay.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove an istio-specific workaround around port handling for PreStop hooks.
```
