### PR TITLE
Preallocate tags and reuse them throughout a request.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -225,10 +225,7 @@ func main() {
 
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
-	var ah http.Handler = activatorhandler.New(
-		ctx,
-		throttler,
-		reporter)
+	var ah http.Handler = activatorhandler.New(ctx, throttler)
 	ah = activatorhandler.NewRequestEventHandler(reqCh, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -74,7 +74,9 @@ func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, 
 	}
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
-	cr.sr.ReportRequestConcurrency(ns, serviceName, configurationName, revName, concurrency)
+	// It's safe to ignore the error. It'll result in a noop reporter.
+	rr, _ := cr.sr.GetRevisionStatsReporter(ns, serviceName, configurationName, revName)
+	rr.ReportRequestConcurrency(concurrency)
 }
 
 // Run runs until stopCh is closed and processes events on all incoming channels

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -42,6 +42,11 @@ func TestActivatorReporter(t *testing.T) {
 	// we get an error about view already being registered.
 	defer unregister()
 
+	rr, err := r.GetRevisionStatsReporter("testns", "testsvc", "testconfig", "testrev")
+	if err != nil {
+		t.Fatalf("Failed to create revision reporter: %v", err)
+	}
+
 	// test ReportResponseConcurrency
 	wantTags1 := map[string]string{
 		metricskey.LabelNamespaceName:     "testns",
@@ -51,13 +56,10 @@ func TestActivatorReporter(t *testing.T) {
 		"pod_name":                        "testpod",
 		"container_name":                  "activator",
 	}
-	expectSuccess(t, func() error {
-		return r.ReportRequestConcurrency("testns", "testsvc", "testconfig", "testrev", 100)
-	})
+
+	rr.ReportRequestConcurrency(100)
 	metricstest.CheckLastValueData(t, "request_concurrency", wantTags1, 100)
-	expectSuccess(t, func() error {
-		return r.ReportRequestConcurrency("testns", "testsvc", "testconfig", "testrev", 200)
-	})
+	rr.ReportRequestConcurrency(200)
 	metricstest.CheckLastValueData(t, "request_concurrency", wantTags1, 200)
 
 	// test ReportRequestCount
@@ -72,12 +74,9 @@ func TestActivatorReporter(t *testing.T) {
 		"response_code_class":             "2xx",
 		"num_tries":                       "6",
 	}
-	expectSuccess(t, func() error {
-		return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 6)
-	})
-	expectSuccess(t, func() error {
-		return r.ReportRequestCount("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 6)
-	})
+
+	rr.ReportRequestCount(http.StatusOK, 6)
+	rr.ReportRequestCount(http.StatusOK, 6)
 	metricstest.CheckCountData(t, "request_count", wantTags2, 2)
 
 	// test ReportResponseTime
@@ -91,21 +90,21 @@ func TestActivatorReporter(t *testing.T) {
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 	}
-	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 1100*time.Millisecond)
-	})
-	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns", "testsvc", "testconfig", "testrev", http.StatusOK, 9100*time.Millisecond)
-	})
+	rr.ReportResponseTime(http.StatusOK, 1100*time.Millisecond)
+	rr.ReportResponseTime(http.StatusOK, 9100*time.Millisecond)
 	metricstest.CheckDistributionData(t, "request_latencies", wantTags3, 2, 1100.0, 9100.0)
 }
 
 func TestActivatorReporterEmptyServiceName(t *testing.T) {
 	r, err := NewStatsReporter("testpod")
 	defer unregister()
-
 	if err != nil {
 		t.Fatalf("Failed to create a new reporter: %v", err)
+	}
+
+	rr, err := r.GetRevisionStatsReporter("testns", "" /*service=*/, "testconfig", "testrev")
+	if err != nil {
+		t.Fatalf("Failed to create revision reporter: %v", err)
 	}
 
 	// test ReportResponseConcurrency
@@ -117,9 +116,8 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		"pod_name":                        "testpod",
 		"container_name":                  "activator",
 	}
-	expectSuccess(t, func() error {
-		return r.ReportRequestConcurrency("testns", "" /*service=*/, "testconfig", "testrev", 100)
-	})
+
+	rr.ReportRequestConcurrency(100)
 	metricstest.CheckLastValueData(t, "request_concurrency", wantTags1, 100)
 
 	// test ReportRequestCount
@@ -134,9 +132,7 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		"response_code_class":             "2xx",
 		"num_tries":                       "6",
 	}
-	expectSuccess(t, func() error {
-		return r.ReportRequestCount("testns", "" /*service=*/, "testconfig", "testrev", 200, 6)
-	})
+	rr.ReportRequestCount(200, 6)
 	metricstest.CheckCountData(t, "request_count", wantTags2, 1)
 
 	// test ReportResponseTime
