### PR TITLE
Assorted linter fixes.

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -499,10 +499,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "add slow healthy",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
-			revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
-			privateSKSService(types.NamespacedName{testNamespace, testRevision}, "129.0.0.1",
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
 				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
@@ -527,10 +527,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "add slow ready http2",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http2", "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
-			revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolH2C),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolH2C),
 		},
 		services: []*corev1.Service{
-			privateSKSService(types.NamespacedName{testNamespace, testRevision}, "129.0.0.1",
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
 				[]corev1.ServicePort{{Name: "http2", Port: 1234}}),
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
@@ -558,13 +558,13 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			ep("test-revision2", 1235, "http", "128.1.0.2"),
 		},
 		revisions: []*v1alpha1.Revision{
-			revisionCC1(types.NamespacedName{testNamespace, "test-revision1"}, networking.ProtocolHTTP1),
-			revisionCC1(types.NamespacedName{testNamespace, "test-revision2"}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision2"}, networking.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
-			privateSKSService(types.NamespacedName{testNamespace, "test-revision1"}, "129.0.0.1",
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, "129.0.0.1",
 				[]corev1.ServicePort{{Name: "http", Port: 2345}}),
-			privateSKSService(types.NamespacedName{testNamespace, "test-revision2"}, "129.0.0.2",
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: "test-revision2"}, "129.0.0.2",
 				[]corev1.ServicePort{{Name: "http", Port: 2345}}),
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
@@ -584,10 +584,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "no pod addressability",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
-			revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
-			privateSKSService(types.NamespacedName{testNamespace, testRevision}, "129.0.0.1",
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
 				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
@@ -610,10 +610,10 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "unhealthy",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1alpha1.Revision{
-			revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
-			privateSKSService(types.NamespacedName{testNamespace, testRevision}, "129.0.0.1",
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
 				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
 		},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
@@ -701,7 +701,7 @@ func TestCheckDests(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
 	svc := privateSKSService(
-		types.NamespacedName{testNamespace, testRevision},
+		types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		"129.0.0.1",
 		[]corev1.ServicePort{{Name: "http", Port: 1234}},
 	)
@@ -724,7 +724,7 @@ func TestCheckDests(t *testing.T) {
 	rw := &revisionWatcher{
 		clusterIPHealthy: true,
 		podsAddressable:  false,
-		rev:              types.NamespacedName{testNamespace, testRevision},
+		rev:              types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		updateCh:         uCh,
 		serviceLister:    si.Lister(),
 		logger:           TestLogger(t),
@@ -754,7 +754,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
 	svc := privateSKSService(
-		types.NamespacedName{testNamespace, testRevision},
+		types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		"10.5.0.1",
 		[]corev1.ServicePort{{Name: "http", Port: 1234}},
 	)
@@ -810,7 +810,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	uCh := make(chan revisionDestsUpdate, 1)
 	dCh := make(chan struct{})
 	rw := &revisionWatcher{
-		rev:             types.NamespacedName{testNamespace, testRevision},
+		rev:             types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		updateCh:        uCh,
 		serviceLister:   si.Lister(),
 		logger:          TestLogger(t),
@@ -821,7 +821,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	// First not ready, second good, clusterIP: not ready.
 	rw.checkDests(sets.NewString("10.0.0.1:1234", "10.0.0.2:1234"))
 	want := revisionDestsUpdate{
-		Rev:           types.NamespacedName{testNamespace, testRevision},
+		Rev:           types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		ClusterIPDest: "",
 		Dests:         sets.NewString("10.0.0.2:1234"),
 	}
@@ -906,7 +906,7 @@ func TestRevisionDeleted(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
 	svc := privateSKSService(
-		types.NamespacedName{testNamespace, testRevision},
+		types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		"129.0.0.1",
 		[]corev1.ServicePort{{Name: "http", Port: 1234}},
 	)
@@ -926,7 +926,7 @@ func TestRevisionDeleted(t *testing.T) {
 		waitInformers()
 	}()
 
-	rev := revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -971,7 +971,7 @@ func TestServiceDoesNotExist(t *testing.T) {
 		waitInformers()
 	}()
 
-	rev := revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -1025,7 +1025,7 @@ func TestServiceMoreThanOne(t *testing.T) {
 		waitInformers()
 	}()
 
-	rev := revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -1033,7 +1033,7 @@ func TestServiceMoreThanOne(t *testing.T) {
 	// Now let's create two!
 	for _, num := range []string{"11", "12"} {
 		svc := privateSKSService(
-			types.NamespacedName{testNamespace, testRevision},
+			types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			"129.0.0."+num,
 			[]corev1.ServicePort{{Name: "http", Port: 1234}},
 		)

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -211,7 +211,7 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 	}()
 
 	// Add the revision we're testing.
-	revID := types.NamespacedName{testNamespace, testRevision}
+	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 	revision := revisionCC1(revID, networking.ProtocolHTTP1)
 	servfake.ServingV1alpha1().Revisions(revision.Namespace).Create(revision)
 	revisions.Informer().GetIndexer().Add(revision)
@@ -261,7 +261,7 @@ func TestThrottlerErrorOneTimesOut(t *testing.T) {
 	}()
 
 	// Add the revision we're testing.
-	revID := types.NamespacedName{testNamespace, testRevision}
+	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 	revision := revisionCC1(revID, networking.ProtocolHTTP1)
 	servfake.ServingV1alpha1().Revisions(revision.Namespace).Create(revision)
 	revisions.Informer().GetIndexer().Add(revision)
@@ -305,37 +305,37 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests   sets.String
 	}{{
 		name:     "single healthy podIP",
-		revision: revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234"),
 		}, {
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234"),
 		}},
 		requests:  1,
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "single healthy podIP, infinite cc",
-		revision: revision(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1, 0),
+		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1, 0),
 		// Double updates exercise additional paths.
 		initUpdates: []revisionDestsUpdate{{
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.2:1234"),
 		}, {
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234"),
 		}},
 		requests:  1,
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "single healthy clusterIP",
-		revision: revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}, {
-			Rev:           types.NamespacedName{testNamespace, testRevision},
+			Rev:           types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			ClusterIPDest: "129.0.0.1:1234",
 			Dests:         sets.NewString("128.0.0.1:1234"),
 		}},
@@ -343,31 +343,31 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("129.0.0.1:1234"),
 	}, {
 		name:     "spread podIP load",
-		revision: revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			// Double update here excercises some additional paths.
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.3:1234"),
 		}, {
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}},
 		requests:  2,
 		wantDests: sets.NewString("128.0.0.2:1234", "128.0.0.1:1234"),
 	}, {
 		name:     "clumping test",
-		revision: revision(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1, 3),
+		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1, 3),
 		initUpdates: []revisionDestsUpdate{{
-			Rev:   types.NamespacedName{testNamespace, testRevision},
+			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}},
 		requests:  3,
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "multiple ClusterIP requests",
-		revision: revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
-			Rev:           types.NamespacedName{testNamespace, testRevision},
+			Rev:           types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			ClusterIPDest: "129.0.0.1:1234",
 			Dests:         sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
 		}},
