### PR TITLE
Set the network prober User-Agent.

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -122,6 +122,14 @@ const (
 	// QueueProxyUserAgent is the user-agent header value set in probe requests sent
 	// from queue-proxy.
 	QueueProxyUserAgent = "Knative-Queue-Proxy-Probe"
+
+	// IngressReadinessUserAgent is the user-agent header value
+	// set in probe requests for Ingress status.
+	IngressReadinessUserAgent = "Knative-Ingress-Probe"
+
+	// AutoscalingUserAgent is the user-agent header value set in probe
+	// requests sent by autoscaling implementations.
+	AutoscalingUserAgent = "Knative-Autoscaling-Probe"
 )
 
 // DomainTemplateValues are the available properties people can choose from

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -388,6 +388,7 @@ func (m *Prober) processWorkItem() bool {
 		item.context,
 		transport,
 		item.url.String(),
+		prober.WithHeader(network.UserAgentKey, network.IngressReadinessUserAgent),
 		prober.WithHeader(network.ProbeHeaderName, network.ProbeHeaderValue),
 		prober.ExpectsStatusCodes([]int{http.StatusOK}),
 		prober.ExpectsHeader(network.HashHeaderName, item.ingressState.hash))

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -64,6 +64,7 @@ const (
 )
 
 var probeOptions = []interface{}{
+	prober.WithHeader(network.UserAgentKey, network.AutoscalingUserAgent),
 	prober.WithHeader(network.ProbeHeaderName, activator.Name),
 	prober.ExpectsBody(activator.Name),
 	prober.ExpectsStatusCodes([]int{http.StatusOK}),


### PR DESCRIPTION
In a couple of cases, the prober omitter the User-Agent header, so server
logs get the generic Go User-Agent, which is not very identifying.

## Proposed Changes

* Set the User-Agent in the network prober.

**Release Note**

NONE.
