### PR TITLE
Remove Route labels to reconcile KIngress

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -35,7 +35,6 @@ import (
 	"go.uber.org/zap"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/network/status"
 	"knative.dev/serving/pkg/reconciler"
@@ -270,10 +269,9 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 	}
 
 	// Now, remove the extra ones.
-	vses, err := r.virtualServiceLister.VirtualServices(resources.VirtualServiceNamespace(ing)).List(
+	vses, err := r.virtualServiceLister.VirtualServices(ing.GetNamespace()).List(
 		labels.Set(map[string]string{
-			networking.IngressLabelKey:     ing.GetName(),
-			serving.RouteNamespaceLabelKey: ing.GetLabels()[serving.RouteNamespaceLabelKey]}).AsSelector())
+			networking.IngressLabelKey: ing.GetName()}).AsSelector())
 	if err != nil {
 		return fmt.Errorf("failed to get VirtualServices: %w", err)
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -270,10 +270,9 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 	}
 
 	// Now, remove the extra ones.
-	// TODO(https://github.com/knative/serving/issues/6363):  Switch to use networking.IngressLabelKey instead.
 	vses, err := r.virtualServiceLister.VirtualServices(resources.VirtualServiceNamespace(ing)).List(
 		labels.Set(map[string]string{
-			serving.RouteLabelKey:          ing.GetLabels()[serving.RouteLabelKey],
+			networking.IngressLabelKey:     ing.GetName(),
 			serving.RouteNamespaceLabelKey: ing.GetLabels()[serving.RouteNamespaceLabelKey]}).AsSelector())
 	if err != nil {
 		return fmt.Errorf("failed to get VirtualServices: %w", err)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -268,7 +268,6 @@ func TestReconcile(t *testing.T) {
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "reconcile-failed",
-						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-failed", 1234))},
@@ -323,7 +322,6 @@ func TestReconcile(t *testing.T) {
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
@@ -336,7 +334,6 @@ func TestReconcile(t *testing.T) {
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
@@ -429,7 +426,6 @@ func TestReconcile(t *testing.T) {
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
 					Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
@@ -443,7 +439,6 @@ func TestReconcile(t *testing.T) {
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteLabelKey:          "test-route",
 						serving.RouteNamespaceLabelKey: "test-ns",
 					},
 					Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -267,8 +267,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-failed",
 					Namespace: "test-ns",
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-failed",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.IngressLabelKey: "reconcile-failed",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-failed", 1234))},
 				},
@@ -321,8 +320,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice",
 					Namespace: "test-ns",
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.IngressLabelKey: "reconcile-virtualservice",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
 				},
@@ -333,8 +331,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice-extra",
 					Namespace: "test-ns",
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.IngressLabelKey: "reconcile-virtualservice",
 					},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
 				},
@@ -425,8 +422,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice",
 					Namespace: "test-ns",
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.IngressLabelKey: "reconcile-virtualservice",
 					},
 					Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
@@ -438,8 +434,7 @@ func TestReconcile(t *testing.T) {
 					Name:      "reconcile-virtualservice-extra",
 					Namespace: "test-ns",
 					Labels: map[string]string{
-						networking.IngressLabelKey:     "reconcile-virtualservice",
-						serving.RouteNamespaceLabelKey: "test-ns",
+						networking.IngressLabelKey: "reconcile-virtualservice",
 					},
 					Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
 					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},


### PR DESCRIPTION

/lint
Fixes #6363 

## Proposed Changes

* Ingress reconciler does not rely on route labels

cc @tcnghia 

