### PR TITLE
Thread in Metric.Spec.StableWindow as the young pod cutoff time.

### DIFF
--- a/pkg/autoscaler/collector.go
+++ b/pkg/autoscaler/collector.go
@@ -283,7 +283,7 @@ func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, tickFactory f
 				scrapeTicker.Stop()
 				return
 			case <-scrapeTicker.C:
-				stat, err := c.getScraper().Scrape()
+				stat, err := c.getScraper().Scrape(c.currentMetric().Spec.StableWindow)
 				if err != nil {
 					copy := metric.DeepCopy()
 					switch {

--- a/pkg/autoscaler/collector_test.go
+++ b/pkg/autoscaler/collector_test.go
@@ -410,7 +410,7 @@ type testScraper struct {
 	url string
 }
 
-func (s *testScraper) Scrape() (Stat, error) {
+func (s *testScraper) Scrape(time.Duration) (Stat, error) {
 	return s.s()
 }
 


### PR DESCRIPTION
Use the stable window as a decision marker for whether the pod is young or not.
It makes sense in general, though I am less sure for very large values of window.
Anyhow, we'll just pick young pods otherwise.

/lint
/assign @markusthoemmes 