### PR TITLE
Update kourier-control image version to v0.3.8

### DIFF
--- a/third_party/kourier-latest/download-kourier.sh
+++ b/third_party/kourier-latest/download-kourier.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # Download Kourier
-KOURIER_VERSION=0.3.7
+KOURIER_VERSION=0.3.8
 KOURIER_YAML=kourier-knative.yaml
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/v${KOURIER_VERSION}/deploy/${KOURIER_YAML}
 

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -119,7 +119,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.7
+        - image: quay.io/3scale/kourier:v0.3.8
           imagePullPolicy: Always
           name: kourier-control
           resources: {}


### PR DESCRIPTION
/lint

## Proposed Changes

* Updates Kourier Control plane version to the v0.3.8. This version solves the "TestUpdate" flakiness.

**Release Note**
```release-note
NONE
```
