### PR TITLE
Set defaults for reconciliation objects and update semantic equal comparison

### DIFF
--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -314,7 +314,7 @@ func configSemanticEquals(ctx context.Context, desiredConfig, config *v1alpha1.C
 	logger := logging.FromContext(ctx)
 	specDiff, err := kmp.SafeDiff(desiredConfig.Spec, config.Spec)
 	if err != nil {
-		logger.Error("Error diffing config spec", zap.Error(err))
+		logger.Errorw("Error diffing config spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Configuration: %w", err)
 	}
 	logger.Infof("Reconciling configuration diff (-desired, +observed): %s", specDiff)

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -317,7 +317,7 @@ func configSemanticEquals(ctx context.Context, desiredConfig, config *v1alpha1.C
 		logger.Errorw("Error diffing config spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Configuration: %w", err)
 	}
-	logger.Infof("Reconciling configuration diff (-desired, +observed): %s", specDiff)
+	logger.Infof("Reconciling configuration diff (-desired, +observed):\n%s", specDiff)
 	return equality.Semantic.DeepEqual(desiredConfig.Spec, config.Spec) &&
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Labels, config.ObjectMeta.Labels) &&
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Annotations, config.ObjectMeta.Annotations) &&
@@ -335,11 +335,9 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alph
 		return nil, err
 	}
 
-	equals, err := configSemanticEquals(ctx, desiredConfig, existing)
-	if err != nil {
+	if equals, err := configSemanticEquals(ctx, desiredConfig, existing); err != nil {
 		return nil, err
-	}
-	if equals {
+	} else if equals {
 		return config, nil
 	}
 
@@ -368,7 +366,7 @@ func routeSemanticEquals(ctx context.Context, desiredRoute, route *v1alpha1.Rout
 		logger.Errorw("Error diffing route spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Route: %w", err)
 	}
-	logger.Infof("Reconciling route diff (-desired, +observed): %s", specDiff)
+	logger.Infof("Reconciling route diff (-desired, +observed):\n%s", specDiff)
 	return equality.Semantic.DeepEqual(desiredRoute.Spec, route.Spec) &&
 		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Labels, route.ObjectMeta.Labels) &&
 		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Annotations, route.ObjectMeta.Annotations) &&
@@ -389,11 +387,9 @@ func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Servi
 		return nil, err
 	}
 
