### PR TITLE
Final change to exclude young pods from stats computations.

### DIFF
--- a/pkg/autoscaler/sample_size.go
+++ b/pkg/autoscaler/sample_size.go
@@ -34,7 +34,7 @@ const (
 // if N <= 3:
 //   n = N
 // else:
-//   n = N*X / (N + X – 1), X = C^2 ­* σ^2 / MOE^2,
+//   n = N*X / (N + X – 1), X = C^2 * σ^2 / MOE^2,
 //
 // where N is the population size, C is the critical value of the Normal distribution
 // for a given confidence level of 95%, MOE is the margin of error and σ^2 is the

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -177,12 +177,10 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 							return nil
 						}
 					}
-				}
-
-				// Return the error if we exhausted our retries and
-				// we had an error returned (we can end up here if
-				// all the pods were young, which is not an error condition).
-				if err != nil && tries >= scraperMaxRetries {
+				} else if tries >= scraperMaxRetries {
+					// Return the error if we exhausted our retries and
+					// we had an error returned (we can end up here if
+					// all the pods were young, which is not an error condition).
 					return err
 				}
 			}

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -176,7 +176,7 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 						// fill up the channel.
 						case youngStatCh <- stat:
 						default:
-							// If so, just return, try again.
+							// If so, just return.
 							return nil
 						}
 					}

--- a/pkg/autoscaler/stats_scraper.go
+++ b/pkg/autoscaler/stats_scraper.go
@@ -222,15 +222,13 @@ func (s *ServiceScraper) Scrape() (Stat, error) {
 		reqCount += stat.RequestCount
 		proxiedReqCount += stat.ProxiedRequestCount
 	}
-	if oldCnt < sampleSize {
-		for i := oldCnt; i < sampleSize; i++ {
-			// This will always succeed, see reasoning above.
-			stat := <-youngStatCh
-			avgConcurrency += stat.AverageConcurrentRequests
-			avgProxiedConcurrency += stat.AverageProxiedConcurrentRequests
-			reqCount += stat.RequestCount
-			proxiedReqCount += stat.ProxiedRequestCount
-		}
+	for i := oldCnt; i < sampleSize; i++ {
+		// This will always succeed, see reasoning above.
+		stat := <-youngStatCh
+		avgConcurrency += stat.AverageConcurrentRequests
+		avgProxiedConcurrency += stat.AverageProxiedConcurrentRequests
+		reqCount += stat.RequestCount
+		proxiedReqCount += stat.ProxiedRequestCount
 	}
 
 	count := float64(sampleSize)


### PR DESCRIPTION
This change introduces the exclusion of the young (less 1min of lifespan) in the stats computation iff:
1. The sample size is at least 4 (small samples, means few pods in general, most likely newly scaled up)
2. The pod scrape has podUptime metric, i.e. pods with 0.12 and newer versions
3. If we scrape that pod again, we'll use its metric. E.g. if revision is actively scaling up, most, if not all, pods will be young. E.g. in our load test we scale within 15 seconds from 0 to 16 pods. Thus, if nothing else is useful, we'll take that pod's stat. This ensures, that if all/most pods are young, we still get the signal we want.

/lint
Fixes #5977

/assign @markusthoemmes mattmoor