### PR TITLE
Order virtualservices to get a stable deletion order.

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -277,6 +278,12 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 	if err != nil {
 		return fmt.Errorf("failed to get VirtualServices: %w", err)
 	}
+
+	// Sort the virtual services by their name to get a stable deletion order.
+	sort.Slice(vses, func(i, j int) bool {
+		return vses[i].Name < vses[j].Name
+	})
+
 	for _, vs := range vses {
 		n, ns := vs.Name, vs.Namespace
 		if kept.Has(n) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Ref #6611

## Proposed Changes

TestReconcile/clean_up_VirtualServices_when_ingress_class_annotation_is_not_istio expand_more fails fairly often because the ordering of the VirtualServices deletions is seemingly random.

This orders the VSs before deleting them to make the order deterministic.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