-	equals, err := routeSemanticEquals(ctx, desiredRoute, existing)
-	if err != nil {
+	if equals, err := routeSemanticEquals(ctx, desiredRoute, existing); err != nil {
 		return nil, err
-	}
-	if equals {
+	} else if equals {
 		return route, nil
 	}
 

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -314,7 +314,7 @@ func configSemanticEquals(ctx context.Context, desiredConfig, config *v1alpha1.C
 	logger := logging.FromContext(ctx)
 	specDiff, err := kmp.SafeDiff(desiredConfig.Spec, config.Spec)
 	if err != nil {
-		logger.Fatalf("Error diffing config spec: %v", err)
+		logger.Error("Error diffing config spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Configuration: %w", err)
 	}
 	logger.Infof("Reconciling configuration diff (-desired, +observed): %s", specDiff)
@@ -365,7 +365,7 @@ func routeSemanticEquals(ctx context.Context, desiredRoute, route *v1alpha1.Rout
 	logger := logging.FromContext(ctx)
 	specDiff, err := kmp.SafeDiff(desiredRoute.Spec, route.Spec)
 	if err != nil {
-		logger.Fatalf("Error diffing route spec: %v", err)
+		logger.Errorw("Error diffing route spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Route: %w", err)
 	}
 	logger.Infof("Reconciling route diff (-desired, +observed): %s", specDiff)

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -310,31 +310,39 @@ func (c *Reconciler) createConfiguration(service *v1alpha1.Service) (*v1alpha1.C
 	return c.ServingClientSet.ServingV1alpha1().Configurations(service.Namespace).Create(cfg)
 }
 
-func configSemanticEquals(desiredConfig, config *v1alpha1.Configuration) bool {
+func configSemanticEquals(ctx context.Context, desiredConfig, config *v1alpha1.Configuration) (bool, error) {
+	logger := logging.FromContext(ctx)
+	specDiff, err := kmp.SafeDiff(desiredConfig.Spec, config.Spec)
+	if err != nil {
+		logger.Fatalf("Error diffing config spec: %v", err)
+		return false, fmt.Errorf("failed to diff Configuration: %w", err)
+	}
+	logger.Infof("Reconciling configuration diff (-desired, +observed): %s", specDiff)
 	return equality.Semantic.DeepEqual(desiredConfig.Spec, config.Spec) &&
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Labels, config.ObjectMeta.Labels) &&
-		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Annotations, config.ObjectMeta.Annotations)
+		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Annotations, config.ObjectMeta.Annotations) &&
+		specDiff == "", nil
 }
 
 func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1alpha1.Service, config *v1alpha1.Configuration) (*v1alpha1.Configuration, error) {
-	logger := logging.FromContext(ctx)
+	existing := config.DeepCopy()
+	// In the case of an upgrade, there can be default values set that don't exist pre-upgrade.
+	// We are setting the up-to-date default values here so an update won't be triggered if the only
+	// diff is the new default values.
+	existing.SetDefaults(ctx)
 	desiredConfig, err := resources.MakeConfiguration(service)
 	if err != nil {
 		return nil, err
 	}
 
-	if configSemanticEquals(desiredConfig, config) {
-		// No differences to reconcile.
+	equals, err := configSemanticEquals(ctx, desiredConfig, existing)
+	if err != nil {
+		return nil, err
+	}
+	if equals {
 		return config, nil
 	}
-	diff, err := kmp.SafeDiff(desiredConfig.Spec, config.Spec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff Configuration: %w", err)
-	}
-	logger.Infof("Reconciling configuration diff (-desired, +observed): %s", diff)
 
-	// Don't modify the informers copy.
-	existing := config.DeepCopy()
 	// Preserve the rest of the object (e.g. ObjectMeta except for labels).
 	existing.Spec = desiredConfig.Spec
 	existing.ObjectMeta.Labels = desiredConfig.ObjectMeta.Labels
@@ -353,14 +361,26 @@ func (c *Reconciler) createRoute(service *v1alpha1.Service) (*v1alpha1.Route, er
 	return c.ServingClientSet.ServingV1alpha1().Routes(service.Namespace).Create(route)
 }
 
-func routeSemanticEquals(desiredRoute, route *v1alpha1.Route) bool {
+func routeSemanticEquals(ctx context.Context, desiredRoute, route *v1alpha1.Route) (bool, error) {
+	logger := logging.FromContext(ctx)
+	specDiff, err := kmp.SafeDiff(desiredRoute.Spec, route.Spec)
+	if err != nil {
+		logger.Fatalf("Error diffing route spec: %v", err)
+		return false, fmt.Errorf("failed to diff Route: %w", err)
+	}
+	logger.Infof("Reconciling route diff (-desired, +observed): %s", specDiff)
 	return equality.Semantic.DeepEqual(desiredRoute.Spec, route.Spec) &&
 		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Labels, route.ObjectMeta.Labels) &&
-		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Annotations, route.ObjectMeta.Annotations)
+		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Annotations, route.ObjectMeta.Annotations) &&
+		specDiff == "", nil
 }
 
 func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Service, route *v1alpha1.Route) (*v1alpha1.Route, error) {
-	logger := logging.FromContext(ctx)
+	existing := route.DeepCopy()
+	// In the case of an upgrade, there can be default values set that don't exist pre-upgrade.
+	// We are setting the up-to-date default values here so an update won't be triggered if the only
+	// diff is the new default values.
+	existing.SetDefaults(ctx)
 	desiredRoute, err := resources.MakeRoute(service)
 	if err != nil {
 		// This should be unreachable as configuration creation
@@ -369,18 +389,14 @@ func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Servi
 		return nil, err
 	}
 
-	if routeSemanticEquals(desiredRoute, route) {
-		// No differences to reconcile.
+	equals, err := routeSemanticEquals(ctx, desiredRoute, existing)
+	if err != nil {
+		return nil, err
+	}
+	if equals {
 		return route, nil
 	}
-	diff, err := kmp.SafeDiff(desiredRoute.Spec, route.Spec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff Route: %w", err)
-	}
-	logger.Infof("Reconciling route diff (-desired, +observed): %s", diff)
 
-	// Don't modify the informers copy.
-	existing := route.DeepCopy()
 	// Preserve the rest of the object (e.g. ObjectMeta except for labels and annotations).
 	existing.Spec = desiredRoute.Spec
 	existing.ObjectMeta.Labels = desiredRoute.ObjectMeta.Labels

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -428,7 +428,6 @@ func WithRouteStatus(targets ...v1alpha1.TrafficTarget) ServiceOption {
 		for _, tt := range targets {
 			tt.URL = domains.URL(domains.HTTPScheme, tt.Tag+".example.com")
 		}
-		// r.Status.Traffic = targets
 		s.Status.RouteStatusFields.Traffic = targets
 	}
 }

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -421,6 +421,18 @@ func WithSvcStatusTraffic(targets ...v1alpha1.TrafficTarget) ServiceOption {
 	}
 }
 
