### PR TITLE
Refactor Auto TLS E2E test

### DIFF
--- a/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
@@ -1,0 +1,48 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-certmanager
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/certificate-provider: cert-manager
+data:
+  issuerRef: |
+    kind: ClusterIssuer
+    name: self-signed-issuer
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # issuerRef is a reference to the issuer for this certificate.
+    # IssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # Please refer `IssuerRef` in https://github.com/jetstack/cert-manager/blob/master/pkg/apis/certmanager/v1alpha1/types_certificate.go
+    # for more details about IssuerRef configuration.
+    issuerRef: |
+      kind: ClusterIssuer
+      name: letsencrypt-issuer

--- a/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/config/autotls/certmanager/selfsigned/issuer.yaml
+++ b/test/config/autotls/certmanager/selfsigned/issuer.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:

--- a/test/config/autotls/certmanager/selfsigned/issuer.yaml
+++ b/test/config/autotls/certmanager/selfsigned/issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: self-signed-issuer
+spec:
+  selfSigned: {}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -420,6 +420,20 @@ function knative_teardown() {
   fi
 }
 
+# Add function call to trap
+# Parameters: $1 - Function to call
+#             $2...$n - Signals for trap
+function add_trap() {
+  local cmd=$1
+  shift
+  for trap_signal in $@; do
+    local current_trap="$(trap -p $trap_signal | cut -d\' -f2)"
+    local new_cmd="($cmd)"
+    [[ -n "${current_trap}" ]] && new_cmd="${current_trap};${new_cmd}"
+    trap -- "${new_cmd}" $trap_signal
+  done
+}
+
 # Create test resources and images
 function test_setup() {
   echo ">> Setting up logging..."
@@ -433,7 +447,7 @@ function test_setup() {
   kail > ${ARTIFACTS}/k8s.log.txt &
   local kail_pid=$!
   # Clean up kail so it doesn't interfere with job shutting down
-  trap "kill $kail_pid || true" EXIT
+  add_trap "kill $kail_pid || true" EXIT
 
   echo ">> Creating test resources (test/config/)"
   ko apply ${KO_FLAGS} -f test/config/ || return 1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -61,10 +61,10 @@ go_test_e2e -timeout=10m \
 
 # Auto TLS E2E tests mutate the cluster and must be ran separately
 kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
+add_trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
   ./test/e2e/autotls || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
-trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -63,7 +63,7 @@ go_test_e2e -timeout=10m \
 kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
 go_test_e2e -timeout=10m \
   ./test/e2e/autotls || failed=1
-kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
+trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/" EXIT SIGKILL SIGTERM SIGQUIT
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -60,6 +60,7 @@ go_test_e2e -timeout=10m \
   ./test/scale || failed=1
 
 # Auto TLS E2E tests mutate the cluster and must be ran separately
+kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
 go_test_e2e -timeout=10m \
   ./test/e2e/autotls || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -63,6 +63,7 @@ go_test_e2e -timeout=10m \
 kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
 go_test_e2e -timeout=10m \
   ./test/e2e/autotls || failed=1
+kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -63,7 +63,8 @@ go_test_e2e -timeout=10m \
 kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
 go_test_e2e -timeout=10m \
   ./test/e2e/autotls || failed=1
-trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/" EXIT SIGKILL SIGTERM SIGQUIT
+kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
+trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT 
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -64,7 +64,7 @@ kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
 go_test_e2e -timeout=10m \
   ./test/e2e/autotls || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
-trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT 
+trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -55,6 +55,8 @@ func TestPerKsvcCert_localCA(t *testing.T) {
 		Image:   "runtime",
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -84,7 +86,7 @@ func createRootCAs(t *testing.T, clients *test.Clients, ns, secretName string) *
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
 	}
-	if ok := rootCAs.AppendCertsFromPEM(secret.Data[corev1.TLSCertKey]); !ok {
+	if !rootCAs.AppendCertsFromPEM(secret.Data[corev1.TLSCertKey]) {
 		t.Fatal("Failed to add the certificate to the root CA")
 	}
 	return rootCAs

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Knative Authors
 
@@ -25,13 +23,12 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	pkgtest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/networking"
-	cmclientset "knative.dev/serving/pkg/client/certmanager/clientset/versioned"
 	routenames "knative.dev/serving/pkg/reconciler/route/resources/names"
 	"knative.dev/serving/test"
 	testingress "knative.dev/serving/test/conformance/ingress"
@@ -44,7 +41,8 @@ import (
 )
 
 const (
-	systemNamespace = "knative-serving"
+	systemNamespace         = "knative-serving"
+	selfSignedClusterIssuer = "self-signed-issuer"
 )
 
 var (
@@ -60,54 +58,59 @@ var (
 	}
 )
 
-type autoTLSClients struct {
-	clients  *test.Clients
-	cmClient cmclientset.Interface
-}
-
 func TestPerKsvcCert_localCA(t *testing.T) {
-	tlsClients := initializeClients(t)
-	disableNamespaceCert(t, tlsClients)
+	clients := e2e.Setup(t)
+	disableNamespaceCert(t, clients)
 
 	// Create Knative Service
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
 		Image:   "runtime",
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(tlsClients.clients, names) })
-	objects, err := v1test.CreateServiceReady(t, tlsClients.clients, &names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	objects, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
 
-	// Create TLS certificate for the Knative Service.
-	rootCAs := x509.NewCertPool()
-	secretName, cancel := testingress.CreateTLSSecretWithCertPool(t, tlsClients.clients, []string{objects.Service.Status.URL.Host}, "cert-manager", rootCAs)
+	cancel := updateConfigCertManangerCM(t, clients, selfSignedClusterIssuer)
 	defer cancel()
 
-	// Create ClusterIssuer and update config-certmanager to reference the created ClusterIssuer
-	clusterIssuer, cancel := createClusterIssuer(t, tlsClients, secretName)
-	defer cancel()
-	cancel = updateConfigCertManangerCM(t, tlsClients, clusterIssuer)
-	defer cancel()
-
-	cancel = turnOnAutoTLS(t, tlsClients)
+	cancel = turnOnAutoTLS(t, clients)
 	defer cancel()
 
 	// wait for certificate to be ready
-	waitForCertificateReady(t, tlsClients, routenames.Certificate(objects.Route))
+	waitForCertificateReady(t, clients, routenames.Certificate(objects.Route))
 
 	// curl HTTPS
-	httpsClient := createHTTPSClient(t, tlsClients, objects, rootCAs)
+	rootCAs := createRootCAs(t, clients, objects)
+	httpsClient := createHTTPSClient(t, clients, objects, rootCAs)
 	testingress.RuntimeRequest(t, httpsClient, "https://"+objects.Service.Status.URL.Host)
 }
 
-func createHTTPSClient(t *testing.T, tlsClients *autoTLSClients, objects *v1test.ResourceObjects, rootCAs *x509.CertPool) *http.Client {
-	ing, err := tlsClients.clients.NetworkingClient.Ingresses.Get(routenames.Ingress(objects.Route), metav1.GetOptions{})
+func createRootCAs(t *testing.T, clients *test.Clients, objects *v1test.ResourceObjects) *x509.CertPool {
+	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(objects.Route.Namespace).Get(
+		routenames.Certificate(objects.Route), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Secret %s: %v", routenames.Certificate(objects.Route), err)
+	}
+
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if ok := rootCAs.AppendCertsFromPEM(secret.Data[corev1.TLSCertKey]); !ok {
+		t.Fatalf("Failed to add the certificate to the root CA")
+	}
+	return rootCAs
+}
+
+func createHTTPSClient(t *testing.T, clients *test.Clients, objects *v1test.ResourceObjects, rootCAs *x509.CertPool) *http.Client {
+	ing, err := clients.NetworkingClient.Ingresses.Get(routenames.Ingress(objects.Route), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Ingress %s: %v", routenames.Ingress(objects.Route), err)
 	}
-	dialer := testingress.CreateDialContext(t, ing, tlsClients.clients)
+	dialer := testingress.CreateDialContext(t, ing, clients)
 	tlsConfig := &tls.Config{
 		RootCAs: rootCAs,
 	}
@@ -118,22 +121,8 @@ func createHTTPSClient(t *testing.T, tlsClients *autoTLSClients, objects *v1test
 		}}
 }
 
-func initializeClients(t *testing.T) *autoTLSClients {
-	clientConfig, err := test.BuildClientConfig(pkgtest.Flags.Kubeconfig, pkgtest.Flags.Cluster)
-	if err != nil {
-		t.Fatalf("Failed to create client config: %v.", err)
-	}
-	clients := &autoTLSClients{}
-	clients.clients = e2e.Setup(t)
-	clients.cmClient, err = cmclientset.NewForConfig(clientConfig)
-	if err != nil {
-		t.Fatalf("Failed to create cert manager client: %v", err)
-	}
-	return clients
-}
-
-func disableNamespaceCert(t *testing.T, tlsClients *autoTLSClients) {
-	namespaces, err := tlsClients.clients.KubeClient.Kube.CoreV1().Namespaces().List(metav1.ListOptions{})
+func disableNamespaceCert(t *testing.T, clients *test.Clients) {
+	namespaces, err := clients.KubeClient.Kube.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Failed to list namespaces: %v", err)
 	}
@@ -142,31 +131,15 @@ func disableNamespaceCert(t *testing.T, tlsClients *autoTLSClients) {
 			ns.Labels = map[string]string{}
 		}
 		ns.Labels[networking.DisableWildcardCertLabelKey] = "true"
-		if _, err := tlsClients.clients.KubeClient.Kube.CoreV1().Namespaces().Update(&ns); err != nil {
+		if _, err := clients.KubeClient.Kube.CoreV1().Namespaces().Update(&ns); err != nil {
 			t.Errorf("Fail to disable namespace cert: %v", err)
 		}
 	}
 }
 
-func createClusterIssuer(t *testing.T, tlsClients *autoTLSClients, tlsSecretName string) (*cmv1alpha2.ClusterIssuer, context.CancelFunc) {
-	copy := caClusterIssuer.DeepCopy()
-	copy.Spec.CA.SecretName = tlsSecretName
-	test.CleanupOnInterrupt(func() {
-		tlsClients.cmClient.CertmanagerV1alpha2().ClusterIssuers().Delete(copy.Name, &metav1.DeleteOptions{})
-	})
-	if _, err := tlsClients.cmClient.CertmanagerV1alpha2().ClusterIssuers().Create(copy); err != nil {
-		t.Fatalf("Failed to create ClusterIssuer %v: %v", &copy, err)
-	}
-	return copy, func() {
-		if err := tlsClients.cmClient.CertmanagerV1alpha2().ClusterIssuers().Delete(copy.Name, &metav1.DeleteOptions{}); err != nil {
-			t.Errorf("Failed to clean up ClusterIssuer %s: %v", copy.Name, err)
-		}
-	}
-}
-
-func updateConfigCertManangerCM(t *testing.T, tlsClients *autoTLSClients, clusterIssuer *cmv1alpha2.ClusterIssuer) context.CancelFunc {
+func updateConfigCertManangerCM(t *testing.T, clients *test.Clients, clusterIsserName string) context.CancelFunc {
 	issuerRef := &cmmeta.ObjectReference{
-		Name: clusterIssuer.Name,
+		Name: clusterIsserName,
 		Kind: "ClusterIssuer",
 	}
 	issuerRefBytes, err := yaml.Marshal(issuerRef)
@@ -174,66 +147,66 @@ func updateConfigCertManangerCM(t *testing.T, tlsClients *autoTLSClients, cluste
 		t.Fatalf("Failed to convert IssuerRef %v to bytes: %v", issuerRef, err)
 	}
 
-	certManagerCM, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-certmanager", metav1.GetOptions{})
+	certManagerCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-certmanager", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get config-certmanager ConfigMap: %v", err)
 	}
 	certManagerCM.Data["issuerRef"] = string(issuerRefBytes)
 	test.CleanupOnInterrupt(func() {
-		cleanUpConfigCertManagerCM(t, tlsClients)
+		cleanUpConfigCertManagerCM(t, clients)
 	})
-	if _, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(certManagerCM.Namespace).Update(certManagerCM); err != nil {
+	if _, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(certManagerCM.Namespace).Update(certManagerCM); err != nil {
 		t.Fatalf("Failed to update the config-certmanager ConfigMap: %v", err)
 	}
 	return func() {
-		cleanUpConfigCertManagerCM(t, tlsClients)
+		cleanUpConfigCertManagerCM(t, clients)
 	}
 }
 
-func cleanUpConfigCertManagerCM(t *testing.T, tlsClients *autoTLSClients) {
-	certManagerCM, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-certmanager", metav1.GetOptions{})
+func cleanUpConfigCertManagerCM(t *testing.T, clients *test.Clients) {
+	certManagerCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-certmanager", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to get config-certmanager ConfigMap: %v", err)
 		return
 	}
 	delete(certManagerCM.Data, "issuerRef")
-	if _, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(certManagerCM.Namespace).Update(certManagerCM); err != nil {
+	if _, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(certManagerCM.Namespace).Update(certManagerCM); err != nil {
 		t.Errorf("Failed to clean up config-certmanager ConfigMap: %v", err)
 	}
 }
 
-func turnOnAutoTLS(t *testing.T, tlsClients *autoTLSClients) context.CancelFunc {
-	configNetworkCM, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-network", metav1.GetOptions{})
+func turnOnAutoTLS(t *testing.T, clients *test.Clients) context.CancelFunc {
+	configNetworkCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-network", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get config-network ConfigMap: %v", err)
 	}
 	configNetworkCM.Data["autoTLS"] = "Enabled"
 	test.CleanupOnInterrupt(func() {
-		turnOffAutoTLS(t, tlsClients)
+		turnOffAutoTLS(t, clients)
 	})
-	if _, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Update(configNetworkCM); err != nil {
+	if _, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Update(configNetworkCM); err != nil {
 		t.Fatalf("Failed to update config-network ConfigMap: %v", err)
 	}
 	return func() {
-		turnOffAutoTLS(t, tlsClients)
+		turnOffAutoTLS(t, clients)
 	}
 }
 
-func turnOffAutoTLS(t *testing.T, tlsClients *autoTLSClients) {
-	configNetworkCM, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-network", metav1.GetOptions{})
+func turnOffAutoTLS(t *testing.T, clients *test.Clients) {
+	configNetworkCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get("config-network", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to get config-network ConfigMap: %v", err)
 		return
 	}
 	delete(configNetworkCM.Data, "autoTLS")
-	if _, err := tlsClients.clients.KubeClient.Kube.CoreV1().ConfigMaps(configNetworkCM.Namespace).Update(configNetworkCM); err != nil {
+	if _, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(configNetworkCM.Namespace).Update(configNetworkCM); err != nil {
 		t.Errorf("Failed to turn off Auto TLS: %v", err)
 	}
 }
 
-func waitForCertificateReady(t *testing.T, tlsClients *autoTLSClients, certName string) {
+func waitForCertificateReady(t *testing.T, clients *test.Clients, certName string) {
 	if err := wait.Poll(10*time.Second, 300*time.Second, func() (bool, error) {
-		cert, err := tlsClients.clients.NetworkingClient.Certificates.Get(certName, metav1.GetOptions{})
+		cert, err := clients.NetworkingClient.Certificates.Get(certName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				t.Logf("Certificate %s has not been created: %v", certName, err)

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -43,14 +43,13 @@ const (
 )
 
 // To run this test locally with cert-manager, you need to
-// 1. install cert-manager from third_party/.
-// 2. Run below command to do the configuration:
+// 1. Install cert-manager from `third_party/` directory.
+// 2. Run the command below to do the configuration:
 // kubectl apply -f test/config/autotls/certmanager/selfsigned/
 func TestPerKsvcCert_localCA(t *testing.T) {
 	clients := e2e.Setup(t)
 	disableNamespaceCert(t, clients)
 
-	// Create Knative Service
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
 		Image:   "runtime",
@@ -86,7 +85,7 @@ func createRootCAs(t *testing.T, clients *test.Clients, ns, secretName string) *
 		rootCAs = x509.NewCertPool()
 	}
 	if ok := rootCAs.AppendCertsFromPEM(secret.Data[corev1.TLSCertKey]); !ok {
-		t.Fatalf("Failed to add the certificate to the root CA")
+		t.Fatal("Failed to add the certificate to the root CA")
 	}
 	return rootCAs
 }

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -68,16 +68,17 @@ func TestPerKsvcCert_localCA(t *testing.T) {
 	waitForCertificateReady(t, clients, routenames.Certificate(objects.Route))
 
 	// curl HTTPS
-	rootCAs := createRootCAs(t, clients, objects)
+	secretName := routenames.Certificate(objects.Route)
+	rootCAs := createRootCAs(t, clients, objects.Route.Namespace, secretName)
 	httpsClient := createHTTPSClient(t, clients, objects, rootCAs)
 	testingress.RuntimeRequest(t, httpsClient, "https://"+objects.Service.Status.URL.Host)
 }
 
-func createRootCAs(t *testing.T, clients *test.Clients, objects *v1test.ResourceObjects) *x509.CertPool {
-	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(objects.Route.Namespace).Get(
-		routenames.Certificate(objects.Route), metav1.GetOptions{})
+func createRootCAs(t *testing.T, clients *test.Clients, ns, secretName string) *x509.CertPool {
+	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(ns).Get(
+		secretName, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get Secret %s: %v", routenames.Certificate(objects.Route), err)
+		t.Fatalf("Failed to get Secret %s: %v", secretName, err)
 	}
 
 	rootCAs, _ := x509.SystemCertPool()

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -60,6 +60,10 @@ var (
 	}
 )
 
+// To run this test locally with cert-manager, you need to
+// 1. install cert-manager from third_party/.
+// 2. Run below command to do the configuration:
+// kubectl apply -f test/config/autotls/certmanager/selfsigned/
 func TestPerKsvcCert_localCA(t *testing.T) {
 	clients := e2e.Setup(t)
 	disableNamespaceCert(t, clients)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
https://github.com/knative/serving/issues/6553

## Proposed Changes
* Move the cert-manager specific configuration from E2E Test so that the test can be re-ran by other Kcert implementation.
* Use self-signed CA to avoid generating certificate secret within test.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

