### PR TITLE
Remove duplicate NS in yamls

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -58,6 +58,7 @@ readonly SERVING_NSCERT_YAML=${YAML_OUTPUT_DIR}/serving-nscert.yaml
 
 readonly MONITORING_FILES=${YAML_OUTPUT_DIR}/monitoring.lst
 readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
+readonly MONITORING_CORE_YAML=${YAML_OUTPUT_DIR}/monitoring-core.yaml
 readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
 readonly MONITORING_TRACE_ZIPKIN_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin.yaml
 readonly MONITORING_TRACE_ZIPKIN_IN_MEM_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin-in-mem.yaml
@@ -129,6 +130,10 @@ echo "${MONITORING_LOG_ELASTICSEARCH_YAML}" >  "${MONITORING_FILES}"
 echo "${MONITORING_METRIC_PROMETHEUS_YAML}" >> "${MONITORING_FILES}"
 echo "${MONITORING_TRACE_ZIPKIN_YAML}"      >> "${MONITORING_FILES}"
 
+# Generate the core monitoring file - basically just the namespace
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+    | "${LABEL_YAML_CMD[@]}" > "${MONITORING_CORE_YAML}"
+
 # Use ko to concatenate them all together.
 ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
     $(sed "s/^/-f /" < "${MONITORING_FILES}") \
@@ -154,6 +159,7 @@ ${SERVING_ISTIO_YAML}
 ${SERVING_NSCERT_YAML}
 ${MONITORING_FILES}
 ${MONITORING_YAML}
+${MONITORING_CORE_YAML}
 ${MONITORING_METRIC_PROMETHEUS_YAML}
 ${MONITORING_TRACE_ZIPKIN_YAML}
 ${MONITORING_TRACE_ZIPKIN_IN_MEM_YAML}

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -56,6 +56,7 @@ readonly SERVING_CERT_MANAGER_YAML=${YAML_OUTPUT_DIR}/serving-cert-manager.yaml
 readonly SERVING_ISTIO_YAML=${YAML_OUTPUT_DIR}/serving-istio.yaml
 readonly SERVING_NSCERT_YAML=${YAML_OUTPUT_DIR}/serving-nscert.yaml
 
+readonly MONITORING_FILES=${YAML_OUTPUT_DIR}/monitoring.lst
 readonly MONITORING_YAML=${YAML_OUTPUT_DIR}/monitoring.yaml
 readonly MONITORING_METRIC_PROMETHEUS_YAML=${YAML_OUTPUT_DIR}/monitoring-metrics-prometheus.yaml
 readonly MONITORING_TRACE_ZIPKIN_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-zipkin.yaml
@@ -103,22 +104,13 @@ cat "${SERVING_CORE_YAML}" > "${SERVING_YAML}"
 cat "${SERVING_HPA_YAML}" >> "${SERVING_YAML}"
 cat "${SERVING_ISTIO_YAML}" >> "${SERVING_YAML}"
 
-echo "Building Monitoring & Logging"
-# Use ko to concatenate them all together.
-ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
-    -f third_party/config/monitoring/logging/elasticsearch \
-    -f config/monitoring/logging/elasticsearch \
-    -f third_party/config/monitoring/metrics/prometheus \
-    -f config/monitoring/metrics/prometheus \
-    -f config/monitoring/tracing/zipkin | "${LABEL_YAML_CMD[@]}" > "${MONITORING_YAML}"
-
 # Metrics via Prometheus & Grafana
-ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+ko resolve ${KO_YAML_FLAGS} -R \
     -f third_party/config/monitoring/metrics/prometheus \
     -f config/monitoring/metrics/prometheus | "${LABEL_YAML_CMD[@]}" > "${MONITORING_METRIC_PROMETHEUS_YAML}"
 
 # Logs via ElasticSearch, Fluentd & Kibana
-ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+ko resolve ${KO_YAML_FLAGS} -R \
     -f third_party/config/monitoring/logging/elasticsearch \
     -f config/monitoring/logging/elasticsearch | "${LABEL_YAML_CMD[@]}" > "${MONITORING_LOG_ELASTICSEARCH_YAML}"
 
@@ -127,6 +119,20 @@ ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/zipkin | "${LABEL_YA
 
 # Traces via Zipkin in Memory when ElasticSearch is not installed
 ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/zipkin-in-mem | "${LABEL_YAML_CMD[@]}" > "${MONITORING_TRACE_ZIPKIN_IN_MEM_YAML}"
+
+echo "Building Monitoring & Logging"
+
+# By putting the list of files used to create the monitoring.yaml
+# people can choose to exclude certain ones via 'grep' but still keep in-sync
+# with the complete list if things change in the future
+echo "${MONITORING_LOG_ELASTICSEARCH_YAML}" >  "${MONITORING_FILES}"
+echo "${MONITORING_METRIC_PROMETHEUS_YAML}" >> "${MONITORING_FILES}"
+echo "${MONITORING_TRACE_ZIPKIN_YAML}"      >> "${MONITORING_FILES}"
+
+# Use ko to concatenate them all together.
+ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/100-namespace.yaml \
+    $(sed "s/^/-f /" < "${MONITORING_FILES}") \
+    | "${LABEL_YAML_CMD[@]}" > "${MONITORING_YAML}"
 
 # Traces via Jaeger when ElasticSearch is installed
 ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/jaeger/elasticsearch -f config/monitoring/tracing/jaeger/105-zipkin-service.yaml | "${LABEL_YAML_CMD[@]}" > "${MONITORING_TRACE_JAEGER_YAML}"
@@ -146,6 +152,7 @@ ${SERVING_CRD_YAML}
 ${SERVING_CERT_MANAGER_YAML}
 ${SERVING_ISTIO_YAML}
 ${SERVING_NSCERT_YAML}
+${MONITORING_FILES}
 ${MONITORING_YAML}
 ${MONITORING_METRIC_PROMETHEUS_YAML}
 ${MONITORING_TRACE_ZIPKIN_YAML}


### PR DESCRIPTION
We'd like to use the monitoring.yaml file but w/o zipkin because istio already installs it. However, it's hard to track the list of files used to construct the monitoring.yam file since it could change over time. So this PR creates the list of files that make up the monitoring.yaml file so that people can grep-out which ones they don't want, and then just cat the other ones. This way tools will always have the full list (even if things change) and won't be out of sync.

Do not merge until https://github.com/knative/docs/pull/2197 is agreed to.

Signed-off-by: Doug Davis <dug@us.ibm.com>