### PR TITLE
Use e2 VMs instead of n1 for test clusters

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -20,7 +20,7 @@
 # with the job config.
 E2E_MIN_CLUSTER_NODES=${E2E_MIN_CLUSTER_NODES:-4}
 E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-4}
-E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-8}
+E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-e2-standard-8}
 
 # This script provides helper methods to perform cluster actions.
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh

--- a/test/performance/benchmarks/dataplane-probe/cluster.yaml
+++ b/test/performance/benchmarks/dataplane-probe/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-central1"
   nodeCount: 10
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"

--- a/test/performance/benchmarks/deployment-probe/cluster.yaml
+++ b/test/performance/benchmarks/deployment-probe/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-west1"
   nodeCount: 4
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"

--- a/test/performance/benchmarks/load-test/cluster.yaml
+++ b/test/performance/benchmarks/load-test/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-central1"
   nodeCount: 5
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"

--- a/test/performance/benchmarks/scale-from-zero/cluster.yaml
+++ b/test/performance/benchmarks/scale-from-zero/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-west1"
   nodeCount: 3
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"


### PR DESCRIPTION
It's more efficient on Google Cloud.