### PR TITLE
Vendor - Configurable SpoofRequestInterval and SpoofRequestTimeout

### DIFF
--- a/vendor/knative.dev/pkg/test/clients.go
+++ b/vendor/knative.dev/pkg/test/clients.go
@@ -39,7 +39,7 @@ type KubeClient struct {
 
 // NewSpoofingClient returns a spoofing client to make requests
 func NewSpoofingClient(client *KubeClient, logf logging.FormatLogger, domain string, resolvable bool, opts ...spoof.TransportOption) (*spoof.SpoofingClient, error) {
-	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint, opts...)
+	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint, Flags.SpoofRequestInterval, Flags.SpoofRequestTimeout, opts...)
 }
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the

--- a/vendor/knative.dev/pkg/test/e2e_flags.go
+++ b/vendor/knative.dev/pkg/test/e2e_flags.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"sync"
 	"text/template"
+	"time"
 
 	_ "github.com/golang/glog" // Needed if glog and klog are to coexist
 	"k8s.io/klog"
@@ -49,14 +50,16 @@ var (
 
 // EnvironmentFlags define the flags that are needed to run the e2e tests.
 type EnvironmentFlags struct {
-	Cluster         string // K8s cluster (defaults to cluster in kubeconfig)
-	Kubeconfig      string // Path to kubeconfig (defaults to ./kube/config)
-	Namespace       string // K8s namespace (blank by default, to be overwritten by test suite)
-	IngressEndpoint string // Host to use for ingress endpoint
-	LogVerbose      bool   // Enable verbose logging
-	ImageTemplate   string // Template to build the image reference (defaults to {{.Repository}}/{{.Name}}:{{.Tag}})
-	DockerRepo      string // Docker repo (defaults to $KO_DOCKER_REPO)
-	Tag             string // Tag for test images
+	Cluster              string        // K8s cluster (defaults to cluster in kubeconfig)
+	Kubeconfig           string        // Path to kubeconfig (defaults to ./kube/config)
+	Namespace            string        // K8s namespace (blank by default, to be overwritten by test suite)
+	IngressEndpoint      string        // Host to use for ingress endpoint
+	LogVerbose           bool          // Enable verbose logging
+	ImageTemplate        string        // Template to build the image reference (defaults to {{.Repository}}/{{.Name}}:{{.Tag}})
+	DockerRepo           string        // Docker repo (defaults to $KO_DOCKER_REPO)
+	Tag                  string        // Tag for test images
+	SpoofRequestInterval time.Duration // SpoofRequestInterval is the interval between requests in SpoofingClient
+	SpoofRequestTimeout  time.Duration // SpoofRequestTimeout is the timeout for polling requests in SpoofingClient
 }
 
 func initializeFlags() *EnvironmentFlags {
@@ -82,6 +85,12 @@ func initializeFlags() *EnvironmentFlags {
 
 	flag.StringVar(&f.ImageTemplate, "imagetemplate", "{{.Repository}}/{{.Name}}:{{.Tag}}",
 		"Provide a template to generate the reference to an image from the test. Defaults to `{{.Repository}}/{{.Name}}:{{.Tag}}`.")
+
+	flag.DurationVar(&f.SpoofRequestInterval, "spoofinterval", 1*time.Second,
+		"Provide an interval between requests for the SpoofingClient")
+
+	flag.DurationVar(&f.SpoofRequestTimeout, "spooftimeout", 5*time.Minute,
+		"Provide a request timeout for the SpoofingClient")
 
 	defaultRepo := os.Getenv("KO_DOCKER_REPO")
 	flag.StringVar(&f.DockerRepo, "dockerrepo", defaultRepo,

--- a/vendor/knative.dev/pkg/test/request.go
+++ b/vendor/knative.dev/pkg/test/request.go
@@ -142,7 +142,7 @@ func WaitForEndpointState(
 	desc string,
 	resolvable bool,
 	opts ...interface{}) (*spoof.Response, error) {
-	return WaitForEndpointStateWithTimeout(kubeClient, logf, url, inState, desc, resolvable, spoof.RequestTimeout, opts...)
+	return WaitForEndpointStateWithTimeout(kubeClient, logf, url, inState, desc, resolvable, Flags.SpoofRequestTimeout, opts...)
 }
 
 // WaitForEndpointStateWithTimeout will poll an endpoint until inState indicates the state is achieved

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -39,9 +39,6 @@ import (
 )
 
 const (
-	requestInterval = 1 * time.Second
-	// RequestTimeout is the default timeout for the polling requests.
-	RequestTimeout = 5 * time.Minute
 	// Name of the temporary HTTP header that is added to http.Request to indicate that
 	// it is a SpoofClient.Poll request. This header is removed before making call to backend.
 	pollReqHeader = "X-Kn-Poll-Request-Do-Not-Trace"
@@ -107,6 +104,8 @@ func New(
 	domain string,
 	resolvable bool,
 	endpointOverride string,
+	requestInterval time.Duration,
+	requestTimeout time.Duration,
 	opts ...TransportOption) (*SpoofingClient, error) {
 	endpoint, err := ResolveEndpoint(kubeClientset, domain, resolvable, endpointOverride)
 	if err != nil {
@@ -140,7 +139,7 @@ func New(
 	sc := SpoofingClient{
 		Client:          &http.Client{Transport: roundTripper},
 		RequestInterval: requestInterval,
-		RequestTimeout:  RequestTimeout,
+		RequestTimeout:  requestTimeout,
 		Logf:            logf,
 	}
 	return &sc, nil


### PR DESCRIPTION
This is changing the vendor dependency on knative pkg in the way described here: https://github.com/knative/pkg/pull/942/

When that PR is merged and the dependecy on knative.dev/pkg is updated in knative/serving I'll rebase this.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
