### PR TITLE
Do not reconcile annotations defined by users in KIngress and VirtualSerrvice

### DIFF
--- a/pkg/reconciler/accessor/istio/virtualservice.go
+++ b/pkg/reconciler/accessor/istio/virtualservice.go
@@ -30,6 +30,7 @@ import (
 	istioclientset "knative.dev/serving/pkg/client/istio/clientset/versioned"
 	istiolisters "knative.dev/serving/pkg/client/istio/listers/networking/v1alpha3"
 	kaccessor "knative.dev/serving/pkg/reconciler/accessor"
+	"knative.dev/serving/pkg/resources"
 )
 
 // VirtualServiceAccessor is an interface for accessing VirtualService.
@@ -74,8 +75,8 @@ func ReconcileVirtualService(ctx context.Context, owner kmeta.Accessor, desired 
 		// Don't modify the informers copy
 		existing := vs.DeepCopy()
 		existing.Spec = desired.Spec
-		existing.Labels = desired.Labels
-		existing.Annotations = desired.Annotations
+		existing.Labels = resources.UnionMaps(vs.Labels, desired.Labels)
+		existing.Annotations = resources.UnionMaps(vs.Annotations, desired.Annotations)
 		vs, err = vsAccessor.GetIstioClient().NetworkingV1alpha3().VirtualServices(ns).Update(existing)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update VirtualService: %w", err)

--- a/pkg/reconciler/accessor/istio/virtualservice_test.go
+++ b/pkg/reconciler/accessor/istio/virtualservice_test.go
@@ -58,6 +58,8 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "vs",
 			Namespace:       "default",
+			Annotations:     map[string]string{"foo": "bar"},
+			Labels:          map[string]string{"baz": "qux"},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: istiov1alpha3.VirtualService{
@@ -69,6 +71,8 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "vs",
 			Namespace:       "default",
+			Annotations:     map[string]string{"foo": "bar"},
+			Labels:          map[string]string{"baz": "qux"},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: istiov1alpha3.VirtualService{

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -40,6 +40,8 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/resources"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
+
+	presources "knative.dev/serving/pkg/resources"
 )
 
 func routeOwnerLabelSelector(route *v1alpha1.Route) labels.Selector {
@@ -82,7 +84,7 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, r *v1alpha1.Route, de
 			// Don't modify the informers copy
 			origin := ingress.DeepCopy()
 			origin.Spec = desired.Spec
-			origin.Annotations = desired.Annotations
+			origin.Annotations = presources.UnionMaps(origin.Annotations, desired.Annotations)
 			updated, err := c.ServingClientSet.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(origin)
 			if err != nil {
 				return nil, fmt.Errorf("failed to update Ingress: %w", err)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -265,10 +265,16 @@ func TestReconcileIngressClassAnnotation(t *testing.T) {
 	ctx, _, reconciler, _, cancel := newTestReconciler(t)
 	defer cancel()
 
-	const expClass = "foo.ingress.networking.knative.dev"
+	const (
+		expClass = "foo.ingress.networking.knative.dev"
+		// These annotation defined by users should not be updated.
+		orgAnnoKey = "mykey"
+		orgAnnoVal = "myval"
+	)
 
 	r := Route("test-ns", "test-route")
 	ci := newTestIngress(t, r)
+	ci.ObjectMeta.Annotations[orgAnnoKey] = orgAnnoVal
 	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), r, ci); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -288,6 +294,10 @@ func TestReconcileIngressClassAnnotation(t *testing.T) {
 	updatedClass := updated.ObjectMeta.Annotations[networking.IngressClassAnnotationKey]
 	if expClass != updatedClass {
 		t.Errorf("Unexpected annotation got %q want %q", expClass, updatedClass)
+	}
+	preservedAnno := updated.ObjectMeta.Annotations[orgAnnoKey]
+	if preservedAnno != orgAnnoVal {
+		t.Errorf("Unexpected annotation got %q want %q", preservedAnno, orgAnnoVal)
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

Currently controller overrides all annotations with desired status,
but they should not override by users defined annotations.

For instance in KIngress, if users

- add new annotations like `foo: bar`, it will be preserved.
- edit controller managed annotation like `networking.knative.dev/ingress.class`, it will be reconciled by controller.

/lint

Fixes https://github.com/knative/serving/pull/6569#discussion_r371799212

**Release Note**

```release-note
NONE
```
