### PR TITLE
Wait for Service to be ready in Auto TLS test

### DIFF
--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -71,6 +71,14 @@ func TestPerKsvcCert_localCA(t *testing.T) {
 	// curl HTTPS
 	secretName := routenames.Certificate(objects.Route)
 	rootCAs := createRootCAs(t, clients, objects.Route.Namespace, secretName)
+
+	// The TLS info is added to the ingress after the service is created, that's
+	// why we need to wait again
+	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady")
+	if err != nil {
+		t.Fatalf("Service %s did not become ready: %v", names.Service, err)
+	}
+
 	httpsClient := createHTTPSClient(t, clients, objects, rootCAs)
 	testingress.RuntimeRequest(t, httpsClient, "https://"+objects.Service.Status.URL.Host)
 }


### PR DESCRIPTION
/lint

I've noticed that the Auto TLS e2e test is flaky. There are some errors when using Kourier, but also when using Istio and others. I believe it's because the test does not wait for the service to become ready.

The test creates a service and waits for it to be ready. However, at that point the ingress does not have yet a TLS section with the secrets, that's created later when auto TLS is configured. When that happens, the service will be in "IngressNotConfigured" state until the ingress is reconciled, so we need to wait for it again.