### PR TITLE
Use a real reporter in handler benchmark to surface allocations.

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -422,6 +422,10 @@ func BenchmarkHandler(b *testing.B) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(&testing.T{})
 	defer cancel()
 	configStore := setupConfigStore(&testing.T{}, logging.FromContext(ctx))
+	reporter, err := activator.NewStatsReporter("test_pod")
+	if err != nil {
+		b.Fatalf("Failed to create a reporter: %v", err)
+	}
 
 	// bodyLength is in kilobytes.
 	for _, bodyLength := range [5]int{2, 16, 32, 64, 128} {
@@ -434,7 +438,7 @@ func BenchmarkHandler(b *testing.B) {
 			}, nil
 		})
 
-		handler := (New(ctx, fakeThrottler{}, &fakeReporter{})).(*activationHandler)
+		handler := (New(ctx, fakeThrottler{}, reporter)).(*activationHandler)
 		handler.transport = rt
 
 		request := func() *http.Request {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

As per title.

### Before (fake)

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-sequential-12         	  199732	      7077 ns/op	    2822 B/op	      30 allocs/op
BenchmarkHandler/002k-resp-len-parallel-12           	 1000000	      1875 ns/op	    2660 B/op	      30 allocs/op
BenchmarkHandler/016k-resp-len-sequential-12         	  193099	      6507 ns/op	    2696 B/op	      30 allocs/op
BenchmarkHandler/016k-resp-len-parallel-12           	  768487	      1842 ns/op	    2778 B/op	      30 allocs/op
BenchmarkHandler/032k-resp-len-sequential-12         	  173136	      6879 ns/op	    2760 B/op	      30 allocs/op
BenchmarkHandler/032k-resp-len-parallel-12           	 1000000	      1712 ns/op	    2691 B/op	      30 allocs/op
BenchmarkHandler/064k-resp-len-sequential-12         	  139226	      8571 ns/op	    2749 B/op	      30 allocs/op
BenchmarkHandler/064k-resp-len-parallel-12           	  973315	      1881 ns/op	    2730 B/op	      30 allocs/op
BenchmarkHandler/128k-resp-len-sequential-12         	  108852	     10707 ns/op	    2750 B/op	      30 allocs/op
BenchmarkHandler/128k-resp-len-parallel-12           	  668649	      2569 ns/op	    2833 B/op	      30 allocs/op
PASS
```

### After (real)

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-sequential-12         	  119193	     10264 ns/op	    4525 B/op	      75 allocs/op
BenchmarkHandler/002k-resp-len-parallel-12           	  482875	      2671 ns/op	    4498 B/op	      75 allocs/op
BenchmarkHandler/016k-resp-len-sequential-12         	  119947	     10349 ns/op	    4527 B/op	      75 allocs/op
BenchmarkHandler/016k-resp-len-parallel-12           	  457052	      2860 ns/op	    4512 B/op	      75 allocs/op
BenchmarkHandler/032k-resp-len-sequential-12         	  110338	     11786 ns/op	    4532 B/op	      75 allocs/op
BenchmarkHandler/032k-resp-len-parallel-12           	  456247	      2883 ns/op	    4527 B/op	      75 allocs/op
BenchmarkHandler/064k-resp-len-sequential-12         	   92254	     13317 ns/op	    4526 B/op	      75 allocs/op
BenchmarkHandler/064k-resp-len-parallel-12           	  370519	      3133 ns/op	    4541 B/op	      75 allocs/op
BenchmarkHandler/128k-resp-len-sequential-12         	   76358	     14995 ns/op	    4514 B/op	      75 allocs/op
BenchmarkHandler/128k-resp-len-parallel-12           	  404475	      4178 ns/op	    4561 B/op	      75 allocs/op
PASS
```

Whoa, that was kinda unexpected. That looks like we want to make our metric reporting a lot slicker. More to come.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
