### PR TITLE
Disabling namespace cert requires explicit "true" value

### DIFF
--- a/pkg/reconciler/nscert/controller.go
+++ b/pkg/reconciler/nscert/controller.go
@@ -58,7 +58,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	c.Logger.Info("Setting up event handlers")
 	nsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.Not(pkgreconciler.LabelExistsFilterFunc(networking.DisableWildcardCertLabelKey)),
+		FilterFunc: pkgreconciler.Not(pkgreconciler.LabelFilterFunc(networking.DisableWildcardCertLabelKey, "true", false)),
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"text/template"
 
 	"go.uber.org/zap"
@@ -83,7 +84,7 @@ func (c *reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	if _, ok := namespace.Labels[networking.DisableWildcardCertLabelKey]; ok {
+	if l, ok := namespace.Labels[networking.DisableWildcardCertLabelKey]; ok && strings.EqualFold(l, "true") {
 		logger.Infof("Skipping wildcard certificate creation for excluded namespace %s", namespace.Name)
 		return nil
 	}

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 	"text/template"
 
 	"go.uber.org/zap"
@@ -84,7 +83,7 @@ func (c *reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	if l, ok := namespace.Labels[networking.DisableWildcardCertLabelKey]; ok && strings.EqualFold(l, "true") {
+	if l := namespace.Labels[networking.DisableWildcardCertLabelKey]; l == "true" {
 		logger.Infof("Skipping wildcard certificate creation for excluded namespace %s", namespace.Name)
 		return nil
 	}

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -462,12 +462,12 @@ func kubeNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func kubeNamespaceWithDisableLabelValue(name, disable string) *corev1.Namespace {
+func kubeNamespaceWithDisableLabelValue(name, value string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				networking.DisableWildcardCertLabelKey: disable,
+				networking.DisableWildcardCertLabelKey: value,
 			},
 		},
 	}

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -170,10 +170,23 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo",
 	}, {
+		Name:                    "create Knative certificate for namespace with explicitily enabled",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			kubeNamespaceWithDisableLabelValue("foo", "false"),
+		},
+		WantCreates: []runtime.Object{
+			knCert(kubeNamespace("foo")),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created Knative Certificate %s/%s", "foo", defaultCertName),
+		},
+		Key: "foo",
+	}, {
 		Name: "certificate not created for excluded namespace",
 		Key:  "foo",
 		Objects: []runtime.Object{
-			kubeExcludedNamespace("foo"),
+			kubeNamespaceWithDisableLabelValue("foo", "true"),
 		},
 	}, {
 		Name:                    "certificate creation failed",
@@ -449,12 +462,12 @@ func kubeNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func kubeExcludedNamespace(name string) *corev1.Namespace {
+func kubeNamespaceWithDisableLabelValue(name, disable string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				networking.DisableWildcardCertLabelKey: "true",
+				networking.DisableWildcardCertLabelKey: disable,
 			},
 		},
 	}


### PR DESCRIPTION

## Proposed Changes
Currently namespace cert is disabled if the "disable" shows up no matter if the value is "true" or "false".
This PR requires the value to be "true" to disable namespace cert.