@@ -150,18 +146,26 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
 	}
-	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns", "" /*service=*/, "testconfig", "testrev", 200, 7100*time.Millisecond)
-	})
-	expectSuccess(t, func() error {
-		return r.ReportResponseTime("testns", "" /*service=*/, "testconfig", "testrev", 200, 5100*time.Millisecond)
-	})
+	rr.ReportResponseTime(200, 7100*time.Millisecond)
+	rr.ReportResponseTime(200, 5100*time.Millisecond)
 	metricstest.CheckDistributionData(t, "request_latencies", wantTags3, 2, 5100.0, 7100.0)
 }
 
-func expectSuccess(t *testing.T, f func() error) {
-	t.Helper()
-	if err := f(); err != nil {
-		t.Errorf("Reporter expected success but got error: %v", err)
+func TestActivatorReporterErrorToNoop(t *testing.T) {
+	r, err := NewStatsReporter("testpod")
+	defer unregister()
+	if err != nil {
+		t.Fatalf("Failed to create a new reporter: %v", err)
 	}
+
+	// Namespace contains non-ASCII characters
+	rr, err := r.GetRevisionStatsReporter("testöns", "" /*service=*/, "test-config", "test-rev")
+	if err == nil {
+		t.Fatalf("Should have failed to create a revision reporter but didn't")
+	}
+
+	rr.ReportRequestConcurrency(100)
+	rr.ReportRequestCount(200, 6)
+	rr.ReportResponseTime(200, 7100*time.Millisecond)
+	rr.ReportResponseTime(200, 5100*time.Millisecond)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The activator reports metrics in multiple stages of a request lifecycle. The revision relevant tags will be static throughout the request so this builds a scoped reporter for these tags to reuse them in later stages.

### Before

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-sequential-12         	  109980	     10660 ns/op	    4531 B/op	      75 allocs/op
BenchmarkHandler/002k-resp-len-parallel-12           	  443875	      2716 ns/op	    4491 B/op	      75 allocs/op
BenchmarkHandler/016k-resp-len-sequential-12         	  111962	     11246 ns/op	    4535 B/op	      75 allocs/op
BenchmarkHandler/016k-resp-len-parallel-12           	  419640	      3512 ns/op	    4519 B/op	      75 allocs/op
BenchmarkHandler/032k-resp-len-sequential-12         	   98715	     13249 ns/op	    4528 B/op	      75 allocs/op
BenchmarkHandler/032k-resp-len-parallel-12           	  389748	      3613 ns/op	    4541 B/op	      75 allocs/op
BenchmarkHandler/064k-resp-len-sequential-12         	   88858	     14147 ns/op	    4537 B/op	      75 allocs/op
BenchmarkHandler/064k-resp-len-parallel-12           	  426769	      3674 ns/op	    4547 B/op	      75 allocs/op
BenchmarkHandler/128k-resp-len-sequential-12         	   67862	     16567 ns/op	    4531 B/op	      75 allocs/op
BenchmarkHandler/128k-resp-len-parallel-12           	  329760	      4208 ns/op	    4561 B/op	      75 allocs/op
PASS
```

### After

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkHandler/002k-resp-len-sequential-12         	  119520	     10047 ns/op	    4053 B/op	      59 allocs/op
BenchmarkHandler/002k-resp-len-parallel-12           	  485211	      2364 ns/op	    4025 B/op	      59 allocs/op
BenchmarkHandler/016k-resp-len-sequential-12         	  122815	     10546 ns/op	    4057 B/op	      59 allocs/op
BenchmarkHandler/016k-resp-len-parallel-12           	  503700	      2755 ns/op	    4043 B/op	      59 allocs/op
BenchmarkHandler/032k-resp-len-sequential-12         	  116455	     10861 ns/op	    4051 B/op	      59 allocs/op
BenchmarkHandler/032k-resp-len-parallel-12           	  509024	      2626 ns/op	    4050 B/op	      59 allocs/op
BenchmarkHandler/064k-resp-len-sequential-12         	  102384	     14049 ns/op	    4047 B/op	      59 allocs/op
BenchmarkHandler/064k-resp-len-parallel-12           	  462595	      3065 ns/op	    4066 B/op	      59 allocs/op
BenchmarkHandler/128k-resp-len-sequential-12         	   72121	     14986 ns/op	    4049 B/op	      59 allocs/op
BenchmarkHandler/128k-resp-len-parallel-12           	  372339	      3878 ns/op	    4090 B/op	      59 allocs/op
PASS
```

16 allocs saved in the Activator's main handler by reusing the tags.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
