### PR TITLE
Improve logging in the autoscale integation test.

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	vegeta "github.com/tsenart/vegeta/lib"
 	"golang.org/x/sync/errgroup"
 	"knative.dev/pkg/system"
@@ -140,7 +139,7 @@ func generateTraffic(
 			totalRequests++
 			if res.Code != http.StatusOK {
 				ctx.t.Logf("Status = %d, want: 200", res.Code)
-				ctx.t.Log("Response:\n" + spew.Sprint(res))
+				ctx.t.Logf("URL: %s Duration: %v Body:\n%s", res.URL, res.Latency, string(res.Body))
 				continue
 			}
 			successfulRequests++


### PR DESCRIPTION
Curently the output in the logs looks likes this:

```
 <*>{load-test 3353 503 2020-01-30 01:29:09.172534647 +0000 UTC m=+1740.078052364 245.388186ms 0 91 503 Service Unavailable [117 112 115 116 114 101 97 109 32 99 111 110 110 101 99 116 32 101 114 114 111 114 32 111 114 32 100 105 115 99 111 110 110 101 99 116 47 114 101 115 101 116 32 98 101 102 111 114 101 32 104 101 97 100 101 114 115 46 32 114 101 115 101 116 32 114 101 97 115 111 110 58 32 99 111 110 110 101 99 116 105 111 110 32 102 97 105 108 117 114 101] GET http://34.67.169.30?sleep=500}
```

As much as I love exercising ascii to text manual conversions, that is not what I want
to do when debugging a test.
So keep just a few important fields.

/assign @markusthoemmes mattmoor