### PR TITLE
Rename 'ia' to 'ing' since IngressAccessor is no longer used

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -486,12 +486,12 @@ func getLBStatus(gatewayServiceURL string) []v1alpha1.LoadBalancerIngressStatus 
 	}
 }
 
-func (r *Reconciler) shouldReconcileTLS(ia *v1alpha1.Ingress) bool {
+func (r *Reconciler) shouldReconcileTLS(ing *v1alpha1.Ingress) bool {
 	// We should keep reconciling the Ingress whose TLS has been reconciled before
 	// to make sure deleting IngressTLS will clean up the TLS server in the Gateway.
-	return (ia.IsPublic() && len(ia.Spec.TLS) > 0) || r.wasTLSReconciled(ia)
+	return (ing.IsPublic() && len(ing.Spec.TLS) > 0) || r.wasTLSReconciled(ing)
 }
 
-func (r *Reconciler) wasTLSReconciled(ia *v1alpha1.Ingress) bool {
-	return len(ia.GetFinalizers()) != 0 && ia.GetFinalizers()[0] == r.finalizer
+func (r *Reconciler) wasTLSReconciled(ing *v1alpha1.Ingress) bool {
+	return len(ing.GetFinalizers()) != 0 && ing.GetFinalizers()[0] == r.finalizer
 }


### PR DESCRIPTION
## Proposed Changes

This makes a tiny change that rename 'ia' to 'ing'. They are remaining ia of https://github.com/knative/serving/pull/6357/files.

/lint

**Release Note**

```release-note
NONE
```