+// WithRouteStatus sets the Service's status's route status field traffic block to the specified traffic targets.
+func WithRouteStatus(targets ...v1alpha1.TrafficTarget) ServiceOption {
+	return func(s *v1alpha1.Service) {
+		// Automatically inject URL into TrafficTarget status
+		for _, tt := range targets {
+			tt.URL = domains.URL(domains.HTTPScheme, tt.Tag+".example.com")
+		}
+		// r.Status.Traffic = targets
+		s.Status.RouteStatusFields.Traffic = targets
+	}
+}
+
 // WithFailedRoute reflects a Route's failure in the Service resource.
 func WithFailedRoute(reason, message string) ServiceOption {
 	return func(s *v1alpha1.Service) {

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -34,6 +34,23 @@ import (
 
 func TestRunLatestServicePostUpgrade(t *testing.T) {
 	t.Parallel()
+	clients := e2e.Setup(t)
+
+	// Before updating the service, the route and configuration objects should
+	// not be updated just because there has been an upgrade.
+	svc, err := clients.ServingAlphaClient.Services.Get(serviceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Service: %v", err)
+	}
+	configName := serviceresourcenames.Configuration(svc)
+	configObj, err := clients.ServingAlphaClient.Configs.Get(configName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Configuration: %v", err)
+	}
+	if configObj.Generation != 1 && configObj.ObjectMeta.Generation != 1 {
+		t.Fatalf("configObj.Generation is %d, configObj.ObjectMeta.Generation is %d", configObj.Generation, configObj.ObjectMeta.Generation)
+	}
+
 	updateService(serviceName, t)
 }
 

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -38,14 +38,12 @@ func TestRunLatestServicePostUpgrade(t *testing.T) {
 
 	// Before updating the service, the route and configuration objects should
 	// not be updated just because there has been an upgrade.
-	if configUpdated(t, clients, serviceName) {
+	if configHasGeneration(t, clients, serviceName, int64(1)) {
 		t.Fatal("Configuration is updated after an upgrade.")
 	}
-	if routeUpdated(t, clients, serviceName) {
+	if routeHasGeneration(t, clients, serviceName, int64(1)) {
 		t.Fatal("Route is updated after an upgrade.")
 	}
-
-
 	updateService(serviceName, t)
 }
 
@@ -74,25 +72,25 @@ func TestBYORevisionPostUpgrade(t *testing.T) {
 	}
 }
 
-func configUpdated(t *testing.T, clients *test.Clients, serviceName string) bool {
+func configHasGeneration(t *testing.T, clients *test.Clients, serviceName string, generation int64) bool {
 	configObj, err := clients.ServingAlphaClient.Configs.Get(serviceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Configuration: %v", err)
 	}
-	if configObj.Generation != 1 && configObj.ObjectMeta.Generation != 1 {
-		t.Errorf("configObj.Generation is %d, configObj.ObjectMeta.Generation is %d", configObj.Generation, configObj.ObjectMeta.Generation)
+	if configObj.Generation != generation {
+		t.Errorf("Want generation %d, got %d", generation, configObj.Generation)
 		return true
 	}
 	return false
 }
 
-func routeUpdated(t *testing.T, clients *test.Clients, serviceName string) bool {
+func routeHasGeneration(t *testing.T, clients *test.Clients, serviceName string, generation int64) bool {
 	routeObj, err := clients.ServingAlphaClient.Routes.Get(serviceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Route: %v", err)
 	}
-	if routeObj.Generation != 1 && routeObj.ObjectMeta.Generation != 1 {
-		t.Errorf("routeObj.Generation is %d, routeObj.ObjectMeta.Generation is %d", routeObj.Generation, routeObj.ObjectMeta.Generation)
+	if routeObj.Generation != generation {
+		t.Errorf("Want generation %d, got %d", generation, routeObj.Generation)
 		return true
 	}
 	return false


### PR DESCRIPTION
/lint

Fixes #6471

## Proposed Changes
Set defaults for reconciliation objects and update semantic equal comparison.
- In the service reconciler, set defaults on config and route objects before comparison. This is added so that when Knative is upgraded, we won't trigger updates to routes/configs if there is ONLY defaulting changes (i.e. new defaults are added by Knative, not the users)
- Object equal comparison is updated, so reconciliation of route/config will exit if safediff returns empty string

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
