### PR TITLE
Configure kingress with ClusterLocal when domain suffix is svc.cluster.local

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -486,7 +486,12 @@ func (c *Reconciler) getServiceNames(ctx context.Context, route *v1alpha1.Route)
 	if err != nil {
 		return nil, err
 	}
-	if labels.IsObjectLocalVisibility(route.ObjectMeta) {
+
+	host, err := domains.DomainNameFromTemplate(ctx, route.ObjectMeta, route.Name)
+	if err != nil {
+		return nil, err
+	}
+	if labels.IsObjectLocalVisibility(route.ObjectMeta) || domains.IsClusterLocal(host) {
 		return &serviceNames{
 			existingPublicServiceNames:       existingPublicServiceNames,
 			existingClusterLocalServiceNames: existingClusterLocalServiceNames,


### PR DESCRIPTION
## Proposed Changes

Currently even when domain suffix is `svc.cluster.local`, KIngress is configured with `ExternalIP`.
Due to this, prober fails to wrong ingress pod's IP and becomes `IngressNotConfigured`.

To fix it, this patch changes to configure KIngress with `ClusterLocal` when domain suffix is `svc.cluster.local`.

Fixes https://github.com/knative/serving/issues/6702

/lint

**Release Note**

```release-note
NONE
```
