### PR TITLE
Remove 'initialized' from all reporters and prove initialization statically.

### DIFF
--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -34,14 +34,8 @@ func unregister() {
 }
 
 func TestActivatorReporter(t *testing.T) {
-	r := &Reporter{}
-
-	if err := r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 1); err == nil {
-		t.Error("Reporter expected an error for Report call before init. Got success.")
-	}
-
-	var err error
-	if r, err = NewStatsReporter("testpod"); err != nil {
+	r, err := NewStatsReporter("testpod")
+	if err != nil {
 		t.Fatalf("Failed to create a new reporter: %v", err)
 	}
 	// Without this `go test ... -count=X`, where X > 1, fails, since

--- a/pkg/autoscaler/stats_reporter_test.go
+++ b/pkg/autoscaler/stats_reporter_test.go
@@ -41,9 +41,11 @@ func TestNewStatsReporterErrors(t *testing.T) {
 
 func TestReporterReport(t *testing.T) {
 	resetMetrics()
-	r := &Reporter{}
 
-	r, _ = NewStatsReporter("testns", "testsvc", "testconfig", "testrev")
+	r, err := NewStatsReporter("testns", "testsvc", "testconfig", "testrev")
+	if err != nil {
+		t.Fatalf("Failed to create a new reporter: %v", err)
+	}
 	wantTags := map[string]string{
 		metricskey.LabelNamespaceName:     "testns",
 		metricskey.LabelServiceName:       "testsvc",
@@ -117,7 +119,10 @@ func TestReporterReport(t *testing.T) {
 func TestReporterEmptyServiceName(t *testing.T) {
 	resetMetrics()
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
-	r, _ := NewStatsReporter("testns", "" /*service=*/, "testconfig", "testrev")
+	r, err := NewStatsReporter("testns", "" /*service=*/, "testconfig", "testrev")
+	if err != nil {
+		t.Fatalf("Failed to create a new reporter: %v", err)
+	}
 	wantTags := map[string]string{
 		metricskey.LabelNamespaceName:     "testns",
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

By making the `reporter` type of each of those reporters private, it's almost (except in the package) guaranteed that all reporters are correctly initialized, as they need to go through the `NewStatsReporter` constructor function. The `initialized` value can therefore be dropped, simplifying the implementation of these reporters.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 

(Sorry if this was on your plate as well, I needed it for some improvements to the activator stat reporting 😂)
