### PR TITLE
Consider NotReadyAddresses for routing in the activator.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -61,6 +61,11 @@ type revisionDestsUpdate struct {
 	Dests         sets.String
 }
 
+type dests struct {
+	ready    sets.String
+	notReady sets.String
+}
+
 const (
 	probeTimeout          time.Duration = 300 * time.Millisecond
 	defaultProbeFrequency time.Duration = 200 * time.Millisecond
@@ -83,7 +88,7 @@ type revisionWatcher struct {
 	clusterIPHealthy bool
 
 	transport     http.RoundTripper
-	destsCh       chan sets.String
+	destsCh       chan dests
 	serviceLister corev1listers.ServiceLister
 	logger        *zap.SugaredLogger
 
@@ -93,7 +98,7 @@ type revisionWatcher struct {
 }
 
 func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol networking.ProtocolType,
-	updateCh chan<- revisionDestsUpdate, destsCh chan sets.String,
+	updateCh chan<- revisionDestsUpdate, destsCh chan dests,
 	transport http.RoundTripper, serviceLister corev1listers.ServiceLister,
 	logger *zap.SugaredLogger) *revisionWatcher {
 	ctx, cancel := context.WithCancel(ctx)
@@ -232,8 +237,8 @@ func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String) {
 
 // checkDests performs probing and potentially sends a dests update. It is
 // assumed this method is not called concurrently.
-func (rw *revisionWatcher) checkDests(dests sets.String) {
-	if len(dests) == 0 {
+func (rw *revisionWatcher) checkDests(dests dests) {
+	if len(dests.ready) == 0 && len(dests.notReady) == 0 {
 		// We must have scaled down.
 		rw.clusterIPHealthy = false
 		rw.healthyPods = sets.NewString()
@@ -249,7 +254,7 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 		// First check the pod IPs. If we can individually address
 		// the Pods we should go that route, since it permits us to do
 		// precise load balancing in the throttler.
-		hs, noop, err := rw.probePodIPs(dests)
+		hs, noop, err := rw.probePodIPs(dests.ready.Union(dests.notReady))
 		if err != nil {
 			rw.logger.With(zap.Error(err)).Warnf("Failed probing: %+v", dests)
 			// We dont want to return here as an error still affects health states.
@@ -278,8 +283,8 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 
 	// If cluster IP is healthy and we haven't scaled down, short circuit.
 	if rw.clusterIPHealthy {
-		rw.logger.Debugf("ClusterIP %s already probed (backends: %d)", dest, len(dests))
-		rw.sendUpdate(dest, dests)
+		rw.logger.Debugf("ClusterIP %s already probed (backends: %d)", dest, len(dests.ready))
+		rw.sendUpdate(dest, dests.ready)
 		return
 	}
 
@@ -290,17 +295,17 @@ func (rw *revisionWatcher) checkDests(dests sets.String) {
 		// We can reach here only iff pods are not successfully individually probed
 		// but ClusterIP conversely has been successfully probed.
 		rw.podsAddressable = false
-		rw.logger.Debugf("ClusterIP is successfully probed: %s (backends: %d)", dest, len(dests))
+		rw.logger.Debugf("ClusterIP is successfully probed: %s (backends: %d)", dest, len(dests.ready))
 		rw.clusterIPHealthy = true
 		rw.healthyPods = nil
-		rw.sendUpdate(dest, dests)
+		rw.sendUpdate(dest, dests.ready)
 	}
 }
 
 func (rw *revisionWatcher) run(probeFrequency time.Duration) {
 	defer close(rw.done)
 
-	var dests sets.String
+	var dests dests
 	timer := time.NewTicker(probeFrequency)
 	defer timer.Stop()
 
@@ -310,7 +315,8 @@ func (rw *revisionWatcher) run(probeFrequency time.Duration) {
 		// successfully probed or clusterIP has not been probed (no pod addressability),
 		// then we want to probe on timer.
 		rw.logger.Debugf("Dests: %+v, healthy dests: %+v, clusterIP: %v", dests, rw.healthyPods, rw.clusterIPHealthy)
-		if len(dests) > 0 && !(rw.clusterIPHealthy || dests.Equal(rw.healthyPods)) {
+		if len(dests.ready)+len(dests.notReady) > 0 && !(rw.clusterIPHealthy ||
+			dests.ready.Union(dests.notReady).Equal(rw.healthyPods)) {
 			rw.logger.Debug("Probing on timer")
 			tickCh = timer.C
 		} else {
@@ -422,7 +428,7 @@ func (rbm *revisionBackendsManager) getOrCreateRevisionWatcher(rev types.Namespa
 			return nil, err
 		}
 
-		destsCh := make(chan sets.String)
+		destsCh := make(chan dests)
 		rw := newRevisionWatcher(rbm.ctx, rev, proto, rbm.updateCh, destsCh, rbm.transport, rbm.serviceLister, rbm.logger)
 		rbm.revisionWatchers[rev] = rw
 		go rw.run(rbm.probeFrequency)
@@ -452,12 +458,12 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 		logger.With(zap.Error(err)).Error("Failed to get revision watcher")
 		return
 	}
-	dests := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
-	logger.Debugf("Updating Endpoints: backends: %d", len(dests))
+	ready, notReady := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
+	logger.Debugf("Updating Endpoints: ready backends: %d, not-ready backends: %d", len(ready), len(notReady))
 	select {
 	case <-rbm.ctx.Done():
 		return
-	case rw.destsCh <- dests:
+	case rw.destsCh <- dests{ready: ready, notReady: notReady}:
 	}
 }
 

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -283,7 +283,7 @@ func (rw *revisionWatcher) checkDests(dests dests) {
 
 	// If cluster IP is healthy and we haven't scaled down, short circuit.
 	if rw.clusterIPHealthy {
-		rw.logger.Debugf("ClusterIP %s already probed (backends: %d)", dest, len(dests.ready))
+		rw.logger.Debugf("ClusterIP %s already probed (ready backends: %d)", dest, len(dests.ready))
 		rw.sendUpdate(dest, dests.ready)
 		return
 	}
@@ -295,7 +295,7 @@ func (rw *revisionWatcher) checkDests(dests dests) {
 		// We can reach here only iff pods are not successfully individually probed
 		// but ClusterIP conversely has been successfully probed.
 		rw.podsAddressable = false
-		rw.logger.Debugf("ClusterIP is successfully probed: %s (backends: %d)", dest, len(dests.ready))
+		rw.logger.Debugf("ClusterIP is successfully probed: %s (ready backends: %d)", dest, len(dests.ready))
 		rw.clusterIPHealthy = true
 		rw.healthyPods = nil
 		rw.sendUpdate(dest, dests.ready)

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -117,7 +117,7 @@ func TestRevisionWatcher(t *testing.T) {
 	logger := TestLogger(t)
 	for _, tc := range []struct {
 		name                  string
-		dests                 []string
+		dests                 dests
 		protocol              networking.ProtocolType
 		clusterPort           corev1.ServicePort
 		clusterIP             string
@@ -127,7 +127,22 @@ func TestRevisionWatcher(t *testing.T) {
 		noPodAddressability   bool // This keeps the test defs shorter.
 	}{{
 		name:  "single healthy podIP",
-		dests: []string{"128.0.0.1:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234")},
+		clusterPort: corev1.ServicePort{
+			Name: "http",
+			Port: 1234,
+		},
+		clusterIP:     "129.0.0.1",
+		expectUpdates: []revisionDestsUpdate{{Dests: sets.NewString("128.0.0.1:1234")}},
+		probeHostResponses: map[string][]activatortest.FakeResponse{
+			"128.0.0.1:1234": {{
+				Code: http.StatusOK,
+				Body: queue.Name,
+			}},
+		},
+	}, {
+		name:  "single not ready but healthy podIP",
+		dests: dests{notReady: sets.NewString("128.0.0.1:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
@@ -142,7 +157,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:     "single http2 podIP",
-		dests:    []string{"128.0.0.1:1234"},
+		dests:    dests{ready: sets.NewString("128.0.0.1:1234")},
 		protocol: networking.ProtocolH2C,
 		clusterPort: corev1.ServicePort{
 			Name: "http2",
@@ -161,7 +176,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:     "single http2 clusterIP",
-		dests:    []string{"128.0.0.1:1234"},
+		dests:    dests{ready: sets.NewString("128.0.0.1:1234"), notReady: sets.NewString("128.0.0.2:1234")},
 		protocol: networking.ProtocolH2C,
 		clusterPort: corev1.ServicePort{
 			Name: "http2",
@@ -178,19 +193,22 @@ func TestRevisionWatcher(t *testing.T) {
 			"128.0.0.1:1234": {{
 				Err: errors.New("clusterIP transport error"),
 			}},
+			"128.0.0.2:1234": {{
+				Err: errors.New("clusterIP transport error"),
+			}},
 		},
 	}, {
 		name:      "no pods",
-		dests:     []string{},
+		dests:     dests{},
 		clusterIP: "129.0.0.1",
 	}, {
 		name:                  "no pods, was happy",
-		dests:                 []string{},
+		dests:                 dests{},
 		clusterIP:             "129.0.0.1",
 		initialClusterIPState: true,
 	}, {
 		name:  "single unavailable podIP",
-		dests: []string{"128.0.0.1:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
@@ -206,7 +224,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:  "single error podIP",
-		dests: []string{"128.0.0.1:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
@@ -222,7 +240,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:  "podIP slow ready",
-		dests: []string{"128.0.0.1:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
@@ -242,13 +260,13 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:  "multiple healthy podIP",
-		dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"), notReady: sets.NewString("128.0.0.3:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
 		},
 		clusterIP:     "129.0.0.1",
-		expectUpdates: []revisionDestsUpdate{{Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234")}},
+		expectUpdates: []revisionDestsUpdate{{Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.3:1234")}},
 		probeHostResponses: map[string][]activatortest.FakeResponse{
 			"128.0.0.1:1234": {{
 				Code: http.StatusOK,
@@ -258,10 +276,14 @@ func TestRevisionWatcher(t *testing.T) {
 				Code: http.StatusOK,
 				Body: queue.Name,
 			}},
+			"128.0.0.3:1234": {{
+				Code: http.StatusOK,
+				Body: queue.Name,
+			}},
 		},
 	}, {
 		name:  "one healthy one unhealthy podIP",
-		dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
@@ -279,7 +301,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:  "one healthy one unhealthy podIP then both healthy",
-		dests: []string{"128.0.0.1:1234", "128.0.0.2:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 4321,
@@ -306,7 +328,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:  "clusterIP slow ready, no pod addressability",
-		dests: []string{"128.0.0.1:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1234,
@@ -332,7 +354,7 @@ func TestRevisionWatcher(t *testing.T) {
 		},
 	}, {
 		name:  "clusterIP  ready, no pod addressability",
-		dests: []string{"128.0.0.1:1234"},
+		dests: dests{ready: sets.NewString("128.0.0.1:1234")},
 		clusterPort: corev1.ServicePort{
 			Name: "http",
 			Port: 1235,
@@ -366,7 +388,7 @@ func TestRevisionWatcher(t *testing.T) {
 			defer close(updateCh)
 
 			// This gets closed up by revisionWatcher
-			destsCh := make(chan sets.String)
+			destsCh := make(chan dests)
 
 			// Default for protocol is http1
 			if tc.protocol == "" {
@@ -411,7 +433,7 @@ func TestRevisionWatcher(t *testing.T) {
 				rw.run(100 * time.Millisecond)
 			}()
 
-			destsCh <- sets.NewString(tc.dests...)
+			destsCh <- tc.dests
 
 			updates := []revisionDestsUpdate{}
 			for i := 0; i < len(tc.expectUpdates); i++ {
@@ -458,7 +480,7 @@ func assertChClosed(t *testing.T, ch chan struct{}) {
 	}
 }
 
-func epSubset(port int32, portName string, ips []string) *corev1.EndpointSubset {
+func epSubset(port int32, portName string, ips []string, notReadyIps []string) *corev1.EndpointSubset {
 	ss := &corev1.EndpointSubset{
 		Ports: []corev1.EndpointPort{{
 			Name: portName,
@@ -468,10 +490,17 @@ func epSubset(port int32, portName string, ips []string) *corev1.EndpointSubset 
 	for _, ip := range ips {
 		ss.Addresses = append(ss.Addresses, corev1.EndpointAddress{IP: ip})
 	}
+	for _, notReady := range notReadyIps {
+		ss.NotReadyAddresses = append(ss.NotReadyAddresses, corev1.EndpointAddress{IP: notReady})
+	}
 	return ss
 }
 
 func ep(revL string, port int32, portName string, ips ...string) *corev1.Endpoints {
+	return epNotReady(revL, port, portName, ips, nil)
+}
+
+func epNotReady(revL string, port int32, portName string, readyIps []string, notReadyIps []string) *corev1.Endpoints {
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: revL + "-ep",
@@ -481,7 +510,7 @@ func ep(revL string, port int32, portName string, ips ...string) *corev1.Endpoin
 				serving.RevisionLabelKey:  revL,
 			},
 		},
-		Subsets: []corev1.EndpointSubset{*epSubset(port, portName, ips)},
+		Subsets: []corev1.EndpointSubset{*epSubset(port, portName, readyIps, notReadyIps)},
 	}
 }
 
@@ -626,6 +655,31 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			}},
 		},
 		expectDests: map[types.NamespacedName]revisionDestsUpdate{},
+	}, {
+		name:         "unready pod successfully probed",
+		endpointsArr: []*corev1.Endpoints{epNotReady(testRevision, 1234, "http", nil, []string{"128.0.0.1"})},
+		revisions: []*v1alpha1.Revision{
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+		},
+		services: []*corev1.Service{
+			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
+				[]corev1.ServicePort{{Name: "http", Port: 1234}}),
+		},
+		probeHostResponses: map[string][]activatortest.FakeResponse{
+			"129.0.0.1:1234": {{
+				Err: errors.New("clusterIP transport error"),
+			}},
+			"128.0.0.1:1234": {{
+				Code: http.StatusOK,
+				Body: queue.Name,
+			}},
+		},
+		expectDests: map[types.NamespacedName]revisionDestsUpdate{
+			{Namespace: testNamespace, Name: testRevision}: {
+				Dests: sets.NewString("128.0.0.1:1234"),
+			},
+		},
+		updateCnt: 1,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeRT := activatortest.FakeRoundTripper{
@@ -730,7 +784,7 @@ func TestCheckDests(t *testing.T) {
 		logger:           TestLogger(t),
 		stopCh:           dCh,
 	}
-	rw.checkDests(sets.NewString("10.1.1.5"))
+	rw.checkDests(dests{ready: sets.NewString("10.1.1.5")})
 	select {
 	case <-uCh:
 		// Success.
@@ -739,7 +793,7 @@ func TestCheckDests(t *testing.T) {
 	}
 
 	close(dCh)
-	rw.checkDests(sets.NewString("10.1.1.5"))
+	rw.checkDests(dests{ready: sets.NewString("10.1.1.5")})
 	select {
 	case <-uCh:
 		t.Error("Expected no update but got one")
@@ -819,7 +873,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 		transport:       network.RoundTripperFunc(fakeRT.RT),
 	}
 	// First not ready, second good, clusterIP: not ready.
-	rw.checkDests(sets.NewString("10.0.0.1:1234", "10.0.0.2:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.1:1234", "10.0.0.2:1234")})
 	want := revisionDestsUpdate{
 		Rev:           types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 		ClusterIPDest: "",
@@ -836,7 +890,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	}
 
 	// Second gone, first becomes ready, clusterIP still not ready.
-	rw.checkDests(sets.NewString("10.0.0.1:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.1:1234")})
 	select {
 	case got := <-uCh:
 		want.Dests = sets.NewString("10.0.0.1:1234")
@@ -848,7 +902,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	}
 
 	// Second is back, but not healthy yet.
-	rw.checkDests(sets.NewString("10.0.0.1:1234", "10.0.0.2:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.1:1234", "10.0.0.2:1234")})
 	select {
 	case got := <-uCh:
 		// No update should be sent out, since there's only healthy pod, same as above.
@@ -857,7 +911,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	}
 
 	// All pods are happy now.
-	rw.checkDests(sets.NewString("10.0.0.1:1234", "10.0.0.2:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.1:1234", "10.0.0.2:1234")})
 	select {
 	case got := <-uCh:
 		want.Dests = sets.NewString("10.0.0.2:1234", "10.0.0.1:1234")
@@ -869,7 +923,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	}
 
 	// Make sure we do not send out redundant updates.
-	rw.checkDests(sets.NewString("10.0.0.1:1234", "10.0.0.2:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.1:1234", "10.0.0.2:1234")})
 	select {
 	case got := <-uCh:
 		t.Errorf("Expected no update, but got %#v", got)
@@ -878,7 +932,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	}
 
 	// Swing to a different pods.
-	rw.checkDests(sets.NewString("10.0.0.3:1234", "10.0.0.2:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.3:1234", "10.0.0.2:1234")})
 	select {
 	case got := <-uCh:
 		want.Dests = sets.NewString("10.0.0.2:1234", "10.0.0.3:1234")
@@ -890,7 +944,7 @@ func TestCheckDestsSwinging(t *testing.T) {
 	}
 
 	// Scale down by 1.
-	rw.checkDests(sets.NewString("10.0.0.2:1234"))
+	rw.checkDests(dests{ready: sets.NewString("10.0.0.2:1234")})
 	select {
 	case got := <-uCh:
 		want.Dests = sets.NewString("10.0.0.2:1234")

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -556,7 +556,8 @@ func (t *Throttler) activatorEndpointsUpdated(newObj interface{}) {
 	endpoints := newObj.(*corev1.Endpoints)
 
 	// We want to pass sorted list, so that we get _some_ stability in the results.
-	eps := endpointsToDests(endpoints, networking.ServicePortNameHTTP1).List()
+	epSet, _ := endpointsToDests(endpoints, networking.ServicePortNameHTTP1)
+	eps := epSet.List()
 	t.logger.Debugf("All Activator IPS: %v, my IP: %s", eps, t.ipAddress)
 	idx := inferIndex(eps, t.ipAddress)
 	activatorCount := resources.ReadyAddressCount(endpoints)

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -563,7 +563,7 @@ func TestMultipleActivators(t *testing.T) {
 			Name:      networking.ActivatorServiceName,
 			Namespace: system.Namespace(),
 		},
-		Subsets: []corev1.EndpointSubset{*epSubset(8012, "http", []string{"130.0.0.1", "130.0.0.2"})},
+		Subsets: []corev1.EndpointSubset{*epSubset(8012, "http", []string{"130.0.0.1", "130.0.0.2"}, nil)},
 	}
 	fake.CoreV1().Endpoints(system.Namespace()).Create(activatorEp)
 	endpoints.Informer().GetIndexer().Add(activatorEp)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

NotReadyAddresses are pods that are already starting up, but they are not quite there yet. However, to cut some corners through the Kubernetes control-plane, we can consider probing them as soon as they appear to use them quicker than they'd be propagated through the APIs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The activator now potentially sees endpoints quicker than the Kubernetes API.
```

/assign @vagababov 
