### PR TITLE
Add KIngress short name "king"

### DIFF
--- a/config/core/resources/ingress.yaml
+++ b/config/core/resources/ingress.yaml
@@ -34,6 +34,7 @@ spec:
     - networking
     shortNames:
     - kingress
+    - king
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
## Proposed Changes

Currently k8s' ingresss has `ing` as short name, but kingress's short name is `kingress` which is still long.
So, this patch adds `king` as KIngress's short name.

BEFORE:
```
$ kubectl api-resources |grep ingress
ingresses                         ing             extensions                         true         Ingress
ingresses                         kingress        networking.internal.knative.dev    true         Ingress
ingresses                         ing             networking.k8s.io                  true         Ingress
```

AFTER:
```
$ kubectl api-resources |grep ingress
ingresses                         ing             extensions                         true         Ingress
ingresses                         kingress,king   networking.internal.knative.dev    true         Ingress
ingresses                         ing             networking.k8s.io                  true         Ingress
```

/lint

**Release Note**

```release-note
NONE
```
