### PR TITLE
Allow specifying default PodAutoscalerClass

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -135,3 +135,8 @@ data:
     # Once enabled, it allows the autoscaler to prioritize pods processing
     # fewer (or zero) requests for removal when scaling down.
     enable-graceful-scaledown: "false"
+
+    # pod-autoscaler-class specifies the default pod autoscaler class
+    # that should be used if none is specified. If omitted, the Knative
+    # Horizontal Pod Autoscaler (KPA) is used by default.
+    pod-autoscaler-class: "kpa.autoscaling.knative.dev"

--- a/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
@@ -21,6 +21,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/config"
 )
 
 func defaultMetric(class string) string {
@@ -36,12 +37,13 @@ func defaultMetric(class string) string {
 
 func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
+	config := config.FromContextOrDefaults(ctx)
 	if r.Annotations == nil {
 		r.Annotations = make(map[string]string)
 	}
 	if _, ok := r.Annotations[autoscaling.ClassAnnotationKey]; !ok {
-		// Default class to KPA.
-		r.Annotations[autoscaling.ClassAnnotationKey] = autoscaling.KPA
+		// Default class based on configmap setting (KPA if none specified).
+		r.Annotations[autoscaling.ClassAnnotationKey] = config.Autoscaler.PodAutoscalerClass
 	}
 	// Default metric per class
 	if _, ok := r.Annotations[autoscaling.MetricAnnotationKey]; !ok {

--- a/pkg/apis/config/testdata/config-autoscaler.yaml
+++ b/pkg/apis/config/testdata/config-autoscaler.yaml
@@ -1,0 +1,1 @@
+../../../../config/core/configmaps/autoscaler.yaml

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"knative.dev/serving/pkg/apis/config"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 )
 
 var (
@@ -64,6 +65,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		in:   &Revision{Spec: RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}}},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
@@ -127,6 +129,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		in:   &Revision{Spec: RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}, TimeoutSeconds: ptr.Int64(0)}},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
@@ -257,6 +260,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -408,6 +409,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
@@ -515,6 +517,7 @@ func TestImmutableFields(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,

--- a/pkg/apis/serving/v1alpha1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_defaults_test.go
@@ -28,6 +28,7 @@ import (
 
 	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 )
 
 var defaultProbe = &corev1.Probe{
@@ -87,6 +88,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			}},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -33,6 +33,7 @@ import (
 	"knative.dev/serving/pkg/apis/config"
 	net "knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -299,6 +300,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
@@ -662,6 +664,7 @@ func TestImmutableFields(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,

--- a/pkg/apis/serving/v1beta1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/revision_defaults_test.go
@@ -30,6 +30,7 @@ import (
 
 	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 )
 
 var (
@@ -65,6 +66,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		in:   &Revision{Spec: v1.RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}}},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
@@ -128,6 +130,7 @@ func TestRevisionDefaulting(t *testing.T) {
 		in:   &Revision{Spec: v1.RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}, TimeoutSeconds: ptr.Int64(0)}},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -410,6 +411,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
@@ -517,6 +519,7 @@ func TestImmutableFields(t *testing.T) {
 		},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -71,6 +71,8 @@ type Config struct {
 	TickInterval             time.Duration
 
 	ScaleToZeroGracePeriod time.Duration
+
+	PodAutoscalerClass string
 }
 
 // NewConfigFromMap creates a Config from the supplied map
@@ -184,6 +186,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		} else {
 			*dur.field = val
 		}
+	}
+
+	lc.PodAutoscalerClass = autoscaling.KPA
+	if pac, ok := data["pod-autoscaler-class"]; ok {
+		lc.PodAutoscalerClass = pac
 	}
 
 	return validate(lc)

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	. "knative.dev/pkg/configmap/testing"
+	"knative.dev/serving/pkg/apis/autoscaling"
 )
 
 var defaultConfig = Config{
@@ -41,6 +42,7 @@ var defaultConfig = Config{
 	TickInterval:                       2 * time.Second,
 	PanicWindowPercentage:              10.0,
 	PanicThresholdPercentage:           200.0,
+	PodAutoscalerClass:                 autoscaling.KPA,
 }
 
 func TestNewConfig(t *testing.T) {
@@ -106,6 +108,7 @@ func TestNewConfig(t *testing.T) {
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
 			"panic-threshold-percentage":              "200",
+			"pod-autoscaler-class":                    "some.class",
 		},
 		want: func(c Config) *Config {
 			c.TargetBurstCapacity = 12345
@@ -115,6 +118,7 @@ func TestNewConfig(t *testing.T) {
 			c.MaxScaleDownRate = 3
 			c.MaxScaleUpRate = 1.01
 			c.StableWindow = 5 * time.Minute
+			c.PodAutoscalerClass = "some.class"
 			return &c
 		}(defaultConfig),
 	}, {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Allow the default `pod-autoscaler-class` to be set via config map. 

Note: the defaulting happens in the webhook (that way changing the default doesn't affect existing revisions) so added the property to `config-defaults.yml` rather than `config-autoscaler.yml`.

Fixes #3415. 