@@ -430,7 +430,7 @@ func TestPodAssignmentFinite(t *testing.T) {
 	// An e2e verification test of pod assignment and capacity
 	// computations.
 	logger := TestLogger(t)
-	revName := types.NamespacedName{testNamespace, testRevision}
+	revName := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	defer cancel()
@@ -482,7 +482,7 @@ func TestPodAssignmentFinite(t *testing.T) {
 
 func TestPodAssignmentInfinite(t *testing.T) {
 	logger := TestLogger(t)
-	revName := types.NamespacedName{testNamespace, testRevision}
+	revName := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	defer cancel()
@@ -543,14 +543,14 @@ func TestMultipleActivators(t *testing.T) {
 		waitInformers()
 	}()
 
-	rev := revisionCC1(types.NamespacedName{testNamespace, testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
 	// Add the revision we're testing.
 	servfake.ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
 	revisions.Informer().GetIndexer().Add(rev)
 
 	throttler := NewThrottler(ctx, defaultParams, "130.0.0.2:8012")
 
-	revID := types.NamespacedName{testNamespace, testRevision}
+	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 	possibleDests := sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.23:1234")
 	throttler.handleUpdate(revisionDestsUpdate{
 		Rev:   revID,
@@ -600,7 +600,7 @@ func TestMultipleActivators(t *testing.T) {
 
 func TestInfiniteBreakerCreation(t *testing.T) {
 	// This test verifies that we use infiniteBreaker when CC==0.
-	tttl := newRevisionThrottler(types.NamespacedName{"a", "b"}, 0, /*cc*/
+	tttl := newRevisionThrottler(types.NamespacedName{Namespace: "a", Name: "b"}, 0, /*cc*/
 		queue.BreakerParams{}, TestLogger(t))
 	if _, ok := tttl.breaker.(*infiniteBreaker); !ok {
 		t.Errorf("The type of revisionBreker = %T, want %T", tttl, (*infiniteBreaker)(nil))

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	granularity = time.Second
-	pod         = "pod"
 )
 
 func TestTimedFloat64BucketsSimple(t *testing.T) {
@@ -36,7 +35,6 @@ func TestTimedFloat64BucketsSimple(t *testing.T) {
 
 	type args struct {
 		time  time.Time
-		name  string
 		value float64
 	}
 	tests := []struct {
@@ -48,10 +46,10 @@ func TestTimedFloat64BucketsSimple(t *testing.T) {
 		name:        "granularity = 1s",
 		granularity: time.Second,
 		stats: []args{
-			{trunc1, pod, 1.0}, // activator scale from 0.
-			{trunc1.Add(100 * time.Millisecond), pod, 10.0}, // from scraping pod/sent by activator.
-			{trunc1.Add(1 * time.Second), pod, 1.0},         // next bucket
-			{trunc1.Add(3 * time.Second), pod, 1.0},         // nextnextnext bucket
+			{trunc1, 1.0}, // activator scale from 0.
+			{trunc1.Add(100 * time.Millisecond), 10.0}, // from scraping pod/sent by activator.
+			{trunc1.Add(1 * time.Second), 1.0},         // next bucket
+			{trunc1.Add(3 * time.Second), 1.0},         // nextnextnext bucket
 		},
 		want: map[time.Time]float64{
 			trunc1:                      11.0,
@@ -62,9 +60,9 @@ func TestTimedFloat64BucketsSimple(t *testing.T) {
 		name:        "granularity = 5s",
 		granularity: 5 * time.Second,
 		stats: []args{
-			{trunc5, pod, 1.0},
-			{trunc5.Add(3 * time.Second), pod, 11.0}, // same bucket
-			{trunc5.Add(6 * time.Second), pod, 1.0},  // next bucket
+			{trunc5, 1.0},
+			{trunc5.Add(3 * time.Second), 11.0}, // same bucket
+			{trunc5.Add(6 * time.Second), 1.0},  // next bucket
 		},
 		want: map[time.Time]float64{
 			trunc5:                      12.0,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

After finding two bugs recently that would've been caught by a linter (just not the one I was usually using), I found a new gem https://github.com/golangci/golangci-lint.

This is a first stab at it's additional errors.

Produced with `golangci-lint run --disable errcheck ./cmd/... ./pkg/...`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
